### PR TITLE
Enhance page navigation and UI across pipeline stages

### DIFF
--- a/apps/studio/src/components/pipeline/StageSidebar.tsx
+++ b/apps/studio/src/components/pipeline/StageSidebar.tsx
@@ -141,8 +141,10 @@ export function StageSidebar({
           )}
         >
           <Link
-            to="/books/$label/$step"
-            params={{ label: bookLabel, step: step.slug }}
+            to={selectedPageId && hasStagePages(step.slug) ? "/books/$label/$step/$pageId" : "/books/$label/$step"}
+            params={selectedPageId && hasStagePages(step.slug)
+              ? { label: bookLabel, step: step.slug, pageId: selectedPageId }
+              : { label: bookLabel, step: step.slug }}
             className={cn("flex items-center gap-2.5 min-w-0", x.flex1)}
             title={step.label}
           >

--- a/apps/studio/src/components/pipeline/stages/CaptionsView.tsx
+++ b/apps/studio/src/components/pipeline/stages/CaptionsView.tsx
@@ -130,7 +130,7 @@ function VersionPicker({
   )
 }
 
-function PageCaptions({ bookLabel, pageId, pageNumber }: { bookLabel: string; pageId: string; pageNumber: number }) {
+function PageCaptions({ bookLabel, pageId, pageNumber, emptyState, largeImages }: { bookLabel: string; pageId: string; pageNumber: number; emptyState?: React.ReactNode; largeImages?: boolean }) {
   const queryClient = useQueryClient()
   const { data: page } = usePage(bookLabel, pageId)
 
@@ -146,7 +146,7 @@ function PageCaptions({ bookLabel, pageId, pageNumber }: { bookLabel: string; pa
   const captions = effective?.captions ?? []
   const dirty = pending != null
 
-  if (!page?.imageCaptioning || captions.length === 0) return null
+  if (!page?.imageCaptioning || captions.length === 0) return emptyState ?? null
 
   const updateCaption = (imageId: string, newCaption: string) => {
     const base = pending ?? page.imageCaptioning
@@ -196,7 +196,7 @@ function PageCaptions({ bookLabel, pageId, pageNumber }: { bookLabel: string; pa
           <img
             src={`/api/books/${bookLabel}/images/${cap.imageId}`}
             alt={cap.caption}
-            className="shrink-0 w-24 self-stretch bg-muted object-cover block"
+            className={`shrink-0 self-stretch bg-muted object-cover block ${largeImages ? "w-96" : "w-48"}`}
           />
           <div className="flex-1 min-w-0 py-2.5 pr-3">
             <div className="flex items-center gap-2 mb-1">
@@ -215,7 +215,7 @@ function PageCaptions({ bookLabel, pageId, pageNumber }: { bookLabel: string; pa
   )
 }
 
-export function CaptionsView({ bookLabel, selectedPageId }: { bookLabel: string; selectedPageId?: string }) {
+export function CaptionsView({ bookLabel, selectedPageId, onSelectPage }: { bookLabel: string; selectedPageId?: string; onSelectPage?: (pageId: string | null) => void }) {
   const { data: pages, isLoading } = usePages(bookLabel)
   const { setExtra } = useStepHeader()
   const { progress: stepProgress, queueRun } = useStepRun()
@@ -276,11 +276,27 @@ export function CaptionsView({ bookLabel, selectedPageId }: { bookLabel: string;
         <div className="w-12 h-12 rounded-full bg-teal-50 flex items-center justify-center mb-3">
           <ImageIcon className="w-6 h-6 text-teal-300" />
         </div>
-        <p className="text-sm font-medium">No captions for this page</p>
-        <p className="text-xs mt-1">This page has no captioned images</p>
+        <p className="text-sm font-medium">No images on this page</p>
+        <button
+          type="button"
+          onClick={() => onSelectPage?.(null)}
+          className="mt-3 text-xs font-medium text-teal-600 hover:text-teal-700 hover:underline transition-colors"
+        >
+          Show all images
+        </button>
       </div>
     )
   }
+
+  const singlePageEmptyState = selectedPageId ? (
+    <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
+      <div className="w-12 h-12 rounded-full bg-teal-50 flex items-center justify-center mb-3">
+        <ImageIcon className="w-6 h-6 text-teal-300" />
+      </div>
+      <p className="text-sm font-medium">No captions for this page</p>
+      <p className="text-xs mt-1">This page has no captioned images</p>
+    </div>
+  ) : undefined
 
   return (
     <div className="space-y-4">
@@ -290,8 +306,21 @@ export function CaptionsView({ bookLabel, selectedPageId }: { bookLabel: string;
           bookLabel={bookLabel}
           pageId={page.pageId}
           pageNumber={page.pageNumber}
+          emptyState={singlePageEmptyState}
+          largeImages={!!selectedPageId}
         />
       ))}
+      {selectedPageId && (
+        <div className="flex justify-center pt-2 pb-4">
+          <button
+            type="button"
+            onClick={() => onSelectPage?.(null)}
+            className="text-xs font-medium text-teal-600 hover:text-teal-700 hover:underline transition-colors"
+          >
+            Show all images
+          </button>
+        </div>
+      )}
     </div>
   )
 }

--- a/apps/studio/src/components/pipeline/stages/StoryboardSectionDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/StoryboardSectionDetail.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback, useMemo, type ReactNode } from "react"
 import { createPortal } from "react-dom"
-import { Check, Eye, EyeOff, Layers, Loader2, ChevronDown, Sparkles, ChevronRight, PanelRightOpen, PanelRightClose, Save, X } from "lucide-react"
+import { Check, Eye, EyeOff, LayoutGrid, Layers, Loader2, ChevronDown, Sparkles, ChevronRight, PanelRightOpen, PanelRightClose, Save, X } from "lucide-react"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { api } from "@/api/client"
 import type { PageDetail, VersionEntry } from "@/api/client"
@@ -1271,8 +1271,12 @@ export function StoryboardSectionDetail({
             applyBodyBackground={applyBodyBackground}
           />
         ) : (
-          <div className="p-4 text-sm text-muted-foreground border rounded">
-            No rendered content for this section.
+          <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
+            <div className="w-12 h-12 rounded-full bg-violet-50 flex items-center justify-center mb-3">
+              <LayoutGrid className="w-6 h-6 text-violet-300" />
+            </div>
+            <p className="text-sm font-medium">No rendered content for this section</p>
+            <p className="text-xs mt-1">This section has no storyboard rendering yet</p>
           </div>
         )}
 

--- a/apps/studio/src/components/pipeline/stages/StoryboardView.tsx
+++ b/apps/studio/src/components/pipeline/stages/StoryboardView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useRef, useCallback } from "react"
-import { ArrowLeft, ArrowRight, Loader2 } from "lucide-react"
+import { ArrowLeft, ArrowRight, LayoutGrid, Loader2 } from "lucide-react"
 import { usePages, usePage } from "@/hooks/use-pages"
 import { useStepHeader } from "../StepViewRouter"
 import { useStepRun } from "@/hooks/use-step-run"
@@ -226,8 +226,12 @@ export function StoryboardView({ bookLabel, selectedPageId: selectedPageIdProp, 
 
   if (sectionCount === 0) {
     return (
-      <div className="p-4 text-sm text-muted-foreground">
-        This page has no sections.
+      <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
+        <div className="w-12 h-12 rounded-full bg-violet-50 flex items-center justify-center mb-3">
+          <LayoutGrid className="w-6 h-6 text-violet-300" />
+        </div>
+        <p className="text-sm font-medium">No sections for this page</p>
+        <p className="text-xs mt-1">This page has no storyboard sections</p>
       </div>
     )
   }

--- a/apps/studio/src/components/pipeline/stages/TranslationsView.tsx
+++ b/apps/studio/src/components/pipeline/stages/TranslationsView.tsx
@@ -12,6 +12,11 @@ import { STAGE_DESCRIPTIONS } from "../stage-config"
 import { cn } from "@/lib/utils"
 import { getBaseLanguage, normalizeLocale } from "@/lib/languages"
 
+const IMAGE_ID_RE = /_im\d{3}/
+function isImageEntry(id: string): boolean {
+  return IMAGE_ID_RE.test(id)
+}
+
 const langNames = new Intl.DisplayNames(["en"], { type: "language" })
 function displayLang(code: string): string {
   try { return langNames.of(code) ?? code } catch { return code }
@@ -135,7 +140,7 @@ function VersionPicker({
   )
 }
 
-export function TranslationsView({ bookLabel, selectedPageId }: { bookLabel: string; selectedPageId?: string }) {
+export function TranslationsView({ bookLabel, selectedPageId, onSelectPage }: { bookLabel: string; selectedPageId?: string; onSelectPage?: (pageId: string | null) => void }) {
   const { setExtra } = useStepHeader()
   const { data: activeConfigData } = useActiveConfig(bookLabel)
   const queryClient = useQueryClient()
@@ -302,6 +307,18 @@ export function TranslationsView({ bookLabel, selectedPageId }: { bookLabel: str
     )
   }
 
+  const showAllButton = selectedPageId ? (
+    <div className="flex justify-center pt-2 pb-4">
+      <button
+        type="button"
+        onClick={() => onSelectPage?.(null)}
+        className="text-xs font-medium text-pink-600 hover:text-pink-700 hover:underline transition-colors"
+      >
+        Show all text &amp; speech
+      </button>
+    </div>
+  ) : null
+
   // No output languages — just show source entries
   if (!hasTranslations) {
     if (selectedPageId && displayEntries.length === 0 && entries.length > 0) {
@@ -318,7 +335,7 @@ export function TranslationsView({ bookLabel, selectedPageId }: { bookLabel: str
     return (
       <div className="space-y-1">
         {displayEntries.map((entry) => (
-          <EntryRow key={entry.id} entry={entry} />
+          <EntryRow key={entry.id} entry={entry} bookLabel={bookLabel} />
         ))}
       </div>
     )
@@ -372,11 +389,21 @@ export function TranslationsView({ bookLabel, selectedPageId }: { bookLabel: str
         {displayEntries.map((entry) => {
           const translated = translatedMap.get(entry.id)
           const audio = audioMap.get(entry.id)
+          const isImg = isImageEntry(entry.id)
           return (
             <div key={entry.id} className="grid grid-cols-2 gap-3 px-3 py-2.5 rounded-md border bg-card">
-              <div>
-                <span className="text-[10px] text-muted-foreground">{entry.id}</span>
-                <p className="text-sm leading-relaxed mt-0.5">{entry.text}</p>
+              <div className="flex items-start gap-3">
+                {isImg && (
+                  <img
+                    src={`/api/books/${bookLabel}/images/${entry.id}`}
+                    alt=""
+                    className="shrink-0 w-16 h-12 rounded object-cover ring-1 ring-border"
+                  />
+                )}
+                <div className="min-w-0">
+                  <span className="text-[10px] text-muted-foreground">{entry.id}</span>
+                  <p className="text-sm leading-relaxed mt-0.5">{entry.text}</p>
+                </div>
               </div>
               <div className="flex items-start gap-2">
                 <div className="flex-1 min-w-0">
@@ -403,6 +430,7 @@ export function TranslationsView({ bookLabel, selectedPageId }: { bookLabel: str
         })}
       </div>
       )}
+      {showAllButton}
     </div>
   )
 }
@@ -449,9 +477,17 @@ function PlayButton({ audioUrl }: { audioUrl: string }) {
   )
 }
 
-function EntryRow({ entry }: { entry: TextCatalogEntry }) {
+function EntryRow({ entry, bookLabel }: { entry: TextCatalogEntry; bookLabel: string }) {
+  const isImg = isImageEntry(entry.id)
   return (
     <div className="flex items-start gap-3 px-3 py-2.5 rounded-md border bg-card">
+      {isImg && (
+        <img
+          src={`/api/books/${bookLabel}/images/${entry.id}`}
+          alt=""
+          className="shrink-0 w-16 h-12 rounded object-cover ring-1 ring-border"
+        />
+      )}
       <span className="shrink-0 text-[10px] font-medium text-muted-foreground w-32 truncate pt-0.5" title={entry.id}>
         {entry.id}
       </span>


### PR DESCRIPTION
## Summary
- Persist selected page when navigating between storyboard and captions stages
- Add larger caption images when viewing a single page (384px vs 192px in all-pages view)
- Display image thumbnails alongside caption entries in text & speech view
- Replace plain text empty states with styled cards featuring icons and descriptions across storyboard, captions, and translations
- Add "Show all" buttons to easily return from single-page filtered views

## Changes
- **StageSidebar**: Carry forward selected page ID when navigating between compatible stages
- **CaptionsView**: Show empty states with icons, support larger images in single-page mode, add "Show all images" button
- **TranslationsView**: Add image detection and thumbnails for caption entries, add "Show all text & speech" button
- **StoryboardView** & **StoryboardSectionDetail**: Add styled empty state for pages/sections with no content