### PR TITLE
Introduce UNICEF blue as primary brand color

### DIFF
--- a/apps/studio/src/components/debug/LlmLogsTab.tsx
+++ b/apps/studio/src/components/debug/LlmLogsTab.tsx
@@ -106,7 +106,7 @@ function StepTracker({ progress }: { progress: PipelineProgress }) {
               className={cn(
                 "flex items-center gap-1 rounded-full px-2.5 py-0.5 text-[11px] transition-colors",
                 completed && "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400",
-                running && "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400 font-medium",
+                running && "bg-primary/10 text-primary font-medium",
                 !completed && !running && "text-muted-foreground",
               )}
             >

--- a/apps/studio/src/components/pipeline/PagePreviewGrid.tsx
+++ b/apps/studio/src/components/pipeline/PagePreviewGrid.tsx
@@ -47,7 +47,7 @@ function MiniPageTile({ label, page }: { label: string; page: PageSummaryItem })
           <div className="mb-1 flex items-center gap-2">
             <span className="text-xs font-medium">Page {page.pageNumber}</span>
             {page.hasRendering && (
-              <Badge variant="default" className="px-1 py-0 text-[10px]">
+              <Badge variant="secondary" className="px-1 py-0 text-[10px] bg-green-100 text-green-700">
                 Rendered
               </Badge>
             )}

--- a/apps/studio/src/components/pipeline/StepIndicator.tsx
+++ b/apps/studio/src/components/pipeline/StepIndicator.tsx
@@ -37,7 +37,7 @@ function StepIcon({ state }: { state: StepState }) {
     case "completed":
       return <Check className="h-4 w-4 text-green-600" />
     case "active":
-      return <Loader2 className="h-4 w-4 animate-spin text-blue-600" />
+      return <Loader2 className="h-4 w-4 animate-spin text-primary" />
     case "error":
       return <AlertCircle className="h-4 w-4 text-destructive" />
     default:
@@ -78,7 +78,7 @@ export function StepIndicator({
     <div
       className={cn(
         "rounded-lg border p-3 transition-all",
-        state === "active" && "border-blue-200 bg-blue-50/50",
+        state === "active" && "border-primary/20 bg-primary/5",
         state === "completed" && "border-green-200 bg-green-50/30",
         state === "error" && "border-destructive/30 bg-destructive/5",
         state === "pending" && "border-border/50 bg-muted/20 opacity-60"
@@ -103,7 +103,7 @@ export function StepIndicator({
         <div
           className={cn(
             "h-full rounded-full transition-all duration-300",
-            state === "active" && "bg-blue-600",
+            state === "active" && "bg-primary",
             state === "completed" && "bg-green-500",
             state === "error" && "bg-destructive",
             state === "pending" && "bg-transparent"

--- a/apps/studio/src/components/storyboard/PageCard.tsx
+++ b/apps/studio/src/components/storyboard/PageCard.tsx
@@ -62,8 +62,8 @@ export function PageCard({
           )}
           <div className="absolute right-1 top-1">
             <Badge
-              variant={hasRendering ? "default" : "secondary"}
-              className="text-[10px] px-1.5 py-0"
+              variant="secondary"
+              className={cn("text-[10px] px-1.5 py-0", hasRendering && "bg-green-100 text-green-700")}
             >
               {hasRendering ? (
                 <Check className="mr-0.5 h-3 w-3" />

--- a/apps/studio/src/routes/books.$label.pages.$pageId.tsx
+++ b/apps/studio/src/routes/books.$label.pages.$pageId.tsx
@@ -205,7 +205,7 @@ function PageDetailPage() {
       <div className="grid min-h-0 flex-1 grid-cols-[1fr_1.2fr_1.2fr] gap-0 divide-x">
         {/* Left: Pipeline inputs (text classification + image classification) */}
         <div className="flex flex-col overflow-hidden">
-          <div className="flex shrink-0 items-center gap-2 border-b bg-muted/30 px-4 py-2">
+          <div className="flex shrink-0 items-center gap-2 border-b bg-muted/50 px-4 py-2">
             <FileText className="h-4 w-4 text-muted-foreground" />
             <span className="text-sm font-medium">Pipeline Inputs</span>
             {isEditing && <Badge variant="secondary" className="text-xs">Editing</Badge>}
@@ -213,18 +213,18 @@ function PageDetailPage() {
           <div className="flex-1 overflow-auto p-4">
             {/* Workflow hint card — view mode only */}
             {!isEditing && !pageGuideDismissed && (
-              <div className="mb-4 rounded-lg border border-blue-200 bg-blue-50/50 p-3">
+              <div className="mb-4 rounded-lg border border-primary/20 bg-primary/5 p-3">
                 <div className="mb-1 flex items-center justify-between">
-                  <p className="text-xs font-medium text-blue-900">Editing workflow</p>
+                  <p className="text-xs font-medium text-primary">Editing workflow</p>
                   <button
                     type="button"
                     onClick={dismissPageGuide}
-                    className="rounded p-0.5 text-blue-400 hover:text-blue-600"
+                    className="rounded p-0.5 text-primary/50 hover:text-primary"
                   >
                     <X className="h-3 w-3" />
                   </button>
                 </div>
-                <ol className="list-inside list-decimal space-y-0.5 text-xs text-blue-800">
+                <ol className="list-inside list-decimal space-y-0.5 text-xs text-foreground">
                   <li>Click <strong>Edit Text & Images</strong> to modify inputs</li>
                   <li><strong>Save</strong> your changes</li>
                   <li>Click <strong>Re-render</strong> to regenerate this page</li>
@@ -316,7 +316,7 @@ function PageDetailPage() {
 
         {/* Center: Pipeline Output — tabs for Preview vs By Section */}
         <Tabs defaultValue="preview" className="flex flex-col overflow-hidden">
-          <div className="flex shrink-0 items-center gap-2 border-b bg-muted/30 px-4 py-1.5">
+          <div className="flex shrink-0 items-center gap-2 border-b bg-muted/50 px-4 py-1.5">
             <Layers className="h-4 w-4 text-muted-foreground" />
             <span className="text-sm font-medium">Pipeline Output</span>
             {reRender.isPending && <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />}
@@ -411,7 +411,7 @@ function PageDetailPage() {
 
         {/* Right: Original page image */}
         <div className="flex flex-col overflow-hidden">
-          <div className="flex shrink-0 items-center gap-2 border-b bg-muted/30 px-4 py-2">
+          <div className="flex shrink-0 items-center gap-2 border-b bg-muted/50 px-4 py-2">
             <Image className="h-4 w-4 text-muted-foreground" />
             <span className="text-sm font-medium">Original Page</span>
           </div>

--- a/apps/studio/src/routes/books.$label.storyboard.tsx
+++ b/apps/studio/src/routes/books.$label.storyboard.tsx
@@ -269,7 +269,7 @@ function StoryboardPage() {
 
       {/* Rebuild progress banner */}
       {progress.isRunning && (
-        <div className="flex shrink-0 items-center gap-2 border-b bg-blue-50 px-4 py-2 text-sm text-blue-800">
+        <div className="flex shrink-0 items-center gap-2 border-b bg-primary/5 px-4 py-2 text-sm text-primary">
           <Loader2 className="h-4 w-4 animate-spin shrink-0" />
           <span className="flex-1">
             Rebuilding storyboard{currentStepLabel ? ` \u2014 ${currentStepLabel}` : ""}...

--- a/apps/studio/src/routes/index.tsx
+++ b/apps/studio/src/routes/index.tsx
@@ -80,7 +80,7 @@ function BookRow({
 }) {
   const hasMetadata = book.title || book.authors.length > 0
   return (
-    <div className="group rounded-xl border bg-card transition-all hover:shadow-md hover:border-primary/30">
+    <div className="group rounded-xl border bg-card transition-all duration-200 hover:shadow-md hover:border-primary/30 hover:-translate-y-0.5">
       <div className="flex items-stretch">
         {/* Main content — clickable */}
         <Link
@@ -220,7 +220,7 @@ function HomePage() {
       {/* Left — workflow guide (30%) */}
       <div className="w-[30%] shrink-0 border-r bg-muted/30 flex flex-col overflow-auto">
         <div className="p-5 pb-3">
-          <h1 className="text-lg font-bold tracking-tight">ADT Studio</h1>
+          <h1 className="text-lg font-bold tracking-tight text-primary">ADT Studio</h1>
           <p className="text-xs text-muted-foreground mt-0.5">
             Accessible Digital Textbooks
           </p>
@@ -259,7 +259,7 @@ function HomePage() {
 
           <Link
             to="/books/new"
-            className="mt-4 flex items-center justify-center gap-1.5 rounded-lg border bg-background px-4 py-2 text-sm font-medium text-primary hover:bg-primary/5 transition-colors"
+            className="mt-4 flex items-center justify-center gap-1.5 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 shadow-sm transition-colors"
           >
             Get started <ArrowRight className="h-3.5 w-3.5" />
           </Link>
@@ -289,7 +289,7 @@ function HomePage() {
           ))}
           {bookList.length === 0 && (
             <Link to="/books/new" className="block">
-              <div className="flex flex-col items-center justify-center rounded-xl border-2 border-dashed bg-muted/30 py-16 transition-all hover:border-primary/40 hover:bg-muted/50 cursor-pointer">
+              <div className="flex flex-col items-center justify-center rounded-xl border-2 border-dashed bg-muted/30 py-16 transition-all hover:border-primary/40 hover:bg-primary/5 cursor-pointer">
                 <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 mb-3">
                   <Plus className="h-6 w-6 text-primary" />
                 </div>

--- a/apps/studio/src/styles/globals.css
+++ b/apps/studio/src/styles/globals.css
@@ -93,8 +93,8 @@
   --card-foreground: oklch(0.145 0 0);
   --popover: oklch(1 0 0);
   --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.62 0.14 230);
+  --primary-foreground: oklch(1 0 0);
   --secondary: oklch(0.97 0 0);
   --secondary-foreground: oklch(0.205 0 0);
   --muted: oklch(0.97 0 0);
@@ -105,7 +105,7 @@
   --destructive-foreground: oklch(0.985 0 0);
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
+  --ring: oklch(0.62 0.14 230);
   --chart-1: oklch(0.646 0.222 41.116);
   --chart-2: oklch(0.6 0.118 184.704);
   --chart-3: oklch(0.398 0.07 227.392);
@@ -129,8 +129,8 @@
   --card-foreground: oklch(0.985 0 0);
   --popover: oklch(0.145 0 0);
   --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.985 0 0);
-  --primary-foreground: oklch(0.205 0 0);
+  --primary: oklch(0.75 0.13 230);
+  --primary-foreground: oklch(0.15 0 0);
   --secondary: oklch(0.269 0 0);
   --secondary-foreground: oklch(0.985 0 0);
   --muted: oklch(0.269 0 0);
@@ -141,7 +141,7 @@
   --destructive-foreground: oklch(0.637 0.237 25.331);
   --border: oklch(0.269 0 0);
   --input: oklch(0.269 0 0);
-  --ring: oklch(0.439 0 0);
+  --ring: oklch(0.75 0.13 230);
   --chart-1: oklch(0.488 0.243 264.376);
   --chart-2: oklch(0.696 0.17 162.48);
   --chart-3: oklch(0.769 0.188 70.08);


### PR DESCRIPTION
## Summary

- Replace achromatic `--primary` CSS variable with UNICEF blue (`#1CABE2` / `oklch(0.62 0.14 230)`) in both light and dark themes, cascading the brand color to all buttons, badges, focus rings, and active states app-wide
- Replace hard-coded `blue-*` Tailwind classes with semantic `primary` tokens in StepIndicator, storyboard rebuild banner, page edit hint card, and LLM logs step tracker
- Keep green for completion states: "Rendered" and "Done" badges now use `bg-green-100 text-green-700` instead of the (now-blue) default badge variant
- Add micro-UX polish: solid blue "Get Started" CTA, blue app title, book card hover lift animation, stronger section header backgrounds (`bg-muted/50`), primary-tinted empty state hover

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm vitest run` — all 289 tests pass
- [ ] Visual check: blue buttons, stepper, sidebar selection, rebuild banner, hint card
- [ ] White text on blue buttons is clearly readable (AA contrast)
- [ ] Green badges still show for Rendered/Done states
- [ ] Dark mode: lighter blue variant renders correctly