### PR TITLE
Add image complexity filter to prune blank/simple images

### DIFF
--- a/apps/studio/src/components/v2/steps/CaptionsView.tsx
+++ b/apps/studio/src/components/v2/steps/CaptionsView.tsx
@@ -250,7 +250,7 @@ export function CaptionsView({ bookLabel }: { bookLabel: string }) {
     return () => setExtra(null)
   }, [pages, totalImages, pagesWithImages.length, setExtra])
 
-  if (isLoading) {
+  if (isLoading && !captionsRunning) {
     return (
       <div className="flex items-center justify-center py-12 text-muted-foreground">
         <Loader2 className="w-4 h-4 animate-spin mr-2" />

--- a/apps/studio/src/components/v2/steps/ExtractSettings.tsx
+++ b/apps/studio/src/components/v2/steps/ExtractSettings.tsx
@@ -43,6 +43,7 @@ export function ExtractSettings({ bookLabel, headerTarget, tab = "general" }: { 
   const [prunedTextTypes, setPrunedTextTypes] = useState<Set<string>>(new Set())
   const [minSide, setMinSide] = useState("")
   const [maxSide, setMaxSide] = useState("")
+  const [minStddev, setMinStddev] = useState("")
   const [metadataModel, setMetadataModel] = useState("")
   const [extractionModel, setExtractionModel] = useState("")
   const [metadataPromptDraft, setMetadataPromptDraft] = useState<string | null>(null)
@@ -74,6 +75,7 @@ export function ExtractSettings({ bookLabel, headerTarget, tab = "general" }: { 
       const filters = merged.image_filters as Record<string, unknown>
       if (filters.min_side != null) setMinSide(String(filters.min_side))
       if (filters.max_side != null) setMaxSide(String(filters.max_side))
+      if (filters.min_stddev != null) setMinStddev(String(filters.min_stddev))
     }
     if (merged.metadata && typeof merged.metadata === "object") {
       const md = merged.metadata as Record<string, unknown>
@@ -156,6 +158,7 @@ export function ExtractSettings({ bookLabel, headerTarget, tab = "general" }: { 
       const filters: Record<string, number> = {}
       if (minSide) filters.min_side = Number(minSide)
       if (maxSide) filters.max_side = Number(maxSide)
+      if (minStddev) filters.min_stddev = Number(minStddev)
       overrides.image_filters = Object.keys(filters).length > 0 ? filters : undefined
     }
     if (shouldWrite("metadata")) {
@@ -263,10 +266,10 @@ export function ExtractSettings({ bookLabel, headerTarget, tab = "general" }: { 
             />
           </div>
 
-          {/* Image Pruning */}
+          {/* Image Filters */}
           <div>
             <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-3">
-              Image Size Filters
+              Image Filters
             </h3>
             <div className="flex items-center gap-2">
               <div className="space-y-1">
@@ -294,6 +297,21 @@ export function ExtractSettings({ bookLabel, headerTarget, tab = "general" }: { 
             </div>
             <p className="text-xs text-muted-foreground mt-1.5">
               Images with shortest side below min or longest side above max are pruned.
+            </p>
+            <div className="space-y-1 mt-3">
+              <Label className="text-xs">Min complexity</Label>
+              <Input
+                type="number"
+                min={0}
+                step={0.1}
+                value={minStddev}
+                onChange={(e) => { setMinStddev(e.target.value); markDirty("image_filters") }}
+                placeholder="2"
+                className="w-28"
+              />
+            </div>
+            <p className="text-xs text-muted-foreground mt-1.5">
+              Higher values filter out simple or blank images.
             </p>
           </div>
         </>

--- a/apps/studio/src/components/v2/steps/ExtractView.tsx
+++ b/apps/studio/src/components/v2/steps/ExtractView.tsx
@@ -217,7 +217,7 @@ export function ExtractView({ bookLabel, selectedPageId: selectedPageIdProp, onS
     return () => window.removeEventListener("keydown", handleKeyDown)
   }, [selectedPageId, prevPageId, nextPageId])
 
-  if (isLoading) {
+  if (isLoading && !extractRunning) {
     return (
       <div className="flex items-center gap-2 p-4 text-sm text-muted-foreground">
         <Loader2 className="h-4 w-4 animate-spin" />

--- a/apps/studio/src/components/v2/steps/GlossaryView.tsx
+++ b/apps/studio/src/components/v2/steps/GlossaryView.tsx
@@ -206,7 +206,7 @@ export function GlossaryView({ bookLabel }: { bookLabel: string }) {
     })
   }
 
-  if (isLoading) {
+  if (isLoading && !glossaryRunning) {
     return (
       <div className="flex items-center justify-center py-12 text-muted-foreground">
         <Loader2 className="w-4 h-4 animate-spin mr-2" />

--- a/apps/studio/src/components/v2/steps/QuizzesView.tsx
+++ b/apps/studio/src/components/v2/steps/QuizzesView.tsx
@@ -230,7 +230,7 @@ export function QuizzesView({ bookLabel }: { bookLabel: string }) {
     })
   }
 
-  if (isLoading) {
+  if (isLoading && !quizzesRunning) {
     return (
       <div className="flex items-center justify-center py-12 text-muted-foreground">
         <Loader2 className="w-4 h-4 animate-spin mr-2" />

--- a/apps/studio/src/components/v2/steps/StoryboardView.tsx
+++ b/apps/studio/src/components/v2/steps/StoryboardView.tsx
@@ -181,7 +181,7 @@ export function StoryboardView({ bookLabel, selectedPageId: selectedPageIdProp, 
     return () => window.removeEventListener("keydown", handleKeyDown)
   }, [selectedPageId, sectionIndex, sectionCount, canGoPrev, canGoNext, prevPageId, nextPageId])
 
-  if (pagesLoading) {
+  if (pagesLoading && !storyboardRunning) {
     return (
       <div className="flex items-center gap-2 p-4 text-sm text-muted-foreground">
         <Loader2 className="h-4 w-4 animate-spin" />

--- a/apps/studio/src/components/v2/steps/TextToSpeechView.tsx
+++ b/apps/studio/src/components/v2/steps/TextToSpeechView.tsx
@@ -86,7 +86,7 @@ export function TextToSpeechView({ bookLabel }: { bookLabel: string }) {
 
   const isLoading = ttsLoading || catalogLoading
 
-  if (isLoading) {
+  if (isLoading && !ttsRunning) {
     return (
       <div className="flex items-center justify-center py-12 text-muted-foreground">
         <Loader2 className="w-4 h-4 animate-spin mr-2" />

--- a/apps/studio/src/components/v2/steps/TranslationsView.tsx
+++ b/apps/studio/src/components/v2/steps/TranslationsView.tsx
@@ -258,7 +258,7 @@ export function TranslationsView({ bookLabel }: { bookLabel: string }) {
     return () => setExtra(null)
   }, [catalog, entries.length, outputLanguages.length, hasTranslations, selectedLang, translationVersion, saving, dirty, bookLabel, isSourceLang])
 
-  if (isLoading) {
+  if (isLoading && !translationsRunning) {
     return (
       <div className="flex items-center justify-center py-12 text-muted-foreground">
         <Loader2 className="w-4 h-4 animate-spin mr-2" />

--- a/config/presets/reference.yaml
+++ b/config/presets/reference.yaml
@@ -41,3 +41,4 @@ pruned_section_types:
 image_filters:
   min_side: 100
   max_side: 5000
+  min_stddev: 2

--- a/config/presets/storybook.yaml
+++ b/config/presets/storybook.yaml
@@ -41,6 +41,7 @@ pruned_section_types:
 image_filters:
   min_side: 150
   max_side: 3500
+  min_stddev: 2
 
 quiz_generation:
   pages_per_quiz: 3

--- a/config/presets/textbook.yaml
+++ b/config/presets/textbook.yaml
@@ -96,3 +96,4 @@ pruned_section_types:
 image_filters:
   min_side: 150
   max_side: 3500
+  min_stddev: 2

--- a/packages/pipeline/package.json
+++ b/packages/pipeline/package.json
@@ -21,9 +21,12 @@
     "js-yaml": "^4.1.0",
     "postcss": "^8.5.0",
     "tailwindcss": "^3.4.0",
+    "jpeg-js": "^0.4.4",
     "zod": "^3.24.0"
   },
   "devDependencies": {
-    "@types/cli-progress": "^3.11.6"
+    "@types/cli-progress": "^3.11.6",
+    "pngjs": "^7.0.0",
+    "@types/pngjs": "^6.0.5"
   }
 }

--- a/packages/pipeline/src/__tests__/image-classification.test.ts
+++ b/packages/pipeline/src/__tests__/image-classification.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest"
+import { PNG } from "pngjs"
 import { classifyPageImages, buildImageClassifyConfig } from "../image-classification.js"
 import type { ImageClassifyConfig } from "../image-classification.js"
 import type { ImageData } from "@adt/storage"
@@ -167,6 +168,103 @@ describe("classifyPageImages", () => {
 
     // Exactly 5000 is not > 5000, so kept
     expect(result.images[0].isPruned).toBe(false)
+  })
+
+  // --- Complexity filter (min_stddev) ---
+
+  function makeSolidPng(width: number, height: number, r: number, g: number, b: number): Buffer {
+    const png = new PNG({ width, height })
+    for (let y = 0; y < height; y++) {
+      for (let x = 0; x < width; x++) {
+        const idx = (y * width + x) * 4
+        png.data[idx] = r
+        png.data[idx + 1] = g
+        png.data[idx + 2] = b
+        png.data[idx + 3] = 255
+      }
+    }
+    return PNG.sync.write(png)
+  }
+
+  function makeGradientPng(width: number, height: number): Buffer {
+    const png = new PNG({ width, height })
+    for (let y = 0; y < height; y++) {
+      for (let x = 0; x < width; x++) {
+        const idx = (y * width + x) * 4
+        const val = Math.floor((x / width) * 255)
+        png.data[idx] = val
+        png.data[idx + 1] = val
+        png.data[idx + 2] = val
+        png.data[idx + 3] = 255
+      }
+    }
+    return PNG.sync.write(png)
+  }
+
+  it("prunes blank images when min_stddev is configured", () => {
+    const blankPng = makeSolidPng(200, 200, 255, 255, 255)
+    const config: ImageClassifyConfig = {
+      filters: { min_stddev: 2 },
+      getImageBytes: () => blankPng,
+    }
+    const images = [makeImage("pg001_im001", 200, 200)]
+    const result = classifyPageImages("pg001", images, config)
+
+    expect(result.images[0].isPruned).toBe(true)
+    expect(result.images[0].reason).toContain("min_stddev")
+  })
+
+  it("keeps complex images when min_stddev is configured", () => {
+    const gradientPng = makeGradientPng(256, 10)
+    const config: ImageClassifyConfig = {
+      filters: { min_stddev: 2 },
+      getImageBytes: () => gradientPng,
+    }
+    const images = [makeImage("pg001_im001", 256, 10)]
+    const result = classifyPageImages("pg001", images, config)
+
+    expect(result.images[0].isPruned).toBe(false)
+  })
+
+  it("skips complexity filter when min_stddev is not configured", () => {
+    const config: ImageClassifyConfig = {
+      filters: { min_side: 100 },
+      getImageBytes: () => {
+        throw new Error("should not be called")
+      },
+    }
+    const images = [makeImage("pg001_im001", 200, 200)]
+    const result = classifyPageImages("pg001", images, config)
+
+    expect(result.images[0].isPruned).toBe(false)
+  })
+
+  it("skips complexity filter when getImageBytes is not provided", () => {
+    const config: ImageClassifyConfig = {
+      filters: { min_stddev: 2 },
+    }
+    const images = [makeImage("pg001_im001", 200, 200)]
+    const result = classifyPageImages("pg001", images, config)
+
+    expect(result.images[0].isPruned).toBe(false)
+  })
+
+  it("does not run complexity filter on images already pruned by size", () => {
+    let getImageBytesCalled = false
+    const config: ImageClassifyConfig = {
+      filters: { min_side: 100, min_stddev: 2 },
+      getImageBytes: () => {
+        getImageBytesCalled = true
+        return makeSolidPng(10, 10, 255, 255, 255)
+      },
+    }
+    // Image is too small — should be pruned by size filter, never reaching complexity
+    const images = [makeImage("pg001_im001", 50, 50)]
+    const result = classifyPageImages("pg001", images, config)
+
+    expect(result.images[0].isPruned).toBe(true)
+    expect(result.images[0].reason).toContain("min_side")
+    expect(getImageBytesCalled).toBe(false)
   })
 })
 

--- a/packages/pipeline/src/__tests__/image-complexity.test.ts
+++ b/packages/pipeline/src/__tests__/image-complexity.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest"
+import { PNG } from "pngjs"
+import jpeg from "jpeg-js"
+import { grayscaleStdDev } from "../image-complexity.js"
+
+function makeSolidPng(width: number, height: number, r: number, g: number, b: number): Buffer {
+  const png = new PNG({ width, height })
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const idx = (y * width + x) * 4
+      png.data[idx] = r
+      png.data[idx + 1] = g
+      png.data[idx + 2] = b
+      png.data[idx + 3] = 255
+    }
+  }
+  return PNG.sync.write(png)
+}
+
+function makeGradientPng(width: number, height: number): Buffer {
+  const png = new PNG({ width, height })
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const idx = (y * width + x) * 4
+      const val = Math.floor((x / width) * 255)
+      png.data[idx] = val
+      png.data[idx + 1] = val
+      png.data[idx + 2] = val
+      png.data[idx + 3] = 255
+    }
+  }
+  return PNG.sync.write(png)
+}
+
+function makeSolidJpeg(width: number, height: number, r: number, g: number, b: number): Buffer {
+  const data = Buffer.alloc(width * height * 4)
+  for (let i = 0; i < width * height; i++) {
+    data[i * 4] = r
+    data[i * 4 + 1] = g
+    data[i * 4 + 2] = b
+    data[i * 4 + 3] = 255
+  }
+  const raw = { data, width, height }
+  return Buffer.from(jpeg.encode(raw, 100).data)
+}
+
+describe("grayscaleStdDev", () => {
+  it("returns 0 for a solid white PNG", () => {
+    const png = makeSolidPng(10, 10, 255, 255, 255)
+    expect(grayscaleStdDev(png)).toBeCloseTo(0, 1)
+  })
+
+  it("returns 0 for a solid color PNG", () => {
+    const png = makeSolidPng(10, 10, 128, 64, 32)
+    expect(grayscaleStdDev(png)).toBeCloseTo(0, 1)
+  })
+
+  it("returns 0 for a solid black PNG", () => {
+    const png = makeSolidPng(10, 10, 0, 0, 0)
+    expect(grayscaleStdDev(png)).toBeCloseTo(0, 1)
+  })
+
+  it("returns significant stddev for a gradient PNG", () => {
+    const png = makeGradientPng(256, 1)
+    const stddev = grayscaleStdDev(png)
+    expect(stddev).toBeGreaterThan(50)
+  })
+
+  it("decodes and computes stddev for JPEG images", () => {
+    const jpegSolid = makeSolidJpeg(10, 10, 255, 255, 255)
+    // JPEG compression may introduce slight variation even for solid images
+    expect(grayscaleStdDev(jpegSolid)).toBeLessThan(5)
+  })
+
+  it("throws for unsupported image format", () => {
+    const garbage = Buffer.from([0x00, 0x01, 0x02, 0x03])
+    expect(() => grayscaleStdDev(garbage)).toThrow("Unsupported image format")
+  })
+})

--- a/packages/pipeline/src/image-classification.ts
+++ b/packages/pipeline/src/image-classification.ts
@@ -1,20 +1,22 @@
 import type { ImageFilters, ImageClassificationOutput, AppConfig } from "@adt/types"
 import type { ImageData } from "@adt/storage"
+import { grayscaleStdDev } from "./image-complexity.js"
 
 export interface ImageClassifyConfig {
   filters: ImageFilters
+  getImageBytes?: (imageId: string) => Buffer
 }
 
 /**
  * Classify images on a single page. Pure function — no side effects.
- * Filters images by size constraints and prunes full-page renders.
+ * Filters images by size constraints, pixel complexity, and prunes full-page renders.
  */
 export function classifyPageImages(
   pageId: string,
   images: ImageData[],
   config: ImageClassifyConfig
 ): ImageClassificationOutput {
-  const { min_side, max_side } = config.filters
+  const { min_side, max_side, min_stddev } = config.filters
 
   return {
     images: images.map((img) => {
@@ -39,6 +41,19 @@ export function classifyPageImages(
           imageId: img.imageId,
           isPruned: true,
           reason: `longest side ${longSide}px > max_side ${max_side}px`,
+        }
+      }
+
+      // Complexity filter — runs after size filters (more expensive, needs pixel data)
+      if (min_stddev !== undefined && config.getImageBytes) {
+        const imageBytes = config.getImageBytes(img.imageId)
+        const stddev = grayscaleStdDev(imageBytes)
+        if (stddev < min_stddev) {
+          return {
+            imageId: img.imageId,
+            isPruned: true,
+            reason: `stddev ${stddev.toFixed(1)} < min_stddev ${min_stddev}`,
+          }
         }
       }
 

--- a/packages/pipeline/src/image-complexity.ts
+++ b/packages/pipeline/src/image-complexity.ts
@@ -1,0 +1,53 @@
+import { decodePng } from "@adt/pdf"
+import jpeg from "jpeg-js"
+
+/**
+ * Compute the standard deviation of grayscale pixel values for an image.
+ * Low stddev indicates a blank or near-blank image (solid color, white page, etc.).
+ *
+ * Supports JPEG and PNG formats (detected via magic bytes).
+ */
+export function grayscaleStdDev(imageBuffer: Buffer): number {
+  const pixels = decodeToRgba(imageBuffer)
+  const pixelCount = pixels.length / 4
+
+  // First pass: compute mean grayscale value
+  let sum = 0
+  for (let i = 0; i < pixels.length; i += 4) {
+    sum += 0.299 * pixels[i] + 0.587 * pixels[i + 1] + 0.114 * pixels[i + 2]
+  }
+  const mean = sum / pixelCount
+
+  // Second pass: compute variance
+  let varianceSum = 0
+  for (let i = 0; i < pixels.length; i += 4) {
+    const gray = 0.299 * pixels[i] + 0.587 * pixels[i + 1] + 0.114 * pixels[i + 2]
+    const diff = gray - mean
+    varianceSum += diff * diff
+  }
+
+  return Math.sqrt(varianceSum / pixelCount)
+}
+
+function decodeToRgba(imageBuffer: Buffer): Uint8Array {
+  // JPEG: starts with 0xFF 0xD8
+  if (imageBuffer[0] === 0xff && imageBuffer[1] === 0xd8) {
+    const decoded = jpeg.decode(imageBuffer, { useTArray: true })
+    return decoded.data
+  }
+
+  // PNG: starts with 0x89 0x50 0x4E 0x47
+  if (
+    imageBuffer[0] === 0x89 &&
+    imageBuffer[1] === 0x50 &&
+    imageBuffer[2] === 0x4e &&
+    imageBuffer[3] === 0x47
+  ) {
+    const { data } = decodePng(imageBuffer)
+    return data
+  }
+
+  throw new Error(
+    `Unsupported image format (magic bytes: 0x${imageBuffer[0].toString(16)} 0x${imageBuffer[1].toString(16)})`
+  )
+}

--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -16,6 +16,7 @@ export {
   buildImageClassifyConfig,
   type ImageClassifyConfig,
 } from "./image-classification.js"
+export { grayscaleStdDev } from "./image-complexity.js"
 export {
   extractMetadata,
   buildMetadataConfig,

--- a/packages/pipeline/src/pipeline.ts
+++ b/packages/pipeline/src/pipeline.ts
@@ -150,7 +150,11 @@ export async function runPipeline(
 
     // Step 3: Create Storyboard (per-page classification, sectioning, rendering)
     const textClassifyConfig = buildClassifyConfig(config)
-    const imageClassifyConfig = buildImageClassifyConfig(config)
+    const imageClassifyConfig = {
+      ...buildImageClassifyConfig(config),
+      getImageBytes: (imageId: string) =>
+        Buffer.from(storage.getImageBase64(imageId), "base64"),
+    }
     const sectioningConfig = buildSectioningConfig(config)
     const resolveRenderConfig = buildRenderStrategyResolver(config)
     const llmModel = createLLMModel({

--- a/packages/types/src/image-classification.ts
+++ b/packages/types/src/image-classification.ts
@@ -3,6 +3,7 @@ import { z } from "zod"
 export const ImageFilters = z.object({
   min_side: z.number().int().min(0).optional(),
   max_side: z.number().int().min(0).optional(),
+  min_stddev: z.number().min(0).optional(),
 })
 export type ImageFilters = z.infer<typeof ImageFilters>
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,6 +198,9 @@ importers:
       htmlparser2:
         specifier: ^10.1.0
         version: 10.1.0
+      jpeg-js:
+        specifier: ^0.4.4
+        version: 0.4.4
       js-yaml:
         specifier: ^4.1.0
         version: 4.1.1
@@ -217,6 +220,12 @@ importers:
       '@types/cli-progress':
         specifier: ^3.11.6
         version: 3.11.6
+      '@types/pngjs':
+        specifier: ^6.0.5
+        version: 6.0.5
+      pngjs:
+        specifier: ^7.0.0
+        version: 7.0.0
 
   packages/storage:
     dependencies:
@@ -2165,6 +2174,9 @@ packages:
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
+
+  jpeg-js@0.4.4:
+    resolution: {integrity: sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -4659,6 +4671,8 @@ snapshots:
   jiti@1.21.7: {}
 
   jiti@2.6.1: {}
+
+  jpeg-js@0.4.4: {}
 
   js-tokens@4.0.0: {}
 


### PR DESCRIPTION
## Summary

- Adds a **grayscale standard deviation filter** (`min_stddev`) that prunes visually simple images (blank backgrounds, solid fills) during image classification, running after existing size filters
- Exposes the complexity threshold in the v2 Extract Settings UI under "Image Filters"
- Fixes a brief "Loading pages..." spinner flash when starting a rerun from settings across all v2 step views

## Details

Images from PDFs often include blank or near-blank artifacts (solid backgrounds, white boxes) that pass size filters but add no value. This mirrors the `is_blank_image` approach from adt-press.

**Pipeline changes:**
- New `grayscaleStdDev()` function in `image-complexity.ts` — pure JS decoding via `jpeg-js` and `pngjs`
- `min_stddev` added to `ImageFilters` Zod schema
- `classifyPageImages` accepts an optional `getImageBytes` accessor; complexity check only runs on images that pass size filters
- Default threshold of `2` added to all config presets (storybook, reference, textbook)

**UI changes:**
- Complexity input added to v2 ExtractSettings under "Image Filters" heading
- Loading guard fix (`isLoading && !stepRunning`) applied to all 7 v2 step views

## Test plan
- [x] New unit tests for `grayscaleStdDev` (solid PNGs, gradient, JPEG, unsupported format)
- [x] New integration tests for complexity filter in `classifyPageImages` (prune blank, keep complex, skip when unconfigured, skip when no bytes accessor, skip already-pruned)
- [ ] Run pipeline on a PDF with known blank images, verify they're pruned with stddev reason
- [ ] Verify no loading spinner flash when starting a rerun from settings