### PR TITLE
Add Windows one-click launcher script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,6 +127,14 @@ jobs:
             --repo ${{ github.repository }} \
             --clobber
 
+      - name: Upload launcher scripts to release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload ${{ steps.version.outputs.tag }} scripts/windows-setup-and-run.bat \
+            --repo ${{ github.repository }} \
+            --clobber
+
       - name: Generate release notes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -91,6 +91,19 @@ docker compose down             # stop
 ```
 </details>
 
+<details>
+<summary>Windows one-click launcher</summary>
+
+Download [`windows-setup-and-run.bat`](https://github.com/unicef/adt-studio/releases/latest/download/windows-setup-and-run.bat) from the latest release and double-click it. The script will:
+
+1. Check that Git and Docker Desktop are installed (with download links if missing)
+2. Clone the repository (first run) or pull the latest changes
+3. Build and start the Docker containers
+4. Open `http://localhost:8080` in your default browser
+
+**Prerequisites:** [Git](https://git-scm.com/download/win) and [Docker Desktop](https://www.docker.com/products/docker-desktop/).
+</details>
+
 ### Local development
 
 Prerequisites: [Node.js](https://nodejs.org/) >= 20, [pnpm](https://pnpm.io/) >= 9, and Playwright Chromium (used by visual refinement in storyboard rendering).

--- a/scripts/windows-setup-and-run.bat
+++ b/scripts/windows-setup-and-run.bat
@@ -1,0 +1,118 @@
+@echo off
+title ADT Studio Launcher
+echo ============================================
+echo   ADT Studio - Update and Start
+echo ============================================
+echo.
+
+REM ---- Prerequisites check ----
+
+where git >nul 2>nul
+if errorlevel 1 (
+    echo ERROR: Git is not installed or not in your PATH.
+    echo.
+    echo Please download and install Git from:
+    echo   https://git-scm.com/download/win
+    echo.
+    echo After installing, restart this script.
+    echo.
+    pause
+    exit /b 1
+)
+
+where docker >nul 2>nul
+if errorlevel 1 (
+    echo ERROR: Docker is not installed or not in your PATH.
+    echo.
+    echo Please download and install Docker Desktop from:
+    echo   https://www.docker.com/products/docker-desktop/
+    echo.
+    echo After installing, restart your computer and run this script again.
+    echo.
+    pause
+    exit /b 1
+)
+
+docker info >nul 2>nul
+if errorlevel 1 (
+    echo ERROR: Docker is installed but the Docker engine is not running.
+    echo.
+    echo Please open Docker Desktop and wait until it shows "Engine running"
+    echo in the bottom-left corner, then run this script again.
+    echo.
+    pause
+    exit /b 1
+)
+
+REM ---- Clone or pull ----
+
+set REPO_DIR=%USERPROFILE%\Documents\adt-studio
+set REPO_URL=https://github.com/unicef/adt-studio.git
+
+if exist "%REPO_DIR%\.git" (
+    echo Repository found at %REPO_DIR%
+    cd /d "%REPO_DIR%"
+    echo Pulling latest changes...
+    git pull
+    if errorlevel 1 (
+        echo.
+        echo ERROR: git pull failed. Check your network connection.
+        pause
+        exit /b 1
+    )
+) else (
+    echo Repository not found. Cloning into %REPO_DIR%...
+    git clone "%REPO_URL%" "%REPO_DIR%"
+    if errorlevel 1 (
+        echo.
+        echo ERROR: git clone failed. Check your network connection.
+        pause
+        exit /b 1
+    )
+    cd /d "%REPO_DIR%"
+)
+
+echo.
+echo Building and starting Docker containers...
+echo.
+
+docker compose up --build -d
+if errorlevel 1 (
+    echo.
+    echo ERROR: Docker build or start failed.
+    echo Run "docker compose logs" to see what went wrong.
+    pause
+    exit /b 1
+)
+
+echo.
+echo Waiting for ADT Studio to be ready...
+set /a ATTEMPTS=0
+set /a MAX_ATTEMPTS=60
+
+:healthcheck
+curl -sf http://localhost:8080/api/health >nul 2>nul
+if not errorlevel 1 (
+    echo.
+    echo ADT Studio is ready!
+    start http://localhost:8080
+    goto logs
+)
+set /a ATTEMPTS+=1
+if %ATTEMPTS% geq %MAX_ATTEMPTS% (
+    echo.
+    echo WARNING: ADT Studio did not become ready after 5 minutes.
+    echo Opening the browser anyway — it may take a moment to load.
+    start http://localhost:8080
+    goto logs
+)
+timeout /t 5 /nobreak >nul
+goto healthcheck
+
+:logs
+echo.
+echo Showing container logs (press Ctrl+C to stop)...
+echo.
+docker compose logs -f
+
+pause


### PR DESCRIPTION
## Summary

- Add `scripts/windows-setup-and-run.bat` — a double-clickable script for non-technical Windows users to set up and run ADT Studio via Docker
- Document it in the README under "Getting Started > Docker"
- Attach it as a GitHub Release asset so users can download it without cloning

## What the script does

1. **Prerequisite checks** — validates Git, Docker, and Docker engine are available, with clear error messages and download URLs if anything is missing
2. **Clone or pull** — clones the repo to `%USERPROFILE%\Documents\adt-studio` on first run, or `git pull` on subsequent runs
3. **Build and start** — runs `docker compose up --build -d`
4. **Health-check polling** — polls `http://localhost:8080/api/health` every 5s (up to 5 min) before opening the browser, instead of using a fixed delay
5. **Log streaming** — attaches to `docker compose logs -f` so the user can monitor container output

## Changes

| File | Change |
|------|--------|
| `scripts/windows-setup-and-run.bat` | New launcher script |
| `README.md` | Added "Windows one-click launcher" collapsible section |
| `.github/workflows/release.yml` | Upload script as release asset alongside `docker-compose.yml` |

## Test plan

- [ ] Double-click the `.bat` on a Windows machine without Git installed → shows Git download URL
- [ ] Double-click with Docker Desktop stopped → shows "open Docker Desktop" message
- [ ] Double-click with all prerequisites met, no prior clone → clones repo, builds, opens browser when healthy
- [ ] Double-click with existing clone → pulls latest, rebuilds, opens browser when healthy