### PR TITLE
Add page sectioning, web rendering and replace Listr2 with cli-progress

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -27,6 +27,28 @@ text_group_types:
   list: A list of items (ordered or unordered)
   other: Anything that doesn't fit the above
 
+section_types:
+  front_cover: Front cover page (first page only)
+  inside_cover: Inside cover page
+  back_cover: Back cover page (last page only)
+  separator: Separator page between logical sections
+  credits: Credits and acknowledgements
+  foreword: Introduction, overview, or author's note
+  table_of_contents: Table of contents
+  boxed_text: Text in a box or callout
+  text_only: Reading section with only text
+  text_and_single_image: Section with text and a single image
+  text_and_images: Reading section with text and multiple images
+  images_only: Section with only images
+  activity_matching: Matching activity
+  activity_fill_in_a_table: Table fill-in activity
+  activity_multiple_choice: Multiple choice activity
+  activity_true_false: True or false activity
+  activity_open_ended_answer: Open-ended text response activity
+  activity_fill_in_the_blank: Fill in the blank activity
+  activity_sorting: Sorting activity
+  other: Any other section type
+
 metadata:
   prompt: metadata_extraction
   model: openai:gpt-4o
@@ -34,12 +56,27 @@ metadata:
 text_classification:
   prompt: text_classification
   model: openai:gpt-4o
-  concurrency: 5
+  concurrency: 16
+
+page_sectioning:
+  prompt: page_sectioning
+  model: openai:gpt-4o
+
+web_rendering:
+  prompt: web_generation_html
+  model: openai:gpt-4o
+  concurrency: 16
+  max_retries: 8
 
 pruned_text_types:
   - header_text
   - footer_text
   - page_number
+
+pruned_section_types:
+  - back_cover
+  - credits
+  - inside_cover
 
 image_filters:
   min_side: 100

--- a/packages/pipeline/package.json
+++ b/packages/pipeline/package.json
@@ -11,12 +11,16 @@
     "pipeline": "./dist/cli.js"
   },
   "dependencies": {
-    "@adt/pdf": "workspace:*",
-    "@adt/types": "workspace:*",
-    "@adt/storage": "workspace:*",
     "@adt/llm": "workspace:*",
+    "@adt/pdf": "workspace:*",
+    "@adt/storage": "workspace:*",
+    "@adt/types": "workspace:*",
+    "cli-progress": "^3.12.0",
+    "htmlparser2": "^10.1.0",
     "js-yaml": "^4.1.0",
-    "listr2": "^9.0.0",
     "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@types/cli-progress": "^3.11.6"
   }
 }

--- a/packages/pipeline/src/__tests__/page-sectioning.test.ts
+++ b/packages/pipeline/src/__tests__/page-sectioning.test.ts
@@ -1,0 +1,360 @@
+import { describe, expect, it } from "vitest"
+import type { AppConfig, TextClassificationOutput } from "@adt/types"
+import type { LLMModel, GenerateObjectResult, GenerateObjectOptions } from "@adt/llm"
+import {
+  buildSectioningConfig,
+  buildGroupSummaries,
+  sectionPage,
+} from "../page-sectioning.js"
+
+describe("buildSectioningConfig", () => {
+  it("extracts section types and config from AppConfig", () => {
+    const appConfig: AppConfig = {
+      text_types: { heading: "Heading" },
+      text_group_types: { paragraph: "Paragraph" },
+      section_types: {
+        text_only: "Reading section with only text",
+        images_only: "Section with only images",
+      },
+      pruned_section_types: ["credits"],
+      page_sectioning: {
+        prompt: "custom_sectioning",
+        model: "openai:gpt-4.1-mini",
+      },
+    }
+
+    const config = buildSectioningConfig(appConfig)
+    expect(config.promptName).toBe("custom_sectioning")
+    expect(config.modelId).toBe("openai:gpt-4.1-mini")
+    expect(config.sectionTypes).toEqual([
+      { key: "text_only", description: "Reading section with only text" },
+      { key: "images_only", description: "Section with only images" },
+    ])
+    expect(config.prunedSectionTypes).toEqual(["credits"])
+  })
+
+  it("defaults prompt and model when not specified", () => {
+    const appConfig: AppConfig = {
+      text_types: { heading: "Heading" },
+      text_group_types: { paragraph: "Paragraph" },
+    }
+
+    const config = buildSectioningConfig(appConfig)
+    expect(config.promptName).toBe("page_sectioning")
+    expect(config.modelId).toBe("openai:gpt-4o")
+    expect(config.sectionTypes).toEqual([])
+    expect(config.prunedSectionTypes).toEqual([])
+  })
+})
+
+describe("buildGroupSummaries", () => {
+  it("builds summaries from unpruned text entries", () => {
+    const textClassification: TextClassificationOutput = {
+      reasoning: "test",
+      groups: [
+        {
+          groupId: "pg001_gp001",
+          groupType: "paragraph",
+          texts: [
+            { textType: "section_text", text: "Hello world.", isPruned: false },
+            { textType: "section_text", text: "More text.", isPruned: false },
+          ],
+        },
+        {
+          groupId: "pg001_gp002",
+          groupType: "heading",
+          texts: [
+            { textType: "section_heading", text: "Chapter 1", isPruned: false },
+          ],
+        },
+      ],
+    }
+
+    const summaries = buildGroupSummaries(textClassification)
+    expect(summaries).toEqual([
+      {
+        groupId: "pg001_gp001",
+        groupType: "paragraph",
+        text: "Hello world. More text.",
+      },
+      {
+        groupId: "pg001_gp002",
+        groupType: "heading",
+        text: "Chapter 1",
+      },
+    ])
+  })
+
+  it("excludes groups where all texts are pruned", () => {
+    const textClassification: TextClassificationOutput = {
+      reasoning: "test",
+      groups: [
+        {
+          groupId: "pg001_gp001",
+          groupType: "paragraph",
+          texts: [
+            { textType: "header_text", text: "Header", isPruned: true },
+          ],
+        },
+        {
+          groupId: "pg001_gp002",
+          groupType: "paragraph",
+          texts: [
+            { textType: "section_text", text: "Body text", isPruned: false },
+          ],
+        },
+      ],
+    }
+
+    const summaries = buildGroupSummaries(textClassification)
+    expect(summaries).toHaveLength(1)
+    expect(summaries[0].groupId).toBe("pg001_gp002")
+  })
+
+  it("excludes pruned texts within a group", () => {
+    const textClassification: TextClassificationOutput = {
+      reasoning: "test",
+      groups: [
+        {
+          groupId: "pg001_gp001",
+          groupType: "paragraph",
+          texts: [
+            { textType: "page_number", text: "42", isPruned: true },
+            { textType: "section_text", text: "Body text", isPruned: false },
+          ],
+        },
+      ],
+    }
+
+    const summaries = buildGroupSummaries(textClassification)
+    expect(summaries).toEqual([
+      { groupId: "pg001_gp001", groupType: "paragraph", text: "Body text" },
+    ])
+  })
+})
+
+describe("sectionPage", () => {
+  it("returns empty sections when no content", async () => {
+    const fakeLlm: LLMModel = {
+      generateObject: async <T>() =>
+        ({ object: { reasoning: "", sections: [] } as T }) as GenerateObjectResult<T>,
+    }
+
+    const result = await sectionPage(
+      {
+        pageId: "pg001",
+        pageNumber: 1,
+        pageImageBase64: "base64img",
+        textClassification: { reasoning: "test", groups: [] },
+        imageClassification: { images: [] },
+        images: [],
+      },
+      {
+        sectionTypes: [{ key: "text_only", description: "Text only" }],
+        prunedSectionTypes: [],
+        promptName: "page_sectioning",
+        modelId: "openai:gpt-4o",
+      },
+      fakeLlm
+    )
+
+    expect(result.reasoning).toBe("No content to section")
+    expect(result.sections).toEqual([])
+  })
+
+  it("calls LLM and post-processes sections", async () => {
+    const response = {
+      reasoning: "Grouped content logically",
+      sections: [
+        {
+          section_type: "text_only",
+          part_ids: ["pg001_gp001"],
+          background_color: "#ffffff",
+          text_color: "#000000",
+          page_number: 1,
+        },
+        {
+          section_type: "credits",
+          part_ids: ["pg001_gp002"],
+          background_color: "#f0f0f0",
+          text_color: "#333333",
+          page_number: null,
+        },
+      ],
+    }
+
+    const fakeLlm: LLMModel = {
+      generateObject: async <T>() =>
+        ({ object: response as T }) as GenerateObjectResult<T>,
+    }
+
+    const result = await sectionPage(
+      {
+        pageId: "pg001",
+        pageNumber: 1,
+        pageImageBase64: "base64img",
+        textClassification: {
+          reasoning: "test",
+          groups: [
+            {
+              groupId: "pg001_gp001",
+              groupType: "paragraph",
+              texts: [
+                {
+                  textType: "section_text",
+                  text: "Body text",
+                  isPruned: false,
+                },
+              ],
+            },
+            {
+              groupId: "pg001_gp002",
+              groupType: "paragraph",
+              texts: [
+                {
+                  textType: "section_text",
+                  text: "Credits info",
+                  isPruned: false,
+                },
+              ],
+            },
+          ],
+        },
+        imageClassification: { images: [] },
+        images: [],
+      },
+      {
+        sectionTypes: [
+          { key: "text_only", description: "Text only" },
+          { key: "credits", description: "Credits" },
+        ],
+        prunedSectionTypes: ["credits"],
+        promptName: "page_sectioning",
+        modelId: "openai:gpt-4o",
+      },
+      fakeLlm
+    )
+
+    expect(result.reasoning).toBe("Grouped content logically")
+    expect(result.sections).toHaveLength(2)
+
+    expect(result.sections[0]).toEqual({
+      sectionType: "text_only",
+      partIds: ["pg001_gp001"],
+      backgroundColor: "#ffffff",
+      textColor: "#000000",
+      pageNumber: 1,
+      isPruned: false,
+    })
+
+    expect(result.sections[1]).toEqual({
+      sectionType: "credits",
+      partIds: ["pg001_gp002"],
+      backgroundColor: "#f0f0f0",
+      textColor: "#333333",
+      pageNumber: null,
+      isPruned: true,
+    })
+  })
+
+  it("filters pruned images from LLM input", async () => {
+    let capturedContext: Record<string, unknown> | undefined
+
+    const fakeLlm: LLMModel = {
+      generateObject: async <T>(opts: GenerateObjectOptions) => {
+        capturedContext = opts.prompt?.context
+        return {
+          object: { reasoning: "test", sections: [] } as T,
+        } as GenerateObjectResult<T>
+      },
+    }
+
+    await sectionPage(
+      {
+        pageId: "pg001",
+        pageNumber: 1,
+        pageImageBase64: "base64img",
+        textClassification: {
+          reasoning: "test",
+          groups: [
+            {
+              groupId: "pg001_gp001",
+              groupType: "paragraph",
+              texts: [
+                {
+                  textType: "section_text",
+                  text: "Body",
+                  isPruned: false,
+                },
+              ],
+            },
+          ],
+        },
+        imageClassification: {
+          images: [
+            { imageId: "pg001_im001", isPruned: true, reason: "too small" },
+            { imageId: "pg001_im002", isPruned: false },
+          ],
+        },
+        images: [
+          { imageId: "pg001_im001", imageBase64: "small" },
+          { imageId: "pg001_im002", imageBase64: "good" },
+        ],
+      },
+      {
+        sectionTypes: [{ key: "text_only", description: "Text only" }],
+        prunedSectionTypes: [],
+        promptName: "page_sectioning",
+        modelId: "openai:gpt-4o",
+      },
+      fakeLlm
+    )
+
+    // Only unpruned image should be passed to LLM
+    const images = capturedContext?.images as Array<{ image_id: string }>
+    expect(images).toHaveLength(1)
+    expect(images[0].image_id).toBe("pg001_im002")
+  })
+
+  it("throws when no section types configured", async () => {
+    const fakeLlm: LLMModel = {
+      generateObject: async <T>() =>
+        ({ object: { reasoning: "", sections: [] } as T }) as GenerateObjectResult<T>,
+    }
+
+    await expect(
+      sectionPage(
+        {
+          pageId: "pg001",
+          pageNumber: 1,
+          pageImageBase64: "base64img",
+          textClassification: {
+            reasoning: "test",
+            groups: [
+              {
+                groupId: "pg001_gp001",
+                groupType: "paragraph",
+                texts: [
+                  {
+                    textType: "section_text",
+                    text: "Body",
+                    isPruned: false,
+                  },
+                ],
+              },
+            ],
+          },
+          imageClassification: { images: [] },
+          images: [],
+        },
+        {
+          sectionTypes: [],
+          prunedSectionTypes: [],
+          promptName: "page_sectioning",
+          modelId: "openai:gpt-4o",
+        },
+        fakeLlm
+      )
+    ).rejects.toThrow("No section types configured")
+  })
+})

