### PR TITLE
Add styleguide generation from page images

### DIFF
--- a/apps/api/src/routes/pages.ts
+++ b/apps/api/src/routes/pages.ts
@@ -8,7 +8,7 @@ import { parseBookLabel, TextClassificationOutput, ImageClassificationOutput, Pa
 import { openBookDb } from "@adt/storage"
 import { createBookStorage } from "@adt/storage"
 import { reRenderPage, aiEditSection } from "../services/page-edit-service.js"
-import { segmentPageImages, getSegmentedImageId, loadBookConfig, applyCrop } from "@adt/pipeline"
+import { segmentPageImages, getSegmentedImageId, loadBookConfig, applyCrop, generateStyleguide, buildStyleguideGenerationConfig } from "@adt/pipeline"
 import { createLLMModel, createPromptEngine } from "@adt/llm"
 
 interface PageSummary {
@@ -1100,6 +1100,100 @@ export function createPageRoutes(
       return c.json({ error: err instanceof Error ? err.message : "Segmentation apply failed" }, 500)
     } finally {
       storage.close()
+    }
+  })
+
+  // POST /books/:label/generate-styleguide — Generate styleguide from page images
+  app.post("/books/:label/generate-styleguide", async (c) => {
+    const { label } = c.req.param()
+    const safeLabel = parseBookLabel(label)
+
+    const apiKey = c.req.header("X-OpenAI-Key")
+    if (!apiKey) {
+      throw new HTTPException(400, { message: "Missing X-OpenAI-Key header" })
+    }
+
+    const body = await c.req.json()
+    const PageIdsSchema = z.object({
+      pageIds: z.array(z.string().min(1)).min(1).max(5),
+    })
+    const parsed = PageIdsSchema.safeParse(body)
+    if (!parsed.success) {
+      throw new HTTPException(400, {
+        message: `Invalid request: ${parsed.error.issues.map((i) => i.message).join(", ")}`,
+      })
+    }
+
+    const { pageIds } = parsed.data
+    const resolvedBooksDir = path.resolve(booksDir)
+    const bookDir = path.join(resolvedBooksDir, safeLabel)
+    const dbPath = path.join(bookDir, `${safeLabel}.db`)
+
+    if (!fs.existsSync(dbPath)) {
+      throw new HTTPException(404, { message: `Book not found: ${safeLabel}` })
+    }
+
+    // Load page images
+    const storage = createBookStorage(safeLabel, booksDir)
+    const pageImages: Array<{ pageId: string; pageNumber: number; imageBase64: string }> = []
+    try {
+      const pages = storage.getPages()
+      for (const pageId of pageIds) {
+        const page = pages.find((p) => p.pageId === pageId)
+        if (!page) {
+          throw new HTTPException(404, { message: `Page not found: ${pageId}` })
+        }
+        const imageBase64 = storage.getPageImageBase64(pageId)
+        pageImages.push({
+          pageId,
+          pageNumber: page.pageNumber,
+          imageBase64,
+        })
+      }
+    } finally {
+      storage.close()
+    }
+
+    // Set API key for LLM
+    const previousKey = process.env.OPENAI_API_KEY
+    process.env.OPENAI_API_KEY = apiKey
+
+    try {
+      const bookPromptsDir = path.join(bookDir, "prompts")
+      const promptEngine = createPromptEngine([bookPromptsDir, promptsDir])
+      const cacheDir = path.join(bookDir, ".cache")
+      const config = buildStyleguideGenerationConfig()
+      const llmModel = createLLMModel({
+        modelId: config.modelId,
+        cacheDir,
+        promptEngine,
+      })
+
+      const result = await generateStyleguide(
+        { pageImages },
+        config,
+        llmModel
+      )
+
+      // Save to assets/styleguides/{label}-generated.md
+      const projectRoot = configPath ? path.dirname(configPath) : path.resolve(booksDir, "..")
+      const styleguidesDir = path.join(projectRoot, "assets", "styleguides")
+      fs.mkdirSync(styleguidesDir, { recursive: true })
+      const sgName = `${safeLabel}-generated`
+      fs.writeFileSync(path.join(styleguidesDir, `${sgName}.md`), result.content, "utf-8")
+      fs.writeFileSync(path.join(styleguidesDir, `${sgName}-preview.html`), result.preview_html, "utf-8")
+
+      return c.json({
+        name: sgName,
+        content: result.content,
+        reasoning: result.reasoning,
+      })
+    } finally {
+      if (previousKey !== undefined) {
+        process.env.OPENAI_API_KEY = previousKey
+      } else {
+        delete process.env.OPENAI_API_KEY
+      }
     }
   })
 

