### PR TITLE
Add activity preview mode to storyboard editor

### DIFF
--- a/apps/api/src/routes/adt-preview.ts
+++ b/apps/api/src/routes/adt-preview.ts
@@ -195,6 +195,24 @@ function buildPreviewConfig(storage: Storage, language: string) {
   const quizData = quizRow?.data as { quizzes?: unknown[] } | undefined
   const hasQuiz = quizData !== undefined && (quizData.quizzes?.length ?? 0) > 0
 
+  // Also check if any rendered sections are activity types
+  let hasActivitySections = false
+  if (!hasQuiz) {
+    const pages = storage.getPages()
+    for (const page of pages) {
+      const renderRow = storage.getLatestNodeData("web-rendering", page.pageId)
+      if (renderRow) {
+        const parsed = WebRenderingOutput.safeParse(renderRow.data)
+        if (parsed.success) {
+          if (parsed.data.sections.some((s) => s.sectionType.startsWith("activity_"))) {
+            hasActivitySections = true
+            break
+          }
+        }
+      }
+    }
+  }
+
   return {
     title: getBookTitle(storage),
     bundleVersion: "1",
@@ -216,7 +234,7 @@ function buildPreviewConfig(storage: Storage, language: string) {
       state: false,
       characterDisplay: false,
       highlight: false,
-      activities: hasQuiz,
+      activities: hasQuiz || hasActivitySections,
     },
     analytics: {
       enabled: false,
@@ -468,6 +486,7 @@ export function createAdtPreviewRoutes(
     const safeLabel = parseBookLabel(label)
     const config = loadBookConfig(safeLabel, booksDir, configPath)
     const applyBodyBackground = config.apply_body_background
+    const embed = c.req.query("embed") === "1"
 
     return withStorage(label, (storage) => {
       const title = getBookTitle(storage)
@@ -500,6 +519,7 @@ export function createAdtPreviewRoutes(
           bundleVersion: "1",
           skipContentWrapper: true,
           applyBodyBackground,
+          embed,
         })
 
         c.header("Content-Type", "text/html; charset=utf-8")
@@ -554,6 +574,7 @@ export function createAdtPreviewRoutes(
         hasMath: false,
         bundleVersion: "1",
         applyBodyBackground,
+        embed,
       })
 
       c.header("Content-Type", "text/html; charset=utf-8")

--- a/apps/studio/src/components/pipeline/stages/StoryboardSectionDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/StoryboardSectionDetail.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback, useMemo, type ReactNode } from "react"
 import { createPortal } from "react-dom"
-import { Check, Copy, Eye, EyeOff, LayoutGrid, Layers, Loader2, ChevronDown, Sparkles, ChevronRight, PanelRightOpen, PanelRightClose, Save, X } from "lucide-react"
+import { Check, Copy, Eye, EyeOff, LayoutGrid, Layers, Loader2, ChevronDown, Sparkles, ChevronRight, PanelRightOpen, PanelRightClose, Play, PenLine, Save, X } from "lucide-react"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { api, BASE_URL } from "@/api/client"
 import type { PageDetail, VersionEntry } from "@/api/client"
@@ -380,6 +380,9 @@ export function StoryboardSectionDetail({
     onGeneratingChange?.(aiImageGen?.status === "generating")
   }, [aiImageGen?.status])
 
+  // Activity preview mode (try the activity in the editor)
+  const [activityPreviewMode, setActivityPreviewMode] = useState(false)
+
   // AI edit state
   const [aiInstruction, setAiInstruction] = useState("")
   const [aiLoading, setAiLoading] = useState(false)
@@ -442,7 +445,8 @@ export function StoryboardSectionDetail({
     setAiError(null)
     setRerendering(false)
     setSaving(false)
-  }, [pageId])
+    setActivityPreviewMode(false)
+  }, [pageId, sectionIndex])
 
   // Reset scroll position when page or section changes
   useEffect(() => {
@@ -1297,17 +1301,27 @@ export function StoryboardSectionDetail({
       {/* Preview — fills remaining space, scrolls independently */}
       <div className="flex-1 overflow-auto px-4 py-4 relative" ref={scrollContainerRef}>
         {renderedSection?.html ? (
-          <BookPreviewFrame
-            ref={previewFrameRef}
-            html={renderedSection.html}
-            className="w-full rounded border"
-            editable={!aiLoading && !rerendering}
-            prunedDataIds={prunedDataIds}
-            changedElements={changedElements}
-            onSelectElement={handleSelectElement}
-            onTextChanged={handleTextChanged}
-            applyBodyBackground={applyBodyBackground}
-          />
+          <>
+            {activityPreviewMode ? (
+              <iframe
+                src={`${BASE_URL}/books/${bookLabel}/adt-preview/${pageId}_sec${String(sectionIndex + 1).padStart(3, "0")}.html?embed=1&v=${page.versions.rendering ?? 0}`}
+                className="w-full rounded border"
+                style={{ height: "80vh" }}
+              />
+            ) : (
+              <BookPreviewFrame
+                ref={previewFrameRef}
+                html={renderedSection.html}
+                className="w-full rounded border"
+                editable={!aiLoading && !rerendering}
+                prunedDataIds={prunedDataIds}
+                changedElements={changedElements}
+                onSelectElement={handleSelectElement}
+                onTextChanged={handleTextChanged}
+                applyBodyBackground={applyBodyBackground}
+              />
+            )}
+          </>
         ) : (
           <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
             <div className="w-12 h-12 rounded-full bg-violet-50 flex items-center justify-center mb-3">
@@ -1407,6 +1421,28 @@ export function StoryboardSectionDetail({
               </>
             )}
           </div>
+        </div>
+      )}
+
+      {/* Activity preview toggle — absolute on outer wrapper, sits left of the debug console button */}
+      {section.sectionType.startsWith("activity_") && renderedSection?.html && (
+        <div className="absolute bottom-4 right-16 z-30 flex items-center gap-2">
+          {activityPreviewMode && renderingDirty && (
+            <span className="text-[10px] text-amber-600 bg-white/90 px-2 py-1 rounded shadow-sm">
+              Save changes first to preview the latest version
+            </span>
+          )}
+          <button
+            type="button"
+            onClick={() => setActivityPreviewMode((v) => !v)}
+            className="flex items-center gap-1.5 h-8 px-3 rounded-full text-xs font-medium bg-blue-50 text-blue-700 hover:bg-blue-100 shadow-md border border-blue-200 transition-colors cursor-pointer opacity-80 hover:opacity-100"
+          >
+            {activityPreviewMode ? (
+              <><PenLine className="h-3 w-3" />Back to Editor</>
+            ) : (
+              <><Play className="h-3 w-3" />Try Activity</>
+            )}
+          </button>
         </div>
       )}
 

--- a/packages/pipeline/src/package-web.ts
+++ b/packages/pipeline/src/package-web.ts
@@ -450,6 +450,9 @@ export interface RenderPageOptions {
    *  Used for quiz pages whose template provides its own #content element. */
   skipContentWrapper?: boolean
   applyBodyBackground?: boolean
+  /** When true, renders a minimal page without navigation/sidebar chrome.
+   *  Content is visible immediately (no opacity-0). Used for storyboard preview. */
+  embed?: boolean
 }
 
 export function renderPageHtml(opts: RenderPageOptions): string {
@@ -464,7 +467,7 @@ export function renderPageHtml(opts: RenderPageOptions): string {
 
   const contentBlock = opts.skipContentWrapper
     ? `    ${opts.content}`
-    : `    <div id="content" class="opacity-0">
+    : `    <div id="content"${opts.embed ? "" : ` class="opacity-0"`}>
     ${opts.content}
     </div>`
 
@@ -476,6 +479,20 @@ export function renderPageHtml(opts: RenderPageOptions): string {
       ? ` style="background-color: ${escapeAttr(bgMatch[1])};"`
       : ""
   }
+
+  // In embed mode, hide all interface chrome except the submit/reset buttons
+  const embedStyles = opts.embed
+    ? `
+    <style>
+      /* Hide navigation, sidebar, and other chrome in embed mode */
+      #nav-container, #back-forward-buttons, #nav-popup,
+      #open-sidebar, #sidebar, #tts-quick-toggle-button, #play-bar,
+      #sl-quick-toggle-button, #sign-language-video,
+      #explain-me-button, #eli5-content, #notepad-button, #notepad-content { display: none !important; }
+      /* Keep submit/reset container fixed at bottom-right in embed mode */
+      #submit-reset-container { position: fixed !important; bottom: 1rem; right: 1rem; z-index: 50; }
+    </style>`
+    : ""
 
   return `<!DOCTYPE html>
 <html lang="${escapeAttr(opts.language)}">
@@ -491,13 +508,13 @@ export function renderPageHtml(opts: RenderPageOptions): string {
     <link href="./content/tailwind_output.css" rel="stylesheet">
     <link href="./assets/libs/fontawesome/css/all.min.css" rel="stylesheet">
     <link href="./assets/fonts.css" rel="stylesheet">
-${mathScript}</head>
+${mathScript}${embedStyles}</head>
 
 <body class="min-h-screen flex items-center justify-center"${bodyStyle}>
 ${contentBlock}
 ${answersScript}
     <div class="relative z-50" id="interface-container"></div>
-    <div class="relative z-50" id="nav-container"></div>
+    <div class="relative z-50" id="nav-container"${opts.embed ? ' style="display:none"' : ""}></div>
     <script src="./assets/base.bundle.min.js?v=${escapeAttr(opts.bundleVersion)}" type="module"></script>
 </body>
 


### PR DESCRIPTION
## Summary
Users can now try interactive activity sections inline in the storyboard editor via a toggleable embed mode. The "Try Activity" button loads the activity in an iframe without editor chrome, enabling real-time preview of activity content while editing.

## Changes
- **API**: Detect activity sections and enable activities feature flag; pass embed query param to renderer
- **UI**: Add toggle between editor and activity preview modes with "Try Activity" button
- **Rendering**: Add embed option to hide navigation chrome and show content immediately for preview mode