### PR TITLE
Add auto-build for preview assets bundle

### DIFF
--- a/apps/api/src/routes/adt-preview.test.ts
+++ b/apps/api/src/routes/adt-preview.test.ts
@@ -87,6 +87,19 @@ describe("ADT preview routes", () => {
     fs.rmSync(webAssetsDir, { recursive: true, force: true })
   })
 
+  it("auto-builds base.bundle.min.js when missing and base.js exists", async () => {
+    // Remove the pre-built bundle but ensure the source entry point exists
+    fs.unlinkSync(path.join(webAssetsDir, "base.bundle.min.js"))
+    fs.writeFileSync(path.join(webAssetsDir, "base.js"), "export const x = 1;")
+
+    const app = createAdtPreviewRoutes(tmpDir, webAssetsDir, path.resolve(process.cwd(), "config.yaml"))
+    const res = await app.request(`/books/${label}/adt-preview/assets/base.bundle.min.js`)
+
+    expect(res.status).toBe(200)
+    // The auto-built file should now exist on disk
+    expect(fs.existsSync(path.join(webAssetsDir, "base.bundle.min.js"))).toBe(true)
+  })
+
   it("renders the requested section id instead of falling back to the first section", async () => {
     const app = createAdtPreviewRoutes(tmpDir, webAssetsDir, path.resolve(process.cwd(), "config.yaml"))
     const res = await app.request(`/books/${label}/adt-preview/${label}_p1_sec002.html`)

--- a/apps/api/src/routes/adt-preview.ts
+++ b/apps/api/src/routes/adt-preview.ts
@@ -294,7 +294,7 @@ export function createAdtPreviewRoutes(
   })
 
   // /assets/* — Static files from webAssetsDir
-  app.get("/books/:label/adt-preview/assets/*", (c) => {
+  app.get("/books/:label/adt-preview/assets/*", async (c) => {
     resolveBook(c.req.param("label")) // validate label
     const assetPath = c.req.path.split("/adt-preview/assets/")[1]
     if (!assetPath) throw new HTTPException(400, { message: "Missing asset path" })
@@ -303,6 +303,24 @@ export function createAdtPreviewRoutes(
     const resolved = path.resolve(webAssetsDir, assetPath)
     if (!resolved.startsWith(path.resolve(webAssetsDir))) {
       throw new HTTPException(403, { message: "Forbidden" })
+    }
+
+    // Auto-build base.bundle.min.js on-the-fly if it doesn't exist (dev mode).
+    // The file is gitignored and normally pre-built by `pnpm --filter @adt/api bundle`.
+    if (!fs.existsSync(resolved) && assetPath === "base.bundle.min.js") {
+      const entryPoint = path.join(webAssetsDir, "base.js")
+      if (fs.existsSync(entryPoint)) {
+        const esbuild = await import("esbuild")
+        await esbuild.build({
+          entryPoints: [entryPoint],
+          bundle: true,
+          minify: true,
+          sourcemap: true,
+          format: "esm",
+          target: "es2020",
+          outfile: resolved,
+        })
+      }
     }
 
     if (!fs.existsSync(resolved) || fs.statSync(resolved).isDirectory()) {


### PR DESCRIPTION
## Summary
The `/assets/*` preview route now automatically builds `base.bundle.min.js` on-the-fly if it doesn't exist on disk but the source entry point exists. This is a dev-mode convenience so developers don't need to manually run the bundle step before testing the preview.

## Changes
- Made the assets route async to support dynamic esbuild compilation
- Added auto-build logic that triggers when the bundle is missing but `base.js` exists
- Added test coverage for the auto-build behavior