### PR TITLE
Add apply_body_background config toggle and XSS fix

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -84,7 +84,7 @@ app.route("/api", createTextCatalogRoutes(booksDir))
 app.route("/api", createTTSRoutes(booksDir))
 app.route("/api", createStepRoutes(stepService, pipelineService, booksDir, promptsDir, configPath))
 app.route("/api", createPresetRoutes(configPath))
-app.route("/api", createAdtPreviewRoutes(booksDir, webAssetsDir))
+app.route("/api", createAdtPreviewRoutes(booksDir, webAssetsDir, configPath))
 app.route("/api", createSpeechConfigRoutes(configPath))
 
 export default app

--- a/apps/api/src/routes/adt-preview.ts
+++ b/apps/api/src/routes/adt-preview.ts
@@ -24,6 +24,7 @@ import {
   buildQuizAnswers,
   buildTextCatalog,
   pad3,
+  loadBookConfig,
 } from "@adt/pipeline"
 
 // ---------------------------------------------------------------------------
@@ -212,6 +213,7 @@ function buildPreviewConfig(storage: Storage, language: string) {
 export function createAdtPreviewRoutes(
   booksDir: string,
   webAssetsDir: string,
+  configPath?: string,
 ): Hono {
   const app = new Hono()
 
@@ -441,6 +443,10 @@ export function createAdtPreviewRoutes(
     if (!filename.endsWith(".html")) throw new HTTPException(404, { message: "Not found" })
     const pageId = filename.replace(/\.html$/, "")
 
+    const safeLabel = parseBookLabel(label)
+    const config = loadBookConfig(safeLabel, booksDir, configPath)
+    const applyBodyBackground = config.apply_body_background
+
     return withStorage(label, (storage) => {
       const title = getBookTitle(storage)
       const language = getBookLanguage(storage)
@@ -471,6 +477,7 @@ export function createAdtPreviewRoutes(
           hasMath: false,
           bundleVersion: "1",
           skipContentWrapper: true,
+          applyBodyBackground,
         })
 
         c.header("Content-Type", "text/html; charset=utf-8")
@@ -503,6 +510,7 @@ export function createAdtPreviewRoutes(
         activityAnswers,
         hasMath: false,
         bundleVersion: "1",
+        applyBodyBackground,
       })
 
       c.header("Content-Type", "text/html; charset=utf-8")

--- a/apps/api/src/routes/package.ts
+++ b/apps/api/src/routes/package.ts
@@ -79,6 +79,7 @@ export function createPackageRoutes(
         outputLanguages,
         title,
         webAssetsDir,
+        applyBodyBackground: config.apply_body_background,
       })
 
       return c.json({ status: "completed", label: safeLabel })

--- a/apps/api/src/services/export-service.ts
+++ b/apps/api/src/services/export-service.ts
@@ -59,6 +59,7 @@ export async function exportBook(
         outputLanguages,
         title,
         webAssetsDir,
+        applyBodyBackground: config.apply_body_background,
       })
     }
 

