### PR TITLE
Add pop-out debug panel to separate window

### DIFF
--- a/apps/studio/src/components/debug/DebugPanel.tsx
+++ b/apps/studio/src/components/debug/DebugPanel.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useRef, useEffect } from "react"
-import { X, GripHorizontal } from "lucide-react"
+import { X, GripHorizontal, ExternalLink } from "lucide-react"
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs"
 import { Button } from "@/components/ui/button"
 import { StatsTab } from "./StatsTab"
@@ -99,6 +99,23 @@ export function DebugPanel({ label, progress, onClose }: DebugPanelProps) {
           <span className="text-xs text-muted-foreground">
             Debug Panel
           </span>
+
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-6 w-6"
+            title="Pop out to new window"
+            onClick={() => {
+              window.open(
+                `/books/${label}/debug`,
+                `debug-${label}`,
+                "width=900,height=700",
+              )
+              onClose()
+            }}
+          >
+            <ExternalLink className="h-3 w-3" />
+          </Button>
 
           <Button
             variant="ghost"

--- a/apps/studio/src/routeTree.gen.ts
+++ b/apps/studio/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as BooksNewRouteImport } from "./routes/books.new"
 import { Route as BooksLabelRouteImport } from "./routes/books.$label"
 import { Route as BooksLabelIndexRouteImport } from "./routes/books.$label.index"
 import { Route as BooksLabelStoryboardRouteImport } from "./routes/books.$label.storyboard"
