### PR TITLE
Preserve section data on storyboard settings save

### DIFF
--- a/apps/api/src/routes/books.test.ts
+++ b/apps/api/src/routes/books.test.ts
@@ -5,7 +5,11 @@ import path from "node:path"
 import { openBookDb, createBookStorage } from "@adt/storage"
 import { SCHEMA_VERSION } from "@adt/types"
 import type { StageName } from "@adt/types"
-import type { StageService, StageRunJob } from "../services/stage-service.js"
+import type {
+  StageService,
+  StageRunJob,
+  StageRunOptions,
+} from "../services/stage-service.js"
 import { createBookRoutes } from "./books.js"
 import { createStageRoutes } from "./stages.js"
 
@@ -438,6 +442,66 @@ function addExtractNodes(label: string, count: number, includeSummary = true): v
     storage.close()
   }
 }
+
+describe("POST /books/:label/stages/run", () => {
+  it("passes renderOnly and preserves page sectioning data for storyboard reruns", async () => {
+    const label = "render-only-route"
+    createTestBook(label)
+    const storage = createBookStorage(label, tmpDir)
+    try {
+      storage.putNodeData("page-sectioning", "pg001", {
+        reasoning: "existing",
+        sections: [],
+      })
+      storage.putNodeData("web-rendering", "pg001", {
+        sections: [{ sectionIndex: 0, sectionType: "content", reasoning: "", html: "<p>x</p>" }],
+      })
+      storage.markStepCompleted("page-sectioning")
+      storage.markStepCompleted("web-rendering")
+    } finally {
+      storage.close()
+    }
+
+    let receivedOptions: StageRunOptions | undefined
+    const stageService: StageService = {
+      getStatus: () => ({ active: null, queue: [] }),
+      getQueuedStages: () => [],
+      addListener: () => () => {},
+      startStageRun: (_label, options) => {
+        receivedOptions = options
+        return { status: "started" as const, id: "run-1" }
+      },
+    }
+
+    const app = createStageRoutes(stageService, tmpDir, "")
+    const res = await app.request(`/books/${label}/stages/run`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-OpenAI-Key": "sk-test",
+      },
+      body: JSON.stringify({
+        fromStage: "storyboard",
+        toStage: "storyboard",
+        renderOnly: true,
+      }),
+    })
+
+    expect(res.status).toBe(200)
+    expect(receivedOptions?.renderOnly).toBe(true)
+
+    const verifyStorage = createBookStorage(label, tmpDir)
+    try {
+      expect(verifyStorage.getLatestNodeData("page-sectioning", "pg001")).not.toBeNull()
+      expect(verifyStorage.getLatestNodeData("web-rendering", "pg001")).toBeNull()
+      const runs = new Map(verifyStorage.getStepRuns().map((r) => [r.step, r.status]))
+      expect(runs.get("page-sectioning")).toBe("done")
+      expect(runs.has("web-rendering")).toBe(false)
+    } finally {
+      verifyStorage.close()
+    }
+  })
+})
 
 describe("GET /books/:label/step-status", () => {
   const extractStageSteps = [

--- a/apps/api/src/routes/stages.ts
+++ b/apps/api/src/routes/stages.ts
@@ -12,12 +12,15 @@ const StageRunBody = z
   .object({
     fromStage: StageName,
     toStage: StageName,
+    renderOnly: z.boolean().optional(),
   })
   .strict()
 
 /** Build a beforeRun callback that clears downstream data for a stage.
- *  The returned function is idempotent — only runs once even if called multiple times. */
-function makeBeforeRun(label: string, fromStage: StageName, booksDir: string): () => void {
+ *  The returned function is idempotent — only runs once even if called multiple times.
+ *  When renderOnly is true and fromStage is "storyboard", page-sectioning data
+ *  and step_run records are preserved so only rendering is regenerated. */
+function makeBeforeRun(label: string, fromStage: StageName, booksDir: string, renderOnly?: boolean): () => void {
   let ran = false
   return () => {
     if (ran) return
@@ -28,15 +31,22 @@ function makeBeforeRun(label: string, fromStage: StageName, booksDir: string): (
         // clearExtractedData also clears step_runs
         storage.clearExtractedData()
       } else {
-        const nodes = getStageClearNodes(fromStage)
+        let nodes = getStageClearNodes(fromStage)
+        // Render-only: keep page-sectioning data, only clear rendering + downstream
+        if (renderOnly && fromStage === "storyboard") {
+          nodes = nodes.filter((n) => n !== "page-sectioning")
+        }
         if (nodes.length > 0) {
           storage.clearNodesByType(nodes)
         }
         // Clear step run records for all downstream stages
         const stagesToClear = getStageClearOrder(fromStage)
-        const stepsToClear = PIPELINE
+        let stepsToClear = PIPELINE
           .filter((s) => stagesToClear.includes(s.name))
           .flatMap((s) => s.steps.map((step) => step.name))
+        if (renderOnly && fromStage === "storyboard") {
+          stepsToClear = stepsToClear.filter((s) => s !== "page-sectioning")
+        }
         storage.clearStepRuns(stepsToClear)
       }
     } finally {
@@ -84,14 +94,14 @@ export function createStageRoutes(
       })
     }
 
-    const { fromStage, toStage } = parsed.data
+    const { fromStage, toStage, renderOnly } = parsed.data
 
     const azureSpeechKey = c.req.header("X-Azure-Speech-Key") || undefined
     const azureSpeechRegion = c.req.header("X-Azure-Speech-Region") || undefined
 
-    console.log(`[stages] ${label}: ${fromStage}→${toStage} azureKey=${azureSpeechKey ? "set" : "NOT SET"} azureRegion=${azureSpeechRegion ?? "NOT SET"}`)
+    console.log(`[stages] ${label}: ${fromStage}→${toStage}${renderOnly ? " (render-only)" : ""} azureKey=${azureSpeechKey ? "set" : "NOT SET"} azureRegion=${azureSpeechRegion ?? "NOT SET"}`)
 
-    const clearData = makeBeforeRun(label, fromStage, booksDir)
+    const clearData = makeBeforeRun(label, fromStage, booksDir, renderOnly)
 
     const result = stageService.startStageRun(label, {
       booksDir,
@@ -100,6 +110,7 @@ export function createStageRoutes(
       configPath,
       fromStage,
       toStage,
+      renderOnly,
       azureSpeechKey,
       azureSpeechRegion,
       // Queued jobs clear data when they start executing

--- a/apps/api/src/services/stage-runner.test.ts
+++ b/apps/api/src/services/stage-runner.test.ts
@@ -2,14 +2,19 @@ import fs from "node:fs"
 import os from "node:os"
 import path from "node:path"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import type { AppConfig } from "@adt/types"
+import type { AppConfig, ProgressEvent } from "@adt/types"
 import { createBookStorage } from "@adt/storage"
 import {
   buildStageRunnerImageClassifyConfig,
   createStageRunner,
 } from "./stage-runner.js"
 
-const { capturedCaptionInputs, captionPageImagesMock } = vi.hoisted(() => {
+const {
+  capturedCaptionInputs,
+  captionPageImagesMock,
+  renderPageMock,
+  sectionPageMock,
+} = vi.hoisted(() => {
   const capturedCaptionInputs: unknown[] = []
   return {
     capturedCaptionInputs,
@@ -17,6 +22,8 @@ const { capturedCaptionInputs, captionPageImagesMock } = vi.hoisted(() => {
       capturedCaptionInputs.push(input)
       return { captions: [] }
     }),
+    renderPageMock: vi.fn(async () => ({ sections: [] })),
+    sectionPageMock: vi.fn(async () => ({ reasoning: "", sections: [] })),
   }
 })
 
@@ -27,6 +34,8 @@ vi.mock("@adt/pipeline", async () => {
   return {
     ...actual,
     captionPageImages: captionPageImagesMock,
+    renderPage: renderPageMock,
+    sectionPage: sectionPageMock,
   }
 })
 
@@ -91,6 +100,52 @@ function seedCaptionBook(
   }
 }
 
+function seedStoryboardBook(booksDir: string, label: string): void {
+  const storage = createBookStorage(label, booksDir)
+  try {
+    storage.putExtractedPage({
+      pageId: "pg001",
+      pageNumber: 1,
+      text: "Page text",
+      pageImage: {
+        imageId: "pg001_page",
+        buffer: Buffer.from("fake-page-image"),
+        format: "png",
+        hash: "hash-page",
+        width: 800,
+        height: 600,
+      },
+      images: [
+        {
+          imageId: "pg001_im001",
+          buffer: Buffer.from("fake-image"),
+          format: "png",
+          hash: "hash-image",
+          width: 400,
+          height: 300,
+        },
+      ],
+    })
+
+    storage.putNodeData("page-sectioning", "pg001", {
+      reasoning: "existing sectioning",
+      sections: [
+        {
+          sectionId: "pg001_sec001",
+          sectionType: "content",
+          parts: [],
+          backgroundColor: "#ffffff",
+          textColor: "#000000",
+          pageNumber: 1,
+          isPruned: false,
+        },
+      ],
+    })
+  } finally {
+    storage.close()
+  }
+}
+
 describe("buildStageRunnerImageClassifyConfig", () => {
   it("injects getImageBytes so min_stddev filtering can decode image bytes", () => {
     const config: AppConfig = {
@@ -125,6 +180,8 @@ describe("createStageRunner captions step", () => {
   beforeEach(() => {
     capturedCaptionInputs.length = 0
     captionPageImagesMock.mockClear()
+    renderPageMock.mockClear()
+    sectionPageMock.mockClear()
   })
 
   afterEach(() => {
@@ -196,5 +253,62 @@ describe("createStageRunner captions step", () => {
     expect(captionPageImagesMock).toHaveBeenCalledTimes(1)
     const firstInput = capturedCaptionInputs[0] as { bookSummary?: string }
     expect(firstInput.bookSummary).toBeUndefined()
+  })
+})
+
+describe("createStageRunner storyboard render-only", () => {
+  let tmpDir = ""
+
+  afterEach(() => {
+    if (tmpDir) {
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+      tmpDir = ""
+    }
+  })
+
+  it("skips page sectioning and re-renders from existing section data", async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "stage-runner-storyboard-"))
+    const booksDir = path.join(tmpDir, "books")
+    const promptsDir = path.join(tmpDir, "prompts")
+    const configPath = path.join(tmpDir, "config.yaml")
+    fs.mkdirSync(promptsDir, { recursive: true })
+    writeBaseConfig(configPath)
+    seedStoryboardBook(booksDir, "render-only")
+
+    const events: ProgressEvent[] = []
+    const runner = createStageRunner()
+    await runner.run(
+      "render-only",
+      {
+        booksDir,
+        apiKey: "sk-test",
+        promptsDir,
+        configPath,
+        fromStage: "storyboard",
+        toStage: "storyboard",
+        renderOnly: true,
+      },
+      { emit: (event) => events.push(event) }
+    )
+
+    expect(sectionPageMock).not.toHaveBeenCalled()
+    expect(renderPageMock).toHaveBeenCalledTimes(1)
+    expect(
+      events.some(
+        (event) => event.type === "step-skip" && event.step === "page-sectioning"
+      )
+    ).toBe(true)
+    expect(
+      events.some(
+        (event) =>
+          event.type === "step-complete" && event.step === "web-rendering"
+      )
+    ).toBe(true)
+    expect(
+      events.some(
+        (event) =>
+          event.type === "step-complete" && event.step === "page-sectioning"
+      )
+    ).toBe(false)
   })
 })

--- a/apps/api/src/services/stage-runner.ts
+++ b/apps/api/src/services/stage-runner.ts
@@ -504,7 +504,7 @@ async function runStoryboardStep(
   options: StageRunOptions,
   progress: StageRunProgress
 ): Promise<void> {
-  const { booksDir, apiKey, promptsDir, configPath } = options
+  const { booksDir, apiKey, promptsDir, configPath, renderOnly } = options
 
   const previousKey = process.env.OPENAI_API_KEY
   process.env.OPENAI_API_KEY = apiKey
@@ -516,11 +516,10 @@ async function runStoryboardStep(
 
     const styleguideContent = loadStyleguideContent(config.styleguide, configPath)
 
-    // Build configs
-    const sectioningConfig = buildSectioningConfig(config)
+    // Render config is always needed
     const resolveRenderConfig = buildRenderStrategyResolver(config)
 
-    // Create prompt engine, rate limiter, LLM model
+    // Shared infrastructure for LLM calls
     const cacheDir = path.join(path.resolve(booksDir), label, ".cache")
     const bookPromptsDir = path.join(path.resolve(booksDir), label, "prompts")
     const promptEngine = createPromptEngine([bookPromptsDir, promptsDir])
@@ -544,14 +543,6 @@ async function runStoryboardStep(
         validationErrors: entry.validationErrors,
       })
     }
-
-    const llmModel = createLLMModel({
-      modelId: sectioningConfig.modelId,
-      cacheDir,
-      promptEngine,
-      rateLimiter,
-      onLog: onLlmLog,
-    })
 
     // Create template engine
     const templatesDir = path.join(path.dirname(promptsDir), "templates")
@@ -578,142 +569,248 @@ async function runStoryboardStep(
     const totalPages = pages.length
     const effectiveConcurrency = config.concurrency ?? 32
 
-    console.log(
-      `[stage-run] ${label}: running storyboard for ${totalPages} pages (concurrency=${effectiveConcurrency})`
-    )
-
-    let completedSectioning = 0
-    let completedRendering = 0
-    const failedPages: string[] = []
-
-    await processWithConcurrency(
-      pages,
-      effectiveConcurrency,
-      async (page: PageData) => {
-        try {
-          // Get text-classification data
-          const textClassificationRow = storage.getLatestNodeData(
-            "text-classification",
-            page.pageId
-          )
-          if (!textClassificationRow) {
-            console.log(
-              `[stage-run] ${label}: skipping ${page.pageId} (no text-classification)`
-            )
-            return
-          }
-          const textClassification = textClassificationRow.data as TextClassificationOutput
-
-          // Get image-filtering data
-          const imageClassificationRow = storage.getLatestNodeData(
-            "image-filtering",
-            page.pageId
-          )
-          const imageClassification = (imageClassificationRow?.data as ImageClassificationOutput) ?? { images: [] }
-
-          // Get page image
-          const pageImageBase64 = storage.getPageImageBase64(page.pageId)
-
-          // Build image lists from classification (includes crop entries).
-          // Fallback to stored page images for partial runs where classification is missing.
-          const classifiedUnprunedImageIds = imageClassification.images
-            .filter((img) => !img.isPruned)
-            .map((img) => img.imageId)
-          const unprunedImageIds = imageClassificationRow
-            ? classifiedUnprunedImageIds
-            : storage.getPageImages(page.pageId).map((img) => img.imageId)
-
-          const sectionImages = unprunedImageIds.map((imageId) => ({
-            imageId,
-            imageBase64: storage.getImageBase64(imageId),
-          }))
-
-          // Page sectioning
-          console.log(
-            `[stage-run] ${label}: sectioning ${page.pageId}`
-          )
-          const sectionResult = await sectionPage(
-            {
-              pageId: page.pageId,
-              pageNumber: page.pageNumber,
-              pageImageBase64,
-              textClassification,
-              imageClassification,
-              images: sectionImages,
-            },
-            sectioningConfig,
-            llmModel
-          )
-          storage.putNodeData("page-sectioning", page.pageId, sectionResult)
-          completedSectioning++
-          progress.emit({
-            type: "step-progress",
-            step: "page-sectioning",
-            message: `${completedSectioning}/${totalPages}`,
-            page: completedSectioning,
-            totalPages,
-          })
-
-          // Build render images map from classification
-          const renderImages = new Map<string, string>()
-          for (const imageId of unprunedImageIds) {
-            renderImages.set(imageId, storage.getImageBase64(imageId))
-          }
-
-          // Web rendering
-          console.log(
-            `[stage-run] ${label}: rendering ${page.pageId}`
-          )
-          const sectioning = sectionResult as PageSectioningOutput
-          const renderResult = await renderPage(
-            {
-              label,
-              pageId: page.pageId,
-              pageImageBase64,
-              sectioning,
-              images: renderImages,
-              styleguide: styleguideContent,
-            },
-            resolveRenderConfig,
-            resolveRenderModel,
-            templateEngine
-          )
-          storage.putNodeData("web-rendering", page.pageId, renderResult)
-          completedRendering++
-          progress.emit({
-            type: "step-progress",
-            step: "web-rendering",
-            message: `${completedRendering}/${totalPages}`,
-            page: completedRendering,
-            totalPages,
-          })
-        } catch (err) {
-          const msg = toErrorMessage(err)
-          const step =
-            err instanceof StepError ? err.step : "page-sectioning"
-          console.error(
-            `[stage-run] ${label}: ${page.pageId} failed at ${step}: ${msg}`
-          )
-          failedPages.push(`${page.pageId} [${step}]: ${msg}`)
-          progress.emit({
-            type: "step-error",
-            step,
-            error: `${page.pageId} failed: ${msg}`,
-          })
-        }
-      }
-    )
-
-    if (failedPages.length > 0) {
-      throw new Error(
-        `${failedPages.length} page(s) failed:\n${failedPages.join("\n")}`
+    if (renderOnly) {
+      // -- RENDER-ONLY PATH --
+      // Skip sectioning, re-render from existing page-sectioning data
+      console.log(
+        `[stage-run] ${label}: re-rendering storyboard for ${totalPages} pages (concurrency=${effectiveConcurrency})`
       )
-    }
 
-    // Emit completion for storyboard steps
-    progress.emit({ type: "step-complete", step: "page-sectioning" })
-    progress.emit({ type: "step-complete", step: "web-rendering" })
-    console.log(`[stage-run] ${label}: storyboard complete`)
+      progress.emit({ type: "step-skip", step: "page-sectioning" })
+
+      let completedRendering = 0
+      const failedPages: string[] = []
+
+      await processWithConcurrency(
+        pages,
+        effectiveConcurrency,
+        async (page: PageData) => {
+          try {
+            // Read existing sectioning data
+            const sectioningRow = storage.getLatestNodeData("page-sectioning", page.pageId)
+            if (!sectioningRow) {
+              console.log(
+                `[stage-run] ${label}: skipping ${page.pageId} (no existing sectioning)`
+              )
+              completedRendering++
+              progress.emit({
+                type: "step-progress",
+                step: "web-rendering",
+                message: `${completedRendering}/${totalPages}`,
+                page: completedRendering,
+                totalPages,
+              })
+              return
+            }
+            const sectioning = sectioningRow.data as PageSectioningOutput
+
+            // Build render images map from page images
+            const allImages = storage.getPageImages(page.pageId)
+            const renderImages = new Map<string, string>()
+            for (const img of allImages) {
+              renderImages.set(img.imageId, storage.getImageBase64(img.imageId))
+            }
+
+            const pageImageBase64 = storage.getPageImageBase64(page.pageId)
+
+            // Web rendering
+            console.log(
+              `[stage-run] ${label}: rendering ${page.pageId}`
+            )
+            const renderResult = await renderPage(
+              {
+                label,
+                pageId: page.pageId,
+                pageImageBase64,
+                sectioning,
+                images: renderImages,
+                styleguide: styleguideContent,
+              },
+              resolveRenderConfig,
+              resolveRenderModel,
+              templateEngine
+            )
+            storage.putNodeData("web-rendering", page.pageId, renderResult)
+            completedRendering++
+            progress.emit({
+              type: "step-progress",
+              step: "web-rendering",
+              message: `${completedRendering}/${totalPages}`,
+              page: completedRendering,
+              totalPages,
+            })
+          } catch (err) {
+            const msg = toErrorMessage(err)
+            console.error(
+              `[stage-run] ${label}: ${page.pageId} failed at web-rendering: ${msg}`
+            )
+            failedPages.push(`${page.pageId} [web-rendering]: ${msg}`)
+            progress.emit({
+              type: "step-error",
+              step: "web-rendering",
+              error: `${page.pageId} failed: ${msg}`,
+            })
+          }
+        }
+      )
+
+      if (failedPages.length > 0) {
+        throw new Error(
+          `${failedPages.length} page(s) failed:\n${failedPages.join("\n")}`
+        )
+      }
+
+      progress.emit({ type: "step-complete", step: "web-rendering" })
+      console.log(`[stage-run] ${label}: storyboard re-render complete`)
+    } else {
+      // -- FULL RUN PATH --
+      // Sectioning config and LLM model only needed for full run
+      const sectioningConfig = buildSectioningConfig(config)
+      const llmModel = createLLMModel({
+        modelId: sectioningConfig.modelId,
+        cacheDir,
+        promptEngine,
+        rateLimiter,
+        onLog: onLlmLog,
+      })
+
+      console.log(
+        `[stage-run] ${label}: running storyboard for ${totalPages} pages (concurrency=${effectiveConcurrency})`
+      )
+
+      let completedSectioning = 0
+      let completedRendering = 0
+      const failedPages: string[] = []
+
+      await processWithConcurrency(
+        pages,
+        effectiveConcurrency,
+        async (page: PageData) => {
+          try {
+            // Get text-classification data
+            const textClassificationRow = storage.getLatestNodeData(
+              "text-classification",
+              page.pageId
+            )
+            if (!textClassificationRow) {
+              console.log(
+                `[stage-run] ${label}: skipping ${page.pageId} (no text-classification)`
+              )
+              return
+            }
+            const textClassification = textClassificationRow.data as TextClassificationOutput
+
+            // Get image-filtering data
+            const imageClassificationRow = storage.getLatestNodeData(
+              "image-filtering",
+              page.pageId
+            )
+            const imageClassification = (imageClassificationRow?.data as ImageClassificationOutput) ?? { images: [] }
+
+            // Get page image
+            const pageImageBase64 = storage.getPageImageBase64(page.pageId)
+
+            // Build image lists from classification (includes crop entries).
+            // Fallback to stored page images for partial runs where classification is missing.
+            const classifiedUnprunedImageIds = imageClassification.images
+              .filter((img) => !img.isPruned)
+              .map((img) => img.imageId)
+            const unprunedImageIds = imageClassificationRow
+              ? classifiedUnprunedImageIds
+              : storage.getPageImages(page.pageId).map((img) => img.imageId)
+
+            const sectionImages = unprunedImageIds.map((imageId) => ({
+              imageId,
+              imageBase64: storage.getImageBase64(imageId),
+            }))
+
+            // Page sectioning
+            console.log(
+              `[stage-run] ${label}: sectioning ${page.pageId}`
+            )
+            const sectionResult = await sectionPage(
+              {
+                pageId: page.pageId,
+                pageNumber: page.pageNumber,
+                pageImageBase64,
+                textClassification,
+                imageClassification,
+                images: sectionImages,
+              },
+              sectioningConfig,
+              llmModel
+            )
+            storage.putNodeData("page-sectioning", page.pageId, sectionResult)
+            completedSectioning++
+            progress.emit({
+              type: "step-progress",
+              step: "page-sectioning",
+              message: `${completedSectioning}/${totalPages}`,
+              page: completedSectioning,
+              totalPages,
+            })
+
+            // Build render images map from classification
+            const renderImages = new Map<string, string>()
+            for (const imageId of unprunedImageIds) {
+              renderImages.set(imageId, storage.getImageBase64(imageId))
+            }
+
+            // Web rendering
+            console.log(
+              `[stage-run] ${label}: rendering ${page.pageId}`
+            )
+            const sectioning = sectionResult as PageSectioningOutput
+            const renderResult = await renderPage(
+              {
+                label,
+                pageId: page.pageId,
+                pageImageBase64,
+                sectioning,
+                images: renderImages,
+                styleguide: styleguideContent,
+              },
+              resolveRenderConfig,
+              resolveRenderModel,
+              templateEngine
+            )
+            storage.putNodeData("web-rendering", page.pageId, renderResult)
+            completedRendering++
+            progress.emit({
+              type: "step-progress",
+              step: "web-rendering",
+              message: `${completedRendering}/${totalPages}`,
+              page: completedRendering,
+              totalPages,
+            })
+          } catch (err) {
+            const msg = toErrorMessage(err)
+            const step =
+              err instanceof StepError ? err.step : "page-sectioning"
+            console.error(
+              `[stage-run] ${label}: ${page.pageId} failed at ${step}: ${msg}`
+            )
+            failedPages.push(`${page.pageId} [${step}]: ${msg}`)
+            progress.emit({
+              type: "step-error",
+              step,
+              error: `${page.pageId} failed: ${msg}`,
+            })
+          }
+        }
+      )
+
+      if (failedPages.length > 0) {
+        throw new Error(
+          `${failedPages.length} page(s) failed:\n${failedPages.join("\n")}`
+        )
+      }
+
+      // Emit completion for storyboard steps
+      progress.emit({ type: "step-complete", step: "page-sectioning" })
+      progress.emit({ type: "step-complete", step: "web-rendering" })
+      console.log(`[stage-run] ${label}: storyboard complete`)
+    }
   } finally {
     storage.close()
     if (previousKey !== undefined) {

--- a/apps/api/src/services/stage-service.ts
+++ b/apps/api/src/services/stage-service.ts
@@ -45,6 +45,8 @@ export interface StageRunOptions {
   configPath?: string
   fromStage: string
   toStage: string
+  /** When true, skip page-sectioning and only re-render from existing section data. */
+  renderOnly?: boolean
   azureSpeechKey?: string
   azureSpeechRegion?: string
   beforeRun?: () => void

--- a/apps/studio/src/api/client.ts
+++ b/apps/studio/src/api/client.ts
@@ -72,6 +72,8 @@ export interface AzureCredentials {
 export interface RunStagesOptions {
   fromStage: string
   toStage: string
+  /** When true, skip page-sectioning and only re-render from existing section data. */
+  renderOnly?: boolean
 }
 
 function buildApiHeaders(

--- a/apps/studio/src/components/pipeline/stages/StoryboardSettings.tsx
+++ b/apps/studio/src/components/pipeline/stages/StoryboardSettings.tsx
@@ -31,6 +31,7 @@ import { PromptViewer } from "@/components/pipeline/PromptViewer"
 import { TemplateViewer } from "@/components/pipeline/TemplateViewer"
 import { useBookRun } from "@/hooks/use-book-run"
 import { useStepConfig } from "@/hooks/use-step-config"
+import { hasSectioningChanges, hasSectioningData } from "./storyboard-rerun-policy"
 
 /** "two_column_story" → "Two Column Story" */
 function titleCase(slug: string): string {
@@ -61,7 +62,7 @@ export function StoryboardSettings({ bookLabel, headerTarget, tab = "general" }:
   const { data: activeConfigData } = useActiveConfig(bookLabel)
   const updateConfig = useUpdateBookConfig()
   const { apiKey, hasApiKey } = useApiKey()
-  const { queueRun } = useBookRun()
+  const { queueRun, stepState } = useBookRun()
   const navigate = useNavigate()
   const [showRerunDialog, setShowRerunDialog] = useState(false)
   const [savingImageGenPrompt, setSavingImageGenPrompt] = useState(false)
@@ -151,6 +152,9 @@ export function StoryboardSettings({ bookLabel, headerTarget, tab = "general" }:
 
   const merged = activeConfigData?.merged as Record<string, unknown> | undefined
   const sectioning = useStepConfig(merged, "page_sectioning", markDirty)
+
+  // Whether sectioning data already exists (storyboard has been run at least once)
+  const hasExistingSectioningData = hasSectioningData(stepState("page-sectioning"))
 
   // Load section types, pruned types, render strategy, and models from active (merged) config
   useEffect(() => {
@@ -332,6 +336,8 @@ export function StoryboardSettings({ bookLabel, headerTarget, tab = "general" }:
     return overrides
   }
 
+  const needsResectioning = hasSectioningChanges(dirty, sectioningPromptDraft)
+
   const confirmSaveAndRerun = async () => {
     // Save any edited prompts/templates first
     const contentSaves: Promise<unknown>[] = []
@@ -343,6 +349,10 @@ export function StoryboardSettings({ bookLabel, headerTarget, tab = "general" }:
     if (activityAnswerDraft != null && selectedActivity?.answer_prompt) contentSaves.push(api.updatePrompt(selectedActivity.answer_prompt, activityAnswerDraft, bookLabel))
     if (imageGenPromptDraft != null) contentSaves.push(api.updatePrompt("ai_image_generation", imageGenPromptDraft, bookLabel))
     if (contentSaves.length > 0) await Promise.all(contentSaves)
+
+    // Only re-render (preserve sections) when sectioning data exists and
+    // no sectioning-related settings were changed.
+    const renderOnly = hasExistingSectioningData && !needsResectioning
 
     const overrides = buildOverrides()
     updateConfig.mutate(
@@ -358,7 +368,7 @@ export function StoryboardSettings({ bookLabel, headerTarget, tab = "general" }:
           setActivityAnswerDraft(null)
           setImageGenPromptDraft(null)
           setShowRerunDialog(false)
-          queueRun({ fromStage: "storyboard", toStage: "storyboard", apiKey })
+          queueRun({ fromStage: "storyboard", toStage: "storyboard", apiKey, renderOnly })
           navigate({ to: "/books/$label/$step", params: { label: bookLabel, step: "storyboard" } })
         },
       }
@@ -955,7 +965,9 @@ export function StoryboardSettings({ bookLabel, headerTarget, tab = "general" }:
             <DialogTitle>Save &amp; Rerun Storyboard</DialogTitle>
             <DialogDescription>
               This will save your settings and re-run the storyboard pipeline.
-              Sectioning and rendering will be regenerated for all pages.
+              {hasExistingSectioningData && !needsResectioning
+                ? " Only rendering will be regenerated — your existing sections will be preserved."
+                : " Sectioning and rendering will be regenerated for all pages."}
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>

--- a/apps/studio/src/components/pipeline/stages/storyboard-rerun-policy.test.ts
+++ b/apps/studio/src/components/pipeline/stages/storyboard-rerun-policy.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest"
+import {
+  hasSectioningChanges,
+  hasSectioningData,
+} from "./storyboard-rerun-policy"
+
+describe("hasSectioningData", () => {
+  it("treats done as existing sectioning data", () => {
+    expect(hasSectioningData("done")).toBe(true)
+  })
+
+  it("treats skipped as existing sectioning data", () => {
+    expect(hasSectioningData("skipped")).toBe(true)
+  })
+
+  it("treats idle as missing sectioning data", () => {
+    expect(hasSectioningData("idle")).toBe(false)
+  })
+})
+
+describe("hasSectioningChanges", () => {
+  it("returns true when prompt draft changed", () => {
+    expect(hasSectioningChanges({}, "updated prompt")).toBe(true)
+  })
+
+  it("returns true when pruned section types changed", () => {
+    expect(hasSectioningChanges({ pruned_section_types: true }, null)).toBe(true)
+  })
+
+  it("returns false for rendering-only changes", () => {
+    expect(hasSectioningChanges({ default_render_strategy: true }, null)).toBe(false)
+  })
+})

--- a/apps/studio/src/components/pipeline/stages/storyboard-rerun-policy.ts
+++ b/apps/studio/src/components/pipeline/stages/storyboard-rerun-policy.ts
@@ -1,0 +1,18 @@
+const SECTIONING_CHANGE_FIELDS = new Set([
+  "section_types",
+  "pruned_section_types",
+  "disabled_section_types",
+  "page_sectioning",
+])
+
+export function hasSectioningData(stepStatus: string): boolean {
+  return stepStatus === "done" || stepStatus === "skipped"
+}
+
+export function hasSectioningChanges(
+  dirty: Record<string, boolean>,
+  sectioningPromptDraft: string | null
+): boolean {
+  if (sectioningPromptDraft != null) return true
+  return Object.keys(dirty).some((field) => SECTIONING_CHANGE_FIELDS.has(field))
+}

--- a/apps/studio/src/hooks/use-book-run.ts
+++ b/apps/studio/src/hooks/use-book-run.ts
@@ -21,6 +21,8 @@ export interface QueueRunOptions {
   fromStage: string
   toStage: string
   apiKey: string
+  /** When true, skip page-sectioning and only re-render from existing section data. */
+  renderOnly?: boolean
   azure?: { key: string; region: string }
 }
 
@@ -224,7 +226,7 @@ export function useBookRunStatus(label: string): BookRunContextValue {
   // ------------------------------------------------------------------
   const queueRun = useCallback(
     (options: QueueRunOptions) => {
-      const { fromStage, toStage, apiKey, azure } = options
+      const { fromStage, toStage, apiKey, renderOnly, azure } = options
 
       // Optimistically mark target stage(s) as queued and clear downstream
       const stagesToClear = new Set(getStageClearOrder(fromStage as StageName))
@@ -237,6 +239,8 @@ export function useBookRunStatus(label: string): BookRunContextValue {
           const stageDef = PIPELINE.find((s) => s.name === stage)
           if (stageDef) {
             for (const step of stageDef.steps) {
+              // Render-only: preserve page-sectioning step state
+              if (renderOnly && step.name === "page-sectioning") continue
               steps[step.name] = "idle"
             }
           }
@@ -254,6 +258,7 @@ export function useBookRunStatus(label: string): BookRunContextValue {
         const stageDef = PIPELINE.find((s) => s.name === stage)
         if (stageDef) {
           for (const step of stageDef.steps) {
+            if (renderOnly && step.name === "page-sectioning") continue
             progressRef.current.delete(step.name)
           }
         }
@@ -263,7 +268,7 @@ export function useBookRunStatus(label: string): BookRunContextValue {
       // Chain the API call so they arrive in click order
       runChainRef.current = runChainRef.current.then(async () => {
         try {
-          await api.runStages(label, apiKey, { fromStage, toStage }, azure)
+          await api.runStages(label, apiKey, { fromStage, toStage, renderOnly }, azure)
           // Refetch to reconcile — backend cleared step_runs
           queryClient.invalidateQueries({ queryKey: stepStatusKey(label) })
         } catch {


### PR DESCRIPTION
## Summary

Users can now modify rendering-only settings (prompts, styleguide, temperature) without losing manual section edits. When saving storyboard settings, if only rendering-related fields changed and sections already exist, the pipeline skips re-sectioning and only regenerates HTML.

## Implementation

- **Backend**: Added `renderOnly` flag to stage run options. When true for storyboard, preserves `page-sectioning` node data and step status while clearing only rendering outputs.
- **Stage runner**: Split `runStoryboardStep` into two paths: render-only (reads existing sections, calls `renderPage()`) vs full-run (current behavior).
- **Frontend**: Automatically detects sectioning changes via field categorization. Computes `renderOnly = hasSectioningData && !hasSectioningChanges` to decide which path to use.
- **UX**: Dialog description clarifies what will be regenerated based on what settings changed.
- **Testing**: New tests for renderOnly behavior and field categorization logic.

## Fixes

Addresses the problem where users had to choose between losing section edits or not updating rendering settings.