### PR TITLE
Close section drawer on save and enable activities for activity sections

### DIFF
--- a/apps/studio/src/components/pipeline/stages/StoryboardSectionDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/StoryboardSectionDetail.tsx
@@ -483,6 +483,7 @@ export function StoryboardSectionDetail({
   const saveSectioning = async () => {
     if (!pendingSectioning) return
     setSaving(true)
+    setPanelOpen(false)
     try {
       const minDelay = new Promise((r) => setTimeout(r, 400))
       await api.updateSectioning(bookLabel, pageId, pendingSectioning)
@@ -525,6 +526,7 @@ export function StoryboardSectionDetail({
   const saveRendering = async () => {
     if (!pendingRendering) return
     setSaving(true)
+    setPanelOpen(false)
     try {
       const minDelay = new Promise((r) => setTimeout(r, 400))
 

--- a/packages/pipeline/src/__tests__/package-web.test.ts
+++ b/packages/pipeline/src/__tests__/package-web.test.ts
@@ -270,6 +270,63 @@ describe("packageAdtWeb", () => {
     expect(fs.existsSync(path.join(bookDir, "adt", "qz001.html"))).toBe(true)
   })
 
+  it("sets activities true in config.json when a section has an activity type", async () => {
+    const bookDir = path.join(tmpDir, "book")
+    const webAssetsDir = path.join(tmpDir, "assets-web")
+    fs.mkdirSync(bookDir, { recursive: true })
+    createWebAssets(webAssetsDir)
+
+    const pages: PageData[] = [
+      { pageId: "pg001", pageNumber: 1, text: "Page one" },
+    ]
+
+    const storage = createMockStorage(pages, {
+      "web-rendering": {
+        pg001: {
+          sections: [
+            {
+              sectionIndex: 0,
+              sectionType: "activity_multiple_choice",
+              reasoning: "ok",
+              html: '<section role="activity"><div>Pick one</div></section>',
+              activityAnswers: { "item-1": true },
+            },
+          ],
+        },
+      },
+      "page-sectioning": {
+        pg001: {
+          reasoning: "ok",
+          sections: [
+            {
+              sectionId: "pg001_sec001",
+              sectionType: "activity_multiple_choice",
+              parts: [],
+              backgroundColor: "#fff",
+              textColor: "#000",
+              pageNumber: 1,
+              isPruned: false,
+            },
+          ],
+        },
+      },
+    })
+
+    await packageAdtWeb(storage, {
+      bookDir,
+      label: "book",
+      language: "en",
+      outputLanguages: ["en"],
+      title: "Book Title",
+      webAssetsDir,
+    })
+
+    const configJson = JSON.parse(
+      fs.readFileSync(path.join(bookDir, "adt", "assets", "config.json"), "utf-8"),
+    ) as { features: { activities: boolean } }
+    expect(configJson.features.activities).toBe(true)
+  })
+
   it("orders rendered sections by sectionIndex before writing pages.json", async () => {
     const bookDir = path.join(tmpDir, "book")
     const webAssetsDir = path.join(tmpDir, "assets-web")

--- a/packages/pipeline/src/package-web.ts
+++ b/packages/pipeline/src/package-web.ts
@@ -105,6 +105,7 @@ export async function packageAdtWeb(
 
   const pageList: PageEntry[] = []
   let hasMath = false
+  let hasActivitySections = false
   const copiedImages = new Set<string>()
 
   // Build a map from afterPageId -> quizzes for interleaving
@@ -134,6 +135,8 @@ export async function packageAdtWeb(
         for (const rs of sections) {
           const sectionMeta = sectioning?.sections[rs.sectionIndex]
           const sectionId = sectionMeta?.sectionId ?? `${page.pageId}_sec${String(rs.sectionIndex + 1).padStart(3, "0")}`
+
+          if (sectionMeta?.sectionType.startsWith("activity_")) hasActivitySections = true
 
           // Rewrite image URLs and copy referenced images
           const { html: rewrittenHtml, referencedImages } = rewriteImageUrls(
@@ -346,7 +349,7 @@ export async function packageAdtWeb(
       state: true,
       characterDisplay: false,
       highlight: false,
-      activities: hasQuiz,
+      activities: hasQuiz || hasActivitySections,
     },
     analytics: {
       enabled: false,


### PR DESCRIPTION
## Summary
- Close section drawer panel immediately on save while waiting for re-render
- Fix activities feature flag to detect activity section types (e.g., activity_multiple_choice, activity_matching) in addition to quiz pages
- The packaging code was only checking for quiz-generation quizzes, missing activity sections from page-sectioning data

## Test plan
- Re-open the section editor, make changes, and save — verify drawer closes immediately
- Generate a book with activity sections and open the preview — verify the submit button appears on activity sections
- Test with both activity sections and quiz pages to ensure both are detected