### PR TITLE
Fixes the double container issue in the preview and adt, which prevented the audio playback

### DIFF
--- a/apps/studio/src/components/pipeline/stages/BookPreviewFrame.tsx
+++ b/apps/studio/src/components/pipeline/stages/BookPreviewFrame.tsx
@@ -128,10 +128,19 @@ export const BookPreviewFrame = forwardRef<BookPreviewFrameHandle, BookPreviewFr
     el.contentEditable = 'false';
     el.style.outline = '';
     el.style.outlineOffset = '';
-    // Grab the innerHTML of the injected wrapper div so we preserve the
-    // full stored structure (including the outer container/content div).
     var wrapper = document.getElementById('content');
-    var fullHtml = wrapper ? wrapper.innerHTML : document.body.innerHTML;
+    var fullHtml;
+    if (wrapper) {
+      // When the LLM provides its own <div id="content" class="container ..."> wrapper,
+      // injectContent places it directly in body (no outer wrapper added). Use outerHTML
+      // to preserve the full div with its layout classes.
+      // When we injected a plain <div id="content"> wrapper ourselves (no classes),
+      // use innerHTML to return just the section content as originally stored.
+      var cls = (wrapper.getAttribute('class') || '').trim();
+      fullHtml = cls ? wrapper.outerHTML : wrapper.innerHTML;
+    } else {
+      fullHtml = document.body.innerHTML;
+    }
     parent.postMessage({
       type: 'text-changed',
       dataId: el.getAttribute('data-id'),
@@ -247,9 +256,10 @@ ${interactiveScript}
 
     // Preserve the interactive script if present
     const scriptEl = doc.body.querySelector("script")
-    // Wrap in the same <div id="content"> wrapper that renderPageHtml uses
-    // in the preview so structure matches the final output.
-    doc.body.innerHTML = `<div id="content">${newHtml}</div>`
+    // If HTML already has <div id="content">, inject directly to avoid a duplicate
+    // wrapper. Otherwise add the plain wrapper to match renderPageHtml's structure.
+    const hasOwnWrapper = /^\s*<div\b[^>]*\bid="content"/.test(newHtml)
+    doc.body.innerHTML = hasOwnWrapper ? newHtml : `<div id="content">${newHtml}</div>`
     if (scriptEl && editable) {
       doc.body.appendChild(scriptEl)
     }

--- a/packages/pipeline/src/package-web.ts
+++ b/packages/pipeline/src/package-web.ts
@@ -456,6 +456,25 @@ export interface RenderPageOptions {
   embed?: boolean
 }
 
+/**
+ * Add `opacity-0` to the first `<div id="content">` element's class list.
+ * Used when the LLM-generated content already provides its own wrapper div so
+ * we don't add a duplicate — but still need the fade-in class for the ADT animation.
+ */
+function injectOpacityClass(html: string): string {
+  return html.replace(
+    /(<div\b[^>]*\bid="content"[^>]*)>/,
+    (_, opening) => {
+      if (/\bopacity-0\b/.test(opening)) return opening + ">"
+      const hasClass = /\bclass="/.test(opening)
+      if (hasClass) {
+        return opening.replace(/\bclass="([^"]*)"/, 'class="$1 opacity-0"') + ">"
+      }
+      return opening + ' class="opacity-0">'
+    }
+  )
+}
+
 export function renderPageHtml(opts: RenderPageOptions): string {
   const mathScript = opts.hasMath
     ? `    <script src="./assets/libs/mathjax/es5/tex-mml-chtml.js"></script>\n`
@@ -466,9 +485,16 @@ export function renderPageHtml(opts: RenderPageOptions): string {
       ? `\n    <script type="text/javascript">\n        window.correctAnswers = JSON.parse('${escapeInlineScriptJson(JSON.stringify(opts.activityAnswers))}');\n    </script>`
       : ""
 
+  // When content already has <div id="content"> (LLM-generated), use it directly to avoid
+  // a duplicate #content element that breaks `body > .container` queries in the ADT JS
+  // (used for audio/TTS init, fade animation, and layout adjustments).
+  // Inject opacity-0 into the existing wrapper for the fade-in animation (skip in embed mode).
+  const contentAlreadyWrapped = /^\s*<div\b[^>]*\bid="content"/.test(opts.content)
   const contentBlock = opts.skipContentWrapper
     ? `    ${opts.content}`
-    : `    <div id="content"${opts.embed ? "" : ` class="opacity-0"`}>
+    : contentAlreadyWrapped
+      ? `    ${!opts.embed ? injectOpacityClass(opts.content) : opts.content}`
+      : `    <div id="content"${opts.embed ? "" : ` class="opacity-0"`}>
     ${opts.content}
     </div>`
 

--- a/packages/pipeline/src/screenshot-html.ts
+++ b/packages/pipeline/src/screenshot-html.ts
@@ -58,9 +58,7 @@ export async function buildScreenshotHtml(
   <style>${fontCss}</style>
 </head>
 <body class="min-h-screen flex items-center justify-center">
-  <div id="content">
-  ${htmlWithInlineImages}
-  </div>
+  ${/^\s*<div\b[^>]*\bid="content"/.test(htmlWithInlineImages) ? htmlWithInlineImages : `<div id="content">\n  ${htmlWithInlineImages}\n  </div>`}
 </body>
 </html>`
 }


### PR DESCRIPTION
Quick fix for a double container that broke the audio preview.

It was `renderPageHtml` that always added `<div id="content" class="opacity-0">`

Fixes and closes #173 