### PR TITLE
feat: pass original page image as visual context to AI section editor

### DIFF
--- a/apps/api/src/services/page-edit-service.ts
+++ b/apps/api/src/services/page-edit-service.ts
@@ -199,10 +199,18 @@ export async function aiEditSection(
       }
     }
 
+    // Load the original page image so the LLM can see the intended layout
+    let pageImageBase64: string | undefined
+    try {
+      pageImageBase64 = storage.getPageImageBase64(pageId)
+    } catch {
+      // Page image not available — proceed without it
+    }
+
     const result = await model.generateObject<{ reasoning: string; content: string }>({
       schema: webRenderingLLMSchema,
       prompt: "html_edit",
-      context: { current_html: currentHtml, instruction },
+      context: { current_html: currentHtml, instruction, page_image_base64: pageImageBase64 },
       validate: (obj) => {
         const r = obj as { content: string }
         // Strip markdown fences before validation so checks run on clean HTML

--- a/prompts/html_edit.liquid
+++ b/prompts/html_edit.liquid
@@ -19,6 +19,11 @@ Return a JSON object with two fields:
 {% endchat %}
 
 {% chat role: "user" %}
+{% if page_image_base64 %}
+This is an image of the original textbook page for visual reference only — use it to understand the intended layout and appearance, but follow the HTML as the source of truth:
+{% image page_image_base64 %}
+{% endif %}
+
 Here is the current HTML for the section:
 
 {{ current_html }}


### PR DESCRIPTION
## Summary

- The AI edit prompt now receives the original extracted page image so the LLM can see the intended layout and appearance when editing section HTML
- Image is passed conditionally — if the page image isn't available, AI edit still works without it
- Prompt frames the image as "for visual reference only — follow the HTML as the source of truth" to avoid the LLM inventing content from the image

## Changes

- `apps/api/src/services/page-edit-service.ts` — loads `storage.getPageImageBase64(pageId)` and passes it as `page_image_base64` in the LLM context
- `prompts/html_edit.liquid` — conditionally includes the page image in the user message via `{% if page_image_base64 %}`

## Test plan

- [ ] Use "Ask AI to edit..." on a storyboard section — verify the edit still works and the LLM makes layout-aware changes
- [ ] Check LLM logs to confirm the page image is included in the request
- [ ] Verify AI edit still works on a page where the original image might be missing