### PR TITLE
fix: handle chained image filters in PDF extraction

### DIFF
--- a/packages/pdf/src/__tests__/extract.test.ts
+++ b/packages/pdf/src/__tests__/extract.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { deflateSync } from "zlib";
 import mupdf from "mupdf";
 import { extractPdf } from "../extract.js";
 import { stitchPngsHorizontally, decodePng } from "../png-utils.js";
@@ -379,5 +380,134 @@ describe("extractPdf spread mode", () => {
     expect(result.pages[0].pageId).toBe("pg004");
     expect(result.pages[1].pageId).toBe("pg005006");
     expect(result.pages[2].pageId).toBe("pg007");
+  });
+});
+
+/**
+ * Create a minimal JPEG buffer (2x2 red pixels) using mupdf.
+ */
+function createTinyJpeg(): Buffer {
+  // Create a pixmap without alpha (JPEG doesn't support alpha)
+  const pixmap = new mupdf.Pixmap(mupdf.ColorSpace.DeviceRGB, [0, 0, 2, 2], false);
+  // Pixmap pixels are initialized to black by default, that's fine for a test image
+  return Buffer.from(pixmap.asJPEG(90, false));
+}
+
+/**
+ * Build a PDF with an image that has chained [FlateDecode, DCTDecode] filters.
+ * This simulates PDFs where JPEG data is additionally compressed with zlib.
+ */
+function createPdfWithChainedFilterImage(): Buffer {
+  const doc = new mupdf.PDFDocument();
+
+  // Create a tiny JPEG, then wrap it in zlib compression
+  const jpegBytes = createTinyJpeg();
+  const zlibBytes = deflateSync(jpegBytes);
+
+  // Build the image dictionary manually
+  const imgDict = doc.newDictionary();
+  imgDict.put("Type", doc.newName("XObject"));
+  imgDict.put("Subtype", doc.newName("Image"));
+  imgDict.put("Width", 2);
+  imgDict.put("Height", 2);
+  imgDict.put("BitsPerComponent", 8);
+  imgDict.put("ColorSpace", doc.newName("DeviceRGB"));
+
+  // Chained filter: data goes through FlateDecode first, then DCTDecode
+  const filters = doc.newArray();
+  filters.push(doc.newName("FlateDecode"));
+  filters.push(doc.newName("DCTDecode"));
+  imgDict.put("Filter", filters);
+
+  // addRawStream stores bytes without applying extra compression
+  const imgObj = doc.addRawStream(zlibBytes, imgDict);
+
+  // Wire the image into a page
+  const resources = doc.newDictionary();
+  const xobjects = doc.newDictionary();
+  xobjects.put("Im1", imgObj);
+  resources.put("XObject", xobjects);
+
+  const pageContent = "q 100 0 0 100 50 650 cm /Im1 Do Q";
+  const pageObj = doc.addPage([0, 0, 612, 792], 0, resources, pageContent);
+  doc.insertPage(-1, pageObj);
+
+  return Buffer.from(doc.saveToBuffer("").asUint8Array());
+}
+
+/**
+ * Build a PDF with an image that uses a single-element filter array [DCTDecode].
+ * This should still be treated as a plain JPEG stream.
+ */
+function createPdfWithSingleArrayDctFilterImage(): Buffer {
+  const doc = new mupdf.PDFDocument();
+  const jpegBytes = createTinyJpeg();
+
+  const imgDict = doc.newDictionary();
+  imgDict.put("Type", doc.newName("XObject"));
+  imgDict.put("Subtype", doc.newName("Image"));
+  imgDict.put("Width", 2);
+  imgDict.put("Height", 2);
+  imgDict.put("BitsPerComponent", 8);
+  imgDict.put("ColorSpace", doc.newName("DeviceRGB"));
+
+  const filters = doc.newArray();
+  filters.push(doc.newName("DCTDecode"));
+  imgDict.put("Filter", filters);
+
+  const imgObj = doc.addRawStream(jpegBytes, imgDict);
+
+  const resources = doc.newDictionary();
+  const xobjects = doc.newDictionary();
+  xobjects.put("Im1", imgObj);
+  resources.put("XObject", xobjects);
+
+  const pageContent = "q 100 0 0 100 50 650 cm /Im1 Do Q";
+  const pageObj = doc.addPage([0, 0, 612, 792], 0, resources, pageContent);
+  doc.insertPage(-1, pageObj);
+
+  return Buffer.from(doc.saveToBuffer("").asUint8Array());
+}
+
+describe("extractPdf chained image filters", () => {
+  it("extracts a valid image from a [FlateDecode, DCTDecode] filter chain", async () => {
+    const pdfBuffer = createPdfWithChainedFilterImage();
+    const result = await extractPdf({ pdfBuffer });
+
+    expect(result.pages).toHaveLength(1);
+    const page = result.pages[0];
+
+    // Should have extracted the raster image
+    const rasterImages = page.images.filter((img) => !img.imageId.endsWith("_page"));
+    expect(rasterImages).toHaveLength(1);
+
+    const img = rasterImages[0];
+    expect(img.buffer.length).toBeGreaterThan(0);
+    expect(img.format).toBe("png");
+
+    // Verify the output is actually a valid PNG (starts with PNG magic bytes)
+    expect(img.buffer[0]).toBe(0x89);
+    expect(img.buffer[1]).toBe(0x50); // 'P'
+    expect(img.buffer[2]).toBe(0x4e); // 'N'
+    expect(img.buffer[3]).toBe(0x47); // 'G'
+  });
+
+  it("keeps single-element [DCTDecode] filter arrays as jpeg", async () => {
+    const pdfBuffer = createPdfWithSingleArrayDctFilterImage();
+    const result = await extractPdf({ pdfBuffer });
+
+    expect(result.pages).toHaveLength(1);
+    const page = result.pages[0];
+    const rasterImages = page.images.filter((img) => !img.imageId.endsWith("_page"));
+    expect(rasterImages).toHaveLength(1);
+
+    const img = rasterImages[0];
+    expect(img.buffer.length).toBeGreaterThan(0);
+    expect(img.format).toBe("jpeg");
+
+    // Verify JPEG SOI signature
+    expect(img.buffer[0]).toBe(0xff);
+    expect(img.buffer[1]).toBe(0xd8);
+    expect(img.buffer[2]).toBe(0xff);
   });
 });