--- a/apps/api/src/routes/presets.ts
+++ b/apps/api/src/routes/presets.ts
@@ -50,10 +50,41 @@ export function createPresetRoutes(configPath: string): Hono {
     const name = result.data
     const styleguidesDir = path.join(path.dirname(configPath), "assets", "styleguides")
     const previewPath = path.join(styleguidesDir, `${name}-preview.html`)
-    if (!fs.existsSync(previewPath)) {
-      throw new HTTPException(404, { message: `Preview not found for styleguide: ${name}` })
+    if (fs.existsSync(previewPath)) {
+      const html = fs.readFileSync(previewPath, "utf-8")
+      return c.json({ name, html })
     }
-    const html = fs.readFileSync(previewPath, "utf-8")
+    // Fallback: render the markdown content as a styled HTML page
+    const mdPath = path.join(styleguidesDir, `${name}.md`)
+    if (!fs.existsSync(mdPath)) {
+      throw new HTTPException(404, { message: `Styleguide not found: ${name}` })
+    }
+    const md = fs.readFileSync(mdPath, "utf-8")
+    const escapedMd = md
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+    // Convert basic markdown to HTML for readability
+    // Extract code blocks into placeholders so paragraph replacement doesn't corrupt them
+    const codeBlocks: string[] = []
+    const withPlaceholders = escapedMd
+      .replace(/```(\w*)\n([\s\S]*?)```/g, (_match, _lang, code) => {
+        const idx = codeBlocks.length
+        codeBlocks.push(`<pre style="background:#f3f4f6;border-radius:0.5rem;padding:1rem;overflow-x:auto;font-size:0.8rem;line-height:1.5;margin:0.75rem 0;"><code>${code}</code></pre>`)
+        return `\x00CODEBLOCK${idx}\x00`
+      })
+    const bodyHtml = withPlaceholders
+      .replace(/^### (.+)$/gm, '<h3 style="font-size:1.1rem;font-weight:700;margin:1.5rem 0 0.5rem;">$1</h3>')
+      .replace(/^## (.+)$/gm, '<h2 style="font-size:1.3rem;font-weight:700;margin:2rem 0 0.75rem;border-bottom:1px solid #e5e7eb;padding-bottom:0.5rem;">$1</h2>')
+      .replace(/^# (.+)$/gm, '<h1 style="font-size:1.6rem;font-weight:800;margin:0 0 1rem;">$1</h1>')
+      .replace(/\n\n/g, '</p><p style="margin:0.5rem 0;line-height:1.6;">')
+      .replace(/\x00CODEBLOCK(\d+)\x00/g, (_match, idx) => codeBlocks[Number(idx)])
+    const html = `<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/>
+<title>Styleguide — ${name}</title>
+<style>body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;max-width:56rem;margin:0 auto;padding:2rem;color:#1f2937;font-size:0.95rem;}
+table{border-collapse:collapse;width:100%;margin:0.75rem 0;}th,td{border:1px solid #e5e7eb;padding:0.4rem 0.75rem;text-align:left;font-size:0.85rem;}th{background:#f9fafb;font-weight:600;}</style>
+</head><body><p style="margin:0.5rem 0;line-height:1.6;">${bodyHtml}</p></body></html>`
     return c.json({ name, html })
   })
 

--- a/apps/studio/src/api/client.ts
+++ b/apps/studio/src/api/client.ts
@@ -623,6 +623,17 @@ export const api = {
   getStyleguidePreview: (name: string) =>
     request<{ name: string; html: string }>(`/styleguides/${name}/preview`),
 
+  generateStyleguide: (label: string, pageIds: string[], apiKey: string, signal?: AbortSignal) =>
+    request<{ name: string; content: string; reasoning: string }>(
+      `/books/${label}/generate-styleguide`,
+      {
+        method: "POST",
+        headers: { "X-OpenAI-Key": apiKey },
+        body: JSON.stringify({ pageIds }),
+        signal: signal ?? AbortSignal.timeout(180_000),
+      }
+    ),
+
   getGlobalConfig: () =>
     request<{ config: Record<string, unknown> }>(`/config`),
 

--- a/apps/studio/src/components/pipeline/stages/StoryboardSettings.tsx
+++ b/apps/studio/src/components/pipeline/stages/StoryboardSettings.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useMemo } from "react"
 import { createPortal } from "react-dom"
 import { useNavigate } from "@tanstack/react-router"
-import { Play, Plus, X, Eye } from "lucide-react"
+import { Play, Plus, X, Eye, Wand2, Loader2, Check } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { PruneToggle } from "@/components/pipeline/PruneToggle"
@@ -25,7 +25,8 @@ import { Label } from "@/components/ui/label"
 import { useBookConfig, useUpdateBookConfig } from "@/hooks/use-book-config"
 import { useActiveConfig } from "@/hooks/use-debug"
 import { useApiKey } from "@/hooks/use-api-key"
-import { useStyleguides, useStyleguidePreview, useTemplates } from "@/hooks/use-presets"
+import { useStyleguides, useStyleguidePreview, useTemplates, useGenerateStyleguide } from "@/hooks/use-presets"
+import { usePages, usePageImage } from "@/hooks/use-pages"
 import { api } from "@/api/client"
 import { PromptViewer } from "@/components/pipeline/PromptViewer"
 import { TemplateViewer } from "@/components/pipeline/TemplateViewer"
@@ -57,6 +58,59 @@ const RENDER_STRATEGY_DESCRIPTIONS: Record<string, string> = {
   "llm-overlay": "LLM positions text over background images",
   two_column: "Fixed two-column template layout",
   two_column_story: "Two-column template for story content",
+}
+
+function PageThumb({
+  bookLabel,
+  page,
+  selected,
+  disabled,
+  onClick,
+}: {
+  bookLabel: string
+  page: { pageId: string; pageNumber: number }
+  selected: boolean
+  disabled: boolean
+  onClick: () => void
+}) {
+  const { data: imageData } = usePageImage(bookLabel, page.pageId)
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className={`relative flex flex-col rounded-md border overflow-hidden transition-colors text-left ${
+        selected
+          ? "border-blue-500 ring-2 ring-blue-500/30"
+          : disabled
+            ? "opacity-40 cursor-not-allowed border-border"
+            : "hover:border-blue-300 cursor-pointer border-border"
+      }`}
+    >
+      <div className="w-full bg-muted/30">
+        {imageData ? (
+          <img
+            src={`data:image/png;base64,${imageData.imageBase64}`}
+            alt={`Page ${page.pageNumber}`}
+            className="w-full h-auto block"
+          />
+        ) : (
+          <div className="flex aspect-[3/4] items-center justify-center text-[10px] text-muted-foreground">
+            ...
+          </div>
+        )}
+      </div>
+      <div className="px-1.5 py-1 border-t text-center">
+        <span className="text-[10px] font-medium">Page {page.pageNumber}</span>
+      </div>
+      {selected && (
+        <div className="absolute top-1 right-1 w-5 h-5 rounded-full bg-blue-500 flex items-center justify-center">
+          <Check className="h-3 w-3 text-white" />
+        </div>
+      )}
+    </button>
+  )
 }
 
 export function StoryboardSettings({ bookLabel, headerTarget, tab = "general" }: { bookLabel: string; headerTarget?: HTMLDivElement | null; tab?: string }) {
@@ -136,6 +190,39 @@ export function StoryboardSettings({ bookLabel, headerTarget, tab = "general" }:
   const { data: templatesData } = useTemplates()
   const availableTemplates = templatesData?.templates ?? []
   const availableStyleguides = styleguidesData?.styleguides ?? []
+
+  // Styleguide generation
+  const { data: pagesData } = usePages(bookLabel)
+  const generateStyleguideMutation = useGenerateStyleguide()
+  const [generateDialogOpen, setGenerateDialogOpen] = useState(false)
+  const [selectedPageIds, setSelectedPageIds] = useState<Set<string>>(new Set())
+
+  const togglePageSelection = (pageId: string) => {
+    setSelectedPageIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(pageId)) {
+        next.delete(pageId)
+      } else if (next.size < 5) {
+        next.add(pageId)
+      }
+      return next
+    })
+  }
+
+  const handleGenerate = () => {
+    if (selectedPageIds.size === 0 || !hasApiKey) return
+    generateStyleguideMutation.mutate(
+      { label: bookLabel, pageIds: Array.from(selectedPageIds), apiKey },
+      {
+        onSuccess: (data) => {
+          setStyleguide(data.name)
+          markDirty("styleguide")
+          setGenerateDialogOpen(false)
+          setSelectedPageIds(new Set())
+        },
+      }
+    )
+  }
 
   // Styleguide preview
   const [styleguidePreviewOpen, setStyleguidePreviewOpen] = useState(false)
@@ -645,53 +732,67 @@ export function StoryboardSettings({ bookLabel, headerTarget, tab = "general" }:
         <div className="flex flex-col h-full">
           {/* Styleguide + Temperature settings */}
           <div className="shrink-0 p-4 pb-0 space-y-4">
-            {availableStyleguides.length > 0 && (
-              <div>
-                <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
-                  Styleguide
-                </h3>
-                <div className="flex items-center gap-2">
-                  <Select
-                    value={styleguide || "__none__"}
-                    onValueChange={(v) => {
-                      setStyleguide(v === "__none__" ? "" : v)
-                      markDirty("styleguide")
-                    }}
-                  >
-                    <SelectTrigger className="w-72">
-                      <SelectValue placeholder="Select styleguide...">
-                        {styleguide ? titleCase(styleguide) : "None"}
-                      </SelectValue>
-                    </SelectTrigger>
-                    <SelectContent align="start">
-                      <SelectItem value="__none__">
-                        <span className="text-muted-foreground">None</span>
+            <div>
+              <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
+                Styleguide
+              </h3>
+              <div className="flex items-center gap-2">
+                <Select
+                  value={styleguide || "__none__"}
+                  onValueChange={(v) => {
+                    setStyleguide(v === "__none__" ? "" : v)
+                    markDirty("styleguide")
+                  }}
+                >
+                  <SelectTrigger className="w-72">
+                    <SelectValue placeholder="Select styleguide...">
+                      {styleguide ? titleCase(styleguide) : "None"}
+                    </SelectValue>
+                  </SelectTrigger>
+                  <SelectContent align="start">
+                    <SelectItem value="__none__">
+                      <span className="text-muted-foreground">None</span>
+                    </SelectItem>
+                    {availableStyleguides.map((sg) => (
+                      <SelectItem key={sg} value={sg}>
+                        {titleCase(sg)}
                       </SelectItem>
-                      {availableStyleguides.map((sg) => (
-                        <SelectItem key={sg} value={sg}>
-                          {titleCase(sg)}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  {styleguide && (
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      className="h-9 px-2.5 shrink-0"
-                      onClick={openStyleguidePreview}
-                    >
-                      <Eye className="h-3.5 w-3.5 mr-1" />
-                      Preview
-                    </Button>
-                  )}
-                </div>
-                <p className="text-xs text-muted-foreground mt-1.5">
-                  Provides consistent HTML/CSS patterns for LLM-generated pages.
-                </p>
+                    ))}
+                  </SelectContent>
+                </Select>
+                {styleguide && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="h-9 px-2.5 shrink-0"
+                    onClick={openStyleguidePreview}
+                  >
+                    <Eye className="h-3.5 w-3.5 mr-1" />
+                    Preview
+                  </Button>
+                )}
+                {pagesData && pagesData.length > 0 && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="h-9 px-2.5 shrink-0"
+                    onClick={() => {
+                      setSelectedPageIds(new Set())
+                      setGenerateDialogOpen(true)
+                    }}
+                    disabled={generateStyleguideMutation.isPending}
+                  >
+                    <Wand2 className="h-3.5 w-3.5 mr-1" />
+                    Generate from pages
+                  </Button>
+                )}
               </div>
-            )}
+              <p className="text-xs text-muted-foreground mt-1.5">
+                Provides consistent HTML/CSS patterns for LLM-generated pages.
+              </p>
+            </div>
 
             <div>
               <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
@@ -978,6 +1079,78 @@ export function StoryboardSettings({ bookLabel, headerTarget, tab = "general" }:
               />
             )}
           </div>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={generateDialogOpen} onOpenChange={(open) => {
+        if (!generateStyleguideMutation.isPending) {
+          setGenerateDialogOpen(open)
+        }
+      }}>
+        <DialogContent className="max-w-3xl max-h-[80vh] flex flex-col">
+          <DialogHeader>
+            <DialogTitle>Generate Styleguide from Pages</DialogTitle>
+            <DialogDescription>
+              Select up to 5 pages to use as visual references. The LLM will analyze them and generate a styleguide.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex-1 min-h-0 overflow-y-auto">
+            <div className="grid grid-cols-4 sm:grid-cols-5 gap-2 p-1">
+              {(pagesData ?? []).map((page) => {
+                const isSelected = selectedPageIds.has(page.pageId)
+                const isDisabled = !isSelected && selectedPageIds.size >= 5
+                return (
+                  <PageThumb
+                    key={page.pageId}
+                    bookLabel={bookLabel}
+                    page={page}
+                    selected={isSelected}
+                    disabled={isDisabled}
+                    onClick={() => togglePageSelection(page.pageId)}
+                  />
+                )
+              })}
+            </div>
+          </div>
+          <DialogFooter className="flex items-center justify-between sm:justify-between">
+            <div className="flex flex-col gap-1">
+              <span className="text-xs text-muted-foreground">
+                {selectedPageIds.size}/5 pages selected
+              </span>
+              {generateStyleguideMutation.isError && (
+                <span className="text-xs text-red-500">
+                  {generateStyleguideMutation.error instanceof Error
+                    ? generateStyleguideMutation.error.message
+                    : "Generation failed. Please try again."}
+                </span>
+              )}
+            </div>
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                onClick={() => setGenerateDialogOpen(false)}
+                disabled={generateStyleguideMutation.isPending}
+              >
+                Cancel
+              </Button>
+              <Button
+                onClick={handleGenerate}
+                disabled={selectedPageIds.size === 0 || !hasApiKey || generateStyleguideMutation.isPending}
+              >
+                {generateStyleguideMutation.isPending ? (
+                  <>
+                    <Loader2 className="h-4 w-4 mr-1.5 animate-spin" />
+                    Generating...
+                  </>
+                ) : (
+                  <>
+                    <Wand2 className="h-4 w-4 mr-1.5" />
+                    Generate
+                  </>
+                )}
+              </Button>
+            </div>
+          </DialogFooter>
         </DialogContent>
       </Dialog>
 

--- a/apps/studio/src/hooks/use-presets.ts
+++ b/apps/studio/src/hooks/use-presets.ts
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query"
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
 import { api } from "@/api/client"
 
 export function usePreset(name: string | null) {
@@ -28,6 +28,17 @@ export function useStyleguidePreview(name: string | null) {
     queryKey: ["styleguide-preview", name],
     queryFn: () => api.getStyleguidePreview(name!),
     enabled: !!name,
+  })
+}
+
+export function useGenerateStyleguide() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ label, pageIds, apiKey }: { label: string; pageIds: string[]; apiKey: string }) =>
+      api.generateStyleguide(label, pageIds, apiKey),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["styleguides"] })
+    },
   })
 }
 

