### PR TITLE
Fix section menu scroll by adding flex container

### DIFF
--- a/apps/studio/src/components/pipeline/stages/SectionDataPanel.tsx
+++ b/apps/studio/src/components/pipeline/stages/SectionDataPanel.tsx
@@ -333,7 +333,7 @@ export function SectionDataPanel({
 
   return (
     <div
-      className={`absolute top-0 right-0 h-full w-[480px] bg-background border-l shadow-lg transition-transform duration-200 ease-in-out z-30 ${
+      className={`absolute top-0 right-0 h-full w-[480px] flex flex-col bg-background border-l shadow-lg transition-transform duration-200 ease-in-out z-30 ${
         open ? "translate-x-0" : "translate-x-full"
       }`}
     >


### PR DESCRIPTION
The SectionDataPanel body uses flex-1 with overflow-auto to enable scrolling, but the parent container wasn't a flex column, preventing the scroll behavior. Added flex and flex-col classes to the root container to fix the layout.