### PR TITLE
Section editor, activity answers, and UX improvements

### DIFF
--- a/apps/api/src/routes/pages.ts
+++ b/apps/api/src/routes/pages.ts
@@ -2,7 +2,7 @@ import fs from "node:fs"
 import path from "node:path"
 import { Hono } from "hono"
 import { HTTPException } from "hono/http-exception"
-import { parseBookLabel, TextClassificationOutput, ImageClassificationOutput } from "@adt/types"
+import { parseBookLabel, TextClassificationOutput, ImageClassificationOutput, PageSectioningOutput } from "@adt/types"
 import { openBookDb } from "@adt/storage"
 import { createBookStorage } from "@adt/storage"
 import { reRenderPage } from "../services/page-edit-service.js"
@@ -223,6 +223,34 @@ export function createPageRoutes(
       }
 
       const version = storage.putNodeData("image-classification", pageId, parsed.data)
+      return c.json({ version })
+    } finally {
+      storage.close()
+    }
+  })
+
+  // PUT /books/:label/pages/:pageId/sectioning — Update page sectioning
+  app.put("/books/:label/pages/:pageId/sectioning", async (c) => {
+    const { label, pageId } = c.req.param()
+    const safeLabel = parseBookLabel(label)
+
+    const body = await c.req.json()
+    const parsed = PageSectioningOutput.safeParse(body)
+    if (!parsed.success) {
+      throw new HTTPException(400, {
+        message: `Invalid page-sectioning data: ${parsed.error.message}`,
+      })
+    }
+
+    const storage = createBookStorage(safeLabel, booksDir)
+    try {
+      const pages = storage.getPages()
+      const page = pages.find((p) => p.pageId === pageId)
+      if (!page) {
+        throw new HTTPException(404, { message: `Page not found: ${pageId}` })
+      }
+
+      const version = storage.putNodeData("page-sectioning", pageId, parsed.data)
       return c.json({ version })
     } finally {
       storage.close()

--- a/apps/studio/src/api/client.ts
+++ b/apps/studio/src/api/client.ts
@@ -70,6 +70,8 @@ export interface SectionRendering {
   sectionType: string
   reasoning: string
   html: string
+  activityReasoning?: string
+  activityAnswers?: Record<string, string | boolean | number>
 }
 
 export interface PageDetail {
@@ -246,6 +248,12 @@ export const api = {
 
   updateImageClassification: (label: string, pageId: string, data: unknown) =>
     request<{ version: number }>(`/books/${label}/pages/${pageId}/image-classification`, {
+      method: "PUT",
+      body: JSON.stringify(data),
+    }),
+
+  updateSectioning: (label: string, pageId: string, data: unknown) =>
+    request<{ version: number }>(`/books/${label}/pages/${pageId}/sectioning`, {
       method: "PUT",
       body: JSON.stringify(data),
     }),

--- a/apps/studio/src/components/page-edit/EditToolbar.tsx
+++ b/apps/studio/src/components/page-edit/EditToolbar.tsx
@@ -52,7 +52,7 @@ export function EditToolbar({
         <div className="flex items-center gap-2">
           <Button variant="outline" size="sm" onClick={onEdit} disabled={!hasRenderingData} title={editTitle}>
             <Pencil className="mr-1 h-3 w-3" />
-            Edit Text & Images
+            Edit
           </Button>
           <Button
             variant="outline"
@@ -71,7 +71,7 @@ export function EditToolbar({
         </div>
         {hasRenderingData && (
           <p className="text-[11px] text-muted-foreground">
-            Modify text groups or toggle image pruning, then re-render.
+            Modify text, images, or sections, then re-render.
           </p>
         )}
       </div>

--- a/apps/studio/src/components/page-edit/SectionEditor.tsx
+++ b/apps/studio/src/components/page-edit/SectionEditor.tsx
@@ -1,0 +1,376 @@
+import { useMemo } from "react"
+import { ArrowUp, ArrowDown, Trash2, Plus, Merge, FileText, Image } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { Switch } from "@/components/ui/switch"
+import { Label } from "@/components/ui/label"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { SECTION_TYPE_GROUPS, getSectionTypeLabel } from "@/lib/section-constants"
+
+interface Section {
+  sectionType: string
+  partIds: string[]
+  backgroundColor: string
+  textColor: string
+  pageNumber: number | null
+  isPruned: boolean
+}
+
+interface SectionEditorProps {
+  sections: Section[]
+  reasoning: string
+  onChange: (sections: Section[]) => void
+  textGroups: Array<{ groupId: string; groupType: string }>
+  images: Array<{ imageId: string; isPruned: boolean }>
+}
+
+export function SectionEditor({
+  sections,
+  onChange,
+  textGroups,
+  images,
+}: SectionEditorProps) {
+  // Compute all valid part IDs and which are assigned
+  const allPartIds = useMemo(() => {
+    const ids: Array<{ id: string; label: string; kind: "text" | "image" }> = []
+    for (const g of textGroups) {
+      ids.push({ id: g.groupId, label: `${g.groupId} (${g.groupType})`, kind: "text" })
+    }
+    for (const img of images) {
+      if (!img.isPruned) {
+        ids.push({ id: img.imageId, label: img.imageId, kind: "image" })
+      }
+    }
+    return ids
+  }, [textGroups, images])
+
+  const assignedPartIds = useMemo(() => {
+    const set = new Set<string>()
+    for (const s of sections) {
+      for (const id of s.partIds) set.add(id)
+    }
+    return set
+  }, [sections])
+
+  const unassignedParts = useMemo(
+    () => allPartIds.filter((p) => !assignedPartIds.has(p.id)),
+    [allPartIds, assignedPartIds]
+  )
+
+  const updateSection = (index: number, patch: Partial<Section>) => {
+    onChange(sections.map((s, i) => (i === index ? { ...s, ...patch } : s)))
+  }
+
+  const moveSection = (index: number, direction: -1 | 1) => {
+    const target = index + direction
+    if (target < 0 || target >= sections.length) return
+    const next = [...sections]
+    ;[next[index], next[target]] = [next[target], next[index]]
+    onChange(next)
+  }
+
+  const deleteSection = (index: number) => {
+    onChange(sections.filter((_, i) => i !== index))
+  }
+
+  const addSection = () => {
+    onChange([
+      ...sections,
+      {
+        sectionType: "text_only",
+        partIds: [],
+        backgroundColor: "#ffffff",
+        textColor: "#333333",
+        pageNumber: null,
+        isPruned: false,
+      },
+    ])
+  }
+
+  const mergeSections = (index: number) => {
+    if (index >= sections.length - 1) return
+    const merged: Section = {
+      ...sections[index],
+      partIds: [...sections[index].partIds, ...sections[index + 1].partIds],
+    }
+    onChange([
+      ...sections.slice(0, index),
+      merged,
+      ...sections.slice(index + 2),
+    ])
+  }
+
+  const removePart = (sectionIndex: number, partId: string) => {
+    updateSection(sectionIndex, {
+      partIds: sections[sectionIndex].partIds.filter((id) => id !== partId),
+    })
+  }
+
+  const addPart = (sectionIndex: number, partId: string) => {
+    // Auto-move: remove from any other section that has this part
+    const updated = sections.map((s, i) => {
+      if (i === sectionIndex) {
+        return { ...s, partIds: [...s.partIds, partId] }
+      }
+      if (s.partIds.includes(partId)) {
+        return { ...s, partIds: s.partIds.filter((id) => id !== partId) }
+      }
+      return s
+    })
+    onChange(updated)
+  }
+
+  /** Parts available for a given section: all parts not already in THIS section */
+  const getAvailableParts = (sectionIndex: number) =>
+    allPartIds.filter((p) => !sections[sectionIndex].partIds.includes(p.id))
+
+  const getPartInfo = (partId: string) => {
+    const tg = textGroups.find((g) => g.groupId === partId)
+    if (tg) return { label: `${partId} (${tg.groupType})`, kind: "text" as const }
+    const img = images.find((im) => im.imageId === partId)
+    if (img) return { label: partId, kind: "image" as const }
+    return { label: partId, kind: "text" as const }
+  }
+
+  return (
+    <div className="space-y-3">
+      {sections.map((section, i) => (
+        <div
+          key={i}
+          className={`rounded border ${section.isPruned ? "opacity-60" : ""}`}
+        >
+          {/* Header row */}
+          <div className="flex items-center gap-1.5 border-b bg-muted/30 px-2 py-1.5">
+            <div className="flex gap-0.5">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 w-6 p-0"
+                disabled={i === 0}
+                onClick={() => moveSection(i, -1)}
+                title="Move up"
+              >
+                <ArrowUp className="h-3 w-3" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 w-6 p-0"
+                disabled={i === sections.length - 1}
+                onClick={() => moveSection(i, 1)}
+                title="Move down"
+              >
+                <ArrowDown className="h-3 w-3" />
+              </Button>
+            </div>
+            <span className="text-xs font-medium text-muted-foreground shrink-0">
+              Section {i + 1}
+            </span>
+            <Select
+              value={section.sectionType}
+              onValueChange={(val) => updateSection(i, { sectionType: val })}
+            >
+              <SelectTrigger className="h-7 w-[180px] text-xs">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {SECTION_TYPE_GROUPS.map((group) => (
+                  <SelectGroup key={group.label}>
+                    <SelectLabel className="text-xs">{group.label}</SelectLabel>
+                    {group.types.map((t) => (
+                      <SelectItem key={t.value} value={t.value} className="text-xs">
+                        {t.label}
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                ))}
+              </SelectContent>
+            </Select>
+            <div className="ml-auto flex items-center gap-2">
+              <div className="flex items-center gap-1">
+                <Label htmlFor={`prune-section-${i}`} className="text-xs">
+                  Pruned
+                </Label>
+                <Switch
+                  id={`prune-section-${i}`}
+                  checked={section.isPruned}
+                  onCheckedChange={(checked: boolean) =>
+                    updateSection(i, { isPruned: checked })
+                  }
+                />
+              </div>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 w-6 p-0 text-destructive hover:text-destructive"
+                onClick={() => deleteSection(i)}
+                title="Delete section"
+              >
+                <Trash2 className="h-3 w-3" />
+              </Button>
+            </div>
+          </div>
+
+          {/* Colors */}
+          <div className="flex items-center gap-4 border-b px-3 py-1.5">
+            <div className="flex items-center gap-1.5">
+              <label className="text-xs text-muted-foreground">BG:</label>
+              <input
+                type="color"
+                value={section.backgroundColor}
+                onChange={(e) =>
+                  updateSection(i, { backgroundColor: e.target.value })
+                }
+                className="h-6 w-6 cursor-pointer rounded border p-0"
+              />
+              <Input
+                value={section.backgroundColor}
+                onChange={(e) =>
+                  updateSection(i, { backgroundColor: e.target.value })
+                }
+                className="h-6 w-20 px-1 text-xs"
+              />
+            </div>
+            <div className="flex items-center gap-1.5">
+              <label className="text-xs text-muted-foreground">Text:</label>
+              <input
+                type="color"
+                value={section.textColor}
+                onChange={(e) =>
+                  updateSection(i, { textColor: e.target.value })
+                }
+                className="h-6 w-6 cursor-pointer rounded border p-0"
+              />
+              <Input
+                value={section.textColor}
+                onChange={(e) =>
+                  updateSection(i, { textColor: e.target.value })
+                }
+                className="h-6 w-20 px-1 text-xs"
+              />
+            </div>
+          </div>
+
+          {/* Parts */}
+          <div className="px-3 py-2">
+            <p className="mb-1 text-xs font-medium text-muted-foreground">
+              Parts ({section.partIds.length})
+            </p>
+            {section.partIds.length > 0 ? (
+              <div className="space-y-1">
+                {section.partIds.map((partId) => {
+                  const info = getPartInfo(partId)
+                  return (
+                    <div
+                      key={partId}
+                      className="flex items-center justify-between rounded bg-muted/30 px-2 py-1"
+                    >
+                      <span className="flex items-center gap-1.5 text-xs">
+                        {info.kind === "image" ? (
+                          <Image className="h-3 w-3 text-muted-foreground" />
+                        ) : (
+                          <FileText className="h-3 w-3 text-muted-foreground" />
+                        )}
+                        {info.label}
+                      </span>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-5 w-5 p-0 text-muted-foreground hover:text-destructive"
+                        onClick={() => removePart(i, partId)}
+                        title="Remove from section"
+                      >
+                        <Trash2 className="h-3 w-3" />
+                      </Button>
+                    </div>
+                  )
+                })}
+              </div>
+            ) : (
+              <p className="text-xs text-muted-foreground italic">No parts assigned</p>
+            )}
+            {/* Add part dropdown — shows all parts not in this section; auto-moves from other sections */}
+            {getAvailableParts(i).length > 0 && (
+              <Select onValueChange={(val) => addPart(i, val)} value="">
+                <SelectTrigger className="mt-1.5 h-7 text-xs">
+                  <SelectValue placeholder="+ Add part..." />
+                </SelectTrigger>
+                <SelectContent>
+                  {getAvailableParts(i).map((p) => {
+                    const isAssigned = assignedPartIds.has(p.id)
+                    return (
+                      <SelectItem key={p.id} value={p.id} className="text-xs">
+                        {p.kind === "image" ? "🖼 " : "📝 "}
+                        {p.label}
+                        {isAssigned ? " (move)" : ""}
+                      </SelectItem>
+                    )
+                  })}
+                </SelectContent>
+              </Select>
+            )}
+          </div>
+
+          {/* Merge with next */}
+          {i < sections.length - 1 && (
+            <div className="border-t px-3 py-1.5">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 w-full text-xs text-muted-foreground"
+                onClick={() => mergeSections(i)}
+              >
+                <Merge className="mr-1 h-3 w-3" />
+                Merge with next section
+              </Button>
+            </div>
+          )}
+        </div>
+      ))}
+
+      {/* Add new section */}
+      <Button
+        variant="outline"
+        size="sm"
+        className="w-full"
+        onClick={addSection}
+      >
+        <Plus className="mr-1 h-3 w-3" />
+        Add Section
+      </Button>
+
+      {/* Unassigned parts warning */}
+      {unassignedParts.length > 0 && (
+        <div className="rounded border border-amber-200 bg-amber-50 p-3">
+          <p className="mb-1 text-xs font-medium text-amber-800">
+            Unassigned Parts ({unassignedParts.length})
+          </p>
+          <div className="space-y-0.5">
+            {unassignedParts.map((p) => (
+              <div key={p.id} className="flex items-center gap-1.5 text-xs text-amber-700">
+                {p.kind === "image" ? (
+                  <Image className="h-3 w-3" />
+                ) : (
+                  <FileText className="h-3 w-3" />
+                )}
+                {p.label}
+              </div>
+            ))}
+          </div>
+          <p className="mt-1 text-[11px] text-amber-600">
+            Use the "+ Add part" dropdown in any section above to assign these.
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/studio/src/components/page-edit/TextGroupEditor.tsx
+++ b/apps/studio/src/components/page-edit/TextGroupEditor.tsx
@@ -1,7 +1,10 @@
+import { Plus, Trash2 } from "lucide-react"
 import { Textarea } from "@/components/ui/textarea"
 import { Switch } from "@/components/ui/switch"
 import { Label } from "@/components/ui/label"
 import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
 
 interface TextGroupEditorProps {
   groups: Array<{
@@ -27,13 +30,73 @@ export function TextGroupEditor({ groups, onChange }: TextGroupEditorProps) {
     onChange(newGroups)
   }
 
+  const updateGroupType = (groupIndex: number, groupType: string) => {
+    onChange(groups.map((g, i) => (i === groupIndex ? { ...g, groupType } : g)))
+  }
+
+  const addTextEntry = (groupIndex: number) => {
+    onChange(
+      groups.map((g, i) =>
+        i === groupIndex
+          ? { ...g, texts: [...g.texts, { textType: "paragraph", text: "", isPruned: false }] }
+          : g
+      )
+    )
+  }
+
+  const removeTextEntry = (groupIndex: number, textIndex: number) => {
+    onChange(
+      groups.map((g, i) =>
+        i === groupIndex
+          ? { ...g, texts: g.texts.filter((_, ti) => ti !== textIndex) }
+          : g
+      )
+    )
+  }
+
+  const addGroup = () => {
+    // Generate a unique groupId based on existing IDs
+    const existingIds = new Set(groups.map((g) => g.groupId))
+    let counter = groups.length + 1
+    let newId = `custom_g${counter}`
+    while (existingIds.has(newId)) {
+      counter++
+      newId = `custom_g${counter}`
+    }
+    onChange([
+      ...groups,
+      {
+        groupId: newId,
+        groupType: "paragraph",
+        texts: [{ textType: "paragraph", text: "", isPruned: false }],
+      },
+    ])
+  }
+
+  const removeGroup = (groupIndex: number) => {
+    onChange(groups.filter((_, i) => i !== groupIndex))
+  }
+
   return (
     <div className="space-y-4">
       {groups.map((group, gi) => (
         <div key={group.groupId} className="rounded border p-3">
           <div className="mb-2 flex items-center gap-2">
-            <Badge variant="secondary">{group.groupType}</Badge>
+            <Input
+              value={group.groupType}
+              onChange={(e) => updateGroupType(gi, e.target.value)}
+              className="h-6 w-28 px-1.5 text-xs"
+            />
             <span className="text-xs text-muted-foreground">{group.groupId}</span>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="ml-auto h-5 w-5 p-0 text-muted-foreground hover:text-destructive"
+              onClick={() => removeGroup(gi)}
+              title="Remove group"
+            >
+              <Trash2 className="h-3 w-3" />
+            </Button>
           </div>
           <div className="space-y-3">
             {group.texts.map((t, ti) => (
@@ -47,6 +110,15 @@ export function TextGroupEditor({ groups, onChange }: TextGroupEditorProps) {
                       checked={t.isPruned}
                       onCheckedChange={(checked: boolean) => updateText(gi, ti, "isPruned", checked)}
                     />
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-5 w-5 p-0 text-muted-foreground hover:text-destructive"
+                      onClick={() => removeTextEntry(gi, ti)}
+                      title="Remove text entry"
+                    >
+                      <Trash2 className="h-3 w-3" />
+                    </Button>
                   </div>
                 </div>
                 <Textarea
@@ -56,9 +128,27 @@ export function TextGroupEditor({ groups, onChange }: TextGroupEditorProps) {
                 />
               </div>
             ))}
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-6 w-full text-xs text-muted-foreground"
+              onClick={() => addTextEntry(gi)}
+            >
+              <Plus className="mr-1 h-3 w-3" />
+              Add text entry
+            </Button>
           </div>
         </div>
       ))}
+      <Button
+        variant="outline"
+        size="sm"
+        className="w-full"
+        onClick={addGroup}
+      >
+        <Plus className="mr-1 h-3 w-3" />
+        Add Text Group
+      </Button>
     </div>
   )
 }

--- a/apps/studio/src/components/storyboard/ActivityAnswerPanel.tsx
+++ b/apps/studio/src/components/storyboard/ActivityAnswerPanel.tsx
@@ -1,0 +1,33 @@
+import { formatAnswerValue } from "@/lib/activity-utils"
+
+export function ActivityAnswerPanel({
+  answers,
+  reasoning,
+}: {
+  answers: Record<string, string | boolean | number>
+  reasoning?: string
+}) {
+  const entries = Object.entries(answers)
+  if (entries.length === 0) return null
+
+  return (
+    <div className="rounded border border-green-200 bg-green-50/50 p-3">
+      <p className="mb-2 text-xs font-semibold text-green-800">Answer Key</p>
+      <div className="space-y-1">
+        {entries.map(([id, value]) => (
+          <div key={id} className="flex items-baseline justify-between gap-2 text-xs">
+            <span className="font-mono text-muted-foreground truncate">{id}</span>
+            <span className="shrink-0 font-medium text-green-900">
+              {formatAnswerValue(value)}
+            </span>
+          </div>
+        ))}
+      </div>
+      {reasoning && (
+        <p className="mt-2 border-t border-green-200 pt-2 text-xs text-muted-foreground">
+          {reasoning}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/apps/studio/src/hooks/use-books.ts
+++ b/apps/studio/src/hooks/use-books.ts
@@ -49,6 +49,7 @@ export function useAcceptStoryboard() {
   return useMutation({
     mutationFn: (label: string) => api.acceptStoryboard(label),
     onSuccess: (_data, label) => {
+      queryClient.invalidateQueries({ queryKey: ["pipeline-status", label] })
       queryClient.invalidateQueries({ queryKey: ["books"] })
       queryClient.invalidateQueries({ queryKey: ["books", label] })
     },

--- a/apps/studio/src/hooks/use-page-mutations.ts
+++ b/apps/studio/src/hooks/use-page-mutations.ts
@@ -21,6 +21,16 @@ export function useSaveImageClassification(label: string, pageId: string) {
   })
 }
 
+export function useSaveSectioning(label: string, pageId: string) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (data: unknown) => api.updateSectioning(label, pageId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["books", label, "pages", pageId] })
+    },
+  })
+}
+
 export function useReRenderPage(label: string, pageId: string) {
   const queryClient = useQueryClient()
   return useMutation({

--- a/apps/studio/src/hooks/use-pipeline.ts
+++ b/apps/studio/src/hooks/use-pipeline.ts
@@ -133,6 +133,7 @@ export function usePipelineSSE(label: string, enabled: boolean) {
         isComplete: true,
         currentStep: null,
       }))
+      queryClient.invalidateQueries({ queryKey: ["pipeline-status", label] })
       queryClient.invalidateQueries({ queryKey: ["books", label] })
       queryClient.invalidateQueries({ queryKey: ["books"] })
       queryClient.invalidateQueries({ queryKey: ["books", label, "pages"] })
@@ -182,6 +183,7 @@ export function usePipelineSSE(label: string, enabled: boolean) {
               currentStep: null,
             }
           })
+          queryClient.invalidateQueries({ queryKey: ["pipeline-status", label] })
           queryClient.invalidateQueries({ queryKey: ["books", label] })
           queryClient.invalidateQueries({ queryKey: ["books"] })
           queryClient.invalidateQueries({ queryKey: ["books", label, "pages"] })

--- a/apps/studio/src/lib/activity-utils.ts
+++ b/apps/studio/src/lib/activity-utils.ts
@@ -1,0 +1,25 @@
+/** Check if a section type is an activity (prefixed with `activity_`) */
+export function isActivitySection(sectionType: string): boolean {
+  return sectionType.startsWith("activity_")
+}
+
+/**
+ * Format a raw section type into a human-readable label.
+ * `activity_multiple_choice` → `Multiple Choice`
+ * `body_text` → `Body Text`
+ */
+export function formatSectionType(sectionType: string): string {
+  const base = sectionType.startsWith("activity_")
+    ? sectionType.slice("activity_".length)
+    : sectionType
+  return base
+    .split("_")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ")
+}
+
+/** Format an answer value for display */
+export function formatAnswerValue(value: string | boolean | number): string {
+  if (typeof value === "boolean") return value ? "True" : "False"
+  return String(value)
+}

--- a/apps/studio/src/lib/section-constants.ts
+++ b/apps/studio/src/lib/section-constants.ts
@@ -1,0 +1,57 @@
+export const SECTION_TYPES = [
+  // Content
+  { value: "text_only", label: "Text Only" },
+  { value: "text_and_single_image", label: "Text & Single Image" },
+  { value: "text_and_images", label: "Text & Images" },
+  { value: "images_only", label: "Images Only" },
+  { value: "boxed_text", label: "Boxed Text" },
+  // Activities
+  { value: "activity_matching", label: "Activity: Matching" },
+  { value: "activity_fill_in_a_table", label: "Activity: Fill in a Table" },
+  { value: "activity_multiple_choice", label: "Activity: Multiple Choice" },
+  { value: "activity_true_false", label: "Activity: True / False" },
+  { value: "activity_open_ended_answer", label: "Activity: Open-Ended Answer" },
+  { value: "activity_fill_in_the_blank", label: "Activity: Fill in the Blank" },
+  { value: "activity_sorting", label: "Activity: Sorting" },
+  // Structure
+  { value: "front_cover", label: "Front Cover" },
+  { value: "inside_cover", label: "Inside Cover" },
+  { value: "back_cover", label: "Back Cover" },
+  { value: "separator", label: "Separator" },
+  { value: "credits", label: "Credits" },
+  { value: "foreword", label: "Foreword" },
+  { value: "table_of_contents", label: "Table of Contents" },
+  // Other
+  { value: "other", label: "Other" },
+] as const
+
+export const SECTION_TYPE_GROUPS = [
+  {
+    label: "Content",
+    types: SECTION_TYPES.filter(
+      (t) =>
+        ["text_only", "text_and_single_image", "text_and_images", "images_only", "boxed_text"].includes(t.value)
+    ),
+  },
+  {
+    label: "Activities",
+    types: SECTION_TYPES.filter((t) => t.value.startsWith("activity_")),
+  },
+  {
+    label: "Structure",
+    types: SECTION_TYPES.filter((t) =>
+      ["front_cover", "inside_cover", "back_cover", "separator", "credits", "foreword", "table_of_contents"].includes(
+        t.value
+      )
+    ),
+  },
+  {
+    label: "Other",
+    types: SECTION_TYPES.filter((t) => t.value === "other"),
+  },
+] as const
+
+export function getSectionTypeLabel(value: string): string {
+  const found = SECTION_TYPES.find((t) => t.value === value)
+  return found?.label ?? value
+}

--- a/apps/studio/src/routes/books.$label.index.tsx
+++ b/apps/studio/src/routes/books.$label.index.tsx
@@ -148,6 +148,21 @@ function BookDetailPage() {
             </Button>
           </Link>
         )}
+        {book.storyboardAccepted && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => exportBook.mutate(label)}
+            disabled={exportBook.isPending}
+          >
+            {exportBook.isPending ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <FileDown className="mr-2 h-4 w-4" />
+            )}
+            Export ZIP
+          </Button>
+        )}
       </div>
 
       {/* Rebuild warning */}
@@ -249,30 +264,6 @@ function BookDetailPage() {
                 Review Storyboard
               </Button>
             </Link>
-          </CardContent>
-        </Card>
-      )}
-
-      {/* Export ZIP CTA */}
-      {book.storyboardAccepted && (
-        <Card className="border-green-200 bg-green-50/50">
-          <CardContent className="flex items-center justify-between py-3">
-            <div>
-              <p className="text-sm font-medium">Storyboard accepted</p>
-              <p className="text-xs text-muted-foreground">Download the book as an HTML + images bundle</p>
-            </div>
-            <Button
-              size="sm"
-              onClick={() => exportBook.mutate(label)}
-              disabled={exportBook.isPending}
-            >
-              {exportBook.isPending ? (
-                <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
-              ) : (
-                <FileDown className="mr-1.5 h-4 w-4" />
-              )}
-              Export ZIP
-            </Button>
           </CardContent>
         </Card>
       )}

--- a/apps/studio/src/routes/books.$label.pages.$pageId.tsx
+++ b/apps/studio/src/routes/books.$label.pages.$pageId.tsx
@@ -9,9 +9,12 @@ import { EditToolbar } from "@/components/page-edit/EditToolbar"
 import { TextGroupEditor } from "@/components/page-edit/TextGroupEditor"
 import { ImagePruningEditor } from "@/components/page-edit/ImagePruningEditor"
 import { RenderedHtml } from "@/components/storyboard/RenderedHtml"
-import { useSaveTextClassification, useSaveImageClassification, useReRenderPage } from "@/hooks/use-page-mutations"
+import { useSaveTextClassification, useSaveImageClassification, useSaveSectioning, useReRenderPage } from "@/hooks/use-page-mutations"
+import { SectionEditor } from "@/components/page-edit/SectionEditor"
 import { useApiKey } from "@/hooks/use-api-key"
 import { useGuideDismissed } from "@/hooks/use-guide-dismissed"
+import { ActivityAnswerPanel } from "@/components/storyboard/ActivityAnswerPanel"
+import { isActivitySection, formatSectionType } from "@/lib/activity-utils"
 import type { PageDetail } from "@/api/client"
 
 export const Route = createFileRoute("/books/$label/pages/$pageId")({
@@ -30,9 +33,11 @@ function PageDetailPage() {
   const [isEditing, setIsEditing] = useState(false)
   const [editedGroups, setEditedGroups] = useState<PageDetail["textClassification"]>(null)
   const [editedImages, setEditedImages] = useState<PageDetail["imageClassification"]>(null)
+  const [editedSectioning, setEditedSectioning] = useState<PageDetail["sectioning"]>(null)
 
   const saveText = useSaveTextClassification(label, pageId)
   const saveImages = useSaveImageClassification(label, pageId)
+  const saveSectioning = useSaveSectioning(label, pageId)
   const reRender = useReRenderPage(label, pageId)
 
   const handleEdit = useCallback(() => {
@@ -42,6 +47,9 @@ function PageDetailPage() {
     if (page?.imageClassification) {
       setEditedImages(structuredClone(page.imageClassification))
     }
+    if (page?.sectioning) {
+      setEditedSectioning(structuredClone(page.sectioning))
+    }
     setIsEditing(true)
   }, [page])
 
@@ -49,6 +57,7 @@ function PageDetailPage() {
     setIsEditing(false)
     setEditedGroups(null)
     setEditedImages(null)
+    setEditedSectioning(null)
   }, [])
 
   const handleSave = useCallback(async () => {
@@ -60,12 +69,16 @@ function PageDetailPage() {
     if (editedImages && JSON.stringify(editedImages) !== JSON.stringify(page?.imageClassification)) {
       promises.push(saveImages.mutateAsync(editedImages))
     }
+    if (editedSectioning && JSON.stringify(editedSectioning) !== JSON.stringify(page?.sectioning)) {
+      promises.push(saveSectioning.mutateAsync(editedSectioning))
+    }
 
     await Promise.all(promises)
     setIsEditing(false)
     setEditedGroups(null)
     setEditedImages(null)
-  }, [editedGroups, editedImages, page, saveText, saveImages])
+    setEditedSectioning(null)
+  }, [editedGroups, editedImages, editedSectioning, page, saveText, saveImages, saveSectioning])
 
   const handleReRender = useCallback(() => {
     if (hasApiKey) {
@@ -74,6 +87,7 @@ function PageDetailPage() {
   }, [apiKey, hasApiKey, reRender])
 
   const [isSaveAndReRendering, setIsSaveAndReRendering] = useState(false)
+  const [expandedAnswers, setExpandedAnswers] = useState<Set<number>>(new Set())
 
   const handleSaveAndReRender = useCallback(async () => {
     setIsSaveAndReRendering(true)
@@ -90,7 +104,42 @@ function PageDetailPage() {
   const hasChanges =
     (editedGroups && JSON.stringify(editedGroups) !== JSON.stringify(page?.textClassification)) ||
     (editedImages && JSON.stringify(editedImages) !== JSON.stringify(page?.imageClassification)) ||
+    (editedSectioning && JSON.stringify(editedSectioning) !== JSON.stringify(page?.sectioning)) ||
     false
+
+  // Find prev/next pages for navigation (computed before hooks that depend on them)
+  const currentIndex = allPages?.findIndex((p) => p.pageId === pageId) ?? -1
+  const prevPage = currentIndex > 0 ? allPages?.[currentIndex - 1] : null
+  const nextPage =
+    allPages && currentIndex < allPages.length - 1
+      ? allPages[currentIndex + 1]
+      : null
+
+  // Keyboard navigation: arrow keys for prev/next page
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // Skip when focus is in an editable element
+      const tag = (e.target as HTMLElement)?.tagName
+      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return
+      if ((e.target as HTMLElement)?.isContentEditable) return
+
+      if (e.key === "ArrowLeft" && prevPage) {
+        e.preventDefault()
+        navigate({
+          to: "/books/$label/pages/$pageId",
+          params: { label, pageId: prevPage.pageId },
+        })
+      } else if (e.key === "ArrowRight" && nextPage) {
+        e.preventDefault()
+        navigate({
+          to: "/books/$label/pages/$pageId",
+          params: { label, pageId: nextPage.pageId },
+        })
+      }
+    }
+    window.addEventListener("keydown", handleKeyDown)
+    return () => window.removeEventListener("keydown", handleKeyDown)
+  }, [navigate, label, prevPage, nextPage])
 
   if (isLoading) {
     return <div className="p-4 text-muted-foreground">Loading page...</div>
@@ -105,14 +154,6 @@ function PageDetailPage() {
   }
 
   if (!page) return null
-
-  // Find prev/next pages for navigation
-  const currentIndex = allPages?.findIndex((p) => p.pageId === pageId) ?? -1
-  const prevPage = currentIndex > 0 ? allPages?.[currentIndex - 1] : null
-  const nextPage =
-    allPages && currentIndex < allPages.length - 1
-      ? allPages[currentIndex + 1]
-      : null
 
   // Combine all section HTMLs into a single preview
   const combinedHtml = page.rendering?.sections
@@ -166,7 +207,7 @@ function PageDetailPage() {
         <EditToolbar
           isEditing={isEditing}
           hasChanges={hasChanges}
-          isSaving={saveText.isPending || saveImages.isPending}
+          isSaving={saveText.isPending || saveImages.isPending || saveSectioning.isPending}
           isReRendering={reRender.isPending}
           hasApiKey={hasApiKey}
           hasRenderingData={!!page.textClassification}
@@ -183,7 +224,11 @@ function PageDetailPage() {
       {reRender.isSuccess && (
         <div className="flex shrink-0 items-center gap-2 border-b bg-green-50 px-4 py-2 text-sm text-green-800">
           <CheckCircle2 className="h-4 w-4 shrink-0" />
-          <span className="flex-1">Page re-rendered successfully.</span>
+          <span className="flex-1">
+            Page re-rendered successfully.
+            {page.rendering?.sections.some((s) => isActivitySection(s.sectionType) && s.sectionType !== "activity_open_ended_answer") &&
+              " Activity answers were also regenerated."}
+          </span>
           <Button variant="ghost" size="sm" onClick={() => reRender.reset()}>
             Dismiss
           </Button>
@@ -225,7 +270,7 @@ function PageDetailPage() {
                   </button>
                 </div>
                 <ol className="list-inside list-decimal space-y-0.5 text-xs text-foreground">
-                  <li>Click <strong>Edit Text & Images</strong> to modify inputs</li>
+                  <li>Click <strong>Edit</strong> to modify text, images, and sections</li>
                   <li><strong>Save</strong> your changes</li>
                   <li>Click <strong>Re-render</strong> to regenerate this page</li>
                 </ol>
@@ -352,7 +397,24 @@ function PageDetailPage() {
           </TabsContent>
 
           <TabsContent value="sections" className="mt-0 flex-1 overflow-auto p-4">
-            {page.rendering && page.sectioning ? (
+            {isEditing && editedSectioning ? (
+              <SectionEditor
+                sections={editedSectioning.sections}
+                reasoning={editedSectioning.reasoning}
+                onChange={(sections) =>
+                  setEditedSectioning({ ...editedSectioning, sections })
+                }
+                textGroups={
+                  (editedGroups ?? page.textClassification)?.groups.map((g) => ({
+                    groupId: g.groupId,
+                    groupType: g.groupType,
+                  })) ?? []
+                }
+                images={
+                  (editedImages ?? page.imageClassification)?.images ?? []
+                }
+              />
+            ) : page.rendering && page.sectioning ? (
               <div className="space-y-4">
                 {page.rendering.sections.map((section, i) => {
                   const sectionMeta = page.sectioning?.sections[i]
@@ -363,8 +425,15 @@ function PageDetailPage() {
                           Section {i + 1}
                         </span>
                         <Badge variant="outline" className="text-xs">
-                          {section.sectionType}
+                          {formatSectionType(section.sectionType)}
                         </Badge>
+                        {isActivitySection(section.sectionType) && (
+                          <Badge className="bg-green-100 text-green-800 hover:bg-green-100 text-xs">
+                            Activity
+                            {section.activityAnswers && Object.keys(section.activityAnswers).length > 0 &&
+                              ` (${Object.keys(section.activityAnswers).length})`}
+                          </Badge>
+                        )}
                         {sectionMeta && (
                           <div className="flex gap-1">
                             <span
@@ -392,6 +461,38 @@ function PageDetailPage() {
                           <p className="mt-2 text-xs text-muted-foreground">
                             {section.reasoning}
                           </p>
+                        )}
+                        {section.activityReasoning && (
+                          <p className="mt-2 text-xs text-muted-foreground">
+                            {section.activityReasoning}
+                          </p>
+                        )}
+                        {section.activityAnswers && Object.keys(section.activityAnswers).length > 0 && (
+                          <div className="mt-3">
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              className="h-6 px-2 text-xs text-green-700"
+                              onClick={() => {
+                                setExpandedAnswers((prev) => {
+                                  const next = new Set(prev)
+                                  if (next.has(i)) next.delete(i)
+                                  else next.add(i)
+                                  return next
+                                })
+                              }}
+                            >
+                              {expandedAnswers.has(i) ? "Hide Answers" : "Show Answers"}
+                            </Button>
+                            {expandedAnswers.has(i) && (
+                              <div className="mt-2">
+                                <ActivityAnswerPanel
+                                  answers={section.activityAnswers}
+                                  reasoning={section.activityReasoning}
+                                />
+                              </div>
+                            )}
+                          </div>
                         )}
                       </div>
                     </div>

--- a/apps/studio/src/routes/books.$label.storyboard.tsx
+++ b/apps/studio/src/routes/books.$label.storyboard.tsx
@@ -10,6 +10,8 @@ import { useApiKey } from "@/hooks/use-api-key"
 import { useReRenderPage } from "@/hooks/use-page-mutations"
 import { STEP_LABELS } from "@/components/pipeline/StepIndicator"
 import { RenderedHtml } from "@/components/storyboard/RenderedHtml"
+import { ActivityAnswerPanel } from "@/components/storyboard/ActivityAnswerPanel"
+import { isActivitySection, formatSectionType } from "@/lib/activity-utils"
 import { StoryboardSettingsSheet } from "@/components/storyboard/StoryboardSettingsSheet"
 import { AcceptStoryboardDialog } from "@/components/storyboard/AcceptStoryboardDialog"
 import { StoryboardGuideDialog } from "@/components/storyboard/StoryboardGuideDialog"
@@ -463,6 +465,7 @@ function PreviewPanel({
   const { data: page, isLoading } = usePage(label, pageId)
   const { apiKey, hasApiKey } = useApiKey()
   const reRender = useReRenderPage(label, pageId)
+  const [showAnswers, setShowAnswers] = useState(false)
 
   const combinedHtml = useMemo(
     () => page?.rendering?.sections.map((s) => s.html).join("\n"),
@@ -470,6 +473,7 @@ function PreviewPanel({
   )
 
   const sectionCount = page?.rendering?.sections.length ?? 0
+  const activityCount = page?.rendering?.sections.filter((s) => isActivitySection(s.sectionType)).length ?? 0
   const hasRenderingData = !!page?.textClassification
 
   const reRenderTitle = !hasApiKey
@@ -487,10 +491,22 @@ function PreviewPanel({
         <div className="flex items-center gap-2">
           <span className="text-sm font-medium">Page {page?.pageNumber ?? "..."}</span>
           {sectionCount > 0 && (
-            <Badge variant="secondary" className="text-xs">{sectionCount} sections</Badge>
+            <Badge variant="secondary" className="text-xs">
+              {sectionCount} section{sectionCount !== 1 && "s"}
+              {activityCount > 0 && ` \u00b7 ${activityCount} activity`}
+            </Badge>
           )}
         </div>
         <div className="flex items-center gap-2">
+          {activityCount > 0 && combinedHtml && (
+            <Button
+              variant={showAnswers ? "secondary" : "outline"}
+              size="sm"
+              onClick={() => setShowAnswers((v) => !v)}
+            >
+              {showAnswers ? "Hide Answers" : "Show Answers"}
+            </Button>
+          )}
           <div className="flex gap-1">
             <Button variant="outline" size="sm" disabled={!hasPrev} onClick={onPrev}>
               <ChevronLeft className="h-3 w-3" />
@@ -527,6 +543,7 @@ function PreviewPanel({
         <div className="flex shrink-0 items-center gap-2 border-b bg-green-50 px-5 py-1.5 text-xs text-green-800">
           <CheckCircle2 className="h-3 w-3 shrink-0" />
           Page re-rendered successfully.
+          {activityCount > 0 && " Activity answers were also regenerated."}
         </div>
       )}
 
@@ -559,11 +576,30 @@ function PreviewPanel({
               <p className="text-sm">Re-rendering page...</p>
             </div>
           </div>
-        ) : combinedHtml ? (
+        ) : combinedHtml && !showAnswers ? (
           <RenderedHtml
             html={combinedHtml}
             className="prose prose-sm max-w-none rounded-lg border bg-white p-6 shadow-sm"
           />
+        ) : combinedHtml && showAnswers && page?.rendering ? (
+          <div className="space-y-4">
+            {page.rendering.sections.map((section, i) => (
+              <div key={i}>
+                <RenderedHtml
+                  html={section.html}
+                  className="prose prose-sm max-w-none rounded-lg border bg-white p-6 shadow-sm"
+                />
+                {isActivitySection(section.sectionType) && section.activityAnswers && Object.keys(section.activityAnswers).length > 0 && (
+                  <div className="mt-2">
+                    <ActivityAnswerPanel
+                      answers={section.activityAnswers}
+                      reasoning={section.activityReasoning}
+                    />
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
         ) : (
           <div className="flex h-full flex-col items-center justify-center gap-2 text-muted-foreground">
             <ImageOff className="h-8 w-8" />


### PR DESCRIPTION
## Summary

- **Section editor** — full layout editing in the page detail "By Section" tab: reorder, change type (all 20 types), toggle pruning, delete, add new sections, merge adjacent sections, edit background/text colors, and manage parts (view, remove, add with auto-move between sections)
- **PUT /sectioning API endpoint** — persists section edits as new versioned `page-sectioning` data; re-render automatically picks up changes
- **Text group editor enhancements** — add/remove text groups and text entries, editable group type, delete groups
- **Activity answer display** — show activity answers and reasoning in both page detail (By Section tab) and storyboard preview panel
- **Fix: pipeline status resetting after storyboard accept** — stale `pipeline-status` query cache caused phantom SSE reconnection showing all steps as "Waiting"; now properly invalidated on pipeline complete and storyboard accept
- **Export ZIP moved to top bar** — removed the green "Storyboard accepted" card, placed Export ZIP button in the header alongside Storyboard button
- **Keyboard navigation** — left/right arrow keys navigate between pages on the page detail view (disabled when focus is in input fields)

## Test plan

- [x] `pnpm typecheck` passes clean
- [x] `pnpm test` — all 322 tests pass
- [x] Non-editing mode: By Section tab renders identically to before (activity badges, answers, colors)
- [x] Edit mode: section editor shows with all controls (reorder, type dropdown, prune toggle, colors, parts, merge, delete, add)
- [x] Save section edits → re-render → changes reflected in output
- [x] Add new text group → assign to section → save → re-render
- [x] Accept storyboard → navigate back → pipeline status shows correctly (no "Waiting" reset)
- [x] Export ZIP button visible in top bar when storyboard accepted
- [x] Arrow key navigation between pages (left/right), disabled in input fields