--- a/assets/styleguides/frankenstein-activity-test-generated-preview.html
+++ b/assets/styleguides/frankenstein-activity-test-generated-preview.html
@@ -1,0 +1,265 @@
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Style Guide Preview</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    .preview-label { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; font-size: 0.7rem; letter-spacing: 0.05em; text-transform: uppercase; color: #6b7280; border-bottom: 1px solid #e5e7eb; padding-bottom: 0.25rem; margin-bottom: 1rem; }
+    .preview-section { border: 2px dashed #d1d5db; border-radius: 1rem; padding: 2rem; margin-bottom: 2.5rem; background: #fafafa; }
+    .preview-divider { border-top: 3px solid #7c3aed; margin: 3rem 0; }
+  </style>
+</head>
+<body class="bg-[#F6F7F7] text-[#1F1F1F]">
+  <main class="mx-auto max-w-6xl px-6 py-12">
+    <!-- Header -->
+    <section class="mb-10">
+      <h1 class="text-4xl md:text-5xl font-extrabold tracking-tight text-[#111827]">Style Guide Preview</h1>
+      <p class="mt-2 text-base md:text-lg text-[#4B4B4B]">Tema: libro escolar con banda verde, títulos grises grandes y actividades con recuadros y líneas punteadas.</p>
+    </section>
+
+    <div class="preview-divider"></div>
+
+    <!-- Text Styles -->
+    <section>
+      <h2 class="text-2xl font-extrabold text-[#111827] mb-6">Text Styles</h2>
+
+      <div class="preview-section">
+        <div class="preview-label">book_title — h1</div>
+        <h1 class="text-4xl md:text-5xl font-extrabold tracking-tight text-[#6F6F6F]">Pensar la lengua escrita</h1>
+      </div>
+
+      <div class="preview-section">
+        <div class="preview-label">book_subtitle — p</div>
+        <p class="mt-2 text-lg md:text-xl font-semibold text-[#4B4B4B]">Actividades para leer, escribir y explicar con tus palabras.</p>
+      </div>
+
+      <div class="preview-section">
+        <div class="preview-label">chapter_title — h2</div>
+        <h2 class="text-3xl md:text-4xl font-extrabold text-[#6F6F6F]">Para definir mejor</h2>
+      </div>
+
+      <div class="preview-section">
+        <div class="preview-label">section_heading — h3</div>
+        <h3 class="flex items-center gap-3 text-xl md:text-2xl font-extrabold text-[#1F1F1F]"><span class="inline-block h-2.5 w-6 rounded-sm bg-[#0AA14B]"></span>El verbo</h3>
+      </div>
+
+      <div class="preview-section">
+        <div class="preview-label">activity_title — h4</div>
+        <h4 class="text-lg font-bold text-[#1F1F1F]">Actividad: completa la guía paso a paso</h4>
+      </div>
+
+      <div class="preview-section">
+        <div class="preview-label">section_text — p</div>
+        <p class="text-base leading-7 text-[#1F1F1F]">En la escuela circulan diversos recursos para estudiar. Observa las imágenes y explica para qué se usa cada uno.</p>
+      </div>
+
+      <div class="preview-section">
+        <div class="preview-label">instruction_text — p</div>
+        <p class="text-base leading-7 text-[#4B4B4B]">Escribe tu respuesta en las líneas punteadas. Revisa si tu explicación tiene ejemplos.</p>
+      </div>
+
+      <div class="preview-section">
+        <div class="preview-label">standalone_text — p</div>
+        <p class="text-base leading-7 text-[#1F1F1F]">Trabaja con un compañero y comparen respuestas.</p>
+      </div>
+
+      <div class="preview-section">
+        <div class="preview-label">image_associated_text — figcaption</div>
+        <figcaption class="mt-2 text-sm leading-6 text-[#4B4B4B]">Figura: ejemplo de recurso de estudio (manual, apuntes, diccionario).</figcaption>
+      </div>
+    </section>
+
+    <div class="preview-divider"></div>
+
+    <!-- Components -->
+    <section>
+      <h2 class="text-2xl font-extrabold text-[#111827] mb-6">Components</h2>
+
+      <div class="preview-section">
+        <div class="preview-label">Chapter Badge</div>
+        <div class="inline-flex items-center gap-2 rounded-full bg-[#0AA14B] px-4 py-2 text-sm font-extrabold text-white shadow-sm">
+          <span class="inline-block h-2 w-2 rounded-full bg-white/90"></span>
+          <span>UNIDAD 2</span>
+        </div>
+      </div>
+
+      <div class="preview-section">
+        <div class="preview-label">Content Card</div>
+        <div class="rounded-sm bg-[#E9ECEF] p-5 ring-1 ring-[#8E8E8E]">
+          <p class="text-base leading-7 text-[#1F1F1F]">Define la palabra <span class="bg-[#FFE24A] px-1 font-semibold">predadores</span> con tus palabras.</p>
+          <div class="mt-4 space-y-3">
+            <div class="border-b border-dotted border-[#7C7C7C] pb-2"></div>
+            <div class="border-b border-dotted border-[#7C7C7C] pb-2"></div>
+          </div>
+        </div>
+      </div>
+
+      <div class="preview-section">
+        <div class="preview-label">Text Group</div>
+        <div class="space-y-3">
+          <div class="flex gap-3">
+            <span class="mt-2 inline-block h-2.5 w-6 rounded-sm bg-[#0AA14B]"></span>
+            <p class="text-base leading-7 text-[#1F1F1F]">Observa la imagen y explica qué información aporta.</p>
+          </div>
+          <div class="flex gap-3">
+            <span class="mt-2 inline-block h-2.5 w-6 rounded-sm bg-[#0AA14B]"></span>
+            <p class="text-base leading-7 text-[#1F1F1F]">Une cada tema con el área de estudio correspondiente.</p>
+          </div>
+          <hr class="my-4 border-t-2 border-dashed border-[#7C7C7C]" />
+          <p class="text-base leading-7 text-[#4B4B4B]">Si lo necesitas, consulta tu manual y tus apuntes.</p>
+        </div>
+      </div>
+    </section>
+
+    <div class="preview-divider"></div>
+
+    <!-- Image Styles -->
+    <section>
+      <h2 class="text-2xl font-extrabold text-[#111827] mb-6">Image Styles</h2>
+
+      <div class="preview-section">
+        <div class="preview-label">Single image</div>
+        <div class="aspect-[4/3] w-full rounded-md bg-gradient-to-br from-emerald-100 to-cyan-100 ring-1 ring-black/10"></div>
+        <p class="mt-2 text-sm text-[#4B4B4B]">Placeholder para una ilustración principal.</p>
+      </div>
+
+      <div class="preview-section">
+        <div class="preview-label">Multiple images row</div>
+        <div class="grid grid-cols-2 gap-4 md:grid-cols-3">
+          <div class="aspect-square rounded-md bg-gradient-to-br from-green-100 to-lime-100 ring-1 ring-black/10"></div>
+          <div class="aspect-square rounded-md bg-gradient-to-br from-emerald-100 to-teal-100 ring-1 ring-black/10"></div>
+          <div class="aspect-square rounded-md bg-gradient-to-br from-cyan-100 to-sky-100 ring-1 ring-black/10"></div>
+        </div>
+      </div>
+
+      <div class="preview-section">
+        <div class="preview-label">Image grid (activity icons)</div>
+        <div class="grid grid-cols-2 gap-6 md:grid-cols-4">
+          <div class="aspect-square rounded-md bg-gradient-to-br from-amber-100 to-yellow-100 ring-1 ring-black/10"></div>
+          <div class="aspect-square rounded-md bg-gradient-to-br from-rose-100 to-orange-100 ring-1 ring-black/10"></div>
+          <div class="aspect-square rounded-md bg-gradient-to-br from-indigo-100 to-violet-100 ring-1 ring-black/10"></div>
+          <div class="aspect-square rounded-md bg-gradient-to-br from-emerald-100 to-cyan-100 ring-1 ring-black/10"></div>
+        </div>
+      </div>
+
+      <div class="preview-section">
+        <div class="preview-label">Side-by-side layout</div>
+        <div class="grid grid-cols-1 gap-6 md:grid-cols-2 md:items-start">
+          <div class="space-y-3">
+            <h3 class="flex items-center gap-3 text-xl md:text-2xl font-extrabold text-[#1F1F1F]"><span class="inline-block h-2.5 w-6 rounded-sm bg-[#0AA14B]"></span>Fuente: el manual de estudio</h3>
+            <p class="text-base leading-7 text-[#1F1F1F]">El manual organiza la información por áreas (ciencias, lengua, matemática). Úsalo para repasar.</p>
+            <div class="rounded-sm bg-[#E9ECEF] p-4 ring-1 ring-[#8E8E8E]">
+              <p class="text-sm text-[#1F1F1F]"><span class="font-bold">Tip:</span> subraya palabras clave y arma un resumen.</p>
+            </div>
+          </div>
+          <div class="aspect-[4/3] w-full rounded-md bg-gradient-to-br from-emerald-100 to-cyan-100 ring-1 ring-black/10"></div>
+        </div>
+      </div>
+    </section>
+
+    <div class="preview-divider"></div>
+
+    <!-- Page Templates -->
+    <section>
+      <h2 class="text-2xl font-extrabold text-[#111827] mb-6">Page Templates</h2>
+
+      <div class="preview-section">
+        <div class="preview-label">Chapter Start Page (example)</div>
+        <div class="mx-auto w-full overflow-hidden rounded-2xl bg-white shadow-sm ring-1 ring-black/5">
+          <header class="relative">
+            <div class="h-20 bg-[#0AA14B]"></div>
+            <div class="absolute inset-x-0 top-10 h-16 bg-white [clip-path:polygon(0_0,70%_0,100%_60%,100%_100%,0_100%)]"></div>
+            <div class="absolute inset-x-0 top-14 h-10 bg-[#D8DADC] opacity-70 [clip-path:polygon(0_0,70%_0,100%_60%,100%_100%,0_100%)]"></div>
+            <div class="absolute right-6 top-4 flex h-16 w-16 items-center justify-center rounded-full bg-white ring-4 ring-[#0AA14B]">
+              <div class="h-12 w-12 rounded-full bg-gradient-to-br from-green-100 to-green-300"></div>
+            </div>
+          </header>
+          <div class="px-8 pb-10 pt-8">
+            <div class="mb-4">
+              <div class="inline-flex items-center gap-2 rounded-full bg-[#0AA14B] px-4 py-2 text-sm font-extrabold text-white shadow-sm">
+                <span class="inline-block h-2 w-2 rounded-full bg-white/90"></span>
+                <span>UNIDAD 2</span>
+              </div>
+            </div>
+            <h1 class="text-4xl md:text-5xl font-extrabold tracking-tight text-[#6F6F6F]">Pensar la lengua escrita</h1>
+            <p class="mt-2 text-lg md:text-xl font-semibold text-[#4B4B4B]">Aprendemos a dar instrucciones claras usando verbos.</p>
+            <hr class="my-6 border-t border-[#8E8E8E]" />
+            <div class="grid grid-cols-1 gap-6 md:grid-cols-2">
+              <div class="space-y-3">
+                <h3 class="flex items-center gap-3 text-xl md:text-2xl font-extrabold text-[#1F1F1F]"><span class="inline-block h-2.5 w-6 rounded-sm bg-[#0AA14B]"></span>El verbo</h3>
+                <p class="text-base leading-7 text-[#1F1F1F]">Marca si te piden, te explican o te ordenan una acción.</p>
+                <div class="rounded-sm bg-[#E9ECEF] p-5 ring-1 ring-[#8E8E8E]">
+                  <p class="text-base leading-7 text-[#1F1F1F]">En conclusión: cuando un hablante <span class="bg-[#FFE24A] px-1 font-semibold">da una instrucción</span>, usa imperativo.</p>
+                </div>
+              </div>
+              <div class="aspect-[4/3] w-full rounded-md bg-gradient-to-br from-emerald-100 to-cyan-100 ring-1 ring-black/10"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="preview-section">
+        <div class="preview-label">Regular Content Page (example)</div>
+        <div class="mx-auto w-full overflow-hidden rounded-2xl bg-white shadow-sm ring-1 ring-black/5">
+          <header class="relative">
+            <div class="h-16 bg-[#0AA14B]"></div>
+            <div class="absolute inset-x-0 top-8 h-14 bg-white [clip-path:polygon(0_0,70%_0,100%_60%,100%_100%,0_100%)]"></div>
+            <div class="absolute inset-x-0 top-11 h-10 bg-[#D8DADC] opacity-70 [clip-path:polygon(0_0,70%_0,100%_60%,100%_100%,0_100%)]"></div>
+          </header>
+          <div class="px-8 pb-10 pt-8">
+            <h2 class="text-3xl md:text-4xl font-extrabold text-[#6F6F6F]">Fuente: el manual de estudio</h2>
+            <hr class="my-5 border-t border-[#8E8E8E]" />
+
+            <div class="space-y-3">
+              <div class="flex gap-3">
+                <span class="mt-2 inline-block h-2.5 w-6 rounded-sm bg-[#0AA14B]"></span>
+                <p class="text-base leading-7 text-[#1F1F1F]">Explica para qué usas cada recurso: cuaderno, diccionario, apuntes.</p>
+              </div>
+            </div>
+
+            <div class="my-6 grid grid-cols-2 gap-6 md:grid-cols-4">
+              <div class="aspect-square rounded-md bg-gradient-to-br from-green-100 to-lime-100 ring-1 ring-black/10"></div>
+              <div class="aspect-square rounded-md bg-gradient-to-br from-emerald-100 to-teal-100 ring-1 ring-black/10"></div>
+              <div class="aspect-square rounded-md bg-gradient-to-br from-cyan-100 to-sky-100 ring-1 ring-black/10"></div>
+              <div class="aspect-square rounded-md bg-gradient-to-br from-amber-100 to-yellow-100 ring-1 ring-black/10"></div>
+            </div>
+
+            <hr class="my-8 border-t-2 border-dashed border-[#7C7C7C]" />
+
+            <div class="flex gap-3">
+              <span class="mt-2 inline-block h-2.5 w-6 rounded-sm bg-[#0AA14B]"></span>
+              <p class="text-base leading-7 text-[#1F1F1F]">Resalta con dos colores las áreas de ciencias naturales y sociales.</p>
+            </div>
+
+            <div class="mt-5 rounded-sm bg-[#E9ECEF] p-5 ring-1 ring-[#8E8E8E]">
+              <p class="text-base leading-7 text-[#1F1F1F]">Escribe ejemplos: <span class="bg-[#FFE24A] px-1 font-semibold">geografía</span>, biología, historia, química.</p>
+              <div class="mt-4 space-y-3">
+                <div class="border-b border-dotted border-[#7C7C7C] pb-2"></div>
+                <div class="border-b border-dotted border-[#7C7C7C] pb-2"></div>
+              </div>
+            </div>
+
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <div class="preview-divider"></div>
+
+    <!-- Required Structure Reference -->
+    <section class="preview-section">
+      <div class="preview-label">Required Structure Reference</div>
+      <pre class="overflow-auto rounded-lg bg-[#111827] p-4 text-sm text-white"><code>&lt;div class=&quot;container content mx-auto flex min-h-screen w-full items-start justify-center px-6 py-12&quot;
+    data-background-color=&quot;<span class="text-yellow-300">BACKGROUND_COLOR</span>&quot; id=&quot;content&quot;&gt;
+  &lt;section class=&quot;w-full&quot; data-section-id=&quot;<span class="text-yellow-300">SECTION_ID</span>&quot; data-section-type=&quot;<span class="text-yellow-300">SECTION_TYPE</span>&quot; data-text-color=&quot;<span class="text-yellow-300">TEXT_COLOR</span>&quot;
+      id=&quot;simple-main&quot; role=&quot;article&quot;&gt;
+    &lt;!-- Content goes here --&gt;
+  &lt;/section&gt;
+&lt;/div&gt;</code></pre>
+    </section>
+
+  </main>
+</body>
+</html>

--- a/assets/styleguides/frankenstein-activity-test-generated.md
+++ b/assets/styleguides/frankenstein-activity-test-generated.md
@@ -1,0 +1,324 @@
+# Styleguide — Manual escolar con acento verde (primaria)
+
+Estilo de libro escolar para niñas y niños: páginas claras, títulos grandes en gris, acentos verdes y actividades tipo “ficha” con recuadros, líneas punteadas y resaltados.
+
+---
+
+## 1) Color Palette
+
+| Role | Hex Code | Usage |
+|---|---:|---|
+| Page background | `#F6F7F7` | Fondo general (muy claro) |
+| Surface / card | `#FFFFFF` | Tarjetas, áreas de lectura |
+| Light panel | `#E9ECEF` | Recuadros de actividad, filas de tabla |
+| Border / rule | `#8E8E8E` | Líneas divisorias finas, contornos |
+| Dotted rule | `#7C7C7C` | Separadores punteados y líneas de respuesta |
+| Title gray | `#6F6F6F` | Títulos grandes de capítulo/sección |
+| Body text | `#1F1F1F` | Texto principal |
+| Muted text | `#4B4B4B` | Indicaciones secundarias |
+| Primary green | `#0AA14B` | Banda superior, bullets, flechas, bordes destacados |
+| Dark green | `#087A3A` | Sombras/contornos verdes, énfasis |
+| Highlight yellow | `#FFE24A` | Resaltado de términos en actividades |
+
+---
+
+## 2) Required Container Structure
+
+> Usar **exactamente** esta estructura externa (puedes ajustar clases de alineación/anchos).
+
+```html
+<div class="container content mx-auto flex min-h-screen w-full items-start justify-center px-6 py-12"
+    data-background-color="#F6F7F7" id="content">
+  <section class="w-full max-w-5xl" data-section-id="SECTION_ID" data-section-type="SECTION_TYPE" data-text-color="#1F1F1F"
+      id="simple-main" role="article">
+    <!-- Content goes here -->
+  </section>
+</div>
+```
+
+---
+
+## 3) Inner Container
+
+Estructura interna recomendada para simular página de libro (cabecera con banda verde + cuerpo con ritmo vertical):
+
+```html
+<div class="mx-auto w-full overflow-hidden rounded-2xl bg-white shadow-sm ring-1 ring-black/5">
+  <!-- Top angled brand band -->
+  <header class="relative">
+    <div class="h-20 bg-[#0AA14B]"></div>
+    <div class="absolute inset-x-0 top-10 h-16 bg-white [clip-path:polygon(0_0,70%_0,100%_60%,100%_100%,0_100%)]"></div>
+    <div class="absolute inset-x-0 top-14 h-10 bg-[#D8DADC] opacity-70 [clip-path:polygon(0_0,70%_0,100%_60%,100%_100%,0_100%)]"></div>
+
+    <!-- Mascot badge placeholder -->
+    <div class="absolute right-6 top-4 flex h-16 w-16 items-center justify-center rounded-full bg-white ring-4 ring-[#0AA14B]">
+      <div class="h-12 w-12 rounded-full bg-gradient-to-br from-green-100 to-green-300"></div>
+    </div>
+  </header>
+
+  <div class="px-8 pb-10 pt-8">
+    <!-- page content -->
+  </div>
+</div>
+```
+
+---
+
+## 4) Text Styles
+
+> Tipografía: sans (por defecto Tailwind). Títulos pesados y grises; cuerpo negro con indicaciones en gris oscuro.
+
+| text_type | Element | Tailwind classes |
+|---|---|---|
+| book_title | `h1` | `text-4xl md:text-5xl font-extrabold tracking-tight text-[#6F6F6F]` |
+| book_subtitle | `p` | `mt-2 text-lg md:text-xl font-semibold text-[#4B4B4B]` |
+| chapter_title | `h2` | `text-3xl md:text-4xl font-extrabold text-[#6F6F6F]` |
+| section_heading | `h3` | `flex items-center gap-3 text-xl md:text-2xl font-extrabold text-[#1F1F1F]` |
+| activity_title | `h4` | `text-lg font-bold text-[#1F1F1F]` |
+| section_text | `p` | `text-base leading-7 text-[#1F1F1F]` |
+| instruction_text | `p` | `text-base leading-7 text-[#4B4B4B]` |
+| standalone_text | `p` | `text-base leading-7 text-[#1F1F1F]` |
+| image_associated_text | `figcaption` | `mt-2 text-sm leading-6 text-[#4B4B4B]` |
+
+### Bullet / instruction marker
+Pequeño cuadrado verde antes de indicaciones.
+
+```html
+<span class="mt-2 inline-block h-2.5 w-6 rounded-sm bg-[#0AA14B]"></span>
+```
+
+---
+
+## 5) Image Styles
+
+| Use case | Wrapper / Element | Tailwind classes |
+|---|---|---|
+| Single image | `figure` | `my-6` |
+| Single image media | `div` (placeholder) | `aspect-[4/3] w-full rounded-md bg-gradient-to-br from-emerald-100 to-cyan-100 ring-1 ring-black/10` |
+| Multiple images row | `div` | `my-6 grid grid-cols-2 gap-4 md:grid-cols-3` |
+| Image grid (activity icons) | `div` | `my-6 grid grid-cols-2 gap-6 md:grid-cols-4` |
+| Side-by-side text+image | container | `grid grid-cols-1 gap-6 md:grid-cols-2 md:items-start` |
+
+---
+
+## 6) Components
+
+### A) Chapter Badge (header tag)
+Etiqueta verde (capítulo/lección) con borde redondeado, tipo “pill”.
+
+```html
+<div class="inline-flex items-center gap-2 rounded-full bg-[#0AA14B] px-4 py-2 text-sm font-extrabold text-white shadow-sm"
+     data-id="ID">
+  <span class="inline-block h-2 w-2 rounded-full bg-white/90"></span>
+  <span data-id="ID">CAPÍTULO 1</span>
+</div>
+```
+
+### B) Content Card (recuadro de actividad)
+Caja gris clara con borde fino, como definiciones/consignas.
+
+```html
+<div class="rounded-sm bg-[#E9ECEF] p-5 ring-1 ring-[#8E8E8E]"
+     data-id="ID">
+  <p class="text-base leading-7 text-[#1F1F1F]" data-id="ID">
+    Escribe tu respuesta en las líneas punteadas.
+  </p>
+  <div class="mt-4 space-y-3" data-id="ID">
+    <div class="border-b border-dotted border-[#7C7C7C] pb-2"></div>
+    <div class="border-b border-dotted border-[#7C7C7C] pb-2"></div>
+  </div>
+</div>
+```
+
+### C) Text Group (párrafos sin card)
+Grupo con bullets verdes y separadores punteados.
+
+```html
+<div class="space-y-3" data-id="ID">
+  <div class="flex gap-3" data-id="ID">
+    <span class="mt-2 inline-block h-2.5 w-6 rounded-sm bg-[#0AA14B]"></span>
+    <p class="text-base leading-7 text-[#1F1F1F]" data-id="ID">Lee el texto y responde.</p>
+  </div>
+  <hr class="my-4 border-t-2 border-dashed border-[#7C7C7C]" />
+  <p class="text-base leading-7 text-[#4B4B4B]" data-id="ID">Trabaja con un compañero.</p>
+</div>
+```
+
+---
+
+## 7) Page Templates
+
+### A) Chapter Start Page
+
+```html
+<div class="mx-auto w-full overflow-hidden rounded-2xl bg-white shadow-sm ring-1 ring-black/5" data-id="ID">
+  <header class="relative" data-id="ID">
+    <div class="h-20 bg-[#0AA14B]"></div>
+    <div class="absolute inset-x-0 top-10 h-16 bg-white [clip-path:polygon(0_0,70%_0,100%_60%,100%_100%,0_100%)]"></div>
+    <div class="absolute inset-x-0 top-14 h-10 bg-[#D8DADC] opacity-70 [clip-path:polygon(0_0,70%_0,100%_60%,100%_100%,0_100%)]"></div>
+    <div class="absolute right-6 top-4 flex h-16 w-16 items-center justify-center rounded-full bg-white ring-4 ring-[#0AA14B]" data-id="ID">
+      <div class="h-12 w-12 rounded-full bg-gradient-to-br from-green-100 to-green-300" data-id="ID"></div>
+    </div>
+  </header>
+
+  <div class="px-8 pb-10 pt-8" data-id="ID">
+    <div class="mb-4" data-id="ID">
+      <div class="inline-flex items-center gap-2 rounded-full bg-[#0AA14B] px-4 py-2 text-sm font-extrabold text-white" data-id="ID">
+        <span class="inline-block h-2 w-2 rounded-full bg-white/90"></span>
+        <span data-id="ID">UNIDAD 2</span>
+      </div>
+    </div>
+    <h1 class="text-4xl md:text-5xl font-extrabold tracking-tight text-[#6F6F6F]" data-id="ID">Pensar la lengua escrita</h1>
+    <p class="mt-2 text-lg md:text-xl font-semibold text-[#4B4B4B]" data-id="ID">Actividades con verbos e instrucciones.</p>
+
+    <hr class="my-6 border-t border-[#8E8E8E]" />
+
+    <div class="grid grid-cols-1 gap-6 md:grid-cols-2" data-id="ID">
+      <div class="space-y-3" data-id="ID">
+        <div class="flex gap-3" data-id="ID">
+          <span class="mt-2 inline-block h-2.5 w-6 rounded-sm bg-[#0AA14B]"></span>
+          <p class="text-base leading-7 text-[#1F1F1F]" data-id="ID">Indica qué expresan los verbos destacados.</p>
+        </div>
+        <div class="rounded-sm bg-[#E9ECEF] p-5 ring-1 ring-[#8E8E8E]" data-id="ID">
+          <p class="text-base leading-7 text-[#1F1F1F]" data-id="ID">En conclusión: usa verbos en <span class="bg-[#FFE24A] px-1 font-semibold">modo imperativo</span>.</p>
+        </div>
+      </div>
+      <div class="aspect-[4/3] w-full rounded-md bg-gradient-to-br from-emerald-100 to-cyan-100 ring-1 ring-black/10" data-id="ID"></div>
+    </div>
+  </div>
+</div>
+```
+
+### B) Regular Content Page (text and images)
+
+```html
+<div class="mx-auto w-full overflow-hidden rounded-2xl bg-white shadow-sm ring-1 ring-black/5" data-id="ID">
+  <header class="relative" data-id="ID">
+    <div class="h-16 bg-[#0AA14B]"></div>
+    <div class="absolute inset-x-0 top-8 h-14 bg-white [clip-path:polygon(0_0,70%_0,100%_60%,100%_100%,0_100%)]"></div>
+    <div class="absolute inset-x-0 top-11 h-10 bg-[#D8DADC] opacity-70 [clip-path:polygon(0_0,70%_0,100%_60%,100%_100%,0_100%)]"></div>
+  </header>
+
+  <div class="px-8 pb-10 pt-8" data-id="ID">
+    <h2 class="text-3xl md:text-4xl font-extrabold text-[#6F6F6F]" data-id="ID">Para definir mejor</h2>
+    <hr class="my-5 border-t border-[#8E8E8E]" />
+
+    <div class="space-y-3" data-id="ID">
+      <div class="flex gap-3" data-id="ID">
+        <span class="mt-2 inline-block h-2.5 w-6 rounded-sm bg-[#0AA14B]"></span>
+        <p class="text-base leading-7 text-[#1F1F1F]" data-id="ID">Completa estas definiciones con palabras de la lista.</p>
+      </div>
+      <div class="flex gap-3" data-id="ID">
+        <span class="mt-2 inline-block h-2.5 w-6 rounded-sm bg-[#0AA14B]"></span>
+        <p class="text-base leading-7 text-[#1F1F1F]" data-id="ID">Escribe en el recuadro de dónde se extrajo cada definición.</p>
+      </div>
+    </div>
+
+    <div class="mt-6 grid grid-cols-1 gap-6 md:grid-cols-[1fr_220px]" data-id="ID">
+      <div class="space-y-4" data-id="ID">
+        <div class="rounded-sm bg-[#E9ECEF] p-5 ring-1 ring-[#8E8E8E]" data-id="ID">
+          <p class="text-base leading-7 text-[#1F1F1F]" data-id="ID">El clima, el relieve, el ______ de una ______ … forman un conjunto llamado bioma.</p>
+          <div class="mt-4 border-b border-dotted border-[#7C7C7C] pb-2"></div>
+        </div>
+        <div class="rounded-sm bg-[#E9ECEF] p-5 ring-1 ring-[#8E8E8E]" data-id="ID">
+          <p class="text-base leading-7 text-[#1F1F1F]" data-id="ID">Bioma: comunidad de ______ definida por factores ______ y ______.</p>
+          <div class="mt-4 border-b border-dotted border-[#7C7C7C] pb-2"></div>
+        </div>
+      </div>
+
+      <aside class="rounded-sm bg-[#F6F0D8] p-4 ring-1 ring-[#8E8E8E]" data-id="ID">
+        <p class="text-sm font-bold text-[#1F1F1F]" data-id="ID">Banco de palabras</p>
+        <ul class="mt-3 space-y-1 text-sm text-[#1F1F1F]" data-id="ID">
+          <li data-id="ID">vegetación</li>
+          <li data-id="ID">seres vivos</li>
+          <li data-id="ID">suelo</li>
+          <li data-id="ID">fauna</li>
+        </ul>
+      </aside>
+    </div>
+
+    <hr class="my-8 border-t-2 border-dashed border-[#7C7C7C]" />
+
+    <div class="flex gap-3" data-id="ID">
+      <span class="mt-2 inline-block h-2.5 w-6 rounded-sm bg-[#0AA14B]"></span>
+      <p class="text-base leading-7 text-[#1F1F1F]" data-id="ID">Explica sobre las líneas punteadas el significado de los términos destacados.</p>
+    </div>
+
+    <div class="mt-5 rounded-md bg-[#EEF0F2] p-6" data-id="ID">
+      <p class="text-base leading-7 text-[#1F1F1F]" data-id="ID">Los bosques tienen árboles de <span class="bg-[#FFE24A] px-1 font-semibold">follaje caduco</span>, es decir…</p>
+      <div class="mt-4 space-y-4" data-id="ID">
+        <div class="border-b border-dotted border-[#7C7C7C] pb-2"></div>
+        <div class="border-b border-dotted border-[#7C7C7C] pb-2"></div>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+### C) Text and Image Side by Side
+
+```html
+<div class="grid grid-cols-1 gap-6 md:grid-cols-2 md:items-start" data-id="ID">
+  <div class="space-y-3" data-id="ID">
+    <h3 class="flex items-center gap-3 text-xl md:text-2xl font-extrabold text-[#1F1F1F]" data-id="ID">
+      <span class="inline-block h-2.5 w-6 rounded-sm bg-[#0AA14B]"></span>
+      Fuente: el manual de estudio
+    </h3>
+    <p class="text-base leading-7 text-[#1F1F1F]" data-id="ID">En la escuela circulan diversos recursos para estudiar.</p>
+  </div>
+  <div class="aspect-[4/3] w-full rounded-md bg-gradient-to-br from-emerald-100 to-cyan-100 ring-1 ring-black/10" data-id="ID"></div>
+</div>
+```
+
+### D) Table of Contents
+
+```html
+<div class="mx-auto w-full overflow-hidden rounded-2xl bg-white shadow-sm ring-1 ring-black/5" data-id="ID">
+  <header class="relative" data-id="ID">
+    <div class="h-16 bg-[#0AA14B]"></div>
+    <div class="absolute inset-x-0 top-8 h-14 bg-white [clip-path:polygon(0_0,70%_0,100%_60%,100%_100%,0_100%)]"></div>
+    <div class="absolute inset-x-0 top-11 h-10 bg-[#D8DADC] opacity-70 [clip-path:polygon(0_0,70%_0,100%_60%,100%_100%,0_100%)]"></div>
+  </header>
+
+  <div class="px-8 pb-10 pt-8" data-id="ID">
+    <h2 class="text-3xl md:text-4xl font-extrabold text-[#6F6F6F]" data-id="ID">Índice</h2>
+    <hr class="my-5 border-t border-[#8E8E8E]" />
+
+    <div class="overflow-hidden rounded-md ring-1 ring-[#8E8E8E]" data-id="ID">
+      <div class="grid grid-cols-[1fr_80px] bg-[#E9ECEF] px-4 py-3 text-sm font-bold text-[#1F1F1F]" data-id="ID">
+        <div data-id="ID">Sección</div>
+        <div class="text-right" data-id="ID">Página</div>
+      </div>
+      <div class="divide-y divide-[#8E8E8E]" data-id="ID">
+        <div class="grid grid-cols-[1fr_80px] px-4 py-3 text-base text-[#1F1F1F]" data-id="ID">
+          <div data-id="ID">Pensar la lengua escrita</div>
+          <div class="text-right" data-id="ID">28</div>
+        </div>
+        <div class="grid grid-cols-[1fr_80px] bg-[#E9ECEF] px-4 py-3 text-base text-[#1F1F1F]" data-id="ID">
+          <div data-id="ID">Para definir mejor</div>
+          <div class="text-right" data-id="ID">21</div>
+        </div>
+        <div class="grid grid-cols-[1fr_80px] px-4 py-3 text-base text-[#1F1F1F]" data-id="ID">
+          <div data-id="ID">Fuente: el manual de estudio</div>
+          <div class="text-right" data-id="ID">16</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+---
+
+## 8) General Rules
+
+1. **Jerarquía fuerte**: títulos grandes en gris (`#6F6F6F`) y peso extra bold.
+2. **Acento verde consistente** (`#0AA14B`): banda superior, bullets cuadrados, bordes destacados y “badges”.
+3. **Consignas con marcador**: cada instrucción inicia con un rectángulo verde corto (no un círculo).
+4. **Separación por reglas**: usar líneas finas grises para cortes suaves y líneas **punteadas/dashed** para separar bloques de actividades.
+5. **Actividades tipo ficha**: recuadros en gris claro (`#E9ECEF`) con borde gris medio (`#8E8E8E`).
+6. **Resaltado textual**: términos a definir van con fondo amarillo (`#FFE24A`) y semibold.
+7. **Respuestas**: líneas de respuesta con `border-dotted` y color `#7C7C7C`.
+8. **Tablas**: encabezado o filas alternas en `#E9ECEF`, bordes simples.
+9. **Espaciado generoso**: padding de página 2rem aprox. y gaps de 1–1.5rem entre módulos.
+10. **Ilustraciones**: se presentan “flotando” sobre fondo blanco con bordes suaves; evitar marcos pesados.

--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -137,6 +137,12 @@ export {
   getTargetLanguages,
   type CatalogTranslationConfig,
 } from "./catalog-translation.js"
+export {
+  generateStyleguide,
+  buildStyleguideGenerationConfig,
+  type StyleguideGenerationConfig,
+  type StyleguideGenerationInput,
+} from "./styleguide-generation.js"
 export { loadConfig, loadBookConfig, deepMerge } from "./config.js"
 export { runPipeline, type RunPipelineOptions } from "./pipeline.js"
 export { runFullPipeline, type FullPipelineOptions } from "./pipeline-dag.js"

--- a/packages/pipeline/src/styleguide-generation.ts
+++ b/packages/pipeline/src/styleguide-generation.ts
@@ -1,0 +1,63 @@
+import type { LLMModel } from "@adt/llm"
+import { StyleguideGenerationOutput } from "@adt/types"
+export type { StyleguideGenerationOutput } from "@adt/types"
+
+export interface StyleguideGenerationInput {
+  pageImages: Array<{
+    pageId: string
+    pageNumber: number
+    imageBase64: string
+  }>
+}
+
+export interface StyleguideGenerationConfig {
+  promptName: string
+  modelId: string
+  maxRetries: number
+  temperature?: number
+}
+
+export function buildStyleguideGenerationConfig(
+  stepConfig?: { prompt?: string; model?: string; max_retries?: number; temperature?: number }
+): StyleguideGenerationConfig {
+  return {
+    promptName: stepConfig?.prompt ?? "styleguide_generation",
+    modelId: stepConfig?.model ?? "openai:gpt-5.2",
+    maxRetries: stepConfig?.max_retries ?? 3,
+    temperature: stepConfig?.temperature,
+  }
+}
+
+/**
+ * Generate a styleguide markdown document and preview HTML from page images.
+ * Pure function — takes images and config, returns generated content.
+ */
+export async function generateStyleguide(
+  input: StyleguideGenerationInput,
+  config: StyleguideGenerationConfig,
+  llmModel: LLMModel
+): Promise<StyleguideGenerationOutput> {
+  const context = {
+    page_images: input.pageImages.map((p) => ({
+      page_id: p.pageId,
+      page_number: p.pageNumber,
+      image_base64: p.imageBase64,
+    })),
+  }
+
+  const result = await llmModel.generateObject<StyleguideGenerationOutput>({
+    schema: StyleguideGenerationOutput,
+    prompt: config.promptName,
+    context,
+    maxRetries: config.maxRetries,
+    maxTokens: 32768,
+    temperature: config.temperature,
+    timeoutMs: 180_000,
+    log: {
+      taskType: "styleguide-generation",
+      promptName: config.promptName,
+    },
+  })
+
+  return result.object
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -130,3 +130,7 @@ export {
   SpeechFileEntry,
   TTSOutput,
 } from "./speech.js"
+
+export {
+  StyleguideGenerationOutput,
+} from "./styleguide-generation.js"

--- a/packages/types/src/styleguide-generation.ts
+++ b/packages/types/src/styleguide-generation.ts
@@ -1,0 +1,8 @@
+import { z } from "zod"
+
+export const StyleguideGenerationOutput = z.object({
+  reasoning: z.string(),
+  content: z.string(),
+  preview_html: z.string(),
+})
+export type StyleguideGenerationOutput = z.infer<typeof StyleguideGenerationOutput>

--- a/prompts/styleguide_generation.liquid
+++ b/prompts/styleguide_generation.liquid
@@ -1,0 +1,103 @@
+{% chat role: "system" %}
+You are an expert frontend designer and CSS architect. Your task is to analyze page images from a textbook/document and generate TWO outputs:
+
+1. A comprehensive **styleguide markdown** document
+2. A **preview HTML** file that visually demonstrates the styleguide
+
+---
+
+## OUTPUT 1: Styleguide Markdown (`content` field)
+
+Generate a complete styleguide Markdown document following this exact structure. Analyze the visual characteristics of the provided page images and create concrete, specific rules.
+
+### Required Sections:
+
+1. **Title and Description** — A short title like "# Styleguide — [Book Style Description]" followed by a 1-2 sentence description of the target audience and visual feel.
+
+2. **Color Palette** — Extract the dominant colors from the page images. Present as a table with Role, Hex Code, and Usage columns. Include:
+   - Background colors (page backgrounds, card backgrounds)
+   - Text colors (headings, body text, captions)
+   - Accent colors (badges, decorations, highlights)
+   - Use actual hex codes observed in the images
+
+3. **Required Container Structure** — MUST include this exact outer structure (adjust colors only):
+```html
+<div class="container content mx-auto flex min-h-screen w-full items-center justify-center px-6 py-12"
+    data-background-color="BACKGROUND_COLOR" id="content">
+  <section class="w-full" data-section-id="SECTION_ID" data-section-type="SECTION_TYPE" data-text-color="TEXT_COLOR"
+      id="simple-main" role="article">
+    <!-- Content goes here -->
+  </section>
+</div>
+```
+You may adjust alignment classes (items-center vs items-start), padding, and max-width based on the visual style.
+
+4. **Inner Container** — The inner wrapper structure with appropriate max-width and spacing.
+
+5. **Text Styles** — A table mapping each text_type to an HTML element and Tailwind classes. Required text_types:
+   - book_title, book_subtitle, chapter_title, section_heading, activity_title
+   - section_text, instruction_text, standalone_text, image_associated_text
+   Choose font sizes, weights, and colors that match the original style.
+
+6. **Image Styles** — A table defining classes for single images, multiple images, and image grid containers.
+
+7. **Components** — Concrete HTML snippets for:
+   - Chapter Badge (for chapter/lesson headers)
+   - Content Card (for body text blocks)
+   - Text Group (for paragraphs without a card)
+
+8. **Page Templates** — Complete HTML examples for:
+   - Chapter Start Page
+   - Regular Content Page (text and images)
+   - Text and Image Side by Side
+   - Table of Contents
+
+9. **General Rules** — Numbered list of design rules (background handling, layout preferences, decoration rules, etc.)
+
+### Critical rules for the styleguide markdown:
+- All HTML examples MUST use Tailwind CSS utility classes
+- Elements with content MUST use `data-id="ID"` placeholders
+- Images MUST use `data-id="ID"` and `src="images/ID.jpg"`
+- The outer container MUST use `data-background-color` for page backgrounds
+- The section element MUST have `role="article"`, `data-section-id`, and `data-section-type` attributes
+- Color values should be specific hex codes extracted from the images, not generic Tailwind color names
+- Text sizes should be appropriate for the target audience (larger for children, standard for adults)
+
+---
+
+## OUTPUT 2: Preview HTML (`preview_html` field)
+
+Generate a standalone HTML file that visually demonstrates the styleguide. It MUST:
+
+- Include `<script src="https://cdn.tailwindcss.com"></script>` in the head
+- Use this wrapper CSS for preview sections:
+```css
+.preview-label { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; font-size: 0.7rem; letter-spacing: 0.05em; text-transform: uppercase; color: #6b7280; border-bottom: 1px solid #e5e7eb; padding-bottom: 0.25rem; margin-bottom: 1rem; }
+.preview-section { border: 2px dashed #d1d5db; border-radius: 1rem; padding: 2rem; margin-bottom: 2.5rem; background: #fafafa; }
+.preview-divider { border-top: 3px solid #7c3aed; margin: 3rem 0; }
+```
+
+### Required preview sections (in order):
+
+1. **Header** — Title "Style Guide Preview" with a subtitle describing the theme
+2. **Text Styles** — One `.preview-section` per text_type showing the styled text with a `.preview-label` identifying it (e.g., "book_title — h1"). Use the exact Tailwind classes from the styleguide and actual inline style colors.
+3. **Components** — Preview sections showing the Chapter Badge, Content Card, and Text Group with sample content
+4. **Image Styles** — Preview sections using gradient placeholder divs (e.g., `bg-gradient-to-br from-blue-100 to-cyan-100`) instead of real images. Show single image, image grid, and side-by-side layout.
+5. **Page Templates** — Full page template examples wrapped in a white card with shadow, showing Chapter Start Page and Regular Content Page using the styleguide's colors and components
+6. **Required Structure Reference** — A code block showing the outer container HTML structure with placeholder values highlighted
+
+Use `.preview-divider` between major sections. Use sample educational content text (not lorem ipsum). Use the actual colors from the color palette throughout the preview.
+
+Do NOT include any `<img>` tags with real images — only use gradient placeholder divs for image placeholders.
+{% endchat %}
+
+{% chat role: "user" %}
+Please analyze these page images from a book and generate both a comprehensive styleguide markdown AND a preview HTML file.
+
+{% for image in page_images %}
+Page {{ image.page_number }}:
+{% image image.image_base64 %}
+{% endfor %}
+
+Generate both outputs that capture the visual design language of this book.
+{% endchat %}


### PR DESCRIPTION
## Summary

Introduces a new styleguide generation feature that analyzes selected book pages via LLM to produce a comprehensive design guide. The system generates both a detailed markdown styleguide and an interactive HTML preview.

- New `POST /books/:label/generate-styleguide` endpoint accepts 1-5 page IDs and returns LLM-generated styleguide markdown and preview HTML
- UI dialog for page selection with visual thumbnails and up-to-5 page limit
- Fallback markdown-to-HTML renderer for preview display with proper code block protection
- Zod schema moved to packages/types/ per CLAUDE.md standards