### PR TITLE
Show image thumbnails in page view

### DIFF
--- a/apps/studio/src/components/page-edit/ImagePruningEditor.tsx
+++ b/apps/studio/src/components/page-edit/ImagePruningEditor.tsx
@@ -7,10 +7,11 @@ interface ImagePruningEditorProps {
     isPruned: boolean
     reason?: string
   }>
+  bookLabel: string
   onChange: (images: ImagePruningEditorProps["images"]) => void
 }
 
-export function ImagePruningEditor({ images, onChange }: ImagePruningEditorProps) {
+export function ImagePruningEditor({ images, bookLabel, onChange }: ImagePruningEditorProps) {
   if (images.length === 0) {
     return <p className="text-sm text-muted-foreground">No images on this page.</p>
   }
@@ -28,10 +29,15 @@ export function ImagePruningEditor({ images, onChange }: ImagePruningEditorProps
       {images.map((img, i) => (
         <div
           key={img.imageId}
-          className={`flex items-center justify-between rounded border p-2 ${img.isPruned ? "opacity-60" : ""}`}
+          className={`flex items-center gap-3 rounded border p-2 ${img.isPruned ? "opacity-60" : ""}`}
         >
-          <div>
-            <span className={`text-sm ${img.isPruned ? "line-through" : ""}`}>{img.imageId}</span>
+          <img
+            src={`/api/books/${bookLabel}/images/${img.imageId}`}
+            alt={img.imageId}
+            className="h-16 w-16 shrink-0 rounded border object-cover bg-muted"
+          />
+          <div className="flex-1 min-w-0">
+            <span className={`text-sm truncate block ${img.isPruned ? "line-through" : ""}`}>{img.imageId}</span>
             {img.reason && (
               <p className="text-xs text-muted-foreground">{img.reason}</p>
             )}

--- a/apps/studio/src/routes/books.$label.pages.$pageId.tsx
+++ b/apps/studio/src/routes/books.$label.pages.$pageId.tsx
@@ -336,6 +336,7 @@ function PageDetailPage() {
                 </h3>
                 <ImagePruningEditor
                   images={editedImages.images}
+                  bookLabel={label}
                   onChange={(images) => setEditedImages({ ...editedImages, images })}
                 />
               </div>
@@ -347,10 +348,17 @@ function PageDetailPage() {
                 </h3>
                 <div className="space-y-2">
                   {page.imageClassification.images.map((img) => (
-                    <div key={img.imageId} className={`flex items-center justify-between rounded border p-2 ${img.isPruned ? "opacity-60" : ""}`}>
-                      <span className={`text-sm ${img.isPruned ? "line-through" : ""}`}>{img.imageId}</span>
-                      {img.reason && <span className="text-xs text-muted-foreground">{img.reason}</span>}
-                      {img.isPruned && <Badge variant="outline" className="text-xs">Pruned</Badge>}
+                    <div key={img.imageId} className={`flex items-center gap-3 rounded border p-2 ${img.isPruned ? "opacity-60" : ""}`}>
+                      <img
+                        src={`/api/books/${label}/images/${img.imageId}`}
+                        alt={img.imageId}
+                        className="h-16 w-16 shrink-0 rounded border object-cover bg-muted"
+                      />
+                      <div className="flex flex-1 flex-col gap-0.5 min-w-0">
+                        <span className={`text-sm truncate ${img.isPruned ? "line-through" : ""}`}>{img.imageId}</span>
+                        {img.reason && <span className="text-xs text-muted-foreground">{img.reason}</span>}
+                      </div>
+                      {img.isPruned && <Badge variant="outline" className="text-xs shrink-0">Pruned</Badge>}
                     </div>
                   ))}
                 </div>


### PR DESCRIPTION
## Summary

- Show 64x64 image thumbnails next to each image entry in the page detail view (both read-only and edit mode)
- Uses the existing `/api/books/:label/images/:imageId` endpoint

Closes #25

## Test plan

- [x] Navigate to a page with extracted images — thumbnails visible in image classification list
- [x] Enter edit mode — thumbnails visible alongside prune toggles
- [x] Pruned images show at reduced opacity with thumbnail still visible
- [x] `pnpm typecheck` passes