### PR TITLE
Add dynamic sectioning mode to page-sectioning

### DIFF
--- a/apps/studio/src/components/config/AdvancedLayoutPanel.tsx
+++ b/apps/studio/src/components/config/AdvancedLayoutPanel.tsx
@@ -479,6 +479,9 @@ export function AdvancedLayoutPanel({
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
+            <SelectItem value="dynamic" className="text-xs">
+              Dynamic
+            </SelectItem>
             <SelectItem value="section" className="text-xs">
               By Section
             </SelectItem>
@@ -490,7 +493,9 @@ export function AdvancedLayoutPanel({
         <p className="text-[10px] text-muted-foreground mt-1">
           {sectioningMode === "page"
             ? "Each page is treated as a single section"
-            : "Content is grouped into logical sections per page"}
+            : sectioningMode === "dynamic"
+              ? "Keeps pages whole unless mixed activity types require splitting"
+              : "Content is grouped into logical sections per page"}
         </p>
       </div>
 

--- a/apps/studio/src/components/pipeline/stages/StoryboardSettings.tsx
+++ b/apps/studio/src/components/pipeline/stages/StoryboardSettings.tsx
@@ -133,7 +133,7 @@ export function StoryboardSettings({ bookLabel, headerTarget, tab = "general" }:
   const [renderStrategyNames, setRenderStrategyNames] = useState<string[]>([])
   const [activityModel, setActivityModel] = useState("")
   const [activityRetries, setActivityRetries] = useState("")
-  const [sectioningMode, setSectioningMode] = useState("section")
+  const [sectioningMode, setSectioningMode] = useState("dynamic")
   const [renderingModel, setRenderingModel] = useState("")
   const [renderingRetries, setRenderingRetries] = useState("")
   const [renderingPromptName, setRenderingPromptName] = useState("web_generation_html")
@@ -695,6 +695,14 @@ export function StoryboardSettings({ bookLabel, headerTarget, tab = "general" }:
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent align="start">
+                  <SelectItem value="dynamic">
+                    <div className="flex flex-col items-start">
+                      <span>Dynamic</span>
+                      <span className="text-xs text-muted-foreground">
+                        Keeps pages whole unless mixed activity types require splitting
+                      </span>
+                    </div>
+                  </SelectItem>
                   <SelectItem value="section">
                     <div className="flex flex-col items-start">
                       <span>By Section</span>

--- a/config/presets/textbook.yaml
+++ b/config/presets/textbook.yaml
@@ -9,7 +9,7 @@ styleguide: default
 spread_mode: false
 
 page_sectioning:
-  mode: section
+  mode: dynamic
 
 render_strategies:
   llm:
@@ -142,6 +142,6 @@ pruned_section_types:
   - inside_cover
 
 image_filters:
-  min_side: 150
+  min_side: 50
   max_side: 3500
   min_stddev: 2

--- a/packages/pipeline/src/page-sectioning.ts
+++ b/packages/pipeline/src/page-sectioning.ts
@@ -290,6 +290,6 @@ export function buildSectioningConfig(appConfig: AppConfig): SectioningConfig {
     modelId: appConfig.page_sectioning?.model ?? "openai:gpt-5.2",
     maxRetries:
       appConfig.page_sectioning?.max_retries ?? DEFAULT_LLM_MAX_RETRIES,
-    mode: appConfig.page_sectioning?.mode ?? "section",
+    mode: appConfig.page_sectioning?.mode ?? "dynamic",
   }
 }

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -24,7 +24,7 @@ export const QuizGenerationConfig = StepConfig.extend({
 })
 export type QuizGenerationConfig = z.infer<typeof QuizGenerationConfig>
 
-export const SectioningMode = z.enum(["section", "page"])
+export const SectioningMode = z.enum(["section", "page", "dynamic"])
 export type SectioningMode = z.infer<typeof SectioningMode>
 
 export const PageSectioningConfig = StepConfig.extend({

--- a/prompts/page_sectioning.liquid
+++ b/prompts/page_sectioning.liquid
@@ -3,6 +3,10 @@
 You are a pedagogical expert at classifying textbook pages for schoolchildren.
 
 You will be shown a page image and its extracted text groups and images. Classify the page as a single section containing ALL of its content.
+{% elsif sectioning_mode == "dynamic" %}
+You are a pedagogical expert at organizing a textbook page into coherent, logical sections for schoolchildren.
+
+You will be shown a page image and its extracted text groups and images. Your default behavior is to keep the entire page as a SINGLE section. Only split into multiple sections when specific conditions are met.
 {% else %}
 You are a pedagogical expert at organizing a textbook page into coherent, logical sections for schoolchildren.
 
@@ -20,6 +24,18 @@ RULES:
 - Choose the single most appropriate section type for the page as a whole
 - ALL listed group IDs and ALL listed image IDs must be assigned to this one section
 - If no image IDs are listed below, do NOT include any image IDs in part_ids
+{% elsif sectioning_mode == "dynamic" %}
+- DEFAULT: Keep all content in a SINGLE section. Prefer one section per page.
+- SPLIT the page into multiple sections when ANY of these conditions are true:
+  1. The page contains MULTIPLE DISTINCT activity types (e.g., open-ended questions followed by a sorting activity followed by multiple choice).
+  2. The page contains MULTIPLE multiple-choice questions — each multiple-choice question (its prompt and answer choices) MUST become its own separate section so the user only sees one question at a time.
+  3. The page contains MULTIPLE true/false questions — same rule, one question per section.
+- EXCEPTION — do NOT split if the page is ENTIRELY open-ended answers or ENTIRELY fill-in-the-blank. These should always remain as ONE section even with many questions.
+- When splitting multiple-choice or true/false questions: put any shared header, instructions, or passage text into the FIRST section, then give each question its own section. Include the question prompt and its answer choices together in each section.
+- When splitting mixed activity types: group consecutive content of the same activity type together.
+- ALL listed group IDs must be assigned to at least one section
+- ALL listed image IDs must be assigned to at least one section — assign each image to the section it visually belongs to
+- Group/image IDs may appear in multiple sections only when it makes strong pedagogical sense (e.g. shared instructions)
 {% else %}
 - ALL listed group IDs must be assigned to at least one section
 - ALL listed image IDs must be assigned to at least one section — assign each image to the section it visually belongs to
@@ -47,6 +63,8 @@ Text groups:
 
 {% if sectioning_mode == "page" %}
 Please place ALL content into a single section.
+{% elsif sectioning_mode == "dynamic" %}
+Keep this page as a single section UNLESS it contains multiple distinct activity types OR multiple multiple-choice/true-false questions. If there are multiple multiple-choice or true/false questions, split each question into its own section. Pages that are entirely open-ended or entirely fill-in-the-blank should always stay as one section.
 {% else %}
 Please organize these into sections.
 {% endif %}


### PR DESCRIPTION
Introduces a new 'dynamic' sectioning mode that keeps pages whole by default but intelligently splits into multiple sections when they contain multiple distinct activity types or multiple multiple-choice/true-false questions.

- Updated Zod schema in `packages/types/src/config.ts` to include "dynamic" mode
- Added UI support for the new mode in both AdvancedLayoutPanel and StoryboardSettings components
- Updated page-sectioning pipeline defaults and textbook preset to use dynamic mode
- Expanded Liquid prompt template with comprehensive rules for the dynamic sectioning algorithm
- Also adjusted `image_filters.min_side` from 150 to 50 in textbook.yaml for better image inclusion