### PR TITLE
Display section count badge in sidebar page thumbnails

### DIFF
--- a/apps/studio/src/components/pipeline/StageSidebar.tsx
+++ b/apps/studio/src/components/pipeline/StageSidebar.tsx
@@ -433,6 +433,11 @@ function PageRow({
           </span>
           <span className="text-[9px] font-mono opacity-50 leading-none">
             pg {page.pageNumber}
+            {page.sectionCount > 1 && (
+              <span className="ml-1 inline-flex items-center justify-center min-w-[14px] h-[12px] px-0.5 rounded bg-black/10 text-[8px] font-semibold not-italic leading-none">
+                {page.sectionCount}
+              </span>
+            )}
           </span>
         </div>
         {showPreview && imgSrc && createPortal(


### PR DESCRIPTION
Add a small badge showing the section count next to the page number in the sidebar page thumbnails. The badge only appears when pages have multiple sections, providing at-a-glance visibility of pagination.

## Changes
- Added section count badge UI to PageRow component
- Badge displays next to page number with Tailwind styling
- Only shown for pages with sectionCount > 1