### PR TITLE
Replace language picker with searchable dropdown

### DIFF
--- a/apps/studio/src/routes/books.new.tsx
+++ b/apps/studio/src/routes/books.new.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo } from "react"
+import { useState, useCallback, useMemo, useRef, useEffect } from "react"
 import { createFileRoute, useNavigate, Link } from "@tanstack/react-router"
 import {
   Upload,
@@ -6,6 +6,7 @@ import {
   ChevronDown,
   Check,
   Search,
+  X,
   GraduationCap,
   BookHeart,
   Library,
@@ -13,6 +14,7 @@ import {
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { Badge } from "@/components/ui/badge"
 import { Card, CardContent } from "@/components/ui/card"
 import { Switch } from "@/components/ui/switch"
 import { useCreateBook } from "@/hooks/use-books"
@@ -26,26 +28,28 @@ const LAYOUT_TYPES = ["textbook", "storybook", "reference"] as const
 type LayoutType = (typeof LAYOUT_TYPES)[number]
 
 const SUPPORTED_LANGUAGES = [
+  { code: "ar", name: "Arabic" },
+  { code: "bn", name: "Bengali" },
+  { code: "zh", name: "Chinese" },
+  { code: "nl", name: "Dutch" },
   { code: "en", name: "English" },
   { code: "fr", name: "French" },
-  { code: "es", name: "Spanish" },
-  { code: "pt", name: "Portuguese" },
-  { code: "ar", name: "Arabic" },
-  { code: "zh", name: "Chinese" },
-  { code: "hi", name: "Hindi" },
-  { code: "bn", name: "Bengali" },
-  { code: "ru", name: "Russian" },
-  { code: "ja", name: "Japanese" },
   { code: "de", name: "German" },
-  { code: "ko", name: "Korean" },
+  { code: "hi", name: "Hindi" },
+  { code: "id", name: "Indonesian" },
   { code: "it", name: "Italian" },
+  { code: "ja", name: "Japanese" },
+  { code: "ko", name: "Korean" },
+  { code: "pl", name: "Polish" },
+  { code: "pt", name: "Portuguese" },
+  { code: "ru", name: "Russian" },
+  { code: "si", name: "Sinhala" },
+  { code: "es", name: "Spanish" },
+  { code: "sw", name: "Swahili" },
+  { code: "ta", name: "Tamil" },
+  { code: "th", name: "Thai" },
   { code: "tr", name: "Turkish" },
   { code: "vi", name: "Vietnamese" },
-  { code: "th", name: "Thai" },
-  { code: "nl", name: "Dutch" },
-  { code: "pl", name: "Polish" },
-  { code: "sw", name: "Swahili" },
-  { code: "id", name: "Indonesian" },
 ] as const
 
 const STEPS = [
@@ -131,6 +135,10 @@ function Stepper({ currentStep }: { currentStep: number }) {
   )
 }
 
+const LANG_MAP = new Map<string, string>(
+  SUPPORTED_LANGUAGES.map((l) => [l.code, l.name])
+)
+
 function LanguagePicker({
   selected,
   onSelect,
@@ -145,6 +153,9 @@ function LanguagePicker({
   hint?: string
 }) {
   const [search, setSearch] = useState("")
+  const [open, setOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
 
   const filtered = useMemo(() => {
     if (!search) return SUPPORTED_LANGUAGES
@@ -158,6 +169,40 @@ function LanguagePicker({
   const isSelected = (code: string) =>
     typeof selected === "string" ? selected === code : selected.has(code)
 
+  const selectedSet =
+    typeof selected === "string" ? null : selected
+
+  const displayValue =
+    typeof selected === "string"
+      ? LANG_MAP.get(selected) ?? selected
+      : null
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false)
+        setSearch("")
+      }
+    }
+    document.addEventListener("mousedown", handler)
+    return () => document.removeEventListener("mousedown", handler)
+  }, [])
+
+  const handleSelect = (code: string) => {
+    onSelect(code)
+    if (!multiple) {
+      setOpen(false)
+      setSearch("")
+    } else {
+      // Keep focus on input for continued selection
+      inputRef.current?.focus()
+    }
+  }
+
   return (
     <div className="space-y-2">
       <div>
@@ -166,41 +211,82 @@ function LanguagePicker({
           <p className="text-xs text-muted-foreground mt-0.5">{hint}</p>
         )}
       </div>
-      <div className="relative">
-        <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+
+      {/* Selected badges for multi-select */}
+      {multiple && selectedSet && selectedSet.size > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {Array.from(selectedSet).map((code) => (
+            <Badge
+              key={code}
+              variant="secondary"
+              className="gap-1 pr-1 text-xs font-normal"
+            >
+              {LANG_MAP.get(code) ?? code}
+              <button
+                type="button"
+                onClick={() => onSelect(code)}
+                className="ml-0.5 rounded-full p-0.5 hover:bg-muted-foreground/20"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </Badge>
+          ))}
+        </div>
+      )}
+
+      <div ref={containerRef} className="relative">
+        <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground z-10" />
         <Input
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          placeholder="Search languages..."
+          ref={inputRef}
+          value={open ? search : search || (!multiple ? displayValue ?? "" : "")}
+          onChange={(e) => {
+            setSearch(e.target.value)
+            setOpen(true)
+          }}
+          onFocus={() => setOpen(true)}
+          placeholder={
+            multiple
+              ? "Search languages..."
+              : displayValue
+                ? `${displayValue} — type to change`
+                : "Search languages..."
+          }
           className="pl-8 h-8 text-xs"
         />
-      </div>
-      <div className="flex flex-wrap gap-1.5">
-        {filtered.map((lang) => {
-          const active = isSelected(lang.code)
-          return (
-            <button
-              key={lang.code}
-              type="button"
-              onClick={() => onSelect(lang.code)}
-              className={`inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-xs font-medium transition-colors ${
-                active
-                  ? "border-primary bg-primary text-primary-foreground"
-                  : "border-border text-foreground hover:border-primary/40 hover:bg-accent"
-              }`}
-            >
-              {active && multiple && <Check className="h-3 w-3" />}
-              {lang.name}
-              <span className={`text-[10px] ${active ? "opacity-70" : "opacity-40"}`}>
-                {lang.code}
-              </span>
-            </button>
-          )
-        })}
-        {filtered.length === 0 && (
-          <p className="text-xs text-muted-foreground py-1">
-            No languages match &ldquo;{search}&rdquo;
-          </p>
+
+        {open && (
+          <div className="absolute z-50 mt-1 w-full rounded-md border bg-popover shadow-md">
+            <div className="max-h-48 overflow-y-auto p-1">
+              {filtered.map((lang) => {
+                const active = isSelected(lang.code)
+                return (
+                  <button
+                    key={lang.code}
+                    type="button"
+                    onClick={() => handleSelect(lang.code)}
+                    className={`flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-xs outline-none transition-colors ${
+                      active
+                        ? "bg-accent text-accent-foreground"
+                        : "hover:bg-accent hover:text-accent-foreground"
+                    }`}
+                  >
+                    <span className="flex h-4 w-4 items-center justify-center">
+                      {active && <Check className="h-3.5 w-3.5" />}
+                    </span>
+                    <span>{lang.name}</span>
+                    <span className="text-[10px] text-muted-foreground ml-auto">
+                      {lang.code}
+                    </span>
+                  </button>
+                )
+              })}
+              {filtered.length === 0 && (
+                <p className="px-2 py-1.5 text-xs text-muted-foreground">
+                  No languages match &ldquo;{search}&rdquo;
+                </p>
+              )}
+            </div>
+          </div>
         )}
       </div>
     </div>
@@ -326,7 +412,7 @@ function AddBookPage() {
 
       <Card>
         <Stepper currentStep={step} />
-        <CardContent className="pt-4 space-y-4">
+        <CardContent className="pt-4 space-y-4 max-h-[calc(100vh-10rem)] overflow-y-auto">
           {/* Step 1 — Upload */}
           {step === 1 && (
             <div key={1} className="animate-wizard-enter space-y-4">


### PR DESCRIPTION
## Summary

- Replace the flat chip grid in the add-book wizard (step 3) with a compact searchable dropdown
- Add Sinhala (`si`) and Tamil (`ta`) to supported languages, sort list alphabetically
- Add `max-height` + `overflow-y-auto` on card content to ensure buttons are always reachable on small viewports

Closes #47

## Details

The chip grid showed all 20+ languages at once, which overflowed on a 14" laptop at 150% scaling — pushing the "Back" and "Create Storyboard" buttons off-screen.

The new searchable dropdown:
- **Single-select** (editing language): type to filter, click to select, dropdown closes
- **Multi-select** (output languages): selected items show as removable badges, dropdown stays open for continued selection
- Fixed-height dropdown (max 192px) with scroll — scales to any number of languages

No new dependencies — built with existing primitives (Input, Badge, plain div).

## Test plan

- [ ] Add book wizard → step 3 shows searchable dropdowns for both language fields
- [ ] Type to filter languages — results update live
- [ ] Single-select: clicking a language selects it and closes dropdown
- [ ] Multi-select: clicking toggles selection, badges appear above input, X removes them
- [ ] Sinhala and Tamil appear in the list
- [ ] Buttons visible without scrolling on small viewports (14" laptop, 150% scale)
- [ ] Dropdown closes on outside click