### PR TITLE
Add image selection UI to storyboard editor

### DIFF
--- a/apps/api/src/routes/books.ts
+++ b/apps/api/src/routes/books.ts
@@ -164,6 +164,52 @@ export function createBookRoutes(
     }
   })
 
+  // GET /books/:label/images — List all images in a book
+  app.get("/books/:label/images", (c) => {
+    const { label } = c.req.param()
+    let safeLabel: string
+    try {
+      safeLabel = parseBookLabel(label)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      throw new HTTPException(400, { message })
+    }
+    const resolvedDir = path.resolve(booksDir)
+    const bookDir = path.join(resolvedDir, safeLabel)
+    const dbPath = path.join(bookDir, `${safeLabel}.db`)
+
+    if (!fs.existsSync(dbPath)) {
+      throw new HTTPException(404, {
+        message: `Book not found: ${safeLabel}`,
+      })
+    }
+
+    const db = openBookDb(dbPath)
+    try {
+      const rows = db.all(
+        "SELECT image_id, page_id, width, height, source FROM images ORDER BY image_id"
+      ) as Array<{
+        image_id: string
+        page_id: string
+        width: number
+        height: number
+        source: string
+      }>
+
+      return c.json({
+        images: rows.map((r) => ({
+          imageId: r.image_id,
+          pageId: r.page_id,
+          width: r.width,
+          height: r.height,
+          source: r.source,
+        })),
+      })
+    } finally {
+      db.close()
+    }
+  })
+
   // GET /books/:label/images/:imageId — Serve extracted image binary
   app.get("/books/:label/images/:imageId", (c) => {
     const { label, imageId } = c.req.param()

--- a/apps/api/src/routes/pages.ts
+++ b/apps/api/src/routes/pages.ts
@@ -962,6 +962,84 @@ export function createPageRoutes(
     }
   })
 
