### PR TITLE
Preserve image sizing in activity rendering

### DIFF
--- a/apps/api/src/services/page-edit-service.ts
+++ b/apps/api/src/services/page-edit-service.ts
@@ -68,9 +68,9 @@ export async function reRenderPage(
 
     // Build image map (all page images — expandParts filters by pruned status)
     const allImages = storage.getPageImages(pageId)
-    const renderImages = new Map<string, string>()
+    const renderImages = new Map<string, { base64: string; width?: number; height?: number }>()
     for (const img of allImages) {
-      renderImages.set(img.imageId, storage.getImageBase64(img.imageId))
+      renderImages.set(img.imageId, { base64: storage.getImageBase64(img.imageId), width: img.width, height: img.height })
     }
 
     // Load config and build render strategy resolver

--- a/apps/api/src/services/stage-runner.ts
+++ b/apps/api/src/services/stage-runner.ts
@@ -606,9 +606,9 @@ async function runStoryboardStep(
 
             // Build render images map from page images
             const allImages = storage.getPageImages(page.pageId)
-            const renderImages = new Map<string, string>()
+            const renderImages = new Map<string, { base64: string; width?: number; height?: number }>()
             for (const img of allImages) {
-              renderImages.set(img.imageId, storage.getImageBase64(img.imageId))
+              renderImages.set(img.imageId, { base64: storage.getImageBase64(img.imageId), width: img.width, height: img.height })
             }
 
             const pageImageBase64 = storage.getPageImageBase64(page.pageId)
@@ -751,9 +751,11 @@ async function runStoryboardStep(
             })
 
             // Build render images map from classification
-            const renderImages = new Map<string, string>()
+            const pageDims = new Map(storage.getPageImages(page.pageId).map((img) => [img.imageId, { width: img.width, height: img.height }]))
+            const renderImages = new Map<string, { base64: string; width?: number; height?: number }>()
             for (const imageId of unprunedImageIds) {
-              renderImages.set(imageId, storage.getImageBase64(imageId))
+              const dims = pageDims.get(imageId)
+              renderImages.set(imageId, { base64: storage.getImageBase64(imageId), width: dims?.width, height: dims?.height })
             }
 
             // Web rendering

--- a/packages/pipeline/src/__tests__/web-rendering.test.ts
+++ b/packages/pipeline/src/__tests__/web-rendering.test.ts
@@ -308,7 +308,7 @@ describe("renderPage", () => {
             },
           ],
         },
-        images: new Map([["pg001_im001", "imagedata"]]),
+        images: new Map([["pg001_im001", { base64: "imagedata" }]]),
       },
       defaultResolveConfig,
       fakeLlm
@@ -995,7 +995,7 @@ describe("renderPage", () => {
             },
           ],
         },
-        images: new Map([["pg001_im001", "imagedata"]]),
+        images: new Map([["pg001_im001", { base64: "imagedata" }]]),
       },
       defaultResolveConfig,
       fakeLlm

