### PR TITLE
Add real-time duplicate book label validation

### DIFF
--- a/apps/studio/src/lib/label-validation.test.ts
+++ b/apps/studio/src/lib/label-validation.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest"
+import { isLabelFormatValid, isLabelDuplicate } from "./label-validation"
+
+describe("isLabelFormatValid", () => {
+  it("accepts valid labels", () => {
+    expect(isLabelFormatValid("my-book")).toBe(true)
+    expect(isLabelFormatValid("book.v2")).toBe(true)
+    expect(isLabelFormatValid("Grade5_Math")).toBe(true)
+    expect(isLabelFormatValid("a")).toBe(true)
+    expect(isLabelFormatValid("1st-edition")).toBe(true)
+  })
+
+  it("rejects empty string", () => {
+    expect(isLabelFormatValid("")).toBe(false)
+  })
+
+  it("rejects labels starting with non-alphanumeric", () => {
+    expect(isLabelFormatValid("-starts-with-dash")).toBe(false)
+    expect(isLabelFormatValid(".starts-with-dot")).toBe(false)
+    expect(isLabelFormatValid("_starts-with-underscore")).toBe(false)
+  })
+
+  it("rejects labels with spaces or special characters", () => {
+    expect(isLabelFormatValid("has space")).toBe(false)
+    expect(isLabelFormatValid("has@symbol")).toBe(false)
+    expect(isLabelFormatValid("path/sep")).toBe(false)
+  })
+})
+
+describe("isLabelDuplicate", () => {
+  const existing = ["math-grade5", "science-101", "history.v2"]
+
+  it("returns true for exact match", () => {
+    expect(isLabelDuplicate("math-grade5", existing)).toBe(true)
+  })
+
+  it("returns false for non-matching label", () => {
+    expect(isLabelDuplicate("new-book", existing)).toBe(false)
+  })
+
+  it("is case-sensitive", () => {
+    expect(isLabelDuplicate("Math-Grade5", existing)).toBe(false)
+  })
+
+  it("returns false when existing labels is undefined", () => {
+    expect(isLabelDuplicate("anything", undefined)).toBe(false)
+  })
+
+  it("returns false for empty existing list", () => {
+    expect(isLabelDuplicate("anything", [])).toBe(false)
+  })
+})

--- a/apps/studio/src/lib/label-validation.ts
+++ b/apps/studio/src/lib/label-validation.ts
@@ -1,0 +1,13 @@
+const LABEL_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/
+
+export function isLabelFormatValid(label: string): boolean {
+  return !!label && LABEL_PATTERN.test(label)
+}
+
+export function isLabelDuplicate(
+  label: string,
+  existingLabels: string[] | undefined
+): boolean {
+  if (!existingLabels) return false
+  return existingLabels.includes(label)
+}

--- a/apps/studio/src/routes/books.new.tsx
+++ b/apps/studio/src/routes/books.new.tsx
@@ -26,7 +26,8 @@ import {
 } from "@/components/ui/dialog"
 import { LanguagePicker } from "@/components/LanguagePicker"
 import { useSettingsDialog } from "@/routes/__root"
-import { useCreateBook } from "@/hooks/use-books"
+import { useBooks, useCreateBook } from "@/hooks/use-books"
+import { isLabelFormatValid, isLabelDuplicate } from "@/lib/label-validation"
 import { useApiKey } from "@/hooks/use-api-key"
 import { api } from "@/api/client"
 import { usePreset, useGlobalConfig, useStyleguides, useStyleguidePreview } from "@/hooks/use-presets"
@@ -145,6 +146,7 @@ function Stepper({ currentStep }: { currentStep: number }) {
 function AddBookPage() {
   const navigate = useNavigate()
   const createMutation = useCreateBook()
+  const { data: existingBooks } = useBooks()
   const { apiKey, hasApiKey, azureKey, azureRegion } = useApiKey()
   const { openSettings } = useSettingsDialog()
 
@@ -374,9 +376,10 @@ function AddBookPage() {
     })
   }
 
-  const isLabelValid =
-    !!label && /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(label)
-  const canAdvanceStep1 = !!file && isLabelValid
+  const isLabelValid = isLabelFormatValid(label)
+  const labelIsDuplicate =
+    isLabelValid && isLabelDuplicate(label, existingBooks?.map((b) => b.label))
+  const canAdvanceStep1 = !!file && isLabelValid && !labelIsDuplicate
 
   const handleSubmit = () => {
     if (!file || !label) return
@@ -591,6 +594,10 @@ function AddBookPage() {
                   <p className="text-xs text-destructive">
                     Must start with a letter or number. Only letters, numbers,
                     hyphens, dots, underscores.
+                  </p>
+                ) : labelIsDuplicate ? (
+                  <p className="text-xs text-destructive">
+                    A book with this label already exists.
                   </p>
                 ) : (
                   <p className="text-xs text-muted-foreground">


### PR DESCRIPTION
## Summary
Check for duplicate labels as the user types on the add book form, rather than waiting until the final submit. This improves UX by providing immediate feedback when a label is already taken.

## Changes
- Extract format and duplicate checks into testable `label-validation` utilities
- Query existing books on form load and check for duplicates in real-time
- Show inline error message and disable "Next" button if label is duplicate
- Add comprehensive test coverage for both validation functions

## Test Plan
- Navigate to `/books/new` and type an existing book label — verify error appears and "Next" is disabled
- Try a new unique label — verify error disappears and "Next" becomes enabled
- All existing tests pass; 9 new tests for label validation added