### PR TITLE
Switch release workflow from deploy branch to tag-triggered

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
-name: Release Windows
+name: Release
 
 on:
   push:
-    branches: [deploy]
-  workflow_dispatch:
+    tags: ["v*"]
 
 permissions:
   contents: write
@@ -15,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # Need full history for version tag detection
+          fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
 
@@ -30,38 +29,12 @@ jobs:
         with:
           workspaces: apps/desktop/src-tauri -> target
 
-      - name: Determine next version
+      - name: Extract version from tag
         id: version
         shell: bash
         run: |
-          LATEST=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)
-          if [ -z "$LATEST" ]; then
-            NEXT="0.1.0"
-          else
-            VERSION="${LATEST#v}"
-            IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
-            PATCH=$((PATCH + 1))
-            NEXT="$MAJOR.$MINOR.$PATCH"
-          fi
-          echo "version=$NEXT" >> "$GITHUB_OUTPUT"
-          echo "tag=v$NEXT" >> "$GITHUB_OUTPUT"
-          echo "Next version: $NEXT"
-
-      - name: Generate release notes
-        id: notes
-        shell: bash
-        run: |
-          PREV_TAG=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)
-          if [ -n "$PREV_TAG" ]; then
-            LOG=$(git log "$PREV_TAG"..HEAD --pretty=format:"- %s" --no-merges)
-          else
-            LOG=$(git log --pretty=format:"- %s" --no-merges -20)
-          fi
-          BODY=$(printf "## What's Changed\n\n%s\n\n---\nDownload the Windows installer (.exe) below." "$LOG")
-          # Multiline output using delimiter
-          echo "body<<RELEASE_EOF" >> "$GITHUB_OUTPUT"
-          echo "$BODY" >> "$GITHUB_OUTPUT"
-          echo "RELEASE_EOF" >> "$GITHUB_OUTPUT"
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Set version in tauri.conf.json
         shell: bash
@@ -83,8 +56,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           projectPath: apps/desktop
-          tagName: ${{ steps.version.outputs.tag }}
-          releaseName: "ADT Studio ${{ steps.version.outputs.tag }}"
-          releaseBody: ${{ steps.notes.outputs.body }}
+          tagName: ${{ github.ref_name }}
+          releaseName: "ADT Studio ${{ github.ref_name }}"
+          releaseBody: ""
           releaseDraft: false
           prerelease: false
+
+      - name: Generate release notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit ${{ github.ref_name }} --generate-notes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,11 +81,13 @@ Key files:
 
 ### Releasing
 
-Push to the `deploy` branch triggers a GitHub Actions workflow that builds a Windows installer and creates a GitHub Release with auto-incremented patch version (v0.1.0 → v0.1.1 → ...).
+Pushing a version tag triggers a GitHub Actions workflow that builds a Windows installer and creates a GitHub Release with auto-generated changelog.
 
 ```bash
-git checkout deploy && git merge main && git push   # Creates next release
+git tag v0.2.0 && git push --tags   # Creates next release
 ```
+
+Or create a new tag in the GitHub UI pointing at `main`.
 
 ## Key Rules
 


### PR DESCRIPTION
## Summary
- Updated GitHub Actions release workflow to be triggered by version tags (`v*`) instead of pushes to the `deploy` branch
- Simplified version extraction — reads version directly from tag name instead of auto-incrementing
- Replaced custom changelog generation with GitHub's built-in `--generate-notes`
- Updated CLAUDE.md documentation to reflect new release process

## Benefits
- Standard practice aligned with Tauri docs and most open source projects
- Explicit version control — you decide what version ships
- Eliminates the fragile `deploy` branch workflow and bash parsing logic
- Auto-generated changelog groups commits by contributor and type