+import { Route as BooksLabelDebugRouteImport } from "./routes/books.$label.debug"
 import { Route as BooksLabelPagesPageIdRouteImport } from "./routes/books.$label.pages.$pageId"
 
 const IndexRoute = IndexRouteImport.update({
@@ -41,6 +42,11 @@ const BooksLabelStoryboardRoute = BooksLabelStoryboardRouteImport.update({
   path: "/storyboard",
   getParentRoute: () => BooksLabelRoute,
 } as any)
+const BooksLabelDebugRoute = BooksLabelDebugRouteImport.update({
+  id: "/debug",
+  path: "/debug",
+  getParentRoute: () => BooksLabelRoute,
+} as any)
 const BooksLabelPagesPageIdRoute = BooksLabelPagesPageIdRouteImport.update({
   id: "/pages/$pageId",
   path: "/pages/$pageId",
@@ -51,6 +57,7 @@ export interface FileRoutesByFullPath {
   "/": typeof IndexRoute
   "/books/$label": typeof BooksLabelRouteWithChildren
   "/books/new": typeof BooksNewRoute
+  "/books/$label/debug": typeof BooksLabelDebugRoute
   "/books/$label/storyboard": typeof BooksLabelStoryboardRoute
   "/books/$label/": typeof BooksLabelIndexRoute
   "/books/$label/pages/$pageId": typeof BooksLabelPagesPageIdRoute
@@ -58,6 +65,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   "/": typeof IndexRoute
   "/books/new": typeof BooksNewRoute
+  "/books/$label/debug": typeof BooksLabelDebugRoute
   "/books/$label/storyboard": typeof BooksLabelStoryboardRoute
   "/books/$label": typeof BooksLabelIndexRoute
   "/books/$label/pages/$pageId": typeof BooksLabelPagesPageIdRoute
@@ -67,6 +75,7 @@ export interface FileRoutesById {
   "/": typeof IndexRoute
   "/books/$label": typeof BooksLabelRouteWithChildren
   "/books/new": typeof BooksNewRoute
+  "/books/$label/debug": typeof BooksLabelDebugRoute
   "/books/$label/storyboard": typeof BooksLabelStoryboardRoute
   "/books/$label/": typeof BooksLabelIndexRoute
   "/books/$label/pages/$pageId": typeof BooksLabelPagesPageIdRoute
@@ -77,6 +86,7 @@ export interface FileRouteTypes {
     | "/"
     | "/books/$label"
     | "/books/new"
+    | "/books/$label/debug"
     | "/books/$label/storyboard"
     | "/books/$label/"
     | "/books/$label/pages/$pageId"
@@ -84,6 +94,7 @@ export interface FileRouteTypes {
   to:
     | "/"
     | "/books/new"
+    | "/books/$label/debug"
     | "/books/$label/storyboard"
     | "/books/$label"
     | "/books/$label/pages/$pageId"
@@ -92,6 +103,7 @@ export interface FileRouteTypes {
     | "/"
     | "/books/$label"
     | "/books/new"
+    | "/books/$label/debug"
     | "/books/$label/storyboard"
     | "/books/$label/"
     | "/books/$label/pages/$pageId"
@@ -140,6 +152,13 @@ declare module "@tanstack/react-router" {
       preLoaderRoute: typeof BooksLabelStoryboardRouteImport
       parentRoute: typeof BooksLabelRoute
     }
+    "/books/$label/debug": {
+      id: "/books/$label/debug"
+      path: "/debug"
+      fullPath: "/books/$label/debug"
+      preLoaderRoute: typeof BooksLabelDebugRouteImport
+      parentRoute: typeof BooksLabelRoute
+    }
     "/books/$label/pages/$pageId": {
       id: "/books/$label/pages/$pageId"
       path: "/pages/$pageId"
@@ -151,12 +170,14 @@ declare module "@tanstack/react-router" {
 }
 
 interface BooksLabelRouteChildren {
+  BooksLabelDebugRoute: typeof BooksLabelDebugRoute
   BooksLabelStoryboardRoute: typeof BooksLabelStoryboardRoute
   BooksLabelIndexRoute: typeof BooksLabelIndexRoute
   BooksLabelPagesPageIdRoute: typeof BooksLabelPagesPageIdRoute
 }
 
 const BooksLabelRouteChildren: BooksLabelRouteChildren = {
+  BooksLabelDebugRoute: BooksLabelDebugRoute,
   BooksLabelStoryboardRoute: BooksLabelStoryboardRoute,
   BooksLabelIndexRoute: BooksLabelIndexRoute,
   BooksLabelPagesPageIdRoute: BooksLabelPagesPageIdRoute,

--- a/apps/studio/src/routes/books.$label.debug.tsx
+++ b/apps/studio/src/routes/books.$label.debug.tsx
@@ -1,0 +1,80 @@
+import { createFileRoute, Link } from "@tanstack/react-router"
+import { Terminal, ArrowLeft } from "lucide-react"
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs"
+import { StatsTab } from "@/components/debug/StatsTab"
+import { LlmLogsTab } from "@/components/debug/LlmLogsTab"
+import { ConfigTab } from "@/components/debug/ConfigTab"
+import { VersionsTab } from "@/components/debug/VersionsTab"
+import { usePipelineSSE, usePipelineStatus } from "@/hooks/use-pipeline"
+
+export const Route = createFileRoute("/books/$label/debug")({
+  component: DebugPage,
+})
+
+function DebugPage() {
+  const { label } = Route.useParams()
+
+  const { data: pipelineStatus } = usePipelineStatus(label)
+  const isRunning = pipelineStatus?.status === "running"
+  const { progress } = usePipelineSSE(label, isRunning)
+
+  return (
+    <div className="flex flex-col h-screen">
+      {/* Header */}
+      <div className="flex items-center gap-3 px-4 py-2 border-b border-border shrink-0">
+        <Terminal className="h-4 w-4 text-muted-foreground" />
+        <span className="text-sm font-medium">Debug — {label}</span>
+        <div className="flex-1" />
+        <Link
+          to="/books/$label"
+          params={{ label }}
+          search={{ autoRun: undefined, startPage: undefined, endPage: undefined }}
+          className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeft className="h-3 w-3" />
+          Back to book
+        </Link>
+      </div>
+
+      {/* Tabs */}
+      <Tabs defaultValue="stats" className="flex flex-col flex-1 min-h-0">
+        <div className="flex items-center px-4 py-1 border-b border-border shrink-0">
+          <TabsList className="h-8">
+            <TabsTrigger value="stats" className="text-xs px-2 py-1">
+              Stats
+            </TabsTrigger>
+            <TabsTrigger value="logs" className="text-xs px-2 py-1">
+              Logs
+              {progress.isRunning && progress.liveLlmLogs.length > 0 && (
+                <span className="ml-1 inline-flex h-4 w-4 items-center justify-center rounded-full bg-green-500 text-[10px] text-white">
+                  {progress.liveLlmLogs.length > 99 ? "99+" : progress.liveLlmLogs.length}
+                </span>
+              )}
+            </TabsTrigger>
+            <TabsTrigger value="config" className="text-xs px-2 py-1">
+              Config
+            </TabsTrigger>
+            <TabsTrigger value="versions" className="text-xs px-2 py-1">
+              Versions
+            </TabsTrigger>
+          </TabsList>
+        </div>
+
+        <div className="flex-1 min-h-0 overflow-auto">
+          <TabsContent value="stats" className="m-0 h-full">
+            <StatsTab label={label} isRunning={progress.isRunning} />
+          </TabsContent>
+          <TabsContent value="logs" className="m-0 h-full">
+            <LlmLogsTab label={label} progress={progress} />
+          </TabsContent>
+          <TabsContent value="config" className="m-0 h-full">
+            <ConfigTab label={label} />
+          </TabsContent>
+          <TabsContent value="versions" className="m-0 h-full">
+            <VersionsTab label={label} />
+          </TabsContent>
+        </div>
+      </Tabs>
+    </div>
+  )
+}

--- a/apps/studio/src/routes/books.$label.tsx
+++ b/apps/studio/src/routes/books.$label.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from "react"
-import { createFileRoute, Outlet } from "@tanstack/react-router"
+import { createFileRoute, Outlet, useMatchRoute } from "@tanstack/react-router"
 import { Terminal } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { DebugPanel } from "@/components/debug/DebugPanel"
@@ -11,6 +11,8 @@ export const Route = createFileRoute("/books/$label")({
 
 function BookLayout() {
   const { label } = Route.useParams()
+  const matchRoute = useMatchRoute()
+  const isDebugRoute = !!matchRoute({ to: "/books/$label/debug", params: { label } })
   const [debugOpen, setDebugOpen] = useState(false)
 
   // SSE connection for debug panel — only active when debug panel is open
@@ -18,13 +20,14 @@ function BookLayout() {
   const isRunning = pipelineStatus?.status === "running"
   const { progress } = usePipelineSSE(label, debugOpen && isRunning)
 
-  // Cmd+Shift+D toggle
+  // Cmd+Shift+D toggle (disabled on debug route — that page IS the debug view)
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
+    if (isDebugRoute) return
     if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === "d") {
       e.preventDefault()
       setDebugOpen((prev) => !prev)
     }
-  }, [])
+  }, [isDebugRoute])
 
   useEffect(() => {
     document.addEventListener("keydown", handleKeyDown)
@@ -38,8 +41,8 @@ function BookLayout() {
         <Outlet />
       </div>
 
-      {/* Debug panel */}
-      {debugOpen && (
+      {/* Debug panel (hidden on debug route — rendered full-page there) */}
+      {debugOpen && !isDebugRoute && (
         <DebugPanel
           label={label}
           progress={progress}
@@ -48,7 +51,7 @@ function BookLayout() {
       )}
 
       {/* Floating toggle button */}
-      {!debugOpen && (
+      {!debugOpen && !isDebugRoute && (
         <Button
           variant="outline"
           size="icon"


### PR DESCRIPTION
## Summary

- Adds a pop-out button (↗ icon) to the debug panel header that opens `/books/$label/debug` in a new browser window (900×700)
- New full-page debug route with its own SSE connection — all 4 tabs (Stats, Logs, Config, Versions) at full viewport height
- Inline panel (Cmd+Shift+D) still works as before; pop-out and inline are complementary
- Named window target (`debug-${label}`) prevents duplicate windows on repeated clicks

Closes #28

## Test plan

- [ ] Open a book → Cmd+Shift+D → inline panel appears as before
- [ ] Click pop-out icon → new window opens at `/books/$label/debug`, inline panel closes
- [ ] In pop-out window: tabs work, no floating terminal button, SSE streams live logs during pipeline run
- [ ] Click pop-out again from inline panel → reuses same window (no duplicates)
- [ ] Direct nav to `/books/$label/debug` works standalone
- [ ] `pnpm typecheck` passes
- [ ] `pnpm test` passes (330/330)