### PR TITLE
Add styleguide system and fix code review issues

### DIFF
--- a/apps/api/src/routes/presets.ts
+++ b/apps/api/src/routes/presets.ts
@@ -3,7 +3,7 @@ import path from "node:path"
 import { Hono } from "hono"
 import { HTTPException } from "hono/http-exception"
 import yaml from "js-yaml"
-import { PresetName } from "@adt/types"
+import { PresetName, StyleguideName } from "@adt/types"
 
 export function createPresetRoutes(configPath: string): Hono {
   const app = new Hono()
@@ -26,6 +26,35 @@ export function createPresetRoutes(configPath: string): Hono {
     const content = fs.readFileSync(presetPath, "utf-8")
     const parsed = yaml.load(content) as Record<string, unknown>
     return c.json({ config: parsed })
+  })
+
+  // GET /styleguides — List available styleguide names
+  app.get("/styleguides", (c) => {
+    const styleguidesDir = path.join(path.dirname(configPath), "assets", "styleguides")
+    if (!fs.existsSync(styleguidesDir)) {
+      return c.json({ styleguides: [] })
+    }
+    const files = fs.readdirSync(styleguidesDir)
+    const names = files
+      .filter((f) => f.endsWith(".md"))
+      .map((f) => f.replace(/\.md$/, ""))
+    return c.json({ styleguides: names })
+  })
+
+  // GET /styleguides/:name/preview — Return preview HTML for a styleguide
+  app.get("/styleguides/:name/preview", (c) => {
+    const result = StyleguideName.safeParse(c.req.param("name"))
+    if (!result.success) {
+      throw new HTTPException(400, { message: "Invalid styleguide name" })
+    }
+    const name = result.data
+    const styleguidesDir = path.join(path.dirname(configPath), "assets", "styleguides")
+    const previewPath = path.join(styleguidesDir, `${name}-preview.html`)
+    if (!fs.existsSync(previewPath)) {
+      throw new HTTPException(404, { message: `Preview not found for styleguide: ${name}` })
+    }
+    const html = fs.readFileSync(previewPath, "utf-8")
+    return c.json({ name, html })
   })
 
   // GET /config — Return the global base config

--- a/apps/api/src/services/page-edit-service.ts
+++ b/apps/api/src/services/page-edit-service.ts
@@ -3,6 +3,7 @@ import { createBookStorage } from "@adt/storage"
 import { createLLMModel, createPromptEngine } from "@adt/llm"
 import type { LLMModel } from "@adt/llm"
 import { renderPage, buildRenderStrategyResolver, createTemplateEngine, loadBookConfig } from "@adt/pipeline"