--- a/apps/studio/src/components/pipeline/stages/BookPreviewFrame.tsx
+++ b/apps/studio/src/components/pipeline/stages/BookPreviewFrame.tsx
@@ -19,6 +19,8 @@ export interface BookPreviewFrameProps {
   onSelectElement?: (dataId: string, rect: DOMRect) => void
   /** Called when a text element is edited (blur/Enter after contenteditable) */
   onTextChanged?: (dataId: string, newText: string, fullHtml: string) => void
+  /** When true (default), applies data-background-color to the iframe body */
+  applyBodyBackground?: boolean
 }
 
 /**
@@ -41,6 +43,7 @@ export const BookPreviewFrame = forwardRef<BookPreviewFrameHandle, BookPreviewFr
   changedElements,
   onSelectElement,
   onTextChanged,
+  applyBodyBackground,
 }, ref) {
   const iframeRef = useRef<HTMLIFrameElement>(null)
 
@@ -241,6 +244,14 @@ ${interactiveScript}
       doc.body.appendChild(scriptEl)
     }
 
+    // Apply data-background-color from content to iframe body
+    if (applyBodyBackground !== false) {
+      const bgEl = doc.querySelector("[data-background-color]")
+      doc.body.style.backgroundColor = bgEl?.getAttribute("data-background-color") ?? ""
+    } else {
+      doc.body.style.backgroundColor = ""
+    }
+
     // Measure multiple times to catch late reflows from Tailwind CDN, fonts, and images.
     // Wait one frame so the browser queues font loads for the new content,
     // then wait for fonts.ready so we measure the final layout.
@@ -275,7 +286,7 @@ ${interactiveScript}
   // When html prop changes, update the body directly (no iframe reload)
   useEffect(() => {
     if (readyRef.current) injectAndMeasure(sanitizedHtml)
-  }, [sanitizedHtml])
+  }, [sanitizedHtml, applyBodyBackground])
 
   // Inject/update pruned element styles into the iframe
   useEffect(() => {

--- a/apps/studio/src/components/pipeline/stages/StoryboardSectionDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/StoryboardSectionDetail.tsx
@@ -5,6 +5,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { api } from "@/api/client"
 import type { PageDetail, VersionEntry } from "@/api/client"
 import { useApiKey } from "@/hooks/use-api-key"
+import { useActiveConfig } from "@/hooks/use-debug"
 import { useStepHeader } from "../StepViewRouter"
 import { BookPreviewFrame, type BookPreviewFrameHandle } from "./BookPreviewFrame"
 import { SectionEditToolbar } from "./SectionEditToolbar"
@@ -314,6 +315,8 @@ export function StoryboardSectionDetail({
   const queryClient = useQueryClient()
   const { apiKey, hasApiKey } = useApiKey()
   const { headerSlotEl } = useStepHeader()
+  const { data: activeConfigData } = useActiveConfig(bookLabel)
+  const applyBodyBackground = (activeConfigData?.merged as Record<string, unknown> | undefined)?.apply_body_background !== false
 
   const [saving, setSaving] = useState(false)
   const [rerendering, setRerendering] = useState(false)
@@ -1265,6 +1268,7 @@ export function StoryboardSectionDetail({
             changedElements={changedElements}
             onSelectElement={handleSelectElement}
             onTextChanged={handleTextChanged}
+            applyBodyBackground={applyBodyBackground}
           />
         ) : (
           <div className="p-4 text-sm text-muted-foreground border rounded">

--- a/apps/studio/src/components/pipeline/stages/StoryboardSettings.tsx
+++ b/apps/studio/src/components/pipeline/stages/StoryboardSettings.tsx
@@ -81,6 +81,7 @@ export function StoryboardSettings({ bookLabel, headerTarget, tab = "general" }:
   const [renderingTemplateName, setRenderingTemplateName] = useState("")
   const [renderingTemperature, setRenderingTemperature] = useState("")
   const [styleguide, setStyleguide] = useState("")
+  const [applyBodyBackground, setApplyBodyBackground] = useState(true)
   const [sectioningPromptDraft, setSectioningPromptDraft] = useState<string | null>(null)
   const [renderingPromptDraft, setRenderingPromptDraft] = useState<string | null>(null)
   const [renderingTemplateDraft, setRenderingTemplateDraft] = useState<string | null>(null)
@@ -174,6 +175,8 @@ export function StoryboardSettings({ bookLabel, headerTarget, tab = "general" }:
     }
     // Styleguide
     setStyleguide(typeof merged.styleguide === "string" ? merged.styleguide : "")
+    // Body background
+    setApplyBodyBackground(merged.apply_body_background !== false)
     // Rendering config comes from the default render strategy
     if (merged.render_strategies && merged.default_render_strategy) {
       const strategies = merged.render_strategies as Record<string, { render_type?: string; config?: { model?: string; prompt?: string; template?: string; temperature?: number } }>
@@ -294,6 +297,9 @@ export function StoryboardSettings({ bookLabel, headerTarget, tab = "general" }:
     }
     if (shouldWrite("styleguide")) {
       overrides.styleguide = styleguide || undefined
+    }
+    if (shouldWrite("apply_body_background")) {
+      overrides.apply_body_background = applyBodyBackground
     }
     // Write rendering temperature into the default render strategy config
     if (shouldWrite("rendering_temperature") && defaultRenderStrategy) {
@@ -679,6 +685,25 @@ export function StoryboardSettings({ bookLabel, headerTarget, tab = "general" }:
               </div>
               <p className="text-xs text-muted-foreground mt-1.5">
                 Lower values produce more consistent styling across pages.
+              </p>
+            </div>
+
+            <div>
+              <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
+                Display
+              </h3>
+              <div className="flex items-center gap-3">
+                <Switch
+                  id="apply-body-background"
+                  checked={applyBodyBackground}
+                  onCheckedChange={(v) => { setApplyBodyBackground(v); markDirty("apply_body_background") }}
+                />
+                <Label htmlFor="apply-body-background" className="text-sm font-normal">
+                  Apply page background colors
+                </Label>
+              </div>
+              <p className="text-xs text-muted-foreground mt-1.5">
+                When enabled, background colors from the styleguide are applied to the full page body.
               </p>
             </div>
           </div>

--- a/apps/studio/src/routes/books.new.tsx
+++ b/apps/studio/src/routes/books.new.tsx
@@ -178,6 +178,7 @@ function AddBookPage() {
   const [textGroupTypes, setTextGroupTypes] = useState<Record<string, string>>({})
   const [sectionTypes, setSectionTypes] = useState<Record<string, string>>({})
   const [sectioningMode, setSectioningMode] = useState("section")
+  const [applyBodyBackground, setApplyBodyBackground] = useState(true)
 
   // Styleguide preview
   const [styleguidePreviewOpen, setStyleguidePreviewOpen] = useState(false)
@@ -314,6 +315,9 @@ function AddBookPage() {
     // Styleguide from preset
     setStyleguide(typeof config.styleguide === "string" ? config.styleguide : "")
 
+    // Body background from preset
+    setApplyBodyBackground(config.apply_body_background !== false)
+
     // Custom layout auto-expands advanced panel
     if (layoutType === "custom") {
       setShowAdvancedLayout(true)
@@ -412,6 +416,7 @@ function AddBookPage() {
       configOverrides.output_languages = Array.from(outputLanguages)
     }
     configOverrides.spread_mode = spreadMode
+    configOverrides.apply_body_background = applyBodyBackground
     if (parsedStartPage !== undefined) {
       configOverrides.start_page = parsedStartPage
     }
@@ -754,6 +759,21 @@ function AddBookPage() {
                     </div>
                     <p className="text-xs text-muted-foreground">
                       Merge facing pages as spreads (cover + page pairs).
+                    </p>
+                  </div>
+                  <div className="space-y-1.5">
+                    <div className="flex items-center gap-2">
+                      <Switch
+                        id="apply-body-background"
+                        checked={applyBodyBackground}
+                        onCheckedChange={setApplyBodyBackground}
+                      />
+                      <Label htmlFor="apply-body-background" className="text-xs">
+                        Apply page background colors
+                      </Label>
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      When enabled, background colors from the styleguide are applied to the full page body.
                     </p>
                   </div>
                   <AdvancedLayoutPanel

--- a/assets/styleguides/sri-lanka-grade2-preview.html
+++ b/assets/styleguides/sri-lanka-grade2-preview.html
@@ -1,0 +1,488 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta content="width=device-width, initial-scale=1" name="viewport"/>
+  <title>Style Guide Preview — Sri Lanka Grade 2</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    .preview-label {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      font-size: 0.7rem;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      color: #6b7280;
+      border-bottom: 1px solid #e5e7eb;
+      padding-bottom: 0.25rem;
+      margin-bottom: 1rem;
+    }
+    .preview-section {
+      border: 2px dashed #d1d5db;
+      border-radius: 1rem;
+      padding: 2rem;
+      margin-bottom: 2.5rem;
+      background: #fafafa;
+    }
+    .preview-divider {
+      border-top: 3px solid #8B2252;
+      margin: 3rem 0;
+    }
+  </style>
+</head>
+<body class="bg-gray-100 py-12 px-4">
+
+  <div class="mx-auto max-w-6xl">
+
+    <!-- Header -->
+    <div class="mb-12 text-center">
+      <h1 class="text-5xl font-extrabold mb-2" style="color: #8B2252;">Style Guide Preview</h1>
+      <p class="text-xl" style="color: #3D8B37;">Sri Lanka Grade 2 &mdash; Child-Friendly Theme</p>
+    </div>
+
+    <!-- ============================================================ -->
+    <!-- COLOR PALETTE                                                 -->
+    <!-- ============================================================ -->
+    <h2 class="text-3xl font-bold mb-6" style="color: #3D2B1F;">Color Palette (from original book)</h2>
+
+    <div class="preview-section">
+      <p class="preview-label">Colors extracted from Sri Lankan Grade 2 Sinhala textbook</p>
+      <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <div class="rounded-2xl p-4 shadow-sm text-center" style="background: #F2D4BC;">
+          <p class="text-sm font-bold" style="color: #3D2B1F;">Warm Peach</p>
+          <p class="text-xs" style="color: #3D2B1F;">#F2D4BC</p>
+        </div>
+        <div class="rounded-2xl p-4 shadow-sm text-center" style="background: #FFF5EB;">
+          <p class="text-sm font-bold" style="color: #3D2B1F;">Cream</p>
+          <p class="text-xs" style="color: #3D2B1F;">#FFF5EB</p>
+        </div>
+        <div class="rounded-2xl p-4 shadow-sm text-center" style="background: #5BACDB;">
+          <p class="text-sm font-bold text-white">Sky Blue</p>
+          <p class="text-xs text-white">#5BACDB</p>
+        </div>
+        <div class="rounded-2xl p-4 shadow-sm text-center" style="background: #B8E0F7;">
+          <p class="text-sm font-bold" style="color: #3D2B1F;">Light Blue</p>
+          <p class="text-xs" style="color: #3D2B1F;">#B8E0F7</p>
+        </div>
+        <div class="rounded-2xl p-4 shadow-sm text-center" style="background: #3D8B37;">
+          <p class="text-sm font-bold text-white">Nature Green</p>
+          <p class="text-xs text-white">#3D8B37</p>
+        </div>
+        <div class="rounded-2xl p-4 shadow-sm text-center" style="background: #8B2252;">
+          <p class="text-sm font-bold text-white">Warm Maroon</p>
+          <p class="text-xs text-white">#8B2252</p>
+        </div>
+        <div class="rounded-2xl p-4 shadow-sm text-center" style="background: #F4A7B9;">
+          <p class="text-sm font-bold" style="color: #3D2B1F;">Playful Pink</p>
+          <p class="text-xs" style="color: #3D2B1F;">#F4A7B9</p>
+        </div>
+        <div class="rounded-2xl p-4 shadow-sm text-center" style="background: #7B68AE;">
+          <p class="text-sm font-bold text-white">Soft Purple</p>
+          <p class="text-xs text-white">#7B68AE</p>
+        </div>
+        <div class="rounded-2xl p-4 shadow-sm text-center" style="background: #F5A623;">
+          <p class="text-sm font-bold text-white">Sunny Orange</p>
+          <p class="text-xs text-white">#F5A623</p>
+        </div>
+        <div class="rounded-2xl p-4 shadow-sm text-center" style="background: #F5C542;">
+          <p class="text-sm font-bold" style="color: #3D2B1F;">Golden Yellow</p>
+          <p class="text-xs" style="color: #3D2B1F;">#F5C542</p>
+        </div>
+        <div class="rounded-2xl p-4 shadow-sm text-center" style="background: #3D2B1F;">
+          <p class="text-sm font-bold text-white">Dark Brown</p>
+          <p class="text-xs text-white">#3D2B1F</p>
+        </div>
+        <div class="rounded-2xl p-4 shadow-sm text-center" style="background: #5AA84A;">
+          <p class="text-sm font-bold text-white">Leaf Green</p>
+          <p class="text-xs text-white">#5AA84A</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="preview-divider"></div>
+
+    <!-- ============================================================ -->
+    <!-- TEXT STYLES                                                    -->
+    <!-- ============================================================ -->
+    <h2 class="text-3xl font-bold mb-6" style="color: #3D2B1F;">Text Styles (Large for Young Readers)</h2>
+
+    <div class="preview-section">
+      <p class="preview-label">book_title &mdash; h1</p>
+      <h1 class="text-5xl md:text-6xl font-extrabold leading-tight" style="color: #8B2252;">The Great Journey Begins</h1>
+    </div>
+
+    <div class="preview-section">
+      <p class="preview-label">book_subtitle &mdash; h2</p>
+      <h2 class="text-3xl md:text-4xl font-semibold" style="color: #3D8B37;">A story of discovery and wonder</h2>
+    </div>
+
+    <div class="preview-section">
+      <p class="preview-label">chapter_title &mdash; h1</p>
+      <h1 class="text-4xl md:text-5xl font-bold leading-tight" style="color: #8B2252;">Chapter Title Example</h1>
+    </div>
+
+    <div class="preview-section">
+      <p class="preview-label">section_heading &mdash; h1</p>
+      <h1 class="text-4xl md:text-5xl font-bold leading-tight" style="color: #3D8B37;">Section Heading Example</h1>
+    </div>
+
+    <div class="preview-section">
+      <p class="preview-label">activity_title &mdash; h2</p>
+      <h2 class="text-3xl md:text-4xl font-bold leading-tight" style="color: #5BACDB;">Activity Title Example</h2>
+    </div>
+
+    <div class="preview-section">
+      <p class="preview-label">section_text &mdash; p (DOUBLED size for young readers)</p>
+      <p class="text-2xl md:text-3xl leading-relaxed" style="color: #3D2B1F;">This is section text. It uses a large, comfortable reading size perfect for Grade 2 children. The text is roughly double the default size to ensure easy readability.</p>
+    </div>
+
+    <div class="preview-section">
+      <p class="preview-label">instruction_text &mdash; p</p>
+      <p class="text-xl md:text-2xl leading-relaxed italic" style="color: #3D2B1F;">Look at the following pictures and answer the questions below.</p>
+    </div>
+
+    <div class="preview-section">
+      <p class="preview-label">standalone_text &mdash; p</p>
+      <p class="text-xl md:text-2xl leading-relaxed" style="color: #3D2B1F;">This is standalone text used for general-purpose content outside of cards or specific sections.</p>
+    </div>
+
+    <div class="preview-section">
+      <p class="preview-label">image_associated_text &mdash; p</p>
+      <p class="text-lg md:text-xl italic mt-2" style="color: #3D2B1F;">Caption: Children playing under a large tree by the river.</p>
+    </div>
+
+    <div class="preview-divider"></div>
+
+    <!-- ============================================================ -->
+    <!-- COMPONENTS                                                    -->
+    <!-- ============================================================ -->
+    <h2 class="text-3xl font-bold mb-6" style="color: #3D2B1F;">Components</h2>
+
+    <!-- Chapter Badge -->
+    <div class="preview-section">
+      <p class="preview-label">Chapter Badge (colorful, child-friendly) &mdash; badge color varies per chapter</p>
+      <div class="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+        <div class="flex items-start gap-4">
+          <div class="shrink-0 rounded-3xl px-6 py-4 shadow-md" style="background: #3D8B37;">
+            <h1 class="text-4xl md:text-5xl font-bold leading-tight" style="color: #FFF5EB;">LESSON</h1>
+            <h1 class="text-5xl md:text-6xl font-extrabold leading-tight" style="color: #F5C542;">1</h1>
+          </div>
+          <div class="pt-2">
+            <h1 class="text-4xl md:text-5xl font-bold leading-tight" style="color: #8B2252;">The Music Class</h1>
+          </div>
+        </div>
+      </div>
+
+      <div class="mt-8 flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+        <div class="flex items-start gap-4">
+          <div class="shrink-0 rounded-3xl px-6 py-4 shadow-md" style="background: #5BACDB;">
+            <h1 class="text-4xl md:text-5xl font-bold leading-tight" style="color: #FFF5EB;">LESSON</h1>
+            <h1 class="text-5xl md:text-6xl font-extrabold leading-tight" style="color: #F5C542;">4</h1>
+          </div>
+          <div class="pt-2">
+            <h1 class="text-4xl md:text-5xl font-bold leading-tight" style="color: #8B2252;">The Swing Song</h1>
+          </div>
+        </div>
+      </div>
+
+      <div class="mt-8 flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+        <div class="flex items-start gap-4">
+          <div class="shrink-0 rounded-3xl px-6 py-4 shadow-md" style="background: #7B68AE;">
+            <h1 class="text-4xl md:text-5xl font-bold leading-tight" style="color: #FFF5EB;">LESSON</h1>
+            <h1 class="text-5xl md:text-6xl font-extrabold leading-tight" style="color: #F5C542;">11</h1>
+          </div>
+          <div class="pt-2">
+            <h1 class="text-4xl md:text-5xl font-bold leading-tight" style="color: #8B2252;">The Star Poem</h1>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Content Card -->
+    <div class="preview-section">
+      <p class="preview-label">Content Card (frosted glass, no borders)</p>
+      <div class="space-y-3 rounded-3xl p-5 shadow-sm" style="background: rgba(255, 255, 255, 0.7);">
+        <p class="text-2xl md:text-3xl leading-relaxed" style="color: #3D2B1F;">The children went to the river bank. Today they were going to have a music class under the big tree.</p>
+        <p class="text-2xl md:text-3xl leading-relaxed" style="color: #3D2B1F;">"I will be the teacher," said little sister Mali.</p>
+      </div>
+    </div>
+
+    <!-- Text Group -->
+    <div class="preview-section">
+      <p class="preview-label">Text Group (paragraphs without card)</p>
+      <div class="space-y-3">
+        <p class="text-2xl md:text-3xl leading-relaxed" style="color: #3D2B1F;">First paragraph in a text group. Large, clear text for young readers.</p>
+        <p class="text-2xl md:text-3xl leading-relaxed" style="color: #3D2B1F;">Second paragraph. Notice the generous size — perfect for children just learning to read.</p>
+      </div>
+    </div>
+
+    <div class="preview-divider"></div>
+
+    <!-- ============================================================ -->
+    <!-- IMAGE STYLES                                                  -->
+    <!-- ============================================================ -->
+    <h2 class="text-3xl font-bold mb-6" style="color: #3D2B1F;">Image Styles</h2>
+
+    <div class="preview-section">
+      <p class="preview-label">Single Image &mdash; rounded, soft shadow, no border</p>
+      <div class="w-full h-56 rounded-3xl shadow-md flex items-center justify-center" style="background: linear-gradient(135deg, #B8E0F7 0%, #5BACDB 100%);">
+        <span class="text-white text-lg font-medium">Single Image Placeholder</span>
+      </div>
+    </div>
+
+    <div class="preview-section">
+      <p class="preview-label">Image Grid (2 columns) &mdash; no borders</p>
+      <div class="grid grid-cols-2 gap-3">
+        <div class="h-40 rounded-2xl shadow-sm flex items-center justify-center" style="background: linear-gradient(135deg, #F2D4BC, #F5A623);">
+          <span class="text-white text-sm font-medium">Image 1</span>
+        </div>
+        <div class="h-40 rounded-2xl shadow-sm flex items-center justify-center" style="background: linear-gradient(135deg, #B8E0F7, #3D8B37);">
+          <span class="text-white text-sm font-medium">Image 2</span>
+        </div>
+        <div class="h-40 rounded-2xl shadow-sm flex items-center justify-center" style="background: linear-gradient(135deg, #F4A7B9, #8B2252);">
+          <span class="text-white text-sm font-medium">Image 3</span>
+        </div>
+        <div class="h-40 rounded-2xl shadow-sm flex items-center justify-center" style="background: linear-gradient(135deg, #7B68AE, #5BACDB);">
+          <span class="text-white text-sm font-medium">Image 4</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="preview-section">
+      <p class="preview-label">Text and Image Side by Side (PRIMARY layout)</p>
+      <div class="flex flex-col md:flex-row gap-4 items-start">
+        <div class="flex-1 space-y-3">
+          <p class="text-2xl md:text-3xl leading-relaxed" style="color: #3D2B1F;">This layout places text and an image side by side. It maximizes visible content for young readers.</p>
+          <p class="text-2xl md:text-3xl leading-relaxed" style="color: #3D2B1F;">Notice the large text size — roughly double the default theme.</p>
+        </div>
+        <div class="flex-1">
+          <div class="w-full h-48 rounded-3xl shadow-md flex items-center justify-center" style="background: linear-gradient(135deg, #FFF5EB, #F2D4BC);">
+            <span class="text-gray-500 text-sm font-medium">Side Image</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="preview-divider"></div>
+
+    <!-- ============================================================ -->
+    <!-- DECORATIONS                                                   -->
+    <!-- ============================================================ -->
+    <h2 class="text-3xl font-bold mb-6" style="color: #3D2B1F;">Decorations (Stars Only)</h2>
+
+    <div class="preview-section">
+      <p class="preview-label">Star Decorations &mdash; for poems, songs &amp; activities only</p>
+      <div class="relative rounded-3xl p-8 h-32 shadow-sm" style="background: rgba(255, 255, 255, 0.75);">
+        <div class="absolute top-3 right-6 text-3xl" style="color: #F5C542;">&#9733;</div>
+        <div class="absolute top-10 right-16 text-xl" style="color: #F4A7B9;">&#9733;</div>
+        <div class="absolute top-5 right-28 text-2xl" style="color: #7B68AE;">&#9733;</div>
+        <div class="absolute bottom-5 left-6 text-2xl" style="color: #5BACDB;">&#9733;</div>
+        <div class="absolute bottom-10 left-16 text-lg" style="color: #F5A623;">&#9733;</div>
+        <div class="absolute top-4 left-8 text-xl" style="color: #3D8B37;">&#9733;</div>
+        <p class="text-gray-400 text-lg">Scattered star decorations using palette colors</p>
+      </div>
+    </div>
+
+    <div class="preview-divider"></div>
+
+    <!-- ============================================================ -->
+    <!-- PAGE TEMPLATES                                                -->
+    <!-- ============================================================ -->
+    <h2 class="text-3xl font-bold mb-6" style="color: #3D2B1F;">Page Templates</h2>
+
+    <!-- Template: Chapter Start Page -->
+    <div class="preview-section">
+      <p class="preview-label">Template: Chapter/Lesson Start Page (warm gradient)</p>
+      <div class="rounded-2xl shadow-md overflow-hidden">
+        <div class="container content mx-auto flex min-h-screen w-full max-w-none items-start justify-center px-4 py-6" style="background: linear-gradient(180deg, #FFF5EB 0%, #F9E8D6 100%);">
+          <section class="w-full" role="article">
+            <div class="mx-auto w-full max-w-6xl space-y-4">
+              <!-- Chapter Badge -->
+              <div class="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                <div class="flex items-start gap-4">
+                  <div class="shrink-0 rounded-3xl px-6 py-4 shadow-md" style="background: #3D8B37;">
+                    <h1 class="text-4xl md:text-5xl font-bold leading-tight" style="color: #FFF5EB;">LESSON</h1>
+                    <h1 class="text-5xl md:text-6xl font-extrabold leading-tight" style="color: #F5C542;">1</h1>
+                  </div>
+                  <div class="pt-2">
+                    <h1 class="text-4xl md:text-5xl font-bold leading-tight" style="color: #8B2252;">The Music Class</h1>
+                  </div>
+                </div>
+              </div>
+              <!-- Side by Side: Text + Image -->
+              <div class="flex flex-col md:flex-row gap-4 items-start">
+                <div class="flex-1">
+                  <div class="space-y-3 rounded-3xl p-5 shadow-sm" style="background: rgba(255, 255, 255, 0.7);">
+                    <p class="text-2xl md:text-3xl leading-relaxed" style="color: #3D2B1F;">The children went to the river bank to have a music class.</p>
+                    <p class="text-2xl md:text-3xl leading-relaxed" style="color: #3D2B1F;">"What are we doing today?" asked the teacher. "Let's have a music class," said Pavani.</p>
+                  </div>
+                </div>
+                <div class="flex-1">
+                  <div class="w-full h-64 rounded-3xl shadow-md flex items-center justify-center" style="background: linear-gradient(135deg, #5AA84A 0%, #3D8B37 100%);">
+                    <span class="text-white text-sm font-medium">Chapter Image</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+
+    <!-- Template: Regular Content Page -->
+    <div class="preview-section">
+      <p class="preview-label">Template: Regular Content Page (cool gradient, alternating layout)</p>
+      <div class="rounded-2xl shadow-md overflow-hidden">
+        <div class="container content mx-auto flex min-h-screen w-full max-w-none items-start justify-center px-4 py-6" style="background: linear-gradient(135deg, #FFF5EB 0%, #EDF6FB 100%);">
+          <section class="w-full" role="article">
+            <div class="mx-auto w-full max-w-6xl space-y-4">
+              <!-- Image LEFT, Text RIGHT -->
+              <div class="flex flex-col md:flex-row gap-4 items-start">
+                <div class="flex-1">
+                  <div class="w-full h-56 rounded-3xl shadow-md flex items-center justify-center" style="background: linear-gradient(135deg, #87CEEB, #5BACDB);">
+                    <span class="text-white text-sm font-medium">Content Image 1</span>
+                  </div>
+                </div>
+                <div class="flex-1 space-y-3">
+                  <div class="rounded-3xl p-5 shadow-sm" style="background: rgba(255, 255, 255, 0.7);">
+                    <p class="text-2xl md:text-3xl leading-relaxed" style="color: #3D2B1F;">The clouds smiled down at the children as they played in the garden.</p>
+                    <p class="text-2xl md:text-3xl leading-relaxed mt-3" style="color: #3D2B1F;">The banana tree swayed gently in the warm breeze.</p>
+                  </div>
+                </div>
+              </div>
+              <!-- Text LEFT, Image RIGHT -->
+              <div class="flex flex-col md:flex-row gap-4 items-start">
+                <div class="flex-1 space-y-3">
+                  <p class="text-2xl md:text-3xl leading-relaxed" style="color: #3D2B1F;">The children carried water for the plants. They loved helping in the garden every day.</p>
+                </div>
+                <div class="flex-1">
+                  <div class="w-full h-48 rounded-3xl shadow-md flex items-center justify-center" style="background: linear-gradient(135deg, #F2D4BC, #F5A623);">
+                    <span class="text-white text-sm font-medium">Content Image 2</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+
+    <!-- Template: Poem / Song Page -->
+    <div class="preview-section">
+      <p class="preview-label">Template: Poem / Song Page (with star decorations)</p>
+      <div class="rounded-2xl shadow-md overflow-hidden">
+        <div class="container content mx-auto flex min-h-screen w-full max-w-none items-start justify-center px-4 py-6" style="background: linear-gradient(180deg, #FFF5EB 0%, #F5EDE4 60%, #EDF6FB 100%);">
+          <section class="w-full" role="article">
+            <div class="mx-auto w-full max-w-6xl space-y-4">
+              <div class="relative rounded-3xl p-6 shadow-sm" style="background: rgba(255, 255, 255, 0.75);">
+                <!-- Star decorations -->
+                <div class="absolute top-2 right-4 text-3xl" style="color: #F5C542;">&#9733;</div>
+                <div class="absolute top-8 right-12 text-xl" style="color: #F4A7B9;">&#9733;</div>
+                <div class="absolute top-4 right-24 text-2xl" style="color: #7B68AE;">&#9733;</div>
+                <div class="absolute bottom-4 left-4 text-2xl" style="color: #5BACDB;">&#9733;</div>
+                <div class="absolute bottom-8 left-12 text-lg" style="color: #F5A623;">&#9733;</div>
+                <!-- Title -->
+                <h1 class="text-4xl md:text-5xl font-bold leading-tight mb-4" style="color: #8B2252;">The Swing Song</h1>
+                <!-- Stanzas -->
+                <div class="space-y-4">
+                  <div class="space-y-1">
+                    <p class="text-2xl md:text-3xl leading-relaxed" style="color: #3D2B1F;">The big cashew tree stands tall</p>
+                    <p class="text-2xl md:text-3xl leading-relaxed" style="color: #3D2B1F;">By the village path we know</p>
+                    <p class="text-2xl md:text-3xl leading-relaxed" style="color: #3D2B1F;">A swing hangs from its branches wide</p>
+                    <p class="text-2xl md:text-3xl leading-relaxed" style="color: #3D2B1F;">Swinging gently to and fro</p>
+                  </div>
+                  <div class="space-y-1">
+                    <p class="text-2xl md:text-3xl leading-relaxed" style="color: #3D2B1F;">The wind sings through the leaves above</p>
+                    <p class="text-2xl md:text-3xl leading-relaxed" style="color: #3D2B1F;">As fruits grow ripe and round</p>
+                    <p class="text-2xl md:text-3xl leading-relaxed" style="color: #3D2B1F;">Come swing with us, come swing with us</p>
+                    <p class="text-2xl md:text-3xl leading-relaxed" style="color: #3D2B1F;">The sweetest swing we found</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+
+    <!-- Template: Table of Contents -->
+    <div class="preview-section">
+      <p class="preview-label">Template: Table of Contents</p>
+      <div class="rounded-2xl shadow-md overflow-hidden">
+        <div class="container content mx-auto flex min-h-screen w-full max-w-none items-start justify-center px-4 py-6" style="background: linear-gradient(135deg, #FFF5EB 0%, #F5EDE4 50%, #EDF6FB 100%);">
+          <section class="w-full" role="article">
+            <div class="mx-auto w-full max-w-4xl space-y-4">
+              <div class="rounded-3xl p-6 shadow-md" style="background: rgba(255, 255, 255, 0.88);">
+                <!-- Title -->
+                <div class="text-center mb-6">
+                  <h1 class="text-4xl md:text-5xl font-extrabold leading-tight" style="color: #8B2252;">Sinhala Reader</h1>
+                  <h2 class="text-2xl md:text-3xl font-semibold mt-2" style="color: #3D8B37;">Table of Contents</h2>
+                </div>
+                <!-- Entries -->
+                <div class="space-y-3">
+                  <div class="flex items-baseline gap-2">
+                    <p class="text-xl font-bold whitespace-nowrap" style="color: #5BACDB;">Lesson 1</p>
+                    <p class="text-xl font-medium flex-1" style="color: #3D2B1F;">The Music Class</p>
+                    <span class="border-b-2 border-dotted flex-1 mx-2" style="border-color: #d1d5db;"></span>
+                    <p class="text-xl font-bold" style="color: #8B2252;">1</p>
+                  </div>
+                  <div class="flex items-baseline gap-2">
+                    <p class="text-xl font-bold whitespace-nowrap" style="color: #3D8B37;">Lesson 4</p>
+                    <p class="text-xl font-medium flex-1" style="color: #3D2B1F;">The Swing Song</p>
+                    <span class="border-b-2 border-dotted flex-1 mx-2" style="border-color: #d1d5db;"></span>
+                    <p class="text-xl font-bold" style="color: #8B2252;">10</p>
+                  </div>
+                  <div class="flex items-baseline gap-2">
+                    <p class="text-xl font-bold whitespace-nowrap" style="color: #7B68AE;">Lesson 7</p>
+                    <p class="text-xl font-medium flex-1" style="color: #3D2B1F;">Clouds and Rain</p>
+                    <span class="border-b-2 border-dotted flex-1 mx-2" style="border-color: #d1d5db;"></span>
+                    <p class="text-xl font-bold" style="color: #8B2252;">17</p>
+                  </div>
+                  <div class="flex items-baseline gap-2">
+                    <p class="text-xl font-bold whitespace-nowrap" style="color: #F5A623;">Lesson 11</p>
+                    <p class="text-xl font-medium flex-1" style="color: #3D2B1F;">The Star Poem</p>
+                    <span class="border-b-2 border-dotted flex-1 mx-2" style="border-color: #d1d5db;"></span>
+                    <p class="text-xl font-bold" style="color: #8B2252;">34</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+
+    <div class="preview-divider"></div>
+
+    <!-- ============================================================ -->
+    <!-- REQUIRED STRUCTURE REFERENCE                                  -->
+    <!-- ============================================================ -->
+    <h2 class="text-3xl font-bold mb-6" style="color: #3D2B1F;">Required Structure Reference</h2>
+
+    <div class="preview-section">
+      <p class="preview-label">Outer Container &mdash; full-bleed background (max-w-none overrides container breakpoints)</p>
+      <div class="bg-white rounded-lg p-4 font-mono text-sm text-gray-700 overflow-x-auto">
+        <pre>&lt;div class="container content mx-auto flex min-h-screen w-full
+     max-w-none items-start justify-center px-4 py-6"
+    data-background-color="<span style="color: #8B2252;">BACKGROUND_COLOR</span>" id="content"
+    style="background: <span style="color: #8B2252;">LIGHT_GRADIENT</span>;"&gt;
+  &lt;section class="w-full"
+      data-section-id="<span style="color: #8B2252;">SECTION_ID</span>"
+      data-section-type="<span style="color: #8B2252;">SECTION_TYPE</span>"
+      data-text-color="<span style="color: #8B2252;">#3D2B1F</span>"
+      id="simple-main" role="article"&gt;
+    &lt;div class="mx-auto w-full max-w-6xl space-y-4"&gt;
+      <span class="text-gray-400">&lt;!-- Page content here --&gt;</span>
+    &lt;/div&gt;
+  &lt;/section&gt;
+&lt;/div&gt;</pre>
+      </div>
+    </div>
+
+    <!-- Footer -->
+    <div class="text-center text-gray-400 text-sm mt-12 pb-8">
+      Generated from <code>assets/styleguides/sri-lanka-grade2.md</code>
+    </div>
+
+  </div>
+</body>
+</html>

--- a/assets/styleguides/sri-lanka-grade2.md
+++ b/assets/styleguides/sri-lanka-grade2.md
@@ -1,0 +1,427 @@
+# Styleguide — Sri Lanka Grade 2 (Child-Friendly)
+
+This styleguide is designed for young children (Grade 2, ages ~7). Use large, readable text and soft, light backgrounds inspired by the original Sri Lankan textbook. Keep the visual design clean and uncluttered. Maximize content visibility by placing text and images side by side wherever possible.
+
+## Color Palette (extracted from original book)
+
+These colors are drawn from the original textbook illustrations. Use them sparingly — primarily for headings, badges, and star decorations. Backgrounds should be very light washes or gentle gradients of these tones.
+
+| Role | Color | Usage |
+|------|-------|-------|
+| Warm Peach | #F2D4BC | Light background washes |
+| Cream | #FFF5EB | Primary page background |
+| Sky Blue | #5BACDB | Headings, badges |
+| Light Blue | #B8E0F7 | Light background washes |
+| Nature Green | #3D8B37 | Headings, badges |
+| Leaf Green | #5AA84A | Accent headings |
+| Warm Maroon | #8B2252 | Headings, chapter titles |
+| Dark Brown | #3D2B1F | Body text color |
+| Playful Pink | #F4A7B9 | Star decorations |
+| Soft Purple | #7B68AE | Badges, star decorations |
+| Sunny Orange | #F5A623 | Badges, star decorations |
+| Golden Yellow | #F5C542 | Star decorations |
+
+## Required Container Structure
+
+Every page MUST use this exact outer container. The page background color is controlled ONLY by the `data-background-color` attribute — the system applies it to the `<body>` element automatically.
+
+**CRITICAL — NO backgrounds on containers**: Do NOT add any `style="background: ..."`, `style="background-color: ..."`, `bg-*` classes, or gradient styles to the outer container, section, or any inner divs. The ONLY background for the page comes from `data-background-color` on the outer container. The system reads this attribute and applies it to the body.
+
+```html
+<div class="container content mx-auto flex min-h-screen w-full max-w-none items-start justify-center px-4 py-6"
+    data-background-color="BACKGROUND_COLOR" id="content">
+  <section class="w-full" data-section-id="SECTION_ID" data-section-type="SECTION_TYPE" data-text-color="#3D2B1F"
+      id="simple-main" role="article">
+    <!-- Content goes here -->
+  </section>
+</div>
+```
+
+**Background color rules:**
+- Set `data-background-color` to a soft, pale color from the palette — this fills the ENTIRE page body
+- Use very light, washed-out tones: `#FFF5EB` (cream), `#FFF0E6` (warm peach), `#F0F7FD` (pale blue), `#F5F0FA` (pale purple), `#F0F8EF` (pale green)
+- Alternate between warm tones and cool tones across pages for variety
+- NEVER use saturated or bright colors — always keep them pale and airy
+- NEVER add any background styles to any HTML element — only use `data-background-color`
+
+**Layout notes**: Use `items-start` (not `items-center`) and `py-6` (not `py-12`) so content starts near the top and more fits in a single view. Content may extend beyond the viewport — that is fine, `min-h-screen` is a minimum not a maximum.
+
+## Inner Container (REQUIRED for all content pages)
+
+Inside the section, ALWAYS use this inner container structure:
+
+```html
+<div class="mx-auto w-full max-w-6xl space-y-4">
+  <!-- Page content here -->
+</div>
+```
+
+Use `max-w-6xl` (wider than default) and `space-y-4` (tighter than default) to fit more content on screen.
+
+---
+
+## Decorations
+
+Keep decorations minimal and tasteful. The only decorative element encouraged is **star decorations** for poem/song/activity pages.
+
+### Star Decorations (inspired by the original book)
+
+For poem or activity pages, scatter decorative stars using palette colors:
+
+```html
+<div class="absolute top-2 right-4 text-2xl" style="color: #F5C542;">&#9733;</div>
+<div class="absolute top-6 right-12 text-lg" style="color: #F4A7B9;">&#9733;</div>
+<div class="absolute top-3 right-20 text-xl" style="color: #7B68AE;">&#9733;</div>
+```
+
+**Decoration rules:**
+- Stars ONLY on poem, song, and activity pages — not on regular content pages
+- No colored borders on cards or content boxes
+- No colored borders on images
+- No dot dividers or section separators
+- Rounded corners on cards and images are fine (`rounded-3xl`)
+- Soft shadows are fine (`shadow-sm`, `shadow-md`)
+
+---
+
+## Text Styles
+
+All text is LARGE for young readers. Paragraph text is roughly double the default size.
+
+| text_type | Element | Classes |
+|-----------|---------|---------|
+| book_title | h1 | text-5xl md:text-6xl font-extrabold leading-tight |
+| book_subtitle | h2 | text-3xl md:text-4xl font-semibold |
+| chapter_title | h1 | text-4xl md:text-5xl font-bold leading-tight |
+| section_heading | h1 | text-4xl md:text-5xl font-bold leading-tight |
+| activity_title | h2 | text-3xl md:text-4xl font-bold leading-tight |
+| section_text | p | text-2xl md:text-3xl leading-relaxed |
+| instruction_text | p | text-xl md:text-2xl leading-relaxed italic |
+| standalone_text | p | text-xl md:text-2xl leading-relaxed |
+| image_associated_text | p | text-lg md:text-xl italic mt-2 |
+
+**Note:** These sizes are intentionally large — this book is for 7-year-old children who need big, clear text.
+
+## Image Styles
+
+Images should be prominent and cleanly presented. No borders on images.
+
+| Type | Classes |
+|------|---------|
+| Single image | w-full rounded-3xl shadow-md |
+| Multiple images | rounded-2xl shadow-sm |
+| Image grid container | grid grid-cols-2 gap-3 |
+
+```html
+<img alt="" class="w-full rounded-3xl shadow-md" data-id="ID" src="images/ID.jpg" />
+```
+
+---
+
+## Layout Strategy: Maximize Visible Content
+
+**CRITICAL**: Lay out content so as much as possible is visible in a single view. Prefer side-by-side layouts over stacked layouts.
+
+### Preferred: Text and Image Side by Side
+
+This is the PRIMARY layout. Use it whenever a page has both text and an image. Alternate which side the image appears on (left vs right) across pages.
+
+**Image on RIGHT, text on LEFT:**
+
+```html
+<div class="mx-auto w-full max-w-6xl space-y-4">
+  <div class="flex flex-col md:flex-row gap-4 items-start">
+    <div class="flex-1 space-y-3">
+      <h1 class="text-4xl md:text-5xl font-bold leading-tight" data-id="HEADING_ID" style="color: #8B2252;">Heading</h1>
+      <p class="text-2xl md:text-3xl leading-relaxed" data-id="ID" style="color: #3D2B1F;">Paragraph text here.</p>
+      <p class="text-2xl md:text-3xl leading-relaxed" data-id="ID" style="color: #3D2B1F;">More paragraph text.</p>
+    </div>
+    <div class="flex-1">
+      <img alt="" class="w-full rounded-3xl shadow-md" data-id="ID" src="images/ID.jpg" />
+    </div>
+  </div>
+</div>
+```
+
+**Image on LEFT, text on RIGHT:**
+
+```html
+<div class="mx-auto w-full max-w-6xl space-y-4">
+  <div class="flex flex-col md:flex-row gap-4 items-start">
+    <div class="flex-1">
+      <img alt="" class="w-full rounded-3xl shadow-md" data-id="ID" src="images/ID.jpg" />
+    </div>
+    <div class="flex-1 space-y-3">
+      <h1 class="text-4xl md:text-5xl font-bold leading-tight" data-id="HEADING_ID" style="color: #8B2252;">Heading</h1>
+      <p class="text-2xl md:text-3xl leading-relaxed" data-id="ID" style="color: #3D2B1F;">Paragraph text here.</p>
+    </div>
+  </div>
+</div>
+```
+
+### Extended Content (scrolling is OK)
+
+If a page has lots of content, it is perfectly fine to extend beyond the viewport height. Use the side-by-side layout first, then stack additional content below:
+
+```html
+<div class="mx-auto w-full max-w-6xl space-y-4">
+  <!-- Side by side section -->
+  <div class="flex flex-col md:flex-row gap-4 items-start">
+    <div class="flex-1 space-y-3">
+      <!-- text elements -->
+    </div>
+    <div class="flex-1">
+      <!-- image -->
+    </div>
+  </div>
+  <!-- Additional content below (scrolling OK) -->
+  <div class="space-y-3">
+    <p class="text-2xl md:text-3xl leading-relaxed" data-id="ID">More text continues below...</p>
+  </div>
+</div>
+```
+
+---
+
+## Components
+
+### Chapter Badge (colorful, child-friendly)
+
+When there is a chapter or lesson number, use this EXACT structure with vibrant colors:
+
+```html
+<div class="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+  <div class="flex items-start gap-4">
+    <div class="shrink-0 rounded-3xl px-6 py-4 shadow-md" style="background: #3D8B37;">
+      <h1 class="text-4xl md:text-5xl font-bold leading-tight" data-id="CHAPTER_WORD_ID" style="color: #FFF5EB;">LESSON</h1>
+      <h1 class="text-5xl md:text-6xl font-extrabold leading-tight" data-id="CHAPTER_NUMBER_ID" style="color: #F5C542;">1</h1>
+    </div>
+    <div class="pt-2">
+      <h1 class="text-4xl md:text-5xl font-bold leading-tight" data-id="CHAPTER_TITLE_ID" style="color: #8B2252;">Lesson Title Here</h1>
+    </div>
+  </div>
+</div>
+```
+
+Vary the badge background color across chapters: #3D8B37, #5BACDB, #8B2252, #F5A623, #7B68AE.
+
+### Content Card (for body text)
+
+Wrap body paragraphs in a clean card with a soft frosted background. No colored borders.
+
+```html
+<div class="space-y-3 rounded-3xl p-5 shadow-sm" style="background: rgba(255, 255, 255, 0.7);">
+  <p class="text-2xl md:text-3xl leading-relaxed" data-id="ID" style="color: #3D2B1F;">Paragraph text</p>
+  <p class="text-2xl md:text-3xl leading-relaxed" data-id="ID" style="color: #3D2B1F;">More text</p>
+</div>
+```
+
+### Text Group (for paragraphs without card)
+
+```html
+<div class="space-y-3">
+  <p class="text-2xl md:text-3xl leading-relaxed" data-id="ID" style="color: #3D2B1F;">Paragraph text</p>
+</div>
+```
+
+---
+
+## Page Templates
+
+### Template: Chapter/Lesson Start Page
+
+Use when page has a chapter/lesson number. Use side-by-side layout with the image:
+
+```html
+<div class="container content mx-auto flex min-h-screen w-full max-w-none items-start justify-center px-4 py-6"
+    data-background-color="#FFF5EB" id="content">
+  <section class="w-full" data-section-id="SECTION_ID" data-section-type="text_and_single_image" data-text-color="#3D2B1F"
+      id="simple-main" role="article">
+    <div class="mx-auto w-full max-w-6xl space-y-4">
+      <!-- Chapter Badge -->
+      <div class="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+        <div class="flex items-start gap-4">
+          <div class="shrink-0 rounded-3xl px-6 py-4 shadow-md" style="background: #3D8B37;">
+            <h1 class="text-4xl md:text-5xl font-bold leading-tight" data-id="chapter-word" style="color: #FFF5EB;">LESSON</h1>
+            <h1 class="text-5xl md:text-6xl font-extrabold leading-tight" data-id="chapter-num" style="color: #F5C542;">1</h1>
+          </div>
+          <div class="pt-2">
+            <h1 class="text-4xl md:text-5xl font-bold leading-tight" data-id="chapter-title" style="color: #8B2252;">The Music Class</h1>
+          </div>
+        </div>
+      </div>
+      <!-- Side by Side: Text + Image -->
+      <div class="flex flex-col md:flex-row gap-4 items-start">
+        <div class="flex-1">
+          <div class="space-y-3 rounded-3xl p-5 shadow-sm" style="background: rgba(255, 255, 255, 0.7);">
+            <p class="text-2xl md:text-3xl leading-relaxed" data-id="text-1" style="color: #3D2B1F;">Paragraph one.</p>
+            <p class="text-2xl md:text-3xl leading-relaxed" data-id="text-2" style="color: #3D2B1F;">Paragraph two.</p>
+          </div>
+        </div>
+        <div class="flex-1">
+          <img alt="" class="w-full rounded-3xl shadow-md" data-id="img-1" src="images/img-1.jpg" />
+        </div>
+      </div>
+    </div>
+  </section>
+</div>
+```
+
+### Template: Regular Content Page (side by side)
+
+Use for pages with text and images. **Always prefer side-by-side layout.**
+
+```html
+<div class="container content mx-auto flex min-h-screen w-full max-w-none items-start justify-center px-4 py-6"
+    data-background-color="#F0F7FD" id="content">
+  <section class="w-full" data-section-id="SECTION_ID" data-section-type="text_and_images" data-text-color="#3D2B1F"
+      id="simple-main" role="article">
+    <div class="mx-auto w-full max-w-6xl space-y-4">
+      <!-- Side by Side: Image LEFT, Text RIGHT -->
+      <div class="flex flex-col md:flex-row gap-4 items-start">
+        <div class="flex-1">
+          <img alt="" class="w-full rounded-3xl shadow-md" data-id="img-1" src="images/img-1.jpg" />
+        </div>
+        <div class="flex-1 space-y-3">
+          <div class="rounded-3xl p-5 shadow-sm" style="background: rgba(255, 255, 255, 0.7);">
+            <p class="text-2xl md:text-3xl leading-relaxed" data-id="text-1" style="color: #3D2B1F;">First paragraph.</p>
+            <p class="text-2xl md:text-3xl leading-relaxed mt-3" data-id="text-2" style="color: #3D2B1F;">Second paragraph.</p>
+          </div>
+        </div>
+      </div>
+      <!-- Additional content below -->
+      <div class="flex flex-col md:flex-row gap-4 items-start">
+        <div class="flex-1 space-y-3">
+          <p class="text-2xl md:text-3xl leading-relaxed" data-id="text-3" style="color: #3D2B1F;">Another paragraph.</p>
+        </div>
+        <div class="flex-1">
+          <img alt="" class="w-full rounded-3xl shadow-md" data-id="img-2" src="images/img-2.jpg" />
+        </div>
+      </div>
+    </div>
+  </section>
+</div>
+```
+
+### Template: Poem / Song Page (with star decorations)
+
+For poems, songs, or rhymes — use decorative stars and a centered layout:
+
+```html
+<div class="container content mx-auto flex min-h-screen w-full max-w-none items-start justify-center px-4 py-6"
+    data-background-color="#FFF0E6" id="content">
+  <section class="w-full" data-section-id="SECTION_ID" data-section-type="text_only" data-text-color="#3D2B1F"
+      id="simple-main" role="article">
+    <div class="mx-auto w-full max-w-6xl space-y-4">
+      <div class="relative rounded-3xl p-6 shadow-sm" style="background: rgba(255, 255, 255, 0.7);">
+        <!-- Star decorations -->
+        <div class="absolute top-2 right-4 text-3xl" style="color: #F5C542;">&#9733;</div>
+        <div class="absolute top-8 right-12 text-xl" style="color: #F4A7B9;">&#9733;</div>
+        <div class="absolute top-4 right-24 text-2xl" style="color: #7B68AE;">&#9733;</div>
+        <div class="absolute bottom-4 left-4 text-2xl" style="color: #5BACDB;">&#9733;</div>
+        <div class="absolute bottom-8 left-12 text-lg" style="color: #F5A623;">&#9733;</div>
+        <!-- Title -->
+        <h1 class="text-4xl md:text-5xl font-bold leading-tight mb-4" data-id="title" style="color: #8B2252;">Poem Title</h1>
+        <!-- Stanzas -->
+        <div class="space-y-4">
+          <div class="space-y-1">
+            <p class="text-2xl md:text-3xl leading-relaxed" data-id="line-1" style="color: #3D2B1F;">First line of poem</p>
+            <p class="text-2xl md:text-3xl leading-relaxed" data-id="line-2" style="color: #3D2B1F;">Second line of poem</p>
+            <p class="text-2xl md:text-3xl leading-relaxed" data-id="line-3" style="color: #3D2B1F;">Third line of poem</p>
+            <p class="text-2xl md:text-3xl leading-relaxed" data-id="line-4" style="color: #3D2B1F;">Fourth line of poem</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</div>
+```
+
+### Template: Text and Image Side by Side (reusable inner block)
+
+```html
+<div class="mx-auto w-full max-w-6xl space-y-4">
+  <div class="flex flex-col md:flex-row gap-4 items-start">
+    <div class="flex-1 space-y-3">
+      <!-- text elements -->
+    </div>
+    <div class="flex-1">
+      <img class="w-full rounded-3xl shadow-md" data-id="ID" src="images/ID.jpg" alt="" />
+    </div>
+  </div>
+</div>
+```
+
+### Template: Table of Contents
+
+Use this EXACT structure for table of contents pages:
+
+```html
+<div class="container content mx-auto flex min-h-screen w-full max-w-none items-start justify-center px-4 py-6"
+    data-background-color="#F5F0FA" id="content">
+  <section class="w-full" data-section-id="SECTION_ID" data-section-type="table_of_contents" data-text-color="#3D2B1F"
+      id="simple-main" role="article">
+    <div class="mx-auto w-full max-w-4xl space-y-4">
+      <!-- Background image (if provided) -->
+      <div class="relative rounded-3xl overflow-hidden shadow-md">
+        <img alt="" class="w-full" data-id="IMG_ID" src="images/IMG_ID.jpg"/>
+        <!-- Overlay card -->
+        <div class="absolute inset-0 flex items-center justify-center p-4">
+          <div class="w-full max-w-3xl rounded-3xl p-6 shadow-md" style="background: rgba(255, 255, 255, 0.88);">
+            <!-- Title -->
+            <div class="text-center mb-6">
+              <h1 class="text-4xl md:text-5xl font-extrabold leading-tight" data-id="TITLE_ID" style="color: #8B2252;">Book Title</h1>
+              <h2 class="text-2xl md:text-3xl font-semibold mt-2" data-id="SUBTITLE_ID" style="color: #3D8B37;">Table of Contents</h2>
+            </div>
+            <!-- Entries -->
+            <div class="space-y-3">
+              <div class="flex items-baseline gap-2">
+                <p class="text-xl font-bold whitespace-nowrap" data-id="CH1_LABEL" style="color: #5BACDB;">Lesson 1</p>
+                <p class="text-xl font-medium flex-1" data-id="CH1_TITLE" style="color: #3D2B1F;">Lesson Title</p>
+                <span class="border-b-2 border-dotted flex-1 mx-2" style="border-color: #d1d5db;"></span>
+                <p class="text-xl font-bold" data-id="CH1_PAGE" style="color: #8B2252;">2</p>
+              </div>
+              <!-- Repeat for each lesson -->
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</div>
+```
+
+**Table of Contents Entry Row (repeat for each lesson):**
+
+```html
+<div class="flex items-baseline gap-2">
+  <p class="text-xl font-bold whitespace-nowrap" data-id="CHAPTER_LABEL_ID" style="color: #5BACDB;">Lesson 1</p>
+  <p class="text-xl font-medium" data-id="CHAPTER_TITLE_ID" style="color: #3D2B1F;">The Music Class</p>
+  <span class="border-b-2 border-dotted flex-1 mx-2" style="border-color: #d1d5db;"></span>
+  <p class="text-xl font-bold" data-id="PAGE_NUMBER_ID" style="color: #8B2252;">2</p>
+</div>
+```
+
+**Important for Table of Contents:**
+- Use `text-xl` for entries (larger than default for young readers)
+- Use `font-bold` for lesson numbers and page numbers
+- Title should be `text-4xl md:text-5xl`
+- Subtitle should be `text-2xl md:text-3xl`
+- Use subtle gray dotted line separator
+- Keep the card spacious with `max-w-3xl`
+
+---
+
+## General Rules
+
+1. **Page background via `data-background-color` ONLY** — never add `style="background: ..."` or `bg-*` classes to any element. The system reads `data-background-color` from the outer container and applies it to the body. Use soft palette tones like `#FFF5EB`, `#FFF0E6`, `#F0F7FD`, `#F5F0FA`, `#F0F8EF`.
+2. **ALWAYS use side-by-side layout** when both text and images are present.
+3. **Alternate image placement** — image on left for odd pages, image on right for even pages (or vice versa).
+4. **Star decorations ONLY on poem/song/activity pages** — no other decorative elements.
+5. **Use large text** — all body text must be `text-2xl md:text-3xl` minimum.
+6. **No borders on images** — use only rounded corners and soft shadows.
+7. **No colored borders on cards** — use only frosted glass backgrounds (`rgba(255, 255, 255, 0.7)`).
+8. **No dot dividers** — if sections need separation, use simple spacing (`space-y-4`).
+9. **Content may extend beyond viewport** — scrolling is acceptable. Pack content densely.
+10. **Rounded corners everywhere** — use `rounded-3xl` on cards, images, and containers.
+11. **Heading colors** — use maroon (#8B2252) or green (#3D8B37) for headings, never plain black.

--- a/packages/pipeline/src/master.ts
+++ b/packages/pipeline/src/master.ts
@@ -179,6 +179,7 @@ export async function runMaster(
         outputLanguages,
         title: bookTitle,
         webAssetsDir: options.webAssetsDir,
+        applyBodyBackground: config.apply_body_background,
       }, progress)
     }
   } finally {

--- a/packages/pipeline/src/package-web.ts
+++ b/packages/pipeline/src/package-web.ts
@@ -25,6 +25,7 @@ export interface PackageAdtWebOptions {
   title: string
   webAssetsDir: string
   bundleVersion?: string
+  applyBodyBackground?: boolean
 }
 
 interface PageEntry {
@@ -55,6 +56,7 @@ export async function packageAdtWeb(
     title,
     webAssetsDir,
     bundleVersion = "1",
+    applyBodyBackground,
   } = options
   const language = normalizeLocale(rawLanguage)
   const outputLanguages = Array.from(new Set(rawOutputLanguages.map((code) => normalizeLocale(code))))
@@ -173,6 +175,7 @@ export async function packageAdtWeb(
             activityAnswers,
             hasMath: containsMathContent(rewrittenHtml),
             bundleVersion,
+            applyBodyBackground,
           })
           fs.writeFileSync(path.join(adtDir, `${page.pageId}.html`), pageHtml)
 
@@ -202,6 +205,7 @@ export async function packageAdtWeb(
         hasMath: false,
         bundleVersion,
         skipContentWrapper: true,
+        applyBodyBackground,
       })
       fs.writeFileSync(path.join(adtDir, `${quizId}.html`), quizPageHtml)
 
@@ -417,6 +421,7 @@ export interface RenderPageOptions {
   /** When true, content is placed directly in <body> without a <div id="content"> wrapper.
    *  Used for quiz pages whose template provides its own #content element. */
   skipContentWrapper?: boolean
