### PR TITLE
Include section images in activity answer prompts

### DIFF
--- a/prompts/activity_fill_in_a_table_answers.liquid
+++ b/prompts/activity_fill_in_a_table_answers.liquid
@@ -109,6 +109,11 @@ IMPORTANT: The `answers` array MUST include ALL `data-activity-item` IDs found i
 This is the base64 image of the entire page from the textbook for context only.
 {% image page_image_base64 %}
 
+{% for image in images %}
+Image ID: {{ image.image_id }}{% if image.width %} ({{ image.width }}×{{ image.height }}px){% endif %}
+{% image image.image_base64 %}
+{% endfor %}
+
 Activity Type: {{ section_type }}
 
 Textbook Context:

--- a/prompts/activity_fill_in_the_blank_answers.liquid
+++ b/prompts/activity_fill_in_the_blank_answers.liquid
@@ -102,6 +102,11 @@ Provide correct text for each blank based on:
 This is the base64 image of the entire page from the textbook for context only.
 {% image page_image_base64 %}
 
+{% for image in images %}
+Image ID: {{ image.image_id }}{% if image.width %} ({{ image.width }}×{{ image.height }}px){% endif %}
+{% image image.image_base64 %}
+{% endfor %}
+
 Activity Type: {{ section_type }}
 
 Textbook Context:

--- a/prompts/activity_matching_answers.liquid
+++ b/prompts/activity_matching_answers.liquid
@@ -84,6 +84,11 @@ CRITICAL:
 This is the base64 image of the entire page from the textbook for context only.
 {% image page_image_base64 %}
 
+{% for image in images %}
+Image ID: {{ image.image_id }}{% if image.width %} ({{ image.width }}×{{ image.height }}px){% endif %}
+{% image image.image_base64 %}
+{% endfor %}
+
 Activity Type: {{ section_type }}
 
 Textbook Context:

--- a/prompts/activity_multiple_choice_answers.liquid
+++ b/prompts/activity_multiple_choice_answers.liquid
@@ -81,6 +81,11 @@ CRITICAL:
 This is the base64 image of the entire page from the textbook for context only.
 {% image page_image_base64 %}
 
+{% for image in images %}
+Image ID: {{ image.image_id }}{% if image.width %} ({{ image.width }}×{{ image.height }}px){% endif %}
+{% image image.image_base64 %}
+{% endfor %}
+
 Activity Type: {{ section_type }}
 
 Textbook Context:

--- a/prompts/activity_sorting_answers.liquid
+++ b/prompts/activity_sorting_answers.liquid
@@ -69,6 +69,11 @@ CRITICAL:
 This is the base64 image of the entire page from the textbook for context only.
 {% image page_image_base64 %}
 
+{% for image in images %}
+Image ID: {{ image.image_id }}{% if image.width %} ({{ image.width }}×{{ image.height }}px){% endif %}
+{% image image.image_base64 %}
+{% endfor %}
+
 Activity Type: {{ section_type }}
 
 Textbook Context:

--- a/prompts/activity_true_false_answers.liquid
+++ b/prompts/activity_true_false_answers.liquid
@@ -69,6 +69,11 @@ CRITICAL:
 This is the base64 image of the entire page from the textbook for context only.
 {% image page_image_base64 %}
 
+{% for image in images %}
+Image ID: {{ image.image_id }}{% if image.width %} ({{ image.width }}×{{ image.height }}px){% endif %}
+{% image image.image_base64 %}
+{% endfor %}
+
 Activity Type: {{ section_type }}
 
 Textbook Context:


### PR DESCRIPTION
## Summary
- Activity answer prompts previously only received the full page image (`page_image_base64`) but not the individual section images
- Now all 6 answer prompts (multiple choice, fill-in-the-blank, fill-in-a-table, matching, sorting, true/false) include the section images with their dimensions (width×height), matching what the activity generation prompts already provide
- This gives the LLM better visual context when reasoning about correct answers

## Test plan
- [ ] Run a book through the pipeline and verify answer generation still works
- [ ] Check that matching activities with images in dropzones produce better answers