### PR TITLE
Fix TOC generation token limit for large books

### DIFF
--- a/packages/pipeline/src/toc-generation.ts
+++ b/packages/pipeline/src/toc-generation.ts
@@ -159,7 +159,7 @@ export async function generateToc(
       original_toc_text: originalTocText ?? "",
     },
     maxRetries: config.maxRetries,
-    maxTokens: 8192,
+    maxTokens: Math.max(8192, headings.length * 80),
     log: {
       taskType: "toc-generation",
       promptName: config.promptName,


### PR DESCRIPTION
## Summary

- Scales `maxTokens` dynamically based on heading count (`Math.max(8192, headings.length * 80)`) so books with many headings don't hit the token ceiling and produce truncated TOC output.

## Test plan

- [ ] Run TOC generation on a small book (< 100 headings) — verify output unchanged
- [ ] Run TOC generation on a large book (100+ headings) — verify complete TOC is returned without truncation