### PR TITLE
Hide API key bar when key is already set

### DIFF
--- a/apps/studio/src/routes/__root.tsx
+++ b/apps/studio/src/routes/__root.tsx
@@ -15,18 +15,20 @@ function RootLayout() {
 
   return (
     <div className="flex flex-col h-screen bg-background text-foreground">
-      <div className="flex items-center justify-end px-3 py-1 border-b">
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-8 w-8"
-          onClick={() => setShowKeyDialog(true)}
-          title="API Key Settings"
-        >
-          <KeyRound className="h-4 w-4" />
-          <span className="sr-only">API Key Settings</span>
-        </Button>
-      </div>
+      {!hasApiKey && (
+        <div className="flex items-center justify-end px-3 py-1 border-b">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
+            onClick={() => setShowKeyDialog(true)}
+            title="API Key Settings"
+          >
+            <KeyRound className="h-4 w-4" />
+            <span className="sr-only">API Key Settings</span>
+          </Button>
+        </div>
+      )}
 
       <main className="flex-1 min-h-0 flex flex-col overflow-hidden">
         <Outlet />


### PR DESCRIPTION
## Summary

- Hide the full-width top bar with the key icon when an API key is already saved in localStorage
- The bar still appears when no key is set, prompting the user to add one
- The dialog continues to auto-open on first visit

## Test plan

- [ ] Fresh visit (no key in localStorage) → top bar visible, dialog auto-opens
- [ ] After saving a key → top bar disappears, reclaiming vertical space
- [ ] Clear localStorage → bar reappears on next load