### PR TITLE
Fix storyboard delete/prune and duplication bugs

### DIFF
--- a/apps/api/src/routes/adt-preview.ts
+++ b/apps/api/src/routes/adt-preview.ts
@@ -150,10 +150,12 @@ function buildPagesManifest(storage: Storage): Array<{ section_id: string; href:
           : null
         const sectioning = sectioningParsed?.success ? sectioningParsed.data : undefined
 
-        // One entry per rendered section (stable by sectionIndex)
+        // One entry per rendered section (stable by sectionIndex), skip pruned
         const sections = [...parsed.data.sections].sort((a, b) => a.sectionIndex - b.sectionIndex)
         for (const rs of sections) {
           const sectionMeta = sectioning?.sections?.[rs.sectionIndex]
+          // Skip sections that are pruned in the sectioning data
+          if (sectionMeta?.isPruned) continue
           const sectionId = sectionMeta?.sectionId ?? `${page.pageId}_sec${String(rs.sectionIndex + 1).padStart(3, "0")}`
           const entry: { section_id: string; href: string; page_number?: number } = {
             section_id: sectionId,

--- a/apps/api/src/routes/pages.ts
+++ b/apps/api/src/routes/pages.ts
@@ -459,6 +459,18 @@ export function createPageRoutes(
       })
     }
 
+    // Optional prompt for LLM guidance during re-render
+    let prompt: string | undefined
+    try {
+      const body = await c.req.json()
+      const parsed = z.object({ prompt: z.string().optional() }).safeParse(body)
+      if (parsed.success) {
+        prompt = parsed.data.prompt
+      }
+    } catch {
+      // No body or not JSON — that's fine, prompt is optional
+    }
+
     const storage = createBookStorage(safeLabel, booksDir)
     try {
       const pages = storage.getPages()
@@ -492,6 +504,7 @@ export function createPageRoutes(
       label: safeLabel,
       pageId,
       sectionIndex,
+      prompt,
       booksDir,
       promptsDir,
       webAssetsDir,
@@ -823,10 +836,6 @@ export function createPageRoutes(
 
       if (idx >= sectioning.sections.length) {
         throw new HTTPException(400, { message: `Section index ${idx} out of range (page has ${sectioning.sections.length} sections)` })
-      }
-
-      if (sectioning.sections.length <= 1) {
-        throw new HTTPException(400, { message: "Cannot delete the only section on a page" })
       }
 
       // Remove section at idx

--- a/apps/api/src/services/page-edit-service.ts
+++ b/apps/api/src/services/page-edit-service.ts
@@ -12,6 +12,8 @@ export interface ReRenderOptions {
   label: string
   pageId: string
   sectionIndex?: number
+  /** Optional user prompt/instructions to guide the LLM during re-render */
+  prompt?: string
   booksDir: string
   promptsDir: string
   webAssetsDir?: string
@@ -46,7 +48,7 @@ export interface AiEditSectionResult {
 export async function reRenderPage(
   options: ReRenderOptions
 ): Promise<ReRenderResult> {
-  const { label, pageId, sectionIndex, booksDir, promptsDir, webAssetsDir, configPath, apiKey } = options
+  const { label, pageId, sectionIndex, prompt, booksDir, promptsDir, webAssetsDir, configPath, apiKey } = options
 
   // Set API key
   const previousKey = process.env.OPENAI_API_KEY
@@ -150,6 +152,7 @@ export async function reRenderPage(
         sectioning: sectioningForRender,
         images: renderImages,
         styleguide: styleguideContent,
+        userPrompt: prompt,
       },
       resolveRenderConfig,
       resolveRenderModel,

--- a/apps/api/src/services/stage-runner.ts
+++ b/apps/api/src/services/stage-runner.ts
@@ -1062,7 +1062,12 @@ async function runCaptionsStep(
           }
 
           const rendering = renderingRow.data as WebRenderingOutput
-          const htmlSections = rendering.sections.map((s) => s.html)
+          // Filter out pruned sections before extracting image IDs
+          const sectioningRow = storage.getLatestNodeData("page-sectioning", page.pageId)
+          const sectioning = sectioningRow?.data as PageSectioningOutput | undefined
+          const htmlSections = rendering.sections
+            .filter((s) => !sectioning?.sections[s.sectionIndex]?.isPruned)
+            .map((s) => s.html)
           const imageIds = extractImageIds(htmlSections)
 
           if (imageIds.length === 0) {

--- a/apps/studio/src/api/client.ts
+++ b/apps/studio/src/api/client.ts
@@ -420,12 +420,13 @@ export const api = {
       body: JSON.stringify(data),
     }),
 
-  reRenderPage: (label: string, pageId: string, apiKey: string, sectionIndex?: number) =>
+  reRenderPage: (label: string, pageId: string, apiKey: string, sectionIndex?: number, prompt?: string) =>
     request<{ version: number; rendering: { sections: SectionRendering[] } }>(
       `/books/${label}/pages/${pageId}/re-render${sectionIndex !== undefined ? `?sectionIndex=${sectionIndex}` : ""}`,
       {
         method: "POST",
         headers: { "X-OpenAI-Key": apiKey },
+        ...(prompt ? { body: JSON.stringify({ prompt }) } : {}),
         signal: AbortSignal.timeout(120_000),
       }
     ),

--- a/apps/studio/src/components/pipeline/stages/SectionDataPanel.tsx
+++ b/apps/studio/src/components/pipeline/stages/SectionDataPanel.tsx
@@ -9,6 +9,7 @@ import {
   Loader2,
   Merge,
   Plus,
+  RefreshCw,
   Trash2,
   X,
 } from "lucide-react"
@@ -55,6 +56,7 @@ interface SectionDataPanelProps {
   onMergeSection: (dir: "prev" | "next") => void
   onCloneSection: () => void
   onDeleteSection: () => void
+  onRerender: (prompt?: string) => void
   onAddImage: () => void
   // Version picker
   versionPickerNode: ReactNode
@@ -63,8 +65,10 @@ interface SectionDataPanelProps {
   cloning: boolean
   deleting: boolean
   saving: boolean
+  rerendering: boolean
   dirty: boolean
   renderingDirty: boolean
+  hasApiKey: boolean
   showPrunedImages: boolean
   onToggleShowPrunedImages: () => void
 }
@@ -151,14 +155,17 @@ export function SectionDataPanel({
   onMergeSection,
   onCloneSection,
   onDeleteSection,
+  onRerender,
   onAddImage,
   versionPickerNode,
   merging,
   cloning,
   deleting,
   saving,
+  rerendering,
   dirty,
   renderingDirty,
+  hasApiKey,
   showPrunedImages,
   onToggleShowPrunedImages,
 }: SectionDataPanelProps) {
@@ -166,6 +173,10 @@ export function SectionDataPanel({
 
   const hasTextParts = parts.some((p) => p.type === "text_group")
   const hasImageParts = parts.some((p) => p.type === "image")
+
+  // Re-render prompt popover state
+  const [rerenderOpen, setRerenderOpen] = useState(false)
+  const [rerenderPrompt, setRerenderPrompt] = useState("")
 
   // -- Group drag state --
   const [dragGroupIdx, setDragGroupIdx] = useState<number | null>(null)
@@ -327,117 +338,160 @@ export function SectionDataPanel({
       }`}
     >
       {/* Panel header */}
-      <div className="flex items-center gap-2 px-4 py-2 border-b text-xs text-muted-foreground">
-        <span className="font-medium uppercase tracking-wider">Content</span>
-        {sectionTypes ? (
-          <Select
-            value={section.sectionType}
-            onValueChange={onChangeSectionType}
-          >
-            <SelectTrigger className="h-6 text-[10px] font-medium px-1.5 py-0 w-auto min-w-[80px] border-0 bg-muted/50">
-              <SelectValue>{section.sectionType}</SelectValue>
-            </SelectTrigger>
-            <SelectContent>
-              {Object.entries(sectionTypes).map(([key, desc]) => (
-                <SelectItem key={key} value={key} className="text-xs">
-                  {key}
-                  <span className="ml-1 text-muted-foreground text-[10px]">
-                    {desc}
-                  </span>
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        ) : (
-          <span className="font-medium">{section.sectionType}</span>
-        )}
-        {!section.isPruned && (
-          <>
-            <span
-              className="w-3.5 h-3.5 rounded border"
-              style={{ backgroundColor: section.backgroundColor }}
-              title={`Background: ${section.backgroundColor}`}
-            />
-            <span
-              className="w-3.5 h-3.5 rounded border"
-              style={{ backgroundColor: section.textColor }}
-              title={`Text color: ${section.textColor}`}
-            />
-          </>
-        )}
-        <div className="ml-auto flex items-center gap-1.5">
-          <button
-            type="button"
-            onClick={onToggleSectionPruned}
-            className="p-0.5 rounded hover:bg-accent transition-colors cursor-pointer"
-            title={
-              section.isPruned
-                ? "Include section in render"
-                : "Exclude section from render"
-            }
-          >
-            {section.isPruned ? (
-              <EyeOff className="h-3.5 w-3.5 text-muted-foreground" />
-            ) : (
-              <Eye className="h-3.5 w-3.5 text-muted-foreground" />
-            )}
-          </button>
-          {sectionIndex > 0 && (
+      <div className="border-b">
+        <div className="flex items-center gap-2 px-4 py-2 text-xs text-muted-foreground">
+          <span className="font-medium uppercase tracking-wider">Content</span>
+          {sectionTypes ? (
+            <Select
+              value={section.sectionType}
+              onValueChange={onChangeSectionType}
+            >
+              <SelectTrigger className="h-6 text-[10px] font-medium px-1.5 py-0 w-auto min-w-[80px] border-0 bg-muted/50">
+                <SelectValue>{section.sectionType}</SelectValue>
+              </SelectTrigger>
+              <SelectContent>
+                {Object.entries(sectionTypes).map(([key, desc]) => (
+                  <SelectItem key={key} value={key} className="text-xs">
+                    {key}
+                    <span className="ml-1 text-muted-foreground text-[10px]">
+                      {desc}
+                    </span>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          ) : (
+            <span className="font-medium">{section.sectionType}</span>
+          )}
+          {/* Re-render button — right next to section type */}
+          <div className="relative">
             <button
               type="button"
-              onClick={() => onMergeSection("prev")}
-              disabled={merging || dirty || renderingDirty || saving}
+              onClick={() => setRerenderOpen(!rerenderOpen)}
+              disabled={rerendering || dirty || renderingDirty || saving || !hasApiKey}
+              className="p-0.5 rounded hover:bg-accent transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-default"
+              title={
+                !hasApiKey
+                  ? "API key required to re-render"
+                  : dirty || renderingDirty
+                    ? "Save changes before re-rendering"
+                    : "Re-render this section"
+              }
+            >
+              {rerendering ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <RefreshCw className="h-3.5 w-3.5 text-blue-600" />
+              )}
+            </button>
+            {rerenderOpen && (
+              <div className="absolute left-0 top-full mt-1 z-50 w-72 rounded-lg border bg-popover p-3 shadow-lg">
+                <p className="text-xs font-medium mb-2">Re-render section</p>
+                <textarea
+                  value={rerenderPrompt}
+                  onChange={(e) => setRerenderPrompt(e.target.value)}
+                  placeholder="Optional instructions for the LLM..."
+                  className="w-full text-xs rounded border bg-background px-2 py-1.5 resize-none focus:outline-none focus:ring-1 focus:ring-ring"
+                  rows={3}
+                />
+                <div className="flex items-center justify-end gap-2 mt-2">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setRerenderOpen(false)
+                      setRerenderPrompt("")
+                    }}
+                    className="text-xs px-2 py-1 rounded hover:bg-accent transition-colors cursor-pointer"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      onRerender(rerenderPrompt.trim() || undefined)
+                      setRerenderOpen(false)
+                      setRerenderPrompt("")
+                    }}
+                    className="text-xs px-2.5 py-1 rounded bg-primary text-primary-foreground hover:bg-primary/90 transition-colors cursor-pointer"
+                  >
+                    Re-render
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+          <div className="ml-auto flex items-center gap-1.5">
+            <button
+              type="button"
+              onClick={onToggleSectionPruned}
+              className="p-0.5 rounded hover:bg-accent transition-colors cursor-pointer"
+              title={
+                section.isPruned
+                  ? "Include section in render"
+                  : "Exclude section from render"
+              }
+            >
+              {section.isPruned ? (
+                <EyeOff className="h-3.5 w-3.5 text-muted-foreground" />
+              ) : (
+                <Eye className="h-3.5 w-3.5 text-muted-foreground" />
+              )}
+            </button>
+            {sectionIndex > 0 && (
+              <button
+                type="button"
+                onClick={() => onMergeSection("prev")}
+                disabled={merging || dirty || renderingDirty || saving}
+                className="p-0.5 rounded hover:bg-accent transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-default"
+                title={
+                  dirty || renderingDirty
+                    ? "Save changes before merging"
+                    : "Merge with previous section"
+                }
+              >
+                {merging ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <Merge className="h-3.5 w-3.5 rotate-180" />
+                )}
+              </button>
+            )}
+            {sectionIndex < sectionCount - 1 && (
+              <button
+                type="button"
+                onClick={() => onMergeSection("next")}
+                disabled={merging || dirty || renderingDirty || saving}
+                className="p-0.5 rounded hover:bg-accent transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-default"
+                title={
+                  dirty || renderingDirty
+                    ? "Save changes before merging"
+                    : "Merge with next section"
+                }
+              >
+                {merging ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <Merge className="h-3.5 w-3.5" />
+                )}
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={onCloneSection}
+              disabled={cloning || dirty || renderingDirty || saving}
               className="p-0.5 rounded hover:bg-accent transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-default"
               title={
                 dirty || renderingDirty
-                  ? "Save changes before merging"
-                  : "Merge with previous section"
+                  ? "Save changes before cloning"
+                  : "Clone this section"
               }
             >
-              {merging ? (
+              {cloning ? (
                 <Loader2 className="h-3.5 w-3.5 animate-spin" />
               ) : (
-                <Merge className="h-3.5 w-3.5 rotate-180" />
+                <Copy className="h-3.5 w-3.5" />
               )}
             </button>
-          )}
-          {sectionIndex < sectionCount - 1 && (
-            <button
-              type="button"
-              onClick={() => onMergeSection("next")}
-              disabled={merging || dirty || renderingDirty || saving}
-              className="p-0.5 rounded hover:bg-accent transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-default"
-              title={
-                dirty || renderingDirty
-                  ? "Save changes before merging"
-                  : "Merge with next section"
-              }
-            >
-              {merging ? (
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
-              ) : (
-                <Merge className="h-3.5 w-3.5" />
-              )}
-            </button>
-          )}
-          <button
-            type="button"
-            onClick={onCloneSection}
-            disabled={cloning || dirty || renderingDirty || saving}
-            className="p-0.5 rounded hover:bg-accent transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-default"
-            title={
-              dirty || renderingDirty
-                ? "Save changes before cloning"
-                : "Clone this section"
-            }
-          >
-            {cloning ? (
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-            ) : (
-              <Copy className="h-3.5 w-3.5" />
-            )}
-          </button>
-          {sectionCount > 1 && (
             <button
               type="button"
               onClick={onDeleteSection}
@@ -455,20 +509,38 @@ export function SectionDataPanel({
                 <Trash2 className="h-3.5 w-3.5 text-red-600" />
               )}
             </button>
-          )}
-          {versionPickerNode}
-          <button
-            type="button"
-            onClick={onClose}
-            className="p-0.5 rounded hover:bg-accent transition-colors cursor-pointer"
-          >
-            <X className="h-3.5 w-3.5" />
-          </button>
+            {versionPickerNode}
+            <button
+              type="button"
+              onClick={onClose}
+              className="p-0.5 rounded hover:bg-accent transition-colors cursor-pointer"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          </div>
         </div>
+        {/* Page row — background & text color */}
+        {!section.isPruned && (
+          <div className="flex items-center gap-2 px-4 py-1.5 text-xs text-muted-foreground border-t">
+            <span className="font-medium uppercase tracking-wider">Page</span>
+            <span
+              className="w-3.5 h-3.5 rounded border"
+              style={{ backgroundColor: section.backgroundColor }}
+              title={`Background: ${section.backgroundColor}`}
+            />
+            <span className="text-[10px]">{section.backgroundColor}</span>
+            <span
+              className="w-3.5 h-3.5 rounded border ml-2"
+              style={{ backgroundColor: section.textColor }}
+              title={`Text color: ${section.textColor}`}
+            />
+            <span className="text-[10px]">{section.textColor}</span>
+          </div>
+        )}
       </div>
 
       {/* Panel body — scrollable */}
-      <div className="overflow-auto h-[calc(100%-41px)] px-4 py-3 space-y-5">
+      <div className="overflow-auto flex-1 px-4 py-3 space-y-5">
         {/* Text groups */}
         <div>
           <h3 className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">

--- a/apps/studio/src/components/pipeline/stages/StoryboardSectionDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/StoryboardSectionDetail.tsx
@@ -22,6 +22,14 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { Input } from "@/components/ui/input"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog"
 
 // -- AI loading messages --
 
@@ -300,8 +308,12 @@ export function StoryboardSectionDetail({
   const [rerendering, setRerendering] = useState(false)
   const [merging, setMerging] = useState(false)
   const [deleting, setDeleting] = useState(false)
+  const [confirmDeleteSection, setConfirmDeleteSection] = useState(false)
   const [pendingSectioning, setPendingSectioning] = useState<SectioningData | null>(null)
   const [pendingRendering, setPendingRendering] = useState<RenderingData | null>(null)
+  // Tracks whether pending sectioning changes require LLM re-render on save.
+  // Pure prune/delete can be resolved locally; unprune/type change/reorder need LLM.
+  const needsRerenderRef = useRef(false)
 
   // Inline editing state
   const [selectedElement, setSelectedElement] = useState<{
@@ -421,6 +433,7 @@ export function StoryboardSectionDetail({
     setRerendering(false)
     setSaving(false)
     setActivityPreviewMode(false)
+    needsRerenderRef.current = false
   }, [pageId, sectionIndex])
 
   // Reset scroll position when page or section changes
@@ -455,27 +468,66 @@ export function StoryboardSectionDetail({
     if (!pendingSectioning) return
     setSaving(true)
     setPanelOpen(false)
+    const shouldRerender = needsRerenderRef.current
     try {
       const minDelay = new Promise((r) => setTimeout(r, 400))
+
+      // Before saving, strip pruned elements from the rendered HTML so they
+      // disappear from the preview without needing an LLM re-render.
+      let renderingFromPrune: RenderingData | null = null
+      const sectionToSave = pendingSectioning.sections[sectionIndex]
+      if (sectionToSave) {
+        const prunedIds: string[] = []
+        for (const p of sectionToSave.parts ?? []) {
+          if (p.type === "image" && p.isPruned) {
+            prunedIds.push(p.imageId)
+          } else if (p.type === "text_group") {
+            const actualIds = resolveGroupDataIds(p.groupId)
+            if (p.isPruned) {
+              prunedIds.push(...actualIds)
+            } else {
+              p.texts.forEach((t, ti) => {
+                if (t.isPruned && actualIds[ti]) {
+                  prunedIds.push(actualIds[ti])
+                }
+              })
+            }
+          }
+        }
+        if (prunedIds.length > 0) {
+          renderingFromPrune = removeElementsFromRendering(prunedIds)
+        }
+      }
+
       await api.updateSectioning(bookLabel, pageId, pendingSectioning)
+
+      // Save rendering if dirty (from delete/prune removing HTML elements).
+      // Use renderingFromPrune if we just stripped pruned elements above,
+      // since React state won't have updated yet within this async call.
+      const renderingToSave = renderingFromPrune ?? pendingRendering
+      if (renderingToSave) {
+        await api.updateRendering(bookLabel, pageId, renderingToSave)
+      }
+
       setPendingSectioning(null)
+      setPendingRendering(null)
+      setAiReasoning(null)
+      needsRerenderRef.current = false
       await queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "pages", pageId] })
       await minDelay
 
-      // Automatically re-render with the updated sectioning
-      if (hasApiKey) {
+      // Only re-render when changes require LLM (e.g., unprune, type change, reorder)
+      // Skip for pure prune/delete — those are already handled by local HTML removal
+      if (shouldRerender && hasApiKey) {
         setRerendering(true)
         const capturedPageId = pageId
         api.reRenderPage(bookLabel, pageId, apiKey, sectionIndex)
           .then(() => {
-            // Discard if user navigated to a different page
             if (pageIdRef.current !== capturedPageId) return
             queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "pages", capturedPageId] })
             queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "pages"] })
           })
-          .catch(() => {
-            // Re-render failed — overlay will be cleared by finally
-          })
+          .catch(() => {})
           .finally(() => {
             if (pageIdRef.current === capturedPageId) {
               setRerendering(false)
@@ -491,6 +543,7 @@ export function StoryboardSectionDetail({
 
   const discardSectioning = () => {
     setPendingSectioning(null)
+    needsRerenderRef.current = false
   }
 
   // Save rendering (including back-propagation to sectioning)
@@ -578,16 +631,19 @@ export function StoryboardSectionDetail({
   }
 
   // Delete current section
-  const handleDeleteSection = async () => {
+  const handleDeleteSection = () => {
     if (deleting || dirty || renderingDirty || saving) return
-    const totalSections = sectioningData?.sections.length ?? 0
-    if (totalSections <= 1) return
+    setConfirmDeleteSection(true)
+  }
+
+  const confirmAndDeleteSection = async () => {
+    setConfirmDeleteSection(false)
     setDeleting(true)
     try {
       const result = await api.deleteSection(bookLabel, pageId, sectionIndex)
       await queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "pages", pageId] })
       await queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "pages"] })
-      onNavigateSection?.(Math.min(sectionIndex, result.remainingSections - 1))
+      onNavigateSection?.(Math.max(0, Math.min(sectionIndex, result.remainingSections - 1)))
     } catch (err) {
       setAiError(err instanceof Error ? err.message : "Delete failed")
     } finally {
@@ -595,31 +651,142 @@ export function StoryboardSectionDetail({
     }
   }
 
-  // Delete selected block from rendered HTML
-  const handleDeleteBlock = useCallback(
-    (dataId: string) => {
+  // Manually trigger a re-render of the current section
+  const handleRerender = (prompt?: string) => {
+    if (rerendering || dirty || renderingDirty || saving || !hasApiKey) return
+    setRerendering(true)
+    setPanelOpen(false)
+    const capturedPageId = pageId
+    api.reRenderPage(bookLabel, pageId, apiKey, sectionIndex, prompt)
+      .then(() => {
+        if (pageIdRef.current !== capturedPageId) return
+        queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "pages", capturedPageId] })
+        queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "pages"] })
+      })
+      .catch((err) => {
+        if (pageIdRef.current === capturedPageId) {
+          setAiError(err instanceof Error ? err.message : "Re-render failed")
+        }
+      })
+      .finally(() => {
+        if (pageIdRef.current === capturedPageId) {
+          setRerendering(false)
+        }
+      })
+  }
+
+  // Resolve the actual data-ids for a text group's elements from the current rendering HTML.
+  // Returns data-ids in document order, which stays in sync with the sectioning texts array
+  // even after local edits (delete/duplicate) that shift positional indices.
+  const resolveGroupDataIds = useCallback(
+    (groupId: string): string[] => {
+      const rBase = pendingRendering ?? page.rendering
+      if (!rBase) return []
+      const currentSection = getRenderedSectionByIndex(rBase, sectionIndex)
+      if (!currentSection?.html) return []
+      const parser = new DOMParser()
+      const doc = parser.parseFromString(currentSection.html, "text/html")
+      const elements = doc.querySelectorAll(`[data-id^="${groupId}_tx"]`)
+      return Array.from(elements).map(el => el.getAttribute("data-id")!).filter(Boolean)
+    },
+    [pendingRendering, page.rendering, sectionIndex]
+  )
+
+  // Remove one or more data-id elements from the rendered HTML and update pendingRendering.
+  // Returns the updated rendering, or null if nothing changed.
+  const removeElementsFromRendering = useCallback(
+    (dataIds: string[]): RenderingData | null => {
+      const rBase = pendingRendering ?? page.rendering
+      if (!rBase) return null
+      const currentSection = getRenderedSectionByIndex(rBase, sectionIndex)
+      if (!currentSection?.html) return null
+
+      const parser = new DOMParser()
+      const doc = parser.parseFromString(currentSection.html, "text/html")
+      let removed = false
+
+      for (const dataId of dataIds) {
+        const el = doc.querySelector(`[data-id="${dataId}"]`)
+        if (!el) continue
+
+        const blockParent = el.closest("div, p, figure, li, tr, section[data-section-id]")
+        if (blockParent && blockParent.getAttribute("data-section-id")) {
+          el.remove()
+        } else if (blockParent && blockParent.querySelectorAll("[data-id]").length <= 1) {
+          blockParent.remove()
+        } else {
+          el.remove()
+        }
+        removed = true
+      }
+
+      if (!removed) return null
+
+      const newHtml = doc.querySelector("section[data-section-id]")?.outerHTML ?? doc.body.innerHTML
+      const updated: RenderingData = {
+        ...rBase,
+        sections: rBase.sections.map((s) => {
+          if (s.sectionIndex !== sectionIndex) return s
+          return { ...s, html: newHtml }
+        }),
+      }
+      setPendingRendering(updated)
+      return updated
+    },
+    [pendingRendering, page.rendering, sectionIndex]
+  )
+
+  // Clone data-id elements in the rendered HTML and insert after the originals.
+  // `mappings` is an array of { sourceDataId, newDataId } pairs.
+  // For group duplication, pass all text entries of the source group mapped to new IDs.
+  const duplicateElementsInRendering = useCallback(
+    (mappings: Array<{ sourceDataId: string; newDataId: string }>) => {
       const rBase = pendingRendering ?? page.rendering
       if (!rBase) return
       const currentSection = getRenderedSectionByIndex(rBase, sectionIndex)
       if (!currentSection?.html) return
 
-      // Remove the element with this data-id from the HTML
       const parser = new DOMParser()
       const doc = parser.parseFromString(currentSection.html, "text/html")
-      const el = doc.querySelector(`[data-id="${dataId}"]`)
-      if (!el) return
 
-      // For block-level elements (divs, sections), remove the element
-      // For inline elements, remove closest block parent if it only contains this element
-      const blockParent = el.closest("div, p, figure, li, tr, section[data-section-id]")
-      if (blockParent && blockParent.getAttribute("data-section-id")) {
-        // Don't remove the outer section wrapper — just remove the element itself
-        el.remove()
-      } else if (blockParent && blockParent.querySelectorAll("[data-id]").length <= 1) {
-        // This block only contains the target element — remove the whole block
-        blockParent.remove()
-      } else {
-        el.remove()
+      // Resolve each source element's block-level target (the node we insert after)
+      function getBlockTarget(el: Element): Element {
+        const blockParent = el.closest("div, p, figure, li, tr")
+        return blockParent && !blockParent.getAttribute("data-section-id") ? blockParent : el
+      }
+
+      // Find the last source element to use as insertion anchor — all clones go after it
+      // so duplicated groups appear together rather than interleaved with originals.
+      let lastTarget: Element | null = null
+      const clones: Element[] = []
+
+      for (const { sourceDataId, newDataId } of mappings) {
+        const el = doc.querySelector(`[data-id="${sourceDataId}"]`)
+        if (!el) continue
+
+        const clone = el.cloneNode(true) as Element
+        clone.setAttribute("data-id", newDataId)
+
+        const target = getBlockTarget(el)
+        lastTarget = target
+
+        // Wrap clone in block parent copy if source was wrapped
+        if (target !== el) {
+          const bp = target.cloneNode(false) as Element
+          bp.appendChild(clone)
+          clones.push(bp)
+        } else {
+          clones.push(clone)
+        }
+      }
+
+      if (!lastTarget || clones.length === 0) return
+
+      // Insert all clones after the last source element's block target
+      const insertionRef = lastTarget.nextSibling
+      const parent = lastTarget.parentNode
+      for (const c of clones) {
+        parent?.insertBefore(c, insertionRef)
       }
 
       const newHtml = doc.querySelector("section[data-section-id]")?.outerHTML ?? doc.body.innerHTML
@@ -631,8 +798,16 @@ export function StoryboardSectionDetail({
         }),
       }
       setPendingRendering(updated)
+    },
+    [pendingRendering, page.rendering, sectionIndex]
+  )
 
-      // Also prune matching part in sectioning if it exists
+  // Delete selected block from rendered HTML
+  const handleDeleteBlock = useCallback(
+    (dataId: string) => {
+      removeElementsFromRendering([dataId])
+
+      // Also delete matching part from sectioning (not just prune)
       const sBase = pendingSectioning ?? page.sectioning
       if (sBase) {
         const loc = findTextByDataId(parts, dataId)
@@ -647,10 +822,7 @@ export function StoryboardSectionDetail({
                   if (pi !== loc.partIndex || p.type !== "text_group") return p
                   return {
                     ...p,
-                    texts: p.texts.map((t, ti) => {
-                      if (ti !== loc.textIndex) return t
-                      return { ...t, isPruned: true }
-                    }),
+                    texts: p.texts.filter((_, ti) => ti !== loc.textIndex),
                   }
                 }),
               }
@@ -658,7 +830,7 @@ export function StoryboardSectionDetail({
           }
           setPendingSectioning(updatedSectioning)
         } else {
-          // Image
+          // Image — filter out entirely
           const imgIdx = parts.findIndex((p) => p.type === "image" && p.imageId === dataId)
           if (imgIdx >= 0) {
             const updatedSectioning: SectioningData = {
@@ -667,10 +839,7 @@ export function StoryboardSectionDetail({
                 if (si !== sectionIndex) return s
                 return {
                   ...s,
-                  parts: s.parts.map((p, pi) => {
-                    if (pi !== imgIdx) return p
-                    return { ...p, isPruned: true }
-                  }),
+                  parts: s.parts.filter((_, pi) => pi !== imgIdx),
                 }
               }),
             }
@@ -681,13 +850,16 @@ export function StoryboardSectionDetail({
 
       setSelectedElement(null)
     },
-    [pendingRendering, page.rendering, pendingSectioning, page.sectioning, sectionIndex, parts]
+    [removeElementsFromRendering, pendingSectioning, page.sectioning, sectionIndex, parts]
   )
 
   // Toggle isPruned on a part within the current section
   const togglePartPruned = (partIndex: number) => {
     const base = pendingSectioning ?? page.sectioning
     if (!base) return
+    // Unpruning requires re-render to add the element back to HTML
+    const currentPart = base.sections[sectionIndex]?.parts[partIndex]
+    if (currentPart?.isPruned) needsRerenderRef.current = true
     const updated: SectioningData = {
       ...base,
       sections: base.sections.map((s, si) => {
@@ -708,6 +880,8 @@ export function StoryboardSectionDetail({
   const toggleSectionPruned = () => {
     const base = pendingSectioning ?? page.sectioning
     if (!base) return
+    // Unpruning requires re-render
+    if (base.sections[sectionIndex]?.isPruned) needsRerenderRef.current = true
     const updated: SectioningData = {
       ...base,
       sections: base.sections.map((s, si) => {
@@ -720,6 +894,7 @@ export function StoryboardSectionDetail({
 
   // Change section type
   const changeSectionType = (newType: string) => {
+    needsRerenderRef.current = true
     const base = pendingSectioning ?? page.sectioning
     if (!base) return
     const updated: SectioningData = {
@@ -734,6 +909,7 @@ export function StoryboardSectionDetail({
 
   // Change text type for a specific text entry
   const changeTextType = (partIndex: number, textIndex: number, newType: string) => {
+    needsRerenderRef.current = true
     const base = pendingSectioning ?? page.sectioning
     if (!base) return
     const updated: SectioningData = {
@@ -760,6 +936,7 @@ export function StoryboardSectionDetail({
 
   // Change group type for a specific text group
   const changeGroupType = (partIndex: number, newType: string) => {
+    needsRerenderRef.current = true
     const base = pendingSectioning ?? page.sectioning
     if (!base) return
     const updated: SectioningData = {
@@ -782,6 +959,11 @@ export function StoryboardSectionDetail({
   const toggleTextPruned = (partIndex: number, textIndex: number) => {
     const base = pendingSectioning ?? page.sectioning
     if (!base) return
+    // Unpruning requires re-render to add the element back
+    const part = base.sections[sectionIndex]?.parts[partIndex]
+    if (part?.type === "text_group" && part.texts[textIndex]?.isPruned) {
+      needsRerenderRef.current = true
+    }
     const updated: SectioningData = {
       ...base,
       sections: base.sections.map((s, si) => {
@@ -804,10 +986,17 @@ export function StoryboardSectionDetail({
     setPendingSectioning(updated)
   }
 
-  // Delete a specific text entry from a group
+  // Delete a specific text entry from a group (removes from sectioning + preview HTML)
   const deleteTextEntry = (partIndex: number, textIndex: number) => {
     const base = pendingSectioning ?? page.sectioning
     if (!base) return
+    // Resolve the actual data-id from the HTML before removing from sectioning
+    const part = parts[partIndex]
+    if (part?.type === "text_group") {
+      const actualIds = resolveGroupDataIds(part.groupId)
+      const dataId = actualIds[textIndex]
+      if (dataId) removeElementsFromRendering([dataId])
+    }
     const updated: SectioningData = {
       ...base,
       sections: base.sections.map((s, si) => {
@@ -831,6 +1020,12 @@ export function StoryboardSectionDetail({
   const duplicateTextEntry = (partIndex: number, textIndex: number) => {
     const base = pendingSectioning ?? page.sectioning
     if (!base) return
+    const part = parts[partIndex]
+    if (!part || part.type !== "text_group") return
+    const newTextId = `user_txt_${crypto.randomUUID().slice(0, 8)}`
+    const actualIds = resolveGroupDataIds(part.groupId)
+    const sourceDataId = actualIds[textIndex]
+    const newDataId = `${part.groupId}_tx_${crypto.randomUUID().slice(0, 8)}`
     const updated: SectioningData = {
       ...base,
       sections: base.sections.map((s, si) => {
@@ -840,7 +1035,7 @@ export function StoryboardSectionDetail({
           parts: s.parts.map((p, pi) => {
             if (pi !== partIndex || p.type !== "text_group") return p
             const newTexts = [...p.texts]
-            const cloned = { ...p.texts[textIndex], textId: `user_txt_${crypto.randomUUID().slice(0, 8)}` }
+            const cloned = { ...p.texts[textIndex], textId: newTextId }
             newTexts.splice(textIndex + 1, 0, cloned)
             return { ...p, texts: newTexts }
           }),
@@ -848,10 +1043,15 @@ export function StoryboardSectionDetail({
       }),
     }
     setPendingSectioning(updated)
+    // Clone the element in the preview HTML
+    if (sourceDataId) {
+      duplicateElementsInRendering([{ sourceDataId, newDataId }])
+    }
   }
 
   // Add a new empty text group
   const addGroup = () => {
+    needsRerenderRef.current = true
     const base = pendingSectioning ?? page.sectioning
     if (!base) return
     const newGroup = {
@@ -876,16 +1076,23 @@ export function StoryboardSectionDetail({
   const duplicateGroup = (partIndex: number) => {
     const base = pendingSectioning ?? page.sectioning
     if (!base) return
+    const srcPart = parts[partIndex]
+    if (!srcPart || srcPart.type !== "text_group") return
+    const newGroupId = `user_grp_${crypto.randomUUID().slice(0, 8)}`
+    // Build mappings from actual HTML data-ids to new data-ids for the preview clone
+    const actualSourceIds = resolveGroupDataIds(srcPart.groupId)
+    const mappings = actualSourceIds.map((sourceDataId, ti) => ({
+      sourceDataId,
+      newDataId: `${newGroupId}_tx${String(ti + 1).padStart(3, "0")}`,
+    }))
     const updated: SectioningData = {
       ...base,
       sections: base.sections.map((s, si) => {
         if (si !== sectionIndex) return s
-        const srcPart = s.parts[partIndex]
-        if (!srcPart || srcPart.type !== "text_group") return s
         const cloned = structuredClone(srcPart)
         const clone = {
           ...cloned,
-          groupId: `user_grp_${crypto.randomUUID().slice(0, 8)}`,
+          groupId: newGroupId,
           texts: cloned.texts.map((t: { textId: string; textType: string; text: string; isPruned: boolean }) => ({
             ...t,
             textId: `user_txt_${crypto.randomUUID().slice(0, 8)}`,
@@ -897,12 +1104,20 @@ export function StoryboardSectionDetail({
       }),
     }
     setPendingSectioning(updated)
+    // Clone the elements in the preview HTML
+    duplicateElementsInRendering(mappings)
   }
 
-  // Delete a text group
+  // Delete a text group (removes from sectioning + preview HTML)
   const deleteGroup = (partIndex: number) => {
     const base = pendingSectioning ?? page.sectioning
     if (!base) return
+    // Remove all text elements belonging to this group from the preview
+    const part = parts[partIndex]
+    if (part?.type === "text_group") {
+      const dataIds = resolveGroupDataIds(part.groupId)
+      if (dataIds.length > 0) removeElementsFromRendering(dataIds)
+    }
     const updated: SectioningData = {
       ...base,
       sections: base.sections.map((s, si) => {
@@ -915,6 +1130,7 @@ export function StoryboardSectionDetail({
 
   // Reorder parts within the section
   const reorderParts = (fromIndex: number, toIndex: number) => {
+    needsRerenderRef.current = true
     const base = pendingSectioning ?? page.sectioning
     if (!base) return
     const updated: SectioningData = {
@@ -937,6 +1153,7 @@ export function StoryboardSectionDetail({
     toPartIndex: number,
     toTextIndex: number
   ) => {
+    needsRerenderRef.current = true
     const base = pendingSectioning ?? page.sectioning
     if (!base) return
     const updated: SectioningData = {
@@ -1771,7 +1988,15 @@ export function StoryboardSectionDetail({
 
       {/* Preview — fills remaining space, scrolls independently */}
       <div className="flex-1 overflow-auto px-4 py-4 relative" ref={scrollContainerRef}>
-        {renderedSection?.html ? (
+        {!section ? (
+          <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
+            <div className="w-12 h-12 rounded-full bg-muted/50 flex items-center justify-center mb-3">
+              <LayoutGrid className="w-6 h-6 text-muted-foreground/40" />
+            </div>
+            <p className="text-sm font-medium">No sections on this page</p>
+            <p className="text-xs mt-1">All sections have been deleted</p>
+          </div>
+        ) : renderedSection?.html ? (
           <>
             {activityPreviewMode ? (
               <iframe
@@ -1804,7 +2029,7 @@ export function StoryboardSectionDetail({
         )}
 
         {/* Pruned section overlay */}
-        {section.isPruned && !aiLoading && !rerendering && (
+        {section?.isPruned && !aiLoading && !rerendering && (
           <div className="absolute inset-0 z-30 bg-background/60 backdrop-blur-[1px] flex items-center justify-center">
             <div className="flex flex-col items-center gap-3 text-center max-w-xs">
               <div className="w-10 h-10 rounded-full bg-amber-100 flex items-center justify-center">
@@ -2026,6 +2251,7 @@ export function StoryboardSectionDetail({
         onMergeSection={handleMergeSection}
         onCloneSection={handleCloneSection}
         onDeleteSection={handleDeleteSection}
+        onRerender={handleRerender}
         onAddImage={() => setAddImageDialogOpen(true)}
         versionPickerNode={
           <VersionPicker
@@ -2050,8 +2276,10 @@ export function StoryboardSectionDetail({
         cloning={cloning}
         deleting={deleting}
         saving={saving}
+        rerendering={rerendering}
         dirty={dirty}
         renderingDirty={renderingDirty}
+        hasApiKey={hasApiKey}
         showPrunedImages={showPrunedImages}
         onToggleShowPrunedImages={() => setShowPrunedImages((v) => !v)}
       />
@@ -2108,6 +2336,34 @@ export function StoryboardSectionDetail({
         onClose={() => setAddImageDialogOpen(false)}
       />
     )}
+
+    {/* Delete section confirmation dialog */}
+    <Dialog open={confirmDeleteSection} onOpenChange={setConfirmDeleteSection}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Delete section</DialogTitle>
+          <DialogDescription>
+            Are you sure you want to delete this section? This action cannot be undone.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <button
+            type="button"
+            onClick={() => setConfirmDeleteSection(false)}
+            className="px-3 py-1.5 text-sm rounded border hover:bg-accent transition-colors cursor-pointer"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={confirmAndDeleteSection}
+            className="px-3 py-1.5 text-sm rounded bg-destructive text-destructive-foreground hover:bg-destructive/90 transition-colors cursor-pointer"
+          >
+            Delete
+          </button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
     </>
   )
 }

--- a/packages/pipeline/src/glossary.ts
+++ b/packages/pipeline/src/glossary.ts
@@ -3,6 +3,7 @@ import type { AppConfig, GlossaryItem, GlossaryOutput } from "@adt/types"
 import {
   glossaryLLMSchema,
   WebRenderingOutput,
+  PageSectioningOutput,
   DEFAULT_LLM_MAX_RETRIES,
 } from "@adt/types"
 import type { LLMModel } from "@adt/llm"
@@ -60,7 +61,12 @@ export function collectPageTexts(
       )
     }
     const rendering = parsed.data
-    const htmlParts = rendering.sections.map((s) => s.html)
+    // Filter out pruned sections
+    const sectioningRow = storage.getLatestNodeData("page-sectioning", page.pageId)
+    const sectioning = sectioningRow ? PageSectioningOutput.safeParse(sectioningRow.data) : null
+    const htmlParts = rendering.sections
+      .filter((s) => !sectioning?.success || !sectioning.data.sections[s.sectionIndex]?.isPruned)
+      .map((s) => s.html)
     const text = stripHtml(htmlParts.join(" "))
     if (text.length > 0) {
       result.push({ pageNumber: page.pageNumber, text })

--- a/packages/pipeline/src/package-web.ts
+++ b/packages/pipeline/src/package-web.ts
@@ -134,10 +134,11 @@ export async function packageAdtWeb(
       if (parsed.success) {
         const rendering = parsed.data
 
-        // One HTML file per rendered section (stable by sectionIndex)
+        // One HTML file per rendered section (stable by sectionIndex), skip pruned
         const sections = [...rendering.sections].sort((a, b) => a.sectionIndex - b.sectionIndex)
         for (const rs of sections) {
           const sectionMeta = sectioning?.sections[rs.sectionIndex]
+          if (sectionMeta?.isPruned) continue
           const sectionId = sectionMeta?.sectionId ?? `${page.pageId}_sec${String(rs.sectionIndex + 1).padStart(3, "0")}`
 
           if (rs.sectionType.startsWith("activity_") || sectionMeta?.sectionType.startsWith("activity_")) {

--- a/packages/pipeline/src/pipeline-dag.ts
+++ b/packages/pipeline/src/pipeline-dag.ts
@@ -618,7 +618,11 @@ export async function runFullPipeline(
         const renderingRow = storage.getLatestNodeData("web-rendering", page.pageId)
         if (!renderingRow) return
         const rendering = renderingRow.data as WebRenderingOutput
-        const htmlSections = rendering.sections.map((s) => s.html)
+        const sectioningRow = storage.getLatestNodeData("page-sectioning", page.pageId)
+        const sectioning = sectioningRow?.data as PageSectioningOutput | undefined
+        const htmlSections = rendering.sections
+          .filter((s) => !sectioning?.sections[s.sectionIndex]?.isPruned)
+          .map((s) => s.html)
         const imageIds = extractImageIds(htmlSections)
         if (imageIds.length === 0) {
           storage.putNodeData("image-captioning", page.pageId, { captions: [] })

--- a/packages/pipeline/src/render-llm.ts
+++ b/packages/pipeline/src/render-llm.ts
@@ -111,6 +111,7 @@ export async function renderSectionLlm(
     styleguide: input.styleguide ?? "",
     viewports: getViewportBreakpoints(),
     _isActivity: isActivity,
+    user_instructions: input.userPrompt ?? "",
   }
 
   const result = await llmModel.generateObject<{

--- a/packages/pipeline/src/text-catalog.ts
+++ b/packages/pipeline/src/text-catalog.ts
@@ -7,7 +7,7 @@ import type {
   TextCatalogEntry,
   TextCatalogOutput,
 } from "@adt/types"
-import { WebRenderingOutput as WebRenderingOutputSchema } from "@adt/types"
+import { WebRenderingOutput as WebRenderingOutputSchema, PageSectioningOutput } from "@adt/types"
 import type { Storage, PageData } from "@adt/storage"
 
 /** Zero-padded 3-digit number */
@@ -25,12 +25,14 @@ function pad3(n: number): string {
 function extractPageEntries(
   pageId: string,
   rendering: WebRenderingOutput,
-  captionMap: Map<string, string>
+  captionMap: Map<string, string>,
+  prunedSectionIndices?: Set<number>
 ): TextCatalogEntry[] {
   const entries: TextCatalogEntry[] = []
   let activityCounter = 0
 
   for (const section of rendering.sections) {
+    if (prunedSectionIndices?.has(section.sectionIndex)) continue
     const doc = parseDocument(section.html)
 
     const elements = DomUtils.findAll(
@@ -149,8 +151,16 @@ export function buildTextCatalog(
     const parsed = WebRenderingOutputSchema.safeParse(renderingRow.data)
     if (!parsed.success) continue
 
+    // Determine which sections are pruned
+    const sectioningRow = storage.getLatestNodeData("page-sectioning", page.pageId)
+    const sectioningParsed = sectioningRow ? PageSectioningOutput.safeParse(sectioningRow.data) : null
+    const prunedIndices = new Set<number>()
+    if (sectioningParsed?.success) {
+      sectioningParsed.data.sections.forEach((s, i) => { if (s.isPruned) prunedIndices.add(i) })
+    }
+
     const captionMap = loadCaptionMap(storage, page.pageId)
-    entries.push(...extractPageEntries(page.pageId, parsed.data, captionMap))
+    entries.push(...extractPageEntries(page.pageId, parsed.data, captionMap, prunedIndices))
   }
 
   // Glossary

--- a/packages/pipeline/src/validate-html.ts
+++ b/packages/pipeline/src/validate-html.ts
@@ -89,6 +89,18 @@ export function validateSectionHtml(
 
   walkNode(section, allowedIds, imageIdSet, errors, options)
 
+  // Verify all expected text IDs are present in the generated HTML.
+  // This ensures the LLM doesn't silently drop entries (e.g. duplicated texts).
+  if (allowedTextIds.length > 0) {
+    const renderedDataIds = new Set<string>()
+    collectDataIds(section, renderedDataIds)
+    for (const textId of allowedTextIds) {
+      if (!renderedDataIds.has(textId)) {
+        errors.push(`Missing required text data-id: "${textId}"`)
+      }
+    }
+  }
+
   if (imageUrlPrefix) {
     rewriteImageSrcs(section, imageIdSet, imageUrlPrefix)
   }
@@ -234,6 +246,19 @@ function walkNode(
 
   if (replacementText !== undefined) {
     replaceChildrenWithText(node, replacementText)
+  }
+}
+
+/** Collect all data-id attribute values from a DOM tree. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function collectDataIds(node: any, ids: Set<string>): void {
+  if (node.type === "tag" && node.attribs?.["data-id"]) {
+    ids.add(node.attribs["data-id"])
+  }
+  if (node.children) {
+    for (const child of node.children) {
+      collectDataIds(child, ids)
+    }
   }
 }
 

--- a/packages/pipeline/src/web-rendering.ts
+++ b/packages/pipeline/src/web-rendering.ts
@@ -61,6 +61,8 @@ export interface RenderSectionInput {
   textColor: string
   parts: SectionPart[]
   styleguide?: string
+  /** Optional user instructions appended to the LLM prompt during re-render */
+  userPrompt?: string
 }
 
 export interface RenderPageInput {
@@ -70,6 +72,8 @@ export interface RenderPageInput {
   sectioning: PageSectioningOutput
   images: Map<string, { base64: string; width?: number; height?: number }>
   styleguide?: string
+  /** Optional user instructions appended to the LLM prompt during re-render */
+  userPrompt?: string
 }
 
 export type ResolveLLMModel = LLMModel | ((modelId: string) => LLMModel)
@@ -163,6 +167,7 @@ export async function renderPage(
       textColor: section.textColor,
       parts,
       styleguide: input.styleguide,
+      userPrompt: input.userPrompt,
     }
 
     let rendering: SectionRendering

--- a/prompts/web_generation_html.liquid
+++ b/prompts/web_generation_html.liquid
@@ -59,4 +59,9 @@ Content parts (in document order):
 [Image: {{ part.image_id }}]
 {% endif %}
 {% endfor %}
+{% if user_instructions != "" %}
+
+## ADDITIONAL INSTRUCTIONS FROM USER
+{{ user_instructions }}
+{% endif %}
 {% endchat %}

--- a/prompts/web_generation_html_overlay.liquid
+++ b/prompts/web_generation_html_overlay.liquid
@@ -257,4 +257,9 @@ Use this ordering plus the page image to determine the vertical position of each
 {% endfor %}
 {% endif %}
 {% endfor %}
+{% if user_instructions != "" %}
+
+## ADDITIONAL INSTRUCTIONS FROM USER
+{{ user_instructions }}
+{% endif %}
 {% endchat %}


### PR DESCRIPTION
## Summary

- **Data-id collision fix**: Resolve data-ids from actual HTML instead of computing positionally, preventing collisions when duplicating text entries. Added `resolveGroupDataIds()` helper to query rendered HTML.
- **Validation enhancement**: Add check to verify all expected text IDs are present in generated HTML, preventing LLM from silently omitting duplicated entries with identical content.
- **API input validation**: Use Zod to validate optional re-render prompt parameter (CLAUDE.md compliance).
- **Pruned section filtering**: Consistently filter pruned sections across pipeline stages (extract, glossary, text-catalog, package-web, adt-preview).
- **Delete/re-render UX**: Add confirmation dialog for section delete, allow deletion of last section, support manual re-render with optional user prompt.

## Test plan

- Duplicate text entries and verify they persist after LLM re-render
- Duplicate text groups and verify all clones appear
- Delete sections including last section and verify state
- Manual re-render with custom prompt and verify it's passed to LLM
- Verify pruned sections excluded from downstream pipeline output