### PR TITLE
Add section-level clone/rerender flow and stricter HTML packaging

### DIFF
--- a/apps/api/src/routes/adt-preview.test.ts
+++ b/apps/api/src/routes/adt-preview.test.ts
@@ -1,0 +1,186 @@
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import { createBookStorage } from "@adt/storage"
+import { createAdtPreviewRoutes } from "./adt-preview.js"
+
+describe("ADT preview routes", () => {
+  let tmpDir: string
+  let webAssetsDir: string
+  const label = "preview-book"
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "adt-preview-route-"))
+    webAssetsDir = fs.mkdtempSync(path.join(os.tmpdir(), "adt-preview-assets-"))
+    fs.writeFileSync(path.join(webAssetsDir, "base.bundle.min.js"), "console.log('ok')")
+
+    const storage = createBookStorage(label, tmpDir)
+    try {
+      storage.putExtractedPage({
+        pageId: `${label}_p1`,
+        pageNumber: 1,
+        text: "Page one",
+        pageImage: {
+          imageId: `${label}_p1_page`,
+          buffer: Buffer.from("fake-png-data"),
+          format: "png",
+          hash: "hash-1",
+          width: 100,
+          height: 100,
+        },
+        images: [],
+      })
+
+      storage.putNodeData("metadata", "book", {
+        title: "Preview Book",
+        language_code: "en",
+        reasoning: "test",
+      })
+      storage.putNodeData("config", "book", { language: "en" })
+      storage.putNodeData("page-sectioning", `${label}_p1`, {
+        reasoning: "ok",
+        sections: [
+          {
+            sectionId: `${label}_p1_sec001`,
+            sectionType: "content",
+            parts: [],
+            backgroundColor: "#fff",
+            textColor: "#000",
+            pageNumber: 1,
+            isPruned: false,
+          },
+          {
+            sectionId: `${label}_p1_sec002`,
+            sectionType: "content",
+            parts: [],
+            backgroundColor: "#fff",
+            textColor: "#000",
+            pageNumber: 1,
+            isPruned: false,
+          },
+        ],
+      })
+      storage.putNodeData("web-rendering", `${label}_p1`, {
+        sections: [
+          {
+            sectionIndex: 0,
+            sectionType: "content",
+            reasoning: "ok",
+            html: `<section data-section-id="${label}_p1_sec001"><p>First section body</p></section>`,
+          },
+          {
+            sectionIndex: 1,
+            sectionType: "content",
+            reasoning: "ok",
+            html: `<section data-section-id="${label}_p1_sec002"><p>Second section body</p></section>`,
+          },
+        ],
+      })
+    } finally {
+      storage.close()
+    }
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+    fs.rmSync(webAssetsDir, { recursive: true, force: true })
+  })
+
+  it("renders the requested section id instead of falling back to the first section", async () => {
+    const app = createAdtPreviewRoutes(tmpDir, webAssetsDir, path.resolve(process.cwd(), "config.yaml"))
+    const res = await app.request(`/books/${label}/adt-preview/${label}_p1_sec002.html`)
+
+    expect(res.status).toBe(200)
+    const html = await res.text()
+    expect(html).toContain("Second section body")
+    expect(html).not.toContain("First section body")
+  })
+
+  it("returns 404 for unknown section ids on an existing page", async () => {
+    const app = createAdtPreviewRoutes(tmpDir, webAssetsDir, path.resolve(process.cwd(), "config.yaml"))
+    const res = await app.request(`/books/${label}/adt-preview/${label}_p1_sec999.html`)
+
+    expect(res.status).toBe(404)
+  })
+
+  it("includes quiz pages anchored to pages without rendered sections in pages.json", async () => {
+    const storage = createBookStorage(label, tmpDir)
+    try {
+      storage.putExtractedPage({
+        pageId: `${label}_p2`,
+        pageNumber: 2,
+        text: "Page two",
+        pageImage: {
+          imageId: `${label}_p2_page`,
+          buffer: Buffer.from("fake-png-data-2"),
+          format: "png",
+          hash: "hash-2",
+          width: 100,
+          height: 100,
+        },
+        images: [],
+      })
+      storage.putNodeData("quiz-generation", "book", {
+        generatedAt: "2026-01-01T00:00:00.000Z",
+        language: "en",
+        pagesPerQuiz: 3,
+        quizzes: [
+          {
+            quizIndex: 0,
+            afterPageId: `${label}_p2`,
+            pageIds: [`${label}_p2`],
+            question: "What is 2+2?",
+            options: [
+              { text: "3", explanation: "Nope" },
+              { text: "4", explanation: "Yes" },
+            ],
+            answerIndex: 1,
+            reasoning: "test",
+          },
+        ],
+      })
+    } finally {
+      storage.close()
+    }
+
+    const app = createAdtPreviewRoutes(tmpDir, webAssetsDir, path.resolve(process.cwd(), "config.yaml"))
+    const res = await app.request(`/books/${label}/adt-preview/content/pages.json`)
+
+    expect(res.status).toBe(200)
+    const pages = await res.json() as Array<{ section_id: string; href: string }>
+    expect(pages.at(-1)).toEqual({ section_id: "qz001", href: "qz001.html" })
+  })
+
+  it("orders pages.json sections by sectionIndex when rendering rows are out of order", async () => {
+    const storage = createBookStorage(label, tmpDir)
+    try {
+      storage.putNodeData("web-rendering", `${label}_p1`, {
+        sections: [
+          {
+            sectionIndex: 1,
+            sectionType: "content",
+            reasoning: "ok",
+            html: `<section data-section-id="${label}_p1_sec002"><p>Second section body</p></section>`,
+          },
+          {
+            sectionIndex: 0,
+            sectionType: "content",
+            reasoning: "ok",
+            html: `<section data-section-id="${label}_p1_sec001"><p>First section body</p></section>`,
+          },
+        ],
+      })
+    } finally {
+      storage.close()
+    }
+
+    const app = createAdtPreviewRoutes(tmpDir, webAssetsDir, path.resolve(process.cwd(), "config.yaml"))
+    const res = await app.request(`/books/${label}/adt-preview/content/pages.json`)
+
+    expect(res.status).toBe(200)
+    const pages = await res.json() as Array<{ section_id: string; href: string }>
+    expect(pages[0]).toEqual({ section_id: `${label}_p1_sec001`, href: `${label}_p1_sec001.html`, page_number: 1 })
+    expect(pages[1]).toEqual({ section_id: `${label}_p1_sec002`, href: `${label}_p1_sec002.html`, page_number: 1 })
+  })
+})