--- a/packages/pdf/src/extract.ts
+++ b/packages/pdf/src/extract.ts
@@ -477,18 +477,25 @@ function extractRasterImagesFromPdf(
       try {
         // Check filter to determine format
         const filter = resolved.get("Filter");
-        const filterName = filter.isNull()
-          ? ""
+        const filterNames = filter.isNull()
+          ? []
           : filter.isArray()
-            ? filter.get(filter.length - 1).asName()
-            : filter.asName();
+            ? Array.from({ length: filter.length }, (_, i) => filter.get(i).asName())
+            : [filter.asName()];
+        const filterName =
+          filterNames.length > 0 ? filterNames[filterNames.length - 1] : "";
         let buf: Buffer;
         let format: ImageFormat;
 
         // Use the original (indirect) obj for stream access — resolve() strips the stream
         const streamObj = obj.isIndirect() ? obj : resolved;
 
-        if (filterName === "DCTDecode") {
+        // readRawStream() only works for single-filter streams. For chained
+        // filters (e.g. [FlateDecode, DCTDecode]) it returns bytes before
+        // filter decoding, so we must not treat those as raw JPEG bytes.
+        const isSingleFilter = filterNames.length === 1;
+
+        if (filterName === "DCTDecode" && isSingleFilter) {
           // Check colorspace — CMYK JPEGs need conversion (browsers can't display them)
           const cs = resolved.get("ColorSpace");
           const isCmyk =
@@ -508,7 +515,7 @@ function extractRasterImagesFromPdf(
             format = "jpeg";
           }
         } else {
-          // Everything else: decode through mupdf → PNG
+          // Multi-filter chains or non-JPEG: decode through mupdf → PNG
           const image = doc.loadImage(streamObj);
           const pixmap = image.toPixmap();
           buf = Buffer.from(pixmap.asPNG());


### PR DESCRIPTION
## Summary

Fixed a bug in PDF image extraction where chained filter streams (e.g., `[FlateDecode, DCTDecode]`) were being incorrectly handled. When multiple filters are present, `readRawStream()` returns bytes before any filters are applied—raw compressed bytes, not valid JPEG data—causing image filtering to fail with "Unsupported image format (magic bytes: 0x78 0x9c)".

The fix adds an `isSingleFilter` check to ensure `readRawStream()` is only used for single-filter streams. Multi-filter chains now go through mupdf's full decode path, which properly applies all filters in sequence.

## Test Plan

- Added test for `[FlateDecode, DCTDecode]` chained filters—verifies output is valid PNG
- Added test for single-element `[DCTDecode]` filter array—verifies output remains JPEG
- All existing extraction tests pass (no regressions)