--- a/packages/pipeline/src/__tests__/validate-html.test.ts
+++ b/packages/pipeline/src/__tests__/validate-html.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest"
+import { validateSectionHtml } from "../validate-html.js"
+
+describe("validateSectionHtml", () => {
+  it("passes valid HTML with correct data-ids", () => {
+    const html = `
+      <div id="content" class="container">
+        <section role="article" data-section-type="text_only">
+          <p data-id="pg001_gp001">Hello world</p>
+        </section>
+      </div>
+    `
+    const result = validateSectionHtml(html, ["pg001_gp001"], [])
+    expect(result.valid).toBe(true)
+    expect(result.errors).toEqual([])
+  })
+
+  it("detects unknown data-id", () => {
+    const html = `
+      <div id="content" class="container">
+        <p data-id="unknown_id">Hello</p>
+      </div>
+    `
+    const result = validateSectionHtml(html, ["pg001_gp001"], [])
+    expect(result.valid).toBe(false)
+    expect(result.errors).toContainEqual(
+      expect.stringContaining('Unknown data-id: "unknown_id"')
+    )
+  })
+
+  it("detects duplicate data-id", () => {
+    const html = `
+      <div id="content" class="container">
+        <p data-id="pg001_gp001">Hello</p>
+        <p data-id="pg001_gp001">World</p>
+      </div>
+    `
+    const result = validateSectionHtml(html, ["pg001_gp001"], [])
+    expect(result.valid).toBe(false)
+    expect(result.errors).toContainEqual(
+      expect.stringContaining('Duplicate data-id: "pg001_gp001"')
+    )
+  })
+
+  it("detects text nodes outside data-id elements", () => {
+    const html = `
+      <div id="content" class="container">
+        <p>Bare text without data-id</p>
+      </div>
+    `
+    const result = validateSectionHtml(html, [], [])
+    expect(result.valid).toBe(false)
+    expect(result.errors).toContainEqual(
+      expect.stringContaining("Text node outside any data-id element")
+    )
+  })
+
+  it("exempts text inside style tags", () => {
+    const html = `
+      <style>.container { color: red; }</style>
+      <div id="content" class="container">
+        <p data-id="pg001_gp001">Hello</p>
+      </div>
+    `
+    const result = validateSectionHtml(html, ["pg001_gp001"], [])
+    expect(result.valid).toBe(true)
+  })
+
+  it("exempts text inside script tags", () => {
+    const html = `
+      <script>console.log("hello")</script>
+      <div id="content" class="container">
+        <p data-id="pg001_gp001">Hello</p>
+      </div>
+    `
+    const result = validateSectionHtml(html, ["pg001_gp001"], [])
+    expect(result.valid).toBe(true)
+  })
+
+  it("accepts image data-ids", () => {
+    const html = `
+      <div id="content" class="container">
+        <p data-id="pg001_gp001">Hello</p>
+        <img data-id="pg001_im001" src="placeholder" alt="test" />
+      </div>
+    `
+    const result = validateSectionHtml(
+      html,
+      ["pg001_gp001"],
+      ["pg001_im001"]
+    )
+    expect(result.valid).toBe(true)
+  })
+
+  it("handles empty HTML", () => {
+    const result = validateSectionHtml("", [], [])
+    expect(result.valid).toBe(true)
+    expect(result.errors).toEqual([])
+  })
+
+  it("allows nested elements within data-id parents", () => {
+    const html = `
+      <div data-id="pg001_gp001">
+        <strong>Bold text inside data-id parent</strong>
+      </div>
+    `
+    const result = validateSectionHtml(html, ["pg001_gp001"], [])
+    expect(result.valid).toBe(true)
+  })
+})

