### PR TITLE
Ignore package-lock.json from Node v25

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Dependencies
 node_modules/
+package-lock.json
 
 # Build output
 dist/


### PR DESCRIPTION
Node v25.4.0 auto-generates `package-lock.json` at the root during `pnpm install`, even though this project uses pnpm exclusively. This change adds the file to `.gitignore` to prevent it from appearing in git status and cluttering PRs.