### PR TITLE
Normalize render strategy defaults and remove dynamic sentinel

### DIFF
--- a/apps/studio/src/components/config/AdvancedLayoutPanel.tsx
+++ b/apps/studio/src/components/config/AdvancedLayoutPanel.tsx
@@ -12,6 +12,10 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { RENDER_TYPES } from "@/lib/config-constants"
+import {
+  listSelectableRenderStrategies,
+  normalizeDefaultRenderStrategy,
+} from "@/lib/render-strategy"
 
 export interface RenderStrategyState {
   render_type: string
@@ -382,11 +386,7 @@ export function AdvancedLayoutPanel({
   onTogglePrunedSection,
   afterStrategySlot,
 }: AdvancedLayoutPanelProps) {
-  const strategyNames = Object.keys(renderStrategies)
-  const dropdownOptions = [
-    "dynamic",
-    ...strategyNames.filter((name) => renderStrategies[name]?.render_type !== "activity"),
-  ]
+  const dropdownOptions = listSelectableRenderStrategies(renderStrategies)
 
   const addRenderStrategy = () => {
     const base = "new_strategy"
@@ -406,11 +406,7 @@ export function AdvancedLayoutPanel({
     delete next[name]
     onRenderStrategiesChange(next)
     if (defaultRenderStrategy === name) {
-      if (Object.keys(next).length > 0) {
-        onDefaultRenderStrategyChange(Object.keys(next)[0])
-      } else {
-        onDefaultRenderStrategyChange("dynamic")
-      }
+      onDefaultRenderStrategyChange(normalizeDefaultRenderStrategy("", next))
     }
   }
 
@@ -464,9 +460,7 @@ export function AdvancedLayoutPanel({
           </SelectContent>
         </Select>
         <p className="text-[10px] text-muted-foreground mt-1">
-          {defaultRenderStrategy === "dynamic"
-            ? "Automatically picks the best strategy per section type"
-            : "All sections rendered with this strategy"}
+          Fallback strategy for sections without a specific mapping
         </p>
       </div>
 

--- a/apps/studio/src/components/pipeline/stages/StoryboardSettings.tsx
+++ b/apps/studio/src/components/pipeline/stages/StoryboardSettings.tsx
@@ -31,6 +31,10 @@ import { PromptViewer } from "@/components/pipeline/PromptViewer"
 import { TemplateViewer } from "@/components/pipeline/TemplateViewer"
 import { useBookRun } from "@/hooks/use-book-run"
 import { useStepConfig } from "@/hooks/use-step-config"
+import {
+  listSelectableRenderStrategies,
+  normalizeDefaultRenderStrategy,
+} from "@/lib/render-strategy"
 import { hasSectioningChanges, hasSectioningData } from "./storyboard-rerun-policy"
 
 /** "two_column_story" → "Two Column Story" */
@@ -42,7 +46,6 @@ function titleCase(slug: string): string {
 const STRATEGY_DISPLAY_NAMES: Record<string, string> = {
   llm: "AI Generated",
   "llm-overlay": "AI Overlay",
-  dynamic: "Dynamic",
 }
 
 function strategyDisplayName(slug: string): string {
@@ -50,7 +53,6 @@ function strategyDisplayName(slug: string): string {
 }
 
 const RENDER_STRATEGY_DESCRIPTIONS: Record<string, string> = {
-  dynamic: "Automatically picks the best strategy per section type",
   llm: "LLM generates HTML from section content",
   "llm-overlay": "LLM positions text over background images",
   two_column: "Fixed two-column template layout",
@@ -169,19 +171,26 @@ export function StoryboardSettings({ bookLabel, headerTarget, tab = "general" }:
     if (Array.isArray(merged.disabled_section_types)) {
       setDisabledSectionTypes(new Set(merged.disabled_section_types as string[]))
     }
-    if (merged.default_render_strategy) {
-      setDefaultRenderStrategy(String(merged.default_render_strategy))
-    }
     if (merged.section_render_strategies && typeof merged.section_render_strategies === "object") {
       setSectionRenderStrategies(merged.section_render_strategies as Record<string, string>)
     }
-    if (merged.render_strategies && typeof merged.render_strategies === "object") {
-      const strategies = merged.render_strategies as Record<string, { render_type?: string; config?: { prompt?: string; answer_prompt?: string; model?: string } }>
-      setAllStrategyNames(Object.keys(strategies))
-      setRenderStrategyNames(
-        Object.keys(strategies).filter((name) => !name.startsWith("activity_"))
-      )
-    }
+    const strategies = (
+      merged.render_strategies && typeof merged.render_strategies === "object"
+        ? merged.render_strategies
+        : {}
+    ) as Record<string, { render_type?: string; config?: { prompt?: string; answer_prompt?: string; model?: string; template?: string; temperature?: number; max_retries?: number } }>
+    const strategyNames = Object.keys(strategies)
+    const normalizedDefaultRenderStrategy = normalizeDefaultRenderStrategy(
+      typeof merged.default_render_strategy === "string"
+        ? String(merged.default_render_strategy)
+        : "",
+      strategies
+    )
+    setDefaultRenderStrategy(normalizedDefaultRenderStrategy)
+
+    setAllStrategyNames(strategyNames)
+    setRenderStrategyNames(listSelectableRenderStrategies(strategies))
+
     if (merged.page_sectioning && typeof merged.page_sectioning === "object") {
       const ps = merged.page_sectioning as Record<string, unknown>
       if (ps.mode) setSectioningMode(String(ps.mode))
@@ -191,19 +200,24 @@ export function StoryboardSettings({ bookLabel, headerTarget, tab = "general" }:
     // Body background
     setApplyBodyBackground(merged.apply_body_background !== false)
     // Rendering config comes from the default render strategy
-    if (merged.render_strategies && merged.default_render_strategy) {
-      const strategies = merged.render_strategies as Record<string, { render_type?: string; config?: { model?: string; prompt?: string; template?: string; temperature?: number; max_retries?: number } }>
-      const defaultStrategy = strategies[String(merged.default_render_strategy)]
-      if (defaultStrategy?.render_type) setRenderingRenderType(defaultStrategy.render_type)
-      if (defaultStrategy?.config?.model) setRenderingModel(String(defaultStrategy.config.model))
-      if (defaultStrategy?.config?.prompt) setRenderingPromptName(String(defaultStrategy.config.prompt))
-      if (defaultStrategy?.config?.template) {
-        setRenderingTemplateName(String(defaultStrategy.config.template))
-        setTemplateTabName(String(defaultStrategy.config.template))
-      }
-      setRenderingTemperature(defaultStrategy?.config?.temperature != null ? String(defaultStrategy.config.temperature) : "")
-      setRenderingRetries(defaultStrategy?.config?.max_retries != null ? String(defaultStrategy.config.max_retries) : "")
+    const defaultStrategy = normalizedDefaultRenderStrategy
+      ? strategies[normalizedDefaultRenderStrategy]
+      : undefined
+    if (defaultStrategy?.render_type) setRenderingRenderType(defaultStrategy.render_type)
+    else setRenderingRenderType("")
+    if (defaultStrategy?.config?.model) setRenderingModel(String(defaultStrategy.config.model))
+    else setRenderingModel("")
+    if (defaultStrategy?.config?.prompt) setRenderingPromptName(String(defaultStrategy.config.prompt))
+    else setRenderingPromptName("")
+    if (defaultStrategy?.config?.template) {
+      setRenderingTemplateName(String(defaultStrategy.config.template))
+      setTemplateTabName(String(defaultStrategy.config.template))
+    } else {
+      setRenderingTemplateName("")
+      setTemplateTabName("")
     }
+    setRenderingTemperature(defaultStrategy?.config?.temperature != null ? String(defaultStrategy.config.temperature) : "")
+    setRenderingRetries(defaultStrategy?.config?.max_retries != null ? String(defaultStrategy.config.max_retries) : "")
   }, [activeConfigData])
 
   const [newTypeKey, setNewTypeKey] = useState("")
@@ -284,8 +298,16 @@ export function StoryboardSettings({ bookLabel, headerTarget, tab = "general" }:
     if (shouldWrite("disabled_section_types")) {
       overrides.disabled_section_types = Array.from(disabledSectionTypes)
     }
+    const mergedStrategies = (merged?.render_strategies ?? {}) as Record<
+      string,
+      { render_type?: string }
+    >
+    const normalizedDefaultRenderStrategy = normalizeDefaultRenderStrategy(
+      defaultRenderStrategy,
+      mergedStrategies
+    )
     if (shouldWrite("default_render_strategy")) {
-      overrides.default_render_strategy = defaultRenderStrategy || undefined
+      overrides.default_render_strategy = normalizedDefaultRenderStrategy || undefined
     }
     if (shouldWrite("section_render_strategies")) {
       const baseStrategies = (merged?.section_render_strategies ?? {}) as Record<string, string>
@@ -415,7 +437,7 @@ export function StoryboardSettings({ bookLabel, headerTarget, tab = "general" }:
                     setTemplateTabDraft(null)
                   }
                 } else {
-                  // Synthetic option like "dynamic" — clear stale rendering config
+                  // Strategy not in render_strategies — clear stale rendering config
                   setRenderingRenderType("")
                   setRenderingModel("")
                   setRenderingPromptName("")
@@ -438,7 +460,7 @@ export function StoryboardSettings({ bookLabel, headerTarget, tab = "general" }:
                 </SelectValue>
               </SelectTrigger>
               <SelectContent align="start">
-                {["dynamic", ...renderStrategyNames.filter((n) => n !== "dynamic")].map((name) => {
+                {renderStrategyNames.map((name) => {
                   const isTemplate = strategyRenderTypes[name] === "template"
                   return (
                     <SelectItem key={name} value={name}>

--- a/apps/studio/src/lib/render-strategy.test.ts
+++ b/apps/studio/src/lib/render-strategy.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest"
+import {
+  listSelectableRenderStrategies,
+  normalizeDefaultRenderStrategy,
+} from "./render-strategy"
+
+describe("listSelectableRenderStrategies", () => {
+  it("filters out activity strategies", () => {
+    const strategies = {
+      llm: { render_type: "llm" },
+      two_column: { render_type: "template" },
+      activity_multiple_choice: { render_type: "activity" },
+    }
+
+    expect(listSelectableRenderStrategies(strategies)).toEqual([
+      "llm",
+      "two_column",
+    ])
+  })
+})
+
+describe("normalizeDefaultRenderStrategy", () => {
+  it("maps legacy dynamic to two_column when available", () => {
+    const strategies = {
+      llm: { render_type: "llm" },
+      two_column: { render_type: "template" },
+    }
+
+    expect(normalizeDefaultRenderStrategy("dynamic", strategies)).toBe(
+      "two_column"
+    )
+  })
+
+  it("maps legacy dynamic to first non-activity strategy when two_column is missing", () => {
+    const strategies = {
+      llm_overlay: { render_type: "llm" },
+      story: { render_type: "template" },
+    }
+
+    expect(normalizeDefaultRenderStrategy("dynamic", strategies)).toBe(
+      "llm_overlay"
+    )
+  })
+
+  it("keeps an explicit valid strategy", () => {
+    const strategies = {
+      llm: { render_type: "llm" },
+      two_column: { render_type: "template" },
+    }
+
+    expect(normalizeDefaultRenderStrategy("llm", strategies)).toBe("llm")
+  })
+
+  it("falls back when requested strategy does not exist", () => {
+    const strategies = {
+      llm: { render_type: "llm" },
+      two_column: { render_type: "template" },
+    }
+
+    expect(normalizeDefaultRenderStrategy("missing", strategies)).toBe(
+      "two_column"
+    )
+  })
+
+  it("does not allow activity strategies as default", () => {
+    const strategies = {
+      llm: { render_type: "llm" },
+      activity_multiple_choice: { render_type: "activity" },
+    }
+
+    expect(
+      normalizeDefaultRenderStrategy("activity_multiple_choice", strategies)
+    ).toBe("llm")
+  })
+
+  it("returns empty when there are no selectable strategies", () => {
+    const strategies = {
+      activity_multiple_choice: { render_type: "activity" },
+    }
+
+    expect(normalizeDefaultRenderStrategy("dynamic", strategies)).toBe("")
+  })
+})

--- a/apps/studio/src/lib/render-strategy.ts
+++ b/apps/studio/src/lib/render-strategy.ts
@@ -1,0 +1,37 @@
+type RenderStrategyLike = {
+  render_type?: string | null
+} | undefined
+
+type RenderStrategyMap = Record<string, RenderStrategyLike>
+
+export function listSelectableRenderStrategies(
+  strategies: RenderStrategyMap
+): string[] {
+  return Object.keys(strategies).filter(
+    (name) => strategies[name]?.render_type !== "activity"
+  )
+}
+
+export function chooseDefaultRenderStrategyFallback(
+  strategies: RenderStrategyMap
+): string {
+  const selectable = listSelectableRenderStrategies(strategies)
+  if (selectable.includes("two_column")) return "two_column"
+  return selectable[0] ?? ""
+}
+
+export function normalizeDefaultRenderStrategy(
+  requested: string | null | undefined,
+  strategies: RenderStrategyMap
+): string {
+  const trimmed = (requested ?? "").trim()
+  const selectable = listSelectableRenderStrategies(strategies)
+
+  if (selectable.length === 0) return ""
+  if (!trimmed || trimmed === "dynamic") {
+    return chooseDefaultRenderStrategyFallback(strategies)
+  }
+  if (selectable.includes(trimmed)) return trimmed
+
+  return chooseDefaultRenderStrategyFallback(strategies)
+}

--- a/apps/studio/src/routes/books.new.tsx
+++ b/apps/studio/src/routes/books.new.tsx
@@ -34,6 +34,7 @@ import {
   AdvancedLayoutPanel,
   type RenderStrategyState,
 } from "@/components/config/AdvancedLayoutPanel"
+import { normalizeDefaultRenderStrategy } from "@/lib/render-strategy"
 
 export const Route = createFileRoute("/books/new")({
   component: AddBookPage,
@@ -223,16 +224,9 @@ function AddBookPage() {
         : {}
     )
 
-    // Use preset's default render strategy, or fall back to "dynamic"
-    setDefaultRenderStrategy(
-      typeof config.default_render_strategy === "string"
-        ? config.default_render_strategy
-        : "dynamic"
-    )
-
     // Render strategies
+    const loaded: Record<string, RenderStrategyState> = {}
     if (config.render_strategies && typeof config.render_strategies === "object") {
-      const loaded: Record<string, RenderStrategyState> = {}
       for (const [name, raw] of Object.entries(
         config.render_strategies as Record<string, Record<string, unknown>>
       )) {
@@ -250,10 +244,17 @@ function AddBookPage() {
           },
         }
       }
-      setRenderStrategies(loaded)
-    } else {
-      setRenderStrategies({})
     }
+    setRenderStrategies(loaded)
+
+    setDefaultRenderStrategy(
+      normalizeDefaultRenderStrategy(
+        typeof config.default_render_strategy === "string"
+          ? config.default_render_strategy
+          : "",
+        loaded
+      )
+    )
 
     // Section render strategies
     if (config.section_render_strategies && typeof config.section_render_strategies === "object") {
@@ -425,10 +426,12 @@ function AddBookPage() {
     }
 
     // Advanced layout settings
-    // "dynamic" means use section_render_strategies mapping with two_column fallback
-    const effectiveStrategy = defaultRenderStrategy === "dynamic" ? "two_column" : defaultRenderStrategy
-    if (effectiveStrategy.trim()) {
-      configOverrides.default_render_strategy = effectiveStrategy.trim()
+    const normalizedDefaultRenderStrategy = normalizeDefaultRenderStrategy(
+      defaultRenderStrategy,
+      renderStrategies
+    )
+    if (normalizedDefaultRenderStrategy) {
+      configOverrides.default_render_strategy = normalizedDefaultRenderStrategy
     }
     if (Object.keys(renderStrategies).length > 0) {
       const strategies: Record<string, unknown> = {}


### PR DESCRIPTION
This removes the synthetic dynamic option from Studio strategy selectors and centralizes default strategy normalization in a shared helper. Legacy or invalid defaults are now normalized to a valid non-activity strategy, preferring two_column when present, and strategy removal no longer leaves stale defaults. Add Book and Storyboard settings now both persist only normalized default_render_strategy values derived from available render_strategies. Included unit tests cover filtering/selectable strategy behavior and normalization edge cases, including legacy dynamic, missing strategies, and activity-only sets.