### PR TITLE
feat: unify stage sidebar and stage color system

### DIFF
--- a/apps/studio/src/components/pipeline/StageRunCard.tsx
+++ b/apps/studio/src/components/pipeline/StageRunCard.tsx
@@ -29,14 +29,14 @@ interface StageRunCardProps {
 }
 
 const HOVER_BG_BY_COLOR: Record<string, string> = {
-  "bg-gray-500": "hover:bg-gray-500",
-  "bg-blue-500": "hover:bg-blue-500",
-  "bg-violet-500": "hover:bg-violet-500",
-  "bg-orange-500": "hover:bg-orange-500",
-  "bg-teal-500": "hover:bg-teal-500",
-  "bg-lime-500": "hover:bg-lime-500",
-  "bg-pink-500": "hover:bg-pink-500",
-  "bg-amber-500": "hover:bg-amber-500",
+  "bg-gray-600": "hover:bg-gray-600",
+  "bg-blue-600": "hover:bg-blue-600",
+  "bg-violet-600": "hover:bg-violet-600",
+  "bg-orange-600": "hover:bg-orange-600",
+  "bg-teal-600": "hover:bg-teal-600",
+  "bg-lime-600": "hover:bg-lime-600",
+  "bg-pink-600": "hover:bg-pink-600",
+  "bg-amber-600": "hover:bg-amber-600",
 }
 
 export function StageRunCard({
@@ -48,19 +48,17 @@ export function StageRunCard({
   onRun,
   disabled,
 }: StageRunCardProps) {
-  const stepConfig = STAGES.find((s) => s.slug === stageSlug)
+  const stage = STAGES.find((s) => s.slug === stageSlug) ?? STAGES[0]
   const { progress } = useStepRun()
   const { subSteps: subStepProgress, error, targetSteps } = progress
-
   const subSteps = STAGE_SUB_STEPS[stageSlug as StageName] ?? []
-  const Icon = stepConfig?.icon ?? Play
-  const bgDark = stepConfig?.bgDark ?? "bg-gray-700"
-  const color = stepConfig?.color ?? "bg-gray-500"
-  const borderColor = stepConfig?.borderColor ?? "border-gray-200"
+  const Icon = stage.icon
+  const color = stage.color
+  const borderColor = stage.borderDark
   const hasError = !!error && targetSteps.has(stageSlug)
   const isCompleted = completed || progress.steps.get(stageSlug)?.state === "done"
   const hasSubSteps = subSteps.length > 0
-  const hoverColorClass = HOVER_BG_BY_COLOR[color] ?? "hover:bg-gray-500"
+  const hoverColorClass = HOVER_BG_BY_COLOR[color] ?? "hover:bg-gray-600"
   const buttonToneClass = isCompleted
     ? cn(color, "text-white", hoverColorClass, "hover:text-white")
     : cn("bg-gray-200 text-gray-700", hoverColorClass, "hover:text-white")
@@ -68,14 +66,14 @@ export function StageRunCard({
   return (
     <Card className={cn("overflow-hidden max-w-xl shadow-none", borderColor)}>
       {/* Colored header */}
-      <CardHeader className={cn("flex-row items-center gap-2.5 space-y-0 px-4 py-2 text-white", bgDark)}>
+      <CardHeader className={cn("flex-row items-center gap-2.5 space-y-0 px-4 py-2 text-white", color)}>
         <div className="flex items-center justify-center w-6 h-6 rounded-full bg-white/20">
           <Icon className="w-3 h-3" />
         </div>
         <CardTitle className="text-sm leading-normal tracking-normal">
           {isRunning
-            ? `${stepConfig?.runningLabel ?? stageSlug}...`
-            : stepConfig?.label ?? stageSlug}
+            ? `${stage.runningLabel}...`
+            : stage.label}
         </CardTitle>
       </CardHeader>
 
@@ -148,8 +146,8 @@ export function StageRunCard({
                   hasError
                     ? "Retry"
                     : isCompleted
-                      ? `Re-run ${stepConfig?.label?.toLowerCase() ?? stageSlug}`
-                      : `Run ${stepConfig?.label?.toLowerCase() ?? stageSlug}`
+                      ? `Re-run ${stage.label.toLowerCase()}`
+                      : `Run ${stage.label.toLowerCase()}`
                 }
               >
                 {hasError || isCompleted ? <RotateCcw className="w-5 h-5" /> : <Play className="w-5 h-5 ml-0.5" />}

--- a/apps/studio/src/components/pipeline/StageSidebar.tsx
+++ b/apps/studio/src/components/pipeline/StageSidebar.tsx
@@ -309,13 +309,24 @@ function PageRow({
   const timerRef = useRef<ReturnType<typeof setTimeout>>(null)
 
   const handleEnter = useCallback(() => {
+    if (timerRef.current) clearTimeout(timerRef.current)
     timerRef.current = setTimeout(() => {
       if (!rowRef.current) return
       const rect = rowRef.current.getBoundingClientRect()
       const previewH = 400
+      const previewW = 300
+      const gap = 20
       const margin = 8
       const top = Math.max(margin, Math.min(rect.top, window.innerHeight - previewH - margin))
-      setPreviewPos({ top, left: rect.right + 20 })
+      const rightEdge = window.innerWidth - margin
+      const rightSideLeft = rect.right + gap
+      const leftSideLeft = rect.left - previewW - gap
+      const unclampedLeft =
+        rightSideLeft + previewW <= rightEdge
+          ? rightSideLeft
+          : leftSideLeft
+      const left = Math.max(margin, Math.min(unclampedLeft, rightEdge - previewW))
+      setPreviewPos({ top, left })
       setShowPreview(true)
     }, 600)
   }, [])
@@ -323,6 +334,12 @@ function PageRow({
   const handleLeave = useCallback(() => {
     if (timerRef.current) clearTimeout(timerRef.current)
     setShowPreview(false)
+  }, [])
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current)
+    }
   }, [])
 
   const imgSrc = data?.imageBase64 ? `data:image/png;base64,${data.imageBase64}` : null

--- a/apps/studio/src/components/pipeline/StepProgressRing.tsx
+++ b/apps/studio/src/components/pipeline/StepProgressRing.tsx
@@ -1,26 +1,20 @@
 import type { UIStepState } from "@/hooks/use-step-run"
+import { STAGES } from "@/components/pipeline/stage-config"
 
 interface StepProgressRingProps {
   /** Icon diameter in pixels (ring renders slightly larger) */
   size: number
   /** Step state: idle | queued | running | done | error */
   state: UIStepState
-  /** Tailwind color class prefix like "blue" for blue-500 */
+  /** Tailwind bg color class (e.g. "bg-blue-700") or "bg-white" */
   colorClass: string
 }
 
-/** Color class to actual stroke color mapping */
-const COLOR_MAP: Record<string, string> = {
-  "bg-blue-500": "#3b82f6",
-  "bg-violet-500": "#8b5cf6",
-  "bg-orange-500": "#f97316",
-  "bg-teal-500": "#14b8a6",
-  "bg-lime-500": "#84cc16",
-  "bg-pink-500": "#ec4899",
-  "bg-amber-500": "#f59e0b",
-  "bg-gray-500": "#6b7280",
-  "bg-white": "#ffffff",
-}
+/** Build hex lookup from stage config, plus the special "bg-white" entry */
+const COLOR_MAP: Record<string, string> = Object.fromEntries([
+  ...STAGES.map((s) => [s.color, s.hex]),
+  ["bg-white", "#ffffff"],
+])
 
 /** Gap between icon edge and ring center in px */
 const GAP = 3

--- a/apps/studio/src/components/pipeline/StepViewRouter.tsx
+++ b/apps/studio/src/components/pipeline/StepViewRouter.tsx
@@ -78,7 +78,7 @@ export function StepViewRouter({ step, bookLabel, selectedPageId, onSelectPage }
     <StepHeaderContext.Provider value={controls}>
       <div className="flex flex-col h-full">
         {/* Step header */}
-        <div className={cn("shrink-0 h-10 px-4 flex items-center gap-3 text-white", stepConfig.bgDark)}>
+        <div className={cn("shrink-0 h-10 px-4 flex items-center gap-3 text-white", stepConfig.color)}>
           <div className="flex items-center justify-center w-6 h-6 rounded-full bg-white/20">
             <Icon className="w-3 h-3" />
           </div>

--- a/apps/studio/src/components/pipeline/stage-config.ts
+++ b/apps/studio/src/components/pipeline/stage-config.ts
@@ -11,24 +11,25 @@ import {
 } from "lucide-react"
 
 export const STAGES = [
-  { slug: "book", label: "Book", runningLabel: "Loading Book", icon: BookMarked, color: "bg-gray-500", textColor: "text-gray-600", bgLight: "bg-gray-50", bgDark: "bg-gray-700", borderColor: "border-gray-200" },
-  { slug: "extract", label: "Extract", runningLabel: "Extracting", icon: FileText, color: "bg-blue-500", textColor: "text-blue-600", bgLight: "bg-blue-50", bgDark: "bg-blue-700", borderColor: "border-blue-200" },
-  { slug: "storyboard", label: "Storyboard", runningLabel: "Building Storyboard", icon: LayoutGrid, color: "bg-violet-500", textColor: "text-violet-600", bgLight: "bg-violet-50", bgDark: "bg-violet-700", borderColor: "border-violet-200" },
-  { slug: "quizzes", label: "Quizzes", runningLabel: "Generating Quizzes", icon: HelpCircle, color: "bg-orange-500", textColor: "text-orange-600", bgLight: "bg-orange-50", bgDark: "bg-orange-700", borderColor: "border-orange-200" },
-  { slug: "captions", label: "Captions", runningLabel: "Captioning Images", icon: Image, color: "bg-teal-500", textColor: "text-teal-600", bgLight: "bg-teal-50", bgDark: "bg-teal-700", borderColor: "border-teal-200" },
-  { slug: "glossary", label: "Glossary", runningLabel: "Generating Glossary", icon: BookOpen, color: "bg-lime-500", textColor: "text-lime-600", bgLight: "bg-lime-50", bgDark: "bg-lime-700", borderColor: "border-lime-200" },
-  { slug: "text-and-speech", label: "Text & Speech", runningLabel: "Translating", icon: Languages, color: "bg-pink-500", textColor: "text-pink-600", bgLight: "bg-pink-50", bgDark: "bg-pink-700", borderColor: "border-pink-200" },
-  { slug: "preview", label: "Preview", runningLabel: "Building Preview", icon: Eye, color: "bg-gray-500", textColor: "text-gray-600", bgLight: "bg-gray-50", bgDark: "bg-gray-700", borderColor: "border-gray-200" },
+  { slug: "book", label: "Book", runningLabel: "Loading Book", icon: BookMarked, color: "bg-gray-600", hex: "#4b5563", textColor: "text-gray-600", bgLight: "bg-gray-50", borderColor: "border-gray-200", borderDark: "border-gray-600" },
+  { slug: "extract", label: "Extract", runningLabel: "Extracting", icon: FileText, color: "bg-blue-600", hex: "#2563eb", textColor: "text-blue-600", bgLight: "bg-blue-50", borderColor: "border-blue-200", borderDark: "border-blue-600" },
+  { slug: "storyboard", label: "Storyboard", runningLabel: "Building Storyboard", icon: LayoutGrid, color: "bg-violet-600", hex: "#7c3aed", textColor: "text-violet-600", bgLight: "bg-violet-50", borderColor: "border-violet-200", borderDark: "border-violet-600" },
+  { slug: "quizzes", label: "Quizzes", runningLabel: "Generating Quizzes", icon: HelpCircle, color: "bg-orange-600", hex: "#ea580c", textColor: "text-orange-600", bgLight: "bg-orange-50", borderColor: "border-orange-200", borderDark: "border-orange-600" },
+  { slug: "captions", label: "Captions", runningLabel: "Captioning Images", icon: Image, color: "bg-teal-600", hex: "#0d9488", textColor: "text-teal-600", bgLight: "bg-teal-50", borderColor: "border-teal-200", borderDark: "border-teal-600" },
+  { slug: "glossary", label: "Glossary", runningLabel: "Generating Glossary", icon: BookOpen, color: "bg-lime-600", hex: "#65a30d", textColor: "text-lime-600", bgLight: "bg-lime-50", borderColor: "border-lime-200", borderDark: "border-lime-600" },
+  { slug: "text-and-speech", label: "Text & Speech", runningLabel: "Translating", icon: Languages, color: "bg-pink-600", hex: "#db2777", textColor: "text-pink-600", bgLight: "bg-pink-50", borderColor: "border-pink-200", borderDark: "border-pink-600" },
+  { slug: "preview", label: "Preview", runningLabel: "Building Preview", icon: Eye, color: "bg-gray-600", hex: "#4b5563", textColor: "text-gray-600", bgLight: "bg-gray-50", borderColor: "border-gray-200", borderDark: "border-gray-600" },
 ] as const satisfies ReadonlyArray<{
   slug: string
   label: string
   runningLabel: string
   icon: LucideIcon
   color: string
+  hex: string
   textColor: string
   bgLight: string
-  bgDark: string
   borderColor: string
+  borderDark: string
 }>
 
 export type StageSlug = (typeof STAGES)[number]["slug"]

--- a/apps/studio/src/routes/books.$label.$step.settings.tsx
+++ b/apps/studio/src/routes/books.$label.$step.settings.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react"
 import { createFileRoute, Link } from "@tanstack/react-router"
-import { STAGES } from "@/components/pipeline/stage-config"
+import { STAGES, isStageSlug } from "@/components/pipeline/stage-config"
 import { ExtractSettings } from "@/components/pipeline/stages/ExtractSettings"
 import { StoryboardSettings } from "@/components/pipeline/stages/StoryboardSettings"
 import { QuizzesSettings } from "@/components/pipeline/stages/QuizzesSettings"
@@ -19,17 +19,40 @@ export const Route = createFileRoute("/books/$label/$step/settings")({
 function StepSettingsPage() {
   const { label, step } = Route.useParams()
   const { tab } = Route.useSearch()
-  const stepConfig = STAGES.find((s) => s.slug === step)
-  const stepLabel = stepConfig?.label ?? step
-  const Icon = stepConfig?.icon
+  const stage = isStageSlug(step) ? STAGES.find((s) => s.slug === step) : undefined
+
+  if (!stage) {
+    return (
+      <div className="flex flex-col h-full">
+        <div className="shrink-0 h-10 px-4 flex items-center gap-2 text-white bg-gray-700">
+          <span className="text-sm font-semibold">Unknown stage</span>
+        </div>
+        <div className="p-4 max-w-2xl">
+          <p className="text-sm text-muted-foreground">
+            Unknown step slug: {step}
+          </p>
+          <Link
+            to="/books/$label/$step"
+            params={{ label, step: "book" }}
+            className="text-sm text-primary hover:underline"
+          >
+            Go to book
+          </Link>
+        </div>
+      </div>
+    )
+  }
+
+  const stepLabel = stage.label
+  const Icon = stage.icon
   const [headerTarget, setHeaderTarget] = useState<HTMLDivElement | null>(null)
 
   return (
     <div className="flex flex-col h-full">
       {/* Step header */}
-      <div className={cn("shrink-0 h-10 px-4 flex items-center gap-2 text-white", stepConfig?.bgDark ?? "bg-gray-700")}>
+      <div className={cn("shrink-0 h-10 px-4 flex items-center gap-2 text-white", stage.color)}>
         <div className="flex items-center justify-center w-6 h-6 rounded-full bg-white/20">
-          {Icon && <Icon className="w-3 h-3" />}
+          <Icon className="w-3 h-3" />
         </div>
         <Link
           to="/books/$label/$step"

--- a/apps/studio/src/routes/books.$label.tsx
+++ b/apps/studio/src/routes/books.$label.tsx
@@ -1,10 +1,11 @@
 import { useState, useEffect, useCallback, useRef } from "react"
 import { createFileRoute, Outlet, useParams, useNavigate, Link, useMatchRoute } from "@tanstack/react-router"
 import { useQueryClient } from "@tanstack/react-query"
-import { Home, Settings, Terminal } from "lucide-react"
+import { Home, Settings, RotateCcw, Terminal } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { DebugPanel } from "@/components/debug/DebugPanel"
 import { StageSidebar } from "@/components/pipeline/StageSidebar"
+import { STAGES } from "@/components/pipeline/stage-config"
 import { useBook } from "@/hooks/use-books"
 import { useStepRunSSE, StepRunContext, type QueueRunOptions } from "@/hooks/use-step-run"
 import { getStartInvalidationKeysForUiStep } from "@/hooks/step-run-invalidation"
@@ -25,6 +26,8 @@ function BookLayout() {
   const isDebugRoute = !!matchRoute({ to: "/books/$label/debug", params: { label } })
 
   const activeStep = step ?? "book"
+  const activeStage = STAGES.find((s) => s.slug === activeStep) ?? STAGES[0]
+  const stageHex = activeStage.hex
 
   const onSelectPage = useCallback(
     (pid: string | null) => {
@@ -149,15 +152,36 @@ function BookLayout() {
                     ADT Studio
                   </span>
                 </Link>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-10 w-10 shrink-0 text-white/70 hover:text-white hover:bg-gray-800 flex"
-                  onClick={openSettings}
-                  title="API Key Settings"
-                >
-                  <Settings className="h-3.5 w-3.5" />
-                </Button>
+                {activeStep === "preview" ? (
+                  <button
+                    onClick={() => window.dispatchEvent(new CustomEvent("adt:repackage"))}
+                    title="Re-package ADT"
+                    className="shrink-0 flex items-center justify-center w-7 h-7 rounded-full text-white hover:brightness-110 transition-[filter] mx-1.5"
+                    style={{ backgroundColor: stageHex }}
+                  >
+                    <RotateCcw className="h-3.5 w-3.5" />
+                  </button>
+                ) : activeStep === "book" ? (
+                  <button
+                    onClick={openSettings}
+                    title="API Key Settings"
+                    className="shrink-0 flex items-center justify-center w-7 h-7 rounded-full text-white hover:brightness-110 transition-[filter] mx-1.5"
+                    style={{ backgroundColor: stageHex }}
+                  >
+                    <Settings className="h-3.5 w-3.5" />
+                  </button>
+                ) : (
+                  <Link
+                    to="/books/$label/$step/settings"
+                    params={{ label, step: activeStep }}
+                    search={{ tab: "general" }}
+                    title={`${activeStage?.label ?? "Stage"} Settings`}
+                    className="shrink-0 flex items-center justify-center w-7 h-7 rounded-full text-white hover:brightness-110 transition-[filter] mx-1.5"
+                    style={{ backgroundColor: stageHex }}
+                  >
+                    <Settings className="h-3.5 w-3.5" />
+                  </Link>
+                )}
               </div>
 
               {/* Steps / Pages */}

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -24,6 +24,9 @@ This document records all significant technology and architecture decisions made
 16. [Home Page Split Layout](#016-home-page-split-layout)
 17. [Two-Level DAG Pipeline (Stage / Step Model)](#017-two-level-dag-pipeline-stage--step-model)
 18. [Per-Book Step Run Queue](#018-per-book-step-run-queue)
+19. [Unified Stage Sidebar (Single Expandable Rail)](#019-unified-stage-sidebar-single-expandable-rail)
+20. [Stage Color System — Single Source of Truth](#020-stage-color-system--single-source-of-truth)
+21. [Context-Aware Top Bar Button](#021-context-aware-top-bar-button)
 
 ---
 
@@ -667,6 +670,90 @@ On every stage start (`status === "started"`), all TanStack Query cache entries 
 | Client-side queue only | Race conditions between tabs/reconnects, server doesn't know about ordering |
 | WebSocket for bidirectional control | Overkill — SSE already handles server→client; we only need client→server ordering |
 | External job queue (Bull, BullMQ) | Violates "minimize dependencies" principle, in-memory queue is sufficient for single-user desktop app |
+ 
+---
+
+## 019: Unified Stage Sidebar (Single Expandable Rail)
+
+**Status**: Decided
+**Date**: 2026-02-20
+
+### Decision
+
+The stage sidebar uses a single component with one shared DOM structure for both collapsed (icon-only) and expanded (labels visible) states. The rail overlays the pages panel on hover via CSS `group-hover` and `overflow-hidden`, with no JavaScript-driven show/hide logic for labels.
+
+### Context
+
+The sidebar originally had two completely separate code paths: an icon rail for when the pages panel was open, and a full labeled list for when it was closed. These diverged visually and structurally, leading to inconsistencies (different widths, different rounding, different hover states).
+
+### Key Design Choices
+
+- **Single DOM structure**: One `stageItems` array rendered in all modes. No conditional component swap.
+- **CSS-driven expansion**: The inner panel uses `w-12 group-hover/rail:w-[220px]` with `overflow-hidden`. Labels are always in the DOM — they're clipped by width, not toggled via `display`. This prevents flash-before-collapse when using transition delays.
+- **Transition delay**: `delay-150` on collapse, `group-hover/rail:delay-100` on expand. Prevents twitchy hover behavior.
+- **`railCollapsed`**: The rail collapses only when `effectivePagesOpen && !isSettings`. When settings are open, the rail expands to show settings sub-tabs.
+- **Fixed export button**: The export button sits outside the expanding overlay (below the `flex-1` rail area) so it doesn't resize during hover transitions.
+
+### Alternatives Considered
+
+| Approach | Why Not |
+|----------|---------|
+| Two separate components | Led to visual drift, double maintenance |
+| JavaScript hover state with `useState` | Adds re-renders, harder to coordinate with CSS transitions |
+| `display: none` / `inline` toggling for labels | Flashes on hover exit before the width transition starts — `overflow-hidden` clipping is smoother |
+
+---
+
+## 020: Stage Color System — Single Source of Truth
+
+**Status**: Decided
+**Date**: 2026-02-20
+
+### Decision
+
+All stage colors are defined once in `apps/studio/src/components/pipeline/stage-config.ts`. Each stage has:
+
+- `color` — Tailwind bg class (e.g. `bg-blue-600`), used for backgrounds, icon fills, card headers, step headers
+- `hex` — Same color as a hex string (e.g. `#2563eb`), used for SVG strokes (progress ring) and inline styles (top-bar button)
+- `borderDark` — Border variant (e.g. `border-blue-600`), used for card outlines
+- `textColor`, `bgLight`, `borderColor` — lighter variants for secondary uses
+
+No other file should define color hex values or Tailwind color mappings for stages. Consumers look up from `STAGES` via `STAGES.find(s => s.slug === slug) ?? STAGES[0]`, eliminating hardcoded fallback colors.
+
+### Context
+
+Stage colors were previously scattered across multiple files: a `COLOR_MAP` in `StepProgressRing.tsx`, a `STAGE_HEX` map in `books.$label.tsx`, a `HOVER_BG_BY_COLOR` map in `StageRunCard.tsx`, and the stage config itself. Changing a color shade required updating 4+ files. After unification, changing the shade from 500→700→600 required editing only `stage-config.ts` (plus the `HOVER_BG_BY_COLOR` in StageRunCard which maps `bg-*` to `hover:bg-*` for Tailwind JIT).
+
+### Tailwind JIT Constraint
+
+Tailwind's JIT compiler scans source files for complete class name strings. Dynamic class generation like `` `bg-${color}-600` `` or `` `hover:${bgClass}` `` will not be detected. All Tailwind classes must appear as complete literal strings in source code.
+
+For hover variants that depend on the stage color, use either:
+- A static lookup map (e.g. `HOVER_BG_BY_COLOR` mapping `"bg-blue-600"` → `"hover:bg-blue-600"`)
+- CSS custom properties with arbitrary value syntax: `style={{ '--stage-clr': hex }}` + `className="text-[var(--stage-clr)] hover:bg-[var(--stage-clr)]"`
+
+---
+
+## 021: Context-Aware Top Bar Button
+
+**Status**: Decided
+**Date**: 2026-02-20
+
+### Decision
+
+The top-right button in the sidebar header changes based on the active stage:
+
+| Stage | Button | Action |
+|-------|--------|--------|
+| Book | Settings gear | Opens API key settings dialog |
+| Preview | Rotate/refresh icon | Dispatches `adt:repackage` event |
+| All others | Settings gear | Navigates to that stage's settings page |
+
+The button is rendered as a round circle filled with the stage's `hex` color (via inline `backgroundColor` style), with a white icon. This provides a visual hint of which stage is active even in the header.
+
+### Context
+
+Previously, each stage row in the sidebar had its own settings gear or refresh button inline. This cluttered the stage list, especially when the rail was collapsed. Moving the action to the fixed header position keeps it always accessible and consistent.
 
 ---
 
@@ -692,3 +779,6 @@ On every stage start (`status === "started"`), all TanStack Query cache entries 
 | 016 | Home layout | 30/70 split (guide + books) | Full-width grid, centered content |
 | 017 | Pipeline model | Two-level DAG (Stage / Step) | Flat step list, config file, per-consumer definitions |
 | 018 | Concurrent stage runs | Per-book queue with promise chain serialization | 409 rejection, client-only queue, external job queue |
+| 019 | Stage sidebar | Single expandable rail with CSS hover | Two separate components, JS-driven hover |
+| 020 | Stage colors | Single source in stage-config.ts | Scattered hex/class maps across files |
+| 021 | Top bar button | Context-aware per stage | Per-stage inline buttons in sidebar |

--- a/docs/GUIDELINES.md
+++ b/docs/GUIDELINES.md
@@ -384,6 +384,26 @@ All screens must follow these layout principles:
 
 **No scrolling when content fits**: If content can fit on screen by using available width, lay it out that way instead of stacking vertically and scrolling. Horizontal space is cheaper than vertical scroll.
 
+### Tailwind JIT Scanning Constraint
+
+Tailwind's JIT compiler scans source files for complete class name strings at build time. **Dynamic class generation will silently fail** — the classes won't be included in the CSS output.
+
+```typescript
+// WRONG: Dynamic template literals — Tailwind JIT can't detect these
+const cls = `bg-${color}-600`           // Not scanned
+const hover = `hover:${bgClass}`        // Not scanned
+const group = `group-hover/rail:${cls}` // Not scanned
+
+// CORRECT: Complete literal strings
+const cls = "bg-blue-600"                           // Scanned
+const hover = HOVER_MAP["bg-blue-600"]              // Value is literal in the map
+const group = cn("group-hover/rail:inline", flag && "inline")  // Both literals
+```
+
+For dynamic stage-colored hover states, use either:
+- **Static lookup map**: `{ "bg-blue-600": "hover:bg-blue-600" }` — each value is a complete literal
+- **CSS custom properties**: `style={{ '--clr': hex }}` + `className="text-[var(--clr)] hover:bg-[var(--clr)]"` — arbitrary value syntax with static class names
+
 ### Styling with Tailwind
 
 **ALWAYS use Tailwind utility classes**:
@@ -1163,6 +1183,8 @@ pnpm lint
 | Step run service (queue) | `apps/api/src/services/step-service.ts` |
 | Step run hook + context | `apps/studio/src/hooks/use-step-run.ts` |
 | Book layout (queueRun) | `apps/studio/src/routes/books.$label.tsx` |
+| Stage config (colors, icons, labels) | `apps/studio/src/components/pipeline/stage-config.ts` |
+| Stage sidebar | `apps/studio/src/components/pipeline/StageSidebar.tsx` |
 | Global config | `config/` |
 | Templates | `templates/` |
 


### PR DESCRIPTION
## Summary
- unify stage sidebar into a single expandable rail structure
- centralize stage colors/icons/labels in `stage-config.ts` and reuse across headers/cards/rings
- add page hover preview improvements (viewport clamping + timer cleanup)
- make settings route handle unknown stage slugs explicitly
- merge latest `main` and resolve conflicts in route/docs

## Validation
- `pnpm -C apps/studio build`
- `pnpm build`
