### PR TITLE
Align TTS default voice handling and move voice setting to Voices tab

### DIFF
--- a/apps/api/src/services/stage-runner.ts
+++ b/apps/api/src/services/stage-runner.ts
@@ -1474,7 +1474,7 @@ async function runTextAndSpeechStep(
         const startMs = Date.now()
         const provider = resolveProviderForLanguage(item.language, routing)
         const providerModel = providerConfigs[provider]?.model ?? (provider === "azure" ? "azure-tts" : speechModel)
-        const voice = config.speech?.voice ?? resolveVoice(provider, item.language, voiceMaps)
+        const voice = resolveVoice(provider, item.language, voiceMaps, config.speech?.voice)
         const instructions = provider === "openai"
           ? resolveInstructions(item.language, instructionsMap)
           : ""

--- a/apps/studio/src/components/pipeline/stages/TranslationsSettings.tsx
+++ b/apps/studio/src/components/pipeline/stages/TranslationsSettings.tsx
@@ -39,7 +39,6 @@ export function TranslationsSettings({ bookLabel, headerTarget, tab = "general" 
 
   // Speech settings
   const [speechModel, setSpeechModel] = useState("")
-  const [voice, setVoice] = useState("")
   const [format, setFormat] = useState("")
   const [defaultProvider, setDefaultProvider] = useState("openai")
   const [openaiModel, setOpenaiModel] = useState("")
@@ -65,7 +64,6 @@ export function TranslationsSettings({ bookLabel, headerTarget, tab = "general" 
     if (m.speech && typeof m.speech === "object") {
       const s = m.speech as Record<string, unknown>
       if (s.model) setSpeechModel(String(s.model))
-      if (s.voice) setVoice(String(s.voice))
       if (s.format) setFormat(String(s.format))
       if (s.default_provider) setDefaultProvider(String(s.default_provider))
       if (s.bit_rate) setBitRate(String(s.bit_rate))
@@ -119,7 +117,6 @@ export function TranslationsSettings({ bookLabel, headerTarget, tab = "general" 
       overrides.speech = {
         ...existing,
         model: speechModel.trim() || undefined,
-        voice: voice.trim() || undefined,
         format: format.trim() || undefined,
         default_provider: defaultProvider || undefined,
         providers: Object.keys(providers).length > 0 ? providers : undefined,
@@ -258,17 +255,6 @@ export function TranslationsSettings({ bookLabel, headerTarget, tab = "general" 
           {/* Audio Settings */}
           <div className="space-y-3">
             <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Audio Settings</h3>
-            <div className="space-y-1.5">
-              <Label className="text-xs">Default Voice</Label>
-              <Input
-                value={voice}
-                onChange={(e) => { setVoice(e.target.value); markDirty("speech") }}
-                placeholder="e.g. alloy"
-                className="w-72 h-8 text-xs"
-              />
-              <p className="text-xs text-muted-foreground">Override voice (leave blank to use voices.yaml per-language mappings).</p>
-            </div>
-
             <div className="flex gap-4">
               <div className="space-y-1.5">
                 <Label className="text-xs">Format</Label>

--- a/apps/studio/src/components/pipeline/stages/VoiceMappingsEditor.tsx
+++ b/apps/studio/src/components/pipeline/stages/VoiceMappingsEditor.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from "react"
+import { useState, useEffect } from "react"
 import { createPortal } from "react-dom"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { Save, Plus, X } from "lucide-react"
@@ -6,6 +6,8 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { api } from "@/api/client"
+import { useBookConfig, useUpdateBookConfig } from "@/hooks/use-book-config"
+import { useActiveConfig } from "@/hooks/use-debug"
 
 interface VoiceMappingsEditorProps {
   bookLabel: string
@@ -20,13 +22,18 @@ interface VoiceRow {
 
 export function VoiceMappingsEditor({ bookLabel, headerTarget }: VoiceMappingsEditorProps) {
   const queryClient = useQueryClient()
+  const { data: bookConfigData, isLoading: isBookConfigLoading } = useBookConfig(bookLabel)
+  const { data: activeConfigData } = useActiveConfig(bookLabel)
+  const updateConfig = useUpdateBookConfig()
   const { data, isLoading } = useQuery({
     queryKey: ["voice-mappings"],
     queryFn: () => api.getVoiceMappings(),
   })
 
   const [rows, setRows] = useState<VoiceRow[]>([])
-  const [dirty, setDirty] = useState(false)
+  const [defaultVoice, setDefaultVoice] = useState("")
+  const [dirtyMappings, setDirtyMappings] = useState(false)
+  const [dirtyDefaultVoice, setDirtyDefaultVoice] = useState(false)
   const [saving, setSaving] = useState(false)
   const [newLangKey, setNewLangKey] = useState("")
   const [showAddLang, setShowAddLang] = useState(false)
@@ -49,14 +56,26 @@ export function VoiceMappingsEditor({ bookLabel, headerTarget }: VoiceMappingsEd
     setRows(built)
   }, [data])
 
+  useEffect(() => {
+    if (dirtyDefaultVoice || !activeConfigData) return
+    const merged = activeConfigData.merged as Record<string, unknown>
+    const speech = merged.speech
+    if (!speech || typeof speech !== "object") {
+      setDefaultVoice("")
+      return
+    }
+    const voice = (speech as Record<string, unknown>).voice
+    setDefaultVoice(typeof voice === "string" ? voice : "")
+  }, [activeConfigData, dirtyDefaultVoice])
+
   const updateRow = (index: number, field: "openai" | "azure", value: string) => {
     setRows((prev) => prev.map((r, i) => i === index ? { ...r, [field]: value } : r))
-    setDirty(true)
+    setDirtyMappings(true)
   }
 
   const removeRow = (index: number) => {
     setRows((prev) => prev.filter((_, i) => i !== index))
-    setDirty(true)
+    setDirtyMappings(true)
   }
 
   const addLanguage = () => {
@@ -65,21 +84,50 @@ export function VoiceMappingsEditor({ bookLabel, headerTarget }: VoiceMappingsEd
     setRows((prev) => [...prev, { lang: key, openai: "", azure: "" }])
     setNewLangKey("")
     setShowAddLang(false)
-    setDirty(true)
+    setDirtyMappings(true)
   }
 
   const handleSave = async () => {
     setSaving(true)
     try {
-      const openai: Record<string, string> = {}
-      const azure: Record<string, string> = {}
-      for (const row of rows) {
-        if (row.openai.trim()) openai[row.lang] = row.openai.trim()
-        if (row.azure.trim()) azure[row.lang] = row.azure.trim()
+      const saves: Promise<unknown>[] = []
+
+      if (dirtyMappings) {
+        const openai: Record<string, string> = {}
+        const azure: Record<string, string> = {}
+        for (const row of rows) {
+          if (row.openai.trim()) openai[row.lang] = row.openai.trim()
+          if (row.azure.trim()) azure[row.lang] = row.azure.trim()
+        }
+        saves.push(api.updateVoiceMappings({ openai, azure }))
       }
-      await api.updateVoiceMappings({ openai, azure })
-      queryClient.invalidateQueries({ queryKey: ["voice-mappings"] })
-      setDirty(false)
+
+      if (dirtyDefaultVoice) {
+        const existingConfig = (bookConfigData?.config ?? {}) as Record<string, unknown>
+        const existingSpeech = existingConfig.speech
+        const speechObject = (existingSpeech && typeof existingSpeech === "object")
+          ? (existingSpeech as Record<string, unknown>)
+          : {}
+        const nextSpeech = {
+          ...speechObject,
+          voice: defaultVoice.trim() || undefined,
+        }
+        const cleanSpeech = Object.fromEntries(
+          Object.entries(nextSpeech).filter(([, value]) => value !== undefined)
+        )
+        const nextConfig: Record<string, unknown> = { ...existingConfig }
+        if (Object.keys(cleanSpeech).length > 0) nextConfig.speech = cleanSpeech
+        else delete nextConfig.speech
+
+        saves.push(updateConfig.mutateAsync({ label: bookLabel, config: nextConfig }))
+      }
+
+      if (saves.length > 0) await Promise.all(saves)
+      if (dirtyMappings) {
+        queryClient.invalidateQueries({ queryKey: ["voice-mappings"] })
+      }
+      setDirtyMappings(false)
+      setDirtyDefaultVoice(false)
     } finally {
       setSaving(false)
     }
@@ -96,13 +144,31 @@ export function VoiceMappingsEditor({ bookLabel, headerTarget }: VoiceMappingsEd
           size="sm"
           className="h-7 px-2.5 text-xs bg-black/15 text-white hover:bg-black/25"
           onClick={handleSave}
-          disabled={saving || !dirty}
+          disabled={saving || updateConfig.isPending || (!dirtyMappings && !dirtyDefaultVoice) || (dirtyDefaultVoice && isBookConfigLoading)}
         >
           <Save className="mr-1.5 h-3.5 w-3.5" />
           {saving ? "Saving..." : "Save"}
         </Button>,
         headerTarget
       )}
+
+      <div className="space-y-1.5">
+        <Label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Default Voice
+        </Label>
+        <Input
+          value={defaultVoice}
+          onChange={(e) => {
+            setDefaultVoice(e.target.value)
+            setDirtyDefaultVoice(true)
+          }}
+          placeholder="e.g. alloy"
+          className="w-72 h-8 text-xs"
+        />
+        <p className="text-xs text-muted-foreground">
+          Default voice used when not specified for a language.
+        </p>
+      </div>
 
       <div className="flex items-center justify-between">
         <div>

--- a/packages/pipeline/src/__tests__/speech.test.ts
+++ b/packages/pipeline/src/__tests__/speech.test.ts
@@ -118,6 +118,20 @@ describe("resolveVoice", () => {
     expect(resolveVoice("openai", "es_UY", voiceMaps)).toBe("nova")
     expect(resolveVoice("openai", "es_MX", voiceMaps)).toBe("coral")
   })
+
+  it("uses defaultVoice as fallback when no match in voiceMaps", () => {
+    const noDefault: VoiceMaps = { openai: { es: "coral" } }
+    expect(resolveVoice("openai", "fr", noDefault, "shimmer")).toBe("shimmer")
+  })
+
+  it("uses defaultVoice for unknown provider", () => {
+    expect(resolveVoice("azure", "en", voiceMaps, "shimmer")).toBe("shimmer")
+  })
+
+  it("prefers voice map match over defaultVoice", () => {
+    expect(resolveVoice("openai", "es-uy", voiceMaps, "shimmer")).toBe("nova")
+    expect(resolveVoice("openai", "es-mx", voiceMaps, "shimmer")).toBe("coral")
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/pipeline/src/speech.ts
+++ b/packages/pipeline/src/speech.ts
@@ -52,10 +52,12 @@ export function loadVoicesConfig(configDir: string): VoiceMaps {
 export function resolveVoice(
   provider: string,
   languageCode: string,
-  voiceMaps: VoiceMaps
+  voiceMaps: VoiceMaps,
+  defaultVoice?: string
 ): string {
+  const fallback = defaultVoice ?? "alloy"
   const providerConfig = voiceMaps[provider]
-  if (!providerConfig) return "alloy"
+  if (!providerConfig) return fallback
 
   const normalized = normalizeLocale(languageCode).toLowerCase()
 
@@ -66,8 +68,8 @@ export function resolveVoice(
   const baseLang = getBaseLanguage(normalized)
   if (baseLang in providerConfig) return providerConfig[baseLang]
 
-  // Default
-  return providerConfig["default"] ?? "alloy"
+  // Default from voices.yaml, then config default, then hardcoded
+  return providerConfig["default"] ?? fallback
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- make `resolveVoice` accept a configurable fallback voice and use it in stage-runner
- add tests covering fallback/default precedence behavior in speech voice resolution
- move `Default Voice` control from Speech settings to the Voices tab
- update Voices tab save flow to persist both `voices.yaml` mappings and `speech.voice` book config

## Validation
- `pnpm exec vitest run packages/pipeline/src/__tests__/speech.test.ts`
- `pnpm exec tsc -p apps/studio/tsconfig.json --noEmit`
