### PR TITLE
Add pipeline UX, config editor, debug panel, and book wizard

### DIFF
--- a/apps/api/src/routes/books.test.ts
+++ b/apps/api/src/routes/books.test.ts
@@ -229,6 +229,109 @@ describe("DELETE /books/:label", () => {
   })
 })
 
+describe("GET /books/:label/config", () => {
+  it("returns empty config when no overrides exist", async () => {
+    createTestBook("config-test")
+    const app = createBookRoutes(tmpDir)
+    const res = await app.request("/books/config-test/config")
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toEqual({ config: {} })
+  })
+
+  it("returns config overrides when they exist", async () => {
+    createTestBook("config-has")
+    fs.writeFileSync(
+      path.join(tmpDir, "config-has", "config.yaml"),
+      "concurrency: 4\n"
+    )
+    const app = createBookRoutes(tmpDir)
+    const res = await app.request("/books/config-has/config")
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.config).toEqual({ concurrency: 4 })
+  })
+
+  it("returns 404 for missing book", async () => {
+    const app = createBookRoutes(tmpDir)
+    const res = await app.request("/books/ghost/config")
+    expect(res.status).toBe(404)
+  })
+
+  it("returns 400 for invalid label", async () => {
+    const app = createBookRoutes(tmpDir)
+    const res = await app.request("/books/-bad/config")
+    expect(res.status).toBe(400)
+  })
+})
+
+describe("PUT /books/:label/config", () => {
+  it("writes config overrides and returns them", async () => {
+    createTestBook("put-config")
+    const app = createBookRoutes(tmpDir)
+    const res = await app.request("/books/put-config/config", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ config: { concurrency: 8 } }),
+    })
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.config).toEqual({ concurrency: 8 })
+
+    expect(
+      fs.existsSync(path.join(tmpDir, "put-config", "config.yaml"))
+    ).toBe(true)
+  })
+
+  it("removes config file when empty overrides", async () => {
+    createTestBook("clear-config")
+    fs.writeFileSync(
+      path.join(tmpDir, "clear-config", "config.yaml"),
+      "concurrency: 4\n"
+    )
+    const app = createBookRoutes(tmpDir)
+    const res = await app.request("/books/clear-config/config", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ config: {} }),
+    })
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.config).toEqual({})
+  })
+
+  it("returns 404 for missing book", async () => {
+    const app = createBookRoutes(tmpDir)
+    const res = await app.request("/books/ghost/config", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ config: { concurrency: 2 } }),
+    })
+    expect(res.status).toBe(404)
+  })
+
+  it("returns 400 for invalid label", async () => {
+    const app = createBookRoutes(tmpDir)
+    const res = await app.request("/books/-bad/config", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ config: {} }),
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it("returns 400 when config is missing from body", async () => {
+    createTestBook("no-body")
+    const app = createBookRoutes(tmpDir)
+    const res = await app.request("/books/no-body/config", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    })
+    expect(res.status).toBe(400)
+  })
+})
+
 describe("GET /books/:label/images/:imageId", () => {
   function createBookWithImage(label: string): void {
     const storage = createBookStorage(label, tmpDir)

--- a/apps/api/src/routes/books.ts
+++ b/apps/api/src/routes/books.ts
@@ -9,6 +9,8 @@ import {
   getBook,
   createBook,
   deleteBook,
+  getBookConfig,
+  updateBookConfig,
 } from "../services/book-service.js"
 
 export function createBookRoutes(booksDir: string): Hono {
@@ -68,6 +70,43 @@ export function createBookRoutes(booksDir: string): Hono {
     try {
       deleteBook(label, booksDir)
       return c.json({ ok: true })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      if (message.includes("not found")) {
+        throw new HTTPException(404, { message })
+      }
+      throw new HTTPException(400, { message })
+    }
+  })
+
+  // GET /books/:label/config — Return book-level config overrides
+  app.get("/books/:label/config", (c) => {
+    const { label } = c.req.param()
+    try {
+      const config = getBookConfig(label, booksDir)
+      return c.json({ config: config ?? {} })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      if (message.includes("not found")) {
+        throw new HTTPException(404, { message })
+      }
+      throw new HTTPException(400, { message })
+    }
+  })
+
+  // PUT /books/:label/config — Update book-level config overrides
+  app.put("/books/:label/config", async (c) => {
+    const { label } = c.req.param()
+    const body = await c.req.json<{ config: Record<string, unknown> }>()
+
+    if (!body.config || typeof body.config !== "object") {
+      throw new HTTPException(400, { message: "config object is required" })
+    }
+
+    try {
+      updateBookConfig(label, booksDir, body.config)
+      const updated = getBookConfig(label, booksDir)
+      return c.json({ config: updated ?? {} })
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
       if (message.includes("not found")) {

--- a/apps/api/src/services/book-service.test.ts
+++ b/apps/api/src/services/book-service.test.ts
@@ -4,7 +4,14 @@ import os from "node:os"
 import path from "node:path"
 import { openBookDb } from "@adt/storage"
 import { SCHEMA_VERSION } from "@adt/types"
-import { listBooks, getBook, createBook, deleteBook } from "./book-service.js"
+import {
+  listBooks,
+  getBook,
+  createBook,
+  deleteBook,
+  getBookConfig,
+  updateBookConfig,
+} from "./book-service.js"
 
 let tmpDir: string
 
@@ -284,6 +291,68 @@ describe("createBook", () => {
     expect(() => createBook("exists", fakePdf, tmpDir)).toThrow(
       "already exists"
     )
+  })
+})
+
+describe("getBookConfig", () => {
+  it("returns null when no config.yaml exists", () => {
+    const bookDir = path.join(tmpDir, "no-config")
+    fs.mkdirSync(bookDir)
+    expect(getBookConfig("no-config", tmpDir)).toBeNull()
+  })
+
+  it("returns parsed config when config.yaml exists", () => {
+    const fakePdf = Buffer.from("%PDF-1.0 fake")
+    createBook("with-config", fakePdf, tmpDir, { concurrency: 4 })
+    const config = getBookConfig("with-config", tmpDir)
+    expect(config).toEqual({ concurrency: 4 })
+  })
+
+  it("throws for non-existent book", () => {
+    expect(() => getBookConfig("ghost", tmpDir)).toThrow("not found")
+  })
+
+  it("throws for invalid label", () => {
+    expect(() => getBookConfig("-bad", tmpDir)).toThrow()
+  })
+})
+
+describe("updateBookConfig", () => {
+  it("writes config.yaml with overrides", () => {
+    const bookDir = path.join(tmpDir, "update-test")
+    fs.mkdirSync(bookDir)
+    updateBookConfig("update-test", tmpDir, { concurrency: 8 })
+    const configPath = path.join(bookDir, "config.yaml")
+    expect(fs.existsSync(configPath)).toBe(true)
+    const content = fs.readFileSync(configPath, "utf-8")
+    expect(content).toContain("concurrency: 8")
+  })
+
+  it("removes config.yaml when overrides are empty", () => {
+    const fakePdf = Buffer.from("%PDF-1.0 fake")
+    createBook("remove-config", fakePdf, tmpDir, { concurrency: 4 })
+    const configPath = path.join(tmpDir, "remove-config", "config.yaml")
+    expect(fs.existsSync(configPath)).toBe(true)
+
+    updateBookConfig("remove-config", tmpDir, {})
+    expect(fs.existsSync(configPath)).toBe(false)
+  })
+
+  it("is a no-op when overrides are empty and no config exists", () => {
+    const bookDir = path.join(tmpDir, "empty-update")
+    fs.mkdirSync(bookDir)
+    updateBookConfig("empty-update", tmpDir, {})
+    expect(fs.existsSync(path.join(bookDir, "config.yaml"))).toBe(false)
+  })
+
+  it("throws for non-existent book", () => {
+    expect(() => updateBookConfig("ghost", tmpDir, { concurrency: 2 })).toThrow(
+      "not found"
+    )
+  })
+
+  it("throws for invalid label", () => {
+    expect(() => updateBookConfig("-bad", tmpDir, {})).toThrow()
   })
 })
 

--- a/apps/api/src/services/book-service.ts
+++ b/apps/api/src/services/book-service.ts
@@ -212,6 +212,53 @@ export function createBook(
   }
 }
 
+export function getBookConfig(
+  label: string,
+  booksDir: string
+): Record<string, unknown> | null {
+  const safeLabel = parseBookLabel(label)
+  const resolvedDir = path.resolve(booksDir)
+  const bookDir = path.join(resolvedDir, safeLabel)
+
+  if (!fs.existsSync(bookDir)) {
+    throw new Error(`Book not found: ${safeLabel}`)
+  }
+
+  const configPath = path.join(bookDir, "config.yaml")
+  if (!fs.existsSync(configPath)) {
+    return null
+  }
+
+  const content = fs.readFileSync(configPath, "utf-8")
+  const parsed = yaml.load(content)
+  return (parsed as Record<string, unknown>) ?? null
+}
+
+export function updateBookConfig(
+  label: string,
+  booksDir: string,
+  overrides: Record<string, unknown>
+): void {
+  const safeLabel = parseBookLabel(label)
+  const resolvedDir = path.resolve(booksDir)
+  const bookDir = path.join(resolvedDir, safeLabel)
+
+  if (!fs.existsSync(bookDir)) {
+    throw new Error(`Book not found: ${safeLabel}`)
+  }
+
+  const configPath = path.join(bookDir, "config.yaml")
+
+  if (!overrides || Object.keys(overrides).length === 0) {
+    if (fs.existsSync(configPath)) {
+      fs.unlinkSync(configPath)
+    }
+    return
+  }
+
+  fs.writeFileSync(configPath, yaml.dump(overrides))
+}
+
 export function deleteBook(label: string, booksDir: string): void {
   const safeLabel = parseBookLabel(label)
   const resolvedDir = path.resolve(booksDir)

--- a/apps/studio/src/api/client.ts
+++ b/apps/studio/src/api/client.ts
@@ -165,6 +165,10 @@ export interface PipelineStatsResponse {
   } | null
 }
 
+export interface BookConfigResponse {
+  config: Record<string, unknown>
+}
+
 export interface ActiveConfigResponse {
   merged: Record<string, unknown>
   hasBookOverride: boolean
@@ -284,4 +288,13 @@ export const api = {
     request<VersionListResponse>(
       `/books/${label}/debug/versions/${node}/${itemId}${includeData ? "?includeData=true" : ""}`
     ),
+
+  getBookConfig: (label: string) =>
+    request<BookConfigResponse>(`/books/${label}/config`),
+
+  updateBookConfig: (label: string, config: Record<string, unknown>) =>
+    request<BookConfigResponse>(`/books/${label}/config`, {
+      method: "PUT",
+      body: JSON.stringify({ config }),
+    }),
 }

--- a/apps/studio/src/components/config/ConfigEditor.tsx
+++ b/apps/studio/src/components/config/ConfigEditor.tsx
@@ -1,0 +1,594 @@
+import { useState, useEffect } from "react"
+import { Play, Save, Settings2 } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Badge } from "@/components/ui/badge"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { useBookConfig, useUpdateBookConfig } from "@/hooks/use-book-config"
+import { useActiveConfig } from "@/hooks/use-debug"
+
+const ALL_TEXT_TYPES = [
+  "book_title", "book_subtitle", "book_author", "book_metadata",
+  "section_heading", "section_text", "instruction_text",
+  "activity_number", "activity_title", "activity_option",
+  "activity_input_placeholder_text", "fill_in_the_blank",
+  "image_associated_text", "image_overlay", "math",
+  "standalone_text", "header_text", "footer_text", "page_number", "other",
+]
+
+const ALL_SECTION_TYPES = [
+  "front_cover", "inside_cover", "back_cover", "separator", "credits",
+  "foreword", "table_of_contents", "boxed_text",
+  "text_only", "text_and_single_image", "text_and_images", "images_only",
+  "activity_matching", "activity_fill_in_a_table", "activity_multiple_choice",
+  "activity_true_false", "activity_open_ended_answer",
+  "activity_fill_in_the_blank", "activity_sorting", "other",
+]
+
+interface ConfigEditorProps {
+  label: string
+  onRun: (options: { startPage?: number; endPage?: number; concurrency?: number }) => void
+  isRunning: boolean
+  isPipelineStarting: boolean
+  hasApiKey: boolean
+  apiKey: string
+  onApiKeyChange: (key: string) => void
+  pageCount: number
+}
+
+export function ConfigEditor({
+  label,
+  onRun,
+  isRunning,
+  isPipelineStarting,
+  hasApiKey,
+  apiKey,
+  onApiKeyChange,
+  pageCount,
+}: ConfigEditorProps) {
+  const { data: bookConfigData } = useBookConfig(label)
+  const { data: activeConfigData } = useActiveConfig(label)
+  const updateConfig = useUpdateBookConfig()
+
+  // Run tab state
+  const [startPage, setStartPage] = useState("")
+  const [endPage, setEndPage] = useState("")
+  const [concurrency, setConcurrency] = useState("16")
+
+  // Config tab state
+  const [configConcurrency, setConfigConcurrency] = useState("")
+  const [rateLimit, setRateLimit] = useState("")
+  const [minSide, setMinSide] = useState("")
+  const [maxSide, setMaxSide] = useState("")
+  const [prunedTextTypes, setPrunedTextTypes] = useState<Set<string>>(new Set())
+  const [prunedSectionTypes, setPrunedSectionTypes] = useState<Set<string>>(new Set())
+  const [metadataModel, setMetadataModel] = useState("")
+  const [textClassModel, setTextClassModel] = useState("")
+  const [pageSectionModel, setPageSectionModel] = useState("")
+  const [webRenderModel, setWebRenderModel] = useState("")
+  const [maxRetries, setMaxRetries] = useState("")
+
+  const [showRebuildDialog, setShowRebuildDialog] = useState(false)
+  const [configDirty, setConfigDirty] = useState(false)
+
+  // Load book-level overrides into form
+  useEffect(() => {
+    if (!bookConfigData) return
+    const c = bookConfigData.config
+    if (c.concurrency != null) setConfigConcurrency(String(c.concurrency))
+    if (c.rate_limit && typeof c.rate_limit === "object" && "requests_per_minute" in c.rate_limit) {
+      setRateLimit(String((c.rate_limit as Record<string, unknown>).requests_per_minute))
+    }
+    if (c.image_filters && typeof c.image_filters === "object") {
+      const f = c.image_filters as Record<string, unknown>
+      if (f.min_side != null) setMinSide(String(f.min_side))
+      if (f.max_side != null) setMaxSide(String(f.max_side))
+    }
+    if (Array.isArray(c.pruned_text_types)) {
+      setPrunedTextTypes(new Set(c.pruned_text_types as string[]))
+    }
+    if (Array.isArray(c.pruned_section_types)) {
+      setPrunedSectionTypes(new Set(c.pruned_section_types as string[]))
+    }
+    if (c.metadata && typeof c.metadata === "object" && "model" in c.metadata) {
+      setMetadataModel(String((c.metadata as Record<string, unknown>).model ?? ""))
+    }
+    if (c.text_classification && typeof c.text_classification === "object" && "model" in c.text_classification) {
+      setTextClassModel(String((c.text_classification as Record<string, unknown>).model ?? ""))
+    }
+    if (c.page_sectioning && typeof c.page_sectioning === "object" && "model" in c.page_sectioning) {
+      setPageSectionModel(String((c.page_sectioning as Record<string, unknown>).model ?? ""))
+    }
+    if (c.web_rendering && typeof c.web_rendering === "object") {
+      const wr = c.web_rendering as Record<string, unknown>
+      if (wr.model) setWebRenderModel(String(wr.model))
+      if (wr.max_retries != null) setMaxRetries(String(wr.max_retries))
+    }
+  }, [bookConfigData])
+
+  const getPlaceholder = (path: string): string => {
+    if (!activeConfigData) return ""
+    const merged = activeConfigData.merged
+    const parts = path.split(".")
+    let val: unknown = merged
+    for (const p of parts) {
+      if (val && typeof val === "object") val = (val as Record<string, unknown>)[p]
+      else return ""
+    }
+    return val != null ? String(val) : ""
+  }
+
+  const getDefaultPrunedTextTypes = (): Set<string> => {
+    if (!activeConfigData) return new Set()
+    const arr = (activeConfigData.merged as Record<string, unknown>).pruned_text_types
+    return Array.isArray(arr) ? new Set(arr as string[]) : new Set()
+  }
+
+  const getDefaultPrunedSectionTypes = (): Set<string> => {
+    if (!activeConfigData) return new Set()
+    const arr = (activeConfigData.merged as Record<string, unknown>).pruned_section_types
+    return Array.isArray(arr) ? new Set(arr as string[]) : new Set()
+  }
+
+  // Determine which pruned types to show (book override if dirty, else defaults from active config)
+  const effectivePrunedTextTypes = configDirty ? prunedTextTypes : (
+    bookConfigData?.config.pruned_text_types ? prunedTextTypes : getDefaultPrunedTextTypes()
+  )
+  const effectivePrunedSectionTypes = configDirty ? prunedSectionTypes : (
+    bookConfigData?.config.pruned_section_types ? prunedSectionTypes : getDefaultPrunedSectionTypes()
+  )
+
+  const togglePrunedText = (t: string) => {
+    setConfigDirty(true)
+    setPrunedTextTypes((prev) => {
+      // If not dirty yet, start from active config defaults
+      const base = configDirty ? prev : (
+        bookConfigData?.config.pruned_text_types ? prev : getDefaultPrunedTextTypes()
+      )
+      const next = new Set(base)
+      if (next.has(t)) next.delete(t)
+      else next.add(t)
+      return next
+    })
+  }
+
+  const togglePrunedSection = (t: string) => {
+    setConfigDirty(true)
+    setPrunedSectionTypes((prev) => {
+      const base = configDirty ? prev : (
+        bookConfigData?.config.pruned_section_types ? prev : getDefaultPrunedSectionTypes()
+      )
+      const next = new Set(base)
+      if (next.has(t)) next.delete(t)
+      else next.add(t)
+      return next
+    })
+  }
+
+  const buildOverrides = (): Record<string, unknown> => {
+    const overrides: Record<string, unknown> = {}
+
+    if (configConcurrency.trim()) overrides.concurrency = Number(configConcurrency)
+    if (rateLimit.trim()) overrides.rate_limit = { requests_per_minute: Number(rateLimit) }
+
+    const imageFilters: Record<string, unknown> = {}
+    if (minSide.trim()) imageFilters.min_side = Number(minSide)
+    if (maxSide.trim()) imageFilters.max_side = Number(maxSide)
+    if (Object.keys(imageFilters).length > 0) overrides.image_filters = imageFilters
+
+    if (configDirty || bookConfigData?.config.pruned_text_types) {
+      overrides.pruned_text_types = Array.from(effectivePrunedTextTypes)
+    }
+    if (configDirty || bookConfigData?.config.pruned_section_types) {
+      overrides.pruned_section_types = Array.from(effectivePrunedSectionTypes)
+    }
+
+    if (metadataModel.trim()) overrides.metadata = { model: metadataModel.trim() }
+    if (textClassModel.trim()) overrides.text_classification = { model: textClassModel.trim() }
+    if (pageSectionModel.trim()) overrides.page_sectioning = { model: pageSectionModel.trim() }
+
+    const webRendering: Record<string, unknown> = {}
+    if (webRenderModel.trim()) webRendering.model = webRenderModel.trim()
+    if (maxRetries.trim()) webRendering.max_retries = Number(maxRetries)
+    if (Object.keys(webRendering).length > 0) overrides.web_rendering = webRendering
+
+    // Preserve existing content settings from book config
+    if (bookConfigData?.config) {
+      const bc = bookConfigData.config
+      if (bc.editing_language) overrides.editing_language = bc.editing_language
+      if (bc.output_languages) overrides.output_languages = bc.output_languages
+      if (bc.book_format) overrides.book_format = bc.book_format
+    }
+
+    return overrides
+  }
+
+  const handleSave = () => {
+    const overrides = buildOverrides()
+    updateConfig.mutate({ label, config: overrides })
+    setConfigDirty(false)
+  }
+
+  const handleSaveAndRebuild = () => {
+    setShowRebuildDialog(true)
+  }
+
+  const confirmRebuild = () => {
+    const overrides = buildOverrides()
+    updateConfig.mutate(
+      { label, config: overrides },
+      {
+        onSuccess: () => {
+          setConfigDirty(false)
+          setShowRebuildDialog(false)
+          const options: { startPage?: number; endPage?: number; concurrency?: number } = {}
+          if (startPage) options.startPage = Number(startPage)
+          if (endPage) options.endPage = Number(endPage)
+          const c = Number(concurrency)
+          if (c && c !== 16) options.concurrency = c
+          onRun(options)
+        },
+      }
+    )
+  }
+
+  const handleRun = () => {
+    const options: { startPage?: number; endPage?: number; concurrency?: number } = {}
+    if (startPage) options.startPage = Number(startPage)
+    if (endPage) options.endPage = Number(endPage)
+    const c = Number(concurrency)
+    if (c && c !== 16) options.concurrency = c
+    onRun(options)
+  }
+
+  return (
+    <>
+      <Card className="h-full">
+        <CardHeader className="pb-3">
+          <CardTitle className="flex items-center gap-2 text-sm">
+            <Settings2 className="h-4 w-4" />
+            Pipeline Configuration
+          </CardTitle>
+          <CardDescription>
+            Configure and run the pipeline, or edit book-level overrides.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Tabs defaultValue="run">
+            <TabsList className="mb-4">
+              <TabsTrigger value="run">Run</TabsTrigger>
+              <TabsTrigger value="config">Config</TabsTrigger>
+            </TabsList>
+
+            {/* Run Tab */}
+            <TabsContent value="run">
+              <div className="space-y-4">
+                <div className="space-y-1.5">
+                  <Label htmlFor="api-key" className="text-xs">OpenAI API Key</Label>
+                  <Input
+                    id="api-key"
+                    type="password"
+                    value={apiKey}
+                    onChange={(e) => onApiKeyChange(e.target.value)}
+                    placeholder="sk-..."
+                    className="font-mono"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Stored in your browser only. Never sent to our servers.
+                  </p>
+                </div>
+
+                <div className="grid grid-cols-2 gap-4">
+                  <div className="space-y-1.5">
+                    <Label className="text-xs">Page Range</Label>
+                    <div className="flex items-center gap-2">
+                      <Input
+                        type="number"
+                        min={1}
+                        value={startPage}
+                        onChange={(e) => setStartPage(e.target.value)}
+                        placeholder="First"
+                        className="w-20"
+                      />
+                      <span className="text-xs text-muted-foreground">to</span>
+                      <Input
+                        type="number"
+                        min={1}
+                        value={endPage}
+                        onChange={(e) => setEndPage(e.target.value)}
+                        placeholder="Last"
+                        className="w-20"
+                      />
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      Leave empty for all pages
+                    </p>
+                  </div>
+
+                  <div className="space-y-1.5">
+                    <Label htmlFor="run-concurrency" className="text-xs">Concurrency</Label>
+                    <Input
+                      id="run-concurrency"
+                      type="number"
+                      min={1}
+                      max={64}
+                      value={concurrency}
+                      onChange={(e) => setConcurrency(e.target.value)}
+                      className="w-20"
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      Parallel LLM calls
+                    </p>
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-3 pt-1">
+                  <Button
+                    onClick={handleRun}
+                    disabled={isPipelineStarting || isRunning || !hasApiKey}
+                  >
+                    <Play className="mr-2 h-4 w-4" />
+                    {isPipelineStarting ? "Starting..." : pageCount > 0 ? "Re-run Pipeline" : "Run Pipeline"}
+                  </Button>
+                  {!hasApiKey && (
+                    <span className="text-xs text-muted-foreground">
+                      Enter your API key above to run.
+                    </span>
+                  )}
+                </div>
+              </div>
+            </TabsContent>
+
+            {/* Config Tab */}
+            <TabsContent value="config">
+              <div className="space-y-5">
+                {/* Processing */}
+                <div>
+                  <h4 className="mb-2 text-xs font-medium text-muted-foreground uppercase tracking-wider">Processing</h4>
+                  <div className="grid grid-cols-2 gap-3">
+                    <div className="space-y-1">
+                      <Label className="text-xs">Concurrency</Label>
+                      <Input
+                        type="number"
+                        min={1}
+                        value={configConcurrency}
+                        onChange={(e) => { setConfigConcurrency(e.target.value); setConfigDirty(true) }}
+                        placeholder={getPlaceholder("concurrency") || "32"}
+                        className="w-24"
+                      />
+                    </div>
+                    <div className="space-y-1">
+                      <Label className="text-xs">Rate Limit (req/min)</Label>
+                      <Input
+                        type="number"
+                        min={1}
+                        value={rateLimit}
+                        onChange={(e) => { setRateLimit(e.target.value); setConfigDirty(true) }}
+                        placeholder={getPlaceholder("rate_limit.requests_per_minute") || "60"}
+                        className="w-24"
+                      />
+                    </div>
+                  </div>
+                </div>
+
+                {/* Image Filters */}
+                <div>
+                  <h4 className="mb-2 text-xs font-medium text-muted-foreground uppercase tracking-wider">Image Filters</h4>
+                  <div className="grid grid-cols-2 gap-3">
+                    <div className="space-y-1">
+                      <Label className="text-xs">Min Side (px)</Label>
+                      <Input
+                        type="number"
+                        min={1}
+                        value={minSide}
+                        onChange={(e) => { setMinSide(e.target.value); setConfigDirty(true) }}
+                        placeholder={getPlaceholder("image_filters.min_side") || "100"}
+                        className="w-24"
+                      />
+                    </div>
+                    <div className="space-y-1">
+                      <Label className="text-xs">Max Side (px)</Label>
+                      <Input
+                        type="number"
+                        min={1}
+                        value={maxSide}
+                        onChange={(e) => { setMaxSide(e.target.value); setConfigDirty(true) }}
+                        placeholder={getPlaceholder("image_filters.max_side") || "5000"}
+                        className="w-24"
+                      />
+                    </div>
+                  </div>
+                </div>
+
+                {/* Pruned Text Types */}
+                <div>
+                  <h4 className="mb-2 text-xs font-medium text-muted-foreground uppercase tracking-wider">Pruned Text Types</h4>
+                  <p className="mb-2 text-xs text-muted-foreground">Pruned types are excluded from rendering.</p>
+                  <div className="flex flex-wrap gap-1.5">
+                    {ALL_TEXT_TYPES.map((t) => {
+                      const pruned = effectivePrunedTextTypes.has(t)
+                      return (
+                        <Badge
+                          key={t}
+                          variant={pruned ? "default" : "outline"}
+                          className="cursor-pointer text-xs"
+                          onClick={() => togglePrunedText(t)}
+                        >
+                          {t.replace(/_/g, " ")}
+                        </Badge>
+                      )
+                    })}
+                  </div>
+                </div>
+
+                {/* Pruned Section Types */}
+                <div>
+                  <h4 className="mb-2 text-xs font-medium text-muted-foreground uppercase tracking-wider">Pruned Section Types</h4>
+                  <div className="flex flex-wrap gap-1.5">
+                    {ALL_SECTION_TYPES.map((t) => {
+                      const pruned = effectivePrunedSectionTypes.has(t)
+                      return (
+                        <Badge
+                          key={t}
+                          variant={pruned ? "default" : "outline"}
+                          className="cursor-pointer text-xs"
+                          onClick={() => togglePrunedSection(t)}
+                        >
+                          {t.replace(/_/g, " ")}
+                        </Badge>
+                      )
+                    })}
+                  </div>
+                </div>
+
+                {/* Model Overrides */}
+                <div>
+                  <h4 className="mb-2 text-xs font-medium text-muted-foreground uppercase tracking-wider">Model Overrides</h4>
+                  <div className="grid grid-cols-2 gap-3">
+                    <div className="space-y-1">
+                      <Label className="text-xs">Metadata</Label>
+                      <Input
+                        value={metadataModel}
+                        onChange={(e) => { setMetadataModel(e.target.value); setConfigDirty(true) }}
+                        placeholder={getPlaceholder("metadata.model") || "openai:gpt-5.2"}
+                        className="text-xs"
+                      />
+                    </div>
+                    <div className="space-y-1">
+                      <Label className="text-xs">Text Classification</Label>
+                      <Input
+                        value={textClassModel}
+                        onChange={(e) => { setTextClassModel(e.target.value); setConfigDirty(true) }}
+                        placeholder={getPlaceholder("text_classification.model") || "openai:gpt-5.2"}
+                        className="text-xs"
+                      />
+                    </div>
+                    <div className="space-y-1">
+                      <Label className="text-xs">Page Sectioning</Label>
+                      <Input
+                        value={pageSectionModel}
+                        onChange={(e) => { setPageSectionModel(e.target.value); setConfigDirty(true) }}
+                        placeholder={getPlaceholder("page_sectioning.model") || "openai:gpt-5.2"}
+                        className="text-xs"
+                      />
+                    </div>
+                    <div className="space-y-1">
+                      <Label className="text-xs">Web Rendering</Label>
+                      <Input
+                        value={webRenderModel}
+                        onChange={(e) => { setWebRenderModel(e.target.value); setConfigDirty(true) }}
+                        placeholder={getPlaceholder("web_rendering.model") || "openai:gpt-5.2"}
+                        className="text-xs"
+                      />
+                    </div>
+                  </div>
+                </div>
+
+                {/* Rendering */}
+                <div>
+                  <h4 className="mb-2 text-xs font-medium text-muted-foreground uppercase tracking-wider">Rendering</h4>
+                  <div className="space-y-1">
+                    <Label className="text-xs">Max Retries</Label>
+                    <Input
+                      type="number"
+                      min={0}
+                      value={maxRetries}
+                      onChange={(e) => { setMaxRetries(e.target.value); setConfigDirty(true) }}
+                      placeholder={getPlaceholder("web_rendering.max_retries") || "25"}
+                      className="w-24"
+                    />
+                  </div>
+                </div>
+
+                {/* Content Settings (read-only) */}
+                {bookConfigData?.config && (
+                  !!bookConfigData.config.editing_language ||
+                  !!bookConfigData.config.output_languages ||
+                  !!bookConfigData.config.book_format
+                ) && (
+                  <div>
+                    <h4 className="mb-2 text-xs font-medium text-muted-foreground uppercase tracking-wider">Content Settings</h4>
+                    <div className="text-xs space-y-1 text-muted-foreground">
+                      {!!bookConfigData.config.editing_language && (
+                        <p>Editing Language: <span className="text-foreground">{String(bookConfigData.config.editing_language)}</span></p>
+                      )}
+                      {Array.isArray(bookConfigData.config.output_languages) && (
+                        <p>Output Languages: <span className="text-foreground">{(bookConfigData.config.output_languages as string[]).join(", ")}</span></p>
+                      )}
+                      {Array.isArray(bookConfigData.config.book_format) && (
+                        <p>Book Format: <span className="text-foreground">{(bookConfigData.config.book_format as string[]).join(", ")}</span></p>
+                      )}
+                    </div>
+                  </div>
+                )}
+
+                {/* Save buttons */}
+                <div className="flex items-center gap-2 pt-2 border-t">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleSave}
+                    disabled={updateConfig.isPending}
+                  >
+                    <Save className="mr-2 h-3 w-3" />
+                    {updateConfig.isPending ? "Saving..." : "Save"}
+                  </Button>
+                  <Button
+                    size="sm"
+                    onClick={handleSaveAndRebuild}
+                    disabled={updateConfig.isPending || !hasApiKey}
+                  >
+                    <Play className="mr-2 h-3 w-3" />
+                    Save & Rebuild
+                  </Button>
+                  {!hasApiKey && (
+                    <span className="text-xs text-muted-foreground">
+                      Set API key in Run tab to rebuild.
+                    </span>
+                  )}
+                </div>
+              </div>
+            </TabsContent>
+          </Tabs>
+        </CardContent>
+      </Card>
+
+      {/* Rebuild confirmation dialog */}
+      <Dialog open={showRebuildDialog} onOpenChange={setShowRebuildDialog}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Save & Rebuild</DialogTitle>
+            <DialogDescription>
+              This will save config changes and re-run the full pipeline. Existing
+              pipeline data will be overwritten for affected pages.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setShowRebuildDialog(false)}>
+              Cancel
+            </Button>
+            <Button onClick={confirmRebuild} disabled={updateConfig.isPending}>
+              {updateConfig.isPending ? "Saving..." : "Confirm Rebuild"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/apps/studio/src/hooks/use-book-config.ts
+++ b/apps/studio/src/hooks/use-book-config.ts
@@ -1,0 +1,27 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
+import { api } from "@/api/client"
+
+export function useBookConfig(label: string) {
+  return useQuery({
+    queryKey: ["book-config", label],
+    queryFn: () => api.getBookConfig(label),
+    enabled: !!label,
+  })
+}
+
+export function useUpdateBookConfig() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({
+      label,
+      config,
+    }: {
+      label: string
+      config: Record<string, unknown>
+    }) => api.updateBookConfig(label, config),
+    onSuccess: (_data, { label }) => {
+      queryClient.invalidateQueries({ queryKey: ["book-config", label] })
+      queryClient.invalidateQueries({ queryKey: ["debug"] })
+    },
+  })
+}

--- a/apps/studio/src/routes/books.$label.index.tsx
+++ b/apps/studio/src/routes/books.$label.index.tsx
@@ -1,10 +1,8 @@
-import { useState, useEffect } from "react"
-import { createFileRoute, Link } from "@tanstack/react-router"
-import { BookOpen, LayoutGrid, Play, Settings2 } from "lucide-react"
+import { useState, useEffect, useRef } from "react"
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router"
+import { BookOpen, LayoutGrid } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
 import {
   Card,
   CardContent,
@@ -17,13 +15,21 @@ import { usePipelineSSE, usePipelineStatus, useRunPipeline } from "@/hooks/use-p
 import { useApiKey } from "@/hooks/use-api-key"
 import { PipelineProgress } from "@/components/pipeline/PipelineProgress"
 import { PagePreviewGrid } from "@/components/pipeline/PagePreviewGrid"
+import { ConfigEditor } from "@/components/config/ConfigEditor"
 
 export const Route = createFileRoute("/books/$label/")({
   component: BookDetailPage,
+  validateSearch: (search: Record<string, unknown>) => ({
+    autoRun: search.autoRun === true || search.autoRun === "true" ? true : undefined,
+    startPage: typeof search.startPage === "number" ? search.startPage : undefined,
+    endPage: typeof search.endPage === "number" ? search.endPage : undefined,
+  }),
 })
 
 function BookDetailPage() {
   const { label } = Route.useParams()
+  const { autoRun, startPage: searchStartPage, endPage: searchEndPage } = Route.useSearch()
+  const navigate = useNavigate()
   const { data: book, isLoading, error } = useBook(label)
   const { apiKey, setApiKey, hasApiKey } = useApiKey()
 
@@ -32,10 +38,8 @@ function BookDetailPage() {
   const { progress, reset } = usePipelineSSE(label, sseEnabled)
   const { data: pipelineStatus } = usePipelineStatus(label)
 
-  // Pipeline config options
-  const [startPage, setStartPage] = useState("")
-  const [endPage, setEndPage] = useState("")
-  const [concurrency, setConcurrency] = useState("16")
+  // Auto-run guard
+  const hasAutoRun = useRef(false)
 
   // Auto-reconnect to SSE if pipeline is already running
   useEffect(() => {
@@ -44,15 +48,44 @@ function BookDetailPage() {
     }
   }, [pipelineStatus?.status, sseEnabled])
 
-  const handleRun = () => {
+  // Auto-run pipeline when navigated from wizard
+  useEffect(() => {
+    if (!autoRun || hasAutoRun.current || !hasApiKey || !book) return
+    hasAutoRun.current = true
+
+    // Clean the URL
+    navigate({
+      to: "/books/$label",
+      params: { label },
+      search: {
+        autoRun: undefined,
+        startPage: undefined,
+        endPage: undefined,
+      },
+      replace: true,
+    })
+
+    // Trigger pipeline
     reset()
     setSseEnabled(true)
 
-    const options: { startPage?: number; endPage?: number; concurrency?: number } = {}
-    if (startPage) options.startPage = Number(startPage)
-    if (endPage) options.endPage = Number(endPage)
-    const c = Number(concurrency)
-    if (c && c !== 16) options.concurrency = c
+    const options: { startPage?: number; endPage?: number } = {}
+    if (searchStartPage) options.startPage = searchStartPage
+    if (searchEndPage) options.endPage = searchEndPage
+
+    runPipeline.mutate(
+      { label, apiKey, options: Object.keys(options).length > 0 ? options : undefined },
+      {
+        onError: () => {
+          setSseEnabled(false)
+        },
+      }
+    )
+  }, [autoRun, hasApiKey, book, label, apiKey, searchStartPage, searchEndPage, navigate, reset, runPipeline])
+
+  const handleRun = (options: { startPage?: number; endPage?: number; concurrency?: number }) => {
+    reset()
+    setSseEnabled(true)
 
     runPipeline.mutate(
       { label, apiKey, options: Object.keys(options).length > 0 ? options : undefined },
@@ -178,109 +211,22 @@ function BookDetailPage() {
           <div className="h-full">
             <PipelineProgress
               progress={progress}
-              onRun={handleRun}
+              onRun={() => handleRun({})}
               isStarting={runPipeline.isPending}
               hasApiKey={hasApiKey}
             />
           </div>
         ) : (
-          <Card className="h-full">
-            <CardHeader className="pb-3">
-              <CardTitle className="flex items-center gap-2 text-sm">
-                <Settings2 className="h-4 w-4" />
-                Pipeline Configuration
-              </CardTitle>
-              <CardDescription>
-                Configure options before running the pipeline.
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-4">
-                {/* API Key */}
-                <div className="space-y-1.5">
-                  <Label htmlFor="api-key" className="text-xs">OpenAI API Key</Label>
-                  <Input
-                    id="api-key"
-                    type="password"
-                    value={apiKey}
-                    onChange={(e) => setApiKey(e.target.value)}
-                    placeholder="sk-..."
-                    className="font-mono"
-                  />
-                  <p className="text-xs text-muted-foreground">
-                    Stored in your browser only. Never sent to our servers.
-                  </p>
-                </div>
-
-                {/* Page Range + Concurrency in a row */}
-                <div className="grid grid-cols-2 gap-4">
-                  <div className="space-y-1.5">
-                    <Label className="text-xs">Page Range</Label>
-                    <div className="flex items-center gap-2">
-                      <Input
-                        type="number"
-                        min={1}
-                        value={startPage}
-                        onChange={(e) => setStartPage(e.target.value)}
-                        placeholder="First"
-                        className="w-20"
-                      />
-                      <span className="text-xs text-muted-foreground">to</span>
-                      <Input
-                        type="number"
-                        min={1}
-                        value={endPage}
-                        onChange={(e) => setEndPage(e.target.value)}
-                        placeholder="Last"
-                        className="w-20"
-                      />
-                    </div>
-                    <p className="text-xs text-muted-foreground">
-                      Leave empty for all pages
-                    </p>
-                  </div>
-
-                  <div className="space-y-1.5">
-                    <Label htmlFor="concurrency" className="text-xs">Concurrency</Label>
-                    <Input
-                      id="concurrency"
-                      type="number"
-                      min={1}
-                      max={64}
-                      value={concurrency}
-                      onChange={(e) => setConcurrency(e.target.value)}
-                      className="w-20"
-                    />
-                    <p className="text-xs text-muted-foreground">
-                      Parallel LLM calls
-                    </p>
-                  </div>
-                </div>
-
-                {/* Run button */}
-                <div className="flex items-center gap-3 pt-1">
-                  <Button
-                    onClick={handleRun}
-                    disabled={runPipeline.isPending || !hasApiKey}
-                  >
-                    <Play className="mr-2 h-4 w-4" />
-                    {runPipeline.isPending ? "Starting..." : book.pageCount > 0 ? "Re-run Pipeline" : "Run Pipeline"}
-                  </Button>
-                  {!hasApiKey && (
-                    <span className="text-xs text-muted-foreground">
-                      Enter your API key above to run.
-                    </span>
-                  )}
-                </div>
-
-                {runPipeline.isError && (
-                  <p className="text-sm text-destructive">
-                    Failed to start pipeline: {runPipeline.error.message}
-                  </p>
-                )}
-              </div>
-            </CardContent>
-          </Card>
+          <ConfigEditor
+            label={label}
+            onRun={handleRun}
+            isRunning={progress.isRunning}
+            isPipelineStarting={runPipeline.isPending}
+            hasApiKey={hasApiKey}
+            apiKey={apiKey}
+            onApiKeyChange={setApiKey}
+            pageCount={book.pageCount}
+          />
         )}
       </div>
 

--- a/apps/studio/src/routes/books.$label.pages.$pageId.tsx
+++ b/apps/studio/src/routes/books.$label.pages.$pageId.tsx
@@ -187,7 +187,7 @@ function PageDetailPage() {
             ADT Studio
           </Link>
           <span className="text-muted-foreground/50 text-xs">/</span>
-          <Link to="/books/$label" params={{ label }} className="text-xs text-muted-foreground hover:text-foreground transition-colors shrink-0">
+          <Link to="/books/$label" params={{ label }} search={{ autoRun: undefined, startPage: undefined, endPage: undefined }} className="text-xs text-muted-foreground hover:text-foreground transition-colors shrink-0">
             {label}
           </Link>
           <span className="text-muted-foreground/50 text-xs">/</span>

--- a/apps/studio/src/routes/books.$label.storyboard.tsx
+++ b/apps/studio/src/routes/books.$label.storyboard.tsx
@@ -36,7 +36,7 @@ function StoryboardPage() {
             ADT Studio
           </Link>
           <span className="text-muted-foreground/50">/</span>
-          <Link to="/books/$label" params={{ label }} className="text-sm text-muted-foreground hover:text-foreground transition-colors shrink-0">
+          <Link to="/books/$label" params={{ label }} search={{ autoRun: undefined, startPage: undefined, endPage: undefined }} className="text-sm text-muted-foreground hover:text-foreground transition-colors shrink-0">
             {book?.title ?? label}
           </Link>
           <span className="text-muted-foreground/50">/</span>

--- a/apps/studio/src/routes/books.new.tsx
+++ b/apps/studio/src/routes/books.new.tsx
@@ -1,27 +1,234 @@
-import { useState, useCallback } from "react"
+import { useState, useCallback, useMemo } from "react"
 import { createFileRoute, useNavigate, Link } from "@tanstack/react-router"
-import { Upload, FileText } from "lucide-react"
+import {
+  Upload,
+  FileText,
+  ChevronDown,
+  Check,
+  Search,
+  GraduationCap,
+  BookHeart,
+  Library,
+} from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card"
+import { Label } from "@/components/ui/label"
+import { Card, CardContent } from "@/components/ui/card"
 import { useCreateBook } from "@/hooks/use-books"
+import { useApiKey } from "@/hooks/use-api-key"
 
 export const Route = createFileRoute("/books/new")({
   component: AddBookPage,
 })
 
+const LAYOUT_TYPES = ["textbook", "storybook", "reference"] as const
+type LayoutType = (typeof LAYOUT_TYPES)[number]
+
+const SUPPORTED_LANGUAGES = [
+  { code: "en", name: "English" },
+  { code: "fr", name: "French" },
+  { code: "es", name: "Spanish" },
+  { code: "pt", name: "Portuguese" },
+  { code: "ar", name: "Arabic" },
+  { code: "zh", name: "Chinese" },
+  { code: "hi", name: "Hindi" },
+  { code: "bn", name: "Bengali" },
+  { code: "ru", name: "Russian" },
+  { code: "ja", name: "Japanese" },
+  { code: "de", name: "German" },
+  { code: "ko", name: "Korean" },
+  { code: "it", name: "Italian" },
+  { code: "tr", name: "Turkish" },
+  { code: "vi", name: "Vietnamese" },
+  { code: "th", name: "Thai" },
+  { code: "nl", name: "Dutch" },
+  { code: "pl", name: "Polish" },
+  { code: "sw", name: "Swahili" },
+  { code: "id", name: "Indonesian" },
+] as const
+
+const STEPS = [
+  { number: 1, label: "Upload" },
+  { number: 2, label: "Layout" },
+  { number: 3, label: "Settings" },
+] as const
+
+const LAYOUT_CARDS: {
+  type: LayoutType
+  icon: typeof GraduationCap
+  color: string
+  selectedBg: string
+  description: string
+}[] = [
+  {
+    type: "textbook",
+    icon: GraduationCap,
+    color: "bg-blue-500",
+    selectedBg: "bg-blue-500/5",
+    description:
+      "Structured chapters, exercises. Best for educational content.",
+  },
+  {
+    type: "storybook",
+    icon: BookHeart,
+    color: "bg-amber-500",
+    selectedBg: "bg-amber-500/5",
+    description:
+      "Large images, narrative flow. Best for illustrated books.",
+  },
+  {
+    type: "reference",
+    icon: Library,
+    color: "bg-emerald-500",
+    selectedBg: "bg-emerald-500/5",
+    description:
+      "Dense text, tables, glossaries. Best for technical material.",
+  },
+]
+
+function Stepper({ currentStep }: { currentStep: number }) {
+  return (
+    <div className="flex items-center px-6 pt-5 pb-2">
+      {STEPS.map((step, i) => (
+        <div key={step.number} className="flex flex-1 items-center">
+          <div className="flex flex-col items-center gap-1">
+            <div
+              className={`flex h-7 w-7 items-center justify-center rounded-full text-xs font-medium transition-colors ${
+                currentStep > step.number
+                  ? "bg-primary text-primary-foreground"
+                  : currentStep === step.number
+                    ? "bg-primary text-primary-foreground"
+                    : "border-2 border-muted-foreground/30 text-muted-foreground"
+              }`}
+            >
+              {currentStep > step.number ? (
+                <Check className="h-3.5 w-3.5" />
+              ) : (
+                step.number
+              )}
+            </div>
+            <span
+              className={`text-xs ${
+                currentStep >= step.number
+                  ? "text-foreground font-medium"
+                  : "text-muted-foreground"
+              }`}
+            >
+              {step.label}
+            </span>
+          </div>
+          {i < STEPS.length - 1 && (
+            <div
+              className={`mx-2 h-0.5 flex-1 transition-colors ${
+                currentStep > step.number ? "bg-primary" : "bg-border"
+              }`}
+            />
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function LanguagePicker({
+  selected,
+  onSelect,
+  multiple,
+  label,
+  hint,
+}: {
+  selected: string | Set<string>
+  onSelect: (code: string) => void
+  multiple?: boolean
+  label: string
+  hint?: string
+}) {
+  const [search, setSearch] = useState("")
+
+  const filtered = useMemo(() => {
+    if (!search) return SUPPORTED_LANGUAGES
+    const q = search.toLowerCase()
+    return SUPPORTED_LANGUAGES.filter(
+      (l) =>
+        l.name.toLowerCase().includes(q) || l.code.toLowerCase().includes(q)
+    )
+  }, [search])
+
+  const isSelected = (code: string) =>
+    typeof selected === "string" ? selected === code : selected.has(code)
+
+  return (
+    <div className="space-y-2">
+      <div>
+        <Label className="text-xs">{label}</Label>
+        {hint && (
+          <p className="text-xs text-muted-foreground mt-0.5">{hint}</p>
+        )}
+      </div>
+      <div className="relative">
+        <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search languages..."
+          className="pl-8 h-8 text-xs"
+        />
+      </div>
+      <div className="flex flex-wrap gap-1.5">
+        {filtered.map((lang) => {
+          const active = isSelected(lang.code)
+          return (
+            <button
+              key={lang.code}
+              type="button"
+              onClick={() => onSelect(lang.code)}
+              className={`inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-xs font-medium transition-colors ${
+                active
+                  ? "border-primary bg-primary text-primary-foreground"
+                  : "border-border text-foreground hover:border-primary/40 hover:bg-accent"
+              }`}
+            >
+              {active && multiple && <Check className="h-3 w-3" />}
+              {lang.name}
+              <span className={`text-[10px] ${active ? "opacity-70" : "opacity-40"}`}>
+                {lang.code}
+              </span>
+            </button>
+          )
+        })}
+        {filtered.length === 0 && (
+          <p className="text-xs text-muted-foreground py-1">
+            No languages match &ldquo;{search}&rdquo;
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}
+
 function AddBookPage() {
   const navigate = useNavigate()
   const createMutation = useCreateBook()
+  const { hasApiKey } = useApiKey()
+
+  const [step, setStep] = useState(1)
+
+  // Step 1 — Upload
   const [label, setLabel] = useState("")
   const [file, setFile] = useState<File | null>(null)
   const [dragOver, setDragOver] = useState(false)
+  const [showAdvanced, setShowAdvanced] = useState(false)
+  const [startPage, setStartPage] = useState("")
+  const [endPage, setEndPage] = useState("")
+
+  // Step 2 — Layout
+  const [layoutType, setLayoutType] = useState<LayoutType>("textbook")
+
+  // Step 3 — Settings
+  const [editingLanguage, setEditingLanguage] = useState("en")
+  const [outputLanguages, setOutputLanguages] = useState<Set<string>>(
+    () => new Set(["en"])
+  )
 
   const suggestLabel = useCallback((filename: string) => {
     return filename
@@ -47,124 +254,291 @@ function AddBookPage() {
     }
   }
 
+  const openFilePicker = () => {
+    const input = document.createElement("input")
+    input.type = "file"
+    input.accept = ".pdf"
+    input.onchange = () => {
+      const selected = input.files?.[0]
+      if (selected) handleFileSelect(selected)
+    }
+    input.click()
+  }
+
+  const toggleOutputLanguage = (code: string) => {
+    setOutputLanguages((prev) => {
+      const next = new Set(prev)
+      if (next.has(code)) next.delete(code)
+      else next.add(code)
+      return next
+    })
+  }
+
+  const isLabelValid =
+    !!label && /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(label)
+  const canAdvanceStep1 = !!file && isLabelValid
+
   const handleSubmit = () => {
     if (!file || !label) return
+
+    const configOverrides: Record<string, unknown> = {}
+    configOverrides.layout_type = layoutType
+    configOverrides.editing_language = editingLanguage
+    if (outputLanguages.size > 0) {
+      configOverrides.output_languages = Array.from(outputLanguages)
+    }
+
     createMutation.mutate(
-      { label, pdf: file },
+      { label, pdf: file, config: configOverrides },
       {
         onSuccess: (book) => {
-          navigate({ to: "/books/$label", params: { label: book.label } })
+          navigate({
+            to: "/books/$label",
+            params: { label: book.label },
+            search: {
+              autoRun: hasApiKey ? true : undefined,
+              startPage: startPage ? Number(startPage) : undefined,
+              endPage: endPage ? Number(endPage) : undefined,
+            },
+          })
         },
       }
     )
   }
 
-  const isValid = !!file && !!label && /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(label)
-
   return (
-    <div className="mx-auto max-w-2xl p-4">
-      <div className="mb-4 flex items-center gap-2">
-        <Link to="/" className="text-sm text-muted-foreground hover:text-foreground transition-colors">
+    <div className="mx-auto max-w-xl p-4">
+      <div className="mb-3 flex items-center gap-2">
+        <Link
+          to="/"
+          className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
           ADT Studio
         </Link>
         <span className="text-muted-foreground/50">/</span>
         <h1 className="text-lg font-semibold">Add Book</h1>
       </div>
 
-      <div className="space-y-6">
-        <Card>
-          <CardHeader>
-            <CardTitle>Upload PDF</CardTitle>
-            <CardDescription>
-              Select or drag a PDF file to process.
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div
-              className={`flex cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed p-8 transition-colors ${
-                dragOver
-                  ? "border-primary bg-primary/5"
-                  : "border-border hover:border-primary/50"
-              }`}
-              onDragOver={(e) => {
-                e.preventDefault()
-                setDragOver(true)
-              }}
-              onDragLeave={() => setDragOver(false)}
-              onDrop={handleDrop}
-              onClick={() => {
-                const input = document.createElement("input")
-                input.type = "file"
-                input.accept = ".pdf"
-                input.onchange = () => {
-                  const selected = input.files?.[0]
-                  if (selected) handleFileSelect(selected)
-                }
-                input.click()
-              }}
-            >
-              {file ? (
-                <>
-                  <FileText className="h-10 w-10 text-primary" />
-                  <p className="mt-2 text-sm font-medium">{file.name}</p>
+      <Card>
+        <Stepper currentStep={step} />
+        <CardContent className="pt-4 space-y-4">
+          {/* Step 1 — Upload */}
+          {step === 1 && (
+            <div key={1} className="animate-wizard-enter space-y-4">
+              {/* Drop zone */}
+              <div
+                className={`flex cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed transition-colors ${
+                  file ? "p-4" : "p-8"
+                } ${
+                  dragOver
+                    ? "border-primary bg-primary/5"
+                    : "border-border hover:border-primary/50"
+                }`}
+                onDragOver={(e) => {
+                  e.preventDefault()
+                  setDragOver(true)
+                }}
+                onDragLeave={() => setDragOver(false)}
+                onDrop={handleDrop}
+                onClick={openFilePicker}
+              >
+                {file ? (
+                  <div className="flex items-center gap-3">
+                    <FileText className="h-5 w-5 text-primary shrink-0" />
+                    <div className="min-w-0">
+                      <p className="text-sm font-medium truncate">
+                        {file.name}
+                      </p>
+                      <p className="text-xs text-muted-foreground">
+                        {(file.size / 1024 / 1024).toFixed(1)} MB — click to
+                        change
+                      </p>
+                    </div>
+                  </div>
+                ) : (
+                  <>
+                    <Upload className="h-8 w-8 text-muted-foreground" />
+                    <p className="mt-2 text-sm text-muted-foreground">
+                      Drop a PDF here, or click to browse
+                    </p>
+                  </>
+                )}
+              </div>
+
+              {/* Label */}
+              <div className="space-y-1.5">
+                <Label htmlFor="book-label" className="text-xs">
+                  Book Label
+                </Label>
+                <Input
+                  id="book-label"
+                  value={label}
+                  onChange={(e) => setLabel(e.target.value)}
+                  placeholder="e.g., my-textbook-grade5"
+                />
+                {label && !isLabelValid ? (
+                  <p className="text-xs text-destructive">
+                    Must start with a letter or number. Only letters, numbers,
+                    hyphens, dots, underscores.
+                  </p>
+                ) : (
                   <p className="text-xs text-muted-foreground">
-                    {(file.size / 1024 / 1024).toFixed(1)} MB
+                    A unique identifier used as the book folder name.
                   </p>
-                </>
-              ) : (
-                <>
-                  <Upload className="h-10 w-10 text-muted-foreground" />
-                  <p className="mt-2 text-sm text-muted-foreground">
-                    Drag and drop a PDF here, or click to browse
-                  </p>
-                </>
+                )}
+              </div>
+
+              {/* Advanced toggle */}
+              <button
+                type="button"
+                onClick={() => setShowAdvanced(!showAdvanced)}
+                className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+              >
+                <ChevronDown
+                  className={`h-3.5 w-3.5 transition-transform ${showAdvanced ? "" : "-rotate-90"}`}
+                />
+                Advanced options
+              </button>
+
+              {showAdvanced && (
+                <div className="space-y-4 rounded-lg border bg-muted/30 p-3">
+                  <div className="space-y-1.5">
+                    <Label className="text-xs">Page Range</Label>
+                    <div className="flex items-center gap-2">
+                      <Input
+                        type="number"
+                        min={1}
+                        value={startPage}
+                        onChange={(e) => setStartPage(e.target.value)}
+                        placeholder="First"
+                        className="w-24"
+                      />
+                      <span className="text-xs text-muted-foreground">to</span>
+                      <Input
+                        type="number"
+                        min={1}
+                        value={endPage}
+                        onChange={(e) => setEndPage(e.target.value)}
+                        placeholder="Last"
+                        className="w-24"
+                      />
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      Leave empty to process all pages.
+                    </p>
+                  </div>
+                </div>
               )}
+
+              {/* Navigation */}
+              <div className="flex justify-end pt-1">
+                <Button
+                  size="sm"
+                  onClick={() => setStep(2)}
+                  disabled={!canAdvanceStep1}
+                >
+                  Next
+                </Button>
+              </div>
             </div>
-          </CardContent>
-        </Card>
+          )}
 
-        <Card>
-          <CardHeader>
-            <CardTitle>Book Label</CardTitle>
-            <CardDescription>
-              A unique identifier for this book (letters, numbers, hyphens,
-              dots).
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <Input
-              value={label}
-              onChange={(e) => setLabel(e.target.value)}
-              placeholder="e.g., my-textbook-grade5"
-              className="max-w-md"
-            />
-            {label && !isValid && (
-              <p className="mt-1 text-xs text-destructive">
-                Must start with a letter or number, containing only letters,
-                numbers, hyphens, dots, and underscores.
-              </p>
-            )}
-          </CardContent>
-        </Card>
+          {/* Step 2 — Layout */}
+          {step === 2 && (
+            <div key={2} className="animate-wizard-enter space-y-4">
+              <div>
+                <h2 className="text-sm font-semibold">Choose a layout</h2>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  This guides how your book pages will be styled
+                </p>
+              </div>
 
-        <div className="flex justify-end gap-2">
-          <Button variant="outline" onClick={() => navigate({ to: "/" })}>
-            Cancel
-          </Button>
-          <Button
-            onClick={handleSubmit}
-            disabled={!isValid || createMutation.isPending}
-          >
-            {createMutation.isPending ? "Creating..." : "Create Book"}
-          </Button>
-        </div>
+              <div className="grid grid-cols-3 gap-3">
+                {LAYOUT_CARDS.map((card) => {
+                  const Icon = card.icon
+                  const selected = layoutType === card.type
+                  return (
+                    <button
+                      key={card.type}
+                      type="button"
+                      onClick={() => setLayoutType(card.type)}
+                      className={`relative flex flex-col items-center rounded-xl border p-4 text-left transition-all ${
+                        selected
+                          ? `ring-2 ring-primary shadow-md ${card.selectedBg}`
+                          : "hover:border-primary/40 hover:shadow-sm"
+                      }`}
+                    >
+                      <div
+                        className={`absolute inset-x-0 top-0 h-0.5 rounded-t-xl ${card.color}`}
+                      />
+                      <Icon className="h-6 w-6 text-muted-foreground mt-1" />
+                      <span className="mt-2 text-sm font-semibold capitalize">
+                        {card.type}
+                      </span>
+                      <span className="mt-1 text-center text-xs text-muted-foreground leading-snug">
+                        {card.description}
+                      </span>
+                    </button>
+                  )
+                })}
+              </div>
 
-        {createMutation.isError && (
-          <p className="text-sm text-destructive">
-            {createMutation.error.message}
-          </p>
-        )}
-      </div>
+              {/* Navigation */}
+              <div className="flex justify-between pt-1">
+                <Button variant="outline" size="sm" onClick={() => setStep(1)}>
+                  Back
+                </Button>
+                <Button size="sm" onClick={() => setStep(3)}>
+                  Next
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {/* Step 3 — Settings */}
+          {step === 3 && (
+            <div key={3} className="animate-wizard-enter space-y-5">
+              <LanguagePicker
+                label="Editing Language"
+                hint="The primary language of your book"
+                selected={editingLanguage}
+                onSelect={setEditingLanguage}
+              />
+
+              <LanguagePicker
+                label="Output Languages"
+                hint="Select languages for translated versions"
+                selected={outputLanguages}
+                onSelect={toggleOutputLanguage}
+                multiple
+              />
+
+              {/* Error */}
+              {createMutation.isError && (
+                <p className="text-sm text-destructive">
+                  {createMutation.error.message}
+                </p>
+              )}
+
+              {/* Navigation */}
+              <div className="flex justify-between pt-1">
+                <Button variant="outline" size="sm" onClick={() => setStep(2)}>
+                  Back
+                </Button>
+                <Button
+                  size="sm"
+                  onClick={handleSubmit}
+                  disabled={createMutation.isPending}
+                >
+                  {createMutation.isPending
+                    ? "Creating..."
+                    : "Create Storyboard"}
+                </Button>
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
     </div>
   )
 }

--- a/apps/studio/src/routes/index.tsx
+++ b/apps/studio/src/routes/index.tsx
@@ -86,6 +86,7 @@ function BookRow({
         <Link
           to="/books/$label"
           params={{ label: book.label }}
+          search={{ autoRun: undefined, startPage: undefined, endPage: undefined }}
           className="flex-1 min-w-0 p-5"
         >
           {/* Top: title + badges */}
@@ -173,7 +174,7 @@ function BookRow({
             className="h-8 w-8 text-muted-foreground hover:text-primary"
             asChild
           >
-            <Link to="/books/$label" params={{ label: book.label }}>
+            <Link to="/books/$label" params={{ label: book.label }} search={{ autoRun: undefined, startPage: undefined, endPage: undefined }}>
               <Pencil className="h-4 w-4" />
             </Link>
           </Button>

--- a/apps/studio/src/styles/globals.css
+++ b/apps/studio/src/styles/globals.css
@@ -45,6 +45,7 @@
   --radius-xl: calc(var(--radius) + 4px);
   --animate-accordion-down: accordion-down 0.2s ease-out;
   --animate-accordion-up: accordion-up 0.2s ease-out;
+  --animate-wizard-enter: wizard-enter 0.25s ease-out;
 }
 
 @keyframes accordion-down {
@@ -62,6 +63,17 @@
   }
   to {
     height: 0;
+  }
+}
+
+@keyframes wizard-enter {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
   }
 }
 

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -14,6 +14,12 @@ export const StepConfig = z.object({
 })
 export type StepConfig = z.infer<typeof StepConfig>
 
+export const BookFormat = z.enum(["web", "epub", "webpub"])
+export type BookFormat = z.infer<typeof BookFormat>
+
+export const LayoutType = z.enum(["textbook", "storybook", "reference"])
+export type LayoutType = z.infer<typeof LayoutType>
+
 export const RenderType = z.enum(["llm", "template"])
 export type RenderType = z.infer<typeof RenderType>
 
@@ -48,6 +54,10 @@ export const AppConfig = z.object({
   image_filters: ImageFilters.optional(),
   concurrency: z.number().int().min(1).optional(),
   rate_limit: RateLimitConfig.optional(),
+  editing_language: z.string().optional(),
+  output_languages: z.array(z.string()).optional(),
+  book_format: z.array(BookFormat).optional(),
+  layout_type: LayoutType.optional(),
 })
 export type AppConfig = z.infer<typeof AppConfig>
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -10,6 +10,8 @@ export { StepName, ProgressEvent } from "./progress.js"
 export { BookLabel, parseBookLabel } from "./book.js"
 
 export {
+  BookFormat,
+  LayoutType,
   StepConfig,
   RenderType,
   RenderStrategyConfig,


### PR DESCRIPTION
## Summary

- **3-step book creation wizard**: Replaces flat form with Upload → Layout → Settings flow, including layout type selection (textbook/storybook/reference) and searchable language tile pickers for editing and output languages
- **Config editor & API**: Per-book config override CRUD endpoints and in-app config editor component
- **Debug panel**: LLM call logs, pipeline stats, version history, and config inspection tabs
- **Pipeline UX overhaul**: Tile grid progress view, live page previews, SSE resilience, and step indicators
- **Book detail & homepage redesign**: Richer book cards with metadata, page counts, and pipeline status

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm vitest run` — 29 test files, 289 tests all passing
- [ ] Manual: `/books/new` → step through wizard → verify `config.yaml` has `layout_type` + languages
- [ ] Manual: pipeline run with live progress tiles and page previews
- [ ] Manual: debug panel tabs (logs, stats, versions, config) on book detail page