### PR TITLE
feat: add llm-overlay render strategy

### DIFF
--- a/apps/studio/src/components/pipeline/stages/BookPreviewFrame.tsx
+++ b/apps/studio/src/components/pipeline/stages/BookPreviewFrame.tsx
@@ -180,6 +180,7 @@ export const BookPreviewFrame = forwardRef<BookPreviewFrameHandle, BookPreviewFr
   <script src="https://cdn.tailwindcss.com"><\/script>
   <style>
     @import url("https://fonts.googleapis.com/css2?family=Merriweather:ital,wght@0,300..800;1,300..800&display=swap");
+    :root { --page-height: 100vh; }
     body { margin: 0; }
     body, p, h1, h2, h3, h4, h5, h6, span, div, button, input, textarea, select {
       font-family: "Merriweather", serif;
@@ -243,6 +244,10 @@ ${interactiveScript}
     if (scriptEl && editable) {
       doc.body.appendChild(scriptEl)
     }
+
+    // Inject parent viewport height as CSS variable so overlay HTML can
+    // constrain images to fit without using vh (which doesn't work in iframes).
+    doc.documentElement.style.setProperty("--page-height", `${window.innerHeight}px`)
 
     // Apply data-background-color from content to iframe body
     if (applyBodyBackground !== false) {
@@ -390,6 +395,10 @@ ${selectors}:hover {
 
     // Re-measure on window resize (e.g. browser resize changes iframe width)
     const onResize = () => {
+      const doc = iframe.contentDocument
+      if (doc) {
+        doc.documentElement.style.setProperty("--page-height", `${window.innerHeight}px`)
+      }
       if (settledRef.current) measureHeight()
     }
     window.addEventListener("resize", onResize)

--- a/apps/studio/src/components/pipeline/stages/StoryboardSettings.tsx
+++ b/apps/studio/src/components/pipeline/stages/StoryboardSettings.tsx
@@ -39,6 +39,7 @@ function titleCase(slug: string): string {
 /** Human-friendly display names for strategy keys */
 const STRATEGY_DISPLAY_NAMES: Record<string, string> = {
   llm: "AI Generated",
+  "llm-overlay": "AI Overlay",
   dynamic: "Dynamic",
 }
 
@@ -49,6 +50,7 @@ function strategyDisplayName(slug: string): string {
 const RENDER_STRATEGY_DESCRIPTIONS: Record<string, string> = {
   dynamic: "Automatically picks the best strategy per section type",
   llm: "LLM generates HTML from section content",
+  "llm-overlay": "LLM positions text over background images",
   two_column: "Fixed two-column template layout",
   two_column_story: "Two-column template for story content",
 }

--- a/config.yaml
+++ b/config.yaml
@@ -79,6 +79,13 @@ render_strategies:
       model: openai:gpt-5.2
       max_retries: 25
       timeout: 180
+  llm-overlay:
+    render_type: llm
+    config:
+      prompt: web_generation_html_overlay
+      model: openai:gpt-5.2
+      max_retries: 25
+      timeout: 180
   two_column:
     render_type: template
     config:

--- a/config/presets/reference.yaml
+++ b/config/presets/reference.yaml
@@ -21,6 +21,13 @@ render_strategies:
       model: openai:gpt-5.2
       max_retries: 25
       timeout: 180
+  llm-overlay:
+    render_type: llm
+    config:
+      prompt: web_generation_html_overlay
+      model: openai:gpt-5.2
+      max_retries: 25
+      timeout: 180
 
 section_render_strategies: {}
 

--- a/config/presets/storybook.yaml
+++ b/config/presets/storybook.yaml
@@ -25,6 +25,13 @@ render_strategies:
       model: openai:gpt-5.2
       max_retries: 25
       timeout: 180
+  llm-overlay:
+    render_type: llm
+    config:
+      prompt: web_generation_html_overlay
+      model: openai:gpt-5.2
+      max_retries: 25
+      timeout: 180
 
 section_render_strategies: {}
 

--- a/config/presets/textbook.yaml
+++ b/config/presets/textbook.yaml
@@ -20,6 +20,14 @@ render_strategies:
       max_retries: 25
       timeout: 180
       temperature: 0.3
+  llm-overlay:
+    render_type: llm
+    config:
+      prompt: web_generation_html_overlay
+      model: openai:gpt-5.2
+      max_retries: 25
+      timeout: 180
+      temperature: 0.3
   two_column:
     render_type: template
     config:

--- a/packages/pipeline/src/render-llm.ts
+++ b/packages/pipeline/src/render-llm.ts
@@ -31,6 +31,52 @@ export async function renderSectionLlm(
   const isActivity = config.renderType === "activity"
   const taskType = isActivity ? "activity-rendering" : "web-rendering"
 
+  // Build structured groups (preserves groupId/groupType for prompts that need it)
+  const groups: Array<{
+    group_id: string
+    group_type: string
+    texts: Array<{ text_id: string; text_type: string; text: string }>
+  }> = []
+  for (const part of input.parts) {
+    if (part.type === "group") {
+      groups.push({
+        group_id: part.groupId,
+        group_type: part.groupType,
+        texts: part.texts.map((t) => ({
+          text_id: t.textId,
+          text_type: t.textType,
+          text: t.text,
+        })),
+      })
+    }
+  }
+
+  // Build ordered parts list preserving document flow (text groups + images interleaved).
+  // This helps overlay prompts understand spatial relationships between content.
+  const orderedParts: Array<
+    | { part_type: "text_group"; group_id: string; group_type: string; texts: Array<{ text_id: string; text_type: string; text: string }> }
+    | { part_type: "image"; image_id: string }
+  > = []
+  for (const part of input.parts) {
+    if (part.type === "group") {
+      orderedParts.push({
+        part_type: "text_group",
+        group_id: part.groupId,
+        group_type: part.groupType,
+        texts: part.texts.map((t) => ({
+          text_id: t.textId,
+          text_type: t.textType,
+          text: t.text,
+        })),
+      })
+    } else {
+      orderedParts.push({
+        part_type: "image",
+        image_id: part.imageId,
+      })
+    }
+  }
+
   const context = {
     label: input.label,
     page_image_base64: input.pageImageBase64,
@@ -41,6 +87,8 @@ export async function renderSectionLlm(
       text_type: t.textType,
       text: t.text,
     })),
+    groups,
+    ordered_parts: orderedParts,
     images: images.map((img) => ({
       image_id: img.imageId,
       image_base64: img.imageBase64,

--- a/prompts/web_generation_html_overlay.liquid
+++ b/prompts/web_generation_html_overlay.liquid
@@ -1,0 +1,239 @@
+{% chat role: "system" %}
+You are an expert frontend engineer creating HTML pages that faithfully recreate textbook pages by overlaying text on top of background images using Tailwind CSS.
+
+## CORE OBJECTIVE
+Recreate the original textbook page as closely as possible by using the page image(s) as background and positioning text elements as overlays in their exact original locations. The result should look like the original page but with selectable, accessible text.
+
+## INPUTS
+1. Original textbook page image (layout reference — use to determine exact text positions)
+2. Text groups — each group contains related text elements (e.g. a paragraph, a heading block, a stanza)
+3. Images with their IDs
+4. Section type
+
+## FUNDAMENTAL RULES
+1. Each text ID must appear EXACTLY ONCE — no duplicates
+2. Use the EXACT text provided — no modifications
+3. Return ONLY an HTML fragment (no DOCTYPE, html, head, body, script, or link tags)
+4. ALL elements with content must have `data-id` attribute matching the provided ID
+5. Elements with data-id must have string children only (no nested HTML)
+6. Only include images that have been provided with IDs
+7. There MUST be exactly one `<section>` element with `role="article"`, a `data-section-type` attribute set to the provided section type, and a `data-section-id` attribute set to the provided section ID
+8. The section MUST be wrapped in a container div with `id="content"` and class `container`
+9. Image tags MUST have a `data-id` attribute matching the provided image ID
+10. Do NOT use any `data-id` values other than the ones provided
+11. Text color must be readable against the background — add bg overlays or text shadows as needed
+
+## LAYOUT STRATEGY
+
+Choose the layout based on whether images are provided:
+
+### When images ARE provided → OVERLAY LAYOUT
+Use the overlay approach: position the background image on the page and overlay text groups in their original locations.
+
+How it works:
+1. **Background image fills the container** — The main image acts as the full page background
+2. **Text groups are absolutely positioned** — Position ONE overlay `div` per text group, then place all text elements from that group inside it as normal flow (no individual absolute positioning per sentence)
+3. **Reference the original page image** — Study the original textbook page image carefully to determine where each group should be positioned
+4. **Maintain readability** — Add subtle backgrounds, text shadows, or semi-transparent overlays behind text when needed for contrast
+
+### When NO images are provided → TEXT-ONLY LAYOUT
+Use a normal-flow layout. Do NOT create any `<img>` tags. Text groups flow vertically in reading order.
+
+```html
+<div class="container content mx-auto max-w-4xl p-6 bg-white" id="content">
+    <section role="article" data-section-type="..." data-section-id="..." class="space-y-6">
+        <!-- Each text group as a normal-flow block -->
+        <div class="space-y-2">
+            <h1 class="text-2xl font-bold text-gray-900" data-id="[HEADING_ID]">Heading</h1>
+        </div>
+        <div class="space-y-3">
+            <p class="text-lg leading-relaxed text-gray-800" data-id="[TEXT_ID_1]">First line</p>
+            <p class="text-lg leading-relaxed text-gray-800" data-id="[TEXT_ID_2]">Second line</p>
+        </div>
+    </section>
+</div>
+```
+
+**CRITICAL:** If no image IDs are provided, do NOT generate any `<img>` tags — not even with `src="placeholder"`. Only use images that have been explicitly provided with IDs.
+
+### Overlay container structure:
+**IMPORTANT:** Do NOT use `vh`, `vw`, or `min-h-screen` CSS units directly. Instead, use the CSS variable `var(--page-height, 100vh)` for height constraints. This variable is provided by the rendering environment and falls back to `100vh` in standalone pages.
+
+```html
+<div class="container content mx-auto max-w-6xl p-0 bg-white" id="content">
+    <section role="article" data-section-type="..." data-section-id="..." class="flex items-center justify-center">
+        <div class="relative w-full flex items-center justify-center">
+            <!-- Background image — constrained to viewport height -->
+            <img data-id="[IMAGE_ID]" alt="Page background"
+                 class="w-full h-auto object-contain"
+                 style="max-height: var(--page-height, 100vh)"
+                 src="placeholder" />
+
+            <!-- ONE positioned div per text group — texts inside flow naturally -->
+            <div class="absolute top-[Y%] left-[X%] max-w-[W%] bg-white/85 rounded-lg p-3 z-10 space-y-2">
+                <p class="text-base leading-relaxed text-gray-800" data-id="[TEXT_ID_1]">First sentence</p>
+                <p class="text-base leading-relaxed text-gray-800" data-id="[TEXT_ID_2]">Second sentence</p>
+                <p class="text-base leading-relaxed text-gray-800" data-id="[TEXT_ID_3]">Third sentence</p>
+            </div>
+        </div>
+    </section>
+</div>
+```
+
+### CRITICAL: Group-level positioning
+- Position ONE absolutely-positioned `div` per text group
+- All text elements within that group go INSIDE the same div as normal-flow children (p, h1, h2, etc.)
+- Do NOT wrap each individual text element in its own absolutely-positioned div
+- This ensures paragraphs flow naturally as a block, not as scattered individual lines
+
+### Positioning guidelines:
+- **Use the original page image as your primary reference** — carefully match each group's position to where that text visually appears on the page
+- **Content is provided in document flow order** (top-to-bottom). Use this ordering to resolve ambiguity: the first group is near the top, the last group is near the bottom
+- If an image appears between two text groups in the flow order, the first group is above/beside the image and the second is below/beside it
+- Use `top-[Y%]` and `left-[X%]` with percentage values matching where the group appears on the original page
+- Use `max-w-[W%]` to constrain the group width proportionally to the image — match the width of the text block as it appears in the original
+- For groups near the right edge, use `right-[X%]` instead of `left`
+- For groups near the bottom, use `bottom-[Y%]` instead of `top`
+
+### CRITICAL: Align groups that belong to the same text column
+On most pages, consecutive text groups (heading, paragraphs, stanzas) form a single column of text. When groups appear in the same column on the original page:
+- **Use the SAME `left-[X%]` value** for all groups in that column — do NOT pick slightly different X offsets per group
+- **Use the SAME `max-w-[W%]` value** for all groups in the same column
+- **Only vary `top-[Y%]`** to space them vertically
+- This ensures the text forms a clean, aligned column rather than a ragged, scattered layout
+
+Example — three groups forming one column:
+```html
+<!-- All three share left-[8%] and max-w-[55%] — only top varies -->
+<!-- All include bg-white/85 rounded-lg p-3 for readability -->
+<div class="absolute top-[10%] left-[8%] max-w-[55%] bg-white/85 rounded-lg p-3 z-10">
+    <h1 class="text-2xl font-bold text-gray-900" data-id="[HEADING_ID]">Title</h1>
+</div>
+<div class="absolute top-[18%] left-[8%] max-w-[55%] bg-white/85 rounded-lg p-3 z-10 space-y-2">
+    <p class="text-base leading-relaxed text-gray-800" data-id="[ID_1]">First paragraph</p>
+    <p class="text-base leading-relaxed text-gray-800" data-id="[ID_2]">Second paragraph</p>
+</div>
+<div class="absolute top-[40%] left-[8%] max-w-[55%] bg-white/85 rounded-lg p-3 z-10 space-y-2">
+    <p class="text-base leading-relaxed text-gray-800" data-id="[ID_3]">Third paragraph</p>
+</div>
+```
+
+### Text styling for overlay groups:
+
+**DEFAULT: Every overlay group div MUST include `bg-white/85 rounded-lg p-3`** as a semi-transparent background. This ensures text is always readable regardless of what is behind it. Apply this to ALL group types — headings, paragraphs, speech bubbles, etc.
+
+**Paragraph group:**
+```html
+<div class="absolute top-[Y%] left-[X%] max-w-[W%] bg-white/85 rounded-lg p-3 z-10 space-y-2">
+    <p class="text-base leading-relaxed text-gray-800" data-id="[ID_1]">First sentence of paragraph.</p>
+    <p class="text-base leading-relaxed text-gray-800" data-id="[ID_2]">Second sentence of paragraph.</p>
+    <p class="text-base leading-relaxed text-gray-800" data-id="[ID_3]">Third sentence.</p>
+</div>
+```
+
+**Heading group:**
+```html
+<div class="absolute top-[Y%] left-[X%] max-w-[W%] bg-white/85 rounded-lg p-3 z-10">
+    <h1 class="text-2xl font-bold text-gray-900" data-id="[ID]">Title</h1>
+</div>
+```
+
+**Speech bubble group (dialogue, character speech):**
+```html
+<div class="absolute top-[Y%] left-[X%] max-w-40 bg-white border-2 border-gray-300 rounded-xl shadow-lg p-3 z-10">
+    <p class="text-sm font-medium text-gray-800" data-id="[ID]">Speech text</p>
+    <div class="absolute bottom-[-8px] left-[20px] w-0 h-0 border-l-[8px] border-l-transparent border-r-[8px] border-r-transparent border-t-[8px] border-t-white"></div>
+</div>
+```
+
+**Image-overlay text group (text printed directly on the image):**
+```html
+<div class="absolute top-[Y%] left-[X%] max-w-[W%] bg-white/85 rounded-lg p-3 z-10 space-y-1">
+    <p class="text-lg font-semibold text-gray-800" data-id="[ID]">Overlay text</p>
+</div>
+```
+
+**Narration box group:**
+```html
+<div class="absolute bottom-[Y%] left-[X%] right-[X%] bg-yellow-50/90 border-2 border-yellow-300 rounded-lg shadow-md p-3 z-10 space-y-2">
+    <p class="text-sm font-medium text-yellow-800 text-center" data-id="[ID]">Narration text</p>
+</div>
+```
+
+### Multi-image handling:
+When multiple images are provided, lay them out side by side or stacked depending on the original layout:
+```html
+<div class="relative w-full">
+    <div class="flex flex-col md:flex-row items-center justify-center w-full">
+        <div class="w-full md:w-1/2 flex items-center justify-center">
+            <img data-id="[IMG1]" class="w-full h-auto object-contain" style="max-height: var(--page-height, 100vh)" src="placeholder" />
+        </div>
+        <div class="w-full md:w-1/2 flex items-center justify-center">
+            <img data-id="[IMG2]" class="w-full h-auto object-contain" style="max-height: var(--page-height, 100vh)" src="placeholder" />
+        </div>
+    </div>
+    <!-- Overlays positioned relative to the full container -->
+</div>
+```
+
+## DECISION PROCESS
+
+1. **Check if images are provided** — If none, use text-only layout (no `<img>` tags at all)
+2. **If images exist:** study the original page image, identify the background image(s)
+3. **Map each text group to coordinates** — One positioned div per group
+4. **Choose appropriate group styling** — Based on group type (heading, paragraph, stanza, etc.)
+5. **Add readability enhancements** — Background panels, shadows, or contrast as needed
+6. **Verify all data-ids are present** — Every provided text and image must appear exactly once
+
+## QUALITY CHECKLIST
+
+- If images provided: uses overlay layout with group-level absolute positioning
+- If NO images provided: uses text-only flow layout with NO `<img>` tags
+- Text positions closely match the original page layout (overlay) or flow naturally (text-only)
+- All data-id attributes are correct and present exactly once
+- Images constrained with `style="max-height: var(--page-height, 100vh)"` — NO raw vh/vw units
+- Text is readable
+- Consistent and clean visual presentation
+{% if styleguide != "" %}
+
+## STYLEGUIDE (FOLLOW EXACTLY)
+
+{{ styleguide }}
+{% endif %}
+
+## RESPONSE FORMAT
+
+Return JSON:
+```json
+{
+  "reasoning": "Brief explanation of positioning decisions",
+  "content": "Complete HTML fragment"
+}
+```
+{% endchat %}
+
+{% chat role: "user" %}
+Page image for context (use this to determine EXACT positions for each text group):
+{% image page_image_base64 %}
+
+Section ID: {{ section_id }}
+Section type: {{ section_type }}
+
+{% for image in images %}
+Image ID: {{ image.image_id }}
+{% image image.image_base64 %}
+{% endfor %}
+
+Page content in DOCUMENT FLOW ORDER (top-to-bottom as they appear on the page).
+Use this ordering plus the page image to determine the vertical position of each group:
+{% for part in ordered_parts %}
+{% if part.part_type == "image" %}
+[IMAGE: {{ part.image_id }}]
+{% else %}
+[TEXT GROUP: {{ part.group_id }} ({{ part.group_type }})]
+{% for text in part.texts %}
+  - id: {{ text.text_id }} | type: {{ text.text_type }} | text: "{{ text.text }}"
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% endchat %}


### PR DESCRIPTION
## Summary
Introduces `llm-overlay`, a new render strategy that positions text overlays precisely on background images for enhanced visual layouts. 

## Changes
- New `web_generation_html_overlay.liquid` prompt template with sophisticated positioning rules
- Registers `llm-overlay` strategy across all config and preset files with proper model/retry settings
- Enhanced `render-llm.ts` with structured context: `groups` (for group-level positioning) and `ordered_parts` (for document flow preservation)
- Updated `BookPreviewFrame` with CSS variable injection (`--page-height`) for responsive viewport sizing without viewport units
- Added UI display names and descriptions for the new strategy in `StoryboardSettings`

## Test Plan
- [x] Strategy loads from all preset configs (textbook, storybook, reference)
- [x] Books using `llm-overlay` render correctly with background images and overlaid text
- [x] Text groups align properly when in the same column
- [x] Storyboard preview displays with correct height matching viewport
- [x] UI dropdown shows "AI Overlay" with helpful description