+  applyBodyBackground?: boolean
 }
 
 export function renderPageHtml(opts: RenderPageOptions): string {
@@ -435,6 +440,15 @@ export function renderPageHtml(opts: RenderPageOptions): string {
     ${opts.content}
     </div>`
 
+  // Extract data-background-color from content to apply on <body>
+  let bodyStyle = ""
+  if (opts.applyBodyBackground !== false) {
+    const bgMatch = opts.content.match(/data-background-color="([^"]*)"/)
+    bodyStyle = bgMatch?.[1]
+      ? ` style="background-color: ${escapeAttr(bgMatch[1])};"`
+      : ""
+  }
+
   return `<!DOCTYPE html>
 <html lang="${escapeAttr(opts.language)}">
 
@@ -451,7 +465,7 @@ export function renderPageHtml(opts: RenderPageOptions): string {
     <link href="./assets/fonts.css" rel="stylesheet">
 ${mathScript}</head>
 
-<body class="min-h-screen flex items-center justify-center">
+<body class="min-h-screen flex items-center justify-center"${bodyStyle}>
 ${contentBlock}
 ${answersScript}
     <div class="relative z-50" id="interface-container"></div>

--- a/packages/pipeline/src/pipeline-dag.ts
+++ b/packages/pipeline/src/pipeline-dag.ts
@@ -847,6 +847,7 @@ export async function runFullPipeline(
         outputLanguages,
         title: bookTitle,
         webAssetsDir: options.webAssetsDir,
+        applyBodyBackground: config.apply_body_background,
       }, progressOnly(p))
     })
 

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -105,6 +105,7 @@ export const AppConfig = z
     image_cropping: StepConfig.optional(),
     layout_type: LayoutType.optional(),
     spread_mode: z.boolean().optional(),
