### PR TITLE
Enforce all image IDs must be assigned to sections

### DIFF
--- a/packages/pipeline/src/page-sectioning.ts
+++ b/packages/pipeline/src/page-sectioning.ts
@@ -244,6 +244,7 @@ function validatePageSectioning(
   ])
 
   const errors: string[] = []
+  const assignedIds = new Set<string>()
   for (const section of r.sections) {
     if (!sectionTypeKeys.has(section.section_type)) {
       errors.push(
@@ -256,8 +257,18 @@ function validatePageSectioning(
           `Invalid part_id "${partId}". Must be one of: ${[...validPartIds].join(", ")}`
         )
       }
+      assignedIds.add(partId)
     }
   }
+
+  // Ensure all parts are assigned to at least one section
+  const unassigned = [...validPartIds].filter((id) => !assignedIds.has(id))
+  if (unassigned.length > 0) {
+    errors.push(
+      `Every part must be assigned to a section. Unassigned part_ids: ${unassigned.join(", ")}`
+    )
+  }
+
   return { valid: errors.length === 0, errors }
 }
 

--- a/prompts/page_sectioning.liquid
+++ b/prompts/page_sectioning.liquid
@@ -18,14 +18,14 @@ RULES:
 {% if sectioning_mode == "page" %}
 - Create EXACTLY ONE section containing ALL listed group IDs and ALL listed image IDs
 - Choose the single most appropriate section type for the page as a whole
-- ALL listed group IDs must be assigned to this one section
+- ALL listed group IDs and ALL listed image IDs must be assigned to this one section
 - If no image IDs are listed below, do NOT include any image IDs in part_ids
 {% else %}
 - ALL listed group IDs must be assigned to at least one section
+- ALL listed image IDs must be assigned to at least one section — assign each image to the section it visually belongs to
 - Group/image IDs may appear in multiple sections only when it makes strong pedagogical sense (e.g. shared instructions)
 - Keep related content together — prefer fewer, more comprehensive sections over many small ones
 {% endif %}
-- Image IDs may be excluded if they have no educational value
 - Extract page number if visible (headers, footers, margins). Use null if none found
 - For background_color: hex code of predominant background. Default #ffffff
 - For text_color: hex code of predominant text color. Must contrast with background. Default #000000


### PR DESCRIPTION
## Summary

Updated page-sectioning validation and prompt to require all image IDs be assigned to at least one section during page sectioning. Previously, images could be excluded if deemed to have no educational value. This change ensures complete coverage: all images must be classified and assigned to appropriate sections.

- **Prompt rule (page mode):** ALL image IDs must be included in the single section
- **Prompt rule (section mode):** ALL image IDs must be assigned to at least one section with visual context guidance
- **Validation:** Rejects outputs with unassigned images with clear error messages listing which IDs were missed

Addresses the image-sectioning gaps identified in the pipeline.