### PR TITLE
Add section merge, delete, and block deletion UI

### DIFF
--- a/apps/api/src/routes/pages.ts
+++ b/apps/api/src/routes/pages.ts
@@ -644,6 +644,257 @@ export function createPageRoutes(
     }
   })
 
+  // POST /books/:label/pages/:pageId/sections/:sectionIndex/merge — Merge two adjacent sections
+  app.post("/books/:label/pages/:pageId/sections/:sectionIndex/merge", async (c) => {
+    const MergeSectionParams = z.object({
+      label: z.string().min(1),
+      pageId: z.string().min(1),
+      sectionIndex: z.coerce.number().int().min(0),
+    })
+    const parsedParams = MergeSectionParams.safeParse(c.req.param())
+    if (!parsedParams.success) {
+      throw new HTTPException(400, {
+        message: `Invalid route params: ${parsedParams.error.issues.map((i) => i.message).join(", ")}`,
+      })
+    }
+    const { label, pageId, sectionIndex: idx } = parsedParams.data
+    const safeLabel = parseBookLabel(label)
+
+    const directionParam = c.req.query("direction") ?? "next"
+    if (directionParam !== "next" && directionParam !== "prev") {
+      throw new HTTPException(400, { message: `Invalid direction: ${directionParam}. Must be "next" or "prev"` })
+    }
+    const direction = directionParam as "next" | "prev"
+
+    const storage = createBookStorage(safeLabel, booksDir)
+    try {
+      const pages = storage.getPages()
+      if (!pages.find((p) => p.pageId === pageId)) {
+        throw new HTTPException(404, { message: `Page not found: ${pageId}` })
+      }
+
+      // Read latest sectioning
+      const sectioningRow = storage.getLatestNodeData("page-sectioning", pageId)
+      if (!sectioningRow) {
+        throw new HTTPException(400, { message: "Page has no sectioning data" })
+      }
+      const sectioningParsed = PageSectioningOutput.safeParse(sectioningRow.data)
+      if (!sectioningParsed.success) {
+        throw new HTTPException(400, { message: "Invalid page-sectioning data" })
+      }
+      const sectioning = sectioningParsed.data
+
+      if (idx >= sectioning.sections.length) {
+        throw new HTTPException(400, { message: `Section index ${idx} out of range (page has ${sectioning.sections.length} sections)` })
+      }
+
+      // Determine which two sections to merge
+      if (direction === "next" && idx >= sectioning.sections.length - 1) {
+        throw new HTTPException(400, { message: `Cannot merge "next": section ${idx} is the last section` })
+      }
+      if (direction === "prev" && idx === 0) {
+        throw new HTTPException(400, { message: `Cannot merge "prev": section ${idx} is the first section` })
+      }
+
+      const keepIdx = direction === "next" ? idx : idx - 1
+      const removeIdx = direction === "next" ? idx + 1 : idx
+
+      // Combine: append remove section's parts into keep section
+      const newSections = [...sectioning.sections]
+      newSections[keepIdx] = {
+        ...newSections[keepIdx],
+        parts: [...newSections[keepIdx].parts, ...newSections[removeIdx].parts],
+      }
+      newSections.splice(removeIdx, 1)
+
+      // Renumber all sectionIds
+      for (let i = 0; i < newSections.length; i++) {
+        newSections[i].sectionId = `${pageId}_sec${String(i + 1).padStart(3, "0")}`
+      }
+
+      const updatedSectioning = { ...sectioning, sections: newSections }
+
+      // Update rendering if present
+      let updatedRendering: z.infer<typeof WebRenderingOutput> | null = null
+      let renderingVersion: number | null = null
+      const renderingRow = storage.getLatestNodeData("web-rendering", pageId)
+      if (renderingRow) {
+        const renderingParsed = WebRenderingOutput.safeParse(renderingRow.data)
+        if (!renderingParsed.success) {
+          throw new HTTPException(400, { message: "Invalid web-rendering data" })
+        }
+        const rendering = renderingParsed.data
+
+        const shifted = [...rendering.sections]
+
+        // Find rendering entries for keepIdx and removeIdx
+        const keepEntry = shifted.find((s) => s.sectionIndex === keepIdx)
+        const removeEntry = shifted.find((s) => s.sectionIndex === removeIdx)
+
+        // Merge HTML if both entries exist
+        if (keepEntry && removeEntry) {
+          // Extract inner content from remove section's <section> tag and append into keep section's <section>
+          const innerContentMatch = removeEntry.html.match(/<section[^>]*>([\s\S]*)<\/section>/)
+          const innerContent = innerContentMatch ? innerContentMatch[1] : removeEntry.html
+          keepEntry.html = keepEntry.html.replace(/<\/section>\s*$/, `${innerContent}</section>`)
+        }
+
+        // Remove the removeIdx rendering entry
+        const removeEntryIndex = shifted.findIndex((s) => s.sectionIndex === removeIdx)
+        if (removeEntryIndex !== -1) {
+          shifted.splice(removeEntryIndex, 1)
+        }
+
+        // Shift sectionIndex for entries after removeIdx (subtract 1)
+        for (const s of shifted) {
+          if (s.sectionIndex > removeIdx) {
+            s.sectionIndex = s.sectionIndex - 1
+          }
+        }
+
+        // Update data-section-id in each rendering's HTML to match new sectionIds
+        for (const rs of shifted) {
+          if (rs.sectionIndex < 0 || rs.sectionIndex >= newSections.length) {
+            throw new HTTPException(400, { message: "Rendering contains invalid section indexes" })
+          }
+          const expectedId = newSections[rs.sectionIndex]?.sectionId
+          if (!expectedId) {
+            throw new HTTPException(400, { message: "Unable to map rendering section to sectionId" })
+          }
+          rs.html = rs.html.replace(
+            /data-section-id="[^"]*"/,
+            `data-section-id="${expectedId}"`
+          )
+        }
+        updatedRendering = { sections: shifted }
+      }
+
+      const sectioningVersion = storage.putNodeData("page-sectioning", pageId, updatedSectioning)
+      if (updatedRendering) {
+        renderingVersion = storage.putNodeData("web-rendering", pageId, updatedRendering)
+      }
+
+      return c.json({
+        mergedSectionIndex: keepIdx,
+        sectioningVersion,
+        renderingVersion,
+      })
+    } finally {
+      storage.close()
+    }
+  })
+
+  // DELETE /books/:label/pages/:pageId/sections/:sectionIndex — Delete a section
+  app.delete("/books/:label/pages/:pageId/sections/:sectionIndex", async (c) => {
+    const DeleteSectionParams = z.object({
+      label: z.string().min(1),
+      pageId: z.string().min(1),
+      sectionIndex: z.coerce.number().int().min(0),
+    })
+    const parsedParams = DeleteSectionParams.safeParse(c.req.param())
+    if (!parsedParams.success) {
+      throw new HTTPException(400, {
+        message: `Invalid route params: ${parsedParams.error.issues.map((i) => i.message).join(", ")}`,
+      })
+    }
+    const { label, pageId, sectionIndex: idx } = parsedParams.data
+    const safeLabel = parseBookLabel(label)
+
+    const storage = createBookStorage(safeLabel, booksDir)
+    try {
+      const pages = storage.getPages()
+      if (!pages.find((p) => p.pageId === pageId)) {
+        throw new HTTPException(404, { message: `Page not found: ${pageId}` })
+      }
+
+      // Read latest sectioning
+      const sectioningRow = storage.getLatestNodeData("page-sectioning", pageId)
+      if (!sectioningRow) {
+        throw new HTTPException(400, { message: "Page has no sectioning data" })
+      }
+      const sectioningParsed = PageSectioningOutput.safeParse(sectioningRow.data)
+      if (!sectioningParsed.success) {
+        throw new HTTPException(400, { message: "Invalid page-sectioning data" })
+      }
+      const sectioning = sectioningParsed.data
+
+      if (idx >= sectioning.sections.length) {
+        throw new HTTPException(400, { message: `Section index ${idx} out of range (page has ${sectioning.sections.length} sections)` })
+      }
+
+      if (sectioning.sections.length <= 1) {
+        throw new HTTPException(400, { message: "Cannot delete the only section on a page" })
+      }
+
+      // Remove section at idx
+      const newSections = [...sectioning.sections]
+      newSections.splice(idx, 1)
+
+      // Renumber all sectionIds
+      for (let i = 0; i < newSections.length; i++) {
+        newSections[i].sectionId = `${pageId}_sec${String(i + 1).padStart(3, "0")}`
+      }
+
+      const updatedSectioning = { ...sectioning, sections: newSections }
+
+      // Update rendering if present
+      let updatedRendering: z.infer<typeof WebRenderingOutput> | null = null
+      let renderingVersion: number | null = null
+      const renderingRow = storage.getLatestNodeData("web-rendering", pageId)
+      if (renderingRow) {
+        const renderingParsed = WebRenderingOutput.safeParse(renderingRow.data)
+        if (!renderingParsed.success) {
+          throw new HTTPException(400, { message: "Invalid web-rendering data" })
+        }
+        const rendering = renderingParsed.data
+
+        const shifted = [...rendering.sections]
+
+        // Remove the rendering entry for idx
+        const removeEntryIndex = shifted.findIndex((s) => s.sectionIndex === idx)
+        if (removeEntryIndex !== -1) {
+          shifted.splice(removeEntryIndex, 1)
+        }
+
+        // Shift sectionIndex for entries after idx (subtract 1)
+        for (const s of shifted) {
+          if (s.sectionIndex > idx) {
+            s.sectionIndex = s.sectionIndex - 1
+          }
+        }
+
+        // Update data-section-id in each rendering's HTML to match new sectionIds
+        for (const rs of shifted) {
+          if (rs.sectionIndex < 0 || rs.sectionIndex >= newSections.length) {
+            throw new HTTPException(400, { message: "Rendering contains invalid section indexes" })
+          }
+          const expectedId = newSections[rs.sectionIndex]?.sectionId
+          if (!expectedId) {
+            throw new HTTPException(400, { message: "Unable to map rendering section to sectionId" })
+          }
+          rs.html = rs.html.replace(
+            /data-section-id="[^"]*"/,
+            `data-section-id="${expectedId}"`
+          )
+        }
+        updatedRendering = { sections: shifted }
+      }
+
+      const sectioningVersion = storage.putNodeData("page-sectioning", pageId, updatedSectioning)
+      if (updatedRendering) {
+        renderingVersion = storage.putNodeData("web-rendering", pageId, updatedRendering)
+      }
+
+      return c.json({
+        sectioningVersion,
+        renderingVersion,
+        remainingSections: newSections.length,
+      })
+    } finally {
+      storage.close()
+    }
+  })
+
   // POST /books/:label/images/ai-generate — Generate image via gpt-image-1.5
   app.post("/books/:label/images/ai-generate", async (c) => {
     try {

--- a/apps/studio/src/api/client.ts
+++ b/apps/studio/src/api/client.ts
@@ -455,6 +455,18 @@ export const api = {
       { method: "POST" }
     ),
 
+  mergeSection: (label: string, pageId: string, sectionIndex: number, direction: "next" | "prev" = "next") =>
+    request<{ mergedSectionIndex: number; sectioningVersion: number; renderingVersion: number | null }>(
+      `/books/${label}/pages/${pageId}/sections/${sectionIndex}/merge?direction=${direction}`,
+      { method: "POST" }
+    ),
+
+  deleteSection: (label: string, pageId: string, sectionIndex: number) =>
+    request<{ sectioningVersion: number; renderingVersion: number | null; remainingSections: number }>(
+      `/books/${label}/pages/${pageId}/sections/${sectionIndex}`,
+      { method: "DELETE" }
+    ),
+
   listBookImages: (label: string) =>
     request<{
       images: Array<{

--- a/apps/studio/src/components/pipeline/stages/SectionEditToolbar.tsx
+++ b/apps/studio/src/components/pipeline/stages/SectionEditToolbar.tsx
@@ -1,4 +1,4 @@
-import { Crop, Eye, EyeOff, Pencil, Scissors, Sparkles, Type, Upload } from "lucide-react"
+import { Crop, Eye, EyeOff, Pencil, Scissors, Sparkles, Trash2, Type, Upload } from "lucide-react"
 import {
   Select,
   SelectContent,
@@ -38,6 +38,8 @@ export interface SectionEditToolbarProps {
   onSegment?: (dataId: string) => void
   /** Whether segmentation is currently running */
   segmenting?: boolean
+  /** Called when delete/remove block is requested */
+  onDelete?: (dataId: string) => void
 }
 
 /**
@@ -61,6 +63,7 @@ export function SectionEditToolbar({
   onAiImage,
   onSegment,
   segmenting,
+  onDelete,
 }: SectionEditToolbarProps) {
   if (!dataId) return null
 
@@ -137,6 +140,17 @@ export function SectionEditToolbar({
                 {segmenting ? "Segmenting..." : "Segment"}
               </button>
             )}
+            {onDelete && (
+              <button
+                type="button"
+                onClick={() => onDelete(dataId)}
+                className="flex items-center gap-1 text-[10px] font-medium rounded px-2 py-1 bg-red-100 hover:bg-red-200 text-red-700 transition-colors cursor-pointer"
+                title="Remove this block"
+              >
+                <Trash2 className="h-3 w-3" />
+                Delete
+              </button>
+            )}
             {onTogglePrune && (
               <button
                 type="button"
@@ -210,6 +224,17 @@ export function SectionEditToolbar({
         <Pencil className="h-2.5 w-2.5" />
         Editing
       </span>
+
+      {onDelete && (
+        <button
+          type="button"
+          onClick={() => onDelete(dataId)}
+          className="p-0.5 rounded hover:bg-red-100 transition-colors cursor-pointer"
+          title="Remove this block"
+        >
+          <Trash2 className="h-3 w-3 text-red-600" />
+        </button>
+      )}
 
       {onTogglePrune && (
         <button

--- a/apps/studio/src/components/pipeline/stages/StoryboardSectionDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/StoryboardSectionDetail.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback, useMemo, type ReactNode } from "react"
 import { createPortal } from "react-dom"
-import { Check, Copy, Eye, EyeOff, ImagePlus, LayoutGrid, Layers, Loader2, ChevronDown, Sparkles, ChevronRight, PanelRightOpen, PanelRightClose, Play, PenLine, Save, X } from "lucide-react"
+import { Check, Copy, Eye, EyeOff, ImagePlus, LayoutGrid, Layers, Loader2, ChevronDown, Sparkles, ChevronRight, PanelRightOpen, PanelRightClose, Play, PenLine, Save, Trash2, Merge, X } from "lucide-react"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { api, BASE_URL } from "@/api/client"
 import type { PageDetail, VersionEntry } from "@/api/client"
@@ -332,6 +332,8 @@ export function StoryboardSectionDetail({
   const [saving, setSaving] = useState(false)
   const [cloning, setCloning] = useState(false)
   const [rerendering, setRerendering] = useState(false)
+  const [merging, setMerging] = useState(false)
+  const [deleting, setDeleting] = useState(false)
   const [pendingSectioning, setPendingSectioning] = useState<SectioningData | null>(null)
   const [pendingRendering, setPendingRendering] = useState<RenderingData | null>(null)
 
@@ -478,16 +480,8 @@ export function StoryboardSectionDetail({
   const renderedSection = getRenderedSectionByIndex(renderingData, sectionIndex)
   const renderingDirty = pendingRendering != null
 
-  if (!section) {
-    return (
-      <div className="p-4 text-sm text-muted-foreground">
-        Section not found.
-      </div>
-    )
-  }
-
-  // Parts are inline in the section data
-  const parts = section.parts
+  // Parts are inline in the section data (empty if section missing — hooks still run)
+  const parts = section?.parts ?? []
 
   // Save / discard sectioning
   const saveSectioning = async () => {
@@ -581,6 +575,147 @@ export function StoryboardSectionDetail({
       setCloning(false)
     }
   }
+
+  // Merge current section with next or previous
+  const handleMergeSection = async (direction: "next" | "prev") => {
+    if (merging || dirty || renderingDirty || saving) return
+    setMerging(true)
+    try {
+      const result = await api.mergeSection(bookLabel, pageId, sectionIndex, direction)
+      await queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "pages", pageId] })
+      await queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "pages"] })
+      onNavigateSection?.(result.mergedSectionIndex)
+
+      // Auto re-render the merged section so the LLM generates proper HTML for the combined content
+      if (hasApiKey) {
+        setRerendering(true)
+        const capturedPageId = pageId
+        api.reRenderPage(bookLabel, pageId, apiKey, result.mergedSectionIndex)
+          .then(() => {
+            if (pageIdRef.current !== capturedPageId) return
+            queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "pages", capturedPageId] })
+            queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "pages"] })
+          })
+          .catch(() => {})
+          .finally(() => {
+            if (pageIdRef.current === capturedPageId) {
+              setRerendering(false)
+            }
+          })
+      }
+    } catch (err) {
+      setAiError(err instanceof Error ? err.message : "Merge failed")
+    } finally {
+      setMerging(false)
+    }
+  }
+
+  // Delete current section
+  const handleDeleteSection = async () => {
+    if (deleting || dirty || renderingDirty || saving) return
+    const totalSections = sectioningData?.sections.length ?? 0
+    if (totalSections <= 1) return
+    setDeleting(true)
+    try {
+      const result = await api.deleteSection(bookLabel, pageId, sectionIndex)
+      await queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "pages", pageId] })
+      await queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "pages"] })
+      onNavigateSection?.(Math.min(sectionIndex, result.remainingSections - 1))
+    } catch (err) {
+      setAiError(err instanceof Error ? err.message : "Delete failed")
+    } finally {
+      setDeleting(false)
+    }
+  }
+
+  // Delete selected block from rendered HTML
+  const handleDeleteBlock = useCallback(
+    (dataId: string) => {
+      const rBase = pendingRendering ?? page.rendering
+      if (!rBase) return
+      const currentSection = getRenderedSectionByIndex(rBase, sectionIndex)
+      if (!currentSection?.html) return
+
+      // Remove the element with this data-id from the HTML
+      const parser = new DOMParser()
+      const doc = parser.parseFromString(currentSection.html, "text/html")
+      const el = doc.querySelector(`[data-id="${dataId}"]`)
+      if (!el) return
+
+      // For block-level elements (divs, sections), remove the element
+      // For inline elements, remove closest block parent if it only contains this element
+      const blockParent = el.closest("div, p, figure, li, tr, section[data-section-id]")
+      if (blockParent && blockParent.getAttribute("data-section-id")) {
+        // Don't remove the outer section wrapper — just remove the element itself
+        el.remove()
+      } else if (blockParent && blockParent.querySelectorAll("[data-id]").length <= 1) {
+        // This block only contains the target element — remove the whole block
+        blockParent.remove()
+      } else {
+        el.remove()
+      }
+
+      const newHtml = doc.querySelector("section[data-section-id]")?.outerHTML ?? doc.body.innerHTML
+      const updated: RenderingData = {
+        ...rBase,
+        sections: rBase.sections.map((s) => {
+          if (s.sectionIndex !== sectionIndex) return s
+          return { ...s, html: newHtml }
+        }),
+      }
+      setPendingRendering(updated)
+
+      // Also prune matching part in sectioning if it exists
+      const sBase = pendingSectioning ?? page.sectioning
+      if (sBase) {
+        const loc = findTextByDataId(parts, dataId)
+        if (loc) {
+          const updatedSectioning: SectioningData = {
+            ...sBase,
+            sections: sBase.sections.map((s, si) => {
+              if (si !== sectionIndex) return s
+              return {
+                ...s,
+                parts: s.parts.map((p, pi) => {
+                  if (pi !== loc.partIndex || p.type !== "text_group") return p
+                  return {
+                    ...p,
+                    texts: p.texts.map((t, ti) => {
+                      if (ti !== loc.textIndex) return t
+                      return { ...t, isPruned: true }
+                    }),
+                  }
+                }),
+              }
+            }),
+          }
+          setPendingSectioning(updatedSectioning)
+        } else {
+          // Image
+          const imgIdx = parts.findIndex((p) => p.type === "image" && p.imageId === dataId)
+          if (imgIdx >= 0) {
+            const updatedSectioning: SectioningData = {
+              ...sBase,
+              sections: sBase.sections.map((s, si) => {
+                if (si !== sectionIndex) return s
+                return {
+                  ...s,
+                  parts: s.parts.map((p, pi) => {
+                    if (pi !== imgIdx) return p
+                    return { ...p, isPruned: true }
+                  }),
+                }
+              }),
+            }
+            setPendingSectioning(updatedSectioning)
+          }
+        }
+      }
+
+      setSelectedElement(null)
+    },
+    [pendingRendering, page.rendering, pendingSectioning, page.sectioning, sectionIndex, parts]
+  )
 
   // Toggle isPruned on a part within the current section
   const togglePartPruned = (partIndex: number) => {
@@ -1337,13 +1472,13 @@ export function StoryboardSectionDetail({
         type="button"
         onClick={toggleSectionPruned}
         className={`flex items-center justify-center w-7 h-7 rounded transition-colors cursor-pointer ${
-          section.isPruned
+          section?.isPruned
             ? "bg-amber-500/30 hover:bg-amber-500/40"
             : "bg-white/10 hover:bg-white/20"
         }`}
-        title={section.isPruned ? "Restore section to flow" : "Prune section from flow"}
+        title={section?.isPruned ? "Restore section to flow" : "Prune section from flow"}
       >
-        {section.isPruned ? (
+        {section?.isPruned ? (
           <EyeOff className="h-3.5 w-3.5 text-amber-200" />
         ) : (
           <Eye className="h-3.5 w-3.5" />
@@ -1401,6 +1536,14 @@ export function StoryboardSectionDetail({
       {navigationArrows}
     </>
   )
+
+  if (!section) {
+    return (
+      <div className="p-4 text-sm text-muted-foreground">
+        Section not found.
+      </div>
+    )
+  }
 
   return (
     <>
@@ -1659,6 +1802,7 @@ export function StoryboardSectionDetail({
           onAiImage={selectedInfo.isImage && hasApiKey ? handleAiImage : undefined}
           onSegment={selectedInfo.isImage && hasApiKey ? handleSegment : undefined}
           segmenting={segmenting}
+          onDelete={handleDeleteBlock}
         />
       )}
 
@@ -1706,6 +1850,36 @@ export function StoryboardSectionDetail({
             <span className="text-destructive text-[10px] font-medium">(pruned)</span>
           )}
           <div className="ml-auto flex items-center gap-1.5">
+          {sectionIndex > 0 && (
+            <button
+              type="button"
+              onClick={() => handleMergeSection("prev")}
+              disabled={merging || dirty || renderingDirty || saving}
+              className="p-0.5 rounded hover:bg-accent transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-default"
+              title={dirty || renderingDirty ? "Save changes before merging" : "Merge with previous section"}
+            >
+              {merging ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Merge className="h-3.5 w-3.5 rotate-180" />
+              )}
+            </button>
+          )}
+          {sectioningData && sectionIndex < sectioningData.sections.length - 1 && (
+            <button
+              type="button"
+              onClick={() => handleMergeSection("next")}
+              disabled={merging || dirty || renderingDirty || saving}
+              className="p-0.5 rounded hover:bg-accent transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-default"
+              title={dirty || renderingDirty ? "Save changes before merging" : "Merge with next section"}
+            >
+              {merging ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Merge className="h-3.5 w-3.5" />
+              )}
+            </button>
+          )}
           <button
             type="button"
             onClick={handleCloneSection}
@@ -1719,6 +1893,21 @@ export function StoryboardSectionDetail({
               <Copy className="h-3.5 w-3.5" />
             )}
           </button>
+          {sectioningData && sectioningData.sections.length > 1 && (
+            <button
+              type="button"
+              onClick={handleDeleteSection}
+              disabled={deleting || dirty || renderingDirty || saving}
+              className="p-0.5 rounded hover:bg-red-100 transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-default"
+              title={dirty || renderingDirty ? "Save changes before deleting" : "Delete this section"}
+            >
+              {deleting ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Trash2 className="h-3.5 w-3.5 text-red-600" />
+              )}
+            </button>
+          )}
           <VersionPicker
             currentVersion={page.versions.sectioning}
             saving={saving}


### PR DESCRIPTION
Adds merge/delete operations for sections and block-level deletion from rendered content. The merge endpoint combines adjacent sections, renumbers IDs, and auto-triggers LLM re-render for proper HTML output. The delete endpoint removes sections and validates the operation cannot result in zero sections. Block-level deletion lets editors remove specific content elements from rendered HTML while syncing the pruning state.

## Changes
- **API**: POST `/sections/:idx/merge` and DELETE `/sections/:idx` with full sectioning + rendering sync
- **Client**: New `mergeSection` and `deleteSection` functions
- **UI**: Merge/delete buttons in section footer, delete button in block toolbar