--- a/packages/pipeline/src/pipeline-dag.ts
+++ b/packages/pipeline/src/pipeline-dag.ts
@@ -543,9 +543,11 @@ export async function runFullPipeline(
         const unprunedImageIds = imageClassification.images
           .filter((img) => !img.isPruned)
           .map((img) => img.imageId)
-        const renderImages = new Map<string, string>()
+        const pageDims = new Map(storage.getPageImages(page.pageId).map((img) => [img.imageId, { width: img.width, height: img.height }]))
+        const renderImages = new Map<string, { base64: string; width?: number; height?: number }>()
         for (const imageId of unprunedImageIds) {
-          renderImages.set(imageId, storage.getImageBase64(imageId))
+          const dims = pageDims.get(imageId)
+          renderImages.set(imageId, { base64: storage.getImageBase64(imageId), width: dims?.width, height: dims?.height })
         }
         const pageImageBase64 = storage.getPageImageBase64(page.pageId)
         const result = await renderPage(

--- a/packages/pipeline/src/pipeline.ts
+++ b/packages/pipeline/src/pipeline.ts
@@ -504,9 +504,11 @@ async function processPage(
 
   // --- Render ---
   const sectioning = sectionResult as PageSectioningOutput
-  const renderImages = new Map<string, string>()
+  const pageDims = new Map(storage.getPageImages(page.pageId).map((img) => [img.imageId, { width: img.width, height: img.height }]))
+  const renderImages = new Map<string, { base64: string; width?: number; height?: number }>()
   for (const imageId of unprunedImageIds) {
-    renderImages.set(imageId, storage.getImageBase64(imageId))
+    const dims = pageDims.get(imageId)
+    renderImages.set(imageId, { base64: storage.getImageBase64(imageId), width: dims?.width, height: dims?.height })
   }
 
   const renderResult = await renderPage(

--- a/packages/pipeline/src/render-llm.ts
+++ b/packages/pipeline/src/render-llm.ts
@@ -24,7 +24,7 @@ export async function renderSectionLlm(
     if (part.type === "group") {
       texts.push(...part.texts)
     } else {
-      images.push({ imageId: part.imageId, imageBase64: part.imageBase64 })
+      images.push({ imageId: part.imageId, imageBase64: part.imageBase64, width: part.width, height: part.height })
     }
   }
 
@@ -92,6 +92,8 @@ export async function renderSectionLlm(
     images: images.map((img) => ({
       image_id: img.imageId,
       image_base64: img.imageBase64,
+      ...(img.width != null && { width: img.width }),
+      ...(img.height != null && { height: img.height }),
     })),
     styleguide: input.styleguide ?? "",
     _isActivity: isActivity,

--- a/packages/pipeline/src/web-rendering.ts
+++ b/packages/pipeline/src/web-rendering.ts
@@ -18,11 +18,13 @@ export interface TextInput {
 export interface ImageInput {
   imageId: string
   imageBase64: string
+  width?: number
+  height?: number
 }
 
 export type SectionPart =
   | { type: "group"; groupId: string; groupType: string; texts: TextInput[] }
-  | { type: "image"; imageId: string; imageBase64: string }
+  | { type: "image"; imageId: string; imageBase64: string; width?: number; height?: number }
 
 export interface RenderConfig {
   renderType: "llm" | "template" | "activity"
@@ -56,7 +58,7 @@ export interface RenderPageInput {
   pageId: string
   pageImageBase64: string
   sectioning: PageSectioningOutput
-  images: Map<string, string> // imageId → base64
+  images: Map<string, { base64: string; width?: number; height?: number }>
   styleguide?: string
 }
 
@@ -78,7 +80,7 @@ function getLLMModel(
  */
 function expandParts(
   sectionParts: import("@adt/types").SectionPart[],
-  images: Map<string, string>
+  images: Map<string, { base64: string; width?: number; height?: number }>
 ): SectionPart[] {
   const parts: SectionPart[] = []
 
@@ -101,9 +103,9 @@ function expandParts(
         })
       }
     } else if (part.type === "image") {
-      const imageBase64 = images.get(part.imageId)
-      if (imageBase64) {
-        parts.push({ type: "image", imageId: part.imageId, imageBase64 })
+      const imgData = images.get(part.imageId)
+      if (imgData) {
+        parts.push({ type: "image", imageId: part.imageId, imageBase64: imgData.base64, width: imgData.width, height: imgData.height })
       }
     }
   }

--- a/prompts/activity_fill_in_a_table.liquid
+++ b/prompts/activity_fill_in_a_table.liquid
@@ -9,7 +9,7 @@ You are an expert frontend engineer creating beautiful, kid-friendly HTML pages 
 ### Common Styling
 - Primary heading (H1): `text-5xl font-bold mb-4 text-amber-700`
 - Instruction line: `text-xl mb-8` with icon `<i class="fas fa-pen-to-square text-blue-700 mr-2"></i>`
-- Images: `class="w-full max-w-sm rounded-lg"`
+- Images: When pixel dimensions are provided, compute each image's width as a percentage of the widest image and set `style="width:X%"`, plus `class="h-auto rounded-lg"`. Do NOT use `w-full` or fixed pixel widths.
 
 ### CRITICAL Requirements
 1. Layout Shell - Start with page wrapper `<div class="flex justify-center items-start min-h-[calc(100dvh-100px)]">`
@@ -108,7 +108,7 @@ Section ID: {{ section_id }}
 Section type: {{ section_type }}
 
 {% for image in images %}
-Image ID: {{ image.image_id }}
+Image ID: {{ image.image_id }}{% if image.width %} ({{ image.width }}×{{ image.height }}px){% endif %}
 {% image image.image_base64 %}
 {% endfor %}
 

--- a/prompts/activity_fill_in_the_blank.liquid
+++ b/prompts/activity_fill_in_the_blank.liquid
@@ -148,7 +148,7 @@ Section ID: {{ section_id }}
 Section type: {{ section_type }}
 
 {% for image in images %}
-Image ID: {{ image.image_id }}
+Image ID: {{ image.image_id }}{% if image.width %} ({{ image.width }}×{{ image.height }}px){% endif %}
 {% image image.image_base64 %}
 {% endfor %}
 

--- a/prompts/activity_matching.liquid
+++ b/prompts/activity_matching.liquid
@@ -9,7 +9,7 @@ You are an expert frontend engineer creating beautiful, kid-friendly HTML pages 
 ### Common Styling
 - Primary heading (H1): `text-5xl font-bold mb-4 text-amber-700`
 - Instruction line: `text-xl mb-8` with icon `<i class="fas fa-pen-to-square text-blue-700 mr-2"></i>`
-- Images: `class="w-full max-w-sm rounded-lg"`
+- Images: When pixel dimensions are provided, compute each image's width as a percentage of the widest image and set `style="width:X%"`, plus `class="h-auto rounded-lg"`. Do NOT use `w-full` or fixed pixel widths.
 
 ### CRITICAL Requirements
 1. Layout Shell - Start with page wrapper `<div class="flex justify-center items-start min-h-[calc(100dvh-100px)]">`
@@ -126,7 +126,7 @@ Section ID: {{ section_id }}
 Section type: {{ section_type }}
 
 {% for image in images %}
-Image ID: {{ image.image_id }}
+Image ID: {{ image.image_id }}{% if image.width %} ({{ image.width }}×{{ image.height }}px){% endif %}
 {% image image.image_base64 %}
 {% endfor %}
 

--- a/prompts/activity_multiple_choice.liquid
+++ b/prompts/activity_multiple_choice.liquid
@@ -47,6 +47,7 @@ Use this exact outer shell:
 - Image-based choices are valid and encouraged when provided images are the actual options.
 - For image choices, place the option image inside the clickable `<label>` and set `data-id` on `<img>` using a provided image ID.
 - If there are not enough text IDs for per-option visible labels, keep options image-only and use `aria-label` for accessibility.
+- IMPORTANT: Preserve relative image sizes for image-based choices. When pixel dimensions are provided, compute each option image's width as a **percentage of the widest option image** and set `style="width:X%"`. For example, if images are 400px and 200px wide, use `style="width:100%"` and `style="width:50%"`. Also add `class="h-auto rounded"`. Do NOT use `w-full` or fixed pixel widths. This ensures both images scale proportionally when the container shrinks.
 
 ## Example Pattern (ID placeholders only - replace with provided IDs)
 ```html
@@ -94,7 +95,7 @@ Use this exact outer shell:
         </div>
         <div class="flex-grow">
           <input type="radio" name="question-group-1" value="item-1" data-activity-item="item-1" class="sr-only" tabindex="0" aria-label="Option 1" />
-          <img data-id="IMAGE_ID_FROM_INPUT" src="images/IMAGE_FILE.png" alt="Option image" class="w-full h-auto rounded" />
+          <img data-id="IMAGE_ID_FROM_INPUT" src="images/IMAGE_FILE.png" alt="Option image" style="width:100%" class="h-auto rounded" />
           <div class="feedback-container mt-2 hidden">
             <div class="flex items-center gap-2">
               <span class="feedback-icon w-5 h-5 rounded-full flex items-center justify-center text-sm"></span>
@@ -117,7 +118,7 @@ Section ID: {{ section_id }}
 Section type: {{ section_type }}
 
 {% for image in images %}
-Image ID: {{ image.image_id }}
+Image ID: {{ image.image_id }}{% if image.width %} ({{ image.width }}×{{ image.height }}px){% endif %}
 {% image image.image_base64 %}
 {% endfor %}
 

--- a/prompts/activity_open_ended_answer.liquid
+++ b/prompts/activity_open_ended_answer.liquid
@@ -122,7 +122,7 @@ Section ID: {{ section_id }}
 Section type: {{ section_type }}
 
 {% for image in images %}
-Image ID: {{ image.image_id }}
+Image ID: {{ image.image_id }}{% if image.width %} ({{ image.width }}×{{ image.height }}px){% endif %}
 {% image image.image_base64 %}
 {% endfor %}
 

--- a/prompts/activity_sorting.liquid
+++ b/prompts/activity_sorting.liquid
@@ -9,7 +9,7 @@ You are an expert frontend engineer creating beautiful, kid-friendly HTML pages 
 ### Common Styling
 - Primary heading (H1): `text-5xl font-bold mb-4 text-amber-700`
 - Instruction line: `text-xl mb-8` with icon `<i class="fas fa-pen-to-square text-blue-700 mr-2"></i>`
-- Images: `class="w-full max-w-sm rounded-lg"`
+- Images: When pixel dimensions are provided, compute each image's width as a percentage of the widest image and set `style="width:X%"`, plus `class="h-auto rounded-lg"`. Do NOT use `w-full` or fixed pixel widths.
 
 ### CRITICAL Requirements
 1. Layout Shell - Start with page wrapper `<div class="flex justify-center items-start min-h-[calc(100dvh-100px)]">`
@@ -58,7 +58,7 @@ Example sorting activity:
 <section class="bg-white mx-auto p-4" data-section-type="activity_sorting" data-section-id="SECTION_ID_FROM_INPUT" role="activity">
   <div class="grid grid-cols-1 lg:grid-cols-3 gap-4">
     <div class="bg-white rounded-lg p-0 lg:col-span-1">
-      <img alt="Description" class="w-full mx-auto rounded-lg" data-id="img-17-1" src="images/image.png">
+      <img alt="Description" class="h-auto mx-auto rounded-lg" style="width:75%" data-id="img-17-1" src="images/image.png">
     </div>
 
     <div class="bg-white rounded-lg p-0 lg:col-span-1">
@@ -105,7 +105,7 @@ Section ID: {{ section_id }}
 Section type: {{ section_type }}
 
 {% for image in images %}
-Image ID: {{ image.image_id }}
+Image ID: {{ image.image_id }}{% if image.width %} ({{ image.width }}×{{ image.height }}px){% endif %}
 {% image image.image_base64 %}
 {% endfor %}
 

--- a/prompts/activity_true_false.liquid
+++ b/prompts/activity_true_false.liquid
@@ -9,7 +9,7 @@ You are an expert frontend engineer creating beautiful, kid-friendly HTML pages 
 ### Common Styling
 - Primary heading (H1): `text-5xl font-bold mb-4 text-amber-700`
 - Instruction line: `text-xl mb-8` with icon `<i class="fas fa-pen-to-square text-blue-700 mr-2"></i>`
-- Images: `class="w-full max-w-sm rounded-lg"`
+- Images: When pixel dimensions are provided, compute each image's width as a percentage of the widest image and set `style="width:X%"`, plus `class="h-auto rounded-lg"`. Do NOT use `w-full` or fixed pixel widths.
 
 ### CRITICAL Requirements
 1. Layout Shell - Start with page wrapper `<div class="flex justify-center items-start min-h-[calc(100dvh-100px)]">`
@@ -57,7 +57,7 @@ Example true/false activity:
 <section class="space-y-4 lg:w-3/4 mx-auto" data-section-type="activity_true_false" data-section-id="SECTION_ID_FROM_INPUT" role="activity">
   <!-- Title and image -->
   <h1 class="font-bold text-4xl text-center mb-4" data-id="text-19-0">Activity Title</h1>
-  <img class="w-full max-w-64 mx-auto block mb-4 rounded-lg" data-id="img-19-0" src="images/image.jpg" alt="Description">
+  <img class="h-auto max-w-64 mx-auto block mb-4 rounded-lg" style="width:75%" data-id="img-19-0" src="images/image.jpg" alt="Description">
 
   <!-- Instructions -->
   <p class="mb-4 text-center mb-8">
@@ -123,7 +123,7 @@ Section ID: {{ section_id }}
 Section type: {{ section_type }}
 
 {% for image in images %}
-Image ID: {{ image.image_id }}
+Image ID: {{ image.image_id }}{% if image.width %} ({{ image.width }}×{{ image.height }}px){% endif %}
 {% image image.image_base64 %}
 {% endfor %}
 


### PR DESCRIPTION
## Summary

Thread image dimensions through the rendering pipeline so LLM prompts can generate markup with proportional image scaling. Images now use percentage-based widths relative to the widest option, ensuring all images shrink together when containers resize.

## Changes

- Add width/height to ImageInput and SectionPart interfaces
- Pass image dimensions from database through web-rendering pipeline to LLM context
- Update all 6 activity prompts to show pixel dimensions and use percentage sizing (e.g., 400px/200px → 100%/50%)

## Technical Details

Previously, `style="width:200px"` + `max-w-full` meant each image shrunk independently. Now using `style="width:100%"` and `style="width:50%"` on equal-width grid cells preserves aspect ratios at all viewport sizes.