### PR TITLE
Storyboard review page with inline re-render and UX improvements

### DIFF
--- a/apps/studio/src/components/config/ConfigEditor.tsx
+++ b/apps/studio/src/components/config/ConfigEditor.tsx
@@ -22,33 +22,14 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { useBookConfig, useUpdateBookConfig } from "@/hooks/use-book-config"
 import { useActiveConfig } from "@/hooks/use-debug"
-
-const ALL_TEXT_TYPES = [
-  "book_title", "book_subtitle", "book_author", "book_metadata",
-  "section_heading", "section_text", "instruction_text",
-  "activity_number", "activity_title", "activity_option",
-  "activity_input_placeholder_text", "fill_in_the_blank",
-  "image_associated_text", "image_overlay", "math",
-  "standalone_text", "header_text", "footer_text", "page_number", "other",
-]
-
-const ALL_SECTION_TYPES = [
-  "front_cover", "inside_cover", "back_cover", "separator", "credits",
-  "foreword", "table_of_contents", "boxed_text",
-  "text_only", "text_and_single_image", "text_and_images", "images_only",
-  "activity_matching", "activity_fill_in_a_table", "activity_multiple_choice",
-  "activity_true_false", "activity_open_ended_answer",
-  "activity_fill_in_the_blank", "activity_sorting", "other",
-]
+import { ALL_TEXT_TYPES, ALL_SECTION_TYPES } from "@/lib/config-constants"
 
 interface ConfigEditorProps {
   label: string
-  onRun: (options: { startPage?: number; endPage?: number; concurrency?: number }) => void
+  onRun: (options: { startPage?: number; endPage?: number }) => void
   isRunning: boolean
   isPipelineStarting: boolean
   hasApiKey: boolean
-  apiKey: string
-  onApiKeyChange: (key: string) => void
   pageCount: number
 }
 