+  // POST /books/:label/images/upload — Upload a new standalone image (not a crop)
+  app.post("/books/:label/images/upload", async (c) => {
+    const { label } = c.req.param()
+    const safeLabel = parseBookLabel(label)
+    const resolvedDir = path.resolve(booksDir)
+    const bookDir = path.join(resolvedDir, safeLabel)
+    const dbPath = path.join(bookDir, `${safeLabel}.db`)
+
+    if (!fs.existsSync(dbPath)) {
+      throw new HTTPException(404, { message: `Book not found: ${safeLabel}` })
+    }
+
+    const formData = await c.req.formData()
+    const imageFile = formData.get("image")
+    const pageId = formData.get("pageId")
+
+    if (!imageFile || !(imageFile instanceof File)) {
+      throw new HTTPException(400, { message: "Missing image file" })
+    }
+    if (!pageId || typeof pageId !== "string") {
+      throw new HTTPException(400, { message: "Missing pageId" })
+    }
+    validateImageId(pageId)
+
+    const buffer = Buffer.from(await imageFile.arrayBuffer())
+    const hash = crypto.createHash("sha256").update(buffer).digest("hex").slice(0, 16)
+
+    const db = openBookDb(dbPath)
+    try {
+      // Generate new imageId: {pageId}_upload{N}
+      const existing = db.all(
+        "SELECT image_id FROM images WHERE image_id LIKE ? AND source = 'upload'",
+        [`${pageId}_upload%`]
+      ) as Array<{ image_id: string }>
+      let maxN = 0
+      for (const row of existing) {
+        const m = row.image_id.match(/_upload(\d+)$/)
+        if (m) maxN = Math.max(maxN, parseInt(m[1], 10))
+      }
+      const newImageId = `${pageId}_upload${maxN + 1}`
+
+      const isPng = imageFile.type === "image/png"
+      const ext = isPng ? "png" : "jpg"
+      const filename = `${newImageId}.${ext}`
+
+      const imagesDir = path.join(bookDir, "images")
+      fs.mkdirSync(imagesDir, { recursive: true })
+      fs.writeFileSync(path.join(imagesDir, filename), buffer)
+
+      // Get dimensions from image header
+      let width = 0
+      let height = 0
+      if (isPng && buffer.length > 24) {
+        width = buffer.readUInt32BE(16)
+        height = buffer.readUInt32BE(20)
+      } else if (!isPng) {
+        // JPEG: scan for SOF0/SOF2 marker (0xFF 0xC0 / 0xFF 0xC2)
+        for (let i = 0; i < buffer.length - 9; i++) {
+          if (buffer[i] === 0xff && (buffer[i + 1] === 0xc0 || buffer[i + 1] === 0xc2)) {
+            height = buffer.readUInt16BE(i + 5)
+            width = buffer.readUInt16BE(i + 7)
+            break
+          }
+        }
+      }
+
+      db.run(
+        `INSERT INTO images (image_id, page_id, path, hash, width, height, source)
+         VALUES (?, ?, ?, ?, ?, ?, 'upload')`,
+        [newImageId, pageId, `images/${filename}`, hash, width, height]
+      )
+
+      return c.json({ imageId: newImageId, width, height })
+    } finally {
+      db.close()
+    }
+  })
+
   // POST /books/:label/images/:imageId/segment — Analyze: run LLM segmentation, return bounding boxes only
   app.post("/books/:label/images/:imageId/segment", async (c) => {
     const { label, imageId } = c.req.param()

--- a/apps/studio/src/api/client.ts
+++ b/apps/studio/src/api/client.ts
@@ -455,6 +455,27 @@ export const api = {
       { method: "POST" }
     ),
 
+  listBookImages: (label: string) =>
+    request<{
+      images: Array<{
+        imageId: string
+        pageId: string
+        width: number
+        height: number
+        source: string
+      }>
+    }>(`/books/${label}/images`),
+
+  uploadNewImage: (label: string, pageId: string, imageBlob: Blob) => {
+    const formData = new FormData()
+    formData.append("image", imageBlob, "upload.png")
+    formData.append("pageId", pageId)
+    return request<{ imageId: string; width: number; height: number }>(
+      `/books/${label}/images/upload`,
+      { method: "POST", body: formData }
+    )
+  },
+
   uploadCroppedImage: (label: string, pageId: string, sourceImageId: string, imageBlob: Blob) => {
     const formData = new FormData()
     formData.append("image", imageBlob, "crop.png")

--- a/apps/studio/src/components/pipeline/stages/AddImageDialog.tsx
+++ b/apps/studio/src/components/pipeline/stages/AddImageDialog.tsx
@@ -1,0 +1,376 @@
+import { useState, useRef, useEffect } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { Check, ImagePlus, Upload, Sparkles, X, ArrowLeft, Search, Loader2 } from "lucide-react"
+import { api, BASE_URL } from "@/api/client"
+
+type Step = "choose" | "pick" | "upload" | "generate"
+
+interface AddImageDialogProps {
+  bookLabel: string
+  onSelectExisting: (imageIds: string[]) => void
+  onUpload: (file: File) => void
+  onGenerate: (prompt: string) => void
+  onClose: () => void
+}
+
+/**
+ * Wizard dialog for adding an image to a section.
+ * Three modes: pick from existing book images, upload a file, or generate with AI.
+ */
+export function AddImageDialog({
+  bookLabel,
+  onSelectExisting,
+  onUpload,
+  onGenerate,
+  onClose,
+}: AddImageDialogProps) {
+  const [step, setStep] = useState<Step>("choose")
+  const [filter, setFilter] = useState("")
+  const [selected, setSelected] = useState<Set<string>>(new Set())
+  const [prompt, setPrompt] = useState("")
+  const [uploadFile, setUploadFile] = useState<File | null>(null)
+  const [uploadPreview, setUploadPreview] = useState<string | null>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  // Revoke object URL on unmount to avoid memory leaks
+  useEffect(() => {
+    return () => {
+      if (uploadPreview) URL.revokeObjectURL(uploadPreview)
+    }
+  }, [uploadPreview])
+
+  // Fetch all images when picking from existing
+  const imagesQuery = useQuery({
+    queryKey: ["books", bookLabel, "images"],
+    queryFn: () => api.listBookImages(bookLabel),
+    enabled: step === "pick",
+    staleTime: 30_000,
+  })
+
+  const filteredImages = imagesQuery.data?.images.filter((img) =>
+    !filter || img.imageId.toLowerCase().includes(filter.toLowerCase())
+  )
+
+  // Exclude page-render images (full page renders) — only show extracted/cropped/generated/uploaded
+  const selectableImages = filteredImages?.filter((img) => img.source !== "page")
+
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    e.target.value = ""
+    setUploadFile(file)
+    if (uploadPreview) URL.revokeObjectURL(uploadPreview)
+    const url = URL.createObjectURL(file)
+    setUploadPreview(url)
+  }
+
+  const handleUploadConfirm = () => {
+    if (!uploadFile) return
+    if (uploadPreview) URL.revokeObjectURL(uploadPreview)
+    onUpload(uploadFile)
+  }
+
+  const handleGenerateSubmit = () => {
+    if (!prompt.trim()) return
+    onGenerate(prompt.trim())
+  }
+
+  return (
+    <div className="fixed inset-0 z-[100] bg-black/60 flex items-center justify-center p-8">
+      <div className="bg-background rounded-xl shadow-2xl w-full max-w-lg flex flex-col overflow-hidden max-h-[80vh]">
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-3.5 border-b shrink-0">
+          <div className="flex items-center gap-2">
+            {step !== "choose" && (
+              <button
+                type="button"
+                onClick={() => {
+                  setStep("choose")
+                  if (uploadPreview) {
+                    URL.revokeObjectURL(uploadPreview)
+                    setUploadPreview(null)
+                    setUploadFile(null)
+                  }
+                }}
+                className="p-1 rounded hover:bg-accent transition-colors cursor-pointer"
+              >
+                <ArrowLeft className="h-4 w-4" />
+              </button>
+            )}
+            <ImagePlus className="h-4 w-4 text-blue-500" />
+            <h2 className="text-sm font-semibold">
+              {step === "choose" && "Add Image"}
+              {step === "pick" && "Pick from Book"}
+              {step === "upload" && "Upload Image"}
+              {step === "generate" && "Generate with AI"}
+            </h2>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="p-1 rounded hover:bg-accent transition-colors cursor-pointer"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto">
+          {/* Step: Choose method */}
+          {step === "choose" && (
+            <div className="p-5 space-y-2">
+              <MethodCard
+                icon={<ImagePlus className="h-4 w-4" />}
+                title="Pick from book"
+                description="Choose an existing image from this project"
+                onClick={() => setStep("pick")}
+              />
+              <MethodCard
+                icon={<Upload className="h-4 w-4" />}
+                title="Upload image"
+                description="Upload a new image file from your computer"
+                onClick={() => setStep("upload")}
+              />
+              <MethodCard
+                icon={<Sparkles className="h-4 w-4" />}
+                title="Generate with AI"
+                description="Create a new image from a text description"
+                onClick={() => setStep("generate")}
+              />
+            </div>
+          )}
+
+          {/* Step: Pick from existing */}
+          {step === "pick" && (
+            <div className="p-4 space-y-3">
+              <div className="relative">
+                <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
+                <input
+                  type="text"
+                  value={filter}
+                  onChange={(e) => setFilter(e.target.value)}
+                  placeholder="Filter by image ID..."
+                  className="w-full text-sm border rounded-lg pl-8 pr-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500/30"
+                  autoFocus
+                />
+              </div>
+
+              {imagesQuery.isLoading && (
+                <div className="flex items-center justify-center py-8">
+                  <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+                </div>
+              )}
+
+              {selectableImages && selectableImages.length === 0 && (
+                <p className="text-center text-sm text-muted-foreground py-8">
+                  {filter ? "No images match your filter" : "No images in this book"}
+                </p>
+              )}
+
+              {selectableImages && selectableImages.length > 0 && (
+                <div className="grid grid-cols-3 gap-2">
+                  {selectableImages.map((img) => {
+                    const isSelected = selected.has(img.imageId)
+                    return (
+                      <button
+                        key={img.imageId}
+                        type="button"
+                        onClick={() => {
+                          setSelected((prev) => {
+                            const next = new Set(prev)
+                            if (next.has(img.imageId)) next.delete(img.imageId)
+                            else next.add(img.imageId)
+                            return next
+                          })
+                        }}
+                        className={`group relative rounded border overflow-hidden bg-card flex flex-col items-center min-h-[60px] transition-all cursor-pointer ${
+                          isSelected
+                            ? "ring-2 ring-blue-500 border-blue-500"
+                            : "hover:ring-2 hover:ring-blue-500/50"
+                        }`}
+                      >
+                        {isSelected && (
+                          <div className="absolute top-1 right-1 z-10 h-5 w-5 rounded-full bg-blue-500 flex items-center justify-center">
+                            <Check className="h-3 w-3 text-white" />
+                          </div>
+                        )}
+                        <img
+                          src={`${BASE_URL}/books/${bookLabel}/images/${img.imageId}`}
+                          alt={img.imageId}
+                          className="max-w-full h-auto block"
+                          loading="lazy"
+                        />
+                        <div className="px-1.5 py-0.5 border-t bg-muted/30 w-full mt-auto">
+                          <span className="text-[9px] text-muted-foreground truncate block">
+                            {img.imageId}
+                          </span>
+                        </div>
+                      </button>
+                    )
+                  })}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Step: Upload */}
+          {step === "upload" && (
+            <div className="p-5 space-y-4">
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                className="hidden"
+                onChange={handleFileSelect}
+              />
+
+              {!uploadPreview ? (
+                <button
+                  type="button"
+                  onClick={() => fileInputRef.current?.click()}
+                  className="w-full flex flex-col items-center justify-center gap-2 rounded-lg border-2 border-dashed border-muted-foreground/30 hover:border-muted-foreground/60 py-12 transition-colors cursor-pointer"
+                >
+                  <Upload className="h-8 w-8 text-muted-foreground" />
+                  <span className="text-sm text-muted-foreground">
+                    Click to select an image
+                  </span>
+                </button>
+              ) : (
+                <div className="space-y-3">
+                  <img
+                    src={uploadPreview}
+                    alt="Preview"
+                    className="max-w-full max-h-[300px] mx-auto rounded-lg border object-contain"
+                  />
+                  <div className="flex items-center justify-between">
+                    <span className="text-xs text-muted-foreground truncate">
+                      {uploadFile?.name}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => fileInputRef.current?.click()}
+                      className="text-xs text-blue-500 hover:text-blue-400 cursor-pointer"
+                    >
+                      Change
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Step: Generate with AI */}
+          {step === "generate" && (
+            <div className="p-5 space-y-4">
+              <div>
+                <label className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider block mb-1">
+                  Describe the image
+                </label>
+                <textarea
+                  value={prompt}
+                  onChange={(e) => setPrompt(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" && !e.shiftKey) {
+                      e.preventDefault()
+                      handleGenerateSubmit()
+                    }
+                  }}
+                  placeholder="e.g., A cheerful leopard family in a green forest, children's book style..."
+                  rows={4}
+                  autoFocus
+                  className="w-full text-sm border rounded-lg px-3 py-2 resize-none focus:outline-none focus:ring-2 focus:ring-purple-500/30"
+                />
+                <p className="text-[10px] text-muted-foreground mt-1">
+                  Be descriptive — include style, colors, mood, and composition.
+                </p>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        {(step === "pick" || step === "upload" || step === "generate") && (
+          <div className="flex items-center justify-between px-5 py-3.5 border-t shrink-0">
+            <p className="text-[10px] text-muted-foreground">
+              {step === "pick" && selected.size > 0
+                ? `${selected.size} image${selected.size === 1 ? "" : "s"} selected`
+                : step === "pick"
+                  ? "Click images to select"
+                  : step === "generate"
+                    ? "Runs in background — you can keep editing"
+                    : ""}
+            </p>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={onClose}
+                className="text-xs font-medium rounded px-3 py-1.5 bg-muted hover:bg-accent transition-colors cursor-pointer"
+              >
+                Cancel
+              </button>
+              {step === "pick" && (
+                <button
+                  type="button"
+                  onClick={() => onSelectExisting(Array.from(selected))}
+                  disabled={selected.size === 0}
+                  className="flex items-center gap-1 text-xs font-medium rounded px-3 py-1.5 bg-blue-600 hover:bg-blue-500 text-white cursor-pointer transition-colors disabled:opacity-50"
+                >
+                  <ImagePlus className="h-3 w-3" />
+                  {selected.size <= 1 ? "Add Image" : `Add ${selected.size} Images`}
+                </button>
+              )}
+              {step === "upload" && (
+                <button
+                  type="button"
+                  onClick={handleUploadConfirm}
+                  disabled={!uploadFile}
+                  className="flex items-center gap-1 text-xs font-medium rounded px-3 py-1.5 bg-blue-600 hover:bg-blue-500 text-white cursor-pointer transition-colors disabled:opacity-50"
+                >
+                  <Upload className="h-3 w-3" />
+                  Add Image
+                </button>
+              )}
+              {step === "generate" && (
+                <button
+                  type="button"
+                  onClick={handleGenerateSubmit}
+                  disabled={!prompt.trim()}
+                  className="flex items-center gap-1 text-xs font-medium rounded px-3 py-1.5 bg-purple-600 hover:bg-purple-500 text-white cursor-pointer transition-colors disabled:opacity-50"
+                >
+                  <Sparkles className="h-3 w-3" />
+                  Generate
+                </button>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function MethodCard({
+  icon,
+  title,
+  description,
+  onClick,
+}: {
+  icon: React.ReactNode
+  title: string
+  description: string
+  onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="w-full flex items-start gap-3 rounded-lg border p-3.5 text-left hover:border-blue-500/50 hover:bg-blue-50/50 dark:hover:bg-blue-500/5 transition-colors cursor-pointer"
+    >
+      <div className="mt-0.5 text-muted-foreground">{icon}</div>
+      <div>
+        <p className="text-xs font-semibold">{title}</p>
+        <p className="text-[10px] text-muted-foreground mt-0.5">{description}</p>
+      </div>
+    </button>
+  )
+}

--- a/apps/studio/src/components/pipeline/stages/StoryboardSectionDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/StoryboardSectionDetail.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback, useMemo, type ReactNode } from "react"
 import { createPortal } from "react-dom"
-import { Check, Copy, Eye, EyeOff, LayoutGrid, Layers, Loader2, ChevronDown, Sparkles, ChevronRight, PanelRightOpen, PanelRightClose, Play, PenLine, Save, X } from "lucide-react"
+import { Check, Copy, Eye, EyeOff, ImagePlus, LayoutGrid, Layers, Loader2, ChevronDown, Sparkles, ChevronRight, PanelRightOpen, PanelRightClose, Play, PenLine, Save, X } from "lucide-react"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { api, BASE_URL } from "@/api/client"
 import type { PageDetail, VersionEntry } from "@/api/client"
@@ -11,6 +11,7 @@ import { BookPreviewFrame, type BookPreviewFrameHandle } from "./BookPreviewFram
 import { SectionEditToolbar } from "./SectionEditToolbar"
 import { ImageCropDialog } from "./ImageCropDialog"
 import { AiImageDialog } from "./AiImageDialog"
+import { AddImageDialog } from "./AddImageDialog"
 import { SegmentPreviewDialog, type SegmentRegion } from "./SegmentPreviewDialog"
 import {
   Select,
@@ -375,6 +376,10 @@ export function StoryboardSectionDetail({
     regions: SegmentRegion[]
   } | null>(null)
 
+  // Add image dialog state
+  const [addImageDialogOpen, setAddImageDialogOpen] = useState(false)
+  const [showPrunedImages, setShowPrunedImages] = useState(true)
+
   // Notify parent when AI image generation starts/stops
   useEffect(() => {
     onGeneratingChange?.(aiImageGen?.status === "generating")
@@ -435,6 +440,7 @@ export function StoryboardSectionDetail({
     setSelectedElement(null)
     setCropTarget(null)
     setAiImageDialogTarget(null)
+    setAddImageDialogOpen(false)
     aiAbortRef.current?.abort()
     aiImageAbortRef.current?.abort()
     setAiImageGen(null)
@@ -1026,6 +1032,106 @@ export function StoryboardSectionDetail({
       })
     },
     [bookLabel, sectionIndex]
+  )
+
+  // Add a new image to the current section (append to parts + inject into HTML)
+  const addImageToSection = useCallback(
+    (newImageId: string, dims?: { w: number; h: number }) => {
+      // Update sectioning
+      setPendingSectioning((prev) => {
+        const sBase = prev ?? pageDataRef.current.sectioning
+        if (!sBase) return prev
+        return {
+          ...sBase,
+          sections: sBase.sections.map((s, si) => {
+            if (si !== sectionIndex) return s
+            // Skip if image already exists in this section
+            if (s.parts.some((p) => p.type === "image" && p.imageId === newImageId)) return s
+            return {
+              ...s,
+              parts: [...s.parts, { type: "image" as const, imageId: newImageId, isPruned: false }],
+            }
+          }),
+        }
+      })
+
+      // Update rendering HTML — append img tag at end of section content
+      setPendingRendering((prev) => {
+        const rBase = prev ?? pageDataRef.current.rendering
+        if (!rBase) return prev
+        const imgTag = `<img data-id="${newImageId}" src="${BASE_URL}/books/${bookLabel}/images/${newImageId}"${dims ? ` width="${dims.w}" height="${dims.h}"` : ""} alt="${newImageId}" class="w-full" />`
+        return {
+          ...rBase,
+          sections: rBase.sections.map((s) => {
+            if (s.sectionIndex !== sectionIndex) return s
+            // Try to insert before closing </section>, otherwise append
+            const closingIdx = s.html.lastIndexOf("</section>")
+            const html = closingIdx >= 0
+              ? s.html.slice(0, closingIdx) + imgTag + s.html.slice(closingIdx)
+              : s.html + imgTag
+            return { ...s, html }
+          }),
+        }
+      })
+    },
+    [bookLabel, sectionIndex]
+  )
+
+  // Handlers for AddImageDialog
+  const handleAddExistingImage = useCallback(
+    (imageIds: string[]) => {
+      setAddImageDialogOpen(false)
+      for (const id of imageIds) {
+        addImageToSection(id)
+      }
+    },
+    [addImageToSection]
+  )
+
+  const handleAddImageUpload = useCallback(
+    async (file: File) => {
+      setAddImageDialogOpen(false)
+      try {
+        const result = await api.uploadNewImage(bookLabel, pageId, file)
+        addImageToSection(result.imageId, { w: result.width, h: result.height })
+      } catch (err) {
+        setAiError(err instanceof Error ? err.message : "Image upload failed")
+      }
+    },
+    [bookLabel, pageId, addImageToSection]
+  )
+
+  const handleAddImageGenerate = useCallback(
+    (prompt: string) => {
+      setAddImageDialogOpen(false)
+      setAiImageGen({ targetImageId: "__adding__", status: "generating" })
+
+      const controller = new AbortController()
+      aiImageAbortRef.current = controller
+
+      api
+        .aiGenerateImage(bookLabel, pageId, prompt, apiKey, pageId, undefined, controller.signal)
+        .then((result) => {
+          addImageToSection(result.imageId, { w: result.width, h: result.height })
+          setAiImageGen({ targetImageId: "__adding__", status: "done" })
+          setTimeout(() => setAiImageGen((prev) => prev?.status === "done" ? null : prev), 3000)
+        })
+        .catch((err) => {
+          if (err instanceof DOMException && err.name === "AbortError") {
+            setAiImageGen(null)
+          } else {
+            setAiImageGen({
+              targetImageId: "__adding__",
+              status: "error",
+              error: err instanceof Error ? err.message : "Image generation failed",
+            })
+          }
+        })
+        .finally(() => {
+          aiImageAbortRef.current = null
+        })
+    },
+    [bookLabel, pageId, apiKey, addImageToSection]
   )
 
   // Submit from AI image dialog: close dialog, run generation in background
@@ -1711,14 +1817,26 @@ export function StoryboardSectionDetail({
           )}
 
           {/* Images */}
-          {hasImageParts && (
-            <div>
-              <h3 className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
-                Images
-              </h3>
-              <div className="grid grid-cols-2 gap-2">
+          <div>
+            <h3 className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
+              Images
+              {hasImageParts && parts.some((p) => p.type === "image" && p.isPruned) && (
+                <button
+                  type="button"
+                  onClick={() => setShowPrunedImages((v) => !v)}
+                  className="ml-auto flex items-center gap-1 text-[10px] font-normal normal-case tracking-normal text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+                  title={showPrunedImages ? "Hide pruned images" : "Show pruned images"}
+                >
+                  {showPrunedImages ? <Eye className="h-3 w-3" /> : <EyeOff className="h-3 w-3" />}
+                  {showPrunedImages ? "Hide Pruned" : "Show Pruned"}
+                </button>
+              )}
+            </h3>
+            {hasImageParts && (
+              <div className="grid grid-cols-2 gap-2 mb-2">
                 {parts.map((p, partIndex) => {
                   if (p.type !== "image") return null
+                  if (p.isPruned && !showPrunedImages) return null
                   return (
                     <div key={p.imageId} className="group relative">
                       <ImageCard
@@ -1743,8 +1861,16 @@ export function StoryboardSectionDetail({
                   )
                 })}
               </div>
-            </div>
-          )}
+            )}
+            <button
+              type="button"
+              onClick={() => setAddImageDialogOpen(true)}
+              className="flex items-center justify-center gap-1.5 w-full rounded border border-dashed border-muted-foreground/30 hover:border-muted-foreground/60 py-3 text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+            >
+              <ImagePlus className="h-3.5 w-3.5" />
+              Add Image
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -1786,6 +1912,17 @@ export function StoryboardSectionDetail({
         regions={segmentPreview.regions}
         onApply={handleSegmentApply}
         onClose={() => setSegmentPreview(null)}
+      />
+    )}
+
+    {/* Add image dialog */}
+    {addImageDialogOpen && (
+      <AddImageDialog
+        bookLabel={bookLabel}
+        onSelectExisting={handleAddExistingImage}
+        onUpload={handleAddImageUpload}
+        onGenerate={handleAddImageGenerate}
+        onClose={() => setAddImageDialogOpen(false)}
       />
     )}
     </>

--- a/packages/storage/src/db.ts
+++ b/packages/storage/src/db.ts
@@ -34,7 +34,7 @@ CREATE TABLE IF NOT EXISTS images (
   hash TEXT NOT NULL DEFAULT '',
   width INTEGER NOT NULL,
   height INTEGER NOT NULL,
-  source TEXT NOT NULL CHECK (source IN ('page', 'extract', 'crop', 'segment'))
+  source TEXT NOT NULL CHECK (source IN ('page', 'extract', 'crop', 'segment', 'upload'))
 );
 
 CREATE TABLE IF NOT EXISTS llm_log (
@@ -109,6 +109,12 @@ function initSchema(db: sqlite.Database): void {
   if (version === 7) {
     migrateV7toV8(db)
     version = 8
+  }
+
+  // Migrate v8 → v9: add 'upload' to images.source CHECK constraint
+  if (version === 8) {
+    migrateV8toV9(db)
+    version = 9
   }
 
   if (version === SCHEMA_VERSION) {
@@ -241,6 +247,34 @@ function migrateV7toV8(db: sqlite.Database): void {
       db.exec("DROP TABLE step_completions")
     }
 
+    db.exec("COMMIT")
+  } catch (err) {
+    db.exec("ROLLBACK")
+    throw err
+  }
+}
+
+/**
+ * Migrate v8 → v9: widen images.source CHECK to include 'upload'.
+ * SQLite doesn't support ALTER CHECK, so we recreate the table.
+ */
+function migrateV8toV9(db: sqlite.Database): void {
+  db.exec("BEGIN IMMEDIATE")
+  try {
+    db.exec(`
+      CREATE TABLE images_new (
+        image_id TEXT PRIMARY KEY,
+        page_id TEXT NOT NULL REFERENCES pages(page_id),
+        path TEXT NOT NULL,
+        hash TEXT NOT NULL DEFAULT '',
+        width INTEGER NOT NULL,
+        height INTEGER NOT NULL,
+        source TEXT NOT NULL CHECK (source IN ('page', 'extract', 'crop', 'segment', 'upload'))
+      );
+      INSERT INTO images_new SELECT * FROM images;
+      DROP TABLE images;
+      ALTER TABLE images_new RENAME TO images;
+    `)
     db.exec("COMMIT")
   } catch (err) {
     db.exec("ROLLBACK")

--- a/packages/types/src/db.ts
+++ b/packages/types/src/db.ts
@@ -1,8 +1,8 @@
 import { z } from "zod"
 
-export const SCHEMA_VERSION = 8
+export const SCHEMA_VERSION = 9
 
-export const ImageSource = z.enum(["page", "extract", "crop", "segment"])
+export const ImageSource = z.enum(["page", "extract", "crop", "segment", "upload"])
 export type ImageSource = z.infer<typeof ImageSource>
 
 export const PageRow = z.object({


### PR DESCRIPTION
Enables users to add images to storyboard sections with three methods: pick from existing book images, upload a new image, or generate with AI.

**Changes:**
- New `GET /books/:label/images` endpoint lists all images in a book
- New `POST /books/:label/images/upload` endpoint handles image uploads with dimension detection
- New `AddImageDialog` component provides wizard UI for image selection
- Schema migration v8→v9 adds 'upload' source type for images
- Integrated dialog into `StoryboardSectionDetail` with handlers for all three flows

**Issues flagged in review:** JPEG dimension parsing can return thumbnail dimensions for photos with EXIF; shared abort ref between concurrent AI generation flows.