### PR TITLE
Use index.html as first ADT page and harden export

### DIFF
--- a/apps/api/src/routes/books.test.ts
+++ b/apps/api/src/routes/books.test.ts
@@ -799,10 +799,12 @@ describe("GET /books/:label/step-status", () => {
 })
 
 describe("GET /books/:label/export", () => {
+  const webAssetsDir = path.resolve(process.cwd(), "assets", "adt")
+
   it("returns ZIP for valid book", async () => {
     createTestBook("export-book")
     addPagesAndRenderings("export-book", 2)
-    const app = createBookRoutes(tmpDir)
+    const app = createBookRoutes(tmpDir, webAssetsDir)
     const res = await app.request("/books/export-book/export")
     expect(res.status).toBe(200)
     expect(res.headers.get("Content-Type")).toBe("application/zip")
@@ -814,15 +816,23 @@ describe("GET /books/:label/export", () => {
   it("exports even when storyboard not accepted", async () => {
     createTestBook("not-accepted-export")
     addPagesAndRenderings("not-accepted-export", 1)
-    const app = createBookRoutes(tmpDir)
+    const app = createBookRoutes(tmpDir, webAssetsDir)
     const res = await app.request("/books/not-accepted-export/export")
     expect(res.status).toBe(200)
   })
 
   it("returns 404 for missing book", async () => {
-    const app = createBookRoutes(tmpDir)
+    const app = createBookRoutes(tmpDir, webAssetsDir)
     const res = await app.request("/books/ghost/export")
     expect(res.status).toBe(404)
+  })
+
+  it("returns 500 when web assets directory is missing", async () => {
+    createTestBook("missing-assets-export")
+    addPagesAndRenderings("missing-assets-export", 1)
+    const app = createBookRoutes(tmpDir, path.join(tmpDir, "no-web-assets"))
+    const res = await app.request("/books/missing-assets-export/export")
+    expect(res.status).toBe(500)
   })
 })
 

--- a/apps/api/src/routes/books.ts
+++ b/apps/api/src/routes/books.ts
@@ -154,7 +154,10 @@ export function createBookRoutes(
       return c.body(Buffer.from(result.zipBuffer))
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
-      if (message.includes("not found")) {
+      if (message.includes("Web assets directory not found")) {
+        throw new HTTPException(500, { message })
+      }
+      if (message.includes("Book not found")) {
         throw new HTTPException(404, { message })
       }
       throw new HTTPException(400, { message })

--- a/apps/api/src/services/export-service.test.ts
+++ b/apps/api/src/services/export-service.test.ts
@@ -7,9 +7,12 @@ import { unzipSync } from "fflate"
 import { exportBook } from "./export-service.js"
 
 let tmpDir: string
+let webAssetsDir: string
 
 beforeEach(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "adt-export-service-"))
+  webAssetsDir = path.join(tmpDir, "assets-web")
+  createWebAssets(webAssetsDir)
 })
 
 afterEach(() => {
@@ -62,12 +65,22 @@ function addConfigYaml(label: string): void {
   )
 }
 
+function createWebAssets(dir: string): void {
+  fs.mkdirSync(dir, { recursive: true })
+  fs.writeFileSync(path.join(dir, "base.js"), 'window.__ADT_BUNDLE_TEST__ = "ok";\n')
+  fs.writeFileSync(path.join(dir, "fonts.css"), "body { font-family: serif; }")
+  fs.writeFileSync(
+    path.join(dir, "tailwind_css.css"),
+    "@tailwind base;\n@tailwind components;\n@tailwind utilities;\n"
+  )
+}
+
 describe("exportBook", () => {
   it("produces a valid ZIP containing the db file", async () => {
     createTestDb("export-test")
     addPages("export-test", 1)
 
-    const result = await exportBook("export-test", tmpDir, "")
+    const result = await exportBook("export-test", tmpDir, webAssetsDir)
     expect(result.zipBuffer).toBeInstanceOf(Uint8Array)
     expect(result.filename).toBe("export-test.zip")
 
@@ -80,7 +93,7 @@ describe("exportBook", () => {
     addPages("with-pdf", 1)
     addPdf("with-pdf")
 
-    const result = await exportBook("with-pdf", tmpDir, "")
+    const result = await exportBook("with-pdf", tmpDir, webAssetsDir)
     const files = unzipSync(result.zipBuffer)
     expect(files["with-pdf.pdf"]).toBeDefined()
     expect(Buffer.from(files["with-pdf.pdf"]).toString()).toContain("%PDF")
@@ -91,7 +104,7 @@ describe("exportBook", () => {
     addPages("with-imgs", 1)
     addImageFile("with-imgs", "my-img")
 
-    const result = await exportBook("with-imgs", tmpDir, "")
+    const result = await exportBook("with-imgs", tmpDir, webAssetsDir)
     const files = unzipSync(result.zipBuffer)
     expect(files["images/my-img.png"]).toBeDefined()
     expect(Buffer.from(files["images/my-img.png"]).toString()).toBe("fake-png-data")
@@ -102,7 +115,7 @@ describe("exportBook", () => {
     addPages("with-config", 1)
     addConfigYaml("with-config")
 
-    const result = await exportBook("with-config", tmpDir, "")
+    const result = await exportBook("with-config", tmpDir, webAssetsDir)
     const files = unzipSync(result.zipBuffer)
     expect(files["config.yaml"]).toBeDefined()
     const content = new TextDecoder().decode(files["config.yaml"])
@@ -113,13 +126,21 @@ describe("exportBook", () => {
     createTestDb("not-accepted")
     addPages("not-accepted", 1)
 
-    const result = await exportBook("not-accepted", tmpDir, "")
+    const result = await exportBook("not-accepted", tmpDir, webAssetsDir)
     expect(result.zipBuffer).toBeInstanceOf(Uint8Array)
     expect(result.filename).toBe("not-accepted.zip")
   })
 
   it("throws for non-existent book", async () => {
-    await expect(exportBook("ghost", tmpDir, "")).rejects.toThrow("not found")
+    await expect(exportBook("ghost", tmpDir, webAssetsDir)).rejects.toThrow("not found")
+  })
+
+  it("throws when web assets directory is missing", async () => {
+    createTestDb("missing-assets")
+    addPages("missing-assets", 1)
+
+    await expect(exportBook("missing-assets", tmpDir, path.join(tmpDir, "missing-assets-dir")))
+      .rejects.toThrow("Web assets directory not found")
   })
 
   it("includes all book directory contents recursively", async () => {
@@ -130,7 +151,7 @@ describe("exportBook", () => {
     addImageFile("full-book", "img-b")
     addConfigYaml("full-book")
 
-    const result = await exportBook("full-book", tmpDir, "")
+    const result = await exportBook("full-book", tmpDir, webAssetsDir)
     const files = unzipSync(result.zipBuffer)
     const paths = Object.keys(files).sort()
 

--- a/apps/api/src/services/export-service.ts
+++ b/apps/api/src/services/export-service.ts
@@ -26,40 +26,36 @@ export async function exportBook(
 
   const storage = createBookStorage(safeLabel, resolvedDir)
   try {
+    if (!webAssetsDir || !fs.existsSync(webAssetsDir)) {
+      throw new Error("Web assets directory not found")
+    }
+
     // Always rebuild ADT package before export to ensure compiled assets are fresh
-    const adtDir = path.join(bookDir, "adt")
-    if (webAssetsDir && fs.existsSync(webAssetsDir)) {
-      const config = loadBookConfig(safeLabel, resolvedDir, configPath)
-      const metadataRow = storage.getLatestNodeData("metadata", "book")
-      const metadata = metadataRow?.data as {
-        title?: string | null
-        language_code?: string | null
-      } | null
-      const language = normalizeLocale(config.editing_language ?? metadata?.language_code ?? "en")
-      const outputLanguages = Array.from(
-        new Set(
-          (config.output_languages && config.output_languages.length > 0
-            ? config.output_languages
-            : [language]).map((code) => normalizeLocale(code))
-        )
+    const config = loadBookConfig(safeLabel, resolvedDir, configPath)
+    const metadataRow = storage.getLatestNodeData("metadata", "book")
+    const metadata = metadataRow?.data as {
+      title?: string | null
+      language_code?: string | null
+    } | null
+    const language = normalizeLocale(config.editing_language ?? metadata?.language_code ?? "en")
+    const outputLanguages = Array.from(
+      new Set(
+        (config.output_languages && config.output_languages.length > 0
+          ? config.output_languages
+          : [language]).map((code) => normalizeLocale(code))
       )
-      const title = metadata?.title ?? safeLabel
+    )
+    const title = metadata?.title ?? safeLabel
 
-      await packageAdtWeb(storage, {
-        bookDir,
-        label: safeLabel,
-        language,
-        outputLanguages,
-        title,
-        webAssetsDir,
-        applyBodyBackground: config.apply_body_background,
-      })
-    }
-
-    // Add index.html that redirects to the first page (only if adt/ exists)
-    if (fs.existsSync(adtDir)) {
-      ensureAdtIndexHtml(adtDir)
-    }
+    await packageAdtWeb(storage, {
+      bookDir,
+      label: safeLabel,
+      language,
+      outputLanguages,
+      title,
+      webAssetsDir,
+      applyBodyBackground: config.apply_body_background,
+    })
   } finally {
     storage.close()
   }
@@ -74,39 +70,6 @@ export async function exportBook(
     zipBuffer,
     filename: `${safeLabel}.zip`,
   }
-}
-
-/**
- * Create an index.html in the adt/ directory that redirects to the first page.
- */
-function ensureAdtIndexHtml(adtDir: string): void {
-  const indexPath = path.join(adtDir, "index.html")
-  if (fs.existsSync(indexPath)) return
-
-  const pagesJsonPath = path.join(adtDir, "content", "pages.json")
-  if (!fs.existsSync(pagesJsonPath)) return
-
-  let firstHref = "pg001.html"
-  try {
-    const pages = JSON.parse(fs.readFileSync(pagesJsonPath, "utf-8")) as Array<{ href?: string }>
-    if (pages.length > 0 && pages[0].href) {
-      firstHref = pages[0].href
-    }
-  } catch { /* use default */ }
-
-  const html = `<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="utf-8" />
-  <meta http-equiv="refresh" content="0; url=./${firstHref}" />
-  <title>Redirecting…</title>
-</head>
-<body>
-  <p>Loading book… <a href="./${firstHref}">Click here</a> if not redirected.</p>
-</body>
-</html>
-`
-  fs.writeFileSync(indexPath, html)
 }
 
 function collectFiles(

--- a/packages/pipeline/src/__tests__/package-web.test.ts
+++ b/packages/pipeline/src/__tests__/package-web.test.ts
@@ -164,7 +164,7 @@ describe("packageAdtWeb", () => {
       fs.readFileSync(path.join(bookDir, "adt", "content", "pages.json"), "utf-8"),
     ) as Array<{ section_id: string; href: string; page_number?: number }>
     expect(pagesJson).toHaveLength(2)
-    expect(pagesJson[0]).toEqual({ section_id: "pg001_sec001", href: "pg001_sec001.html", page_number: 10 })
+    expect(pagesJson[0]).toEqual({ section_id: "pg001_sec001", href: "index.html", page_number: 10 })
     expect(pagesJson[1]).toEqual({ section_id: "pg002_sec001", href: "pg002_sec001.html" })
 
     const configJson = JSON.parse(
@@ -173,7 +173,7 @@ describe("packageAdtWeb", () => {
     expect(configJson.languages.available).toEqual(["fr"])
     expect(configJson.languages.default).toBe("fr")
 
-    const pageHtml = fs.readFileSync(path.join(bookDir, "adt", "pg001_sec001.html"), "utf-8")
+    const pageHtml = fs.readFileSync(path.join(bookDir, "adt", "index.html"), "utf-8")
     expect(pageHtml).toContain("window.correctAnswers = JSON.parse(")
     expect(pageHtml).not.toContain("</script><script>alert('x')</script>")
     expect(pageHtml).toContain("\\u003c/script\\u003e\\u003cscript\\u003e")
@@ -264,10 +264,10 @@ describe("packageAdtWeb", () => {
     ) as Array<{ section_id: string; href: string; page_number?: number }>
 
     expect(pagesJson).toEqual([
-      { section_id: "qz001", href: "qz001.html" },
+      { section_id: "qz001", href: "index.html" },
       { section_id: "pg002_sec001", href: "pg002_sec001.html" },
     ])
-    expect(fs.existsSync(path.join(bookDir, "adt", "qz001.html"))).toBe(true)
+    expect(fs.existsSync(path.join(bookDir, "adt", "index.html"))).toBe(true)
   })
 
   it("sets activities true in config.json when a section has an activity type", async () => {
@@ -437,7 +437,7 @@ describe("packageAdtWeb", () => {
       fs.readFileSync(path.join(bookDir, "adt", "content", "pages.json"), "utf-8"),
     ) as Array<{ section_id: string; href: string; page_number?: number }>
     expect(pagesJson).toEqual([
-      { section_id: "pg001_sec001", href: "pg001_sec001.html", page_number: 1 },
+      { section_id: "pg001_sec001", href: "index.html", page_number: 1 },
       { section_id: "pg001_sec002", href: "pg001_sec002.html", page_number: 1 },
     ])
   })

--- a/packages/pipeline/src/package-web.ts
+++ b/packages/pipeline/src/package-web.ts
@@ -167,6 +167,9 @@ export async function packageAdtWeb(
           // Check for math content
           if (containsMathContent(rewrittenHtml)) hasMath = true
 
+          const isFirstPage = pageList.length === 0
+          const filename = isFirstPage ? "index.html" : `${sectionId}.html`
+
           const pageHtml = renderPageHtml({
             content: rewrittenHtml,
             language,
@@ -178,11 +181,11 @@ export async function packageAdtWeb(
             bundleVersion,
             applyBodyBackground,
           })
-          fs.writeFileSync(path.join(adtDir, `${sectionId}.html`), pageHtml)
+          fs.writeFileSync(path.join(adtDir, filename), pageHtml)
 
           const entry: PageEntry = {
             section_id: sectionId,
-            href: `${sectionId}.html`,
+            href: filename,
           }
           if (sectionMeta?.pageNumber !== null && sectionMeta?.pageNumber !== undefined) {
             entry.page_number = sectionMeta.pageNumber
@@ -197,6 +200,9 @@ export async function packageAdtWeb(
       const quizIndex = quizData!.quizzes.indexOf(quiz)
       const quizId = `qz${pad3(quizIndex + 1)}`
 
+      const isFirstPage = pageList.length === 0
+      const quizFilename = isFirstPage ? "index.html" : `${quizId}.html`
+
       const quizHtmlContent = renderQuizHtml(quiz, quizId, catalog)
       const quizPageHtml = renderPageHtml({
         content: quizHtmlContent,
@@ -210,9 +216,9 @@ export async function packageAdtWeb(
         skipContentWrapper: true,
         applyBodyBackground,
       })
-      fs.writeFileSync(path.join(adtDir, `${quizId}.html`), quizPageHtml)
+      fs.writeFileSync(path.join(adtDir, quizFilename), quizPageHtml)
 
-      pageList.push({ section_id: quizId, href: `${quizId}.html` })
+      pageList.push({ section_id: quizId, href: quizFilename })
     }
   }
 


### PR DESCRIPTION
This updates ADT packaging so the first generated section/quiz is written to `adt/index.html`, and `content/pages.json` now points its first `href` to `index.html` instead of a section-named file.
It removes the export-time `ensureAdtIndexHtml` redirect fallback and makes export packaging explicit: `exportBook` now fails fast when web assets are missing instead of silently skipping package rebuild.
The books export route now maps missing web assets to HTTP 500 and keeps missing-book behavior as 404.
Tests were updated across pipeline and API to cover the new `index.html` behavior and the missing-assets failure path (`pnpm exec vitest run packages/pipeline/src/__tests__/package-web.test.ts apps/api/src/services/export-service.test.ts apps/api/src/routes/books.test.ts`).
