### PR TITLE
Show inline image thumbnails in LLM log detail view

### DIFF
--- a/apps/api/src/routes/debug.ts
+++ b/apps/api/src/routes/debug.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto"
 import fs from "node:fs"
 import path from "node:path"
 import { Hono } from "hono"
@@ -176,6 +177,53 @@ export function createDebugRoutes(
     const hasBookOverride = fs.existsSync(path.join(bookDir, "config.yaml"))
 
     return c.json({ merged, hasBookOverride })
+  })
+
+  // GET /books/:label/debug/llm-image/:hash — resolve LLM log image hash to binary
+  app.get("/books/:label/debug/llm-image/:hash", (c) => {
+    const { label, hash } = c.req.param()
+
+    if (!/^[0-9a-f]{16}$/.test(hash)) {
+      throw new HTTPException(400, { message: "Invalid hash format" })
+    }
+
+    const { safeLabel, dbPath } = requireDb(label, booksDir)
+    const bookDir = path.join(path.resolve(booksDir), safeLabel)
+
+    const db = openBookDb(dbPath)
+    try {
+      const rows = db.all(
+        "SELECT image_id, path FROM images",
+        []
+      ) as Array<{ image_id: string; path: string }>
+
+      for (const row of rows) {
+        const imagePath = path.resolve(bookDir, row.path)
+        if (!imagePath.startsWith(bookDir + path.sep)) continue
+
+        let buf: Buffer
+        try {
+          buf = fs.readFileSync(imagePath)
+        } catch {
+          continue
+        }
+
+        const base64 = buf.toString("base64")
+        const logHash = createHash("sha256").update(base64).digest("hex").slice(0, 16)
+        if (logHash === hash) {
+          const ext = path.extname(imagePath).toLowerCase()
+          const contentType =
+            ext === ".jpg" || ext === ".jpeg" ? "image/jpeg" : "image/png"
+          c.header("Content-Type", contentType)
+          c.header("Cache-Control", "public, max-age=86400")
+          return c.body(new Uint8Array(buf))
+        }
+      }
+
+      throw new HTTPException(404, { message: `Image not found for hash: ${hash}` })
+    } finally {
+      db.close()
+    }
   })
 
   // GET /books/:label/debug/versions/:node/:itemId — version history

--- a/apps/studio/src/components/debug/LlmLogsTab.tsx
+++ b/apps/studio/src/components/debug/LlmLogsTab.tsx
@@ -131,7 +131,7 @@ function StepTracker({ progress }: { progress: PipelineProgress }) {
 
 // --- Expanded Detail View ---
 
-function LogDetail({ data, loading }: { data: LlmLogEntry["data"] | null; loading: boolean }) {
+function LogDetail({ data, loading, label }: { data: LlmLogEntry["data"] | null; loading: boolean; label: string }) {
   if (loading) {
     return (
       <td colSpan={9} className="px-4 py-3 bg-muted/20 text-xs text-muted-foreground">
@@ -214,8 +214,16 @@ function LogDetail({ data, loading }: { data: LlmLogEntry["data"] | null; loadin
                           {part.text}
                         </pre>
                       ) : (
-                        <div className="text-muted-foreground italic">
-                          [Image: {part.width}x{part.height}, {Math.round(part.byteLength / 1024)}KB]
+                        <div className="my-1">
+                          <img
+                            src={`/api/books/${label}/debug/llm-image/${part.hash}`}
+                            alt={`${part.width}×${part.height}`}
+                            className="max-h-48 rounded border bg-muted object-contain"
+                            loading="lazy"
+                          />
+                          <div className="text-[10px] text-muted-foreground mt-0.5">
+                            {part.width}×{part.height}, {Math.round(part.byteLength / 1024)}KB
+                          </div>
                         </div>
                       )}
                     </div>
@@ -307,7 +315,7 @@ function LiveLogRow({ entry, label }: { entry: LlmLogSummary; label: string }) {
       </tr>
       {expanded && (
         <tr className="border-b border-border/50">
-          <LogDetail data={detail} loading={loading} />
+          <LogDetail data={detail} loading={loading} label={label} />
         </tr>
       )}
     </>
@@ -316,7 +324,7 @@ function LiveLogRow({ entry, label }: { entry: LlmLogSummary; label: string }) {
 
 // --- History Log Row (from REST) ---
 
-function HistoryLogRow({ entry }: { entry: LlmLogEntry }) {
+function HistoryLogRow({ entry, label }: { entry: LlmLogEntry; label: string }) {
   const [expanded, setExpanded] = useState(false)
   const status = getStatusFromHistory(entry)
 
@@ -354,7 +362,7 @@ function HistoryLogRow({ entry }: { entry: LlmLogEntry }) {
       </tr>
       {expanded && (
         <tr className="border-b border-border/50">
-          <LogDetail data={entry.data} loading={false} />
+          <LogDetail data={entry.data} loading={false} label={label} />
         </tr>
       )}
     </>
@@ -499,7 +507,7 @@ export function LlmLogsTab({ label, progress }: LlmLogsTabProps) {
 
             {/* History logs from REST API */}
             {data?.logs.map((entry) => (
-              <HistoryLogRow key={entry.id} entry={entry} />
+              <HistoryLogRow key={entry.id} entry={entry} label={label} />
             ))}
           </tbody>
         </table>


### PR DESCRIPTION
## Summary

- Add `GET /books/:label/debug/llm-image/:hash` endpoint that resolves LLM log image hashes (`sha256(base64).slice(0,16)`) back to original image files from the book's images table
- Replace text placeholders (`[Image: 800x600, 45KB]`) in the LLM log detail view with actual inline image thumbnails
- Thread `label` prop through `HistoryLogRow` → `LogDetail` so the frontend can construct the image URL

Closes #29

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (330 tests)
- [ ] Open a book processed through the pipeline
- [ ] Go to Debug → LLM Logs, expand a log entry for `text-classification` or `image-classification`
- [ ] Confirm images render as thumbnails with dimensions below
- [ ] Confirm text messages still render as before