### PR TITLE
Add page-by-page sectioning mode and fix validation issues

### DIFF
--- a/apps/studio/src/components/config/AdvancedLayoutPanel.tsx
+++ b/apps/studio/src/components/config/AdvancedLayoutPanel.tsx
@@ -29,6 +29,8 @@ export interface RenderStrategyState {
 export interface AdvancedLayoutPanelProps {
   defaultRenderStrategy: string
   onDefaultRenderStrategyChange: (value: string) => void
+  sectioningMode: string
+  onSectioningModeChange: (value: string) => void
   renderStrategies: Record<string, RenderStrategyState>
   onRenderStrategiesChange: (strategies: Record<string, RenderStrategyState>) => void
   textTypes: Record<string, string>
@@ -364,6 +366,8 @@ function RenderStrategyEditor({
 export function AdvancedLayoutPanel({
   defaultRenderStrategy,
   onDefaultRenderStrategyChange,
+  sectioningMode,
+  onSectioningModeChange,
   renderStrategies,
   onRenderStrategiesChange,
   textTypes,
@@ -467,6 +471,34 @@ export function AdvancedLayoutPanel({
       </div>
 
       {afterStrategySlot}
+
+      {/* Sectioning Mode */}
+      <div>
+        <h4 className="mb-1.5 text-xs font-medium text-muted-foreground uppercase tracking-wider">
+          Sectioning Mode
+        </h4>
+        <Select
+          value={sectioningMode}
+          onValueChange={onSectioningModeChange}
+        >
+          <SelectTrigger className="h-8 w-52 text-xs">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="section" className="text-xs">
+              By Section
+            </SelectItem>
+            <SelectItem value="page" className="text-xs">
+              By Page
+            </SelectItem>
+          </SelectContent>
+        </Select>
+        <p className="text-[10px] text-muted-foreground mt-1">
+          {sectioningMode === "page"
+            ? "Each page is treated as a single section"
+            : "Content is grouped into logical sections per page"}
+        </p>
+      </div>
 
       {/* 2. Available Render Strategies — collapsed */}
       <CollapsibleSection title="Available Render Strategies">

--- a/apps/studio/src/components/v2/StepSidebar.tsx
+++ b/apps/studio/src/components/v2/StepSidebar.tsx
@@ -60,7 +60,7 @@ const EXTRACT_SETTINGS_TABS = [
 
 const STORYBOARD_SETTINGS_TABS = [
   { key: "general", label: "General" },
-  { key: "sectioning-prompt", label: "Sectioning Prompt" },
+  { key: "sectioning-prompt", label: "Sectioning Mode" },
   { key: "rendering-prompt", label: "AI Rendering" },
   { key: "rendering-template", label: "Template Rendering" },
   { key: "activity-prompts", label: "Activity Rendering" },

--- a/apps/studio/src/components/v2/steps/StoryboardSettings.tsx
+++ b/apps/studio/src/components/v2/steps/StoryboardSettings.tsx
@@ -72,6 +72,7 @@ export function StoryboardSettings({ bookLabel, headerTarget, tab = "general" }:
   const [allStrategyNames, setAllStrategyNames] = useState<string[]>([])
   const [renderStrategyNames, setRenderStrategyNames] = useState<string[]>([])
   const [activityModel, setActivityModel] = useState("")
+  const [sectioningMode, setSectioningMode] = useState("section")
   const [sectioningModel, setSectioningModel] = useState("")
   const [renderingModel, setRenderingModel] = useState("")
   const [renderingPromptName, setRenderingPromptName] = useState("web_generation_html")
@@ -167,6 +168,7 @@ export function StoryboardSettings({ bookLabel, headerTarget, tab = "general" }:
     if (merged.page_sectioning && typeof merged.page_sectioning === "object") {
       const ps = merged.page_sectioning as Record<string, unknown>
       if (ps.model) setSectioningModel(String(ps.model))
+      if (ps.mode) setSectioningMode(String(ps.mode))
     }
     // Styleguide
     setStyleguide(typeof merged.styleguide === "string" ? merged.styleguide : "")
@@ -286,7 +288,7 @@ export function StoryboardSettings({ bookLabel, headerTarget, tab = "general" }:
     }
     if (shouldWrite("page_sectioning")) {
       const existing = (bookConfigData?.config?.page_sectioning ?? {}) as Record<string, unknown>
-      overrides.page_sectioning = { ...existing, model: sectioningModel.trim() || undefined }
+      overrides.page_sectioning = { ...existing, model: sectioningModel.trim() || undefined, mode: sectioningMode }
     }
     if (shouldWrite("styleguide")) {
       overrides.styleguide = styleguide || undefined
@@ -531,15 +533,58 @@ export function StoryboardSettings({ bookLabel, headerTarget, tab = "general" }:
       )}
 
       {tab === "sectioning-prompt" && (
-        <PromptViewer
-          promptName="page_sectioning"
-          bookLabel={bookLabel}
-          title="Page Sectioning Prompt"
-          description="The prompt template used to split each page into logical sections. This is a Liquid template processed with page context."
-          model={sectioningModel}
-          onModelChange={(v) => { setSectioningModel(v); markDirty("page_sectioning") }}
-          onContentChange={setSectioningPromptDraft}
-        />
+        <div className="flex flex-col h-full">
+          <div className="shrink-0 p-4 pb-0 space-y-4">
+            <div>
+              <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
+                Sectioning Mode
+              </h3>
+              <Select
+                value={sectioningMode}
+                onValueChange={(v) => {
+                  setSectioningMode(v)
+                  markDirty("page_sectioning")
+                }}
+              >
+                <SelectTrigger className="w-72">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent align="start">
+                  <SelectItem value="section">
+                    <div className="flex flex-col items-start">
+                      <span>By Section</span>
+                      <span className="text-xs text-muted-foreground">
+                        Groups content into logical sections
+                      </span>
+                    </div>
+                  </SelectItem>
+                  <SelectItem value="page">
+                    <div className="flex flex-col items-start">
+                      <span>By Page</span>
+                      <span className="text-xs text-muted-foreground">
+                        Treats each page as a single section
+                      </span>
+                    </div>
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-muted-foreground mt-1.5">
+                Controls how page content is grouped during the sectioning step.
+              </p>
+            </div>
+          </div>
+          <div className="flex-1 min-h-0">
+            <PromptViewer
+              promptName="page_sectioning"
+              bookLabel={bookLabel}
+              title="Page Sectioning Prompt"
+              description="The prompt template used to split each page into logical sections. This is a Liquid template processed with page context."
+              model={sectioningModel}
+              onModelChange={(v) => { setSectioningModel(v); markDirty("page_sectioning") }}
+              onContentChange={setSectioningPromptDraft}
+            />
+          </div>
+        </div>
       )}
 
       {tab === "rendering-prompt" && (

--- a/apps/studio/src/routes/books.new.tsx
+++ b/apps/studio/src/routes/books.new.tsx
@@ -170,6 +170,7 @@ function AddBookPage() {
   const [textTypes, setTextTypes] = useState<Record<string, string>>({})
   const [textGroupTypes, setTextGroupTypes] = useState<Record<string, string>>({})
   const [sectionTypes, setSectionTypes] = useState<Record<string, string>>({})
+  const [sectioningMode, setSectioningMode] = useState("section")
 
   // Styleguide preview
   const [styleguidePreviewOpen, setStyleguidePreviewOpen] = useState(false)
@@ -280,6 +281,14 @@ function AddBookPage() {
     // Spread mode from preset
     if (typeof config.spread_mode === "boolean") {
       setSpreadMode(config.spread_mode)
+    }
+
+    // Sectioning mode from preset
+    if (config.page_sectioning && typeof config.page_sectioning === "object") {
+      const ps = config.page_sectioning as Record<string, unknown>
+      setSectioningMode(ps.mode ? String(ps.mode) : "section")
+    } else {
+      setSectioningMode("section")
     }
 
     // Styleguide from preset
@@ -439,6 +448,7 @@ function AddBookPage() {
     if (Object.keys(sectionTypes).length > 0) {
       configOverrides.section_types = sectionTypes
     }
+    configOverrides.page_sectioning = { mode: sectioningMode }
 
     createMutation.mutate(
       { label, pdf: file, config: configOverrides },
@@ -666,6 +676,8 @@ function AddBookPage() {
                   <AdvancedLayoutPanel
                     defaultRenderStrategy={defaultRenderStrategy}
                     onDefaultRenderStrategyChange={setDefaultRenderStrategy}
+                    sectioningMode={sectioningMode}
+                    onSectioningModeChange={setSectioningMode}
                     renderStrategies={renderStrategies}
                     onRenderStrategiesChange={setRenderStrategies}
                     textTypes={textTypes}

--- a/config/presets/reference.yaml
+++ b/config/presets/reference.yaml
@@ -6,6 +6,9 @@ default_render_strategy: two_column
 
 spread_mode: false
 
+page_sectioning:
+  mode: page
+
 render_strategies:
   two_column:
     render_type: template

--- a/config/presets/storybook.yaml
+++ b/config/presets/storybook.yaml
@@ -6,6 +6,9 @@ default_render_strategy: two_column_story
 
 spread_mode: true
 
+page_sectioning:
+  mode: page
+
 render_strategies:
   two_column_story:
     render_type: template

--- a/config/presets/textbook.yaml
+++ b/config/presets/textbook.yaml
@@ -8,6 +8,9 @@ styleguide: default
 
 spread_mode: false
 
+page_sectioning:
+  mode: section
+
 render_strategies:
   llm:
     render_type: llm

--- a/packages/pipeline/src/page-sectioning.ts
+++ b/packages/pipeline/src/page-sectioning.ts
@@ -5,6 +5,7 @@ import type {
   SectionPart,
   AppConfig,
   TypeDef,
+  SectioningMode,
 } from "@adt/types"
 import { buildPageSectioningLLMSchema } from "@adt/types"
 import type { LLMModel, ValidationResult } from "@adt/llm"
@@ -14,6 +15,7 @@ export interface SectioningConfig {
   prunedSectionTypes: string[]
   promptName: string
   modelId: string
+  mode: SectioningMode
 }
 
 export interface SectionPageInput {
@@ -99,6 +101,7 @@ export async function sectionPage(
     schema,
     prompt: config.promptName,
     context: {
+      sectioning_mode: config.mode,
       page: { imageBase64: input.pageImageBase64 },
       images: unprunedImages.map((img) => ({
         image_id: img.imageId,
@@ -263,5 +266,6 @@ export function buildSectioningConfig(appConfig: AppConfig): SectioningConfig {
     prunedSectionTypes: appConfig.pruned_section_types ?? [],
     promptName: appConfig.page_sectioning?.prompt ?? "page_sectioning",
     modelId: appConfig.page_sectioning?.model ?? "openai:gpt-5.2",
+    mode: appConfig.page_sectioning?.mode ?? "section",
   }
 }

--- a/packages/pipeline/src/validate-html.ts
+++ b/packages/pipeline/src/validate-html.ts
@@ -118,7 +118,9 @@ function walkNode(node: any, allowedIds: Set<string>, errors: string[], options?
     }
 
     const dataId = node.attribs?.["data-id"]
-    if (dataId !== undefined && !allowedIds.has(dataId)) {
+    // Skip data-id validation on <section> elements — their data-id is a
+    // section identifier (e.g. "pg028_section"), not a content element ID.
+    if (dataId !== undefined && tagName !== "section" && !allowedIds.has(dataId)) {
       if (!(options?.allowActivityGeneratedIds && dataId.startsWith("activity_gen_"))) {
         errors.push(`Unknown data-id: "${dataId}"`)
       }

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -21,6 +21,14 @@ export const QuizGenerationConfig = StepConfig.extend({
 })
 export type QuizGenerationConfig = z.infer<typeof QuizGenerationConfig>
 
+export const SectioningMode = z.enum(["section", "page"])
+export type SectioningMode = z.infer<typeof SectioningMode>
+
+export const PageSectioningConfig = StepConfig.extend({
+  mode: SectioningMode.optional(),
+})
+export type PageSectioningConfig = z.infer<typeof PageSectioningConfig>
+
 export const BookFormat = z.enum(["web", "epub", "webpub"])
 export type BookFormat = z.infer<typeof BookFormat>
 
@@ -75,7 +83,7 @@ export const AppConfig = z
     text_classification: StepConfig.optional(),
     translation: StepConfig.optional(),
     metadata: StepConfig.optional(),
-    page_sectioning: StepConfig.optional(),
+    page_sectioning: PageSectioningConfig.optional(),
     quiz_generation: QuizGenerationConfig.optional(),
     default_render_strategy: z.string().optional(),
     render_strategies: z.record(z.string(), RenderStrategyConfig).optional(),

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -16,6 +16,8 @@ export {
   StyleguideName,
   StepConfig,
   QuizGenerationConfig,
+  SectioningMode,
+  PageSectioningConfig,
   RenderType,
   RenderStrategyConfig,
   AppConfig,

--- a/prompts/page_sectioning.liquid
+++ b/prompts/page_sectioning.liquid
@@ -1,17 +1,31 @@
 {% chat role: "system" %}
+{% if sectioning_mode == "page" %}
+You are a pedagogical expert at classifying textbook pages for schoolchildren.
+
+You will be shown a page image and its extracted text groups and images. Classify the page as a single section containing ALL of its content.
+{% else %}
 You are a pedagogical expert at organizing a textbook page into coherent, logical sections for schoolchildren.
 
 You will be shown a page image and its extracted text groups and images. Group the text and images into natural, logical sections that belong together as complete units.
+{% endif %}
 
 SECTION TYPES:
 {% for t in section_types %}- {{ t.key }}: {{ t.description }}
 {% endfor %}
 
 RULES:
-- ALL group IDs must be assigned to at least one section
-- Image IDs may be excluded if they have no educational value
+- ONLY use IDs that are explicitly listed below in "Text groups" and "Image" entries. Do NOT invent or generate new IDs.
+{% if sectioning_mode == "page" %}
+- Create EXACTLY ONE section containing ALL listed group IDs and ALL listed image IDs
+- Choose the single most appropriate section type for the page as a whole
+- ALL listed group IDs must be assigned to this one section
+- If no image IDs are listed below, do NOT include any image IDs in part_ids
+{% else %}
+- ALL listed group IDs must be assigned to at least one section
 - Group/image IDs may appear in multiple sections only when it makes strong pedagogical sense (e.g. shared instructions)
 - Keep related content together — prefer fewer, more comprehensive sections over many small ones
+{% endif %}
+- Image IDs may be excluded if they have no educational value
 - Extract page number if visible (headers, footers, margins). Use null if none found
 - For background_color: hex code of predominant background. Default #ffffff
 - For text_color: hex code of predominant text color. Must contrast with background. Default #000000
@@ -31,5 +45,9 @@ Text groups:
 - {{ group.group_id }} ({{ group.group_type }}): {{ group.text }}
 {% endfor %}
 
+{% if sectioning_mode == "page" %}
+Please place ALL content into a single section.
+{% else %}
 Please organize these into sections.
+{% endif %}
 {% endchat %}


### PR DESCRIPTION
Introduces a new "sectioning mode" configuration (page vs. section) that controls how pages are divided during the storyboard pipeline step.

**Changes:**
- New SectioningMode enum and PageSectioningConfig in packages/types
- Page sectioning prompt (page_sectioning.liquid) now branches on mode, with enhanced rules to prevent LLM ID hallucination
- Pipeline passes sectioning_mode to prompt context
- UI controls in new book form and storyboard settings
- Presets: reference and storybook use "page" mode; textbook uses "section" mode
- Fixed web generation HTML validation to skip data-id checks on <section> elements (they carry section identifiers, not content IDs)