### PR TITLE
feat: image gen prompt settings + sticky generating pill

### DIFF
--- a/apps/api/src/routes/pages.ts
+++ b/apps/api/src/routes/pages.ts
@@ -509,6 +509,22 @@ export function createPageRoutes(
       const targetImageId =
         typeof body.targetImageId === "string" ? validateImageId(body.targetImageId) : referenceImageId
 
+      // Render the global image generation prompt template (book-level override takes priority).
+      // The template may contain {{ user_prompt }} where the per-image request is injected.
+      const bookPromptPath = path.join(bookDir, "prompts", "ai_image_generation.liquid")
+      const globalPromptPath = path.join(path.resolve(promptsDir), "ai_image_generation.liquid")
+      let templateContent: string | null = null
+      if (fs.existsSync(bookPromptPath)) {
+        templateContent = fs.readFileSync(bookPromptPath, "utf-8")
+      } else if (fs.existsSync(globalPromptPath)) {
+        templateContent = fs.readFileSync(globalPromptPath, "utf-8")
+      }
+      // Use a replacer function to avoid JS special replacement patterns ($&, $1, etc.)
+      // being interpreted if the user's prompt happens to contain them.
+      const finalPrompt = templateContent
+        ? templateContent.trim().replace(/\{\{\s*user_prompt\s*\}\}/g, () => prompt)
+        : prompt
+
       // Look up target image dimensions once — used for both aspect ratio size selection
       // and returning originalWidth/originalHeight to the frontend
       let originalWidth = 0
@@ -559,7 +575,7 @@ export function createPageRoutes(
 
         const formData = new FormData()
         formData.append("model", "gpt-image-1.5")
-        formData.append("prompt", prompt)
+        formData.append("prompt", finalPrompt)
         formData.append("size", size)
         formData.append("image[]", new Blob([imageBuffer], { type: "image/png" }), `${referenceImageId}.png`)
 
@@ -579,7 +595,7 @@ export function createPageRoutes(
           },
           body: JSON.stringify({
             model: "gpt-image-1.5",
-            prompt,
+            prompt: finalPrompt,
             size,
           }),
           signal: AbortSignal.timeout(180_000),
@@ -665,7 +681,7 @@ export function createPageRoutes(
             attempt: 1,
             durationMs: Date.now() - startTime,
             messages: [
-              { role: "user", content: [{ type: "text", text: prompt }] },
+              { role: "user", content: [{ type: "text", text: finalPrompt }] },
               { role: "assistant", content: [{ type: "text", text: `Generated image: ${newImageId} (${width}x${height})` }] },
             ],
           }

--- a/apps/studio/src/components/v2/PromptViewer.tsx
+++ b/apps/studio/src/components/v2/PromptViewer.tsx
@@ -4,7 +4,7 @@ import { Label } from "@/components/ui/label"
 import { useQuery } from "@tanstack/react-query"
 import { api } from "@/api/client"
 
-interface PromptViewerProps {
+interface PromptViewerBaseProps {
   /** Prompt template name to fetch (e.g. "page_sectioning") */
   promptName: string
   /** Book label for book-scoped prompt overrides */
@@ -13,10 +13,6 @@ interface PromptViewerProps {
   title: string
   /** Short description shown above the prompt */
   description: string
-  /** Current model value */
-  model: string
-  /** Called when the user changes the model */
-  onModelChange: (model: string) => void
   /** Called when the user edits the prompt content (null = reverted to original) */
   onContentChange?: (content: string | null) => void
   /** Placeholder for the model input */
@@ -24,6 +20,10 @@ interface PromptViewerProps {
   /** Whether to fetch the prompt (set false to defer loading) */
   enabled?: boolean
 }
+
+type PromptViewerProps =
+  | (PromptViewerBaseProps & { hideModel: true; model?: never; onModelChange?: never })
+  | (PromptViewerBaseProps & { hideModel?: false; model: string; onModelChange: (model: string) => void })
 
 /** Simple Liquid template syntax highlighter */
 function highlightLiquid(text: string): string {
@@ -51,6 +51,7 @@ export function PromptViewer({
   onContentChange,
   modelPlaceholder = "openai:gpt-5.2",
   enabled = true,
+  hideModel = false,
 }: PromptViewerProps) {
   const { data: promptData, isLoading } = useQuery({
     queryKey: ["prompts", promptName, bookLabel],
@@ -98,15 +99,17 @@ export function PromptViewer({
       </div>
 
       {/* Model picker */}
-      <div className="shrink-0 max-w-xs">
-        <Label className="text-xs">Model</Label>
-        <Input
-          value={model}
-          onChange={(e) => onModelChange(e.target.value)}
-          placeholder={modelPlaceholder}
-          className="mt-1 text-xs"
-        />
-      </div>
+      {!hideModel && (
+        <div className="shrink-0 max-w-xs">
+          <Label className="text-xs">Model</Label>
+          <Input
+            value={model ?? ""}
+            onChange={(e) => onModelChange?.(e.target.value)}
+            placeholder={modelPlaceholder}
+            className="mt-1 text-xs"
+          />
+        </div>
+      )}
 
       {/* Prompt editor */}
       {isLoading ? (

--- a/apps/studio/src/components/v2/StepSidebar.tsx
+++ b/apps/studio/src/components/v2/StepSidebar.tsx
@@ -68,6 +68,7 @@ const STORYBOARD_SETTINGS_TABS = [
   { key: "rendering-prompt", label: "AI Rendering" },
   { key: "rendering-template", label: "Template Rendering" },
   { key: "activity-prompts", label: "Activity Rendering" },
+  { key: "image-generation", label: "Image Generation" },
 ]
 
 const QUIZ_SETTINGS_TABS = [

--- a/apps/studio/src/components/v2/stages/StoryboardSectionDetail.tsx
+++ b/apps/studio/src/components/v2/stages/StoryboardSectionDetail.tsx
@@ -1173,56 +1173,57 @@ export function StoryboardSectionDetail({
           </div>
         )}
 
-        {/* Background image generation indicator (non-blocking) */}
-        {aiImageGen && (
-          <div className="absolute top-3 right-3 z-40 animate-in fade-in slide-in-from-top-2 duration-200">
-            <div
-              className={`flex items-center gap-2 rounded-full px-3.5 py-2 shadow-lg text-white text-xs font-medium ${
-                aiImageGen.status === "generating"
-                  ? "bg-purple-600"
-                  : aiImageGen.status === "done"
-                    ? "bg-green-600"
-                    : "bg-destructive"
-              }`}
-            >
-              {aiImageGen.status === "generating" && (
-                <>
-                  <Loader2 className="h-3 w-3 animate-spin" />
-                  <span>Generating image...</span>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      aiImageAbortRef.current?.abort()
-                      setAiImageGen(null)
-                    }}
-                    className="p-0.5 rounded-full hover:bg-white/20 transition-colors cursor-pointer"
-                  >
-                    <X className="h-3 w-3" />
-                  </button>
-                </>
-              )}
-              {aiImageGen.status === "done" && (
-                <>
-                  <Sparkles className="h-3 w-3" />
-                  <span>Image generated</span>
-                </>
-              )}
-              {aiImageGen.status === "error" && (
-                <>
-                  <span>{aiImageGen.error ?? "Generation failed"}</span>
-                  <button
-                    type="button"
-                    onClick={() => setAiImageGen(null)}
-                    className="p-0.5 rounded-full hover:bg-white/20 transition-colors cursor-pointer"
-                  >
-                    <X className="h-3 w-3" />
-                  </button>
-                </>
-              )}
-            </div>
-          </div>
-        )}
       </div>
+
+      {/* Background image generation indicator — absolute to outer panel so it stays visible while scrolling */}
+      {aiImageGen && (
+        <div className="absolute top-3 right-3 z-40 animate-in fade-in slide-in-from-top-2 duration-200">
+          <div
+            className={`flex items-center gap-2 rounded-full px-3.5 py-2 shadow-lg text-white text-xs font-medium ${
+              aiImageGen.status === "generating"
+                ? "bg-purple-600"
+                : aiImageGen.status === "done"
+                  ? "bg-green-600"
+                  : "bg-destructive"
+            }`}
+          >
+            {aiImageGen.status === "generating" && (
+              <>
+                <Loader2 className="h-3 w-3 animate-spin" />
+                <span>Generating image...</span>
+                <button
+                  type="button"
+                  onClick={() => {
+                    aiImageAbortRef.current?.abort()
+                    setAiImageGen(null)
+                  }}
+                  className="p-0.5 rounded-full hover:bg-white/20 transition-colors cursor-pointer"
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </>
+            )}
+            {aiImageGen.status === "done" && (
+              <>
+                <Sparkles className="h-3 w-3" />
+                <span>Image generated</span>
+              </>
+            )}
+            {aiImageGen.status === "error" && (
+              <>
+                <span>{aiImageGen.error ?? "Generation failed"}</span>
+                <button
+                  type="button"
+                  onClick={() => setAiImageGen(null)}
+                  className="p-0.5 rounded-full hover:bg-white/20 transition-colors cursor-pointer"
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </>
+            )}
+          </div>
+        </div>
+      )}
 
       {/* Floating save/discard bar */}
       {(dirty || renderingDirty) && !saving && (

--- a/apps/studio/src/components/v2/stages/StoryboardSettings.tsx
+++ b/apps/studio/src/components/v2/stages/StoryboardSettings.tsx
@@ -63,6 +63,7 @@ export function StoryboardSettings({ bookLabel, headerTarget, tab = "general" }:
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const [showRerunDialog, setShowRerunDialog] = useState(false)
+  const [savingImageGenPrompt, setSavingImageGenPrompt] = useState(false)
 
   // Form state
   const [sectionTypes, setSectionTypes] = useState<Record<string, string>>({})
@@ -88,6 +89,7 @@ export function StoryboardSettings({ bookLabel, headerTarget, tab = "general" }:
   const [activityStrategyName, setActivityStrategyName] = useState("")
   const [activityPromptDraft, setActivityPromptDraft] = useState<string | null>(null)
   const [activityAnswerDraft, setActivityAnswerDraft] = useState<string | null>(null)
+  const [imageGenPromptDraft, setImageGenPromptDraft] = useState<string | null>(null)
 
   // Derive activity strategies directly from merged config (synchronous)
   const activityStrategies = useMemo(() => {
@@ -329,6 +331,7 @@ export function StoryboardSettings({ bookLabel, headerTarget, tab = "general" }:
     if (templateTabDraft != null && templateTabName) contentSaves.push(api.updateTemplate(templateTabName, templateTabDraft, bookLabel))
     if (activityPromptDraft != null && selectedActivity?.prompt) contentSaves.push(api.updatePrompt(selectedActivity.prompt, activityPromptDraft, bookLabel))
     if (activityAnswerDraft != null && selectedActivity?.answer_prompt) contentSaves.push(api.updatePrompt(selectedActivity.answer_prompt, activityAnswerDraft, bookLabel))
+    if (imageGenPromptDraft != null) contentSaves.push(api.updatePrompt("ai_image_generation", imageGenPromptDraft, bookLabel))
     if (contentSaves.length > 0) await Promise.all(contentSaves)
 
     const overrides = buildOverrides()
@@ -343,6 +346,7 @@ export function StoryboardSettings({ bookLabel, headerTarget, tab = "general" }:
           setTemplateTabDraft(null)
           setActivityPromptDraft(null)
           setActivityAnswerDraft(null)
+          setImageGenPromptDraft(null)
           setShowRerunDialog(false)
           // Start step-scoped storyboard run — blocks until data is cleared on backend
           startRun("storyboard", "storyboard")
@@ -358,8 +362,20 @@ export function StoryboardSettings({ bookLabel, headerTarget, tab = "general" }:
     )
   }
 
+  // Image gen prompt is on-demand (not pipeline) — save without triggering a rerun
+  const saveImageGenPrompt = async () => {
+    if (imageGenPromptDraft == null) return
+    setSavingImageGenPrompt(true)
+    try {
+      await api.updatePrompt("ai_image_generation", imageGenPromptDraft, bookLabel)
+      setImageGenPromptDraft(null)
+    } finally {
+      setSavingImageGenPrompt(false)
+    }
+  }
+
   return (
-    <div className={tab === "sectioning-prompt" || tab === "rendering-prompt" || tab === "rendering-template" || tab === "activity-prompts" ? "h-full" : "p-4 space-y-6"}>
+    <div className={tab === "sectioning-prompt" || tab === "rendering-prompt" || tab === "rendering-template" || tab === "activity-prompts" || tab === "image-generation" ? "h-full" : "p-4 space-y-6"}>
       {tab === "general" && (
         <>
           {/* Default Render Strategy */}
@@ -854,16 +870,40 @@ export function StoryboardSettings({ bookLabel, headerTarget, tab = "general" }:
         )
       })()}
 
+      {tab === "image-generation" && (
+        <div className="h-full">
+          <PromptViewer
+            promptName="ai_image_generation"
+            bookLabel={bookLabel}
+            title="Image Generation Prompt"
+            description="Wraps every AI image generation request — define style guidelines and rules here, then use {{ user_prompt }} where the per-image request should be injected."
+            hideModel
+            onContentChange={setImageGenPromptDraft}
+          />
+        </div>
+      )}
+
       {headerTarget && createPortal(
-        <Button
-          size="sm"
-          className="h-7 px-2.5 text-xs bg-black/15 text-white hover:bg-black/25"
-          onClick={() => setShowRerunDialog(true)}
-          disabled={updateConfig.isPending || !hasApiKey}
-        >
-          <Play className="mr-1.5 h-3.5 w-3.5" />
-          Save &amp; Rerun
-        </Button>,
+        tab === "image-generation" ? (
+          <Button
+            size="sm"
+            className="h-7 px-2.5 text-xs bg-black/15 text-white hover:bg-black/25"
+            onClick={saveImageGenPrompt}
+            disabled={savingImageGenPrompt || imageGenPromptDraft == null}
+          >
+            {savingImageGenPrompt ? "Saving..." : "Save"}
+          </Button>
+        ) : (
+          <Button
+            size="sm"
+            className="h-7 px-2.5 text-xs bg-black/15 text-white hover:bg-black/25"
+            onClick={() => setShowRerunDialog(true)}
+            disabled={updateConfig.isPending || !hasApiKey}
+          >
+            <Play className="mr-1.5 h-3.5 w-3.5" />
+            Save &amp; Rerun
+          </Button>
+        ),
         headerTarget
       )}
 

--- a/prompts/ai_image_generation.liquid
+++ b/prompts/ai_image_generation.liquid
@@ -1,0 +1,10 @@
+Generate a high-quality illustration suitable for a children's educational book. Use a clear, friendly, and engaging visual style with bright colors and simple forms. The image should be culturally inclusive and age-appropriate.
+
+## RULES
+1. No violent, disturbing, or inappropriate content
+2. Positive and uplifting imagery
+3. Diverse and inclusive representation
+4. Suitable for children aged 6–12
+
+## REQUEST
+{{ user_prompt }}


### PR DESCRIPTION
## Summary

- **Sticky generating pill** — the "Generating image..." status pill was pinned to the top of the scroll content, scrolling away. Moved it outside the `overflow-auto` container so it stays fixed below the header regardless of scroll position.
- **Image Generation prompt settings** — new "Image Generation" tab in storyboard settings with a full prompt editor (same `PromptViewer` as all other prompts). A global `prompts/ai_image_generation.liquid` default is shipped; books can override it at `books/{label}/prompts/ai_image_generation.liquid`.
- **`{{ user_prompt }}` injection** — the global prompt is a template; `{{ user_prompt }}` is replaced with the user's per-image request at generation time. Backend reads the file on each request (book override → global fallback).
- **Standalone Save button** — image gen prompt changes save without triggering a pipeline rerun (it's on-demand, not pipeline). Header shows "Save" instead of "Save & Rerun" on this tab.

## Bug fixes

- `String.replace(regex, userPrompt)` — if the user's prompt contained `$&`, `$1`, etc., JS would interpret them as special replacement patterns, corrupting the final prompt. Fixed with a replacer function `() => prompt`.
- `PromptViewer` — made `model`/`onModelChange` required when `hideModel` is false via a discriminated union type, so the missing-model case is caught at compile time.
- `pages.ts` path — was re-resolving `booksDir` mid-handler when `bookDir` was already computed at the top.

## Test plan

- [x] Open a book in storyboard view, trigger AI image generation, scroll the preview — confirm the "Generating image..." pill stays visible at the top-right
- [x] Go to Storyboard → Settings → Image Generation — confirm the prompt editor loads with the default prompt
- [x] Edit the prompt and click Save — confirm it saves without triggering a pipeline rerun
- [x] Generate an image — confirm the edited global prompt is used (check debug panel LLM log for the final prompt sent to OpenAI)
- [x] Verify `{{ user_prompt }}` is correctly replaced with the user's per-image input
- [x] Verify a prompt containing `$&` or `$1` in the user input doesn't corrupt the final prompt