--- a/packages/pipeline/src/__tests__/web-rendering.test.ts
+++ b/packages/pipeline/src/__tests__/web-rendering.test.ts
@@ -1,0 +1,412 @@
+import { describe, expect, it } from "vitest"
+import type { AppConfig } from "@adt/types"
+import type { LLMModel, GenerateObjectResult, GenerateObjectOptions } from "@adt/llm"
+import { buildRenderConfig, renderPage } from "../web-rendering.js"
+
+describe("buildRenderConfig", () => {
+  it("extracts web rendering config from AppConfig", () => {
+    const appConfig: AppConfig = {
+      text_types: { heading: "Heading" },
+      text_group_types: { paragraph: "Paragraph" },
+      web_rendering: {
+        prompt: "custom_render",
+        model: "openai:gpt-4.1-mini",
+        max_retries: 8,
+      },
+    }
+
+    const config = buildRenderConfig(appConfig)
+    expect(config.promptName).toBe("custom_render")
+    expect(config.modelId).toBe("openai:gpt-4.1-mini")
+    expect(config.maxRetries).toBe(8)
+  })
+
+  it("defaults prompt, model, and maxRetries when not specified", () => {
+    const appConfig: AppConfig = {
+      text_types: { heading: "Heading" },
+      text_group_types: { paragraph: "Paragraph" },
+    }
+
+    const config = buildRenderConfig(appConfig)
+    expect(config.promptName).toBe("web_generation_html")
+    expect(config.modelId).toBe("openai:gpt-4o")
+    expect(config.maxRetries).toBe(8)
+  })
+})
+
+describe("renderPage", () => {
+  const htmlResponse = {
+    reasoning: "test",
+    content: '<div id="content" class="container"><section role="article" data-section-type="text_only"><p data-id="pg001_gp001_tx001">Hello</p></section></div>',
+  }
+
+  it("skips pruned sections", async () => {
+    const calls: string[] = []
+    const fakeLlm: LLMModel = {
+      generateObject: async <T>() => {
+        calls.push("called")
+        return { object: htmlResponse as T } as GenerateObjectResult<T>
+      },
+    }
+
+    const result = await renderPage(
+      {
+        pageId: "pg001",
+        pageImageBase64: "base64img",
+        sectioning: {
+          reasoning: "test",
+          sections: [
+            {
+              sectionType: "text_only",
+              partIds: ["pg001_gp001"],
+              backgroundColor: "#ffffff",
+              textColor: "#000000",
+              pageNumber: 1,
+              isPruned: false,
+            },
+            {
+              sectionType: "credits",
+              partIds: ["pg001_gp002"],
+              backgroundColor: "#ffffff",
+              textColor: "#000000",
+              pageNumber: null,
+              isPruned: true,
+            },
+          ],
+        },
+        textClassification: {
+          reasoning: "test",
+          groups: [
+            {
+              groupId: "pg001_gp001",
+              groupType: "paragraph",
+              texts: [
+                {
+                  textType: "section_text",
+                  text: "Hello",
+                  isPruned: false,
+                },
+              ],
+            },
+            {
+              groupId: "pg001_gp002",
+              groupType: "paragraph",
+              texts: [
+                {
+                  textType: "section_text",
+                  text: "Credits info",
+                  isPruned: false,
+                },
+              ],
+            },
+          ],
+        },
+        images: new Map(),
+      },
+      { promptName: "web_generation_html", modelId: "openai:gpt-4o", maxRetries: 8 },
+      fakeLlm
+    )
+
+    // Only one section rendered (credits was pruned)
+    expect(result.sections).toHaveLength(1)
+    expect(result.sections[0].sectionType).toBe("text_only")
+    expect(calls).toHaveLength(1)
+  })
+
+  it("skips sections with no content", async () => {
+    const calls: string[] = []
+    const fakeLlm: LLMModel = {
+      generateObject: async <T>() => {
+        calls.push("called")
+        return {
+          object: { reasoning: "test", content: "<div></div>" } as T,
+        } as GenerateObjectResult<T>
+      },
+    }
+
+    const result = await renderPage(
+      {
+        pageId: "pg001",
+        pageImageBase64: "base64img",
+        sectioning: {
+          reasoning: "test",
+          sections: [
+            {
+              sectionType: "text_only",
+              partIds: ["pg001_gp001"],
+              backgroundColor: "#ffffff",
+              textColor: "#000000",
+              pageNumber: 1,
+              isPruned: false,
+            },
+          ],
+        },
+        textClassification: {
+          reasoning: "test",
+          groups: [
+            {
+              groupId: "pg001_gp001",
+              groupType: "paragraph",
+              texts: [
+                // All texts pruned — section has no content
+                {
+                  textType: "header_text",
+                  text: "Header",
+                  isPruned: true,
+                },
+              ],
+            },
+          ],
+        },
+        images: new Map(),
+      },
+      { promptName: "web_generation_html", modelId: "openai:gpt-4o", maxRetries: 8 },
+      fakeLlm
+    )
+
+    expect(result.sections).toHaveLength(0)
+    expect(calls).toHaveLength(0)
+  })
+
+  it("resolves image part IDs to image base64", async () => {
+    let capturedContext: Record<string, unknown> | undefined
+
+    const imgResponse = {
+      reasoning: "test",
+      content:
+        '<div id="content" class="container"><section role="article" data-section-type="images_only"><img data-id="pg001_im001" src="placeholder" alt="test" /></section></div>',
+    }
+
+    const fakeLlm: LLMModel = {
+      generateObject: async <T>(opts: GenerateObjectOptions) => {
+        capturedContext = opts.prompt?.context
+        return { object: imgResponse as T } as GenerateObjectResult<T>
+      },
+    }
+
+    await renderPage(
+      {
+        pageId: "pg001",
+        pageImageBase64: "base64img",
+        sectioning: {
+          reasoning: "test",
+          sections: [
+            {
+              sectionType: "images_only",
+              partIds: ["pg001_im001"],
+              backgroundColor: "#ffffff",
+              textColor: "#000000",
+              pageNumber: 1,
+              isPruned: false,
+            },
+          ],
+        },
+        textClassification: {
+          reasoning: "test",
+          groups: [],
+        },
+        images: new Map([["pg001_im001", "imagedata"]]),
+      },
+      { promptName: "web_generation_html", modelId: "openai:gpt-4o", maxRetries: 8 },
+      fakeLlm
+    )
+
+    const images = capturedContext?.images as Array<{
+      image_id: string
+      image_base64: string
+    }>
+    expect(images).toHaveLength(1)
+    expect(images[0].image_id).toBe("pg001_im001")
+    expect(images[0].image_base64).toBe("imagedata")
+  })
+
+  it("generates unique text IDs for multi-text groups", async () => {
+    let capturedContext: Record<string, unknown> | undefined
+
+    const fakeLlm: LLMModel = {
+      generateObject: async <T>(opts: GenerateObjectOptions) => {
+        capturedContext = opts.prompt?.context
+        return {
+          object: {
+            reasoning: "test",
+            content:
+              '<div id="content" class="container"><section role="article" data-section-type="text_only"><p data-id="pg001_gp001_tx001">Hello</p><p data-id="pg001_gp001_tx002">World</p></section></div>',
+          } as T,
+        } as GenerateObjectResult<T>
+      },
+    }
+
+    await renderPage(
+      {
+        pageId: "pg001",
+        pageImageBase64: "base64img",
+        sectioning: {
+          reasoning: "test",
+          sections: [
+            {
+              sectionType: "text_only",
+              partIds: ["pg001_gp001"],
+              backgroundColor: "#ffffff",
+              textColor: "#000000",
+              pageNumber: 1,
+              isPruned: false,
+            },
+          ],
+        },
+        textClassification: {
+          reasoning: "test",
+          groups: [
+            {
+              groupId: "pg001_gp001",
+              groupType: "paragraph",
+              texts: [
+                { textType: "section_text", text: "Hello", isPruned: false },
+                { textType: "section_text", text: "World", isPruned: false },
+                { textType: "header_text", text: "Pruned", isPruned: true },
+              ],
+            },
+          ],
+        },
+        images: new Map(),
+      },
+      { promptName: "web_generation_html", modelId: "openai:gpt-4o", maxRetries: 8 },
+      fakeLlm
+    )
+
+    const texts = capturedContext?.texts as Array<{
+      text_id: string
+      text_type: string
+      text: string
+    }>
+    expect(texts).toHaveLength(2)
+    expect(texts[0].text_id).toBe("pg001_gp001_tx001")
+    expect(texts[1].text_id).toBe("pg001_gp001_tx002")
+  })
+
+  it("generates tx ID for single-text groups", async () => {
+    let capturedContext: Record<string, unknown> | undefined
+
+    const fakeLlm: LLMModel = {
+      generateObject: async <T>(opts: GenerateObjectOptions) => {
+        capturedContext = opts.prompt?.context
+        return {
+          object: {
+            reasoning: "test",
+            content:
+              '<div id="content" class="container"><section role="article" data-section-type="text_only"><p data-id="pg001_gp001_tx001">Hello</p></section></div>',
+          } as T,
+        } as GenerateObjectResult<T>
+      },
+    }
+
+    await renderPage(
+      {
+        pageId: "pg001",
+        pageImageBase64: "base64img",
+        sectioning: {
+          reasoning: "test",
+          sections: [
+            {
+              sectionType: "text_only",
+              partIds: ["pg001_gp001"],
+              backgroundColor: "#ffffff",
+              textColor: "#000000",
+              pageNumber: 1,
+              isPruned: false,
+            },
+          ],
+        },
+        textClassification: {
+          reasoning: "test",
+          groups: [
+            {
+              groupId: "pg001_gp001",
+              groupType: "paragraph",
+              texts: [
+                { textType: "section_text", text: "Hello", isPruned: false },
+              ],
+            },
+          ],
+        },
+        images: new Map(),
+      },
+      { promptName: "web_generation_html", modelId: "openai:gpt-4o", maxRetries: 8 },
+      fakeLlm
+    )
+
+    const texts = capturedContext?.texts as Array<{
+      text_id: string
+    }>
+    expect(texts).toHaveLength(1)
+    expect(texts[0].text_id).toBe("pg001_gp001_tx001")
+  })
+
+  it("renders multiple non-pruned sections sequentially", async () => {
+    let callCount = 0
+    const fakeLlm: LLMModel = {
+      generateObject: async <T>() => {
+        callCount++
+        return {
+          object: {
+            reasoning: `section ${callCount}`,
+            content: `<div id="content" class="container"><section role="article" data-section-type="text_only"><p data-id="pg001_gp00${callCount}_tx001">Text ${callCount}</p></section></div>`,
+          } as T,
+        } as GenerateObjectResult<T>
+      },
+    }
+
+    const result = await renderPage(
+      {
+        pageId: "pg001",
+        pageImageBase64: "base64img",
+        sectioning: {
+          reasoning: "test",
+          sections: [
+            {
+              sectionType: "text_only",
+              partIds: ["pg001_gp001"],
+              backgroundColor: "#ffffff",
+              textColor: "#000000",
+              pageNumber: 1,
+              isPruned: false,
+            },
+            {
+              sectionType: "text_only",
+              partIds: ["pg001_gp002"],
+              backgroundColor: "#ffffff",
+              textColor: "#000000",
+              pageNumber: 1,
+              isPruned: false,
+            },
+          ],
+        },
+        textClassification: {
+          reasoning: "test",
+          groups: [
+            {
+              groupId: "pg001_gp001",
+              groupType: "paragraph",
+              texts: [
+                { textType: "section_text", text: "First", isPruned: false },
+              ],
+            },
+            {
+              groupId: "pg001_gp002",
+              groupType: "paragraph",
+              texts: [
+                { textType: "section_text", text: "Second", isPruned: false },
+              ],
+            },
+          ],
+        },
+        images: new Map(),
+      },
+      { promptName: "web_generation_html", modelId: "openai:gpt-4o", maxRetries: 8 },
+      fakeLlm
+    )
+
+    expect(result.sections).toHaveLength(2)
+    expect(result.sections[0].sectionIndex).toBe(0)
+    expect(result.sections[1].sectionIndex).toBe(1)
+  })
+})

--- a/packages/pipeline/src/cli.ts
+++ b/packages/pipeline/src/cli.ts
@@ -2,23 +2,69 @@
 
 import fs from "node:fs"
 import path from "node:path"
-import { Listr } from "listr2"
+import cliProgress from "cli-progress"
 import { createBookStorage } from "@adt/storage"
 import type { Storage } from "@adt/storage"
-import type { ExtractResult } from "@adt/pdf"
 import { createLLMModel, createPromptEngine } from "@adt/llm"
 import { parseCliArgs, USAGE } from "./cli-args.js"
 import { extractPDF } from "./pdf-extraction.js"
 import { extractMetadata, buildMetadataConfig } from "./metadata-extraction.js"
 import { classifyPageText, buildClassifyConfig } from "./text-classification.js"
 import { classifyPageImages, buildImageClassifyConfig } from "./image-classification.js"
+import { sectionPage, buildSectioningConfig } from "./page-sectioning.js"
+import { renderPage, buildRenderConfig } from "./web-rendering.js"
 import { loadBookConfig } from "./config.js"
+import type {
+  TextClassificationOutput,
+  ImageClassificationOutput,
+  PageSectioningOutput,
+} from "@adt/types"
+import type { PageData } from "@adt/storage"
 
 const DEFAULT_METADATA_PAGES = 3
 
