### PR TITLE
fix: storyboard page height, navigation race conditions, and image selectability

### DIFF
--- a/apps/studio/src/components/v2/stages/BookPreviewFrame.tsx
+++ b/apps/studio/src/components/v2/stages/BookPreviewFrame.tsx
@@ -52,6 +52,7 @@ export const BookPreviewFrame = forwardRef<BookPreviewFrameHandle, BookPreviewFr
   const readyRef = useRef(false)
   const latestHtmlRef = useRef("")
   const settledRef = useRef(false)
+  const measureTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const sanitizedHtml = useMemo(() => DOMPurify.sanitize(html), [html])
   latestHtmlRef.current = sanitizedHtml
@@ -162,7 +163,8 @@ export const BookPreviewFrame = forwardRef<BookPreviewFrameHandle, BookPreviewFr
   // Interactive hover styles
   const interactiveStyles = editable
     ? `[data-id] { cursor: pointer; transition: outline 0.1s; }
-    [data-id]:hover { outline: 2px solid rgba(59,130,246,0.3); outline-offset: 2px; }`
+    [data-id]:hover { outline: 2px solid rgba(59,130,246,0.3); outline-offset: 2px; }
+    img[data-id] { position: relative; z-index: 1; }`
     : ""
 
   // Stable shell — loaded once, never changes
@@ -239,9 +241,12 @@ ${interactiveScript}
       doc.body.appendChild(scriptEl)
     }
 
+    // Measure multiple times to catch late reflows from Tailwind CDN, fonts, and images.
     // Wait one frame so the browser queues font loads for the new content,
     // then wait for fonts.ready so we measure the final layout.
     requestAnimationFrame(() => {
+      measureHeight()
+
       const settle = () => {
         settledRef.current = true
         measureHeight()
@@ -253,6 +258,18 @@ ${interactiveScript}
         settle()
       }
     })
+
+    // Re-measure when images finish loading (they affect content height)
+    doc.querySelectorAll("img").forEach((img) => {
+      if (!img.complete) {
+        img.addEventListener("load", measureHeight, { once: true })
+        img.addEventListener("error", measureHeight, { once: true })
+      }
+    })
+
+    // Safety net for late reflows (e.g. Tailwind CDN processing injected classes)
+    if (measureTimerRef.current) clearTimeout(measureTimerRef.current)
+    measureTimerRef.current = setTimeout(measureHeight, 500)
   }
 
   // When html prop changes, update the body directly (no iframe reload)
@@ -370,6 +387,7 @@ ${selectors}:hover {
     return () => {
       iframe.removeEventListener("load", onLoad)
       window.removeEventListener("resize", onResize)
+      if (measureTimerRef.current) clearTimeout(measureTimerRef.current)
       readyRef.current = false
       setIframeReady(false)
     }

--- a/apps/studio/src/components/v2/stages/StoryboardSectionDetail.tsx
+++ b/apps/studio/src/components/v2/stages/StoryboardSectionDetail.tsx
@@ -329,6 +329,10 @@ export function StoryboardSectionDetail({
   const previewFrameRef = useRef<BookPreviewFrameHandle>(null)
   const scrollContainerRef = useRef<HTMLDivElement>(null)
 
+  // Track current pageId so async callbacks can detect stale closures
+  const pageIdRef = useRef(pageId)
+  pageIdRef.current = pageId
+
   // Section data panel state
   const [panelOpen, setPanelOpen] = useState(false)
 
@@ -392,19 +396,29 @@ export function StoryboardSectionDetail({
     }
   }, [])
 
-  // Clear pending state when page changes
+  // Clear pending state and abort ALL in-flight requests when page changes
   useEffect(() => {
     setPendingSectioning(null)
     setPendingRendering(null)
     setSelectedElement(null)
     setCropTarget(null)
     setAiImageDialogTarget(null)
+    aiAbortRef.current?.abort()
     aiImageAbortRef.current?.abort()
     setAiImageGen(null)
     setAiInstruction("")
+    setAiLoading(false)
     setAiReasoning(null)
+    setAiReasoningOpen(false)
     setAiError(null)
+    setRerendering(false)
+    setSaving(false)
   }, [pageId])
+
+  // Reset scroll position when page or section changes
+  useEffect(() => {
+    scrollContainerRef.current?.scrollTo(0, 0)
+  }, [pageId, sectionIndex])
 
   // Dismiss toolbar on scroll (position would be stale)
   useEffect(() => {
@@ -450,12 +464,17 @@ export function StoryboardSectionDetail({
       // Automatically re-render with the updated sectioning
       if (hasApiKey) {
         setRerendering(true)
+        const capturedPageId = pageId
         api.reRenderPage(bookLabel, pageId, apiKey)
           .then(() => {
-            queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "pages", pageId] })
+            // Discard if user navigated to a different page
+            if (pageIdRef.current !== capturedPageId) return
+            queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "pages", capturedPageId] })
             queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "pages"] })
           })
-          .finally(() => setRerendering(false))
+          .finally(() => {
+            if (pageIdRef.current === capturedPageId) setRerendering(false)
+          })
       }
     } catch (err) {
       setAiError(err instanceof Error ? err.message : "Save failed")
@@ -892,6 +911,9 @@ export function StoryboardSectionDetail({
         currentHtml,
         controller.signal
       )
+
+      // Discard result if user navigated to a different page during the request
+      if (pageIdRef.current !== pageId) return
 
       // Apply the AI edit as pending rendering
       const base = pendingRendering ?? page.rendering


### PR DESCRIPTION
## Summary

- **Page content cut off after navigation** — iframe now re-measures height after images load (+ 500ms safety timeout), so full page is always visible when switching between pages
- **AI edit / re-render applying to wrong page** — all in-flight async operations are aborted on page change, and callbacks verify the page hasn't changed before applying results
- **Images not clickable for editing** — images get `position: relative; z-index: 1` in edit mode so they're always selectable for crop/replace/AI generate

Also fixes scroll position not resetting on page/section navigation and loading overlays persisting on the wrong page.

## Test plan

- [ ] Navigate between pages in the storyboard sidebar — content should always be fully visible (no cutoff at bottom, especially pages with large images)
- [ ] Start an AI edit on one page, quickly switch to another page — the edit result should NOT appear on the new page
- [ ] Save sectioning (which triggers auto re-render), switch pages before it finishes — re-rendering overlay should not persist on the new page
- [ ] Click on images in the storyboard preview — they should always be selectable and show the crop/replace/AI toolbar
- [ ] Navigate between pages and sections — scroll should reset to top each time