### PR TITLE
fix: strip pre-release suffix from version for MSI/WiX

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,11 @@ jobs:
         run: |
           REF="${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}"
           VERSION="${REF#v}"
+          # Strip pre-release suffix (e.g. 0.2.1-rc1 → 0.2.1) — WiX/MSI requires
+          # numeric-only pre-release identifiers, so any alpha suffix breaks the build.
+          VERSION_MSI="${VERSION%%-*}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "version_msi=$VERSION_MSI" >> "$GITHUB_OUTPUT"
           echo "tag=${REF}" >> "$GITHUB_OUTPUT"
 
       - name: Set version in tauri.conf.json
@@ -55,7 +59,7 @@ jobs:
             const fs = require('fs');
             const p = 'apps/desktop/src-tauri/tauri.conf.json';
             const conf = JSON.parse(fs.readFileSync(p, 'utf-8'));
-            conf.version = '${{ steps.version.outputs.version }}';
+            conf.version = '${{ steps.version.outputs.version_msi }}';
             fs.writeFileSync(p, JSON.stringify(conf, null, 2) + '\n');
           "
 


### PR DESCRIPTION
## Problem

The release workflow failed when a tag with a pre-release suffix was pushed (e.g. `v0.2.1-test1`):

```
failed to bundle project `optional pre-release identifier in app version
must be numeric-only and cannot be greater than 65535 for msi target`
```

WiX (the Windows MSI bundler used by Tauri) only accepts versions in `major.minor.patch` format. Any pre-release suffix containing letters (`-test1`, `-rc1`, `-beta`) is rejected.

## Fix

Strip the pre-release suffix before writing the version to `tauri.conf.json`. A new `version_msi` output holds the clean version (`0.2.1-test1` → `0.2.1`). The git tag and GitHub Release name still use the full original version string.

```bash
VERSION_MSI="${VERSION%%-*}"   # 0.2.1-rc1 → 0.2.1
```

## Test plan

- [ ] Push a tag like `v0.2.1-rc1` and confirm the MSI build succeeds
- [ ] Confirm the GitHub Release is still tagged `v0.2.1-rc1`
- [ ] Confirm the installer version shows `0.2.1`