--- a/apps/api/src/routes/adt-preview.ts
+++ b/apps/api/src/routes/adt-preview.ts
@@ -5,6 +5,7 @@ import { HTTPException } from "hono/http-exception"
 import { parseBookLabel } from "@adt/types"
 import {
   WebRenderingOutput,
+  PageSectioningOutput,
   type TextCatalogOutput,
   type GlossaryOutput,
   type QuizGenerationOutput,
@@ -14,7 +15,6 @@ import {
 import { createBookStorage, type Storage } from "@adt/storage"
 import {
   renderPageHtml,
-  combineSections,
   NAV_HTML,
   buildPreviewTailwindCss,
   buildGlossaryJson,
@@ -122,8 +122,8 @@ function buildTextsMap(
   return textsMap
 }
 
-/** Build the pages.json manifest from all rendered pages, interleaving quiz pages */
-function buildPagesManifest(storage: Storage): Array<{ section_id: string; href: string }> {
+/** Build the pages.json manifest — one entry per rendered section, interleaving quiz pages */
+function buildPagesManifest(storage: Storage): Array<{ section_id: string; href: string; page_number?: number }> {
   const pages = storage.getPages()
   const quizData = getQuizData(storage)
 
@@ -137,14 +137,35 @@ function buildPagesManifest(storage: Storage): Array<{ section_id: string; href:
     }
   }
 
-  const list: Array<{ section_id: string; href: string }> = []
+  const list: Array<{ section_id: string; href: string; page_number?: number }> = []
   for (const page of pages) {
     const renderRow = storage.getLatestNodeData("web-rendering", page.pageId)
-    if (!renderRow) continue
-    const parsed = WebRenderingOutput.safeParse(renderRow.data)
-    if (!parsed.success || parsed.data.sections.length === 0) continue
+    if (renderRow) {
+      const parsed = WebRenderingOutput.safeParse(renderRow.data)
+      if (parsed.success && parsed.data.sections.length > 0) {
+        // Get sectioning data for sectionIds and page numbers
+        const sectioningRow = storage.getLatestNodeData("page-sectioning", page.pageId)
+        const sectioningParsed = sectioningRow
+          ? PageSectioningOutput.safeParse(sectioningRow.data)
+          : null
+        const sectioning = sectioningParsed?.success ? sectioningParsed.data : undefined
 
-    list.push({ section_id: page.pageId, href: `${page.pageId}.html` })
+        // One entry per rendered section (stable by sectionIndex)
+        const sections = [...parsed.data.sections].sort((a, b) => a.sectionIndex - b.sectionIndex)
+        for (const rs of sections) {
+          const sectionMeta = sectioning?.sections?.[rs.sectionIndex]
+          const sectionId = sectionMeta?.sectionId ?? `${page.pageId}_sec${String(rs.sectionIndex + 1).padStart(3, "0")}`
+          const entry: { section_id: string; href: string; page_number?: number } = {
+            section_id: sectionId,
+            href: `${sectionId}.html`,
+          }
+          if (sectionMeta?.pageNumber !== null && sectionMeta?.pageNumber !== undefined) {
+            entry.page_number = sectionMeta.pageNumber
+          }
+          list.push(entry)
+        }
+      }
+    }
 
     // Insert quiz pages after this page
     const quizzes = quizzesByAfterPageId.get(page.pageId)
@@ -309,8 +330,9 @@ export function createAdtPreviewRoutes(
         if (renderRow) {
           const parsed = WebRenderingOutput.safeParse(renderRow.data)
           if (parsed.success) {
-            const { html } = combineSections(parsed.data)
-            allHtml += html + "\n"
+            for (const section of parsed.data.sections) {
+              allHtml += section.html + "\n"
+            }
           }
         }
       }
@@ -484,10 +506,18 @@ export function createAdtPreviewRoutes(
         return c.body(html)
       }
 
-      // Regular content page
-      const renderRow = storage.getLatestNodeData("web-rendering", pageId)
+      // Content page — require sectionId format (e.g. pg001_sec001).
+      // This prevents ambiguous fallback to unrelated sections.
+      const sectionIdMatch = pageId.match(/^(.+)_sec(\d{3})$/)
+      if (!sectionIdMatch) {
+        throw new HTTPException(404, { message: `Section not found: ${pageId}` })
+      }
+      const ownerPageId = sectionIdMatch[1]
+      const fallbackSectionIndex = parseInt(sectionIdMatch[2], 10) - 1
+
+      const renderRow = storage.getLatestNodeData("web-rendering", ownerPageId)
       if (!renderRow) {
-        throw new HTTPException(404, { message: `No rendering data for page: ${pageId}` })
+        throw new HTTPException(404, { message: `No rendering data for page: ${ownerPageId}` })
       }
 
       const parsed = WebRenderingOutput.safeParse(renderRow.data)
@@ -495,19 +525,32 @@ export function createAdtPreviewRoutes(
         throw new HTTPException(500, { message: "Invalid rendering data" })
       }
 
-      const { html: sectionHtml, activityAnswers } = combineSections(parsed.data)
+      // Get sectioning to look up sectionId → sectionIndex mapping
+      const sectioningRow = storage.getLatestNodeData("page-sectioning", ownerPageId)
+      const sectioningParsed = sectioningRow
+        ? PageSectioningOutput.safeParse(sectioningRow.data)
+        : null
+      const resolvedIndex = sectioningParsed?.success
+        ? sectioningParsed.data.sections.findIndex((s) => s.sectionId === pageId)
+        : -1
+      const targetSectionIndex = resolvedIndex >= 0 ? resolvedIndex : fallbackSectionIndex
+      const renderedSection = parsed.data.sections.find((s) => s.sectionIndex === targetSectionIndex)
+
+      if (!renderedSection || targetSectionIndex < 0) {
+        throw new HTTPException(404, { message: `Section not found: ${pageId}` })
+      }
 
       // Determine page index from manifest (includes quiz pages)
       const manifest = buildPagesManifest(storage)
       const manifestIndex = manifest.findIndex((e) => e.section_id === pageId)
 
       const html = renderPageHtml({
-        content: sectionHtml,
+        content: renderedSection.html,
         language,
         sectionId: pageId,
         pageTitle: title,
         pageIndex: manifestIndex >= 0 ? manifestIndex + 1 : 1,
-        activityAnswers,
+        activityAnswers: renderedSection.activityAnswers,
         hasMath: false,
         bundleVersion: "1",
         applyBodyBackground,

--- a/apps/api/src/routes/pages.test.ts
+++ b/apps/api/src/routes/pages.test.ts
@@ -73,7 +73,13 @@ describe("Page routes", () => {
           {
             sectionId: `${label}_p1_sec001`,
             sectionType: "content",
-            parts: [{ type: "text_group", groupId: "g1", groupType: "paragraph", texts: [{ textType: "section_text", text: "Hello world", isPruned: false }], isPruned: false }],
+            parts: [{
+              type: "text_group",
+              groupId: "g1",
+              groupType: "paragraph",
+              texts: [{ textId: "g1_tx001", textType: "section_text", text: "Hello world", isPruned: false }],
+              isPruned: false,
+            }],
             backgroundColor: "#ffffff",
             textColor: "#000000",
             pageNumber: 1,
@@ -297,6 +303,88 @@ describe("Page routes", () => {
       expect(res.status).toBe(400)
       const body = await res.json()
       expect(body.error).toContain("X-OpenAI-Key")
+    })
+
+    it("returns 400 when sectionIndex query is out of range", async () => {
+      const res = await app.request(
+        `/api/books/${label}/pages/${label}_p1/re-render?sectionIndex=99`,
+        {
+          method: "POST",
+          headers: { "X-OpenAI-Key": "sk-test" },
+        }
+      )
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error).toContain("out of range")
+    })
+  })
+
+  describe("POST /api/books/:label/pages/:pageId/sections/:sectionIndex/clone", () => {
+    it("clones sectioning and rendering for a valid section index", async () => {
+      const res = await app.request(
+        `/api/books/${label}/pages/${label}_p1/sections/0/clone`,
+        { method: "POST" }
+      )
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.clonedSectionIndex).toBe(1)
+
+      const storage = createBookStorage(label, tmpDir)
+      try {
+        const sectioningRow = storage.getLatestNodeData("page-sectioning", `${label}_p1`)
+        const renderingRow = storage.getLatestNodeData("web-rendering", `${label}_p1`)
+
+        const sectioning = sectioningRow?.data as {
+          sections: Array<{ sectionId: string }>
+        }
+        const rendering = renderingRow?.data as {
+          sections: Array<{ sectionIndex: number }>
+        }
+
+        expect(sectioning.sections).toHaveLength(2)
+        expect(sectioning.sections[0].sectionId).toBe(`${label}_p1_sec001`)
+        expect(sectioning.sections[1].sectionId).toBe(`${label}_p1_sec002`)
+
+        expect(rendering.sections).toHaveLength(2)
+        expect(rendering.sections[0].sectionIndex).toBe(0)
+        expect(rendering.sections[1].sectionIndex).toBe(1)
+      } finally {
+        storage.close()
+      }
+    })
+
+    it("returns 400 for invalid section index param", async () => {
+      const res = await app.request(
+        `/api/books/${label}/pages/${label}_p1/sections/not-a-number/clone`,
+        { method: "POST" }
+      )
+      expect(res.status).toBe(400)
+    })
+
+    it("fails before writing sectioning when rendering payload is invalid", async () => {
+      const storage = createBookStorage(label, tmpDir)
+      try {
+        storage.putNodeData("web-rendering", `${label}_p1`, { bad: "payload" })
+      } finally {
+        storage.close()
+      }
+
+      const res = await app.request(
+        `/api/books/${label}/pages/${label}_p1/sections/0/clone`,
+        { method: "POST" }
+      )
+      expect(res.status).toBe(400)
+
+      const verifyStorage = createBookStorage(label, tmpDir)
+      try {
+        const sectioningRow = verifyStorage.getLatestNodeData("page-sectioning", `${label}_p1`)
+        const sectioning = sectioningRow?.data as { sections: unknown[] }
+        expect(sectioning.sections).toHaveLength(1)
+      } finally {
+        verifyStorage.close()
+      }
     })
   })
 

--- a/apps/api/src/routes/pages.ts
+++ b/apps/api/src/routes/pages.ts
@@ -410,6 +410,18 @@ export function createPageRoutes(
   app.post("/books/:label/pages/:pageId/re-render", async (c) => {
     const { label, pageId } = c.req.param()
     const safeLabel = parseBookLabel(label)
+    const ReRenderQuery = z.object({
+      sectionIndex: z.coerce.number().int().min(0).optional(),
+    })
+    const queryParsed = ReRenderQuery.safeParse({
+      sectionIndex: c.req.query("sectionIndex"),
+    })
+    if (!queryParsed.success) {
+      throw new HTTPException(400, {
+        message: `Invalid query params: ${queryParsed.error.issues.map((i) => i.message).join(", ")}`,
+      })
+    }
+    const { sectionIndex } = queryParsed.data
 
     const apiKey = c.req.header("X-OpenAI-Key")
     if (!apiKey) {
@@ -425,6 +437,24 @@ export function createPageRoutes(
       if (!page) {
         throw new HTTPException(404, { message: `Page not found: ${pageId}` })
       }
+
+      if (sectionIndex !== undefined) {
+        const sectioningRow = storage.getLatestNodeData("page-sectioning", pageId)
+        if (!sectioningRow) {
+          throw new HTTPException(400, {
+            message: "Page must have page-sectioning data before re-rendering",
+          })
+        }
+        const sectioningParsed = PageSectioningOutput.safeParse(sectioningRow.data)
+        if (!sectioningParsed.success) {
+          throw new HTTPException(400, { message: "Invalid page-sectioning data" })
+        }
+        if (sectionIndex >= sectioningParsed.data.sections.length) {
+          throw new HTTPException(400, {
+            message: `Section index ${sectionIndex} out of range (page has ${sectioningParsed.data.sections.length} sections)`,
+          })
+        }
+      }
     } finally {
       storage.close()
     }
@@ -432,6 +462,7 @@ export function createPageRoutes(
     const result = await reRenderPage({
       label: safeLabel,
       pageId,
+      sectionIndex,
       booksDir,
       promptsDir,
       configPath,
@@ -475,6 +506,114 @@ export function createPageRoutes(
     })
 
     return c.json(result)
+  })
+
+  // POST /books/:label/pages/:pageId/sections/:sectionIndex/clone — Duplicate a section
+  app.post("/books/:label/pages/:pageId/sections/:sectionIndex/clone", async (c) => {
+    const CloneSectionParams = z.object({
+      label: z.string().min(1),
+      pageId: z.string().min(1),
+      sectionIndex: z.coerce.number().int().min(0),
+    })
+    const parsedParams = CloneSectionParams.safeParse(c.req.param())
+    if (!parsedParams.success) {
+      throw new HTTPException(400, {
+        message: `Invalid route params: ${parsedParams.error.issues.map((i) => i.message).join(", ")}`,
+      })
+    }
+    const { label, pageId, sectionIndex: idx } = parsedParams.data
+    const safeLabel = parseBookLabel(label)
+
+    const storage = createBookStorage(safeLabel, booksDir)
+    try {
+      const pages = storage.getPages()
+      if (!pages.find((p) => p.pageId === pageId)) {
+        throw new HTTPException(404, { message: `Page not found: ${pageId}` })
+      }
+
+      // Read latest sectioning
+      const sectioningRow = storage.getLatestNodeData("page-sectioning", pageId)
+      if (!sectioningRow) {
+        throw new HTTPException(400, { message: "Page has no sectioning data" })
+      }
+      const sectioningParsed = PageSectioningOutput.safeParse(sectioningRow.data)
+      if (!sectioningParsed.success) {
+        throw new HTTPException(400, { message: "Invalid page-sectioning data" })
+      }
+      const sectioning = sectioningParsed.data
+
+      if (idx >= sectioning.sections.length) {
+        throw new HTTPException(400, { message: `Section index ${idx} out of range (page has ${sectioning.sections.length} sections)` })
+      }
+
+      // Clone the section and insert after the original
+      const clonedSection = structuredClone(sectioning.sections[idx])
+      const newSections = [...sectioning.sections]
+      newSections.splice(idx + 1, 0, clonedSection)
+
+      // Renumber all sectionIds to maintain {pageId}_sec{NNN} convention
+      for (let i = 0; i < newSections.length; i++) {
+        newSections[i].sectionId = `${pageId}_sec${String(i + 1).padStart(3, "0")}`
+      }
+
+      const updatedSectioning = { ...sectioning, sections: newSections }
+
+      // Clone rendering if present
+      let updatedRendering: z.infer<typeof WebRenderingOutput> | null = null
+      let renderingVersion: number | null = null
+      const renderingRow = storage.getLatestNodeData("web-rendering", pageId)
+      if (renderingRow) {
+        const renderingParsed = WebRenderingOutput.safeParse(renderingRow.data)
+        if (!renderingParsed.success) {
+          throw new HTTPException(400, { message: "Invalid web-rendering data" })
+        }
+        const rendering = renderingParsed.data
+
+        // Shift sectionIndex for entries after the cloned position
+        const shifted = rendering.sections.map((s) =>
+          s.sectionIndex > idx ? { ...s, sectionIndex: s.sectionIndex + 1 } : { ...s }
+        )
+
+        // Clone the rendering entry for the source section
+        const sourceRendering = shifted.find((s) => s.sectionIndex === idx)
+        if (sourceRendering) {
+          const clonedRendering = structuredClone(sourceRendering)
+          clonedRendering.sectionIndex = idx + 1
+
+          // Insert clone after the source in the array
+          const insertPos = shifted.indexOf(sourceRendering) + 1
+          shifted.splice(insertPos, 0, clonedRendering)
+        }
+
+        // Update data-section-id in each rendering's HTML to match new sectionIds
+        for (const rs of shifted) {
+          if (rs.sectionIndex < 0 || rs.sectionIndex >= newSections.length) {
+            throw new HTTPException(400, { message: "Rendering contains invalid section indexes" })
+          }
+          const expectedId = newSections[rs.sectionIndex]?.sectionId
+          if (!expectedId) {
+            throw new HTTPException(400, { message: "Unable to map rendering section to sectionId" })
+          }
+          rs.html = rs.html.replace(
+            /data-section-id="[^"]*"/,
+            `data-section-id="${expectedId}"`
+          )
+        }
+        updatedRendering = { sections: shifted }
+      }
+      const sectioningVersion = storage.putNodeData("page-sectioning", pageId, updatedSectioning)
+      if (updatedRendering) {
+        renderingVersion = storage.putNodeData("web-rendering", pageId, updatedRendering)
+      }
+
+      return c.json({
+        clonedSectionIndex: idx + 1,
+        sectioningVersion,
+        renderingVersion,
+      })
+    } finally {
+      storage.close()
+    }
   })
 
   // POST /books/:label/images/ai-generate — Generate image via gpt-image-1.5

--- a/apps/api/src/services/page-edit-service.test.ts
+++ b/apps/api/src/services/page-edit-service.test.ts
@@ -1,9 +1,21 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
 import fs from "node:fs"
 import path from "node:path"
 import os from "node:os"
 import { createBookStorage } from "@adt/storage"
-import { reRenderPage } from "./page-edit-service.js"
+
+const llmMocks = vi.hoisted(() => ({
+  generateObject: vi.fn(),
+  createLLMModel: vi.fn(),
+  createPromptEngine: vi.fn(),
+}))
+
+vi.mock("@adt/llm", () => ({
+  createLLMModel: llmMocks.createLLMModel,
+  createPromptEngine: llmMocks.createPromptEngine,
+}))
+
+import { reRenderPage, aiEditSection } from "./page-edit-service.js"
 
 describe("page-edit-service", () => {
   let tmpDir: string
@@ -11,6 +23,13 @@ describe("page-edit-service", () => {
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "page-edit-svc-"))
+    llmMocks.generateObject.mockReset()
+    llmMocks.createLLMModel.mockReset()
+    llmMocks.createPromptEngine.mockReset()
+    llmMocks.createPromptEngine.mockReturnValue({} as never)
+    llmMocks.createLLMModel.mockReturnValue({
+      generateObject: llmMocks.generateObject,
+    } as never)
 
     // Create a book with extracted pages but no pipeline data
     const storage = createBookStorage(label, tmpDir)
@@ -28,7 +47,24 @@ describe("page-edit-service", () => {
         pageNumber: 1,
         text: "Page one text content",
         pageImage: fakeImage,
-        images: [],
+        images: [
+          {
+            imageId: `${label}_p1_im001`,
+            buffer: Buffer.from("fake-image-1"),
+            format: "png" as const,
+            hash: "img-1",
+            width: 320,
+            height: 240,
+          },
+          {
+            imageId: `${label}_p1_im002`,
+            buffer: Buffer.from("fake-image-2"),
+            format: "png" as const,
+            hash: "img-2",
+            width: 320,
+            height: 240,
+          },
+        ],
       })
     } finally {
       storage.close()
@@ -52,6 +88,150 @@ describe("page-edit-service", () => {
       ).rejects.toThrow(
         "Page must have page-sectioning data before re-rendering"
       )
+    })
+
+    it("re-renders only the requested section index and merges it", async () => {
+      const pageId = `${label}_p1`
+      const storage = createBookStorage(label, tmpDir)
+      try {
+        storage.putNodeData("page-sectioning", pageId, {
+          reasoning: "ok",
+          sections: [
+            {
+              sectionId: `${pageId}_sec001`,
+              sectionType: "content",
+              parts: [{ type: "image", imageId: `${pageId}_im001`, isPruned: false }],
+              backgroundColor: "#fff",
+              textColor: "#000",
+              pageNumber: 1,
+              isPruned: false,
+            },
+            {
+              sectionId: `${pageId}_sec002`,
+              sectionType: "content",
+              parts: [{ type: "image", imageId: `${pageId}_im002`, isPruned: false }],
+              backgroundColor: "#fff",
+              textColor: "#000",
+              pageNumber: 1,
+              isPruned: false,
+            },
+          ],
+        })
+        storage.putNodeData("web-rendering", pageId, {
+          sections: [
+            {
+              sectionIndex: 0,
+              sectionType: "content",
+              reasoning: "old",
+              html: "<section data-section-id=\"test-book_p1_sec001\"><p>old-sec1</p></section>",
+            },
+            {
+              sectionIndex: 1,
+              sectionType: "content",
+              reasoning: "old",
+              html: "<section data-section-id=\"test-book_p1_sec002\"><p>old-sec2</p></section>",
+            },
+          ],
+        })
+      } finally {
+        storage.close()
+      }
+      fs.writeFileSync(
+        path.join(tmpDir, label, "config.yaml"),
+        "default_render_strategy: llm\n"
+      )
+
+      llmMocks.generateObject.mockImplementation(async (opts: unknown) => {
+        const context = (opts as {
+          context: {
+            section_id: string
+            section_type: string
+            images: Array<{ image_id: string }>
+          }
+        }).context
+        const sectionId = context.section_id
+        const sectionType = context.section_type
+        const imageId = context.images[0]?.image_id
+        return {
+          object: {
+            reasoning: "rerendered",
+            content: `<div id="content" class="container"><section role="article" data-section-type="${sectionType}" data-section-id="${sectionId}"><img data-id="${imageId}" src="/api/books/${label}/images/${imageId}" alt="img" /></section></div>`,
+          },
+        } as never
+      })
+
+      const result = await reRenderPage({
+        label,
+        pageId,
+        sectionIndex: 1,
+        booksDir: tmpDir,
+        promptsDir: tmpDir,
+        configPath: path.resolve(process.cwd(), "config.yaml"),
+        apiKey: "test-key",
+      })
+
+      expect(llmMocks.generateObject).toHaveBeenCalledTimes(1)
+      const rendering = result.rendering as {
+        sections: Array<{ sectionIndex: number; html: string }>
+      }
+      expect(rendering.sections).toHaveLength(2)
+      expect(rendering.sections.find((s) => s.sectionIndex === 0)?.html).toContain("old-sec1")
+      expect(rendering.sections.find((s) => s.sectionIndex === 1)?.html).toContain(`${pageId}_im002`)
+      expect(rendering.sections.find((s) => s.sectionIndex === 1)?.html).not.toContain(`${pageId}_im001`)
+    })
+  })
+
+  describe("aiEditSection", () => {
+    it("resolves section by sectionIndex value instead of array position", async () => {
+      const pageId = `${label}_p1`
+      const storage = createBookStorage(label, tmpDir)
+      try {
+        storage.putNodeData("web-rendering", pageId, {
+          sections: [
+            {
+              sectionIndex: 0,
+              sectionType: "content",
+              reasoning: "ok",
+              html: `<section data-id="first"><img data-id="img-first" src="/api/books/${label}/images/img-first" /></section>`,
+            },
+            {
+              sectionIndex: 2,
+              sectionType: "content",
+              reasoning: "ok",
+              html: `<section data-id="dup"><img data-id="img-dup" src="/api/books/${label}/images/img-dup" /></section>`,
+            },
+          ],
+        })
+      } finally {
+        storage.close()
+      }
+
+      let capturedHtml = ""
+      llmMocks.generateObject.mockImplementation(async (opts: unknown) => {
+        const context = (opts as { context: { current_html: string } }).context
+        capturedHtml = context.current_html
+        return {
+          object: {
+            reasoning: "ok",
+            content: context.current_html,
+          },
+        } as never
+      })
+
+      const result = await aiEditSection({
+        label,
+        pageId,
+        sectionIndex: 2,
+        instruction: "Keep layout and wording",
+        booksDir: tmpDir,
+        promptsDir: tmpDir,
+        configPath: path.resolve(process.cwd(), "config.yaml"),
+        apiKey: "test-key",
+      })
+
+      expect(capturedHtml).toContain("img-dup")
+      expect(capturedHtml).not.toContain("img-first")
+      expect(result.html).toContain("img-dup")
     })
   })
 })

--- a/apps/api/src/services/page-edit-service.ts
+++ b/apps/api/src/services/page-edit-service.ts
@@ -4,12 +4,12 @@ import { createLLMModel, createPromptEngine } from "@adt/llm"
 import type { LLMModel } from "@adt/llm"
 import { renderPage, buildRenderStrategyResolver, createTemplateEngine, loadBookConfig } from "@adt/pipeline"
 import { loadStyleguideContent } from "./styleguide.js"
-import type { PageSectioningOutput, WebRenderingOutput } from "@adt/types"
-import { webRenderingLLMSchema } from "@adt/types"
+import { PageSectioningOutput, WebRenderingOutput, webRenderingLLMSchema } from "@adt/types"
 
 export interface ReRenderOptions {
   label: string
   pageId: string
+  sectionIndex?: number
   booksDir: string
   promptsDir: string
   configPath?: string
@@ -42,7 +42,7 @@ export interface AiEditSectionResult {
 export async function reRenderPage(
   options: ReRenderOptions
 ): Promise<ReRenderResult> {
-  const { label, pageId, booksDir, promptsDir, configPath, apiKey } = options
+  const { label, pageId, sectionIndex, booksDir, promptsDir, configPath, apiKey } = options
 
   // Set API key
   const previousKey = process.env.OPENAI_API_KEY
@@ -60,7 +60,11 @@ export async function reRenderPage(
       )
     }
 
-    const sectioning = sectionRow.data as PageSectioningOutput
+    const sectioningParsed = PageSectioningOutput.safeParse(sectionRow.data)
+    if (!sectioningParsed.success) {
+      throw new Error("Invalid page-sectioning data")
+    }
+    const sectioning = sectioningParsed.data
 
     // Build image map (all page images — expandParts filters by pruned status)
     const allImages = storage.getPageImages(pageId)
@@ -98,13 +102,28 @@ export async function reRenderPage(
     // Get page image
     const pageImageBase64 = storage.getPageImageBase64(pageId)
 
-    // Render page
+    if (sectionIndex !== undefined && (sectionIndex < 0 || sectionIndex >= sectioning.sections.length)) {
+      throw new Error(`Section index ${sectionIndex} out of range`)
+    }
+
+    // Render either a single section (preferred) or the full page.
+    // For section re-render we force all other sections to pruned in-memory so
+    // renderPage preserves the original sectionIndex while skipping extra LLM calls.
+    const sectioningForRender = sectionIndex === undefined
+      ? sectioning
+      : {
+          ...sectioning,
+          sections: sectioning.sections.map((section, idx) =>
+            idx === sectionIndex ? section : { ...section, isPruned: true }
+          ),
+        }
+
     const renderResult = await renderPage(
       {
         label,
         pageId,
         pageImageBase64,
-        sectioning,
+        sectioning: sectioningForRender,
         images: renderImages,
         styleguide: styleguideContent,
       },
@@ -113,10 +132,32 @@ export async function reRenderPage(
       templateEngine
     )
 
-    // Store result
-    const version = storage.putNodeData("web-rendering", pageId, renderResult)
+    if (sectionIndex === undefined) {
+      const version = storage.putNodeData("web-rendering", pageId, renderResult)
+      return { version, rendering: renderResult }
+    }
 
-    return { version, rendering: renderResult }
+    // Merge the newly rendered section back into existing rendering, preserving
+    // other sections as-is.
+    const existingRenderingRow = storage.getLatestNodeData("web-rendering", pageId)
+    const existingRenderingParsed = existingRenderingRow
+      ? WebRenderingOutput.safeParse(existingRenderingRow.data)
+      : null
+    if (existingRenderingRow && !existingRenderingParsed?.success) {
+      throw new Error("Invalid web-rendering data")
+    }
+    const existingSections = existingRenderingParsed?.success
+      ? existingRenderingParsed.data.sections
+      : []
+    const withoutTarget = existingSections.filter((s) => s.sectionIndex !== sectionIndex)
+    const newTarget = renderResult.sections.find((s) => s.sectionIndex === sectionIndex)
+    const mergedSections = newTarget
+      ? [...withoutTarget, newTarget].sort((a, b) => a.sectionIndex - b.sectionIndex)
+      : withoutTarget.sort((a, b) => a.sectionIndex - b.sectionIndex)
+    const mergedRendering = { sections: mergedSections }
+
+    const version = storage.putNodeData("web-rendering", pageId, mergedRendering)
+    return { version, rendering: mergedRendering }
   } finally {
     storage.close()
     // Restore previous key
@@ -152,8 +193,11 @@ export async function aiEditSection(
       if (!renderingRow) {
         throw new Error("Page must have web-rendering data before AI editing")
       }
-      const rendering = renderingRow.data as WebRenderingOutput
-      const section = rendering.sections[sectionIndex]
+      const renderingParsed = WebRenderingOutput.safeParse(renderingRow.data)
+      if (!renderingParsed.success) {
+        throw new Error("Invalid web-rendering data")
+      }
+      const section = renderingParsed.data.sections.find((s) => s.sectionIndex === sectionIndex)
       if (!section) {
         throw new Error(`Section ${sectionIndex} not found in rendering`)
       }

--- a/apps/studio/src/api/client.ts
+++ b/apps/studio/src/api/client.ts
@@ -415,9 +415,9 @@ export const api = {
       body: JSON.stringify(data),
     }),
 
-  reRenderPage: (label: string, pageId: string, apiKey: string) =>
+  reRenderPage: (label: string, pageId: string, apiKey: string, sectionIndex?: number) =>
     request<{ version: number; rendering: { sections: SectionRendering[] } }>(
-      `/books/${label}/pages/${pageId}/re-render`,
+      `/books/${label}/pages/${pageId}/re-render${sectionIndex !== undefined ? `?sectionIndex=${sectionIndex}` : ""}`,
       {
         method: "POST",
         headers: { "X-OpenAI-Key": apiKey },
@@ -442,6 +442,12 @@ export const api = {
         body: JSON.stringify({ instruction, currentHtml }),
         signal: signal ?? AbortSignal.timeout(120_000),
       }
+    ),
+
+  cloneSection: (label: string, pageId: string, sectionIndex: number) =>
+    request<{ clonedSectionIndex: number; sectioningVersion: number; renderingVersion: number | null }>(
+      `/books/${label}/pages/${pageId}/sections/${sectionIndex}/clone`,
+      { method: "POST" }
     ),
 
   uploadCroppedImage: (label: string, pageId: string, sourceImageId: string, imageBlob: Blob) => {

--- a/apps/studio/src/components/pipeline/stages/StoryboardSectionDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/StoryboardSectionDetail.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback, useMemo, type ReactNode } from "react"
 import { createPortal } from "react-dom"
-import { Check, Eye, EyeOff, LayoutGrid, Layers, Loader2, ChevronDown, Sparkles, ChevronRight, PanelRightOpen, PanelRightClose, Save, X } from "lucide-react"
+import { Check, Copy, Eye, EyeOff, LayoutGrid, Layers, Loader2, ChevronDown, Sparkles, ChevronRight, PanelRightOpen, PanelRightClose, Save, X } from "lucide-react"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { api } from "@/api/client"
 import type { PageDetail, VersionEntry } from "@/api/client"
@@ -210,6 +210,13 @@ function ImageCard({ imageId, bookLabel, isPruned, reason }: { imageId: string; 
 type SectioningData = NonNullable<PageDetail["sectioning"]>
 type RenderingData = NonNullable<PageDetail["rendering"]>
 
+function getRenderedSectionByIndex(
+  rendering: RenderingData | null | undefined,
+  sectionIndex: number
+) {
+  return rendering?.sections.find((s) => s.sectionIndex === sectionIndex)
+}
+
 // -- Helpers --
 
 function escapeRegex(s: string) {
@@ -300,6 +307,7 @@ export function StoryboardSectionDetail({
   navigationExtra,
   navigationArrows,
   onGeneratingChange,
+  onNavigateSection,
 }: {
   bookLabel: string
   pageId: string
@@ -311,6 +319,8 @@ export function StoryboardSectionDetail({
   navigationArrows?: ReactNode
   /** Called when AI image generation starts/stops so parent can guard navigation */
   onGeneratingChange?: (generating: boolean) => void
+  /** Called to navigate to a different section index (e.g. after clone) */
+  onNavigateSection?: (index: number) => void
 }) {
   const queryClient = useQueryClient()
   const { apiKey, hasApiKey } = useApiKey()
@@ -319,6 +329,7 @@ export function StoryboardSectionDetail({
   const applyBodyBackground = (activeConfigData?.merged as Record<string, unknown> | undefined)?.apply_body_background !== false
 
   const [saving, setSaving] = useState(false)
+  const [cloning, setCloning] = useState(false)
   const [rerendering, setRerendering] = useState(false)
   const [pendingSectioning, setPendingSectioning] = useState<SectioningData | null>(null)
   const [pendingRendering, setPendingRendering] = useState<RenderingData | null>(null)
@@ -450,7 +461,7 @@ export function StoryboardSectionDetail({
   // Current section data
   const section = sectioningData?.sections[sectionIndex]
   const renderingData = pendingRendering ?? page.rendering
-  const renderedSection = renderingData?.sections[sectionIndex]
+  const renderedSection = getRenderedSectionByIndex(renderingData, sectionIndex)
   const renderingDirty = pendingRendering != null
 
   if (!section) {
@@ -479,15 +490,20 @@ export function StoryboardSectionDetail({
       if (hasApiKey) {
         setRerendering(true)
         const capturedPageId = pageId
-        api.reRenderPage(bookLabel, pageId, apiKey)
+        api.reRenderPage(bookLabel, pageId, apiKey, sectionIndex)
           .then(() => {
             // Discard if user navigated to a different page
             if (pageIdRef.current !== capturedPageId) return
             queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "pages", capturedPageId] })
             queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "pages"] })
           })
+          .catch(() => {
+            // Re-render failed — overlay will be cleared by finally
+          })
           .finally(() => {
-            if (pageIdRef.current === capturedPageId) setRerendering(false)
+            if (pageIdRef.current === capturedPageId) {
+              setRerendering(false)
+            }
           })
       }
     } catch (err) {
@@ -512,7 +528,7 @@ export function StoryboardSectionDetail({
       await api.updateRendering(bookLabel, pageId, pendingRendering)
 
       // Back-propagate: if we have sectioning data and edited HTML, update sectioning too
-      const editedHtml = pendingRendering.sections[sectionIndex]?.html
+      const editedHtml = getRenderedSectionByIndex(pendingRendering, sectionIndex)?.html
       if (editedHtml && page.sectioning) {
         const updatedSectioning = backPropagateTextChanges(
           pendingSectioning ?? page.sectioning,
@@ -531,6 +547,22 @@ export function StoryboardSectionDetail({
       setAiError(err instanceof Error ? err.message : "Save failed")
     } finally {
       setSaving(false)
+    }
+  }
+
+  // Clone current section
+  const handleCloneSection = async () => {
+    if (cloning || dirty || renderingDirty || saving) return
+    setCloning(true)
+    try {
+      const result = await api.cloneSection(bookLabel, pageId, sectionIndex)
+      await queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "pages", pageId] })
+      await queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "pages"] })
+      onNavigateSection?.(result.clonedSectionIndex)
+    } catch (err) {
+      setAiError(err instanceof Error ? err.message : "Clone failed")
+    } finally {
+      setCloning(false)
     }
   }
 
@@ -601,8 +633,8 @@ export function StoryboardSectionDetail({
       const base = pendingRendering ?? page.rendering
       const updated: RenderingData = {
         ...base,
-        sections: base.sections.map((s, si) => {
-          if (si !== sectionIndex) return s
+        sections: base.sections.map((s) => {
+          if (s.sectionIndex !== sectionIndex) return s
           return { ...s, html: fullHtml }
         }),
       }
@@ -714,8 +746,8 @@ export function StoryboardSectionDetail({
         const newSrc = `/api/books/${bookLabel}/images/${result.imageId}`
         const updatedRendering: RenderingData = {
           ...rBase,
-          sections: rBase.sections.map((s, si) => {
-            if (si !== sectionIndex) return s
+          sections: rBase.sections.map((s) => {
+            if (s.sectionIndex !== sectionIndex) return s
             // Replace data-id and src references to the old imageId
             let html = s.html
             html = html.replace(new RegExp(`data-id="${escapeRegex(cropTarget)}"`, "g"), `data-id="${result.imageId}"`)
@@ -784,8 +816,8 @@ export function StoryboardSectionDetail({
         const newSrc = `/api/books/${bookLabel}/images/${result.imageId}`
         const updatedRendering: RenderingData = {
           ...rBase,
-          sections: rBase.sections.map((s, si) => {
-            if (si !== sectionIndex) return s
+          sections: rBase.sections.map((s) => {
+            if (s.sectionIndex !== sectionIndex) return s
             let html = s.html
             html = html.replace(new RegExp(`data-id="${escapeRegex(targetId)}"`, "g"), `data-id="${result.imageId}"`)
             html = html.replace(new RegExp(escapeRegex(oldSrc), "g"), newSrc)
@@ -885,8 +917,8 @@ export function StoryboardSectionDetail({
           if (!rBase) return prev
           return {
             ...rBase,
-            sections: rBase.sections.map((s, si) => {
-              if (si !== sectionIndex) return s
+            sections: rBase.sections.map((s) => {
+              if (s.sectionIndex !== sectionIndex) return s
               let html = s.html
               const segImgs = result.segments
                 .map(
@@ -946,8 +978,8 @@ export function StoryboardSectionDetail({
         const newSrc = `/api/books/${bookLabel}/images/${newImageId}`
         return {
           ...rBase,
-          sections: rBase.sections.map((s, si) => {
-            if (si !== sectionIndex) return s
+          sections: rBase.sections.map((s) => {
+            if (s.sectionIndex !== sectionIndex) return s
             let html = s.html
             html = html.replace(new RegExp(`data-id="${escapeRegex(targetId)}"`, "g"), `data-id="${newImageId}"`)
             html = html.replace(new RegExp(escapeRegex(oldSrc), "g"), newSrc)
@@ -1040,8 +1072,8 @@ export function StoryboardSectionDetail({
       if (!base) return
       const updated: RenderingData = {
         ...base,
-        sections: base.sections.map((s, si) => {
-          if (si !== sectionIndex) return s
+        sections: base.sections.map((s) => {
+          if (s.sectionIndex !== sectionIndex) return s
           return { ...s, html: result.html }
         }),
       }
@@ -1118,8 +1150,8 @@ export function StoryboardSectionDetail({
 
     // Diff rendered HTML for text edits + image src swaps
     if (pendingRendering && page.rendering) {
-      const savedHtml = page.rendering.sections[sectionIndex]?.html ?? ""
-      const pendingHtml = pendingRendering.sections[sectionIndex]?.html ?? ""
+      const savedHtml = getRenderedSectionByIndex(page.rendering, sectionIndex)?.html ?? ""
+      const pendingHtml = getRenderedSectionByIndex(pendingRendering, sectionIndex)?.html ?? ""
       if (savedHtml !== pendingHtml) {
         const parser = new DOMParser()
         const savedDoc = parser.parseFromString(savedHtml, "text/html")
@@ -1476,6 +1508,20 @@ export function StoryboardSectionDetail({
           {section.isPruned && (
             <span className="text-destructive text-[10px] font-medium">(pruned)</span>
           )}
+          <div className="ml-auto flex items-center gap-1.5">
+          <button
+            type="button"
+            onClick={handleCloneSection}
+            disabled={cloning || dirty || renderingDirty || saving}
+            className="p-0.5 rounded hover:bg-accent transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-default"
+            title={dirty || renderingDirty ? "Save changes before cloning" : "Clone this section"}
+          >
+            {cloning ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <Copy className="h-3.5 w-3.5" />
+            )}
+          </button>
           <VersionPicker
             currentVersion={page.versions.sectioning}
             saving={saving}
@@ -1483,17 +1529,24 @@ export function StoryboardSectionDetail({
             bookLabel={bookLabel}
             node="page-sectioning"
             itemId={pageId}
-            onPreview={(data) => setPendingSectioning(data as SectioningData)}
+            onPreview={(data) => {
+              const s = data as SectioningData
+              setPendingSectioning(s)
+              if (s.sections && sectionIndex >= s.sections.length) {
+                onNavigateSection?.(Math.max(0, s.sections.length - 1))
+              }
+            }}
             onSave={saveSectioning}
             onDiscard={discardSectioning}
           />
           <button
             type="button"
             onClick={() => setPanelOpen(false)}
-            className="ml-auto p-0.5 rounded hover:bg-accent transition-colors cursor-pointer"
+            className="p-0.5 rounded hover:bg-accent transition-colors cursor-pointer"
           >
             <X className="h-3.5 w-3.5" />
           </button>
+          </div>
         </div>
 
         {/* Panel body — scrollable */}

--- a/apps/studio/src/components/pipeline/stages/StoryboardView.tsx
+++ b/apps/studio/src/components/pipeline/stages/StoryboardView.tsx
@@ -52,7 +52,15 @@ export function StoryboardView({ bookLabel, selectedPageId: selectedPageIdProp, 
 
   const sectionCount = page?.sectioning?.sections.length ?? 0
 
+  // Reset section index when page changes externally (must run before resolve effect)
+  useEffect(() => {
+    if (!pendingLastSection.current) {
+      setSectionIndex(0)
+    }
+  }, [selectedPageId])
+
   // Resolve pending "last section" once page data loads
+  // Declared after the reset effect so it runs later and its setSectionIndex wins
   useEffect(() => {
     if (pendingLastSection.current && sectionCount > 0) {
       setSectionIndex(sectionCount - 1)
@@ -90,13 +98,6 @@ export function StoryboardView({ bookLabel, selectedPageId: selectedPageIdProp, 
       setSelectedPageId(nextPageId)
     }
   }
-
-  // Reset section index when page changes externally
-  useEffect(() => {
-    if (!pendingLastSection.current) {
-      setSectionIndex(0)
-    }
-  }, [selectedPageId])
 
   // Navigation elements for the purple header — passed to StoryboardSectionDetail
   // which controls the full header content (nav + version + AI + panel toggle)
@@ -273,6 +274,7 @@ export function StoryboardView({ bookLabel, selectedPageId: selectedPageIdProp, 
       navigationExtra={navigationExtra}
       navigationArrows={navigationArrows}
       onGeneratingChange={handleGeneratingChange}
+      onNavigateSection={setSectionIndex}
     />
   )
 }

--- a/packages/pipeline/src/__tests__/package-web.test.ts
+++ b/packages/pipeline/src/__tests__/package-web.test.ts
@@ -164,8 +164,8 @@ describe("packageAdtWeb", () => {
       fs.readFileSync(path.join(bookDir, "adt", "content", "pages.json"), "utf-8"),
     ) as Array<{ section_id: string; href: string; page_number?: number }>
     expect(pagesJson).toHaveLength(2)
-    expect(pagesJson[0].page_number).toBe(10)
-    expect(Object.prototype.hasOwnProperty.call(pagesJson[1], "page_number")).toBe(false)
+    expect(pagesJson[0]).toEqual({ section_id: "pg001_sec001", href: "pg001_sec001.html", page_number: 10 })
+    expect(pagesJson[1]).toEqual({ section_id: "pg002_sec001", href: "pg002_sec001.html" })
 
     const configJson = JSON.parse(
       fs.readFileSync(path.join(bookDir, "adt", "assets", "config.json"), "utf-8"),
@@ -173,7 +173,7 @@ describe("packageAdtWeb", () => {
     expect(configJson.languages.available).toEqual(["fr"])
     expect(configJson.languages.default).toBe("fr")
 
-    const pageHtml = fs.readFileSync(path.join(bookDir, "adt", "pg001.html"), "utf-8")
+    const pageHtml = fs.readFileSync(path.join(bookDir, "adt", "pg001_sec001.html"), "utf-8")
     expect(pageHtml).toContain("window.correctAnswers = JSON.parse(")
     expect(pageHtml).not.toContain("</script><script>alert('x')</script>")
     expect(pageHtml).toContain("\\u003c/script\\u003e\\u003cscript\\u003e")
@@ -264,9 +264,83 @@ describe("packageAdtWeb", () => {
     ) as Array<{ section_id: string; href: string; page_number?: number }>
 
     expect(pagesJson).toEqual([
-      { section_id: "qz001", href: "qz001.html", page_number: 10 },
-      { section_id: "pg002", href: "pg002.html" },
+      { section_id: "qz001", href: "qz001.html" },
+      { section_id: "pg002_sec001", href: "pg002_sec001.html" },
     ])
     expect(fs.existsSync(path.join(bookDir, "adt", "qz001.html"))).toBe(true)
+  })
+
+  it("orders rendered sections by sectionIndex before writing pages.json", async () => {
+    const bookDir = path.join(tmpDir, "book")
+    const webAssetsDir = path.join(tmpDir, "assets-web")
+    fs.mkdirSync(bookDir, { recursive: true })
+    createWebAssets(webAssetsDir)
+
+    const pages: PageData[] = [
+      { pageId: "pg001", pageNumber: 1, text: "Page one" },
+    ]
+
+    const storage = createMockStorage(pages, {
+      "web-rendering": {
+        pg001: {
+          sections: [
+            {
+              sectionIndex: 1,
+              sectionType: "content",
+              reasoning: "ok",
+              html: "<div>Second section</div>",
+            },
+            {
+              sectionIndex: 0,
+              sectionType: "content",
+              reasoning: "ok",
+              html: "<div>First section</div>",
+            },
+          ],
+        },
+      },
+      "page-sectioning": {
+        pg001: {
+          reasoning: "ok",
+          sections: [
+            {
+              sectionId: "pg001_sec001",
+              sectionType: "content",
+              parts: [],
+              backgroundColor: "#fff",
+              textColor: "#000",
+              pageNumber: 1,
+              isPruned: false,
+            },
+            {
+              sectionId: "pg001_sec002",
+              sectionType: "content",
+              parts: [],
+              backgroundColor: "#fff",
+              textColor: "#000",
+              pageNumber: 1,
+              isPruned: false,
+            },
+          ],
+        },
+      },
+    })
+
+    await packageAdtWeb(storage, {
+      bookDir,
+      label: "book",
+      language: "en",
+      outputLanguages: ["en"],
+      title: "Book Title",
+      webAssetsDir,
+    })
+
+    const pagesJson = JSON.parse(
+      fs.readFileSync(path.join(bookDir, "adt", "content", "pages.json"), "utf-8"),
+    ) as Array<{ section_id: string; href: string; page_number?: number }>
+    expect(pagesJson).toEqual([
+      { section_id: "pg001_sec001", href: "pg001_sec001.html", page_number: 1 },
+      { section_id: "pg001_sec002", href: "pg001_sec002.html", page_number: 1 },
+    ])
   })
 })

--- a/packages/pipeline/src/__tests__/validate-html.test.ts
+++ b/packages/pipeline/src/__tests__/validate-html.test.ts
@@ -93,6 +93,45 @@ describe("validateSectionHtml", () => {
     expect(result.valid).toBe(true)
   })
 
+  it("rejects img tags without data-id", () => {
+    const html = `
+      <section>
+        <img src="placeholder" alt="test" />
+      </section>
+    `
+    const result = validateSectionHtml(html, [], ["pg001_im001"])
+    expect(result.valid).toBe(false)
+    expect(result.errors).toContainEqual(
+      expect.stringContaining('<img> tag missing required "data-id" attribute')
+    )
+  })
+
+  it("rejects img tags whose data-id is not an allowed image id", () => {
+    const html = `
+      <section>
+        <img data-id="pg001_gp001" src="placeholder" alt="test" />
+      </section>
+    `
+    const result = validateSectionHtml(html, ["pg001_gp001"], ["pg001_im001"])
+    expect(result.valid).toBe(false)
+    expect(result.errors).toContainEqual(
+      expect.stringContaining('Invalid image data-id: "pg001_gp001"')
+    )
+  })
+
+  it("rejects image data-ids on non-img elements", () => {
+    const html = `
+      <section>
+        <div data-id="pg001_im001">Not an image</div>
+      </section>
+    `
+    const result = validateSectionHtml(html, [], ["pg001_im001"])
+    expect(result.valid).toBe(false)
+    expect(result.errors).toContainEqual(
+      expect.stringContaining('Image data-id "pg001_im001" must be used on an <img> tag')
+    )
+  })
+
   it("fails when no section tag is found", () => {
     const result = validateSectionHtml("<p>no section</p>", [], [])
     expect(result.valid).toBe(false)

--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -153,7 +153,6 @@ export {
   packageAdtWeb,
   type PackageAdtWebOptions,
   renderPageHtml,
-  combineSections,
   NAV_HTML,
   type RenderPageOptions,
   buildPreviewTailwindCss,

--- a/packages/pipeline/src/package-web.ts
+++ b/packages/pipeline/src/package-web.ts
@@ -3,7 +3,6 @@ import path from "node:path"
 import { parseDocument, DomUtils } from "htmlparser2"
 import type { Storage } from "@adt/storage"
 import type {
-  WebRenderingOutput,
   PageSectioningOutput,
   TextCatalogOutput,
   GlossaryOutput,
@@ -124,28 +123,21 @@ export async function packageAdtWeb(
     const sectioningRow = storage.getLatestNodeData("page-sectioning", page.pageId)
     const sectioning = sectioningRow?.data as PageSectioningOutput | undefined
 
-    // Determine page number from sectioning
-    let pageNumber: number | undefined
-    if (sectioning?.sections) {
-      for (const s of sectioning.sections) {
-        if (s.pageNumber !== null) pageNumber = s.pageNumber
-      }
-    }
-
     const renderRow = storage.getLatestNodeData("web-rendering", page.pageId)
     if (renderRow) {
       const parsed = WebRenderingOutputSchema.safeParse(renderRow.data)
       if (parsed.success) {
         const rendering = parsed.data
 
-        // Skip pages with no rendered sections (all pruned)
-        if (rendering.sections.length > 0) {
-          // Concatenate section HTML and merge activity answers
-          const { html: sectionHtml, activityAnswers } = combineSections(rendering)
+        // One HTML file per rendered section (stable by sectionIndex)
+        const sections = [...rendering.sections].sort((a, b) => a.sectionIndex - b.sectionIndex)
+        for (const rs of sections) {
+          const sectionMeta = sectioning?.sections[rs.sectionIndex]
+          const sectionId = sectionMeta?.sectionId ?? `${page.pageId}_sec${String(rs.sectionIndex + 1).padStart(3, "0")}`
 
           // Rewrite image URLs and copy referenced images
           const { html: rewrittenHtml, referencedImages } = rewriteImageUrls(
-            sectionHtml,
+            rs.html,
             label,
             imageMap,
           )
@@ -169,21 +161,23 @@ export async function packageAdtWeb(
           const pageHtml = renderPageHtml({
             content: rewrittenHtml,
             language,
-            sectionId: page.pageId,
+            sectionId,
             pageTitle: title,
             pageIndex: pageList.length + 1,
-            activityAnswers,
+            activityAnswers: rs.activityAnswers,
             hasMath: containsMathContent(rewrittenHtml),
             bundleVersion,
             applyBodyBackground,
           })
-          fs.writeFileSync(path.join(adtDir, `${page.pageId}.html`), pageHtml)
+          fs.writeFileSync(path.join(adtDir, `${sectionId}.html`), pageHtml)
 
           const entry: PageEntry = {
-            section_id: page.pageId,
-            href: `${page.pageId}.html`,
+            section_id: sectionId,
+            href: `${sectionId}.html`,
           }
-          if (pageNumber !== undefined) entry.page_number = pageNumber
+          if (sectionMeta?.pageNumber !== null && sectionMeta?.pageNumber !== undefined) {
+            entry.page_number = sectionMeta.pageNumber
+          }
           pageList.push(entry)
         }
       }
@@ -209,9 +203,7 @@ export async function packageAdtWeb(
       })
       fs.writeFileSync(path.join(adtDir, `${quizId}.html`), quizPageHtml)
 
-      const quizEntry: PageEntry = { section_id: quizId, href: `${quizId}.html` }
-      if (pageNumber !== undefined) quizEntry.page_number = pageNumber
-      pageList.push(quizEntry)
+      pageList.push({ section_id: quizId, href: `${quizId}.html` })
     }
   }
 
@@ -699,28 +691,6 @@ export function htmlToXhtml(html: string): string {
   xhtml = xhtml.replace(/&bull;/g, "&#8226;")
   xhtml = xhtml.replace(/&copy;/g, "&#169;")
   return xhtml
-}
-
-// ---------------------------------------------------------------------------
-// Section helpers
-// ---------------------------------------------------------------------------
-
-export function combineSections(rendering: WebRenderingOutput): {
-  html: string
-  activityAnswers?: Record<string, string | boolean | number>
-} {
-  let allHtml = ""
-  let mergedAnswers: Record<string, string | boolean | number> | undefined
-
-  for (const section of rendering.sections) {
-    allHtml += section.html + "\n"
-    if (section.activityAnswers) {
-      if (!mergedAnswers) mergedAnswers = {}
-      Object.assign(mergedAnswers, section.activityAnswers)
-    }
-  }
-
-  return { html: allHtml.trim(), activityAnswers: mergedAnswers }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/pipeline/src/validate-html.ts
+++ b/packages/pipeline/src/validate-html.ts
@@ -67,7 +67,7 @@ export function validateSectionHtml(
   const section = sections[0]
   validateRequiredSectionAttributes(section, options, errors)
 
-  walkNode(section, allowedIds, errors, options)
+  walkNode(section, allowedIds, imageIdSet, errors, options)
 
   if (imageUrlPrefix) {
     rewriteImageSrcs(section, imageIdSet, imageUrlPrefix)
@@ -118,7 +118,13 @@ function validateRequiredSectionAttributes(
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function walkNode(node: any, allowedIds: Set<string>, errors: string[], options?: HtmlValidationOptions): void {
+function walkNode(
+  node: any,
+  allowedIds: Set<string>,
+  imageIds: Set<string>,
+  errors: string[],
+  options?: HtmlValidationOptions
+): void {
   if (node.type === "text") {
     if (node.data.trim().length > 0) {
       if (isInsideExemptTag(node)) return
@@ -155,6 +161,17 @@ function walkNode(node: any, allowedIds: Set<string>, errors: string[], options?
     }
 
     const dataId = node.attribs?.["data-id"]
+
+    if (tagName === "img") {
+      if (dataId === undefined) {
+        errors.push('<img> tag missing required "data-id" attribute')
+      } else if (!imageIds.has(dataId)) {
+        errors.push(`Invalid image data-id: "${dataId}"`)
+      }
+    } else if (dataId !== undefined && tagName !== "section" && imageIds.has(dataId)) {
+      errors.push(`Image data-id "${dataId}" must be used on an <img> tag`)
+    }
+
     // Skip data-id validation on <section> elements — their data-id is a
     // section identifier (e.g. "pg028_section"), not a content element ID.
     if (dataId !== undefined && tagName !== "section" && !allowedIds.has(dataId)) {
@@ -177,7 +194,7 @@ function walkNode(node: any, allowedIds: Set<string>, errors: string[], options?
 
   if (node.children) {
     for (const child of node.children) {
-      walkNode(child, allowedIds, errors, options)
+      walkNode(child, allowedIds, imageIds, errors, options)
     }
   }
 }
@@ -187,7 +204,7 @@ function walkNode(node: any, allowedIds: Set<string>, errors: string[], options?
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function rewriteImageSrcs(node: any, imageIds: Set<string>, urlPrefix: string): void {
-  if (node.type === "tag") {
+  if (node.type === "tag" && (node.name ?? "").toLowerCase() === "img") {
     const dataId = node.attribs?.["data-id"]
     if (dataId !== undefined && imageIds.has(dataId)) {
       node.attribs.src = `${urlPrefix}/${dataId}`

--- a/prompts/activity_fill_in_a_table.liquid
+++ b/prompts/activity_fill_in_a_table.liquid
@@ -13,11 +13,14 @@ You are an expert frontend engineer creating beautiful, kid-friendly HTML pages 
 
 ### CRITICAL Requirements
 1. Layout Shell - Start with page wrapper `<div class="flex justify-center items-start min-h-[calc(100dvh-100px)]">`
-2. ONE `<section>` tag with `data-section-type` and `role="activity"`
-3. ALL text elements MUST have `data-id` matching provided text ID
-4. ALL images MUST have `data-id` matching provided image ID
-5. Only use provided images and text IDs
-6. EVERY input field MUST include a unique `data-activity-item="item-X"` attribute (`item-1`, `item-2`, ...). No input is allowed without this attribute.
+2. ONE `<section>` tag with `role="activity"`, `data-section-type` equal to the provided section type, and `data-section-id` equal to the provided section ID
+3. Use ONLY provided text IDs and image IDs for `data-id` values (never invent IDs)
+4. ALL text elements MUST have `data-id` matching a provided text ID
+5. ALL images MUST have `data-id` matching a provided image ID
+6. Text for each text ID must match the provided text exactly (no paraphrasing, no added text, no punctuation changes)
+7. Do not output visible raw text outside an element with a valid provided `data-id`
+8. EVERY input field MUST include a unique `data-activity-item="item-X"` attribute (`item-1`, `item-2`, ...). No input is allowed without this attribute.
+9. If validator feedback says an exact expected value (for example section ID), use that exact value
 
 ### Response Format
 ```json
@@ -46,7 +49,7 @@ IMPORTANT: Your reasoning MUST be written in English, regardless of the activity
 
 Example fill in table activity:
 ```html
-<section data-section-type="activity_fill_in_a_table" role="activity" class="max-w-6xl mx-auto">
+<section data-section-type="activity_fill_in_a_table" data-section-id="SECTION_ID_FROM_INPUT" role="activity" class="max-w-6xl mx-auto">
   <div class="flex items-center justify-center mb-4">
     <h1 class="text-2xl font-bold mb-4 bg-green-200 -mr-4 p-4 pr-8 rounded-lg" data-id="text-10-0">
       Form title here
@@ -101,16 +104,16 @@ Example fill in table activity:
 This is the base64 image of the entire page from the textbook for context only.
 {% image page_image_base64 %}
 
-The section type for this section is: {{ section_type }}.
+Section ID: {{ section_id }}
+Section type: {{ section_type }}
 
 {% for image in images %}
-ID of the following image is: {{ image.image_id }}.
+Image ID: {{ image.image_id }}
 {% image image.image_base64 %}
 {% endfor %}
 
-The following are text blocks for the section. Each must have its corresponding data-id in the HTML:
+Allowed text IDs and exact text values (must be copied verbatim):
 {% for text in texts %}
-id: {{ text.text_id }} text type: {{ text.text_type }}.
-text: {{ text.text }}
+- id: {{ text.text_id }} | type: {{ text.text_type }} | text: "{{ text.text }}"
 {% endfor %}
 {% endchat %}

--- a/prompts/activity_fill_in_the_blank.liquid
+++ b/prompts/activity_fill_in_the_blank.liquid
@@ -9,7 +9,7 @@ You are an expert frontend engineer creating beautiful, kid-friendly HTML pages 
 </div>
 
 ### Section Structure
-<section data-section-type="activity_fill_in_the_blank" role="activity" class="max-w-6xl mx-auto">
+<section data-section-type="activity_fill_in_the_blank" data-section-id="SECTION_ID_FROM_INPUT" role="activity" class="max-w-6xl mx-auto">
 
 ### Activity Components
 
@@ -85,13 +85,17 @@ You are an expert frontend engineer creating beautiful, kid-friendly HTML pages 
 ```
 
 ### CRITICAL Requirements
-1. ALL text elements MUST have `data-id` matching provided text IDs
-2. ALL images MUST have `data-id` matching provided image IDs
-3. ALL inputs MUST have both `data-aria-id` AND `data-activity-item`
-4. `data-activity-item` values must be unique and sequential (item-1, item-2, etc.)
-5. NO stray text directly inside `<section>` - wrap everything in tagged elements
-6. Use semantic colors: green for main level, blue for secondary, gray for tertiary
-7. Match layout complexity to the educational goal (simple list vs. hierarchy)
+1. Include exactly ONE `<section>` with `role="activity"`, `data-section-type` equal to the provided section type, and `data-section-id` equal to the provided section ID
+2. Use ONLY provided text IDs and image IDs for `data-id` values (never invent IDs)
+3. ALL text elements MUST have `data-id` matching provided text IDs
+4. ALL images MUST have `data-id` matching provided image IDs
+5. Text for each text ID must match the provided text exactly (no paraphrasing, no added text, no punctuation changes)
+6. ALL inputs MUST have both `data-aria-id` AND `data-activity-item`
+7. `data-activity-item` values must be unique and sequential (item-1, item-2, etc.)
+8. NO stray visible text outside elements with valid provided `data-id`
+9. Use semantic colors: green for main level, blue for secondary, gray for tertiary
+10. Match layout complexity to the educational goal (simple list vs. hierarchy)
+11. If validator feedback says an exact expected value (for example section ID), use that exact value
 
 ### Response Format (STRICT)
 Return JSON object:
@@ -109,7 +113,7 @@ IMPORTANT: Your reasoning MUST be written in English, regardless of the activity
 ```html
 <div class="flex justify-center items-start min-h-[calc(100dvh-100px)]">
   <div class="container mx-auto max-w-5xl bg-white rounded-lg lg:px-24 md:px-12 sm:px-6 pt-12 pb-12" id="content">
-    <section data-section-type="activity_fill_in_the_blank" role="activity">
+    <section data-section-type="activity_fill_in_the_blank" data-section-id="SECTION_ID_FROM_INPUT" role="activity">
       <p class="mb-4 text-center">
         <i class="fas fa-pen-to-square text-blue-700 mr-2"></i>
         <span data-id="text-1">Complete the sentences.</span>
@@ -140,16 +144,16 @@ Use when showing text structure, concept maps, or organizational charts.
 This is the base64 image of the entire page from the textbook for context only.
 {% image page_image_base64 %}
 
-The section type for this section is: {{ section_type }}.
+Section ID: {{ section_id }}
+Section type: {{ section_type }}
 
 {% for image in images %}
-ID of the following image is: {{ image.image_id }}.
+Image ID: {{ image.image_id }}
 {% image image.image_base64 %}
 {% endfor %}
 
-The following are text blocks for the section. Each must have its corresponding data-id in the HTML:
+Allowed text IDs and exact text values (must be copied verbatim):
 {% for text in texts %}
-id: {{ text.text_id }} text type: {{ text.text_type }}.
-text: {{ text.text }}
+- id: {{ text.text_id }} | type: {{ text.text_type }} | text: "{{ text.text }}"
 {% endfor %}
 {% endchat %}

--- a/prompts/activity_matching.liquid
+++ b/prompts/activity_matching.liquid
@@ -13,10 +13,13 @@ You are an expert frontend engineer creating beautiful, kid-friendly HTML pages 
 
 ### CRITICAL Requirements
 1. Layout Shell - Start with page wrapper `<div class="flex justify-center items-start min-h-[calc(100dvh-100px)]">`
-2. ONE `<section>` tag with `data-section-type` and `role="activity"`
-3. ALL text elements MUST have `data-id` matching provided text ID
-4. ALL images MUST have `data-id` matching provided image ID
-5. Only use provided images and text IDs
+2. ONE `<section>` tag with `role="activity"`, `data-section-type` equal to the provided section type, and `data-section-id` equal to the provided section ID
+3. Use ONLY provided text IDs and image IDs for `data-id` values (never invent IDs)
+4. ALL text elements MUST have `data-id` matching a provided text ID
+5. ALL images MUST have `data-id` matching a provided image ID
+6. Text for each text ID must match the provided text exactly (no paraphrasing, no added text, no punctuation changes)
+7. Do not output visible raw text outside an element with a valid provided `data-id`
+8. If validator feedback says an exact expected value (for example section ID), use that exact value
 
 ### Response Format
 ```json
@@ -58,7 +61,7 @@ IMPORTANT: Your reasoning MUST be written in English, regardless of the activity
 
 Example matching activity:
 ```html
-<section data-section-type="activity_matching" role="activity" class="max-w-6xl mx-auto" aria-labelledby="main-heading">
+<section data-section-type="activity_matching" data-section-id="SECTION_ID_FROM_INPUT" role="activity" class="max-w-6xl mx-auto" aria-labelledby="main-heading">
   <div class="flex flex-col md:flex-row gap-4 mb-6 md:items-start">
     <!-- Draggable items -->
     <div class="grow grid grid-cols-2 md:grid-cols-1 gap-4 text-center">
@@ -119,16 +122,16 @@ Example matching activity:
 This is the base64 image of the entire page from the textbook for context only.
 {% image page_image_base64 %}
 
-The section type for this section is: {{ section_type }}.
+Section ID: {{ section_id }}
+Section type: {{ section_type }}
 
 {% for image in images %}
-ID of the following image is: {{ image.image_id }}.
+Image ID: {{ image.image_id }}
 {% image image.image_base64 %}
 {% endfor %}
 
-The following are text blocks for the section. Each must have its corresponding data-id in the HTML:
+Allowed text IDs and exact text values (must be copied verbatim):
 {% for text in texts %}
-id: {{ text.text_id }} text type: {{ text.text_type }}.
-text: {{ text.text }}
+- id: {{ text.text_id }} | type: {{ text.text_type }} | text: "{{ text.text }}"
 {% endfor %}
 {% endchat %}

--- a/prompts/activity_multiple_choice.liquid
+++ b/prompts/activity_multiple_choice.liquid
@@ -1,210 +1,121 @@
 {% chat role: "system" %}
-You are an expert frontend engineer creating beautiful, kid-friendly HTML pages for educational textbooks.
+You are an expert frontend engineer creating HTML for educational textbook activities.
 
-### Layout Shell (MANDATORY)
-Every page must be wrapped in this exact structure:
-```html
-<div class="flex justify-center items-start min-h-[calc(100dvh-100px)]">
-  <div class="container mx-auto max-w-5xl bg-white rounded-lg lg:px-24 md:px-12 sm:px-6 pt-12 pb-12" id="content">
-    <!-- Your section content goes here -->
-  </div>
-</div>
-```
-
-### Section Structure
-Your generated content must include:
-1. ONE `<section>` tag with `data-section-type="activity_multiple_choice"` and `role="activity"`
-2. Question text in a colored background container with `data-id` attributes
-3. Multiple radio button options (typically 2-5 options) with:
-   - Each option wrapped in a `<label>` with class `activity-option`
-   - Letter circles (A, B, C, D, etc.) for visual identification
-   - Radio `<input>` elements with:
-     - `type="radio"`
-     - `name` attribute (same for all options in a question)
-     - `data-activity-item` attribute with unique ID (e.g., "item-1", "item-2")
-     - `aria-label` describing the option
-     - `class="sr-only"` to hide visually but keep accessible
-     - `tabindex="0"` for keyboard navigation
-   - Option text with `data-id` attributes
-   - Hidden feedback containers for correct/incorrect responses
-4. Optional images with `data-id` attributes
-5. All text content must have `data-id` attributes matching the text IDs from the provided context
-
-### Required Radio Button Structure
-```html
-<div class="option-container">
-  <label class="activity-option flex items-start gap-4 p-4 rounded-lg hover:bg-gray-50 cursor-pointer">
-    <div class="flex-shrink-0">
-      <div class="w-8 h-8 rounded-full border-2 border-gray-300 flex items-center justify-center text-gray-500 option-letter">
-        <i class="fas fa-circle text-xs"></i>
-      </div>
-    </div>
-    <div class="flex-grow">
-      <input aria-label="Option A: [description]"
-             class="sr-only"
-             data-activity-item="item-1"
-             name="question-group"
-             tabindex="0"
-             type="radio"
-             value="item-1" />
-      <div class="text-gray-700" data-id="text-id">Option text here</div>
-      <div class="feedback-container mt-2 hidden">
-        <div class="flex items-center gap-2">
-          <span class="feedback-icon w-5 h-5 rounded-full flex items-center justify-center text-sm"></span>
-          <span class="feedback-text text-sm font-medium"></span>
-        </div>
-      </div>
-    </div>
-  </label>
-</div>
-```
-
-### Styling Guidelines
-- Question containers: Use `bg-green-100`, `bg-blue-100`, or `bg-amber-100` for visibility
-- Options: Use `hover:bg-gray-50` for interactive feedback
-- Letter circles: Use `border-2 border-gray-300` with centered text
-- Feedback containers: Keep `hidden` class by default (JavaScript will show them)
-- Use Tailwind CSS classes for all styling
-
-### Accessibility Requirements
-- Each radio input must have descriptive `aria-label`
-- All options in a group share the same `name` attribute
-- Use `tabindex="0"` for keyboard navigation
-- Option text should be in separate `div` with `data-id` for translations
-- Hidden feedback structure must be present for runtime evaluation
-
-### Layout Options
-- **Text-only**: Question and options in single column
-- **With image**: Use `flex-col md:flex-row` to place image alongside options
-- **Multiple questions**: Separate each question with clear spacing
-
-### FontAwesome Icons (optional)
-You can use icons for visual enhancement:
-- `<i class="fas fa-question-circle"></i>` for questions
-- `<i class="fas fa-check-circle"></i>` for hints
-- `<i class="fas fa-lightbulb"></i>` for tips
-
-### Response Format
-You MUST respond with valid JSON containing exactly two fields:
-
+## Required Output Contract
+You MUST return valid JSON with exactly two fields:
 ```json
 {
-  "reasoning": "Brief explanation of your HTML generation decisions (ALWAYS in English)",
-    "content": "<div class=\"flex justify-center...\">...</div>"
+  "reasoning": "1-2 sentence explanation in English",
+  "content": "<div class=\"flex justify-center...\">...</div>"
 }
-IMPORTANT: Your reasoning MUST be written in English, regardless of the activity language. The HTML content itself should match the activity language.
 ```
+- `reasoning` must be English, regardless of activity language.
+- `content` must be complete HTML starting with the wrapper below.
 
-The `content` field must contain the complete HTML starting with the layout shell wrapper.
-
-### Example Output Structure
+## Layout Shell (MANDATORY)
+Use this exact outer shell:
 ```html
 <div class="flex justify-center items-start min-h-[calc(100dvh-100px)]">
   <div class="container mx-auto max-w-5xl bg-white rounded-lg lg:px-24 md:px-12 sm:px-6 pt-12 pb-12" id="content">
-    <section data-section-type="activity_multiple_choice" role="activity" class="section mb-8">
-      <div class="flex flex-col md:flex-row gap-4 items-center max-w-5xl mx-auto activity-text">
-        <div class="questions grow space-y-4" role="group" aria-labelledby="question-label">
-          <!-- Question text -->
-          <div class="mb-4 bg-green-100 rounded-lg p-4">
-            <p data-id="text-123">What is 2 + 2?</p>
-          </div>
-
-          <!-- Option A -->
-          <div class="option-container">
-            <label class="activity-option flex items-start gap-4 p-4 rounded-lg hover:bg-gray-50 cursor-pointer">
-              <div class="flex-shrink-0">
-                <div class="w-8 h-8 rounded-full border-2 border-gray-300 flex items-center justify-center text-gray-500 option-letter">
-                  <i class="fas fa-circle text-xs"></i>
-                </div>
-              </div>
-              <div class="flex-grow">
-                <input aria-label="Option A: 3" class="sr-only" data-activity-item="item-1" name="math-question" tabindex="0" type="radio" value="item-1" />
-                <div class="text-gray-700" data-id="text-124">3</div>
-                <div class="feedback-container mt-2 hidden">
-                  <div class="flex items-center gap-2">
-                    <span class="feedback-icon w-5 h-5 rounded-full flex items-center justify-center text-sm"></span>
-                    <span class="feedback-text text-sm font-medium"></span>
-                  </div>
-                </div>
-              </div>
-            </label>
-          </div>
-
-          <!-- Option B -->
-          <div class="option-container">
-            <label class="activity-option flex items-start gap-4 p-4 rounded-lg hover:bg-gray-50 cursor-pointer">
-              <div class="flex-shrink-0">
-                <div class="w-8 h-8 rounded-full border-2 border-gray-300 flex items-center justify-center text-gray-500 option-letter">
-                  <i class="fas fa-circle text-xs"></i>
-                </div>
-              </div>
-              <div class="flex-grow">
-                <input aria-label="Option B: 4" class="sr-only" data-activity-item="item-2" name="math-question" tabindex="0" type="radio" value="item-2" />
-                <div class="text-gray-700" data-id="text-125">4</div>
-                <div class="feedback-container mt-2 hidden">
-                  <div class="flex items-center gap-2">
-                    <span class="feedback-icon w-5 h-5 rounded-full flex items-center justify-center text-sm"></span>
-                    <span class="feedback-text text-sm font-medium"></span>
-                  </div>
-                </div>
-              </div>
-            </label>
-          </div>
-
-          <!-- Option C -->
-          <div class="option-container">
-            <label class="activity-option flex items-start gap-4 p-4 rounded-lg hover:bg-gray-50 cursor-pointer">
-              <div class="flex-shrink-0">
-                <div class="w-8 h-8 rounded-full border-2 border-gray-300 flex items-center justify-center text-gray-500 option-letter">
-                  <i class="fas fa-circle text-xs"></i>
-                </div>
-              </div>
-              <div class="flex-grow">
-                <input aria-label="Option C: 5" class="sr-only" data-activity-item="item-3" name="math-question" tabindex="0" type="radio" value="item-3" />
-                <div class="text-gray-700" data-id="text-126">5</div>
-                <div class="feedback-container mt-2 hidden">
-                  <div class="flex items-center gap-2">
-                    <span class="feedback-icon w-5 h-5 rounded-full flex items-center justify-center text-sm"></span>
-                    <span class="feedback-text text-sm font-medium"></span>
-                  </div>
-                </div>
-              </div>
-            </label>
-          </div>
-        </div>
-
-        <!-- Optional image -->
-        <img src="images/example.png" alt="Example diagram" data-id="img-123" class="mb-4 w-1/3">
-      </div>
-    </section>
+    <!-- one section goes here -->
   </div>
 </div>
 ```
 
-Remember:
-- All text content needs `data-id` attributes
-- Radio inputs need `data-activity-item` attributes for answer checking
-- Use FontAwesome icons (`<i class="fas fa-circle text-xs"></i>`) in letter circles - DO NOT use text letters
-- Keep feedback containers hidden (JavaScript handles display)
-- Use semantic HTML and ARIA labels for accessibility
-- Maintain consistent styling with Tailwind CSS classes
+## Critical Validation Rules (MUST PASS)
+1. Include exactly ONE `<section>` inside `#content`.
+2. The section must have ALL of these attributes exactly:
+   - `role="activity"`
+   - `data-section-type` equal to the provided section type
+   - `data-section-id` equal to the provided section ID
+3. Use ONLY the provided `data-id` values (text IDs and image IDs). Never invent IDs.
+4. Every provided text ID must appear exactly once in one element's `data-id`.
+5. Every image ID used in HTML must be from the provided image list.
+6. Text for each text ID must match the provided text exactly (no paraphrasing, no punctuation/case changes).
+7. Do not output visible raw text outside an element that has a valid provided `data-id`.
+8. Do not include extra instructional labels as text (for example, do not print "A", "B", "C"). If you need markers, use non-text icons.
+9. No markdown, no code fences in `content`, and no additional top-level fields.
 
+## Multiple Choice Structure
+- Render option rows with radio inputs (`type="radio"`), one shared `name` per question group.
+- Each radio input must include:
+  - `class="sr-only"`
+  - `tabindex="0"`
+  - unique `data-activity-item` value within the section (for answer checking)
+  - descriptive `aria-label`
+- Keep feedback containers present and hidden by default.
+- Image-based choices are valid and encouraged when provided images are the actual options.
+- For image choices, place the option image inside the clickable `<label>` and set `data-id` on `<img>` using a provided image ID.
+- If there are not enough text IDs for per-option visible labels, keep options image-only and use `aria-label` for accessibility.
+
+## Example Pattern (ID placeholders only - replace with provided IDs)
+```html
+<section class="section mb-8" role="activity" data-section-type="SECTION_TYPE_FROM_INPUT" data-section-id="SECTION_ID_FROM_INPUT">
+  <div class="questions grow space-y-4" role="group">
+    <div class="mb-4 bg-green-100 rounded-lg p-4">
+      <p data-id="TEXT_ID_FROM_INPUT">EXACT_TEXT_FROM_INPUT</p>
+    </div>
+
+    <div class="option-container">
+      <label class="activity-option flex items-start gap-4 p-4 rounded-lg hover:bg-gray-50 cursor-pointer">
+        <div class="flex-shrink-0">
+          <div class="w-8 h-8 rounded-full border-2 border-gray-300 flex items-center justify-center text-gray-500 option-letter">
+            <i class="fas fa-circle text-xs"></i>
+          </div>
+        </div>
+        <div class="flex-grow">
+          <input type="radio" name="question-group-1" value="item-1" data-activity-item="item-1" class="sr-only" tabindex="0" aria-label="Option" />
+          <div class="text-gray-700" data-id="TEXT_ID_FROM_INPUT">EXACT_TEXT_FROM_INPUT</div>
+          <div class="feedback-container mt-2 hidden">
+            <div class="flex items-center gap-2">
+              <span class="feedback-icon w-5 h-5 rounded-full flex items-center justify-center text-sm"></span>
+              <span class="feedback-text text-sm font-medium"></span>
+            </div>
+          </div>
+        </div>
+      </label>
+    </div>
+  </div>
+</section>
+```
+
+## Example Pattern: Image-Based Choices (allowed)
+```html
+<section class="section mb-8" role="activity" data-section-type="SECTION_TYPE_FROM_INPUT" data-section-id="SECTION_ID_FROM_INPUT">
+  <div class="questions grow space-y-4" role="group">
+    <p data-id="TEXT_ID_FROM_INPUT">EXACT_TEXT_FROM_INPUT</p>
+
+    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      <label class="activity-option block p-3 rounded-lg border border-gray-200 hover:bg-gray-50 cursor-pointer">
+        <input type="radio" name="question-group-1" value="item-1" data-activity-item="item-1" class="sr-only" tabindex="0" aria-label="Option 1" />
+        <img data-id="IMAGE_ID_FROM_INPUT" src="images/IMAGE_FILE.png" alt="Option image" class="w-full h-auto rounded" />
+        <div class="feedback-container mt-2 hidden">
+          <div class="flex items-center gap-2">
+            <span class="feedback-icon w-5 h-5 rounded-full flex items-center justify-center text-sm"></span>
+            <span class="feedback-text text-sm font-medium"></span>
+          </div>
+        </div>
+      </label>
+    </div>
+  </div>
+</section>
+```
 {% endchat %}
 
 {% chat role: "user" %}
 This is the base64 image of the entire page from the textbook for context only.
 {% image page_image_base64 %}
 
-The section type for this section is: {{ section_type }}.
+Section ID: {{ section_id }}
+Section type: {{ section_type }}
 
 {% for image in images %}
-ID of the following image is: {{ image.image_id }}.
+Image ID: {{ image.image_id }}
 {% image image.image_base64 %}
 {% endfor %}
 
-The following are text blocks for the section. Each must have its corresponding data-id in the HTML:
+Allowed text IDs and exact text values (must be copied verbatim):
 {% for text in texts %}
-id: {{ text.text_id }} text type: {{ text.text_type }}.
-text: {{ text.text }}
+- id: {{ text.text_id }} | type: {{ text.text_type }} | text: "{{ text.text }}"
 {% endfor %}
 {% endchat %}

--- a/prompts/activity_open_ended_answer.liquid
+++ b/prompts/activity_open_ended_answer.liquid
@@ -9,7 +9,7 @@ You are an expert frontend engineer creating beautiful, kid-friendly HTML pages 
 </div>
 
 ### Section Structure
-<section data-section-type="activity_open_ended_answer" role="activity" class="max-w-6xl mx-auto">
+<section data-section-type="activity_open_ended_answer" data-section-id="SECTION_ID_FROM_INPUT" role="activity" class="max-w-6xl mx-auto">
 
 ### Activity Components
 
@@ -43,11 +43,14 @@ You are an expert frontend engineer creating beautiful, kid-friendly HTML pages 
 - Can include image alongside with `flex items-center justify-center`
 
 ### CRITICAL Requirements
-1. ALL text must have `data-id` matching provided text IDs
-2. ALL images must have `data-id` matching provided image IDs
-3. NO stray text directly in `<section>` - wrap everything in tagged elements
-4. Textarea must have `data-aria-id` for accessibility
-5. Use provided text IDs in exact order when possible
+1. Include exactly ONE `<section>` with `role="activity"`, `data-section-type` equal to the provided section type, and `data-section-id` equal to the provided section ID
+2. Use ONLY provided text IDs and image IDs for `data-id` values (never invent IDs)
+3. ALL text must have `data-id` matching provided text IDs
+4. ALL images must have `data-id` matching provided image IDs
+5. Text for each text ID must match the provided text exactly (no paraphrasing, no added text, no punctuation changes)
+6. NO stray visible text outside elements with valid provided `data-id`
+7. Textarea must have `data-aria-id` for accessibility
+8. If validator feedback says an exact expected value (for example section ID), use that exact value
 
 ### Response Format (STRICT)
 Return JSON object:
@@ -63,7 +66,7 @@ IMPORTANT: Your reasoning MUST be written in English, regardless of the activity
 ```html
 <div class="flex justify-center items-start min-h-[calc(100dvh-100px)]">
   <div class="container mx-auto max-w-5xl bg-white rounded-lg lg:px-24 md:px-12 sm:px-6 pt-12 pb-12" id="content">
-    <section data-section-type="activity_open_ended_answer" role="activity" class="max-w-6xl mx-auto">
+    <section data-section-type="activity_open_ended_answer" data-section-id="SECTION_ID_FROM_INPUT" role="activity" class="max-w-6xl mx-auto">
       <h1 class="text-5xl font-bold mb-4 text-amber-700" data-id="text-1">Activity Title</h1>
 
       <p class="text-xl mb-8">
@@ -115,16 +118,16 @@ IMPORTANT: Your reasoning MUST be written in English, regardless of the activity
 This is the base64 image of the entire page from the textbook for context only.
 {% image page_image_base64 %}
 
-The section type for this section is: {{ section_type }}.
+Section ID: {{ section_id }}
+Section type: {{ section_type }}
 
 {% for image in images %}
-ID of the following image is: {{ image.image_id }}.
+Image ID: {{ image.image_id }}
 {% image image.image_base64 %}
 {% endfor %}
 
-The following are text blocks for the section. Each must have its corresponding data-id in the HTML:
+Allowed text IDs and exact text values (must be copied verbatim):
 {% for text in texts %}
-id: {{ text.text_id }} text type: {{ text.text_type }}.
-text: {{ text.text }}
+- id: {{ text.text_id }} | type: {{ text.text_type }} | text: "{{ text.text }}"
 {% endfor %}
 {% endchat %}

--- a/prompts/activity_sorting.liquid
+++ b/prompts/activity_sorting.liquid
@@ -13,10 +13,13 @@ You are an expert frontend engineer creating beautiful, kid-friendly HTML pages 
 
 ### CRITICAL Requirements
 1. Layout Shell - Start with page wrapper `<div class="flex justify-center items-start min-h-[calc(100dvh-100px)]">`
-2. ONE `<section>` tag with `data-section-type` and `role="activity"`
-3. ALL text elements MUST have `data-id` matching provided text ID
-4. ALL images MUST have `data-id` matching provided image ID
-5. Only use provided images and text IDs
+2. ONE `<section>` tag with `role="activity"`, `data-section-type` equal to the provided section type, and `data-section-id` equal to the provided section ID
+3. Use ONLY provided text IDs and image IDs for `data-id` values (never invent IDs)
+4. ALL text elements MUST have `data-id` matching a provided text ID
+5. ALL images MUST have `data-id` matching a provided image ID
+6. Text for each text ID must match the provided text exactly (no paraphrasing, no added text, no punctuation changes)
+7. Do not output visible raw text outside an element with a valid provided `data-id`
+8. If validator feedback says an exact expected value (for example section ID), use that exact value
 
 ### Response Format
 ```json
@@ -52,7 +55,7 @@ IMPORTANT: Your reasoning MUST be written in English, regardless of the activity
 
 Example sorting activity:
 ```html
-<section class="bg-white mx-auto p-4" data-section-type="activity_sorting" role="activity">
+<section class="bg-white mx-auto p-4" data-section-type="activity_sorting" data-section-id="SECTION_ID_FROM_INPUT" role="activity">
   <div class="grid grid-cols-1 lg:grid-cols-3 gap-4">
     <div class="bg-white rounded-lg p-0 lg:col-span-1">
       <img alt="Description" class="w-full mx-auto rounded-lg" data-id="img-17-1" src="images/image.png">
@@ -98,16 +101,16 @@ Example sorting activity:
 This is the base64 image of the entire page from the textbook for context only.
 {% image page_image_base64 %}
 
-The section type for this section is: {{ section_type }}.
+Section ID: {{ section_id }}
+Section type: {{ section_type }}
 
 {% for image in images %}
-ID of the following image is: {{ image.image_id }}.
+Image ID: {{ image.image_id }}
 {% image image.image_base64 %}
 {% endfor %}
 
-The following are text blocks for the section. Each must have its corresponding data-id in the HTML:
+Allowed text IDs and exact text values (must be copied verbatim):
 {% for text in texts %}
-id: {{ text.text_id }} text type: {{ text.text_type }}.
-text: {{ text.text }}
+- id: {{ text.text_id }} | type: {{ text.text_type }} | text: "{{ text.text }}"
 {% endfor %}
 {% endchat %}

--- a/prompts/activity_true_false.liquid
+++ b/prompts/activity_true_false.liquid
@@ -13,10 +13,13 @@ You are an expert frontend engineer creating beautiful, kid-friendly HTML pages 
 
 ### CRITICAL Requirements
 1. Layout Shell - Start with page wrapper `<div class="flex justify-center items-start min-h-[calc(100dvh-100px)]">`
-2. ONE `<section>` tag with `data-section-type` and `role="activity"`
-3. ALL text elements MUST have `data-id` matching provided text ID
-4. ALL images MUST have `data-id` matching provided image ID
-5. Only use provided images and text IDs
+2. ONE `<section>` tag with `role="activity"`, `data-section-type` equal to the provided section type, and `data-section-id` equal to the provided section ID
+3. Use ONLY provided text IDs and image IDs for `data-id` values (never invent IDs)
+4. ALL text elements MUST have `data-id` matching a provided text ID
+5. ALL images MUST have `data-id` matching a provided image ID
+6. Text for each text ID must match the provided text exactly (no paraphrasing, no added text, no punctuation changes)
+7. Do not output visible raw text outside an element with a valid provided `data-id`
+8. If validator feedback says an exact expected value (for example section ID), use that exact value
 
 ### Response Format
 ```json
@@ -46,12 +49,12 @@ IMPORTANT: Your reasoning MUST be written in English, regardless of the activity
 
 **Required attributes:**
 - Each question needs one statement identifier (e.g., `item-1`) and BOTH radio inputs for that question must share that same `data-activity-item`
-- Use same `data-id` for "Yes" and "No" text across all questions (reusable text)
+- Only render "Yes"/"No" text if matching provided text IDs exist; otherwise use non-text markers/icons and keep labels in `aria-label`
 - Proper `name` attributes to group radio buttons per question
 
 Example true/false activity:
 ```html
-<section class="space-y-4 lg:w-3/4 mx-auto" data-section-type="activity_true_false" role="activity">
+<section class="space-y-4 lg:w-3/4 mx-auto" data-section-type="activity_true_false" data-section-id="SECTION_ID_FROM_INPUT" role="activity">
   <!-- Title and image -->
   <h1 class="font-bold text-4xl text-center mb-4" data-id="text-19-0">Activity Title</h1>
   <img class="w-full max-w-64 mx-auto block mb-4 rounded-lg" data-id="img-19-0" src="images/image.jpg" alt="Description">
@@ -116,16 +119,16 @@ Example true/false activity:
 This is the base64 image of the entire page from the textbook for context only.
 {% image page_image_base64 %}
 
-The section type for this section is: {{ section_type }}.
+Section ID: {{ section_id }}
+Section type: {{ section_type }}
 
 {% for image in images %}
-ID of the following image is: {{ image.image_id }}.
+Image ID: {{ image.image_id }}
 {% image image.image_base64 %}
 {% endfor %}
 
-The following are text blocks for the section. Each must have its corresponding data-id in the HTML:
+Allowed text IDs and exact text values (must be copied verbatim):
 {% for text in texts %}
-id: {{ text.text_id }} text type: {{ text.text_type }}.
-text: {{ text.text }}
+- id: {{ text.text_id }} | type: {{ text.text_type }} | text: "{{ text.text }}"
 {% endfor %}
 {% endchat %}


### PR DESCRIPTION
This PR adds section-level editing workflows across API and Studio, including targeted re-render and section cloning support. It updates preview and web packaging to emit per-section pages with stable section-index ordering and consistent quiz interleaving. It tightens HTML validation for image/data-id correctness and refreshes activity prompts to enforce section IDs plus exact text/ID usage. Tests were expanded across routes, services, and pipeline packaging/validation to cover the new behavior and regressions.