### PR TITLE
Improve multiple choice activity UX

### DIFF
--- a/assets/adt/modules/activities/multiple_choice.js
+++ b/assets/adt/modules/activities/multiple_choice.js
@@ -4,6 +4,9 @@ import { updateSubmitButtonAndToast, ActivityTypes } from '../utils.js';
 import { translateText } from '../translations.js';
 import { executeMail } from './send-email.js';
 import { updateResetButtonVisibility } from '../../activity.js';
+import { isTypingTarget } from './shortcut-utils.js';
+
+let multipleChoiceShortcutHandler = null;
 
 const restoreSubmitButtonToValidate = () => {
     const submitButton = document.getElementById("submit-button");
@@ -105,6 +108,32 @@ export const prepareMultipleChoice = (section) => {
 
         shortcutHint.textContent = translateText('quiz-shortcut-hint');
     }
+
+    // Allow digit keys (1-9) to select options, Enter to submit
+    const options = [...section.querySelectorAll(".activity-option")];
+    const keyHandler = (e) => {
+        if (isTypingTarget(e.target)) {
+            return;
+        }
+
+        const digit = parseInt(e.key, 10);
+        if (digit >= 1 && digit <= options.length) {
+            e.preventDefault();
+            selectOption(options[digit - 1]);
+        } else if (e.key === "Enter") {
+            const submitButton = document.getElementById("submit-button");
+            if (submitButton) {
+                e.preventDefault();
+                submitButton.click();
+            }
+        }
+    };
+    // Remove any previous handler before adding a new one
+    if (multipleChoiceShortcutHandler) {
+        document.removeEventListener("keydown", multipleChoiceShortcutHandler);
+    }
+    multipleChoiceShortcutHandler = keyHandler;
+    document.addEventListener("keydown", multipleChoiceShortcutHandler);
 };
 const saveSelectionState = (option) => {
     const activityId = location.pathname
@@ -258,7 +287,7 @@ const clearAllValidationStyling = () => {
         // Reset the letter appearance
         setLetterAppearance(
             option,
-            'w-8 h-8 rounded-full border-2 border-gray-300 flex items-center justify-center',
+            'w-8 h-8 aspect-square rounded-full border-2 border-gray-300 flex items-center justify-center',
             'option-letter text-gray-500'
         );
 
@@ -279,7 +308,7 @@ const resetOptions = (radioGroup) => {
 
         setLetterAppearance(
             opt,
-            'w-8 h-8 rounded-full border-2 border-gray-300 flex items-center justify-center',
+            'w-8 h-8 aspect-square rounded-full border-2 border-gray-300 flex items-center justify-center',
             'option-letter text-gray-500'
         );
 
@@ -306,7 +335,7 @@ const selectClickedOption = (option) => {
 
     setLetterAppearance(
         option,
-        'w-8 h-8 rounded-full border-2 border-blue-500 bg-blue-500 flex items-center justify-center',
+        'w-8 h-8 aspect-square rounded-full border-2 border-blue-500 bg-blue-500 flex items-center justify-center',
         'option-letter text-white'
     );
 
@@ -370,7 +399,7 @@ const styleSelectedOption = (option, isCorrect) => {
 
     setLetterAppearance(
         option,
-        `w-8 h-8 rounded-full border-2 flex items-center justify-center ${isCorrect
+        `w-8 h-8 aspect-square rounded-full border-2 flex items-center justify-center ${isCorrect
             ? 'border-green-500 bg-green-500 text-white'
             : 'border-red-500 bg-red-500 text-white'
             }`,

--- a/assets/adt/modules/activities/quiz.js
+++ b/assets/adt/modules/activities/quiz.js
@@ -268,7 +268,7 @@ const clearQuizValidationStyling = () => {
 
     setLetterAppearance(
       option,
-      'w-8 h-8 rounded-full border-2 border-gray-300 flex items-center justify-center',
+      'w-8 h-8 aspect-square rounded-full border-2 border-gray-300 flex items-center justify-center',
       'option-letter text-gray-500'
     );
   });
@@ -289,7 +289,7 @@ const resetQuizOptions = (radioGroup) => {
 
     setLetterAppearance(
       option,
-      'w-8 h-8 rounded-full border-2 border-gray-300 flex items-center justify-center',
+      'w-8 h-8 aspect-square rounded-full border-2 border-gray-300 flex items-center justify-center',
       'option-letter text-gray-500'
     );
 
@@ -312,7 +312,7 @@ const markQuizSelection = (option) => {
 
   setLetterAppearance(
     option,
-    'w-8 h-8 rounded-full border-2 border-blue-500 bg-blue-500 flex items-center justify-center',
+    'w-8 h-8 aspect-square rounded-full border-2 border-blue-500 bg-blue-500 flex items-center justify-center',
     'option-letter text-white'
   );
 
@@ -793,7 +793,7 @@ const styleQuizOption = (option, isCorrect) => {
 
   setLetterAppearance(
     option,
-    `w-8 h-8 rounded-full border-2 flex items-center justify-center ${
+    `w-8 h-8 aspect-square rounded-full border-2 flex items-center justify-center ${
       isCorrect ? 'border-green-500 bg-green-500 text-white' : 'border-red-500 bg-red-500 text-white'
     }`,
     'option-letter text-white'

--- a/assets/adt/modules/activities/shortcut-utils.js
+++ b/assets/adt/modules/activities/shortcut-utils.js
@@ -1,0 +1,13 @@
+export const isTypingTarget = (target) => {
+    if (!target) {
+        return false;
+    }
+
+    const tagName = target.tagName?.toLowerCase();
+    const interactiveTags = ['input', 'textarea', 'select', 'button'];
+    if (interactiveTags.includes(tagName)) {
+        return true;
+    }
+
+    return Boolean(target.isContentEditable);
+};

--- a/packages/pipeline/src/__tests__/package-web.test.ts
+++ b/packages/pipeline/src/__tests__/package-web.test.ts
@@ -327,6 +327,47 @@ describe("packageAdtWeb", () => {
     expect(configJson.features.activities).toBe(true)
   })
 
+  it("sets activities true from rendered section type even without section metadata", async () => {
+    const bookDir = path.join(tmpDir, "book")
+    const webAssetsDir = path.join(tmpDir, "assets-web")
+    fs.mkdirSync(bookDir, { recursive: true })
+    createWebAssets(webAssetsDir)
+
+    const pages: PageData[] = [
+      { pageId: "pg001", pageNumber: 1, text: "Page one" },
+    ]
+
+    const storage = createMockStorage(pages, {
+      "web-rendering": {
+        pg001: {
+          sections: [
+            {
+              sectionIndex: 0,
+              sectionType: "activity_multiple_choice",
+              reasoning: "ok",
+              html: '<section role="activity"><div>Pick one</div></section>',
+              activityAnswers: { "item-1": true },
+            },
+          ],
+        },
+      },
+    })
+
+    await packageAdtWeb(storage, {
+      bookDir,
+      label: "book",
+      language: "en",
+      outputLanguages: ["en"],
+      title: "Book Title",
+      webAssetsDir,
+    })
+
+    const configJson = JSON.parse(
+      fs.readFileSync(path.join(bookDir, "adt", "assets", "config.json"), "utf-8"),
+    ) as { features: { activities: boolean } }
+    expect(configJson.features.activities).toBe(true)
+  })
+
   it("orders rendered sections by sectionIndex before writing pages.json", async () => {
     const bookDir = path.join(tmpDir, "book")
     const webAssetsDir = path.join(tmpDir, "assets-web")

--- a/packages/pipeline/src/__tests__/shortcut-utils.test.ts
+++ b/packages/pipeline/src/__tests__/shortcut-utils.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest"
+import { isTypingTarget } from "../../../../assets/adt/modules/activities/shortcut-utils.js"
+
+describe("isTypingTarget", () => {
+  it("returns true for interactive form elements", () => {
+    expect(isTypingTarget({ tagName: "INPUT" })).toBe(true)
+    expect(isTypingTarget({ tagName: "TEXTAREA" })).toBe(true)
+    expect(isTypingTarget({ tagName: "SELECT" })).toBe(true)
+    expect(isTypingTarget({ tagName: "BUTTON" })).toBe(true)
+  })
+
+  it("returns true for contenteditable targets", () => {
+    expect(isTypingTarget({ tagName: "DIV", isContentEditable: true })).toBe(true)
+  })
+
+  it("returns false for non-interactive targets", () => {
+    expect(isTypingTarget({ tagName: "DIV" })).toBe(false)
+    expect(isTypingTarget({})).toBe(false)
+    expect(isTypingTarget(null)).toBe(false)
+  })
+})

--- a/packages/pipeline/src/package-web.ts
+++ b/packages/pipeline/src/package-web.ts
@@ -136,7 +136,9 @@ export async function packageAdtWeb(
           const sectionMeta = sectioning?.sections[rs.sectionIndex]
           const sectionId = sectionMeta?.sectionId ?? `${page.pageId}_sec${String(rs.sectionIndex + 1).padStart(3, "0")}`
 
-          if (sectionMeta?.sectionType.startsWith("activity_")) hasActivitySections = true
+          if (rs.sectionType.startsWith("activity_") || sectionMeta?.sectionType.startsWith("activity_")) {
+            hasActivitySections = true
+          }
 
           // Rewrite image URLs and copy referenced images
           const { html: rewrittenHtml, referencedImages } = rewriteImageUrls(

--- a/packages/pipeline/src/validate-html.ts
+++ b/packages/pipeline/src/validate-html.ts
@@ -128,6 +128,8 @@ function walkNode(
   if (node.type === "text") {
     if (node.data.trim().length > 0) {
       if (isInsideExemptTag(node)) return
+      // Allow single-digit numbers as bare text (used as option markers in activities)
+      if (/^\d$/.test(node.data.trim())) return
       if (!hasAncestorWithDataId(node)) {
         const snippet = node.data.trim().slice(0, 50)
         errors.push(`Text node outside any data-id element: "${snippet}"`)

--- a/prompts/activity_multiple_choice.liquid
+++ b/prompts/activity_multiple_choice.liquid
@@ -32,8 +32,8 @@ Use this exact outer shell:
 4. Every provided text ID must appear exactly once in one element's `data-id`.
 5. Every image ID used in HTML must be from the provided image list.
 6. Text for each text ID must match the provided text exactly (no paraphrasing, no punctuation/case changes).
-7. Do not output visible raw text outside an element that has a valid provided `data-id`.
-8. Do not include extra instructional labels as text (for example, do not print "A", "B", "C"). If you need markers, use non-text icons.
+7. Do not output visible raw text outside an element that has a valid provided `data-id`. The only exception is single-digit numbers used as option markers.
+8. Use sequential numbers (1, 2, 3, …) as option markers inside the `.option-letter` element. Do not use letters (A, B, C) as they are not language-neutral.
 9. No markdown, no code fences in `content`, and no additional top-level fields.
 
 ## Multiple Choice Structure
@@ -59,8 +59,8 @@ Use this exact outer shell:
     <div class="option-container">
       <label class="activity-option flex items-start gap-4 p-4 rounded-lg hover:bg-gray-50 cursor-pointer">
         <div class="flex-shrink-0">
-          <div class="w-8 h-8 rounded-full border-2 border-gray-300 flex items-center justify-center text-gray-500 option-letter">
-            <i class="fas fa-circle text-xs"></i>
+          <div class="w-8 h-8 aspect-square rounded-full border-2 border-gray-300 flex items-center justify-center text-gray-500 option-letter">
+            1
           </div>
         </div>
         <div class="flex-grow">
@@ -86,13 +86,20 @@ Use this exact outer shell:
     <p data-id="TEXT_ID_FROM_INPUT">EXACT_TEXT_FROM_INPUT</p>
 
     <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-      <label class="activity-option block p-3 rounded-lg border border-gray-200 hover:bg-gray-50 cursor-pointer">
-        <input type="radio" name="question-group-1" value="item-1" data-activity-item="item-1" class="sr-only" tabindex="0" aria-label="Option 1" />
-        <img data-id="IMAGE_ID_FROM_INPUT" src="images/IMAGE_FILE.png" alt="Option image" class="w-full h-auto rounded" />
-        <div class="feedback-container mt-2 hidden">
-          <div class="flex items-center gap-2">
-            <span class="feedback-icon w-5 h-5 rounded-full flex items-center justify-center text-sm"></span>
-            <span class="feedback-text text-sm font-medium"></span>
+      <label class="activity-option flex items-start gap-4 p-4 rounded-lg border border-gray-200 hover:bg-gray-50 cursor-pointer">
+        <div class="flex-shrink-0">
+          <div class="w-8 h-8 aspect-square rounded-full border-2 border-gray-300 flex items-center justify-center text-gray-500 option-letter">
+            1
+          </div>
+        </div>
+        <div class="flex-grow">
+          <input type="radio" name="question-group-1" value="item-1" data-activity-item="item-1" class="sr-only" tabindex="0" aria-label="Option 1" />
+          <img data-id="IMAGE_ID_FROM_INPUT" src="images/IMAGE_FILE.png" alt="Option image" class="w-full h-auto rounded" />
+          <div class="feedback-container mt-2 hidden">
+            <div class="flex items-center gap-2">
+              <span class="feedback-icon w-5 h-5 rounded-full flex items-center justify-center text-sm"></span>
+              <span class="feedback-text text-sm font-medium"></span>
+            </div>
           </div>
         </div>
       </label>


### PR DESCRIPTION
## Summary
- Use sequential numbers (1, 2, 3) instead of icon circles as option markers in multiple choice activities — more accessible across languages
- Add numbered markers to image-based choices, fixing missing selection highlight when clicking image options
- Add `aspect-square` to option circles in prompt and JS to prevent oval rendering in flex layouts
- Add keyboard shortcuts: digit keys (1-9) to select options, Enter to submit
- Allow single-digit bare text in HTML validation for option markers
- Also detect activity sections from rendered `sectionType` for the activities config flag

## Test plan
- Re-render a multiple choice activity and verify numbered markers appear
- Click image-based options and verify blue selection highlight appears
- Press digit keys to select options, Enter to submit
- Verify circles stay round (not oval) across all selection states
- Run `pnpm test` — all tests pass