### PR TITLE
Fix release notes generation in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,4 +65,9 @@ jobs:
       - name: Generate release notes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release edit ${{ github.ref_name }} --generate-notes
+        shell: bash
+        run: |
+          NOTES=$(gh api repos/${{ github.repository }}/releases/generate-notes \
+            -f tag_name=${{ github.ref_name }} \
+            --jq '.body')
+          gh release edit ${{ github.ref_name }} --notes "$NOTES"


### PR DESCRIPTION
## Summary
- `gh release edit --generate-notes` doesn't exist — that flag is only on `gh release create`
- Use the GitHub API `releases/generate-notes` endpoint to generate notes, then pass them via `--notes`

This was causing the release workflow to fail at the final step (assets were uploaded but no changelog was generated).