### PR TITLE
Fix container deletion in storyboard editor

### DIFF
--- a/apps/studio/src/components/pipeline/stages/BookPreviewFrame.tsx
+++ b/apps/studio/src/components/pipeline/stages/BookPreviewFrame.tsx
@@ -128,14 +128,10 @@ export const BookPreviewFrame = forwardRef<BookPreviewFrameHandle, BookPreviewFr
     el.contentEditable = 'false';
     el.style.outline = '';
     el.style.outlineOffset = '';
-    var section = document.querySelector('section');
-    var fullHtml;
-    if (section) {
-      fullHtml = section.outerHTML;
-    } else {
-      var content = document.getElementById('content');
-      fullHtml = content ? content.outerHTML : document.body.innerHTML;
-    }
+    // Grab the innerHTML of the injected wrapper div so we preserve the
+    // full stored structure (including the outer container/content div).
+    var wrapper = document.getElementById('content');
+    var fullHtml = wrapper ? wrapper.innerHTML : document.body.innerHTML;
     parent.postMessage({
       type: 'text-changed',
       dataId: el.getAttribute('data-id'),

--- a/apps/studio/src/components/pipeline/stages/StoryboardSectionDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/StoryboardSectionDetail.tsx
@@ -724,7 +724,11 @@ export function StoryboardSectionDetail({
         if (!el) continue
 
         const blockParent = el.closest("div, p, figure, li, tr, section[data-section-id]")
-        if (blockParent && blockParent.getAttribute("data-section-id")) {
+        // Guard: never remove the section wrapper or the outer content/container div
+        const isSectionWrapper = blockParent?.getAttribute("data-section-id") != null
+        const isOuterContainer =
+          blockParent?.id === "content" || blockParent?.classList.contains("container")
+        if (isSectionWrapper || isOuterContainer) {
           el.remove()
         } else if (blockParent && blockParent.querySelectorAll("[data-id]").length <= 1) {
           blockParent.remove()
@@ -736,7 +740,7 @@ export function StoryboardSectionDetail({
 
       if (!removed) return null
 
-      const newHtml = doc.querySelector("section[data-section-id]")?.outerHTML ?? doc.body.innerHTML
+      const newHtml = doc.body.innerHTML
       const updated: RenderingData = {
         ...rBase,
         sections: rBase.sections.map((s) => {
@@ -803,7 +807,7 @@ export function StoryboardSectionDetail({
         parent?.insertBefore(c, insertionRef)
       }
 
-      const newHtml = doc.querySelector("section[data-section-id]")?.outerHTML ?? doc.body.innerHTML
+      const newHtml = doc.body.innerHTML
       const updated: RenderingData = {
         ...rBase,
         sections: rBase.sections.map((s) => {


### PR DESCRIPTION
Preserve HTML structure during element removal and duplication by:
- Always serializing from doc.body.innerHTML (not section.outerHTML)
- Guarding against deletion of section wrapper and outer container divs
- Making BookPreviewFrame HTML serialization consistent with content injection

Fixes #167