### PR TITLE
Add image cropping/segmentation toggles and min-side filter

### DIFF
--- a/apps/api/src/services/step-runner.ts
+++ b/apps/api/src/services/step-runner.ts
@@ -409,10 +409,20 @@ async function runExtractStep(
 
     // Emit completion for classification steps
     progress.emit({ type: "step-complete", step: "image-filtering" })
+    if (segmentationConfig) {
+      progress.emit({ type: "step-complete", step: "image-segmentation" })
+    } else {
+      progress.emit({ type: "step-skip", step: "image-segmentation" })
+    }
     if (croppingConfig) {
       progress.emit({ type: "step-complete", step: "image-cropping" })
     } else {
       progress.emit({ type: "step-skip", step: "image-cropping" })
+    }
+    if (meaningfulnessConfig) {
+      progress.emit({ type: "step-complete", step: "image-meaningfulness" })
+    } else {
+      progress.emit({ type: "step-skip", step: "image-meaningfulness" })
     }
     progress.emit({ type: "step-complete", step: "text-classification" })
     if (translationConfig) {
@@ -1574,8 +1584,10 @@ async function classifyPage(
           .filter((img) => !img.isPruned)
           .map((img) => img.imageId)
       )
+      const segMinSide = segmentationConfig.minSide
       const unprunedImages = images
         .filter((img) => unprunedIds.has(img.imageId))
+        .filter((img) => segMinSide === undefined || Math.min(img.width, img.height) >= segMinSide)
         .map((img) => ({
           imageId: img.imageId,
           imageBase64: storage.getImageBase64(img.imageId),
@@ -1594,9 +1606,11 @@ async function classifyPage(
           segmentationModel
         )
         const segVersion = storage.putNodeData("image-segmentation", page.pageId, segmentationResult)
+        const segDims = new Map(images.map((img) => [img.imageId, { width: img.width, height: img.height }]))
         const applied = applySegmentation(
           segmentationResult,
-          (imageId) => storage.getImageBase64(imageId)
+          (imageId) => storage.getImageBase64(imageId),
+          segDims,
         )
         for (const seg of applied) {
           storage.putSegmentedImage({

--- a/apps/studio/src/components/pipeline/stages/ExtractSettings.tsx
+++ b/apps/studio/src/components/pipeline/stages/ExtractSettings.tsx
@@ -53,6 +53,7 @@ export function ExtractSettings({ bookLabel, headerTarget, tab = "general" }: { 
   const [meaningfulnessModel, setMeaningfulnessModel] = useState("")
   const [croppingModel, setCroppingModel] = useState("")
   const [segmentationModel, setSegmentationModel] = useState("")
+  const [segmentationMinSide, setSegmentationMinSide] = useState("")
   const [bookSummaryModel, setBookSummaryModel] = useState("")
   const [metadataPromptDraft, setMetadataPromptDraft] = useState<string | null>(null)
   const [extractionPromptDraft, setExtractionPromptDraft] = useState<string | null>(null)
@@ -111,6 +112,7 @@ export function ExtractSettings({ bookLabel, headerTarget, tab = "general" }: { 
     if (merged.image_segmentation && typeof merged.image_segmentation === "object") {
       const is = merged.image_segmentation as Record<string, unknown>
       if (is.model) setSegmentationModel(String(is.model))
+      if (is.min_side != null) setSegmentationMinSide(String(is.min_side))
     }
     if (merged.book_summary && typeof merged.book_summary === "object") {
       const bs = merged.book_summary as Record<string, unknown>
@@ -214,7 +216,11 @@ export function ExtractSettings({ bookLabel, headerTarget, tab = "general" }: { 
     }
     if (shouldWrite("image_segmentation")) {
       const existing = (bookConfigData?.config?.image_segmentation ?? {}) as Record<string, unknown>
-      overrides.image_segmentation = { ...existing, model: segmentationModel.trim() || undefined }
+      overrides.image_segmentation = {
+        ...existing,
+        model: segmentationModel.trim() || undefined,
+        min_side: segmentationMinSide.trim() ? Number(segmentationMinSide) : undefined,
+      }
     }
     if (shouldWrite("book_summary")) {
       const existing = (bookConfigData?.config?.book_summary ?? {}) as Record<string, unknown>
@@ -549,16 +555,34 @@ export function ExtractSettings({ bookLabel, headerTarget, tab = "general" }: { 
       )}
 
       {tab === "segmentation-prompt" && (
-        <PromptViewer
-          promptName="image_segmentation"
-          bookLabel={bookLabel}
-          title="Image Segmentation Prompt"
-          description="LLM-based segmentation to detect and split composited images into individual segments. Requires GPT-5.2+ for accurate bounding box coordinates."
-          model={segmentationModel}
-          onModelChange={(v) => { setSegmentationModel(v); markDirty("image_segmentation") }}
-          onContentChange={setSegmentationPromptDraft}
-          enabled={tab === "segmentation-prompt"}
-        />
+        <div className="flex flex-col h-full">
+          <div className="shrink-0 px-4 pt-4 pb-3 space-y-1.5 border-b">
+            <Label className="text-xs">Min image dimension (px)</Label>
+            <Input
+              type="number"
+              min={0}
+              value={segmentationMinSide}
+              onChange={(e) => { setSegmentationMinSide(e.target.value); markDirty("image_segmentation") }}
+              placeholder="None"
+              className="w-32"
+            />
+            <p className="text-xs text-muted-foreground">
+              Skip segmentation for images whose shortest side is below this threshold.
+            </p>
+          </div>
+          <div className="flex-1 min-h-0">
+            <PromptViewer
+              promptName="image_segmentation"
+              bookLabel={bookLabel}
+              title="Image Segmentation Prompt"
+              description="LLM-based segmentation to detect and split composited images into individual segments. Requires GPT-5.2+ for accurate bounding box coordinates."
+              model={segmentationModel}
+              onModelChange={(v) => { setSegmentationModel(v); markDirty("image_segmentation") }}
+              onContentChange={setSegmentationPromptDraft}
+              enabled={tab === "segmentation-prompt"}
+            />
+          </div>
+        </div>
       )}
 
       {tab === "book-summary-prompt" && (

--- a/apps/studio/src/routes/books.new.tsx
+++ b/apps/studio/src/routes/books.new.tsx
@@ -159,6 +159,9 @@ function AddBookPage() {
   const [startPage, setStartPage] = useState("")
   const [endPage, setEndPage] = useState("")
   const [spreadMode, setSpreadMode] = useState(false)
+  const [imageCropping, setImageCropping] = useState(false)
+  const [imageSegmentation, setImageSegmentation] = useState(true)
+  const [segMinSide, setSegMinSide] = useState("")
 
   // Step 2 — Layout
   const [layoutType, setLayoutType] = useState<LayoutType>("textbook")
@@ -277,9 +280,22 @@ function AddBookPage() {
       const f = config.image_filters as Record<string, unknown>
       setImageMinSide(f.min_side != null ? String(f.min_side) : "")
       setImageMaxSide(f.max_side != null ? String(f.max_side) : "")
+      setImageCropping(f.cropping === true)
+      // Default segmentation to true unless explicitly disabled
+      setImageSegmentation(f.segmentation !== false)
     } else {
       setImageMinSide("")
       setImageMaxSide("")
+      setImageCropping(false)
+      setImageSegmentation(true)
+    }
+
+    // Segmentation min side from preset
+    if (config.image_segmentation && typeof config.image_segmentation === "object") {
+      const s = config.image_segmentation as Record<string, unknown>
+      setSegMinSide(s.min_side != null ? String(s.min_side) : "")
+    } else {
+      setSegMinSide("")
     }
 
     // Spread mode from preset
@@ -436,11 +452,18 @@ function AddBookPage() {
     if (prunedSectionTypes.size > 0) {
       configOverrides.pruned_section_types = Array.from(prunedSectionTypes)
     }
-    const imageFilters: Record<string, number> = {}
+    const imageFilters: Record<string, unknown> = {}
     if (imageMinSide.trim()) imageFilters.min_side = Number(imageMinSide)
     if (imageMaxSide.trim()) imageFilters.max_side = Number(imageMaxSide)
+    imageFilters.cropping = imageCropping
+    imageFilters.segmentation = imageSegmentation
     if (Object.keys(imageFilters).length > 0) {
       configOverrides.image_filters = imageFilters
+    }
+    if (imageSegmentation && segMinSide.trim()) {
+      configOverrides.image_segmentation = {
+        min_side: Number(segMinSide),
+      }
     }
     // Type definitions
     if (Object.keys(textTypes).length > 0) {
@@ -604,6 +627,52 @@ function AddBookPage() {
                     <p className="text-xs text-muted-foreground">
                       Leave empty to process all pages.
                     </p>
+                  </div>
+                  <div className="space-y-1.5">
+                    <div className="flex items-center gap-2">
+                      <Switch
+                        id="image-cropping"
+                        checked={imageCropping}
+                        onCheckedChange={setImageCropping}
+                      />
+                      <Label htmlFor="image-cropping" className="text-xs">
+                        LLM image cropping
+                      </Label>
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      Use an LLM to crop away stray text, artifacts, and excessive whitespace from image edges.
+                    </p>
+                  </div>
+                  <div className="space-y-1.5">
+                    <div className="flex items-center gap-2">
+                      <Switch
+                        id="image-segmentation"
+                        checked={imageSegmentation}
+                        onCheckedChange={setImageSegmentation}
+                      />
+                      <Label htmlFor="image-segmentation" className="text-xs">
+                        LLM image segmentation
+                      </Label>
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      Use an LLM to detect and split composited images into individual segments.
+                    </p>
+                    {imageSegmentation && (
+                      <div className="pt-1">
+                        <Label className="text-xs">Min image dimension (px)</Label>
+                        <Input
+                          type="number"
+                          min={0}
+                          value={segMinSide}
+                          onChange={(e) => setSegMinSide(e.target.value)}
+                          placeholder="None"
+                          className="w-28 mt-1"
+                        />
+                        <p className="text-xs text-muted-foreground mt-1">
+                          Skip segmentation for images whose shortest side is below this threshold.
+                        </p>
+                      </div>
+                    )}
                   </div>
                 </div>
               )}

--- a/packages/pipeline/src/image-segmentation.ts
+++ b/packages/pipeline/src/image-segmentation.ts
@@ -12,6 +12,7 @@ export interface SegmentationPageInput {
 export interface SegmentationConfig {
   promptName: string
   modelId: string
+  minSide?: number
 }
 
 const DEFAULT_SEGMENTATION_MODEL = "openai:gpt-5.2"
@@ -29,6 +30,7 @@ export function buildSegmentationConfig(
   return {
     promptName: appConfig.image_segmentation?.prompt ?? "image_segmentation",
     modelId: appConfig.image_segmentation?.model || DEFAULT_SEGMENTATION_MODEL,
+    minSide: appConfig.image_segmentation?.min_side,
   }
 }
 
@@ -182,13 +184,22 @@ export interface AppliedSegment {
   height: number
 }
 
+const DEFAULT_SEGMENT_PADDING = 10
+
 /**
  * Apply segmentation bounding boxes to images, returning cropped buffers.
  * Only returns entries for images that need segmentation.
+ *
+ * Each bounding box is expanded outward by `padding` pixels (default 10)
+ * and clamped to the image dimensions. When clamping reduces padding on
+ * one side (e.g. near an image edge), the lost space is added to the
+ * opposite side so the content stays centered in the crop box.
  */
 export function applySegmentation(
   segmentationOutput: ImageSegmentationOutput,
-  getImageBase64: (imageId: string) => string
+  getImageBase64: (imageId: string) => string,
+  imageDims?: Map<string, { width: number; height: number }>,
+  padding: number = DEFAULT_SEGMENT_PADDING,
 ): AppliedSegment[] {
   const results: AppliedSegment[] = []
 
@@ -199,18 +210,38 @@ export function applySegmentation(
 
     const originalBase64 = getImageBase64(result.imageId)
     const buffer = Buffer.from(originalBase64, "base64")
+    const dims = imageDims?.get(result.imageId)
 
     for (let i = 0; i < result.segments.length; i++) {
       const seg = result.segments[i]
-      const width = seg.cropRight - seg.cropLeft
-      const height = seg.cropBottom - seg.cropTop
+
+      // Expand bounding box outward by padding, clamped to image bounds
+      let left = Math.max(0, seg.cropLeft - padding)
+      let top = Math.max(0, seg.cropTop - padding)
+      let right = dims ? Math.min(dims.width, seg.cropRight + padding) : seg.cropRight + padding
+      let bottom = dims ? Math.min(dims.height, seg.cropBottom + padding) : seg.cropBottom + padding
+
+      // Compensate clamped padding on the opposite side to center content
+      if (dims) {
+        const leftLoss = Math.max(0, -(seg.cropLeft - padding))
+        const topLoss = Math.max(0, -(seg.cropTop - padding))
+        const rightLoss = Math.max(0, (seg.cropRight + padding) - dims.width)
+        const bottomLoss = Math.max(0, (seg.cropBottom + padding) - dims.height)
+        right = Math.min(dims.width, right + leftLoss)
+        left = Math.max(0, left - rightLoss)
+        bottom = Math.min(dims.height, bottom + topLoss)
+        top = Math.max(0, top - bottomLoss)
+      }
+
+      const width = right - left
+      const height = bottom - top
       if (width <= 0 || height <= 0) continue
 
       const cropped = applyCrop(buffer, {
-        cropLeft: seg.cropLeft,
-        cropTop: seg.cropTop,
-        cropRight: seg.cropRight,
-        cropBottom: seg.cropBottom,
+        cropLeft: left,
+        cropTop: top,
+        cropRight: right,
+        cropBottom: bottom,
       })
       results.push({
         sourceImageId: result.imageId,

--- a/packages/pipeline/src/pipeline-dag.ts
+++ b/packages/pipeline/src/pipeline-dag.ts
@@ -257,8 +257,10 @@ export async function runFullPipeline(
           imageClassification.images.filter((img) => !img.isPruned).map((img) => img.imageId)
         )
         const allImages = storage.getPageImages(page.pageId)
+        const segMinSide = segmentationConfig.minSide
         const unprunedImages = allImages
           .filter((img) => unprunedImageIds.has(img.imageId))
+          .filter((img) => segMinSide === undefined || Math.min(img.width, img.height) >= segMinSide)
           .map((img) => ({
             imageId: img.imageId,
             imageBase64: storage.getImageBase64(img.imageId),
@@ -274,9 +276,11 @@ export async function runFullPipeline(
               model,
             )
             const segVersion = storage.putNodeData("image-segmentation", page.pageId, segmentationResult)
+            const segDims = new Map(allImages.map((img) => [img.imageId, { width: img.width, height: img.height }]))
             const applied = applySegmentation(
               segmentationResult,
               (imageId) => storage.getImageBase64(imageId),
+              segDims,
             )
             for (const seg of applied) {
               storage.putSegmentedImage({

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -99,7 +99,9 @@ export const AppConfig = z
     output_languages: z.array(z.string()).optional(),
     book_format: z.array(BookFormat).optional(),
     image_captioning: StepConfig.optional(),
-    image_segmentation: StepConfig.optional(),
+    image_segmentation: StepConfig.extend({
+      min_side: z.number().int().min(0).optional(),
+    }).optional(),
     image_cropping: StepConfig.optional(),
     layout_type: LayoutType.optional(),
     spread_mode: z.boolean().optional(),

--- a/prompts/image_segmentation.liquid
+++ b/prompts/image_segmentation.liquid
@@ -29,11 +29,11 @@ Coordinates use a pixel coordinate system:
 - crop_bottom: y-coordinate of the bottom edge of the segment
 
 CRITICAL — Bounding box placement rules:
-- Each bounding box should tightly wrap the visual content of ONE sub-image, plus comfortable padding (10–20 pixels on each side). Do NOT extend boxes to fill the entire source image — ignore large whitespace regions between or around sub-images.
-- NEVER crop into the content of a figure, diagram, or photograph. It is far better to include a little extra whitespace than to cut off any part of an image.
-- When images are arranged in a grid or row, split along the natural gutters (whitespace between images). Each box should stop at the gutter, not extend through it.
-- Bounding boxes may overlap slightly at gutter boundaries — that is acceptable. What matters is that every sub-image is fully contained within its box with no content clipped.
-- When in doubt about where one image ends and another begins, include more space rather than less.
+- Each bounding box should GENEROUSLY wrap the visual content of ONE sub-image. Add at least 10–30 pixels of padding on every side beyond the visible content edge. Do NOT extend boxes to fill the entire source image — ignore large whitespace regions between or around sub-images.
+- ABSOLUTELY NEVER crop into the content of a figure, diagram, or photograph. This is the single most important rule. Extra whitespace around a segment is always acceptable; clipping even a single pixel of content is NOT.
+- When images are arranged in a grid or row, split along the natural gutters (whitespace between images). Place each box boundary at the MIDPOINT of the gutter rather than at the edge of the content, so both adjacent segments get a generous margin.
+- Bounding boxes may overlap at gutter boundaries — that is acceptable and preferred over tight crops.
+- When in doubt about where one image ends and another begins, always include MORE space rather than less. Err on the side of too much whitespace.
 
 IMPORTANT:
 - Provide reasoning before your determination for each image.


### PR DESCRIPTION
## Summary

- Add UI toggles in the "Add Book" wizard to control LLM image cropping and segmentation
- Introduce a configurable "min image dimension" threshold to skip expensive segmentation on small images
- Enhance segmentation bounding boxes with padding and edge-compensation logic to prevent content clipping
- Update segmentation prompt to emphasize generous padding over tight crops

## Implementation

Config schema extended to support `image_segmentation.min_side`. Both `step-runner.ts` and `pipeline-dag.ts` filter images by their shortest dimension before passing to the segmentation LLM. The `applySegmentation` function now expands bounding boxes by configurable padding (default 10px) and compensates for clamping at image edges to keep content centered. UI controls added to both the book creation wizard and Extract settings panel.