+    apply_body_background: z.boolean().optional(),
     start_page: z.number().int().min(1).optional(),
     end_page: z.number().int().min(1).optional(),
     speech: SpeechConfig.optional(),


### PR DESCRIPTION
## Summary

Add `apply_body_background` boolean config option (default true) to control whether background colors extracted from content are applied to the page body. Thread through all rendering paths: packaging, API preview, and live preview. Also fixes XSS/CSS injection vulnerability where `bgMatch[1]` was interpolated without `escapeAttr()`. Includes Sri Lanka Grade 2 styleguide assets.

## Changes

- Add `apply_body_background` to `AppConfig` schema
- Make background extraction conditional in `renderPageHtml()`
- Fix CSS injection by wrapping with `escapeAttr()`
- Thread config through packaging routes, services, and pipeline runners
- Add UI toggle in onboarding wizard step 2 (Layout) under Advanced settings
- Add UI toggle in Storyboard settings for runtime control
- Add toggle to BookPreviewFrame and StoryboardSectionDetail for live preview

## Test Plan

- Verify typecheck passes ✓
- Toggle off in onboarding — new book should have white body
- Toggle on in onboarding — new book should apply styleguide backgrounds
- In existing book storyboard settings, toggle to control preview backgrounds
- Verify packaged output respects the toggle