+import { loadStyleguideContent } from "./pipeline-runner"
 import type { PageSectioningOutput } from "@adt/types"
 
 export interface ReRenderOptions {
@@ -53,6 +54,8 @@ export async function reRenderPage(
     const config = loadBookConfig(label, booksDir, configPath)
     const resolveRenderConfig = buildRenderStrategyResolver(config)
 
+    const styleguideContent = loadStyleguideContent(config.styleguide, configPath)
+
     // Create LLM model resolver (model-specific, cached)
     const cacheDir = path.join(path.resolve(booksDir), label, ".cache")
     const bookPromptsDir = path.join(path.resolve(booksDir), label, "prompts")
@@ -84,6 +87,7 @@ export async function reRenderPage(
         pageImageBase64,
         sectioning,
         images: renderImages,
+        styleguide: styleguideContent,
       },
       resolveRenderConfig,
       resolveRenderModel,

--- a/apps/api/src/services/pipeline-runner.ts
+++ b/apps/api/src/services/pipeline-runner.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs"
 import path from "node:path"
 import { createBookStorage } from "@adt/storage"
 import type { Storage } from "@adt/storage"
@@ -57,6 +58,19 @@ function wrapStepError(step: StepName, err: unknown): never {
   throw new PipelineStepError(step, toErrorMessage(err))
 }
 
+export function loadStyleguideContent(
+  styleguideName: string | undefined,
+  configPath: string | undefined
+): string | undefined {
+  if (!styleguideName) return undefined
+  const projectRoot = configPath ? path.dirname(configPath) : process.cwd()
+  const styleguidesDir = path.resolve(projectRoot, "assets", "styleguides")
+  const filePath = path.resolve(styleguidesDir, `${styleguideName}.md`)
+  if (!filePath.startsWith(styleguidesDir + path.sep)) return undefined
+  if (!fs.existsSync(filePath)) return undefined
+  return fs.readFileSync(filePath, "utf-8")
+}
+
 async function processWithConcurrency<T>(
   items: T[],
   concurrency: number,
@@ -104,6 +118,7 @@ export function createPipelineRunner(): PipelineRunner {
 
         // Step 1: Extract PDF
         const config = loadBookConfig(label, booksDir, configPath)
+        const styleguideContent = loadStyleguideContent(config.styleguide, configPath)
 
         await extractPDF(
           {
@@ -311,7 +326,8 @@ export function createPipelineRunner(): PipelineRunner {
                   },
                 },
                 translationConfig,
-                translationModel
+                translationModel,
+                styleguideContent
               )
             } catch (err) {
               const msg = toErrorMessage(err)
@@ -396,7 +412,8 @@ async function processPage(
   _totalPages: number,
   callbacks: PageCallbacks,
   translationConfig: TranslationConfig | null,
-  translationModel: LLMModel | null
+  translationModel: LLMModel | null,
+  styleguideContent?: string
 ): Promise<void> {
   const {
     textClassifyConfig,
@@ -512,6 +529,7 @@ async function processPage(
         pageImageBase64,
         sectioning,
         images: renderImages,
+        styleguide: styleguideContent,
       },
       resolveRenderConfig,
       resolveRenderModel,

--- a/apps/api/src/services/step-runner.ts
+++ b/apps/api/src/services/step-runner.ts
@@ -41,6 +41,7 @@ import {
   generateSpeechFile,
 } from "@adt/pipeline"
 import type { TranslationConfig, QuizPageInput } from "@adt/pipeline"
+import { loadStyleguideContent } from "./pipeline-runner"
 import { createTTSSynthesizer } from "@adt/llm"
 import type {
   TextClassificationOutput,
@@ -371,6 +372,8 @@ async function runStoryboardStep(
   try {
     const config = loadBookConfig(label, booksDir, configPath)
 
+    const styleguideContent = loadStyleguideContent(config.styleguide, configPath)
+
     // Build configs
     const sectioningConfig = buildSectioningConfig(config)
     const resolveRenderConfig = buildRenderStrategyResolver(config)
@@ -531,6 +534,7 @@ async function runStoryboardStep(
               pageImageBase64,
               sectioning,
               images: renderImages,
+              styleguide: styleguideContent,
             },
             resolveRenderConfig,
             resolveRenderModel,

--- a/apps/studio/src/api/client.ts
+++ b/apps/studio/src/api/client.ts
@@ -584,6 +584,12 @@ export const api = {
   getPreset: (name: string) =>
     request<{ config: Record<string, unknown> }>(`/presets/${name}`),
 
+  getStyleguides: () =>
+    request<{ styleguides: string[] }>(`/styleguides`),
+
+  getStyleguidePreview: (name: string) =>
+    request<{ name: string; html: string }>(`/styleguides/${name}/preview`),
+
   getGlobalConfig: () =>
     request<{ config: Record<string, unknown> }>(`/config`),
 

--- a/apps/studio/src/components/config/AdvancedLayoutPanel.tsx
+++ b/apps/studio/src/components/config/AdvancedLayoutPanel.tsx
@@ -20,6 +20,7 @@ export interface RenderStrategyState {
     model?: string
     max_retries?: string
     timeout?: string
+    temperature?: string
     answer_prompt?: string
     template?: string
   }
@@ -291,7 +292,7 @@ function RenderStrategyEditor({
                   />
                 </div>
               </div>
-              <div className="grid grid-cols-2 gap-2">
+              <div className="grid grid-cols-3 gap-2">
                 <div className="space-y-1">
                   <Label className="text-[10px] text-muted-foreground">Max Retries</Label>
                   <Input
@@ -311,6 +312,19 @@ function RenderStrategyEditor({
                     value={strategy.config.timeout ?? ""}
                     onChange={(e) => updateConfig("timeout", e.target.value)}
                     placeholder="180"
+                    className="h-7 text-xs"
+                  />
+                </div>
+                <div className="space-y-1">
+                  <Label className="text-[10px] text-muted-foreground">Temperature</Label>
+                  <Input
+                    type="number"
+                    min={0}
+                    max={2}
+                    step={0.1}
+                    value={strategy.config.temperature ?? ""}
+                    onChange={(e) => updateConfig("temperature", e.target.value)}
+                    placeholder="0.3"
                     className="h-7 text-xs"
                   />
                 </div>

--- a/apps/studio/src/components/v2/steps/StoryboardSettings.tsx
+++ b/apps/studio/src/components/v2/steps/StoryboardSettings.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react"
 import { createPortal } from "react-dom"
 import { useNavigate } from "@tanstack/react-router"
 import { useQueryClient } from "@tanstack/react-query"
-import { Play, Plus, X } from "lucide-react"
+import { Play, Plus, X, Eye } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { PruneToggle } from "@/components/v2/PruneToggle"
@@ -21,9 +21,11 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import { Label } from "@/components/ui/label"
 import { useBookConfig, useUpdateBookConfig } from "@/hooks/use-book-config"
 import { useActiveConfig } from "@/hooks/use-debug"
 import { useApiKey } from "@/hooks/use-api-key"
+import { useStyleguides, useStyleguidePreview } from "@/hooks/use-presets"
 import { api } from "@/api/client"
 import { PromptViewer } from "@/components/v2/PromptViewer"
 import { TemplateViewer } from "@/components/v2/TemplateViewer"
@@ -62,9 +64,25 @@ export function StoryboardSettings({ bookLabel, headerTarget, tab = "general" }:
   const [renderingPromptName, setRenderingPromptName] = useState("web_generation_html")
   const [renderingRenderType, setRenderingRenderType] = useState<string>("llm")
   const [renderingTemplateName, setRenderingTemplateName] = useState("")
+  const [renderingTemperature, setRenderingTemperature] = useState("")
+  const [styleguide, setStyleguide] = useState("")
   const [sectioningPromptDraft, setSectioningPromptDraft] = useState<string | null>(null)
   const [renderingPromptDraft, setRenderingPromptDraft] = useState<string | null>(null)
   const [renderingTemplateDraft, setRenderingTemplateDraft] = useState<string | null>(null)
+
+  const { data: styleguidesData } = useStyleguides()
+  const availableStyleguides = styleguidesData?.styleguides ?? []
+
+  // Styleguide preview
+  const [styleguidePreviewOpen, setStyleguidePreviewOpen] = useState(false)
+  const [previewName, setPreviewName] = useState<string | null>(null)
+  const { data: previewData, isLoading: styleguidePreviewLoading } = useStyleguidePreview(previewName)
+
+  const openStyleguidePreview = () => {
+    if (!styleguide) return
+    setPreviewName(styleguide)
+    setStyleguidePreviewOpen(true)
+  }
 
   // Track which field groups the user has actually touched
   const [dirty, setDirty] = useState<Record<string, boolean>>({})
@@ -97,14 +115,17 @@ export function StoryboardSettings({ bookLabel, headerTarget, tab = "general" }:
       const ps = merged.page_sectioning as Record<string, unknown>
       if (ps.model) setSectioningModel(String(ps.model))
     }
+    // Styleguide
+    setStyleguide(typeof merged.styleguide === "string" ? merged.styleguide : "")
     // Rendering config comes from the default render strategy
     if (merged.render_strategies && merged.default_render_strategy) {
-      const strategies = merged.render_strategies as Record<string, { render_type?: string; config?: { model?: string; prompt?: string; template?: string } }>
+      const strategies = merged.render_strategies as Record<string, { render_type?: string; config?: { model?: string; prompt?: string; template?: string; temperature?: number } }>
       const defaultStrategy = strategies[String(merged.default_render_strategy)]
       if (defaultStrategy?.render_type) setRenderingRenderType(defaultStrategy.render_type)
       if (defaultStrategy?.config?.model) setRenderingModel(String(defaultStrategy.config.model))
       if (defaultStrategy?.config?.prompt) setRenderingPromptName(String(defaultStrategy.config.prompt))
       if (defaultStrategy?.config?.template) setRenderingTemplateName(String(defaultStrategy.config.template))
+      setRenderingTemperature(defaultStrategy?.config?.temperature != null ? String(defaultStrategy.config.temperature) : "")
     }
   }, [activeConfigData])
 
@@ -211,6 +232,20 @@ export function StoryboardSettings({ bookLabel, headerTarget, tab = "general" }:
       const existing = (bookConfigData?.config?.page_sectioning ?? {}) as Record<string, unknown>
       overrides.page_sectioning = { ...existing, model: sectioningModel.trim() || undefined }
     }
+    if (shouldWrite("styleguide")) {
+      overrides.styleguide = styleguide || undefined
+    }
+    // Write rendering temperature into the default render strategy config
+    if (shouldWrite("rendering_temperature") && defaultRenderStrategy) {
+      const existingStrategies = (overrides.render_strategies ?? merged?.render_strategies ?? {}) as Record<string, Record<string, unknown>>
+      const stratCopy = JSON.parse(JSON.stringify(existingStrategies)) as Record<string, Record<string, unknown>>
+      if (stratCopy[defaultRenderStrategy]) {
+        const cfg = (stratCopy[defaultRenderStrategy].config ?? {}) as Record<string, unknown>
+        cfg.temperature = renderingTemperature.trim() ? Number(renderingTemperature) : undefined
+        stratCopy[defaultRenderStrategy].config = cfg
+        overrides.render_strategies = stratCopy
+      }
+    }
 
     return overrides
   }
@@ -251,6 +286,55 @@ export function StoryboardSettings({ bookLabel, headerTarget, tab = "general" }:
     <div className={tab === "sectioning-prompt" || tab === "rendering-prompt" || tab === "rendering-template" ? "h-full max-w-4xl" : "p-4 space-y-6"}>
       {tab === "general" && (
         <>
+          {/* Styleguide */}
+          {availableStyleguides.length > 0 && (
+            <div>
+              <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-3">
+                Styleguide
+              </h3>
+              <div className="flex items-center gap-2">
+                <Select
+                  value={styleguide || "__none__"}
+                  onValueChange={(v) => {
+                    setStyleguide(v === "__none__" ? "" : v)
+                    markDirty("styleguide")
+                  }}
+                >
+                  <SelectTrigger className="w-72">
+                    <SelectValue placeholder="Select styleguide...">
+                      {styleguide ? titleCase(styleguide) : "None"}
+                    </SelectValue>
+                  </SelectTrigger>
+                  <SelectContent align="start">
+                    <SelectItem value="__none__">
+                      <span className="text-muted-foreground">None</span>
+                    </SelectItem>
+                    {availableStyleguides.map((sg) => (
+                      <SelectItem key={sg} value={sg}>
+                        {titleCase(sg)}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                {styleguide && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="h-9 px-2.5 shrink-0"
+                    onClick={openStyleguidePreview}
+                  >
+                    <Eye className="h-3.5 w-3.5 mr-1" />
+                    Preview
+                  </Button>
+                )}
+              </div>
+              <p className="text-xs text-muted-foreground mt-1.5">
+                Provides consistent HTML/CSS patterns for LLM-generated pages.
+              </p>
+            </div>
+          )}
+
           {/* Default Render Strategy */}
           <div>
             <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-3">
@@ -293,6 +377,34 @@ export function StoryboardSettings({ bookLabel, headerTarget, tab = "general" }:
             </Select>
             <p className="text-xs text-muted-foreground mt-1.5">
               The rendering strategy used for sections without an explicit mapping.
+            </p>
+          </div>
+
+          {/* Rendering Temperature */}
+          <div>
+            <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-3">
+              Rendering Temperature
+            </h3>
+            <div className="flex items-center gap-2">
+              <Input
+                type="number"
+                min={0}
+                max={2}
+                step={0.1}
+                value={renderingTemperature}
+                onChange={(e) => {
+                  setRenderingTemperature(e.target.value)
+                  markDirty("rendering_temperature")
+                }}
+                placeholder="0.3"
+                className="h-9 w-24 text-sm"
+              />
+              <Label className="text-xs text-muted-foreground">
+                0 = deterministic, 2 = max creativity
+              </Label>
+            </div>
+            <p className="text-xs text-muted-foreground mt-1.5">
+              Lower values produce more consistent styling across pages.
             </p>
           </div>
 
@@ -440,6 +552,31 @@ export function StoryboardSettings({ bookLabel, headerTarget, tab = "general" }:
         </Button>,
         headerTarget
       )}
+
+      <Dialog open={styleguidePreviewOpen} onOpenChange={setStyleguidePreviewOpen}>
+        <DialogContent className="max-w-4xl h-[80vh] flex flex-col p-0">
+          <DialogHeader className="px-6 pt-6 pb-0">
+            <DialogTitle>Styleguide Preview — {styleguide}</DialogTitle>
+            <DialogDescription>
+              Preview of the HTML/CSS patterns used for LLM-generated pages.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex-1 min-h-0 px-6 pb-6">
+            {styleguidePreviewLoading ? (
+              <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
+                Loading preview...
+              </div>
+            ) : (
+              <iframe
+                srcDoc={previewData?.html ?? ""}
+                className="w-full h-full rounded-md border"
+                sandbox="allow-scripts"
+                title="Styleguide Preview"
+              />
+            )}
+          </div>
+        </DialogContent>
+      </Dialog>
 
       <Dialog open={showRerunDialog} onOpenChange={setShowRerunDialog}>
         <DialogContent>

--- a/apps/studio/src/hooks/use-presets.ts
+++ b/apps/studio/src/hooks/use-presets.ts
@@ -9,6 +9,21 @@ export function usePreset(name: string | null) {
   })
 }
 
+export function useStyleguides() {
+  return useQuery({
+    queryKey: ["styleguides"],
+    queryFn: api.getStyleguides,
+  })
+}
+
+export function useStyleguidePreview(name: string | null) {
+  return useQuery({
+    queryKey: ["styleguide-preview", name],
+    queryFn: () => api.getStyleguidePreview(name!),
+    enabled: !!name,
+  })
+}
+
 export function useGlobalConfig() {
   return useQuery({
     queryKey: ["global-config"],

--- a/apps/studio/src/routes/books.new.tsx
+++ b/apps/studio/src/routes/books.new.tsx
@@ -9,17 +9,24 @@ import {
   BookHeart,
   Library,
   SlidersHorizontal,
+  Eye,
 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Card, CardContent } from "@/components/ui/card"
 import { Switch } from "@/components/ui/switch"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
 import { LanguagePicker } from "@/components/LanguagePicker"
 import { useCreateBook } from "@/hooks/use-books"
 import { useApiKey } from "@/hooks/use-api-key"
 import { api } from "@/api/client"
-import { usePreset, useGlobalConfig } from "@/hooks/use-presets"
+import { usePreset, useGlobalConfig, useStyleguides, useStyleguidePreview } from "@/hooks/use-presets"
 import {
   AdvancedLayoutPanel,
   type RenderStrategyState,
@@ -151,6 +158,7 @@ function AddBookPage() {
 
   // Step 2 — Layout
   const [layoutType, setLayoutType] = useState<LayoutType>("textbook")
+  const [styleguide, setStyleguide] = useState("")
   const [showAdvancedLayout, setShowAdvancedLayout] = useState(false)
   const [defaultRenderStrategy, setDefaultRenderStrategy] = useState("")
   const [renderStrategies, setRenderStrategies] = useState<Record<string, RenderStrategyState>>({})
@@ -163,10 +171,23 @@ function AddBookPage() {
   const [textGroupTypes, setTextGroupTypes] = useState<Record<string, string>>({})
   const [sectionTypes, setSectionTypes] = useState<Record<string, string>>({})
 
-  // Fetch preset + global config via TanStack Query
+  // Styleguide preview
+  const [styleguidePreviewOpen, setStyleguidePreviewOpen] = useState(false)
+  const [previewName, setPreviewName] = useState<string | null>(null)
+  const { data: previewData, isLoading: styleguidePreviewLoading } = useStyleguidePreview(previewName)
+
+  const openStyleguidePreview = () => {
+    if (!styleguide) return
+    setPreviewName(styleguide)
+    setStyleguidePreviewOpen(true)
+  }
+
+  // Fetch preset + global config + styleguides via TanStack Query
   const presetName = layoutType === "custom" ? null : layoutType
   const { data: presetData } = usePreset(presetName)
   const { data: globalConfigData } = useGlobalConfig()
+  const { data: styleguidesData } = useStyleguides()
+  const availableStyleguides = styleguidesData?.styleguides ?? []
 
   // Populate local state when query data or layout type changes
   useEffect(() => {
@@ -214,6 +235,7 @@ function AddBookPage() {
             model: cfg.model != null ? String(cfg.model) : undefined,
             max_retries: cfg.max_retries != null ? String(cfg.max_retries) : undefined,
             timeout: cfg.timeout != null ? String(cfg.timeout) : undefined,
+            temperature: cfg.temperature != null ? String(cfg.temperature) : undefined,
             answer_prompt: cfg.answer_prompt != null ? String(cfg.answer_prompt) : undefined,
             template: cfg.template != null ? String(cfg.template) : undefined,
           },
@@ -259,6 +281,9 @@ function AddBookPage() {
     if (typeof config.spread_mode === "boolean") {
       setSpreadMode(config.spread_mode)
     }
+
+    // Styleguide from preset
+    setStyleguide(typeof config.styleguide === "string" ? config.styleguide : "")
 
     // Custom layout auto-expands advanced panel
     if (layoutType === "custom") {
@@ -348,6 +373,9 @@ function AddBookPage() {
 
     const configOverrides: Record<string, unknown> = {}
     configOverrides.layout_type = layoutType
+    if (styleguide) {
+      configOverrides.styleguide = styleguide
+    }
     if (editingLanguage.trim()) {
       configOverrides.editing_language = editingLanguage.trim()
     }
@@ -376,6 +404,7 @@ function AddBookPage() {
         if (strategy.config.model) config.model = strategy.config.model
         if (strategy.config.max_retries) config.max_retries = Number(strategy.config.max_retries)
         if (strategy.config.timeout) config.timeout = Number(strategy.config.timeout)
+        if (strategy.config.temperature) config.temperature = Number(strategy.config.temperature)
         if (strategy.config.answer_prompt) config.answer_prompt = strategy.config.answer_prompt
         if (strategy.config.template) config.template = strategy.config.template
         strategies[name] = {
@@ -634,6 +663,40 @@ function AddBookPage() {
                       Merge facing pages as spreads (cover + page pairs).
                     </p>
                   </div>
+                  {availableStyleguides.length > 0 && (
+                    <div className="space-y-1.5">
+                      <Label className="text-xs">Styleguide</Label>
+                      <div className="flex items-center gap-2">
+                        <select
+                          value={styleguide}
+                          onChange={(e) => setStyleguide(e.target.value)}
+                          className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                        >
+                          <option value="">None</option>
+                          {availableStyleguides.map((sg) => (
+                            <option key={sg} value={sg}>
+                              {sg}
+                            </option>
+                          ))}
+                        </select>
+                        {styleguide && (
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            className="h-9 px-2.5 shrink-0"
+                            onClick={openStyleguidePreview}
+                          >
+                            <Eye className="h-3.5 w-3.5 mr-1" />
+                            Preview
+                          </Button>
+                        )}
+                      </div>
+                      <p className="text-xs text-muted-foreground">
+                        Provides consistent HTML/CSS patterns for LLM-generated pages.
+                      </p>
+                    </div>
+                  )}
                   <AdvancedLayoutPanel
                     defaultRenderStrategy={defaultRenderStrategy}
                     onDefaultRenderStrategyChange={setDefaultRenderStrategy}
@@ -723,6 +786,28 @@ function AddBookPage() {
           )}
         </CardContent>
       </Card>
+
+      <Dialog open={styleguidePreviewOpen} onOpenChange={setStyleguidePreviewOpen}>
+        <DialogContent className="max-w-4xl h-[80vh] flex flex-col p-0">
+          <DialogHeader className="px-6 pt-6 pb-0">
+            <DialogTitle>Styleguide Preview — {styleguide}</DialogTitle>
+          </DialogHeader>
+          <div className="flex-1 min-h-0 px-6 pb-6">
+            {styleguidePreviewLoading ? (
+              <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
+                Loading preview...
+              </div>
+            ) : (
+              <iframe
+                srcDoc={previewData?.html ?? ""}
+                className="w-full h-full rounded-md border"
+                sandbox="allow-scripts"
+                title="Styleguide Preview"
+              />
+            )}
+          </div>
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }

--- a/assets/styleguides/default-preview.html
+++ b/assets/styleguides/default-preview.html
@@ -1,0 +1,338 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta content="width=device-width, initial-scale=1" name="viewport"/>
+  <title>Style Guide Preview</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    .preview-label {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      font-size: 0.7rem;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      color: #6b7280;
+      border-bottom: 1px solid #e5e7eb;
+      padding-bottom: 0.25rem;
+      margin-bottom: 1rem;
+    }
+    .preview-section {
+      border: 2px dashed #d1d5db;
+      border-radius: 1rem;
+      padding: 2rem;
+      margin-bottom: 2.5rem;
+      background: #fafafa;
+    }
+    .preview-divider {
+      border-top: 3px solid #7c3aed;
+      margin: 3rem 0;
+    }
+  </style>
+</head>
+<body class="bg-gray-100 py-12 px-4">
+
+  <div class="mx-auto max-w-6xl">
+
+    <!-- Header -->
+    <div class="mb-12 text-center">
+      <h1 class="text-5xl font-extrabold text-purple-700 mb-2">Style Guide Preview</h1>
+      <p class="text-xl text-gray-500">Visual reference for publishers &mdash; default theme</p>
+    </div>
+
+    <!-- ============================================================ -->
+    <!-- TEXT STYLES                                                    -->
+    <!-- ============================================================ -->
+    <h2 class="text-3xl font-bold text-gray-800 mb-6">Text Styles</h2>
+
+    <div class="preview-section">
+      <p class="preview-label">book_title &mdash; h1</p>
+      <h1 class="text-4xl md:text-5xl font-extrabold leading-tight">The Great Journey Begins</h1>
+    </div>
+
+    <div class="preview-section">
+      <p class="preview-label">book_subtitle &mdash; h2</p>
+      <h2 class="text-2xl md:text-3xl font-semibold text-gray-700">A story of discovery and wonder</h2>
+    </div>
+
+    <div class="preview-section">
+      <p class="preview-label">chapter_title &mdash; h1</p>
+      <h1 class="text-3xl md:text-4xl font-bold leading-tight">Chapter Title Example</h1>
+    </div>
+
+    <div class="preview-section">
+      <p class="preview-label">section_heading &mdash; h1</p>
+      <h1 class="text-3xl md:text-4xl font-bold leading-tight">Section Heading Example</h1>
+    </div>
+
+    <div class="preview-section">
+      <p class="preview-label">activity_title &mdash; h2</p>
+      <h2 class="text-2xl md:text-3xl font-bold leading-tight">Activity Title Example</h2>
+    </div>
+
+    <div class="preview-section">
+      <p class="preview-label">section_text &mdash; p</p>
+      <p class="text-lg md:text-xl leading-relaxed">This is section text. It uses a comfortable reading size with relaxed line-height, ideal for body paragraphs in educational content. Listening and speaking skills are important for effective communication.</p>
+    </div>
+
+    <div class="preview-section">
+      <p class="preview-label">instruction_text &mdash; p</p>
+      <p class="text-base md:text-lg leading-relaxed text-gray-700 italic">Look at the following pictures and answer the questions below.</p>
+    </div>
+
+    <div class="preview-section">
+      <p class="preview-label">standalone_text &mdash; p</p>
+      <p class="text-base md:text-lg leading-relaxed">This is standalone text used for general-purpose content outside of cards or specific sections.</p>
+    </div>
+
+    <div class="preview-section">
+      <p class="preview-label">image_associated_text &mdash; p</p>
+      <p class="text-sm md:text-base text-gray-600 italic mt-2">Caption: A photo of the Serengeti National Park at sunrise.</p>
+    </div>
+
+    <div class="preview-divider"></div>
+
+    <!-- ============================================================ -->
+    <!-- COMPONENTS                                                    -->
+    <!-- ============================================================ -->
+    <h2 class="text-3xl font-bold text-gray-800 mb-6">Components</h2>
+
+    <!-- Chapter Badge -->
+    <div class="preview-section">
+      <p class="preview-label">Chapter Badge</p>
+      <div class="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
+        <div class="flex items-start gap-6">
+          <div class="shrink-0 rounded-3xl bg-purple-200 px-6 py-5 shadow-sm">
+            <h1 class="text-3xl md:text-4xl font-bold leading-tight">CHAPTER</h1>
+            <h1 class="text-3xl md:text-4xl font-bold leading-tight">1</h1>
+          </div>
+          <div class="pt-2">
+            <h1 class="text-3xl md:text-4xl font-bold leading-tight">The Nile River</h1>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Content Card -->
+    <div class="preview-section">
+      <p class="preview-label">Content Card (for body text)</p>
+      <div class="space-y-4 rounded-3xl bg-white/80 p-6 shadow-sm ring-1 ring-black/5">
+        <p class="text-lg md:text-xl leading-relaxed">Listening and speaking skills are important for effective communication. In this unit, you will learn to listen to and communicate information orally in English.</p>
+        <p class="text-lg md:text-xl leading-relaxed">The competencies developed will enable you to communicate with friends, teachers, parents and other people in different situations.</p>
+      </div>
+    </div>
+
+    <!-- Text Group -->
+    <div class="preview-section">
+      <p class="preview-label">Text Group (paragraphs without card)</p>
+      <div class="space-y-3">
+        <p class="text-lg md:text-xl leading-relaxed">First paragraph in a text group. No card background, just clean stacked text.</p>
+        <p class="text-lg md:text-xl leading-relaxed">Second paragraph in the same text group, separated by consistent spacing.</p>
+      </div>
+    </div>
+
+    <div class="preview-divider"></div>
+
+    <!-- ============================================================ -->
+    <!-- IMAGE STYLES                                                  -->
+    <!-- ============================================================ -->
+    <h2 class="text-3xl font-bold text-gray-800 mb-6">Image Styles</h2>
+
+    <div class="preview-section">
+      <p class="preview-label">Single Image &mdash; w-full rounded-2xl shadow-lg</p>
+      <div class="bg-gradient-to-br from-purple-100 to-blue-100 w-full h-56 rounded-2xl shadow-lg flex items-center justify-center">
+        <span class="text-gray-400 text-lg font-medium">Single Image Placeholder</span>
+      </div>
+    </div>
+
+    <div class="preview-section">
+      <p class="preview-label">Image Grid (2 columns) &mdash; grid grid-cols-2 gap-4</p>
+      <div class="grid grid-cols-2 gap-4">
+        <div class="bg-gradient-to-br from-amber-100 to-orange-100 h-40 rounded-xl shadow-md flex items-center justify-center">
+          <span class="text-gray-400 text-sm font-medium">Image 1</span>
+        </div>
+        <div class="bg-gradient-to-br from-green-100 to-teal-100 h-40 rounded-xl shadow-md flex items-center justify-center">
+          <span class="text-gray-400 text-sm font-medium">Image 2</span>
+        </div>
+        <div class="bg-gradient-to-br from-blue-100 to-indigo-100 h-40 rounded-xl shadow-md flex items-center justify-center">
+          <span class="text-gray-400 text-sm font-medium">Image 3</span>
+        </div>
+        <div class="bg-gradient-to-br from-pink-100 to-rose-100 h-40 rounded-xl shadow-md flex items-center justify-center">
+          <span class="text-gray-400 text-sm font-medium">Image 4</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="preview-section">
+      <p class="preview-label">Text and Image Side by Side</p>
+      <div class="flex flex-col md:flex-row gap-8">
+        <div class="flex-1 space-y-4">
+          <p class="text-lg md:text-xl leading-relaxed">This layout places text and an image side by side on wider screens. On mobile, the image stacks below the text.</p>
+          <p class="text-lg md:text-xl leading-relaxed">It is useful when text directly relates to a single accompanying image.</p>
+        </div>
+        <div class="flex-1">
+          <div class="bg-gradient-to-br from-violet-100 to-purple-100 w-full h-48 rounded-2xl shadow-lg flex items-center justify-center">
+            <span class="text-gray-400 text-sm font-medium">Side Image</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="preview-divider"></div>
+
+    <!-- ============================================================ -->
+    <!-- PAGE TEMPLATES                                                -->
+    <!-- ============================================================ -->
+    <h2 class="text-3xl font-bold text-gray-800 mb-6">Page Templates</h2>
+
+    <!-- Template: Chapter Start Page -->
+    <div class="preview-section">
+      <p class="preview-label">Template: Chapter Start Page</p>
+      <div class="bg-white rounded-2xl shadow-md overflow-hidden">
+        <div class="container content mx-auto flex min-h-[480px] w-full items-center justify-center px-6 py-12" style="background-color:#ffffff">
+          <section class="w-full" role="article">
+            <div class="mx-auto w-full max-w-5xl space-y-8">
+              <!-- Chapter Badge -->
+              <div class="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
+                <div class="flex items-start gap-6">
+                  <div class="shrink-0 rounded-3xl bg-purple-200 px-6 py-5 shadow-sm">
+                    <h1 class="text-3xl md:text-4xl font-bold leading-tight">CHAPTER</h1>
+                    <h1 class="text-3xl md:text-4xl font-bold leading-tight">1</h1>
+                  </div>
+                  <div class="pt-2">
+                    <h1 class="text-3xl md:text-4xl font-bold leading-tight">The Nile River</h1>
+                  </div>
+                </div>
+              </div>
+              <!-- Content Card -->
+              <div class="space-y-4 rounded-3xl bg-white/80 p-6 shadow-sm ring-1 ring-black/5">
+                <p class="text-lg md:text-xl leading-relaxed">The Nile is the longest river in Africa, stretching over 6,600 kilometres through multiple countries.</p>
+                <p class="text-lg md:text-xl leading-relaxed">It has been a source of life for civilisations for thousands of years, providing water, food, and fertile land.</p>
+              </div>
+              <!-- Image -->
+              <div class="bg-gradient-to-br from-blue-100 to-cyan-100 w-full h-48 rounded-2xl shadow-lg flex items-center justify-center">
+                <span class="text-gray-400 text-sm font-medium">Chapter Image</span>
+              </div>
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+
+    <!-- Template: Regular Content Page -->
+    <div class="preview-section">
+      <p class="preview-label">Template: Regular Content Page (text and images)</p>
+      <div class="bg-white rounded-2xl shadow-md overflow-hidden">
+        <div class="container content mx-auto flex min-h-[480px] w-full items-center justify-center px-6 py-12" style="background-color:#ffffff">
+          <section class="w-full" role="article">
+            <div class="mx-auto w-full max-w-5xl space-y-8">
+              <!-- Text Group -->
+              <div class="space-y-3">
+                <p class="text-lg md:text-xl leading-relaxed">Mrs Mashaka is our Geography and the Environment teacher. One day, she taught us about the national parks in Tanzania.</p>
+                <p class="text-lg md:text-xl leading-relaxed">She said, "The Serengeti is among the largest national parks in the country. It has many animals, birds and insects."</p>
+              </div>
+              <!-- Image -->
+              <div class="bg-gradient-to-br from-green-100 to-emerald-100 w-full h-48 rounded-2xl shadow-lg flex items-center justify-center">
+                <span class="text-gray-400 text-sm font-medium">Content Image 1</span>
+              </div>
+              <!-- More Text -->
+              <div class="space-y-3">
+                <p class="text-lg md:text-xl leading-relaxed">She asked, "How many of you have been to the Serengeti?" The whole class replied, "No one!"</p>
+              </div>
+              <!-- Another Image -->
+              <div class="bg-gradient-to-br from-amber-100 to-yellow-100 w-full h-48 rounded-2xl shadow-lg flex items-center justify-center">
+                <span class="text-gray-400 text-sm font-medium">Content Image 2</span>
+              </div>
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+
+    <!-- Template: Table of Contents -->
+    <div class="preview-section">
+      <p class="preview-label">Template: Table of Contents</p>
+      <div class="rounded-2xl shadow-md overflow-hidden">
+        <div class="container content mx-auto flex min-h-[520px] w-full items-center justify-center px-6 py-12" style="background-color:#f3f0f7">
+          <section class="w-full" role="article">
+            <div class="mx-auto w-full max-w-3xl space-y-8">
+              <div class="relative rounded-3xl overflow-hidden shadow-lg">
+                <!-- Background placeholder -->
+                <div class="bg-gradient-to-br from-purple-200 to-indigo-200 w-full h-[420px]"></div>
+                <!-- Overlay card -->
+                <div class="absolute inset-0 flex items-center justify-center p-6">
+                  <div class="w-full max-w-2xl rounded-2xl bg-white/90 backdrop-blur-sm p-8 shadow-lg">
+                    <!-- Title -->
+                    <div class="text-center mb-8">
+                      <h1 class="text-3xl md:text-4xl font-extrabold leading-tight text-purple-700">English for Primary Schools</h1>
+                      <h2 class="text-xl md:text-2xl font-semibold text-purple-600 mt-2">Table of Contents</h2>
+                    </div>
+                    <!-- Entries -->
+                    <div class="space-y-3">
+                      <div class="flex items-baseline gap-2">
+                        <p class="text-base font-medium text-gray-700 whitespace-nowrap">Chapter 1</p>
+                        <p class="text-base font-medium text-gray-800">Listening and Speaking</p>
+                        <span class="border-b border-dotted border-gray-400 flex-1 mx-2"></span>
+                        <p class="text-base font-medium text-gray-600">1</p>
+                      </div>
+                      <div class="flex items-baseline gap-2">
+                        <p class="text-base font-medium text-gray-700 whitespace-nowrap">Chapter 2</p>
+                        <p class="text-base font-medium text-gray-800">Reading and Writing</p>
+                        <span class="border-b border-dotted border-gray-400 flex-1 mx-2"></span>
+                        <p class="text-base font-medium text-gray-600">15</p>
+                      </div>
+                      <div class="flex items-baseline gap-2">
+                        <p class="text-base font-medium text-gray-700 whitespace-nowrap">Chapter 3</p>
+                        <p class="text-base font-medium text-gray-800">Grammar and Vocabulary</p>
+                        <span class="border-b border-dotted border-gray-400 flex-1 mx-2"></span>
+                        <p class="text-base font-medium text-gray-600">28</p>
+                      </div>
+                      <div class="flex items-baseline gap-2">
+                        <p class="text-base font-medium text-gray-700 whitespace-nowrap">Chapter 4</p>
+                        <p class="text-base font-medium text-gray-800">Geography and Environment</p>
+                        <span class="border-b border-dotted border-gray-400 flex-1 mx-2"></span>
+                        <p class="text-base font-medium text-gray-600">42</p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+
+    <div class="preview-divider"></div>
+
+    <!-- ============================================================ -->
+    <!-- REQUIRED STRUCTURE REFERENCE                                  -->
+    <!-- ============================================================ -->
+    <h2 class="text-3xl font-bold text-gray-800 mb-6">Required Structure Reference</h2>
+
+    <div class="preview-section">
+      <p class="preview-label">Outer Container &mdash; every page uses this</p>
+      <div class="bg-white rounded-lg p-4 font-mono text-sm text-gray-700 overflow-x-auto">
+        <pre>&lt;div class="container content mx-auto flex min-h-screen w-full
+     items-center justify-center px-6 py-12"
+    data-background-color="<span class="text-purple-600">BACKGROUND_COLOR</span>" id="content"&gt;
+  &lt;section class="w-full"
+      data-id="<span class="text-purple-600">SECTION_ID</span>"
+      data-section-type="<span class="text-purple-600">SECTION_TYPE</span>"
+      data-text-color="<span class="text-purple-600">TEXT_COLOR</span>"
+      id="simple-main" role="article"&gt;
+    &lt;div class="mx-auto w-full max-w-5xl space-y-8"&gt;
+      <span class="text-gray-400">&lt;!-- Page content here --&gt;</span>
+    &lt;/div&gt;
+  &lt;/section&gt;
+&lt;/div&gt;</pre>
+      </div>
+    </div>
+
+    <!-- Footer -->
+    <div class="text-center text-gray-400 text-sm mt-12 pb-8">
+      Generated from <code>assets/styleguides/default.md</code>
+    </div>
+
+  </div>
+</body>
+</html>

--- a/assets/styleguides/default.md
+++ b/assets/styleguides/default.md
@@ -1,0 +1,229 @@
+# Styleguide
+
+## Required Container Structure
+
+Every page MUST use this exact outer container:
+
+```html
+<div class="container content mx-auto flex min-h-screen w-full items-center justify-center px-6 py-12"
+    data-background-color="BACKGROUND_COLOR" id="content">
+  <section class="w-full" data-id="SECTION_ID" data-section-type="SECTION_TYPE" data-text-color="TEXT_COLOR"
+      id="simple-main" role="article">
+    <!-- Content goes here -->
+  </section>
+</div>
+```
+
+## Inner Container (REQUIRED for all content pages)
+
+Inside the section, ALWAYS use this inner container structure:
+
+```html
+<div class="mx-auto w-full max-w-5xl space-y-8">
+  <!-- Page content here -->
+</div>
+```
+
+---
+
+## Components
+
+### Chapter Badge (EXACT - use for chapter headers)
+
+When there is a chapter number (like "CHAPTER 1"), use this EXACT structure:
+
+```html
+<div class="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
+  <div class="flex items-start gap-6">
+    <div class="shrink-0 rounded-3xl bg-purple-200 px-6 py-5 shadow-sm">
+      <h1 class="text-3xl md:text-4xl font-bold leading-tight" data-id="CHAPTER_WORD_ID">CHAPTER</h1>
+      <h1 class="text-3xl md:text-4xl font-bold leading-tight" data-id="CHAPTER_NUMBER_ID">1</h1>
+    </div>
+    <div class="pt-2">
+      <h1 class="text-3xl md:text-4xl font-bold leading-tight" data-id="CHAPTER_TITLE_ID">Chapter Title Here</h1>
+    </div>
+  </div>
+</div>
+```
+
+### Content Card (for body text)
+
+Wrap body paragraphs in this card:
+
+```html
+<div class="space-y-4 rounded-3xl bg-white/80 p-6 shadow-sm ring-1 ring-black/5">
+  <p class="text-lg md:text-xl leading-relaxed" data-id="ID">Paragraph text</p>
+  <p class="text-lg md:text-xl leading-relaxed" data-id="ID">More text</p>
+</div>
+```
+
+### Text Group (for paragraphs without card)
+
+```html
+<div class="space-y-3">
+  <p class="text-lg md:text-xl leading-relaxed" data-id="ID">Paragraph text</p>
+</div>
+```
+
+---
+
+## Text Styles
+
+| text_type | Element | Classes |
+|-----------|---------|---------|
+| book_title | h1 | text-4xl md:text-5xl font-extrabold leading-tight |
+| book_subtitle | h2 | text-2xl md:text-3xl font-semibold text-gray-700 |
+| chapter_title | h1 | text-3xl md:text-4xl font-bold leading-tight |
+| section_heading | h1 | text-3xl md:text-4xl font-bold leading-tight |
+| activity_title | h2 | text-2xl md:text-3xl font-bold leading-tight |
+| section_text | p | text-lg md:text-xl leading-relaxed |
+| instruction_text | p | text-base md:text-lg leading-relaxed text-gray-700 italic |
+| standalone_text | p | text-base md:text-lg leading-relaxed |
+| image_associated_text | p | text-sm md:text-base text-gray-600 italic mt-2 |
+
+## Image Styles
+
+| Type | Classes |
+|------|---------|
+| Single image | w-full rounded-2xl shadow-lg |
+| Multiple images | rounded-xl shadow-md |
+| Image grid container | grid grid-cols-2 gap-4 |
+
+---
+
+## Page Templates
+
+### Template: Chapter Start Page (with chapter badge)
+
+Use when page has "CHAPTER" and a number:
+
+```html
+<div class="container content mx-auto flex min-h-screen w-full items-center justify-center px-6 py-12"
+    data-background-color="#ffffff" id="content">
+  <section class="w-full" data-id="SECTION_ID" data-section-type="text_and_single_image" data-text-color="#000000"
+      id="simple-main" role="article">
+    <div class="mx-auto w-full max-w-5xl space-y-8">
+      <!-- Chapter Badge -->
+      <div class="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
+        <div class="flex items-start gap-6">
+          <div class="shrink-0 rounded-3xl bg-purple-200 px-6 py-5 shadow-sm">
+            <h1 class="text-3xl md:text-4xl font-bold leading-tight" data-id="chapter-word">CHAPTER</h1>
+            <h1 class="text-3xl md:text-4xl font-bold leading-tight" data-id="chapter-num">1</h1>
+          </div>
+          <div class="pt-2">
+            <h1 class="text-3xl md:text-4xl font-bold leading-tight" data-id="chapter-title">The Nile River</h1>
+          </div>
+        </div>
+      </div>
+      <!-- Content Card -->
+      <div class="space-y-4 rounded-3xl bg-white/80 p-6 shadow-sm ring-1 ring-black/5">
+        <p class="text-lg md:text-xl leading-relaxed" data-id="text-1">Paragraph one.</p>
+        <p class="text-lg md:text-xl leading-relaxed" data-id="text-2">Paragraph two.</p>
+      </div>
+      <!-- Image -->
+      <img alt="" class="w-full rounded-2xl shadow-lg" data-id="img-1" src="images/img-1.jpg"/>
+    </div>
+  </section>
+</div>
+```
+
+### Template: Regular Content Page (text and images)
+
+Use for pages with just text and images (no chapter header):
+
+```html
+<div class="container content mx-auto flex min-h-screen w-full items-center justify-center px-6 py-12"
+    data-background-color="#ffffff" id="content">
+  <section class="w-full" data-id="SECTION_ID" data-section-type="text_and_images" data-text-color="#000000"
+      id="simple-main" role="article">
+    <div class="mx-auto w-full max-w-5xl space-y-8">
+      <!-- Text Group -->
+      <div class="space-y-3">
+        <p class="text-lg md:text-xl leading-relaxed" data-id="text-1">First paragraph.</p>
+        <p class="text-lg md:text-xl leading-relaxed" data-id="text-2">Second paragraph.</p>
+      </div>
+      <!-- Image -->
+      <img alt="" class="w-full rounded-2xl shadow-lg" data-id="img-1" src="images/img-1.jpg"/>
+      <!-- More Text -->
+      <div class="space-y-3">
+        <p class="text-lg md:text-xl leading-relaxed" data-id="text-3">Another paragraph.</p>
+      </div>
+      <!-- Another Image -->
+      <img alt="" class="w-full rounded-2xl shadow-lg" data-id="img-2" src="images/img-2.jpg"/>
+    </div>
+  </section>
+</div>
+```
+
+### Template: Text and Image Side by Side
+
+```html
+<div class="mx-auto w-full max-w-5xl space-y-8">
+  <div class="flex flex-col md:flex-row gap-8">
+    <div class="flex-1 space-y-4">
+      <!-- text elements -->
+    </div>
+    <div class="flex-1">
+      <img class="w-full rounded-2xl shadow-lg" data-id="ID" src="images/ID.jpg" alt="" />
+    </div>
+  </div>
+</div>
+```
+
+### Template: Table of Contents (EXACT - use for section_type "table_of_contents")
+
+Use this EXACT structure for table of contents pages:
+
+```html
+<div class="container content mx-auto flex min-h-screen w-full items-center justify-center px-6 py-12"
+    data-background-color="#f3f0f7" id="content">
+  <section class="w-full" data-id="SECTION_ID" data-section-type="table_of_contents" data-text-color="#2c2c2c"
+      id="simple-main" role="article">
+    <div class="mx-auto w-full max-w-3xl space-y-8">
+      <!-- Background image (if provided) -->
+      <div class="relative rounded-3xl overflow-hidden shadow-lg">
+        <img alt="" class="w-full" data-id="IMG_ID" src="images/IMG_ID.jpg"/>
+        <!-- Overlay card -->
+        <div class="absolute inset-0 flex items-center justify-center p-6">
+          <div class="w-full max-w-2xl rounded-2xl bg-white/90 backdrop-blur-sm p-8 shadow-lg">
+            <!-- Title -->
+            <div class="text-center mb-8">
+              <h1 class="text-3xl md:text-4xl font-extrabold leading-tight text-purple-700" data-id="TITLE_ID">Book Title</h1>
+              <h2 class="text-xl md:text-2xl font-semibold text-purple-600 mt-2" data-id="SUBTITLE_ID">Table of Contents</h2>
+            </div>
+            <!-- Entries -->
+            <div class="space-y-3">
+              <div class="flex items-baseline gap-2">
+                <p class="text-base font-medium text-gray-700 whitespace-nowrap" data-id="CH1_LABEL">Chapter 1</p>
+                <p class="text-base font-medium text-gray-800 flex-1" data-id="CH1_TITLE">Chapter Title</p>
+                <span class="border-b border-dotted border-gray-400 flex-1 mx-2"></span>
+                <p class="text-base font-medium text-gray-600" data-id="CH1_PAGE">2</p>
+              </div>
+              <!-- Repeat for each chapter -->
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</div>
+```
+
+**Table of Contents Entry Row (repeat for each chapter):**
+
+```html
+<div class="flex items-baseline gap-2">
+  <p class="text-base font-medium text-gray-700 whitespace-nowrap" data-id="CHAPTER_LABEL_ID">Chapter 1</p>
+  <p class="text-base font-medium text-gray-800" data-id="CHAPTER_TITLE_ID">The Nile River</p>
+  <span class="border-b border-dotted border-gray-400 flex-1 mx-2"></span>
+  <p class="text-base font-medium text-gray-600" data-id="PAGE_NUMBER_ID">2</p>
+</div>
+```
+
+**Important for Table of Contents:**
+- Use `text-base` (not text-3xl or text-4xl) for chapter entries
+- Use `font-medium` (not font-bold) for entries
+- Title should be `text-3xl md:text-4xl`
+- Subtitle "Table of Contents" should be `text-xl md:text-2xl`
+- Keep the card compact with `max-w-2xl`
+- Use dotted line separator between title and page number

--- a/config/presets/textbook.yaml
+++ b/config/presets/textbook.yaml
@@ -4,6 +4,8 @@
 
 default_render_strategy: llm
 
+styleguide: default
+
 spread_mode: false
 
 render_strategies:
@@ -14,6 +16,7 @@ render_strategies:
       model: openai:gpt-5.2
       max_retries: 25
       timeout: 180
+      temperature: 0.3
   two_column:
     render_type: template
     config:
@@ -26,6 +29,7 @@ render_strategies:
       model: openai:gpt-5.2
       max_retries: 25
       timeout: 180
+      temperature: 0.3
   activity_true_false:
     render_type: activity
     config:
@@ -34,6 +38,7 @@ render_strategies:
       model: openai:gpt-5.2
       max_retries: 25
       timeout: 180
+      temperature: 0.3
   activity_fill_in_the_blank:
     render_type: activity
     config:
@@ -42,6 +47,7 @@ render_strategies:
       model: openai:gpt-5.2
       max_retries: 25
       timeout: 180
+      temperature: 0.3
   activity_fill_in_a_table:
     render_type: activity
     config:
@@ -50,6 +56,7 @@ render_strategies:
       model: openai:gpt-5.2
       max_retries: 25
       timeout: 180
+      temperature: 0.3
   activity_matching:
     render_type: activity
     config:
@@ -58,6 +65,7 @@ render_strategies:
       model: openai:gpt-5.2
       max_retries: 25
       timeout: 180
+      temperature: 0.3
   activity_sorting:
     render_type: activity
     config:
@@ -66,6 +74,7 @@ render_strategies:
       model: openai:gpt-5.2
       max_retries: 25
       timeout: 180
+      temperature: 0.3
   activity_open_ended_answer:
     render_type: activity
     config:
@@ -73,6 +82,7 @@ render_strategies:
       model: openai:gpt-5.2
       max_retries: 25
       timeout: 180
+      temperature: 0.3
 
 section_render_strategies:
   activity_multiple_choice: activity_multiple_choice

--- a/packages/llm/src/cache.ts
+++ b/packages/llm/src/cache.ts
@@ -18,6 +18,7 @@ export function computeHash(data: {
   system?: string
   messages: Message[]
   schema: unknown
+  temperature?: number
 }): string {
   const json = JSON.stringify(data, stableReplacer)
   return crypto.createHash("sha256").update(json).digest("hex")

--- a/packages/llm/src/client.ts
+++ b/packages/llm/src/client.ts
@@ -83,6 +83,7 @@ export function createLLMModel(options: CreateLLMModelOptions): LLMModel {
           system,
           messages: currentMessages,
           schema: opts.schema,
+          temperature: opts.temperature,
         })
 
         try {
@@ -339,6 +340,9 @@ async function callLLM<T>(
   }
   if (opts.maxTokens) {
     generateOpts.maxTokens = opts.maxTokens
+  }
+  if (opts.temperature !== undefined) {
+    generateOpts.temperature = opts.temperature
   }
   const generated = await (generateObject as Function)(
     generateOpts

--- a/packages/llm/src/types.ts
+++ b/packages/llm/src/types.ts
@@ -14,6 +14,7 @@ export interface GenerateObjectOptions {
   validate?: (result: unknown, context: Record<string, unknown>) => ValidationResult
   maxRetries?: number
   maxTokens?: number
+  temperature?: number
   timeoutMs?: number
   log?: {
     taskType: string

--- a/packages/pipeline/src/render-llm.ts
+++ b/packages/pipeline/src/render-llm.ts
@@ -44,6 +44,7 @@ export async function renderSectionLlm(
       image_id: img.imageId,
       image_base64: img.imageBase64,
     })),
+    styleguide: input.styleguide ?? "",
     _isActivity: isActivity,
   }
 
@@ -57,6 +58,7 @@ export async function renderSectionLlm(
     validate: validateWebRendering,
     maxRetries: config.maxRetries,
     maxTokens: 16384,
+    temperature: config.temperature,
     timeoutMs: config.timeoutMs,
     log: {
       taskType,
@@ -84,6 +86,7 @@ export async function renderSectionLlm(
       },
       maxRetries: config.maxRetries,
       maxTokens: 4096,
+      temperature: config.temperature,
       timeoutMs: config.timeoutMs,
       log: {
         taskType: "activity-answers",

--- a/packages/pipeline/src/web-rendering.ts
+++ b/packages/pipeline/src/web-rendering.ts
@@ -30,6 +30,7 @@ export interface RenderConfig {
   modelId: string
   maxRetries: number
   timeoutMs: number
+  temperature: number
   // activity fields — answer generation prompt
   answerPromptName: string
   // template fields
@@ -45,6 +46,7 @@ export interface RenderSectionInput {
   backgroundColor: string
   textColor: string
   parts: SectionPart[]
+  styleguide?: string
 }
 
 export interface RenderPageInput {
@@ -53,6 +55,7 @@ export interface RenderPageInput {
   pageImageBase64: string
   sectioning: PageSectioningOutput
   images: Map<string, string> // imageId → base64
+  styleguide?: string
 }
 
 export type ResolveLLMModel = LLMModel | ((modelId: string) => LLMModel)
@@ -143,6 +146,7 @@ export async function renderPage(
       backgroundColor: section.backgroundColor,
       textColor: section.textColor,
       parts,
+      styleguide: input.styleguide,
     }
 
     let rendering: SectionRendering
@@ -179,6 +183,7 @@ const DEFAULT_RENDER_CONFIG = {
   model: "openai:gpt-5.2",
   max_retries: 25,
   timeout: 180,
+  temperature: 0.3,
 }
 
 /**
@@ -213,6 +218,7 @@ export function buildRenderStrategyResolver(
       modelId: cfg?.model ?? DEFAULT_RENDER_CONFIG.model,
       maxRetries: cfg?.max_retries ?? DEFAULT_RENDER_CONFIG.max_retries,
       timeoutMs: (cfg?.timeout ?? DEFAULT_RENDER_CONFIG.timeout) * 1000,
+      temperature: cfg?.temperature ?? DEFAULT_RENDER_CONFIG.temperature,
       answerPromptName: cfg?.answer_prompt ?? "",
       templateName: cfg?.template ?? "",
     }

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -12,6 +12,7 @@ export const StepConfig = z.object({
   model: z.string().optional(),
   max_retries: z.number().int().min(0).optional(),
   timeout: z.number().int().min(1).optional(),
+  temperature: z.number().min(0).max(2).optional(),
 })
 export type StepConfig = z.infer<typeof StepConfig>
 
@@ -29,6 +30,9 @@ export type LayoutType = z.infer<typeof LayoutType>
 export const PresetName = z.enum(["textbook", "storybook", "reference"])
 export type PresetName = z.infer<typeof PresetName>
 
+export const StyleguideName = z.string().regex(/^[a-zA-Z0-9_-]+$/)
+export type StyleguideName = z.infer<typeof StyleguideName>
+
 export const RenderType = z.enum(["llm", "template", "activity"])
 export type RenderType = z.infer<typeof RenderType>
 
@@ -42,6 +46,7 @@ export const RenderStrategyConfig = z
         model: z.string().optional(),
         max_retries: z.number().int().min(0).optional(),
         timeout: z.number().int().min(1).optional(),
+        temperature: z.number().min(0).max(2).optional(),
         // activity render type — answer generation prompt
         answer_prompt: z.string().optional(),
         // template render type
@@ -88,6 +93,7 @@ export const AppConfig = z
     start_page: z.number().int().min(1).optional(),
     end_page: z.number().int().min(1).optional(),
     speech: SpeechConfig.optional(),
+    styleguide: z.string().regex(/^[a-zA-Z0-9_-]+$/).optional(),
   })
   .superRefine((value, ctx) => {
     if (

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -13,6 +13,7 @@ export {
   BookFormat,
   LayoutType,
   PresetName,
+  StyleguideName,
   StepConfig,
   QuizGenerationConfig,
   RenderType,

--- a/prompts/web_generation_html.liquid
+++ b/prompts/web_generation_html.liquid
@@ -1,53 +1,45 @@
 {% chat role: "system" %}
-You are an expert in frontend engineering. I want you to create a beautiful kid-friendly HTML page with any embedded TAILWIND CSS / JS based on data extracted from a textbook page.
+You are an expert frontend engineer. Generate a beautiful, kid-friendly HTML page using Tailwind CSS based on textbook data.
 
-You are given:
-1. The original textbook page as an image. Use it to position elements in the page properly. DO NOT INSERT ADDITIONAL SENTENCES FROM THE TEXTBOOK. However, you can use the text from the textbook to slightly augment the text I provided.
-2. The text extracted from the page. You must only use this text for the HTML generation. This is the text we want to render as a beautiful HTML page.
-3. The images that will be displayed with the text (if any) that you can use as img tags in the html.
-4. The section type.
+## INPUTS
+1. Original textbook page image (layout reference only)
+2. Text elements with their text_type
+3. Images with their IDs
+4. Section type
 
-IMPORTANT, THE GENERATED HTML MUST:
-1. You MAY VERY SLIGHTLY truncate the text if it makes pedagogical sense to do so for the page.
-2. You may exclude text if it does not makes sense in the section. The entire text and its text id provided must be excluded.
-3. THERE MUST BE ONE AND ONLY ONE `<section />` IN THE HTML.
-4. There MUST be an id="content" attribute on the main content container, which is a div tag, and this div MUST have the "container" class.
-5. There MUST be a role="article" or role="activity" on the `<section />` in the html based on the section type.
-6. There MUST be a data-section-type attribute on the `<section />` with the value of the section type provided (e.g., data-section-type="text-and-images").
-7. All elements with text MUST have "data-id" attribute that is set to the text id.
-8. All elements that you add a data-id attribute to MUST have a string as their immediate children AND NOT ANY OTHER HTML TAGS. For example,
-    - <p data-id="pg001_gp001_tx001">This is a paragraph</p> # OK
-    - <strong><p data-id="pg001_gp001_tx001">This is a paragraph</p></strong> # OK
-    - <p data-id="pg001_gp001_tx001"><strong>This is a paragraph</strong></p> # NOT OK
-9. DO NOT USE ANY PLACEHOLDER IMAGE TAGS IF I DID NOT PROVIDE IMAGES. YOU CAN ONLY INCLUDE IMAGE TAGS WHEN I PROVIDE YOU IMAGES.
-10. You can change the text color, but make sure it is readable against the background color.
-11. DO NOT USE ANY OTHER DATA-IDS OTHER THAN THE ONES I PROVIDED.
+## RULES
+1. Each text ID must appear EXACTLY ONCE - no duplicates
+2. Use the EXACT text provided - no modifications
+3. Return ONLY an HTML fragment (no DOCTYPE, html, head, body, script, or link tags)
+4. ALL elements with content must have `data-id` attribute matching the provided ID
+5. Elements with data-id must have string children only (no nested HTML)
+6. Only include images that have been provided with IDs
+7. There MUST be exactly one `<section>` element with `role="article"` (or `role="activity"` for activity sections) and a `data-section-type` attribute set to the provided section type
+8. The section MUST be wrapped in a container div with `id="content"` and class `container`
+9. Image tags MUST have a `data-id` attribute matching the provided image ID
+10. Do NOT use any `data-id` values other than the ones provided
+11. Text color must be readable against the background color
+{% if styleguide != "" %}
 
-IMPORTANT NOTES FOR IMAGE TAGS:
-1. Do not include an image in the html if I did not provide an image with an id associated with it.
-2. ALL IMAGE TAGS MUST HAVE A data-id attribute THAT CORRESPONDS TO AN IMAGE ID I PROVIDED. e.g. <img src="placeholder" data-id="pg001_im001" alt="placeholder" />
-3. DO NOT, I REPEAT, DO NOT ADD ANY ADDITIONAL IMAGE TAGS TO THE HTML OTHER THAN THE IMAGE IDS PROVIDED.
-4. You must size the image appropriately to make sure it does not take up the entire web page.
-5. Do not include a title tag or any other metadata in the HEAD tag
+## STYLEGUIDE (FOLLOW EXACTLY)
 
-Provide me the answer in the given structure. Please take your time and think carefully before giving me the answers.
-Take extra effort to make the web pages beautiful and as aesthetically pleasing as possible. Give the background a color or gradient that matches the textbook.
+{{ styleguide }}
+{% endif %}
 {% endchat %}
 
 {% chat role: "user" %}
-This is the base64 image of the entire page from the textbook for context only.
+Page image for context:
 {% image page_image_base64 %}
 
-The section type for this section is: {{ section_type }}.
+Section type: {{ section_type }}
 
 {% for image in images %}
-ID of the following image is: {{ image.image_id }}.
+Image ID: {{ image.image_id }}
 {% image image.image_base64 %}
 {% endfor %}
 
-The following are text for the section to use for web asset generation. You may use it verbatim or modify it as needed.
+Text elements:
 {% for text in texts %}
-id: {{ text.text_id }} text type: {{ text.text_type }}.
-text: {{ text.text }}
+- id: {{ text.text_id }} | type: {{ text.text_type }} | text: "{{ text.text }}"
 {% endfor %}
 {% endchat %}

--- a/prompts/web_generation_html_old.liquid
+++ b/prompts/web_generation_html_old.liquid
@@ -1,0 +1,59 @@
+{% chat role: "system" %}
+You are an expert in frontend engineering. I want you to create a beautiful kid-friendly HTML page with any embedded TAILWIND CSS / JS based on data extracted from a textbook page.
+
+You are given:
+1. The original textbook page as an image. Use it to position elements in the page properly. DO NOT INSERT ADDITIONAL SENTENCES FROM THE TEXTBOOK. However, you can use the text from the textbook to slightly augment the text I provided.
+2. The text extracted from the page. You must only use this text for the HTML generation. This is the text we want to render as a beautiful HTML page.
+3. The images that will be displayed with the text (if any) that you can use as img tags in the html.
+4. The section type.
+
+IMPORTANT, THE GENERATED HTML MUST:
+1. You MAY VERY SLIGHTLY truncate the text if it makes pedagogical sense to do so for the page.
+2. You may exclude text if it does not makes sense in the section. The entire text and its text id provided must be excluded.
+3. THERE MUST BE ONE AND ONLY ONE `<section />` IN THE HTML.
+4. There MUST be an id="content" attribute on the main content container, which is a div tag, and this div MUST have the "container" class.
+5. There MUST be a role="article" or role="activity" on the `<section />` in the html based on the section type.
+6. There MUST be a data-section-type attribute on the `<section />` with the value of the section type provided (e.g., data-section-type="text-and-images").
+7. All elements with text MUST have "data-id" attribute that is set to the text id.
+8. All elements that you add a data-id attribute to MUST have a string as their immediate children AND NOT ANY OTHER HTML TAGS. For example,
+    - <p data-id="pg001_gp001_tx001">This is a paragraph</p> # OK
+    - <strong><p data-id="pg001_gp001_tx001">This is a paragraph</p></strong> # OK
+    - <p data-id="pg001_gp001_tx001"><strong>This is a paragraph</strong></p> # NOT OK
+9. DO NOT USE ANY PLACEHOLDER IMAGE TAGS IF I DID NOT PROVIDE IMAGES. YOU CAN ONLY INCLUDE IMAGE TAGS WHEN I PROVIDE YOU IMAGES.
+10. You can change the text color, but make sure it is readable against the background color.
+11. DO NOT USE ANY OTHER DATA-IDS OTHER THAN THE ONES I PROVIDED.
+
+IMPORTANT NOTES FOR IMAGE TAGS:
+1. Do not include an image in the html if I did not provide an image with an id associated with it.
+2. ALL IMAGE TAGS MUST HAVE A data-id attribute THAT CORRESPONDS TO AN IMAGE ID I PROVIDED. e.g. <img src="placeholder" data-id="pg001_im001" alt="placeholder" />
+3. DO NOT, I REPEAT, DO NOT ADD ANY ADDITIONAL IMAGE TAGS TO THE HTML OTHER THAN THE IMAGE IDS PROVIDED.
+4. You must size the image appropriately to make sure it does not take up the entire web page.
+5. Do not include a title tag or any other metadata in the HEAD tag
+
+Provide me the answer in the given structure. Please take your time and think carefully before giving me the answers.
+Take extra effort to make the web pages beautiful and as aesthetically pleasing as possible. Give the background a color or gradient that matches the textbook.
+{% if styleguide != "" %}
+
+## STYLEGUIDE (FOLLOW EXACTLY)
+
+{{ styleguide }}
+{% endif %}
+{% endchat %}
+
+{% chat role: "user" %}
+This is the base64 image of the entire page from the textbook for context only.
+{% image page_image_base64 %}
+
+The section type for this section is: {{ section_type }}.
+
+{% for image in images %}
+ID of the following image is: {{ image.image_id }}.
+{% image image.image_base64 %}
+{% endfor %}
+
+The following are text for the section to use for web asset generation. You may use it verbatim or modify it as needed.
+{% for text in texts %}
+id: {{ text.text_id }} text type: {{ text.text_type }}.
+text: {{ text.text }}
+{% endfor %}
+{% endchat %}


### PR DESCRIPTION
## Summary

- Add StyleguideName Zod schema for API validation of styleguide names
- Replace direct API calls with useStyleguidePreview() TanStack Query hook for proper server state management
- Add structural HTML requirements to web generation prompt (section, container div, data-section-type)
- Update API endpoint validation to use Zod instead of hand-rolled regex

## Changes

**Backend**: New `/styleguides` and `/styleguides/:name/preview` endpoints with Zod validation. Styleguide content is loaded and threaded through the rendering pipeline in pipeline-runner, step-runner, and page-edit-service.

**Frontend**: New useStyleguidePreview() hook for TanStack Query. Updated StoryboardSettings and books.new components to use this hook instead of imperative API calls. Added styleguide dropdown selection and preview modal.

**Prompt**: Refined web_generation_html.liquid with clearer structure, removed verbose prose, and explicit rules for section/container/data-section-type elements that are now documented in the styleguide.

**Types**: Added StyleguideName Zod schema, temperature field to RenderConfig and render strategies, styleguide field to AppConfig.