@@ -58,8 +39,6 @@ export function ConfigEditor({
   isRunning,
   isPipelineStarting,
   hasApiKey,
-  apiKey,
-  onApiKeyChange,
   pageCount,
 }: ConfigEditorProps) {
   const { data: bookConfigData } = useBookConfig(label)
@@ -69,7 +48,6 @@ export function ConfigEditor({
   // Run tab state
   const [startPage, setStartPage] = useState("")
   const [endPage, setEndPage] = useState("")
-  const [concurrency, setConcurrency] = useState("16")
 
   // Config tab state
   const [configConcurrency, setConfigConcurrency] = useState("")
@@ -237,11 +215,9 @@ export function ConfigEditor({
         onSuccess: () => {
           setConfigDirty(false)
           setShowRebuildDialog(false)
-          const options: { startPage?: number; endPage?: number; concurrency?: number } = {}
+          const options: { startPage?: number; endPage?: number } = {}
           if (startPage) options.startPage = Number(startPage)
           if (endPage) options.endPage = Number(endPage)
-          const c = Number(concurrency)
-          if (c && c !== 16) options.concurrency = c
           onRun(options)
         },
       }
@@ -249,11 +225,9 @@ export function ConfigEditor({
   }
 
   const handleRun = () => {
-    const options: { startPage?: number; endPage?: number; concurrency?: number } = {}
+    const options: { startPage?: number; endPage?: number } = {}
     if (startPage) options.startPage = Number(startPage)
     if (endPage) options.endPage = Number(endPage)
-    const c = Number(concurrency)
-    if (c && c !== 16) options.concurrency = c
     onRun(options)
   }
 
@@ -279,21 +253,6 @@ export function ConfigEditor({
             {/* Run Tab */}
             <TabsContent value="run">
               <div className="space-y-4">
-                <div className="space-y-1.5">
-                  <Label htmlFor="api-key" className="text-xs">OpenAI API Key</Label>
-                  <Input
-                    id="api-key"
-                    type="password"
-                    value={apiKey}
-                    onChange={(e) => onApiKeyChange(e.target.value)}
-                    placeholder="sk-..."
-                    className="font-mono"
-                  />
-                  <p className="text-xs text-muted-foreground">
-                    Stored in your browser only. Never sent to our servers.
-                  </p>
-                </div>
-
                 <div className="grid grid-cols-2 gap-4">
                   <div className="space-y-1.5">
                     <Label className="text-xs">Page Range</Label>
@@ -321,21 +280,6 @@ export function ConfigEditor({
                     </p>
                   </div>
 
-                  <div className="space-y-1.5">
-                    <Label htmlFor="run-concurrency" className="text-xs">Concurrency</Label>
-                    <Input
-                      id="run-concurrency"
-                      type="number"
-                      min={1}
-                      max={64}
-                      value={concurrency}
-                      onChange={(e) => setConcurrency(e.target.value)}
-                      className="w-20"
-                    />
-                    <p className="text-xs text-muted-foreground">
-                      Parallel LLM calls
-                    </p>
-                  </div>
                 </div>
 
                 <div className="flex items-center gap-3 pt-1">

--- a/apps/studio/src/components/page-edit/EditToolbar.tsx
+++ b/apps/studio/src/components/page-edit/EditToolbar.tsx
@@ -8,10 +8,12 @@ interface EditToolbarProps {
   isReRendering: boolean
   hasApiKey: boolean
   hasRenderingData: boolean
+  isSaveAndReRendering?: boolean
   onEdit: () => void
   onSave: () => void
   onCancel: () => void
   onReRender: () => void
+  onSaveAndReRender?: () => void
 }
 
 export function EditToolbar({
@@ -21,50 +23,94 @@ export function EditToolbar({
   isReRendering,
   hasApiKey,
   hasRenderingData,
+  isSaveAndReRendering,
   onEdit,
   onSave,
   onCancel,
   onReRender,
+  onSaveAndReRender,
 }: EditToolbarProps) {
+  const editTitle = !hasRenderingData ? "Run the pipeline first to extract text" : ""
+  const reRenderViewTitle = !hasApiKey
+    ? "Set your API key first"
+    : !hasRenderingData
+      ? "Run the pipeline first"
+      : isReRendering
+        ? "Re-rendering..."
+        : ""
+  const reRenderEditTitle = hasChanges
+    ? "Save changes before re-rendering"
+    : !hasApiKey
+      ? "Set your API key first"
+      : isReRendering
+        ? "Re-rendering..."
+        : ""
+
   if (!isEditing) {
     return (
-      <div className="flex items-center gap-2">
-        <Button variant="outline" size="sm" onClick={onEdit} disabled={!hasRenderingData}>
-          <Pencil className="mr-1 h-3 w-3" />
-          Edit Inputs
-        </Button>
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={onReRender}
-          disabled={!hasApiKey || isReRendering || !hasRenderingData}
-        >
-          {isReRendering ? (
-            <Loader2 className="mr-1 h-3 w-3 animate-spin" />
-          ) : (
-            <RefreshCw className="mr-1 h-3 w-3" />
-          )}
-          Re-render Page
-        </Button>
+      <div className="flex flex-col items-end gap-1">
+        <div className="flex items-center gap-2">
+          <Button variant="outline" size="sm" onClick={onEdit} disabled={!hasRenderingData} title={editTitle}>
+            <Pencil className="mr-1 h-3 w-3" />
+            Edit Text & Images
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onReRender}
+            disabled={!hasApiKey || isReRendering || !hasRenderingData}
+            title={reRenderViewTitle}
+          >
+            {isReRendering ? (
+              <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+            ) : (
+              <RefreshCw className="mr-1 h-3 w-3" />
+            )}
+            Re-render
+          </Button>
+        </div>
+        {hasRenderingData && (
+          <p className="text-[11px] text-muted-foreground">
+            Modify text groups or toggle image pruning, then re-render.
+          </p>
+        )}
       </div>
     )
   }
+
+  const busy = isSaving || !!isSaveAndReRendering
 
   return (
     <div className="flex items-center gap-2">
       <Button
         size="sm"
         onClick={onSave}
-        disabled={!hasChanges || isSaving}
+        disabled={!hasChanges || busy}
       >
-        {isSaving ? (
+        {isSaving && !isSaveAndReRendering ? (
           <Loader2 className="mr-1 h-3 w-3 animate-spin" />
         ) : (
           <Save className="mr-1 h-3 w-3" />
         )}
         Save Changes
       </Button>
-      <Button variant="outline" size="sm" onClick={onCancel} disabled={isSaving}>
+      {onSaveAndReRender && (
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onSaveAndReRender}
+          disabled={!hasChanges || busy || !hasApiKey}
+          title={!hasApiKey ? "Set your API key first" : !hasChanges ? "No changes to save" : ""}
+        >
+          {isSaveAndReRendering ? (
+            <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+          ) : (
+            <RefreshCw className="mr-1 h-3 w-3" />
+          )}
+          {isSaveAndReRendering ? "Saving & re-rendering..." : "Save & Re-render"}
+        </Button>
+      )}
+      <Button variant="outline" size="sm" onClick={onCancel} disabled={busy}>
         <X className="mr-1 h-3 w-3" />
         Cancel
       </Button>
@@ -73,14 +119,14 @@ export function EditToolbar({
         size="sm"
         onClick={onReRender}
         disabled={!hasApiKey || isReRendering || hasChanges}
-        title={hasChanges ? "Save changes before re-rendering" : ""}
+        title={reRenderEditTitle}
       >
         {isReRendering ? (
           <Loader2 className="mr-1 h-3 w-3 animate-spin" />
         ) : (
           <RefreshCw className="mr-1 h-3 w-3" />
         )}
-        Re-render Page
+        Re-render
       </Button>
     </div>
   )

--- a/apps/studio/src/components/storyboard/AcceptStoryboardDialog.tsx
+++ b/apps/studio/src/components/storyboard/AcceptStoryboardDialog.tsx
@@ -1,0 +1,98 @@
+import { useNavigate } from "@tanstack/react-router"
+import { CheckCircle2, BookOpen, Languages, HelpCircle, FileDown } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+
+interface AcceptStoryboardDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  renderedCount: number
+  totalCount: number
+  label: string
+}
+
+const NEXT_STEPS = [
+  { icon: BookOpen, label: "Glossary Generation", description: "Extract and define key terms" },
+  { icon: Languages, label: "Easy Read Version", description: "Simplified language variant" },
+  { icon: HelpCircle, label: "Quiz Generation", description: "Comprehension questions per section" },
+  { icon: FileDown, label: "Export Bundle", description: "Package for print and digital distribution" },
+]
+
+export function AcceptStoryboardDialog({
+  open,
+  onOpenChange,
+  renderedCount,
+  totalCount,
+  label,
+}: AcceptStoryboardDialogProps) {
+  const navigate = useNavigate()
+
+  const handleAccept = () => {
+    onOpenChange(false)
+    navigate({
+      to: "/books/$label",
+      params: { label },
+      search: { autoRun: undefined, startPage: undefined, endPage: undefined },
+    })
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <CheckCircle2 className="h-5 w-5 text-green-600" />
+            Accept Storyboard
+          </DialogTitle>
+          <DialogDescription>
+            All {totalCount} pages have been rendered and reviewed.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3 py-2">
+          <p className="text-sm text-muted-foreground">
+            Next steps in the production pipeline:
+          </p>
+          <div className="space-y-2">
+            {NEXT_STEPS.map((step) => (
+              <div
+                key={step.label}
+                className="flex items-center gap-3 rounded-lg border p-3 opacity-60"
+              >
+                <step.icon className="h-4 w-4 text-muted-foreground shrink-0" />
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium">{step.label}</span>
+                    <Badge variant="secondary" className="text-[10px]">Coming Soon</Badge>
+                  </div>
+                  <p className="text-xs text-muted-foreground">{step.description}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+          <p className="text-xs text-muted-foreground">
+            These features are actively being built. Accepting the storyboard locks in
+            your current rendering as the baseline for downstream generation steps.
+          </p>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={handleAccept}>
+            Accept & Continue
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/studio/src/components/storyboard/RenderedHtml.tsx
+++ b/apps/studio/src/components/storyboard/RenderedHtml.tsx
@@ -1,0 +1,77 @@
+import { useRef, useMemo, useEffect } from "react"
+import DOMPurify from "dompurify"
+
+/**
+ * Renders HTML content and gracefully handles broken images by replacing
+ * them with a styled placeholder showing the alt text.
+ */
+export function RenderedHtml({ html, className }: { html: string; className?: string }) {
+  const ref = useRef<HTMLDivElement>(null)
+  const sanitizedHtml = useMemo(
+    () => DOMPurify.sanitize(html),
+    [html]
+  )
+
+  useEffect(() => {
+    if (!ref.current) return
+
+    // Strip inline font-family from all elements so the app font is used consistently
+    const allEls = ref.current.querySelectorAll("*")
+    for (const el of allEls) {
+      if (el instanceof HTMLElement && el.style.fontFamily) {
+        el.style.fontFamily = ""
+      }
+    }
+
+    const imgs = ref.current.querySelectorAll("img")
+    for (const img of imgs) {
+      img.onerror = () => {
+        const placeholder = document.createElement("div")
+        placeholder.style.cssText =
+          "display:flex;flex-direction:column;align-items:center;justify-content:center;gap:8px;" +
+          "min-height:120px;padding:16px;border-radius:8px;" +
+          "border:2px dashed #d1d5db;background:#f9fafb;"
+
+        // Icon (SVG inline since we can't use React components here)
+        const icon = document.createElementNS("http://www.w3.org/2000/svg", "svg")
+        icon.setAttribute("width", "32")
+        icon.setAttribute("height", "32")
+        icon.setAttribute("viewBox", "0 0 24 24")
+        icon.setAttribute("fill", "none")
+        icon.setAttribute("stroke", "#9ca3af")
+        icon.setAttribute("stroke-width", "1.5")
+        icon.innerHTML =
+          '<rect x="3" y="3" width="18" height="18" rx="2"/>' +
+          '<circle cx="9" cy="9" r="2"/>' +
+          '<path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"/>' +
+          '<line x1="2" y1="2" x2="22" y2="22" stroke="#ef4444" stroke-width="2"/>'
+        placeholder.appendChild(icon)
+
+        // Alt text label
+        if (img.alt) {
+          const label = document.createElement("span")
+          label.style.cssText = "font-size:13px;font-weight:500;color:#6b7280;text-align:center;"
+          label.textContent = img.alt
+          placeholder.appendChild(label)
+        }
+
+        // Error detail with src path
+        const detail = document.createElement("span")
+        detail.style.cssText = "font-size:11px;color:#9ca3af;text-align:center;word-break:break-all;max-width:100%;"
+        const src = img.getAttribute("src") || ""
+        detail.textContent = src ? `Image not found: ${src}` : "Image source unavailable"
+        placeholder.appendChild(detail)
+
+        img.replaceWith(placeholder)
+      }
+    }
+  }, [sanitizedHtml])
+
+  return (
+    <div
+      ref={ref}
+      className={className}
+      dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
+    />
+  )
+}

--- a/apps/studio/src/components/storyboard/StoryboardGuideDialog.tsx
+++ b/apps/studio/src/components/storyboard/StoryboardGuideDialog.tsx
@@ -1,0 +1,115 @@
+import { useState } from "react"
+import { LayoutGrid, Pencil, RefreshCw, CheckCircle2 } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog"
+
+const STEPS = [
+  {
+    icon: LayoutGrid,
+    title: "Browse & Filter Pages",
+    description:
+      "Use the sidebar to browse all extracted pages. Filter by Rendered or Pending status. Use arrow keys for quick navigation.",
+  },
+  {
+    icon: Pencil,
+    title: "Edit Page Content",
+    description:
+      "Click Edit Page on any page to modify its text and images. Toggle pruning to exclude content from the final render.",
+  },
+  {
+    icon: RefreshCw,
+    title: "Re-render Pages",
+    description:
+      "After editing, Re-render a single page, or open Settings \u2192 Save & Rebuild to regenerate all pages with new config.",
+  },
+  {
+    icon: CheckCircle2,
+    title: "Accept & Continue",
+    description:
+      "Once all pages are rendered and reviewed, click Accept Storyboard to lock in your baseline for downstream steps.",
+  },
+] as const
+
+interface StoryboardGuideDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function StoryboardGuideDialog({
+  open,
+  onOpenChange,
+}: StoryboardGuideDialogProps) {
+  const [step, setStep] = useState(0)
+
+  const current = STEPS[step]
+  const Icon = current.icon
+  const isLast = step === STEPS.length - 1
+
+  function handleClose() {
+    onOpenChange(false)
+    // Reset to first step for next open
+    setStep(0)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => { if (!o) handleClose() }}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Storyboard Review</DialogTitle>
+          <DialogDescription>
+            Review and refine your book pages in 4 steps.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col items-center gap-3 py-4 text-center">
+          <div className="flex h-14 w-14 items-center justify-center rounded-full bg-primary/10">
+            <Icon className="h-7 w-7 text-primary" />
+          </div>
+          <h3 className="text-base font-semibold">{current.title}</h3>
+          <p className="text-sm text-muted-foreground leading-relaxed max-w-sm">
+            {current.description}
+          </p>
+        </div>
+
+        {/* Step indicator dots */}
+        <div className="flex justify-center gap-1.5">
+          {STEPS.map((_, i) => (
+            <div
+              key={i}
+              className={`h-1.5 w-1.5 rounded-full transition-colors ${
+                i === step ? "bg-primary" : "bg-muted-foreground/30"
+              }`}
+            />
+          ))}
+        </div>
+
+        <DialogFooter className="sm:justify-between">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setStep((s) => s - 1)}
+            disabled={step === 0}
+          >
+            Back
+          </Button>
+          {isLast ? (
+            <Button size="sm" onClick={handleClose}>
+              Got it
+            </Button>
+          ) : (
+            <Button size="sm" onClick={() => setStep((s) => s + 1)}>
+              Next
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/studio/src/components/storyboard/StoryboardSettingsSheet.tsx
+++ b/apps/studio/src/components/storyboard/StoryboardSettingsSheet.tsx
@@ -1,0 +1,320 @@
+import { useState, useEffect } from "react"
+import { Link } from "@tanstack/react-router"
+import { Save, Play, ExternalLink } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet"
+import { useBookConfig, useUpdateBookConfig } from "@/hooks/use-book-config"
+import { useActiveConfig } from "@/hooks/use-debug"
+import { ALL_TEXT_TYPES, ALL_SECTION_TYPES } from "@/lib/config-constants"
+
+interface StoryboardSettingsSheetProps {
+  label: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onRebuild: () => void
+  isRebuilding: boolean
+  pageCount?: number
+}
+
+export function StoryboardSettingsSheet({
+  label,
+  open,
+  onOpenChange,
+  onRebuild,
+  isRebuilding,
+  pageCount,
+}: StoryboardSettingsSheetProps) {
+  const { data: bookConfigData } = useBookConfig(label)
+  const { data: activeConfigData } = useActiveConfig(label)
+  const updateConfig = useUpdateBookConfig()
+
+  const [minSide, setMinSide] = useState("")
+  const [maxSide, setMaxSide] = useState("")
+  const [prunedTextTypes, setPrunedTextTypes] = useState<Set<string>>(new Set())
+  const [prunedSectionTypes, setPrunedSectionTypes] = useState<Set<string>>(new Set())
+  const [configDirty, setConfigDirty] = useState(false)
+  const [confirmingRebuild, setConfirmingRebuild] = useState(false)
+
+  // Load book-level overrides when sheet opens
+  useEffect(() => {
+    if (!open || !bookConfigData) return
+    const c = bookConfigData.config
+    if (c.image_filters && typeof c.image_filters === "object") {
+      const f = c.image_filters as Record<string, unknown>
+      if (f.min_side != null) setMinSide(String(f.min_side))
+      if (f.max_side != null) setMaxSide(String(f.max_side))
+    }
+    if (Array.isArray(c.pruned_text_types)) {
+      setPrunedTextTypes(new Set(c.pruned_text_types as string[]))
+    }
+    if (Array.isArray(c.pruned_section_types)) {
+      setPrunedSectionTypes(new Set(c.pruned_section_types as string[]))
+    }
+    setConfigDirty(false)
+    setConfirmingRebuild(false)
+  }, [open, bookConfigData])
+
+  const getDefaultPrunedTextTypes = (): Set<string> => {
+    if (!activeConfigData) return new Set()
+    const arr = (activeConfigData.merged as Record<string, unknown>).pruned_text_types
+    return Array.isArray(arr) ? new Set(arr as string[]) : new Set()
+  }
+
+  const getDefaultPrunedSectionTypes = (): Set<string> => {
+    if (!activeConfigData) return new Set()
+    const arr = (activeConfigData.merged as Record<string, unknown>).pruned_section_types
+    return Array.isArray(arr) ? new Set(arr as string[]) : new Set()
+  }
+
+  const effectivePrunedTextTypes = configDirty ? prunedTextTypes : (
+    bookConfigData?.config.pruned_text_types ? prunedTextTypes : getDefaultPrunedTextTypes()
+  )
+  const effectivePrunedSectionTypes = configDirty ? prunedSectionTypes : (
+    bookConfigData?.config.pruned_section_types ? prunedSectionTypes : getDefaultPrunedSectionTypes()
+  )
+
+  const togglePrunedText = (t: string) => {
+    setConfigDirty(true)
+    setPrunedTextTypes((prev) => {
+      const base = configDirty ? prev : (
+        bookConfigData?.config.pruned_text_types ? prev : getDefaultPrunedTextTypes()
+      )
+      const next = new Set(base)
+      if (next.has(t)) next.delete(t)
+      else next.add(t)
+      return next
+    })
+  }
+
+  const togglePrunedSection = (t: string) => {
+    setConfigDirty(true)
+    setPrunedSectionTypes((prev) => {
+      const base = configDirty ? prev : (
+        bookConfigData?.config.pruned_section_types ? prev : getDefaultPrunedSectionTypes()
+      )
+      const next = new Set(base)
+      if (next.has(t)) next.delete(t)
+      else next.add(t)
+      return next
+    })
+  }
+
+  const buildOverrides = (): Record<string, unknown> => {
+    const overrides: Record<string, unknown> = {}
+
+    // Image filters
+    const imageFilters: Record<string, unknown> = {}
+    if (minSide.trim()) imageFilters.min_side = Number(minSide)
+    if (maxSide.trim()) imageFilters.max_side = Number(maxSide)
+    if (Object.keys(imageFilters).length > 0) overrides.image_filters = imageFilters
+
+    // Pruned types
+    if (configDirty || bookConfigData?.config.pruned_text_types) {
+      overrides.pruned_text_types = Array.from(effectivePrunedTextTypes)
+    }
+    if (configDirty || bookConfigData?.config.pruned_section_types) {
+      overrides.pruned_section_types = Array.from(effectivePrunedSectionTypes)
+    }
+
+    // Preserve existing book config fields we don't manage here
+    if (bookConfigData?.config) {
+      const bc = bookConfigData.config
+      if (bc.editing_language) overrides.editing_language = bc.editing_language
+      if (bc.output_languages) overrides.output_languages = bc.output_languages
+      if (bc.book_format) overrides.book_format = bc.book_format
+      if (bc.concurrency != null) overrides.concurrency = bc.concurrency
+      if (bc.rate_limit) overrides.rate_limit = bc.rate_limit
+      if (bc.metadata) overrides.metadata = bc.metadata
+      if (bc.text_classification) overrides.text_classification = bc.text_classification
+      if (bc.page_sectioning) overrides.page_sectioning = bc.page_sectioning
+      if (bc.web_rendering) overrides.web_rendering = bc.web_rendering
+    }
+
+    return overrides
+  }
+
+  const handleSave = () => {
+    const overrides = buildOverrides()
+    updateConfig.mutate(
+      { label, config: overrides },
+      {
+        onSuccess: () => {
+          setConfigDirty(false)
+          onOpenChange(false)
+        },
+      }
+    )
+  }
+
+  const handleSaveAndRebuild = () => {
+    if (!confirmingRebuild) {
+      setConfirmingRebuild(true)
+      return
+    }
+    const overrides = buildOverrides()
+    updateConfig.mutate(
+      { label, config: overrides },
+      {
+        onSuccess: () => {
+          setConfigDirty(false)
+          setConfirmingRebuild(false)
+          onOpenChange(false)
+          onRebuild()
+        },
+      }
+    )
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="flex flex-col overflow-hidden sm:max-w-md">
+        <SheetHeader>
+          <SheetTitle>Storyboard Settings</SheetTitle>
+          <SheetDescription>
+            Adjust rendering settings for this book. Changes affect future pipeline runs.
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="flex-1 overflow-y-auto space-y-5 py-4">
+          {/* Pruned Text Types */}
+          <div>
+            <h4 className="mb-2 text-xs font-medium text-muted-foreground uppercase tracking-wider">
+              Pruned Text Types
+            </h4>
+            <p className="mb-2 text-xs text-muted-foreground">
+              Pruned types are excluded from rendering.
+            </p>
+            <div className="flex flex-wrap gap-1.5">
+              {ALL_TEXT_TYPES.map((t) => {
+                const pruned = effectivePrunedTextTypes.has(t)
+                return (
+                  <Badge
+                    key={t}
+                    variant={pruned ? "default" : "outline"}
+                    className="cursor-pointer text-xs"
+                    onClick={() => togglePrunedText(t)}
+                  >
+                    {t.replace(/_/g, " ")}
+                  </Badge>
+                )
+              })}
+            </div>
+          </div>
+
+          {/* Pruned Section Types */}
+          <div>
+            <h4 className="mb-2 text-xs font-medium text-muted-foreground uppercase tracking-wider">
+              Pruned Section Types
+            </h4>
+            <div className="flex flex-wrap gap-1.5">
+              {ALL_SECTION_TYPES.map((t) => {
+                const pruned = effectivePrunedSectionTypes.has(t)
+                return (
+                  <Badge
+                    key={t}
+                    variant={pruned ? "default" : "outline"}
+                    className="cursor-pointer text-xs"
+                    onClick={() => togglePrunedSection(t)}
+                  >
+                    {t.replace(/_/g, " ")}
+                  </Badge>
+                )
+              })}
+            </div>
+          </div>
+
+          {/* Image Filters */}
+          <div>
+            <h4 className="mb-2 text-xs font-medium text-muted-foreground uppercase tracking-wider">
+              Image Filters
+            </h4>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1">
+                <Label className="text-xs">Min Side (px)</Label>
+                <Input
+                  type="number"
+                  min={1}
+                  value={minSide}
+                  onChange={(e) => { setMinSide(e.target.value); setConfigDirty(true) }}
+                  placeholder="100"
+                  className="w-24"
+                />
+              </div>
+              <div className="space-y-1">
+                <Label className="text-xs">Max Side (px)</Label>
+                <Input
+                  type="number"
+                  min={1}
+                  value={maxSide}
+                  onChange={(e) => { setMaxSide(e.target.value); setConfigDirty(true) }}
+                  placeholder="5000"
+                  className="w-24"
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* Advanced link */}
+          <div className="pt-2 border-t">
+            <Link
+              to="/books/$label"
+              params={{ label }}
+              search={{ autoRun: undefined, startPage: undefined, endPage: undefined }}
+              className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+            >
+              Advanced settings
+              <ExternalLink className="h-3 w-3" />
+            </Link>
+          </div>
+        </div>
+
+        <SheetFooter className="border-t pt-4">
+          {pageCount != null && pageCount > 0 && (
+            <p className="text-xs text-amber-700 mb-2">
+              Rebuilding will re-render all {pageCount} pages with the updated settings.
+            </p>
+          )}
+          <div className="flex w-full items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleSave}
+              disabled={updateConfig.isPending}
+            >
+              <Save className="mr-1.5 h-3 w-3" />
+              {updateConfig.isPending ? "Saving..." : "Save"}
+            </Button>
+            <Button
+              size="sm"
+              onClick={handleSaveAndRebuild}
+              disabled={updateConfig.isPending || isRebuilding}
+              variant={confirmingRebuild ? "destructive" : "default"}
+            >
+              <Play className="mr-1.5 h-3 w-3" />
+              {confirmingRebuild ? "Confirm Rebuild" : "Save & Rebuild"}
+            </Button>
+            {confirmingRebuild && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setConfirmingRebuild(false)}
+              >
+                Cancel
+              </Button>
+            )}
+          </div>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/apps/studio/src/components/ui/sheet.tsx
+++ b/apps/studio/src/components/ui/sheet.tsx
@@ -1,0 +1,131 @@
+import * as React from "react"
+import * as SheetPrimitive from "@radix-ui/react-dialog"
+import { X } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+const Sheet = SheetPrimitive.Root
+
+const SheetTrigger = SheetPrimitive.Trigger
+
+const SheetClose = SheetPrimitive.Close
+
+const SheetPortal = SheetPrimitive.Portal
+
+const SheetOverlay = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+))
+SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
+
+interface SheetContentProps
+  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content> {
+  side?: "top" | "bottom" | "left" | "right"
+}
+
+const sheetVariants = {
+  top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+  bottom:
+    "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+  left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+  right:
+    "inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+}
+
+const SheetContent = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Content>,
+  SheetContentProps
+>(({ side = "right", className, children, ...props }, ref) => (
+  <SheetPortal>
+    <SheetOverlay />
+    <SheetPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out",
+        sheetVariants[side],
+        className
+      )}
+      {...props}
+    >
+      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </SheetPrimitive.Close>
+      {children}
+    </SheetPrimitive.Content>
+  </SheetPortal>
+))
+SheetContent.displayName = SheetPrimitive.Content.displayName
+
+const SheetHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+SheetHeader.displayName = "SheetHeader"
+
+const SheetFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+SheetFooter.displayName = "SheetFooter"
+
+const SheetTitle = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold text-foreground", className)}
+    {...props}
+  />
+))
+SheetTitle.displayName = SheetPrimitive.Title.displayName
+
+const SheetDescription = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+SheetDescription.displayName = SheetPrimitive.Description.displayName
+
+export {
+  Sheet,
+  SheetPortal,
+  SheetOverlay,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+}

--- a/apps/studio/src/hooks/use-guide-dismissed.ts
+++ b/apps/studio/src/hooks/use-guide-dismissed.ts
@@ -1,0 +1,28 @@
+import { useState, useCallback } from "react"
+
+/**
+ * Hook to track whether a guide/tutorial has been dismissed via localStorage.
+ * Returns [isDismissed, dismiss] — call dismiss() to permanently hide.
+ */
+export function useGuideDismissed(key: string): [boolean, () => void] {
+  const storageKey = `adt-studio-guide-${key}-dismissed`
+
+  const [isDismissed, setIsDismissed] = useState<boolean>(() => {
+    try {
+      return localStorage.getItem(storageKey) === "1"
+    } catch {
+      return false
+    }
+  })
+
+  const dismiss = useCallback(() => {
+    setIsDismissed(true)
+    try {
+      localStorage.setItem(storageKey, "1")
+    } catch {
+      // localStorage unavailable
+    }
+  }, [storageKey])
+
+  return [isDismissed, dismiss]
+}

--- a/apps/studio/src/hooks/use-pipeline.ts
+++ b/apps/studio/src/hooks/use-pipeline.ts
@@ -135,6 +135,7 @@ export function usePipelineSSE(label: string, enabled: boolean) {
       }))
       queryClient.invalidateQueries({ queryKey: ["books", label] })
       queryClient.invalidateQueries({ queryKey: ["books"] })
+      queryClient.invalidateQueries({ queryKey: ["books", label, "pages"] })
       queryClient.invalidateQueries({ queryKey: ["debug"] })
       es.close()
     })
@@ -183,6 +184,7 @@ export function usePipelineSSE(label: string, enabled: boolean) {
           })
           queryClient.invalidateQueries({ queryKey: ["books", label] })
           queryClient.invalidateQueries({ queryKey: ["books"] })
+          queryClient.invalidateQueries({ queryKey: ["books", label, "pages"] })
           es.close()
           clearInterval(pollInterval)
         } else if (status.status === "failed") {

--- a/apps/studio/src/lib/config-constants.ts
+++ b/apps/studio/src/lib/config-constants.ts
@@ -1,0 +1,17 @@
+export const ALL_TEXT_TYPES = [
+  "book_title", "book_subtitle", "book_author", "book_metadata",
+  "section_heading", "section_text", "instruction_text",
+  "activity_number", "activity_title", "activity_option",
+  "activity_input_placeholder_text", "fill_in_the_blank",
+  "image_associated_text", "image_overlay", "math",
+  "standalone_text", "header_text", "footer_text", "page_number", "other",
+]
+
+export const ALL_SECTION_TYPES = [
+  "front_cover", "inside_cover", "back_cover", "separator", "credits",
+  "foreword", "table_of_contents", "boxed_text",
+  "text_only", "text_and_single_image", "text_and_images", "images_only",
+  "activity_matching", "activity_fill_in_a_table", "activity_multiple_choice",
+  "activity_true_false", "activity_open_ended_answer",
+  "activity_fill_in_the_blank", "activity_sorting", "other",
+]

--- a/apps/studio/src/routes/books.$label.index.tsx
+++ b/apps/studio/src/routes/books.$label.index.tsx
@@ -31,7 +31,7 @@ function BookDetailPage() {
   const { autoRun, startPage: searchStartPage, endPage: searchEndPage } = Route.useSearch()
   const navigate = useNavigate()
   const { data: book, isLoading, error } = useBook(label)
-  const { apiKey, setApiKey, hasApiKey } = useApiKey()
+  const { apiKey, hasApiKey } = useApiKey()
 
   const runPipeline = useRunPipeline()
   const [sseEnabled, setSseEnabled] = useState(false)
@@ -83,7 +83,7 @@ function BookDetailPage() {
     )
   }, [autoRun, hasApiKey, book, label, apiKey, searchStartPage, searchEndPage, navigate, reset, runPipeline])
 
-  const handleRun = (options: { startPage?: number; endPage?: number; concurrency?: number }) => {
+  const handleRun = (options: { startPage?: number; endPage?: number }) => {
     reset()
     setSseEnabled(true)
 
@@ -134,7 +134,7 @@ function BookDetailPage() {
           </Badge>
         )}
         {book.pageCount > 0 && (
-          <Link to="/books/$label/storyboard" params={{ label }}>
+          <Link to="/books/$label/storyboard" params={{ label }} search={{ page: undefined }}>
             <Button variant="outline" size="sm">
               <LayoutGrid className="mr-2 h-4 w-4" />
               Storyboard
@@ -223,12 +223,28 @@ function BookDetailPage() {
             isRunning={progress.isRunning}
             isPipelineStarting={runPipeline.isPending}
             hasApiKey={hasApiKey}
-            apiKey={apiKey}
-            onApiKeyChange={setApiKey}
             pageCount={book.pageCount}
           />
         )}
       </div>
+
+      {/* Review Storyboard CTA */}
+      {progress.isComplete && (
+        <Card className="border-green-200 bg-green-50/50">
+          <CardContent className="flex items-center justify-between py-3">
+            <div>
+              <p className="text-sm font-medium">Pipeline complete</p>
+              <p className="text-xs text-muted-foreground">Review the generated storyboard</p>
+            </div>
+            <Link to="/books/$label/storyboard" params={{ label }} search={{ page: undefined }}>
+              <Button size="sm">
+                <LayoutGrid className="mr-1.5 h-4 w-4" />
+                Review Storyboard
+              </Button>
+            </Link>
+          </CardContent>
+        </Card>
+      )}
 
       {/* Full-width page preview grid */}
       {(progress.isRunning || progress.isComplete || book.pageCount > 0) && (

--- a/apps/studio/src/routes/books.$label.pages.$pageId.tsx
+++ b/apps/studio/src/routes/books.$label.pages.$pageId.tsx
@@ -1,7 +1,6 @@
 import { createFileRoute, useNavigate, Link } from "@tanstack/react-router"
-import { useState, useCallback, useEffect, useMemo, useRef } from "react"
-import { ArrowLeft, ArrowRight, FileText, Image, Layers, Loader2, AlertCircle, ImageOff } from "lucide-react"
-import DOMPurify from "dompurify"
+import { useState, useCallback, useEffect } from "react"
+import { ArrowLeft, ArrowRight, FileText, Image, Layers, Loader2, AlertCircle, CheckCircle2, ImageOff, X } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
@@ -9,88 +8,15 @@ import { usePage, usePageImage, usePages } from "@/hooks/use-pages"
 import { EditToolbar } from "@/components/page-edit/EditToolbar"
 import { TextGroupEditor } from "@/components/page-edit/TextGroupEditor"
 import { ImagePruningEditor } from "@/components/page-edit/ImagePruningEditor"
+import { RenderedHtml } from "@/components/storyboard/RenderedHtml"
 import { useSaveTextClassification, useSaveImageClassification, useReRenderPage } from "@/hooks/use-page-mutations"
 import { useApiKey } from "@/hooks/use-api-key"
+import { useGuideDismissed } from "@/hooks/use-guide-dismissed"
 import type { PageDetail } from "@/api/client"
 
 export const Route = createFileRoute("/books/$label/pages/$pageId")({
   component: PageDetailPage,
 })
-
-/**
- * Renders HTML content and gracefully handles broken images by replacing
- * them with a styled placeholder showing the alt text.
- */
-function RenderedHtml({ html, className }: { html: string; className?: string }) {
-  const ref = useRef<HTMLDivElement>(null)
-  const sanitizedHtml = useMemo(
-    () => DOMPurify.sanitize(html),
-    [html]
-  )
-
-  useEffect(() => {
-    if (!ref.current) return
-
-    // Strip inline font-family from all elements so the app font is used consistently
-    const allEls = ref.current.querySelectorAll("*")
-    for (const el of allEls) {
-      if (el instanceof HTMLElement && el.style.fontFamily) {
-        el.style.fontFamily = ""
-      }
-    }
-
-    const imgs = ref.current.querySelectorAll("img")
-    for (const img of imgs) {
-      img.onerror = () => {
-        const placeholder = document.createElement("div")
-        placeholder.style.cssText =
-          "display:flex;flex-direction:column;align-items:center;justify-content:center;gap:8px;" +
-          "min-height:120px;padding:16px;border-radius:8px;" +
-          "border:2px dashed #d1d5db;background:#f9fafb;"
-
-        // Icon (SVG inline since we can't use React components here)
-        const icon = document.createElementNS("http://www.w3.org/2000/svg", "svg")
-        icon.setAttribute("width", "32")
-        icon.setAttribute("height", "32")
-        icon.setAttribute("viewBox", "0 0 24 24")
-        icon.setAttribute("fill", "none")
-        icon.setAttribute("stroke", "#9ca3af")
-        icon.setAttribute("stroke-width", "1.5")
-        icon.innerHTML =
-          '<rect x="3" y="3" width="18" height="18" rx="2"/>' +
-          '<circle cx="9" cy="9" r="2"/>' +
-          '<path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"/>' +
-          '<line x1="2" y1="2" x2="22" y2="22" stroke="#ef4444" stroke-width="2"/>'
-        placeholder.appendChild(icon)
-
-        // Alt text label
-        if (img.alt) {
-          const label = document.createElement("span")
-          label.style.cssText = "font-size:13px;font-weight:500;color:#6b7280;text-align:center;"
-          label.textContent = img.alt
-          placeholder.appendChild(label)
-        }
-
-        // Error detail with src path
-        const detail = document.createElement("span")
-        detail.style.cssText = "font-size:11px;color:#9ca3af;text-align:center;word-break:break-all;max-width:100%;"
-        const src = img.getAttribute("src") || ""
-        detail.textContent = src ? `Image not found: ${src}` : "Image source unavailable"
-        placeholder.appendChild(detail)
-
-        img.replaceWith(placeholder)
-      }
-    }
-  }, [sanitizedHtml])
-
-  return (
-    <div
-      ref={ref}
-      className={className}
-      dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
-    />
-  )
-}
 
 function PageDetailPage() {
   const { label, pageId } = Route.useParams()
@@ -100,6 +26,7 @@ function PageDetailPage() {
   const { data: allPages } = usePages(label)
 
   const { apiKey, hasApiKey } = useApiKey()
+  const [pageGuideDismissed, dismissPageGuide] = useGuideDismissed("page-edit")
   const [isEditing, setIsEditing] = useState(false)
   const [editedGroups, setEditedGroups] = useState<PageDetail["textClassification"]>(null)
   const [editedImages, setEditedImages] = useState<PageDetail["imageClassification"]>(null)
@@ -146,6 +73,20 @@ function PageDetailPage() {
     }
   }, [apiKey, hasApiKey, reRender])
 
+  const [isSaveAndReRendering, setIsSaveAndReRendering] = useState(false)
+
+  const handleSaveAndReRender = useCallback(async () => {
+    setIsSaveAndReRendering(true)
+    try {
+      await handleSave()
+      if (hasApiKey) {
+        reRender.mutate(apiKey)
+      }
+    } finally {
+      setIsSaveAndReRendering(false)
+    }
+  }, [handleSave, apiKey, hasApiKey, reRender])
+
   const hasChanges =
     (editedGroups && JSON.stringify(editedGroups) !== JSON.stringify(page?.textClassification)) ||
     (editedImages && JSON.stringify(editedImages) !== JSON.stringify(page?.imageClassification)) ||
@@ -183,12 +124,11 @@ function PageDetailPage() {
       {/* Compact header: breadcrumb + nav + toolbar in one row */}
       <div className="flex shrink-0 items-center justify-between border-b px-4 py-1.5">
         <div className="flex items-center gap-2">
-          <Link to="/" className="text-xs text-muted-foreground hover:text-foreground transition-colors shrink-0">
-            ADT Studio
-          </Link>
-          <span className="text-muted-foreground/50 text-xs">/</span>
-          <Link to="/books/$label" params={{ label }} search={{ autoRun: undefined, startPage: undefined, endPage: undefined }} className="text-xs text-muted-foreground hover:text-foreground transition-colors shrink-0">
-            {label}
+          <Link to="/books/$label/storyboard" params={{ label }} search={{ page: pageId }}>
+            <Button variant="ghost" size="sm" className="h-7 px-2">
+              <ArrowLeft className="mr-1 h-3 w-3" />
+              Storyboard
+            </Button>
           </Link>
           <span className="text-muted-foreground/50 text-xs">/</span>
           <span className="text-sm font-semibold">Page {page.pageNumber}</span>
@@ -230,12 +170,25 @@ function PageDetailPage() {
           isReRendering={reRender.isPending}
           hasApiKey={hasApiKey}
           hasRenderingData={!!page.textClassification}
+          isSaveAndReRendering={isSaveAndReRendering}
           onEdit={handleEdit}
           onSave={handleSave}
           onCancel={handleCancel}
           onReRender={handleReRender}
+          onSaveAndReRender={handleSaveAndReRender}
         />
       </div>
+
+      {/* Success banner */}
+      {reRender.isSuccess && (
+        <div className="flex shrink-0 items-center gap-2 border-b bg-green-50 px-4 py-2 text-sm text-green-800">
+          <CheckCircle2 className="h-4 w-4 shrink-0" />
+          <span className="flex-1">Page re-rendered successfully.</span>
+          <Button variant="ghost" size="sm" onClick={() => reRender.reset()}>
+            Dismiss
+          </Button>
+        </div>
+      )}
 
       {/* Error banner */}
       {reRender.error && (
@@ -258,6 +211,27 @@ function PageDetailPage() {
             {isEditing && <Badge variant="secondary" className="text-xs">Editing</Badge>}
           </div>
           <div className="flex-1 overflow-auto p-4">
+            {/* Workflow hint card — view mode only */}
+            {!isEditing && !pageGuideDismissed && (
+              <div className="mb-4 rounded-lg border border-blue-200 bg-blue-50/50 p-3">
+                <div className="mb-1 flex items-center justify-between">
+                  <p className="text-xs font-medium text-blue-900">Editing workflow</p>
+                  <button
+                    type="button"
+                    onClick={dismissPageGuide}
+                    className="rounded p-0.5 text-blue-400 hover:text-blue-600"
+                  >
+                    <X className="h-3 w-3" />
+                  </button>
+                </div>
+                <ol className="list-inside list-decimal space-y-0.5 text-xs text-blue-800">
+                  <li>Click <strong>Edit Text & Images</strong> to modify inputs</li>
+                  <li><strong>Save</strong> your changes</li>
+                  <li>Click <strong>Re-render</strong> to regenerate this page</li>
+                </ol>
+              </div>
+            )}
+
             {/* Text classification */}
             {isEditing && editedGroups ? (
               <div className="mb-6">

--- a/apps/studio/src/routes/books.$label.storyboard.tsx
+++ b/apps/studio/src/routes/books.$label.storyboard.tsx
@@ -1,20 +1,210 @@
 import { createFileRoute, Link } from "@tanstack/react-router"
-import { Grid, List } from "lucide-react"
-import { useState } from "react"
+import { useState, useMemo, useEffect, useCallback, useRef } from "react"
+import { Check, Clock, CheckCircle2, ChevronLeft, ChevronRight, ImageOff, Loader2, ExternalLink, RefreshCw, Settings2, AlertCircle, HelpCircle, Lightbulb, BookOpen } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
 import { useBook } from "@/hooks/use-books"
-import { usePages } from "@/hooks/use-pages"
-import { StoryboardGrid } from "@/components/storyboard/StoryboardGrid"
+import { usePages, usePage, usePageImage } from "@/hooks/use-pages"
+import { usePipelineSSE, usePipelineStatus, useRunPipeline } from "@/hooks/use-pipeline"
+import { useApiKey } from "@/hooks/use-api-key"
+import { useReRenderPage } from "@/hooks/use-page-mutations"
+import { STEP_LABELS } from "@/components/pipeline/StepIndicator"
+import { RenderedHtml } from "@/components/storyboard/RenderedHtml"
+import { StoryboardSettingsSheet } from "@/components/storyboard/StoryboardSettingsSheet"
+import { AcceptStoryboardDialog } from "@/components/storyboard/AcceptStoryboardDialog"
+import { StoryboardGuideDialog } from "@/components/storyboard/StoryboardGuideDialog"
+import { useGuideDismissed } from "@/hooks/use-guide-dismissed"
+import type { StepName } from "@/hooks/use-pipeline"
 
 export const Route = createFileRoute("/books/$label/storyboard")({
   component: StoryboardPage,
+  validateSearch: (search: Record<string, unknown>) => ({
+    page: typeof search.page === "string" ? search.page : undefined,
+  }),
 })
+
+type Filter = "all" | "rendered" | "pending"
+
+function MiniPageCard({
+  label,
+  pageId,
+  pageNumber,
+  textPreview,
+  hasRendering,
+  isSelected,
+  onClick,
+}: {
+  label: string
+  pageId: string
+  pageNumber: number
+  textPreview: string
+  hasRendering: boolean
+  isSelected: boolean
+  onClick: () => void
+}) {
+  const { data: imageData } = usePageImage(label, pageId)
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`flex w-full items-center gap-2.5 px-3 py-2 text-left transition-colors cursor-pointer ${
+        isSelected
+          ? "bg-primary/5 border-l-2 border-l-primary"
+          : "border-l-2 border-l-transparent hover:bg-muted/50"
+      }`}
+    >
+      <div className="h-12 w-9 shrink-0 overflow-hidden rounded bg-muted">
+        {imageData ? (
+          <img
+            src={`data:image/png;base64,${imageData.imageBase64}`}
+            alt={`Page ${pageNumber}`}
+            className="h-full w-full object-cover"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center text-[10px] text-muted-foreground">
+            {pageNumber}
+          </div>
+        )}
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="text-xs font-medium">Page {pageNumber}</div>
+        {textPreview && (
+          <div className="text-xs text-muted-foreground truncate">
+            {textPreview}
+          </div>
+        )}
+      </div>
+      <div className="shrink-0">
+        {hasRendering ? (
+          <Check className="h-3.5 w-3.5 text-green-600" />
+        ) : (
+          <Clock className="h-3.5 w-3.5 text-muted-foreground" />
+        )}
+      </div>
+    </button>
+  )
+}
 
 function StoryboardPage() {
   const { label } = Route.useParams()
+  const { page: initialPageId } = Route.useSearch()
   const { data: book } = useBook(label)
   const { data: pages, isLoading, error } = usePages(label)
-  const [viewMode, setViewMode] = useState<"grid" | "list">("grid")
+
+  const { apiKey, hasApiKey } = useApiKey()
+  const runPipeline = useRunPipeline()
+  const [sseEnabled, setSseEnabled] = useState(false)
+  const { progress, reset } = usePipelineSSE(label, sseEnabled)
+  const { data: pipelineStatus } = usePipelineStatus(label)
+
+  const [selectedPageId, setSelectedPageId] = useState<string | null>(null)
+  const [filter, setFilter] = useState<Filter>("all")
+  const [settingsOpen, setSettingsOpen] = useState(false)
+  const [acceptDialogOpen, setAcceptDialogOpen] = useState(false)
+  const [guideDismissed, dismissGuide] = useGuideDismissed("storyboard")
+  const [guideOpen, setGuideOpen] = useState(!guideDismissed)
+
+  // Track whether we've consumed the initial page search param
+  const initialPageConsumed = useRef(false)
+
+  // Auto-reconnect to SSE if pipeline is already running
+  useEffect(() => {
+    if (pipelineStatus?.status === "running" && !sseEnabled) {
+      setSseEnabled(true)
+    }
+  }, [pipelineStatus?.status, sseEnabled])
+
+  const handleRebuild = useCallback(() => {
+    if (!hasApiKey) return
+    reset()
+    setSseEnabled(true)
+    runPipeline.mutate(
+      { label, apiKey },
+      {
+        onError: () => {
+          setSseEnabled(false)
+        },
+      }
+    )
+  }, [label, apiKey, hasApiKey, reset, runPipeline])
+
+  const filteredPages = useMemo(() => {
+    if (!pages) return []
+    switch (filter) {
+      case "rendered":
+        return pages.filter((p) => p.hasRendering)
+      case "pending":
+        return pages.filter((p) => !p.hasRendering)
+      default:
+        return pages
+    }
+  }, [pages, filter])
+
+  const renderedCount = useMemo(
+    () => pages?.filter((p) => p.hasRendering).length ?? 0,
+    [pages]
+  )
+  const totalCount = pages?.length ?? 0
+  const pendingCount = totalCount - renderedCount
+
+  const canAccept = renderedCount > 0 && renderedCount === totalCount && !progress.isRunning
+
+  // Auto-select page: prefer initialPageId from search param, then first page
+  useEffect(() => {
+    if (filteredPages.length === 0) {
+      setSelectedPageId(null)
+      return
+    }
+
+    // Use search param page on first load
+    if (initialPageId && !initialPageConsumed.current) {
+      const found = filteredPages.some((p) => p.pageId === initialPageId)
+      if (found) {
+        setSelectedPageId(initialPageId)
+        initialPageConsumed.current = true
+        return
+      }
+    }
+
+    const currentStillVisible = selectedPageId && filteredPages.some((p) => p.pageId === selectedPageId)
+    if (!currentStillVisible) {
+      setSelectedPageId(filteredPages[0].pageId)
+    }
+  }, [filteredPages, selectedPageId, initialPageId])
+
+  // Keyboard navigation
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      const tag = (e.target as HTMLElement).tagName
+      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return
+
+      if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+        e.preventDefault()
+        const idx = filteredPages.findIndex((p) => p.pageId === selectedPageId)
+        if (idx > 0) setSelectedPageId(filteredPages[idx - 1].pageId)
+      } else if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+        e.preventDefault()
+        const idx = filteredPages.findIndex((p) => p.pageId === selectedPageId)
+        if (idx < filteredPages.length - 1) setSelectedPageId(filteredPages[idx + 1].pageId)
+      }
+    },
+    [filteredPages, selectedPageId]
+  )
+
+  useEffect(() => {
+    window.addEventListener("keydown", handleKeyDown)
+    return () => window.removeEventListener("keydown", handleKeyDown)
+  }, [handleKeyDown])
+
+  const selectedIndex = filteredPages.findIndex((p) => p.pageId === selectedPageId)
+  const hasPrev = selectedIndex > 0
+  const hasNext = selectedIndex < filteredPages.length - 1
+
+  // Current step label for rebuild banner
+  const currentStepLabel = progress.currentStep
+    ? STEP_LABELS[progress.currentStep as StepName] ?? progress.currentStep
+    : null
 
   if (isLoading) {
     return <div className="p-4 text-muted-foreground">Loading pages...</div>
@@ -29,46 +219,347 @@ function StoryboardPage() {
   }
 
   return (
-    <div className="p-4">
-      <div className="mb-3 flex items-center justify-between">
+    <div className="flex flex-1 min-h-0 flex-col">
+      {/* Header */}
+      <div className="flex shrink-0 items-center justify-between border-b px-4 py-2">
         <div className="flex items-center gap-2">
-          <Link to="/" className="text-sm text-muted-foreground hover:text-foreground transition-colors shrink-0">
+          <Link to="/" className="text-xs text-muted-foreground hover:text-foreground transition-colors shrink-0">
             ADT Studio
           </Link>
-          <span className="text-muted-foreground/50">/</span>
-          <Link to="/books/$label" params={{ label }} search={{ autoRun: undefined, startPage: undefined, endPage: undefined }} className="text-sm text-muted-foreground hover:text-foreground transition-colors shrink-0">
+          <span className="text-muted-foreground/50 text-xs">/</span>
+          <Link to="/books/$label" params={{ label }} search={{ autoRun: undefined, startPage: undefined, endPage: undefined }} className="text-xs text-muted-foreground hover:text-foreground transition-colors shrink-0">
             {book?.title ?? label}
           </Link>
-          <span className="text-muted-foreground/50">/</span>
-          <h1 className="text-lg font-semibold">Storyboard</h1>
-          <span className="text-xs text-muted-foreground ml-1">
-            {pages?.length ?? 0} pages
-            {pages && ` (${pages.filter((p) => p.hasRendering).length} rendered)`}
-          </span>
+          <span className="text-muted-foreground/50 text-xs">/</span>
+          <span className="text-sm font-semibold">Storyboard Review</span>
         </div>
-        <div className="flex gap-1 rounded-md border p-0.5">
+        <div className="flex items-center gap-2">
           <Button
-            variant={viewMode === "grid" ? "secondary" : "ghost"}
+            variant="ghost"
             size="sm"
-            onClick={() => setViewMode("grid")}
+            className="h-8 w-8 p-0"
+            onClick={() => setGuideOpen(true)}
+            title="Show guide"
           >
-            <Grid className="h-4 w-4" />
+            <HelpCircle className="h-4 w-4" />
           </Button>
           <Button
-            variant={viewMode === "list" ? "secondary" : "ghost"}
+            variant="outline"
             size="sm"
-            onClick={() => setViewMode("list")}
+            onClick={() => setSettingsOpen(true)}
           >
-            <List className="h-4 w-4" />
+            <Settings2 className="mr-1.5 h-4 w-4" />
+            Settings
+          </Button>
+          <Button
+            size="sm"
+            disabled={!canAccept}
+            onClick={() => setAcceptDialogOpen(true)}
+          >
+            <CheckCircle2 className="mr-1.5 h-4 w-4" />
+            Accept Storyboard
+            {pendingCount > 0 && (
+              <Badge variant="secondary" className="ml-1.5 text-[10px]">
+                {pendingCount} pending
+              </Badge>
+            )}
           </Button>
         </div>
       </div>
 
-      <StoryboardGrid
+      {/* Rebuild progress banner */}
+      {progress.isRunning && (
+        <div className="flex shrink-0 items-center gap-2 border-b bg-blue-50 px-4 py-2 text-sm text-blue-800">
+          <Loader2 className="h-4 w-4 animate-spin shrink-0" />
+          <span className="flex-1">
+            Rebuilding storyboard{currentStepLabel ? ` \u2014 ${currentStepLabel}` : ""}...
+          </span>
+        </div>
+      )}
+      {progress.error && !progress.isRunning && (
+        <div className="flex shrink-0 items-center gap-2 border-b bg-destructive/10 px-4 py-2 text-sm text-destructive">
+          <AlertCircle className="h-4 w-4 shrink-0" />
+          <span className="flex-1">Rebuild failed: {progress.error}</span>
+        </div>
+      )}
+
+      {/* Two-panel layout */}
+      <div className="flex flex-1 min-h-0">
+        {/* Sidebar */}
+        <div className="flex w-[272px] shrink-0 flex-col border-r">
+          {/* Progress bar */}
+          <div className="shrink-0 border-b bg-muted/30 px-3 py-2">
+            <div className="flex items-center justify-between text-xs text-muted-foreground mb-1">
+              <span>{renderedCount} of {totalCount} rendered</span>
+              <span>{totalCount > 0 ? Math.round((renderedCount / totalCount) * 100) : 0}%</span>
+            </div>
+            <div className="h-1 w-full rounded-full bg-muted">
+              <div
+                className="h-1 rounded-full bg-green-600 transition-all"
+                style={{ width: totalCount > 0 ? `${(renderedCount / totalCount) * 100}%` : "0%" }}
+              />
+            </div>
+          </div>
+
+          {/* Filter chips */}
+          <div className="flex shrink-0 gap-1 border-b px-3 py-2">
+            <Button
+              variant={filter === "all" ? "secondary" : "ghost"}
+              size="sm"
+              className="h-7 text-xs"
+              onClick={() => setFilter("all")}
+            >
+              All ({totalCount})
+            </Button>
+            <Button
+              variant={filter === "rendered" ? "secondary" : "ghost"}
+              size="sm"
+              className="h-7 text-xs"
+              onClick={() => setFilter("rendered")}
+            >
+              Rendered ({renderedCount})
+            </Button>
+            <Button
+              variant={filter === "pending" ? "secondary" : "ghost"}
+              size="sm"
+              className="h-7 text-xs"
+              onClick={() => setFilter("pending")}
+            >
+              Pending ({pendingCount})
+            </Button>
+          </div>
+
+          {/* Page list */}
+          <div className="flex-1 overflow-y-auto">
+            {filteredPages.map((page) => (
+              <MiniPageCard
+                key={page.pageId}
+                label={label}
+                pageId={page.pageId}
+                pageNumber={page.pageNumber}
+                textPreview={page.textPreview}
+                hasRendering={page.hasRendering}
+                isSelected={page.pageId === selectedPageId}
+                onClick={() => setSelectedPageId(page.pageId)}
+              />
+            ))}
+            {filteredPages.length === 0 && (
+              <div className="px-3 py-6 text-center text-xs text-muted-foreground">
+                No pages match this filter.
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Preview panel */}
+        <div className="flex flex-1 min-w-0 flex-col">
+          {selectedPageId ? (
+            <PreviewPanel
+              label={label}
+              pageId={selectedPageId}
+              hasPrev={hasPrev}
+              hasNext={hasNext}
+              onPrev={() => hasPrev && setSelectedPageId(filteredPages[selectedIndex - 1].pageId)}
+              onNext={() => hasNext && setSelectedPageId(filteredPages[selectedIndex + 1].pageId)}
+            />
+          ) : (
+            <div className="flex flex-1 items-center justify-center">
+              {totalCount === 0 ? (
+                <div className="flex flex-col items-center gap-3 text-center">
+                  <BookOpen className="h-10 w-10 text-muted-foreground/50" />
+                  <div>
+                    <p className="text-sm font-medium text-muted-foreground">No pages extracted yet</p>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      Run the pipeline from the{" "}
+                      <Link
+                        to="/books/$label"
+                        params={{ label }}
+                        search={{ autoRun: undefined, startPage: undefined, endPage: undefined }}
+                        className="underline hover:text-foreground"
+                      >
+                        book detail page
+                      </Link>{" "}
+                      to extract pages.
+                    </p>
+                  </div>
+                </div>
+              ) : (
+                <p className="text-sm text-muted-foreground">Select a page to preview.</p>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Settings Sheet */}
+      <StoryboardSettingsSheet
         label={label}
-        pages={pages ?? []}
-        viewMode={viewMode}
+        open={settingsOpen}
+        onOpenChange={setSettingsOpen}
+        onRebuild={handleRebuild}
+        isRebuilding={progress.isRunning || runPipeline.isPending}
+        pageCount={totalCount}
+      />
+
+      {/* Accept Dialog */}
+      <AcceptStoryboardDialog
+        open={acceptDialogOpen}
+        onOpenChange={setAcceptDialogOpen}
+        renderedCount={renderedCount}
+        totalCount={totalCount}
+        label={label}
+      />
+
+      {/* Guide Dialog */}
+      <StoryboardGuideDialog
+        open={guideOpen}
+        onOpenChange={(open) => {
+          setGuideOpen(open)
+          if (!open) dismissGuide()
+        }}
       />
     </div>
+  )
+}
+
+function PreviewPanel({
+  label,
+  pageId,
+  hasPrev,
+  hasNext,
+  onPrev,
+  onNext,
+}: {
+  label: string
+  pageId: string
+  hasPrev: boolean
+  hasNext: boolean
+  onPrev: () => void
+  onNext: () => void
+}) {
+  const { data: page, isLoading } = usePage(label, pageId)
+  const { apiKey, hasApiKey } = useApiKey()
+  const reRender = useReRenderPage(label, pageId)
+
+  const combinedHtml = useMemo(
+    () => page?.rendering?.sections.map((s) => s.html).join("\n"),
+    [page]
+  )
+
+  const sectionCount = page?.rendering?.sections.length ?? 0
+  const hasRenderingData = !!page?.textClassification
+
+  const reRenderTitle = !hasApiKey
+    ? "Set your API key first"
+    : !hasRenderingData
+      ? "Run the pipeline first"
+      : reRender.isPending
+        ? "Re-rendering..."
+        : ""
+
+  return (
+    <>
+      {/* Preview header */}
+      <div className="flex shrink-0 items-center justify-between border-b px-5 py-2.5">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium">Page {page?.pageNumber ?? "..."}</span>
+          {sectionCount > 0 && (
+            <Badge variant="secondary" className="text-xs">{sectionCount} sections</Badge>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="flex gap-1">
+            <Button variant="outline" size="sm" disabled={!hasPrev} onClick={onPrev}>
+              <ChevronLeft className="h-3 w-3" />
+            </Button>
+            <Button variant="outline" size="sm" disabled={!hasNext} onClick={onNext}>
+              <ChevronRight className="h-3 w-3" />
+            </Button>
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => hasApiKey && reRender.mutate(apiKey)}
+            disabled={!hasApiKey || reRender.isPending || !hasRenderingData}
+            title={reRenderTitle}
+          >
+            {reRender.isPending ? (
+              <Loader2 className="mr-1.5 h-3 w-3 animate-spin" />
+            ) : (
+              <RefreshCw className="mr-1.5 h-3 w-3" />
+            )}
+            Re-render
+          </Button>
+          <Link to="/books/$label/pages/$pageId" params={{ label, pageId }}>
+            <Button variant="outline" size="sm">
+              Edit Page
+              <ExternalLink className="ml-1.5 h-3 w-3" />
+            </Button>
+          </Link>
+        </div>
+      </div>
+
+      {/* Success banner after re-render */}
+      {reRender.isSuccess && (
+        <div className="flex shrink-0 items-center gap-2 border-b bg-green-50 px-5 py-1.5 text-xs text-green-800">
+          <CheckCircle2 className="h-3 w-3 shrink-0" />
+          Page re-rendered successfully.
+        </div>
+      )}
+
+      {/* Error banner after re-render */}
+      {reRender.error && !reRender.isPending && (
+        <div className="flex shrink-0 items-center gap-2 border-b bg-destructive/10 px-5 py-1.5 text-xs text-destructive">
+          <AlertCircle className="h-3 w-3 shrink-0" />
+          Re-render failed: {reRender.error.message}
+        </div>
+      )}
+
+      {/* Inline hint */}
+      {combinedHtml && !reRender.isSuccess && (
+        <div className="flex shrink-0 items-center gap-2 border-b bg-muted/30 px-5 py-1.5 text-xs text-muted-foreground">
+          <Lightbulb className="h-3 w-3 shrink-0" />
+          Edit text and images on the <strong className="font-medium">Edit Page</strong>, or re-render directly from here.
+        </div>
+      )}
+
+      {/* Preview content */}
+      <div className="flex-1 overflow-auto p-6">
+        {isLoading ? (
+          <div className="flex h-full items-center justify-center">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </div>
+        ) : reRender.isPending ? (
+          <div className="flex h-full items-center justify-center">
+            <div className="flex flex-col items-center gap-2 text-muted-foreground">
+              <Loader2 className="h-6 w-6 animate-spin" />
+              <p className="text-sm">Re-rendering page...</p>
+            </div>
+          </div>
+        ) : combinedHtml ? (
+          <RenderedHtml
+            html={combinedHtml}
+            className="prose prose-sm max-w-none rounded-lg border bg-white p-6 shadow-sm"
+          />
+        ) : (
+          <div className="flex h-full flex-col items-center justify-center gap-2 text-muted-foreground">
+            <ImageOff className="h-8 w-8" />
+            <p className="text-sm font-medium">Not yet rendered</p>
+            <p className="text-xs text-center max-w-xs">
+              Open <strong className="font-medium">Settings → Save & Rebuild</strong> to run the pipeline, or go to the{" "}
+              <Link
+                to="/books/$label"
+                params={{ label }}
+                search={{ autoRun: undefined, startPage: undefined, endPage: undefined }}
+                className="underline hover:text-foreground"
+              >
+                book detail page
+              </Link>{" "}
+              for full pipeline controls.
+            </p>
+          </div>
+        )}
+      </div>
+    </>
   )
 }


### PR DESCRIPTION
## Summary

- **Storyboard review page**: Two-panel layout with page sidebar and rendered HTML preview, inline re-render button with success/error banners
- **Accept Storyboard**: Dialog with pending count badge showing how many pages still need rendering
- **Page edit UX**: "Back to Storyboard" button, "Save & Re-render" combined action, success banner after re-render
- **Disabled button tooltips**: All disabled buttons now explain why (no API key, no pipeline data, unsaved changes)
- **Settings sheet**: Rebuild warning showing how many pages will be affected, pruning controls for text/section types

## Test plan

- [ ] Storyboard: select a rendered page → see "Re-render" button in preview header
- [ ] Click Re-render → spinner → success banner appears
- [ ] Accept button shows "N pending" badge when not all pages are rendered
- [ ] Page edit: see "← Storyboard" button at top left, navigates back
- [ ] Edit mode: "Save & Re-render" button available when changes exist
- [ ] Click Save & Re-render → saves then re-renders, success banner appears
- [ ] Hover disabled buttons → tooltip explains why they're disabled
- [ ] Settings sheet: warning text before Save & Rebuild says "all N pages"
- [ ] `pnpm typecheck` — clean
- [ ] `pnpm vitest run` — 289 tests pass