### PR TITLE
Add table text group type and semantic table HTML rendering

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -25,6 +25,7 @@ text_group_types:
   paragraph: A block of continuous prose
   stanza: A verse or stanza of poetry
   list: A list of items (ordered or unordered)
+  table: A data table with rows and columns
   other: Anything that doesn't fit the above
 
 section_types:

--- a/prompts/text_classification.liquid
+++ b/prompts/text_classification.liquid
@@ -18,6 +18,7 @@ EXTRACTION RULES:
 6. For drop caps, merge the large initial letter with the rest of the word/sentence
 7. For tables of contents, each entry should be a separate text entry in a single "list" group
 8. For poetry or verse, each stanza should be a separate group with group_type "stanza"
+9. For data tables (grids with rows and columns), use a "table" group. Each cell should be a separate text entry, ordered left-to-right then top-to-bottom. Include header cells as well. Preserve the row/column structure by keeping cells in reading order — the renderer will reconstruct the table layout from the cell count and the page image.
 9. Preserve original spelling and punctuation exactly as shown
 10. If the page is blank or contains only images with no text, return an empty groups array
 11. Use the OCR text as a reference but trust the image as the primary source — correct OCR errors when the image clearly shows different text

--- a/prompts/web_generation_html_overlay.liquid
+++ b/prompts/web_generation_html_overlay.liquid
@@ -160,6 +160,35 @@ Preserve the original text alignment from the page image. Most body text and hea
 </div>
 ```
 
+**Table group (data table with rows and columns):**
+When a text group has group_type "table", render it as a semantic HTML `<table>`. Use the page image to determine the number of columns and which cells are headers (`<th>`) vs data (`<td>`). Each text entry is one cell — place them left-to-right, top-to-bottom into rows. Every `<td>` or `<th>` must have the `data-id` of its corresponding text entry.
+```html
+<div class="absolute top-[Y%] left-[X%] max-w-[W%] bg-white/85 rounded-lg p-3 z-10">
+    <table class="w-full border-collapse text-sm text-gray-800">
+        <thead>
+            <tr>
+                <th class="border border-gray-300 px-3 py-2 bg-gray-100 font-semibold text-left" data-id="[HEADER_ID_1]">Header 1</th>
+                <th class="border border-gray-300 px-3 py-2 bg-gray-100 font-semibold text-left" data-id="[HEADER_ID_2]">Header 2</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td class="border border-gray-300 px-3 py-2" data-id="[CELL_ID_1]">Cell 1</td>
+                <td class="border border-gray-300 px-3 py-2" data-id="[CELL_ID_2]">Cell 2</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+```
+For text-only layout (no images), use the same `<table>` structure without absolute positioning:
+```html
+<div class="space-y-2">
+    <table class="w-full border-collapse text-sm text-gray-800">
+        <!-- same thead/tbody structure as above -->
+    </table>
+</div>
+```
+
 **Image-overlay text group (text printed directly on the image):**
 ```html
 <div class="absolute top-[Y%] left-[X%] max-w-[W%] bg-white/85 rounded-lg p-3 z-10 space-y-1">


### PR DESCRIPTION
## Summary

Adds native support for data table extraction and HTML rendering across the pipeline:

- **Text classification**: New `table` group type to identify and capture data tables
- **Extraction rules**: LLM extracts table cells as separate text entries in row-major order
- **HTML rendering**: Semantic `<table>` elements with proper `<thead>`/`<tbody>` and `<th>`/`<td>` cells, each carrying its `data-id` for validation
- **Layout support**: Works with both overlay layout (image backgrounds) and text-only layouts

Tables are now preserved as structured data instead of being flattened into paragraphs or lists.