-interface PipelineContext {
-  storage?: Storage
-  result?: ExtractResult
+function log(msg: string): void {
+  if (msg.startsWith("\r")) {
+    process.stderr.write("\x1b[2K\r" + msg.slice(1))
+  } else {
+    process.stderr.write(msg)
+  }
+}
+
+async function processWithConcurrency<T>(
+  items: T[],
+  concurrency: number,
+  fn: (item: T) => Promise<void>
+): Promise<void> {
+  const executing = new Set<Promise<void>>()
+  for (const item of items) {
+    const p = fn(item).finally(() => {
+      executing.delete(p)
+    })
+    executing.add(p)
+    if (executing.size >= concurrency) {
+      await Promise.race(executing)
+    }
+  }
+  await Promise.all(executing)
+}
+
+const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
+
+function startSpinner(label: string): () => void {
+  let i = 0
+  const id = setInterval(() => {
+    process.stderr.write(`\x1b[2K\r  ${SPINNER_FRAMES[i % SPINNER_FRAMES.length]} ${label}`)
+    i++
+  }, 80)
+  return () => clearInterval(id)
+}
+
+interface StepBars {
+  classifyImages: cliProgress.SingleBar
+  classifyText: cliProgress.SingleBar
+  section: cliProgress.SingleBar
+  render: cliProgress.SingleBar
 }
 
 async function main(): Promise<void> {
@@ -36,171 +82,245 @@ async function main(): Promise<void> {
     throw new Error(`PDF not found: ${pdfPath}`)
   }
 
-  let activeStorage: Storage | undefined
-
-  const tasks = new Listr<PipelineContext>(
-    [
-      {
-        title: `Extract PDF: ${path.basename(pdfPath)}`,
-        task: async (ctx, task) => {
-          activeStorage = createBookStorage(label, booksRoot)
-          ctx.storage = activeStorage
-
-          ctx.result = await extractPDF(
-            { pdfPath, startPage, endPage },
-            ctx.storage,
-            {
-              emit(event) {
-                if (
-                  event.type === "step-progress" &&
-                  event.page !== undefined &&
-                  event.totalPages !== undefined
-                ) {
-                  task.title = `Extract PDF: ${path.basename(pdfPath)} [${event.page}/${event.totalPages}]`
-                }
-              },
-            }
-          )
-
-          task.title = `Extract PDF: ${ctx.result.pages.length} pages extracted`
-        },
-        rendererOptions: { persistentOutput: false },
-      },
-      {
-        title: "Extract Metadata",
-        task: async (ctx) => {
-          const storage = ctx.storage!
-          const config = loadBookConfig(label, booksRoot)
-          const metadataConfig = buildMetadataConfig(config)
-
-          const cacheDir = path.join(booksRoot, label, ".cache")
-
-          const promptsDir = path.resolve(process.cwd(), "prompts")
-          const promptEngine = createPromptEngine(promptsDir)
-
-          const llmModel = createLLMModel({
-            modelId: metadataConfig.modelId,
-            cacheDir,
-            promptEngine,
-            onLog: (entry) => storage.appendLlmLog(entry),
-          })
-
-          const pages = storage.getPages()
-          const metadataPages = pages.slice(0, DEFAULT_METADATA_PAGES)
-
-          const pageInputs = metadataPages.map((page) => ({
-            pageNumber: page.pageNumber,
-            text: page.text,
-            imageBase64: storage.getPageImageBase64(page.pageId),
-          }))
-
-          const result = await extractMetadata(
-            pageInputs,
-            metadataConfig,
-            llmModel
-          )
-
-          storage.putNodeData("metadata", "book", result)
-        },
-        rendererOptions: { persistentOutput: false },
-      },
-      {
-        title: "Classify Pages",
-        task: async (ctx, task) => {
-          const storage = ctx.storage!
-
-          const config = loadBookConfig(label, booksRoot)
-          const textClassifyConfig = buildClassifyConfig(config)
-          const imageClassifyConfig = buildImageClassifyConfig(config)
-          const cacheDir = path.join(booksRoot, label, ".cache")
-          const promptsDir = path.resolve(process.cwd(), "prompts")
-          const promptEngine = createPromptEngine(promptsDir)
-          const llmModel = createLLMModel({
-            modelId: textClassifyConfig.modelId,
-            cacheDir,
-            promptEngine,
-            onLog: (entry) => storage.appendLlmLog(entry),
-          })
-
-          const pages = storage.getPages()
-          const effectiveConcurrency =
-            concurrency ?? config.text_classification?.concurrency ?? 5
-
-          return task.newListr(
-            pages.map((page) => ({
-              title: `Page ${page.pageNumber}`,
-              task: (_, pageTask) => {
-                const imageBase64 = storage.getPageImageBase64(page.pageId)
-                const images = storage.getPageImages(page.pageId)
-
-                return pageTask.newListr(
-                  [
-                    {
-                      title: "Classify Text",
-                      task: async () => {
-                        const result = await classifyPageText(
-                          {
-                            pageId: page.pageId,
-                            pageNumber: page.pageNumber,
-                            text: page.text,
-                            imageBase64,
-                          },
-                          textClassifyConfig,
-                          llmModel
-                        )
-                        storage.putNodeData(
-                          "text-classification",
-                          page.pageId,
-                          result
-                        )
-                      },
-                    },
-                    {
-                      title: "Classify Images",
-                      task: () => {
-                        const result = classifyPageImages(
-                          page.pageId,
-                          images,
-                          imageClassifyConfig
-                        )
-                        storage.putNodeData(
-                          "image-classification",
-                          page.pageId,
-                          result
-                        )
-                      },
-                    },
-                  ],
-                  { concurrent: true }
-                )
-              },
-              exitOnError: false,
-            })),
-            { concurrent: effectiveConcurrency }
-          )
-        },
-        rendererOptions: { persistentOutput: false },
-      },
-    ],
-    {
-      rendererOptions: {
-        collapseSubtasks: false,
-      },
-    }
-  )
+  const storage = createBookStorage(label, booksRoot)
 
   try {
-    await tasks.run({})
+    // Step 1: Extract PDF
+    let extractBar: cliProgress.SingleBar | undefined
+    const result = await extractPDF(
+      { pdfPath, startPage, endPage },
+      storage,
+      {
+        emit(event) {
+          if (
+            event.type === "step-progress" &&
+            event.page !== undefined &&
+            event.totalPages !== undefined
+          ) {
+            if (!extractBar) {
+              extractBar = new cliProgress.SingleBar(
+                {
+                  clearOnComplete: true,
+                  hideCursor: true,
+                  barsize: 30,
+                  linewrap: false,
+                  format: `  Extracting ${path.basename(pdfPath)} [{bar}] {value}/{total} pages`,
+                },
+                cliProgress.Presets.shades_grey
+              )
+              extractBar.start(event.totalPages, 0)
+            }
+            extractBar.update(event.page)
+          }
+        },
+      }
+    )
+    extractBar?.stop()
+    log(`✔ Extract PDF: ${result.pages.length} pages extracted\n`)
 
-    process.stderr.write(`\nOutput: ${path.join(booksRoot, label)}/\n`)
+    // Step 2: Extract Metadata
+    const config = loadBookConfig(label, booksRoot)
+    const metadataConfig = buildMetadataConfig(config)
+    const cacheDir = path.join(booksRoot, label, ".cache")
+    const promptsDir = path.resolve(process.cwd(), "prompts")
+    const promptEngine = createPromptEngine(promptsDir)
+
+    const metadataModel = createLLMModel({
+      modelId: metadataConfig.modelId,
+      cacheDir,
+      promptEngine,
+      onLog: (entry) => storage.appendLlmLog(entry.taskType, entry.pageId ?? "", entry),
+    })
+
+    const pages = storage.getPages()
+    const metadataPages = pages.slice(0, DEFAULT_METADATA_PAGES)
+    const pageInputs = metadataPages.map((page) => ({
+      pageNumber: page.pageNumber,
+      text: page.text,
+      imageBase64: storage.getPageImageBase64(page.pageId),
+    }))
+
+    const stopSpinner = startSpinner("Extracting metadata...")
+    try {
+      const metadataResult = await extractMetadata(
+        pageInputs,
+        metadataConfig,
+        metadataModel
+      )
+      storage.putNodeData("metadata", "book", metadataResult)
+    } finally {
+      stopSpinner()
+    }
+    log("\r✔ Extract Metadata\n")
+
+    // Step 3: Creating Storyboard
+    log("\nCreating Storyboard:\n")
+
+    const textClassifyConfig = buildClassifyConfig(config)
+    const imageClassifyConfig = buildImageClassifyConfig(config)
+    const sectioningConfig = buildSectioningConfig(config)
+    const renderConfig = buildRenderConfig(config)
+    const llmModel = createLLMModel({
+      modelId: textClassifyConfig.modelId,
+      cacheDir,
+      promptEngine,
+      onLog: (entry) => storage.appendLlmLog(entry.taskType, entry.pageId ?? "", entry),
+    })
+
+    const effectiveConcurrency =
+      concurrency ?? config.text_classification?.concurrency ?? 16
+    const totalPages = pages.length
+
+    const multibar = new cliProgress.MultiBar(
+      {
+        clearOnComplete: false,
+        hideCursor: true,
+        barsize: 30,
+        linewrap: false,
+        forceRedraw: true,
+      },
+      cliProgress.Presets.shades_grey
+    )
+
+    const barFormat = (label: string) =>
+      ` ${label.padEnd(16)} [{bar}] {value}/${totalPages}`
+
+    const stepBars: StepBars = {
+      classifyImages: multibar.create(totalPages, 0, {}, { format: barFormat("Classify Images") }),
+      classifyText: multibar.create(totalPages, 0, {}, { format: barFormat("Classify Text") }),
+      section: multibar.create(totalPages, 0, {}, { format: barFormat("Section Pages") }),
+      render: multibar.create(totalPages, 0, {}, { format: barFormat("Render Pages") }),
+    }
+
+    try {
+      await processWithConcurrency(
+        pages,
+        effectiveConcurrency,
+        async (page) => {
+          await processPage(
+            page,
+            stepBars,
+            storage,
+            {
+              textClassifyConfig,
+              imageClassifyConfig,
+              sectioningConfig,
+              renderConfig,
+            },
+            llmModel
+          )
+        }
+      )
+    } finally {
+      multibar.stop()
+    }
+
+    log(`\nOutput: ${path.join(booksRoot, label)}/\n`)
   } finally {
-    activeStorage?.close()
+    storage.close()
   }
 }
 
-main().catch((err) => {
-  process.stderr.write(
-    `\nFailed: ${err instanceof Error ? err.message : String(err)}\n`
+interface StepConfigs {
+  textClassifyConfig: ReturnType<typeof buildClassifyConfig>
+  imageClassifyConfig: ReturnType<typeof buildImageClassifyConfig>
+  sectioningConfig: ReturnType<typeof buildSectioningConfig>
+  renderConfig: ReturnType<typeof buildRenderConfig>
+}
+
+async function processPage(
+  page: PageData,
+  bars: StepBars,
+  storage: Storage,
+  configs: StepConfigs,
+  llmModel: ReturnType<typeof createLLMModel>
+): Promise<void> {
+  const { textClassifyConfig, imageClassifyConfig, sectioningConfig, renderConfig } =
+    configs
+
+  // --- Classify ---
+  const imageBase64 = storage.getPageImageBase64(page.pageId)
+  const images = storage.getPageImages(page.pageId)
+
+  const textPromise = classifyPageText(
+    {
+      pageId: page.pageId,
+      pageNumber: page.pageNumber,
+      text: page.text,
+      imageBase64,
+    },
+    textClassifyConfig,
+    llmModel
   )
+
+  const imageResult = classifyPageImages(page.pageId, images, imageClassifyConfig)
+  storage.putNodeData("image-classification", page.pageId, imageResult)
+  bars.classifyImages.increment()
+
+  const textResult = await textPromise
+  storage.putNodeData("text-classification", page.pageId, textResult)
+  bars.classifyText.increment()
+
+  // --- Section ---
+  const textClassification = textResult as TextClassificationOutput
+  const imageClassification = imageResult as ImageClassificationOutput
+
+  const allImages = storage.getPageImages(page.pageId)
+  const prunedImageIds = new Set(
+    imageClassification.images
+      .filter((img) => img.isPruned)
+      .map((img) => img.imageId)
+  )
+  const sectionImages = allImages
+    .filter((img) => !prunedImageIds.has(img.imageId))
+    .map((img) => ({
+      imageId: img.imageId,
+      imageBase64: storage.getImageBase64(img.imageId),
+    }))
+
+  const pageImageBase64 = storage.getPageImageBase64(page.pageId)
+  const sectionResult = await sectionPage(
+    {
+      pageId: page.pageId,
+      pageNumber: page.pageNumber,
+      pageImageBase64,
+      textClassification,
+      imageClassification,
+      images: sectionImages,
+    },
+    sectioningConfig,
+    llmModel
+  )
+  storage.putNodeData("page-sectioning", page.pageId, sectionResult)
+  bars.section.increment()
+
+  // --- Render ---
+  const sectioning = sectionResult as PageSectioningOutput
+  const renderImages = new Map<string, string>()
+  for (const img of allImages) {
+    if (!prunedImageIds.has(img.imageId)) {
+      renderImages.set(img.imageId, storage.getImageBase64(img.imageId))
+    }
+  }
+
+  const renderResult = await renderPage(
+    {
+      pageId: page.pageId,
+      pageImageBase64,
+      sectioning,
+      textClassification,
+      images: renderImages,
+    },
+    renderConfig,
+    llmModel
+  )
+  storage.putNodeData("web-rendering", page.pageId, renderResult)
+  bars.render.increment()
+}
+
+main().catch((err) => {
+  const detail =
+    err instanceof Error ? err.stack ?? err.message : String(err)
+  process.stderr.write(`\nFailed: ${detail}\n`)
   process.exit(1)
 })

--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -21,4 +21,22 @@ export {
   type MetadataConfig,
   type MetadataPageInput,
 } from "./metadata-extraction.js"
+export {
+  sectionPage,
+  buildSectioningConfig,
+  buildGroupSummaries,
+  type SectioningConfig,
+  type SectionPageInput,
+} from "./page-sectioning.js"
+export {
+  renderPage,
+  renderSection,
+  buildRenderConfig,
+  type RenderConfig,
+  type RenderPageInput,
+  type RenderSectionInput,
+  type TextInput,
+  type ImageInput,
+} from "./web-rendering.js"
+export { validateSectionHtml } from "./validate-html.js"
 export { loadConfig, loadBookConfig, deepMerge } from "./config.js"

--- a/packages/pipeline/src/page-sectioning.ts
+++ b/packages/pipeline/src/page-sectioning.ts
@@ -1,0 +1,159 @@
+import type {
+  TextClassificationOutput,
+  ImageClassificationOutput,
+  PageSectioningOutput,
+  AppConfig,
+  TypeDef,
+} from "@adt/types"
+import { buildPageSectioningLLMSchema } from "@adt/types"
+import type { LLMModel } from "@adt/llm"
+
+export interface SectioningConfig {
+  sectionTypes: TypeDef[]
+  prunedSectionTypes: string[]
+  promptName: string
+  modelId: string
+}
+
+export interface SectionPageInput {
+  pageId: string
+  pageNumber: number
+  pageImageBase64: string
+  textClassification: TextClassificationOutput
+  imageClassification: ImageClassificationOutput
+  images: Array<{ imageId: string; imageBase64: string }>
+}
+
+/**
+ * Build concise group summaries from text classification, excluding pruned text entries.
+ * Groups with no unpruned texts are omitted entirely.
+ */
+export function buildGroupSummaries(
+  textClassification: TextClassificationOutput
+): Array<{ groupId: string; groupType: string; text: string }> {
+  return textClassification.groups
+    .map((g) => {
+      const unprunedTexts = g.texts.filter((t) => !t.isPruned)
+      if (unprunedTexts.length === 0) return null
+
+      return {
+        groupId: g.groupId,
+        groupType: g.groupType,
+        text: unprunedTexts.map((t) => t.text).join(" "),
+      }
+    })
+    .filter((g): g is NonNullable<typeof g> => g !== null)
+}
+
+/**
+ * Section a page into semantic groups. Pure function — no side effects.
+ * The caller handles concurrency, storage writes, and progress.
+ */
+export async function sectionPage(
+  input: SectionPageInput,
+  config: SectioningConfig,
+  llmModel: LLMModel
+): Promise<PageSectioningOutput> {
+  // Build group summaries (excludes pruned text entries)
+  const groupSummaries = buildGroupSummaries(input.textClassification)
+
+  // Filter to un-pruned images
+  const prunedImageIds = new Set(
+    input.imageClassification.images
+      .filter((img) => img.isPruned)
+      .map((img) => img.imageId)
+  )
+  const unprunedImages = input.images.filter(
+    (img) => !prunedImageIds.has(img.imageId)
+  )
+
+  // Build valid part IDs for the schema
+  const validPartIds = [
+    ...groupSummaries.map((g) => g.groupId),
+    ...unprunedImages.map((img) => img.imageId),
+  ]
+
+  // If no parts to section, return empty result
+  if (validPartIds.length === 0) {
+    return { reasoning: "No content to section", sections: [] }
+  }
+
+  const sectionTypeKeys = config.sectionTypes.map((s) => s.key)
+  if (sectionTypeKeys.length === 0) {
+    throw new Error("No section types configured")
+  }
+
+  const schema = buildPageSectioningLLMSchema(
+    sectionTypeKeys as [string, ...string[]],
+    validPartIds as [string, ...string[]]
+  )
+
+  const result = await llmModel.generateObject<{
+    reasoning: string
+    sections: Array<{
+      section_type: string
+      part_ids: string[]
+      background_color: string
+      text_color: string
+      page_number: number | null
+    }>
+  }>({
+    schema,
+    prompt: {
+      name: config.promptName,
+      context: {
+        page: { imageBase64: input.pageImageBase64 },
+        images: unprunedImages.map((img) => ({
+          image_id: img.imageId,
+          imageBase64: img.imageBase64,
+        })),
+        groups: groupSummaries.map((g) => ({
+          group_id: g.groupId,
+          group_type: g.groupType,
+          text: g.text,
+        })),
+        section_types: config.sectionTypes,
+      },
+    },
+    maxRetries: 2,
+    maxTokens: 16384,
+    log: {
+      taskType: "page-sectioning",
+      pageId: input.pageId,
+      promptName: config.promptName,
+    },
+  })
+
+  // Post-process: mark pruned sections
+  const prunedSet = new Set(config.prunedSectionTypes)
+
+  const sections = result.object.sections.map((s) => ({
+    sectionType: s.section_type,
+    partIds: s.part_ids,
+    backgroundColor: s.background_color,
+    textColor: s.text_color,
+    pageNumber: s.page_number,
+    isPruned: prunedSet.has(s.section_type),
+  }))
+
+  return {
+    reasoning: result.object.reasoning,
+    sections,
+  }
+}
+
+/**
+ * Build SectioningConfig from AppConfig.
+ */
+export function buildSectioningConfig(appConfig: AppConfig): SectioningConfig {
+  const sectionTypes: TypeDef[] = Object.entries(
+    appConfig.section_types ?? {}
+  ).map(([key, description]) => ({ key, description }))
+
+  return {
+    sectionTypes,
+    prunedSectionTypes: appConfig.pruned_section_types ?? [],
+    promptName: appConfig.page_sectioning?.prompt ?? "page_sectioning",
+    modelId: appConfig.page_sectioning?.model ?? "openai:gpt-4o",
+  }
+}

--- a/packages/pipeline/src/validate-html.ts
+++ b/packages/pipeline/src/validate-html.ts
@@ -1,0 +1,80 @@
+import { parseDocument } from "htmlparser2"
+
+export interface HtmlValidationResult {
+  valid: boolean
+  errors: string[]
+}
+
+const EXEMPT_TAGS = new Set(["style", "script"])
+
+export function validateSectionHtml(
+  html: string,
+  allowedTextIds: string[],
+  allowedImageIds: string[]
+): HtmlValidationResult {
+  const allowedIds = new Set([...allowedTextIds, ...allowedImageIds])
+  const errors: string[] = []
+  const seenIds = new Set<string>()
+  const doc = parseDocument(html)
+
+  walkNode(doc, allowedIds, seenIds, errors)
+
+  return { valid: errors.length === 0, errors }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function walkNode(node: any, allowedIds: Set<string>, seenIds: Set<string>, errors: string[]): void {
+  if (node.type === "text") {
+    if (node.data.trim().length > 0) {
+      if (isInsideExemptTag(node)) return
+      if (!hasAncestorWithDataId(node)) {
+        const snippet = node.data.trim().slice(0, 50)
+        errors.push(`Text node outside any data-id element: "${snippet}"`)
+      }
+    }
+    return
+  }
+
+  if (node.type === "tag") {
+    const dataId = node.attribs?.["data-id"]
+    if (dataId !== undefined) {
+      if (!allowedIds.has(dataId)) {
+        errors.push(`Unknown data-id: "${dataId}"`)
+      } else if (seenIds.has(dataId)) {
+        errors.push(`Duplicate data-id: "${dataId}"`)
+      } else {
+        seenIds.add(dataId)
+      }
+    }
+  }
+
+  if (node.children) {
+    for (const child of node.children) {
+      walkNode(child, allowedIds, seenIds, errors)
+    }
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function isInsideExemptTag(node: any): boolean {
+  let current = node.parent
+  while (current) {
+    if ((current.type === "tag" || current.type === "style" || current.type === "script") && EXEMPT_TAGS.has(current.name)) {
+      return true
+    }
+    current = current.parent
+  }
+  return false
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function hasAncestorWithDataId(node: any): boolean {
+  let current = node.parent
+  while (current) {
+    if (current.type === "tag" && current.attribs?.["data-id"] !== undefined) {
+      return true
+    }
+    current = current.parent
+  }
+  return false
+}

--- a/packages/pipeline/src/web-rendering.ts
+++ b/packages/pipeline/src/web-rendering.ts
@@ -1,0 +1,202 @@
+import type {
+  PageSectioningOutput,
+  TextClassificationOutput,
+  AppConfig,
+  SectionRendering,
+  WebRenderingOutput,
+} from "@adt/types"
+import { webRenderingLLMSchema } from "@adt/types"
+import type { LLMModel, ValidationResult } from "@adt/llm"
+import { validateSectionHtml } from "./validate-html.js"
+
+export interface RenderConfig {
+  promptName: string
+  modelId: string
+  maxRetries: number
+}
+
+export interface TextInput {
+  textId: string
+  textType: string
+  text: string
+}
+
+export interface ImageInput {
+  imageId: string
+  imageBase64: string
+}
+
+export interface RenderPageInput {
+  pageId: string
+  pageImageBase64: string
+  sectioning: PageSectioningOutput
+  textClassification: TextClassificationOutput
+  images: Map<string, string> // imageId → base64
+}
+
+/**
+ * Resolve section part IDs to text entries. Each partId that matches a group ID
+ * expands to the individual text entries within that group (excluding pruned texts).
+ */
+function resolveTexts(
+  partIds: string[],
+  textClassification: TextClassificationOutput
+): TextInput[] {
+  const groupMap = new Map(
+    textClassification.groups.map((g) => [g.groupId, g])
+  )
+  const texts: TextInput[] = []
+
+  for (const partId of partIds) {
+    const group = groupMap.get(partId)
+    if (!group) continue
+
+    const nonPruned = group.texts.filter((t) => !t.isPruned)
+    for (let i = 0; i < nonPruned.length; i++) {
+      texts.push({
+        textId: `${partId}_tx${String(i + 1).padStart(3, "0")}`,
+        textType: nonPruned[i].textType,
+        text: nonPruned[i].text,
+      })
+    }
+  }
+
+  return texts
+}
+
+/**
+ * Resolve section part IDs to image entries.
+ */
+function resolveImages(
+  partIds: string[],
+  images: Map<string, string>
+): ImageInput[] {
+  const resolved: ImageInput[] = []
+
+  for (const partId of partIds) {
+    const imageBase64 = images.get(partId)
+    if (imageBase64) {
+      resolved.push({ imageId: partId, imageBase64 })
+    }
+  }
+
+  return resolved
+}
+
+/**
+ * Render all sections for a page as HTML. Pure function — no side effects.
+ * The caller handles concurrency, storage writes, and progress.
+ */
+export async function renderPage(
+  input: RenderPageInput,
+  config: RenderConfig,
+  llmModel: LLMModel
+): Promise<WebRenderingOutput> {
+  const sections: SectionRendering[] = []
+
+  for (let i = 0; i < input.sectioning.sections.length; i++) {
+    const section = input.sectioning.sections[i]
+
+    // Skip pruned sections
+    if (section.isPruned) continue
+
+    // Resolve texts and images from part IDs
+    const texts = resolveTexts(section.partIds, input.textClassification)
+    const sectionImages = resolveImages(section.partIds, input.images)
+
+    // Skip sections with no content
+    if (texts.length === 0 && sectionImages.length === 0) continue
+
+    const rendering = await renderSection(
+      {
+        pageId: input.pageId,
+        pageImageBase64: input.pageImageBase64,
+        sectionIndex: i,
+        sectionType: section.sectionType,
+        texts,
+        images: sectionImages,
+      },
+      config,
+      llmModel
+    )
+
+    sections.push(rendering)
+  }
+
+  return { sections }
+}
+
+export interface RenderSectionInput {
+  pageId: string
+  pageImageBase64: string
+  sectionIndex: number
+  sectionType: string
+  texts: TextInput[]
+  images: ImageInput[]
+}
+
+/**
+ * Render a single section as HTML.
+ */
+export async function renderSection(
+  input: RenderSectionInput,
+  config: RenderConfig,
+  llmModel: LLMModel
+): Promise<SectionRendering> {
+  const allowedTextIds = input.texts.map((t) => t.textId)
+  const allowedImageIds = input.images.map((img) => img.imageId)
+
+  const validate = (result: unknown): ValidationResult => {
+    const r = result as { reasoning: string; content: string }
+    return validateSectionHtml(r.content, allowedTextIds, allowedImageIds)
+  }
+
+  const result = await llmModel.generateObject<{
+    reasoning: string
+    content: string
+  }>({
+    schema: webRenderingLLMSchema,
+    prompt: {
+      name: config.promptName,
+      context: {
+        page_image_base64: input.pageImageBase64,
+        section_type: input.sectionType,
+        texts: input.texts.map((t) => ({
+          text_id: t.textId,
+          text_type: t.textType,
+          text: t.text,
+        })),
+        images: input.images.map((img) => ({
+          image_id: img.imageId,
+          image_base64: img.imageBase64,
+        })),
+      },
+    },
+    validate,
+    maxRetries: config.maxRetries,
+    maxTokens: 16384,
+    log: {
+      taskType: "web-rendering",
+      pageId: input.pageId,
+      promptName: config.promptName,
+    },
+  })
+
+  return {
+    sectionIndex: input.sectionIndex,
+    sectionType: input.sectionType,
+    reasoning: result.object.reasoning,
+    html: result.object.content,
+  }
+}
+
+/**
+ * Build RenderConfig from AppConfig.
+ */
+export function buildRenderConfig(appConfig: AppConfig): RenderConfig {
+  return {
+    promptName: appConfig.web_rendering?.prompt ?? "web_generation_html",
+    modelId: appConfig.web_rendering?.model ?? "openai:gpt-4o",
+    maxRetries: appConfig.web_rendering?.max_retries ?? 8,
+  }
+}

--- a/packages/storage/src/__tests__/book-storage.test.ts
+++ b/packages/storage/src/__tests__/book-storage.test.ts
@@ -345,21 +345,26 @@ describe("putNodeData / getLatestNodeData", () => {
 })
 
 describe("appendLlmLog", () => {
-  it("appends log entries", () => {
+  it("appends log entries with step and item_id", () => {
     const { storage, paths } = createTempStorage()
 
-    storage.appendLlmLog({ taskType: "test", modelId: "gpt-4o" })
-    storage.appendLlmLog({ taskType: "test2", modelId: "gpt-4o" })
+    storage.appendLlmLog("text-classification", "pg001", { taskType: "text-classification", modelId: "gpt-4o" })
+    storage.appendLlmLog("web-rendering", "pg002", { taskType: "web-rendering", modelId: "gpt-4o" })
 
     const db = openBookDb(paths.dbPath)
     const rows = db.all("SELECT * FROM llm_log ORDER BY id") as Array<{
       id: number
       timestamp: string
+      step: string
+      item_id: string
       data: string
     }>
     expect(rows).toHaveLength(2)
-    expect(JSON.parse(rows[0].data).taskType).toBe("test")
-    expect(JSON.parse(rows[1].data).taskType).toBe("test2")
+    expect(rows[0].step).toBe("text-classification")
+    expect(rows[0].item_id).toBe("pg001")
+    expect(JSON.parse(rows[0].data).taskType).toBe("text-classification")
+    expect(rows[1].step).toBe("web-rendering")
+    expect(rows[1].item_id).toBe("pg002")
     expect(rows[0].timestamp).toBeTruthy()
     db.close()
 

--- a/packages/storage/src/__tests__/db.test.ts
+++ b/packages/storage/src/__tests__/db.test.ts
@@ -74,6 +74,50 @@ describe("openBookDb", () => {
     raw.close()
   })
 
+  it("migrates v2 database to v3 adding llm_log columns", () => {
+    const dbPath = makeDbPath("v2.db")
+    const v2Db = new sqlite.Database(dbPath)
+    v2Db.exec(`
+      CREATE TABLE schema_version (
+        id INTEGER PRIMARY KEY CHECK (id = 1),
+        version INTEGER NOT NULL
+      );
+      INSERT INTO schema_version (id, version) VALUES (1, 2);
+      CREATE TABLE pages (page_id TEXT PRIMARY KEY, page_number INTEGER NOT NULL, text TEXT NOT NULL);
+      CREATE TABLE node_data (node TEXT NOT NULL, item_id TEXT NOT NULL, version INTEGER NOT NULL, data TEXT, PRIMARY KEY (node, item_id, version));
+      CREATE TABLE images (image_id TEXT PRIMARY KEY, page_id TEXT NOT NULL, path TEXT NOT NULL, hash TEXT NOT NULL DEFAULT '', width INTEGER NOT NULL, height INTEGER NOT NULL, source TEXT NOT NULL);
+      CREATE TABLE llm_log (id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp TEXT NOT NULL, data TEXT NOT NULL);
+      INSERT INTO llm_log (timestamp, data) VALUES ('2024-01-01', '{"old":"entry"}');
+    `)
+    v2Db.close()
+
+    const db = openBookDb(dbPath)
+
+    const rows = db.all("SELECT id, version FROM schema_version") as Array<{
+      id: number
+      version: number
+    }>
+    expect(rows).toEqual([{ id: 1, version: SCHEMA_VERSION }])
+
+    const cols = db.all("PRAGMA table_info(llm_log)") as Array<{ name: string }>
+    const colNames = cols.map((c) => c.name)
+    expect(colNames).toContain("step")
+    expect(colNames).toContain("item_id")
+
+    // Old data preserved with default values
+    const logRows = db.all("SELECT step, item_id, data FROM llm_log") as Array<{
+      step: string
+      item_id: string
+      data: string
+    }>
+    expect(logRows).toHaveLength(1)
+    expect(logRows[0].step).toBe("")
+    expect(logRows[0].item_id).toBe("")
+    expect(JSON.parse(logRows[0].data)).toEqual({ old: "entry" })
+
+    db.close()
+  })
+
   it("throws when schema version does not match", () => {
     const dbPath = makeDbPath("mismatch.db")
     const legacyDb = new sqlite.Database(dbPath)

--- a/packages/storage/src/book-storage.ts
+++ b/packages/storage/src/book-storage.ts
@@ -81,6 +81,19 @@ export function createBookStorage(label: string, booksRoot: string): Storage {
       return fs.readFileSync(filePath).toString("base64")
     },
 
+    getImageBase64(imageId: string): string {
+      const rows = db.all(
+        "SELECT path FROM images WHERE image_id = ?",
+        [imageId]
+      ) as Array<{ path: string }>
+      if (rows.length === 0) {
+        throw new Error(`No image found for ${imageId}`)
+      }
+      const filePath = path.resolve(paths.bookDir, rows[0].path)
+      ensureWithinRoot(filePath, paths.bookDir)
+      return fs.readFileSync(filePath).toString("base64")
+    },
+
     getPageImages(pageId: string): ImageData[] {
       const rows = db.all(
         "SELECT image_id, width, height FROM images WHERE page_id = ? ORDER BY image_id",
@@ -118,10 +131,10 @@ export function createBookStorage(label: string, booksRoot: string): Storage {
       }
     },
 
-    appendLlmLog(entry: unknown): void {
+    appendLlmLog(step: string, itemId: string, entry: unknown): void {
       db.run(
-        "INSERT INTO llm_log (timestamp, data) VALUES (?, ?)",
-        [new Date().toISOString(), JSON.stringify(entry)]
+        "INSERT INTO llm_log (timestamp, step, item_id, data) VALUES (?, ?, ?, ?)",
+        [new Date().toISOString(), step, itemId, JSON.stringify(entry)]
       )
     },
 

--- a/packages/storage/src/db.ts
+++ b/packages/storage/src/db.ts
@@ -38,6 +38,8 @@ CREATE TABLE IF NOT EXISTS images (
 CREATE TABLE IF NOT EXISTS llm_log (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   timestamp TEXT NOT NULL,
+  step TEXT NOT NULL DEFAULT '',
+  item_id TEXT NOT NULL DEFAULT '',
   data TEXT NOT NULL
 );
 `
@@ -67,12 +69,16 @@ function initSchema(db: sqlite.Database): void {
   }>
   const existing = rows[0]?.version ?? 0
 
-  if (existing !== SCHEMA_VERSION) {
+  if (existing === SCHEMA_VERSION) return
+
+  if (existing > SCHEMA_VERSION) {
     db.close()
     throw new Error(
       `Schema version mismatch: found v${existing}, expected v${SCHEMA_VERSION}`
     )
   }
+
+  migrate(db, existing)
 }
 
 function upsertSchemaVersion(db: sqlite.Database, version: number): void {
@@ -81,6 +87,28 @@ function upsertSchemaVersion(db: sqlite.Database, version: number): void {
      ON CONFLICT (id) DO UPDATE SET version = excluded.version`,
     [version]
   )
+}
+
+function migrate(db: sqlite.Database, from: number): void {
+  db.exec("BEGIN IMMEDIATE")
+  try {
+    if (from < 3) {
+      // v2 → v3: add step + item_id columns to llm_log
+      const cols = db.all("PRAGMA table_info(llm_log)") as Array<{ name: string }>
+      const colNames = new Set(cols.map((c) => c.name))
+      if (!colNames.has("step")) {
+        db.run("ALTER TABLE llm_log ADD COLUMN step TEXT NOT NULL DEFAULT ''")
+      }
+      if (!colNames.has("item_id")) {
+        db.run("ALTER TABLE llm_log ADD COLUMN item_id TEXT NOT NULL DEFAULT ''")
+      }
+    }
+    upsertSchemaVersion(db, SCHEMA_VERSION)
+    db.exec("COMMIT")
+  } catch (err) {
+    db.exec("ROLLBACK")
+    throw err
+  }
 }
 
 function migrateLegacySchemaVersionTable(db: sqlite.Database): void {

--- a/packages/storage/src/storage.ts
+++ b/packages/storage/src/storage.ts
@@ -23,12 +23,13 @@ export interface Storage {
 
   getPages(): PageData[]
   getPageImageBase64(pageId: string): string
+  getImageBase64(imageId: string): string
   getPageImages(pageId: string): ImageData[]
 
   putNodeData(node: string, itemId: string, data: unknown): number
   getLatestNodeData(node: string, itemId: string): NodeDataRow | null
 
-  appendLlmLog(entry: unknown): void
+  appendLlmLog(step: string, itemId: string, entry: unknown): void
 
   close(): void
 }

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -5,15 +5,20 @@ export const StepConfig = z.object({
   prompt: z.string().optional(),
   model: z.string().optional(),
   concurrency: z.number().int().min(1).optional(),
+  max_retries: z.number().int().min(0).optional(),
 })
 export type StepConfig = z.infer<typeof StepConfig>
 
 export const AppConfig = z.object({
   text_types: z.record(z.string(), z.string()),
   text_group_types: z.record(z.string(), z.string()),
+  section_types: z.record(z.string(), z.string()).optional(),
   pruned_text_types: z.array(z.string()).optional(),
+  pruned_section_types: z.array(z.string()).optional(),
   text_classification: StepConfig.optional(),
   metadata: StepConfig.optional(),
+  page_sectioning: StepConfig.optional(),
+  web_rendering: StepConfig.optional(),
   image_filters: ImageFilters.optional(),
 })
 export type AppConfig = z.infer<typeof AppConfig>

--- a/packages/types/src/db.ts
+++ b/packages/types/src/db.ts
@@ -1,6 +1,6 @@
 import { z } from "zod"
 
-export const SCHEMA_VERSION = 2
+export const SCHEMA_VERSION = 3
 
 export const ImageSource = z.enum(["page", "extract", "crop"])
 export type ImageSource = z.infer<typeof ImageSource>

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -29,3 +29,15 @@ export {
 } from "./image-classification.js"
 
 export { BookMetadata } from "./metadata.js"
+
+export {
+  PageSection,
+  PageSectioningOutput,
+  buildPageSectioningLLMSchema,
+} from "./page-sectioning.js"
+
+export {
+  SectionRendering,
+  WebRenderingOutput,
+  webRenderingLLMSchema,
+} from "./web-rendering.js"

--- a/packages/types/src/page-sectioning.ts
+++ b/packages/types/src/page-sectioning.ts
@@ -1,0 +1,38 @@
+import { z } from "zod"
+
+export const PageSection = z.object({
+  sectionType: z.string(),
+  partIds: z.array(z.string()),
+  backgroundColor: z.string(),
+  textColor: z.string(),
+  pageNumber: z.number().int().nullable(),
+  isPruned: z.boolean(),
+})
+export type PageSection = z.infer<typeof PageSection>
+
+export const PageSectioningOutput = z.object({
+  reasoning: z.string(),
+  sections: z.array(PageSection),
+})
+export type PageSectioningOutput = z.infer<typeof PageSectioningOutput>
+
+/**
+ * Build an LLM-facing schema with enum-constrained section types and part IDs.
+ */
+export function buildPageSectioningLLMSchema(
+  sectionTypes: [string, ...string[]],
+  validPartIds: [string, ...string[]]
+) {
+  return z.object({
+    reasoning: z.string(),
+    sections: z.array(
+      z.object({
+        section_type: z.enum(sectionTypes),
+        part_ids: z.array(z.enum(validPartIds)),
+        background_color: z.string(),
+        text_color: z.string(),
+        page_number: z.number().int().nullable(),
+      })
+    ),
+  })
+}

--- a/packages/types/src/progress.ts
+++ b/packages/types/src/progress.ts
@@ -1,6 +1,6 @@
 import { z } from "zod"
 
-export const StepName = z.enum(["extract", "metadata", "text-classification", "image-classification"])
+export const StepName = z.enum(["extract", "metadata", "text-classification", "image-classification", "page-sectioning", "web-rendering"])
 export type StepName = z.infer<typeof StepName>
 
 export const ProgressEvent = z.discriminatedUnion("type", [

--- a/packages/types/src/web-rendering.ts
+++ b/packages/types/src/web-rendering.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const SectionRendering = z.object({
+  sectionIndex: z.number().int(),
+  sectionType: z.string(),
+  reasoning: z.string(),
+  html: z.string(),
+})
+export type SectionRendering = z.infer<typeof SectionRendering>
+
+export const WebRenderingOutput = z.object({
+  sections: z.array(SectionRendering),
+})
+export type WebRenderingOutput = z.infer<typeof WebRenderingOutput>
+
+export const webRenderingLLMSchema = z.object({
+  reasoning: z.string(),
+  content: z.string(),
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,15 +69,22 @@ importers:
       '@adt/types':
         specifier: workspace:*
         version: link:../types
+      cli-progress:
+        specifier: ^3.12.0
+        version: 3.12.0
+      htmlparser2:
+        specifier: ^10.1.0
+        version: 10.1.0
       js-yaml:
         specifier: ^4.1.0
         version: 4.1.1
-      listr2:
-        specifier: ^9.0.0
-        version: 9.0.5
       zod:
         specifier: ^3.24.0
         version: 3.25.76
+    devDependencies:
+      '@types/cli-progress':
+        specifier: ^3.11.6
+        version: 3.11.6
 
   packages/storage:
     dependencies:
@@ -429,6 +436,9 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/cli-progress@3.11.6':
+    resolution: {integrity: sha512-cE3+jb9WRlu+uOSAugewNpITJDt1VF8dHOopPO4IABFc3SXYL5WE/+PTz/FCdZRRfIujiWW3n3aMbv1eIGVRWA==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -486,17 +496,9 @@ packages:
       react:
         optional: true
 
-  ansi-escapes@7.3.0:
-    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
-    engines: {node: '>=18'}
-
-  ansi-regex@6.2.2:
-    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
-    engines: {node: '>=12'}
-
-  ansi-styles@6.2.3:
-    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
-    engines: {node: '>=12'}
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -513,16 +515,9 @@ packages:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
-  cli-cursor@5.0.0:
-    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
-    engines: {node: '>=18'}
-
-  cli-truncate@5.1.1:
-    resolution: {integrity: sha512-SroPvNHxUnk+vIW/dOSfNqdy1sPEFkrTk6TUtqLCnBlo3N7TNYYkzzN7uSD6+jVjrdO4+p8nH7JzH6cIvUem6A==}
-    engines: {node: '>=20'}
-
-  colorette@2.0.20:
-    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+  cli-progress@3.12.0:
+    resolution: {integrity: sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A==}
+    engines: {node: '>=4'}
 
   commander@10.0.1:
     resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
@@ -535,12 +530,29 @@ packages:
   diff-match-patch@1.0.5:
     resolution: {integrity: sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==}
 
-  emoji-regex@10.6.0:
-    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
 
-  environment@1.1.0:
-    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
-    engines: {node: '>=18'}
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
@@ -552,9 +564,6 @@ packages:
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
-
-  eventemitter3@5.0.4:
-    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
@@ -574,16 +583,15 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
-  get-east-asian-width@1.4.0:
-    resolution: {integrity: sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==}
-    engines: {node: '>=18'}
-
   get-tsconfig@4.13.6:
     resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
 
-  is-fullwidth-code-point@5.1.0:
-    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
-    engines: {node: '>=18'}
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
 
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
@@ -602,20 +610,8 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
-  listr2@9.0.5:
-    resolution: {integrity: sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==}
-    engines: {node: '>=20.0.0'}
-
-  log-update@6.1.0:
-    resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
-    engines: {node: '>=18'}
-
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
-
-  mimic-function@5.0.1:
-    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
-    engines: {node: '>=18'}
 
   mupdf@1.27.0:
     resolution: {integrity: sha512-vEPUYwZeu5NgiFLz4e20R7Vp2pNY7szirGEvTxHyQQpQs6ab4DeGdonwT6sH1JZG5EhyHSrojZrZn2/0ee6qZQ==}
@@ -630,10 +626,6 @@ packages:
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
-
-  onetime@7.0.0:
-    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
-    engines: {node: '>=18'}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -660,13 +652,6 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
-  restore-cursor@5.1.0:
-    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
-    engines: {node: '>=18'}
-
-  rfdc@1.4.1:
-    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
-
   rollup@4.57.1:
     resolution: {integrity: sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -678,14 +663,6 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
-  signal-exit@4.1.0:
-    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
-    engines: {node: '>=14'}
-
-  slice-ansi@7.1.2:
-    resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
-    engines: {node: '>=18'}
-
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -696,17 +673,13 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
-  string-width@7.2.0:
-    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
-    engines: {node: '>=18'}
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
 
-  string-width@8.1.1:
-    resolution: {integrity: sha512-KpqHIdDL9KwYk22wEOg/VIqYbrnLeSApsKT/bSj6Ez7pn3CftUiLAv2Lccpq1ALcpLV9UX1Ppn92npZWu2w/aw==}
-    engines: {node: '>=20'}
-
-  strip-ansi@7.1.2:
-    resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
-    engines: {node: '>=12'}
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
 
   swr@2.4.0:
     resolution: {integrity: sha512-sUlC20T8EOt1pHmDiqueUWMmRRX03W7w5YxovWX7VR2KHEPCTMly85x05vpkP5i6Bu4h44ePSMD9Tc+G2MItFw==}
@@ -828,10 +801,6 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
-
-  wrap-ansi@9.0.2:
-    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
-    engines: {node: '>=18'}
 
   zod-to-json-schema@3.25.1:
     resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
@@ -1043,6 +1012,10 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/cli-progress@3.11.6':
+    dependencies:
+      '@types/node': 20.19.33
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/diff-match-patch@1.0.36': {}
@@ -1110,13 +1083,7 @@ snapshots:
     optionalDependencies:
       react: 19.2.4
 
-  ansi-escapes@7.3.0:
-    dependencies:
-      environment: 1.1.0
-
-  ansi-regex@6.2.2: {}
-
-  ansi-styles@6.2.3: {}
+  ansi-regex@5.0.1: {}
 
   argparse@2.0.1: {}
 
@@ -1126,16 +1093,9 @@ snapshots:
 
   chalk@5.6.2: {}
 
-  cli-cursor@5.0.0:
+  cli-progress@3.12.0:
     dependencies:
-      restore-cursor: 5.1.0
-
-  cli-truncate@5.1.1:
-    dependencies:
-      slice-ansi: 7.1.2
-      string-width: 8.1.1
-
-  colorette@2.0.20: {}
+      string-width: 4.2.3
 
   commander@10.0.1: {}
 
@@ -1143,9 +1103,29 @@ snapshots:
 
   diff-match-patch@1.0.5: {}
 
-  emoji-regex@10.6.0: {}
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
 
-  environment@1.1.0: {}
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+
+  emoji-regex@8.0.0: {}
+
+  entities@4.5.0: {}
+
+  entities@7.0.1: {}
 
   es-module-lexer@1.7.0: {}
 
@@ -1182,8 +1162,6 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
-  eventemitter3@5.0.4: {}
-
   expect-type@1.3.0: {}
 
   fdir@6.5.0(picomatch@4.0.3):
@@ -1193,15 +1171,18 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  get-east-asian-width@1.4.0: {}
-
   get-tsconfig@4.13.6:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
-  is-fullwidth-code-point@5.1.0:
+  htmlparser2@10.1.0:
     dependencies:
-      get-east-asian-width: 1.4.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
+
+  is-fullwidth-code-point@3.0.0: {}
 
   js-yaml@4.1.1:
     dependencies:
@@ -1219,28 +1200,9 @@ snapshots:
     dependencies:
       commander: 10.0.1
 
-  listr2@9.0.5:
-    dependencies:
-      cli-truncate: 5.1.1
-      colorette: 2.0.20
-      eventemitter3: 5.0.4
-      log-update: 6.1.0
-      rfdc: 1.4.1
-      wrap-ansi: 9.0.2
-
-  log-update@6.1.0:
-    dependencies:
-      ansi-escapes: 7.3.0
-      cli-cursor: 5.0.0
-      slice-ansi: 7.1.2
-      strip-ansi: 7.1.2
-      wrap-ansi: 9.0.2
-
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
-
-  mimic-function@5.0.1: {}
 
   mupdf@1.27.0: {}
 
@@ -1249,10 +1211,6 @@ snapshots:
   node-sqlite3-wasm@0.8.53: {}
 
   obug@2.1.1: {}
-
-  onetime@7.0.0:
-    dependencies:
-      mimic-function: 5.0.1
 
   pathe@2.0.3: {}
 
@@ -1271,13 +1229,6 @@ snapshots:
   react@19.2.4: {}
 
   resolve-pkg-maps@1.0.0: {}
-
-  restore-cursor@5.1.0:
-    dependencies:
-      onetime: 7.0.0
-      signal-exit: 4.1.0
-
-  rfdc@1.4.1: {}
 
   rollup@4.57.1:
     dependencies:
@@ -1314,33 +1265,21 @@ snapshots:
 
   siginfo@2.0.0: {}
 
-  signal-exit@4.1.0: {}
-
-  slice-ansi@7.1.2:
-    dependencies:
-      ansi-styles: 6.2.3
-      is-fullwidth-code-point: 5.1.0
-
   source-map-js@1.2.1: {}
 
   stackback@0.0.2: {}
 
   std-env@3.10.0: {}
 
-  string-width@7.2.0:
+  string-width@4.2.3:
     dependencies:
-      emoji-regex: 10.6.0
-      get-east-asian-width: 1.4.0
-      strip-ansi: 7.1.2
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
 
-  string-width@8.1.1:
+  strip-ansi@6.0.1:
     dependencies:
-      get-east-asian-width: 1.4.0
-      strip-ansi: 7.1.2
-
-  strip-ansi@7.1.2:
-    dependencies:
-      ansi-regex: 6.2.2
+      ansi-regex: 5.0.1
 
   swr@2.4.0(react@19.2.4):
     dependencies:
@@ -1431,12 +1370,6 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
-
-  wrap-ansi@9.0.2:
-    dependencies:
-      ansi-styles: 6.2.3
-      string-width: 7.2.0
-      strip-ansi: 7.1.2
 
   zod-to-json-schema@3.25.1(zod@3.25.76):
     dependencies:

--- a/prompts/page_sectioning.liquid
+++ b/prompts/page_sectioning.liquid
@@ -1,0 +1,35 @@
+{% chat role: "system" %}
+You are a pedagogical expert at organizing a textbook page into coherent, logical sections for schoolchildren.
+
+You will be shown a page image and its extracted text groups and images. Group the text and images into natural, logical sections that belong together as complete units.
+
+SECTION TYPES:
+{% for t in section_types %}- {{ t.key }}: {{ t.description }}
+{% endfor %}
+
+RULES:
+- ALL group IDs must be assigned to at least one section
+- Image IDs may be excluded if they have no educational value
+- Group/image IDs may appear in multiple sections only when it makes strong pedagogical sense (e.g. shared instructions)
+- Keep related content together — prefer fewer, more comprehensive sections over many small ones
+- Extract page number if visible (headers, footers, margins). Use null if none found
+- For background_color: hex code of predominant background. Default #ffffff
+- For text_color: hex code of predominant text color. Must contrast with background. Default #000000
+{% endchat %}
+
+{% chat role: "user" %}
+Page image:
+{% image page.imageBase64 %}
+
+{% for image in images %}
+Image {{ image.image_id }}:
+{% image image.imageBase64 %}
+{% endfor %}
+
+Text groups:
+{% for group in groups %}
+- {{ group.group_id }} ({{ group.group_type }}): {{ group.text }}
+{% endfor %}
+
+Please organize these into sections.
+{% endchat %}

--- a/prompts/web_generation_html.liquid
+++ b/prompts/web_generation_html.liquid
@@ -1,0 +1,53 @@
+{% chat role: "system" %}
+You are an expert in frontend engineering. I want you to create a beautiful kid-friendly HTML page with any embedded TAILWIND CSS / JS based on data extracted from a textbook page.
+
+You are given:
+1. The original textbook page as an image. Use it to position elements in the page properly. DO NOT INSERT ADDITIONAL SENTENCES FROM THE TEXTBOOK. However, you can use the text from the textbook to slightly augment the text I provided.
+2. The text extracted from the page. You must only use this text for the HTML generation. This is the text we want to render as a beautiful HTML page.
+3. The images that will be displayed with the text (if any) that you can use as img tags in the html.
+4. The section type.
+
+IMPORTANT, THE GENERATED HTML MUST:
+1. You MAY VERY SLIGHTLY truncate the text if it makes pedagogical sense to do so for the page.
+2. You may exclude text if it does not makes sense in the section. The entire text and its text id provided must be excluded.
+3. THERE MUST BE ONE AND ONLY ONE `<section />` IN THE HTML.
+4. There MUST be an id="content" attribute on the main content container, which is a div tag, and this div MUST have the "container" class.
+5. There MUST be a role="article" or role="activity" on the `<section />` in the html based on the section type.
+6. There MUST be a data-section-type attribute on the `<section />` with the value of the section type provided (e.g., data-section-type="text-and-images").
+7. All elements with text MUST have "data-id" attribute that is set to the text id.
+8. All elements that you add a data-id attribute to MUST have a string as their immediate children AND NOT ANY OTHER HTML TAGS. For example,
+    - <p data-id="pg001_gp001_tx001">This is a paragraph</p> # OK
+    - <strong><p data-id="pg001_gp001_tx001">This is a paragraph</p></strong> # OK
+    - <p data-id="pg001_gp001_tx001"><strong>This is a paragraph</strong></p> # NOT OK
+9. DO NOT USE ANY PLACEHOLDER IMAGE TAGS IF I DID NOT PROVIDE IMAGES. YOU CAN ONLY INCLUDE IMAGE TAGS WHEN I PROVIDE YOU IMAGES.
+10. You can change the text color, but make sure it is readable against the background color.
+11. DO NOT USE ANY OTHER DATA-IDS OTHER THAN THE ONES I PROVIDED.
+
+IMPORTANT NOTES FOR IMAGE TAGS:
+1. Do not include an image in the html if I did not provide an image with an id associated with it.
+2. ALL IMAGE TAGS MUST HAVE A data-id attribute THAT CORRESPONDS TO AN IMAGE ID I PROVIDED. e.g. <img src="placeholder" data-id="pg001_im001" alt="placeholder" />
+3. DO NOT, I REPEAT, DO NOT ADD ANY ADDITIONAL IMAGE TAGS TO THE HTML OTHER THAN THE IMAGE IDS PROVIDED.
+4. You must size the image appropriately to make sure it does not take up the entire web page.
+5. Do not include a title tag or any other metadata in the HEAD tag
+
+Provide me the answer in the given structure. Please take your time and think carefully before giving me the answers.
+Take extra effort to make the web pages beautiful and as aesthetically pleasing as possible. Give the background a color or gradient that matches the textbook.
+{% endchat %}
+
+{% chat role: "user" %}
+This is the base64 image of the entire page from the textbook for context only.
+{% image page_image_base64 %}
+
+The section type for this section is: {{ section_type }}.
+
+{% for image in images %}
+ID of the following image is: {{ image.image_id }}.
+{% image image.image_base64 %}
+{% endfor %}
+
+The following are text for the section to use for web asset generation. You may use it verbatim or modify it as needed.
+{% for text in texts %}
+id: {{ text.text_id }} text type: {{ text.text_type }}.
+text: {{ text.text }}
+{% endfor %}
+{% endchat %}


### PR DESCRIPTION
## Summary
- Add page sectioning pipeline step with LLM-based section grouping and pruned section type support
- Add web rendering pipeline step that generates HTML for each section via LLM with HTML validation
- Replace Listr2 with cli-progress for pipeline orchestration — fixes concurrency bug where nested subtask lists weren't properly awaited
- Add per-step progress bars (Classify Images, Classify Text, Section Pages, Render Pages) and PDF extraction progress bar with metadata spinner
- Add `step` and `item_id` fields to LLM log with v2→v3 schema migration
- Make max retries configurable per step (default 8 for web rendering)

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` — all tests pass
- [x] Manual test with `pnpm pipeline raven assets/raven.pdf` — pages process through Classify→Section→Render sequentially per page, concurrently across pages