### PR TITLE
fix: harden Gemini TTS retries and fallbacks

### DIFF
--- a/apps/api/src/routes/tts.test.ts
+++ b/apps/api/src/routes/tts.test.ts
@@ -127,6 +127,202 @@ describe("POST /books/:label/tts/generate-one", () => {
     ).toBe(true)
   })
 
+  it("generates Gemini audio when the response includes a text part before the audio part", async () => {
+    const label = "gemini-audio-multipart"
+    seedBook(label)
+
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          candidates: [
+            {
+              content: {
+                parts: [
+                  { text: "Audio generated successfully." },
+                  {
+                    inlineData: {
+                      mimeType: "audio/L16;rate=24000",
+                      data: Buffer.from(new Uint8Array([9, 10, 11, 12])).toString(
+                        "base64"
+                      ),
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }
+      )
+    )
+
+    const app = createTTSRoutes(tmpDir, configPath)
+    const res = await app.request(`/books/${label}/tts/generate-one`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Gemini-API-Key": "gm-test",
+      },
+      body: JSON.stringify({ textId: "pg001_t001", language: "en" }),
+    })
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.entry.fileName).toBe("pg001_t001.wav")
+    expect(body.remainingItems).toBe(0)
+  })
+
+  it("retries single-item Gemini audio generation with the alternate preview model when the first model returns no audio", async () => {
+    const label = "gemini-audio-fallback-model"
+    seedBook(label)
+
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            candidates: [
+              {
+                content: {
+                  parts: [
+                    { text: "No audio returned for this request." },
+                  ],
+                },
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            candidates: [
+              {
+                content: {
+                  parts: [
+                    {
+                      inlineData: {
+                        data: Buffer.from(new Uint8Array([13, 14, 15, 16])).toString(
+                          "base64"
+                        ),
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }
+        )
+      )
+
+    const app = createTTSRoutes(tmpDir, configPath)
+    const res = await app.request(`/books/${label}/tts/generate-one`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Gemini-API-Key": "gm-test",
+      },
+      body: JSON.stringify({ textId: "pg001_t001", language: "en" }),
+    })
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.entry.fileName).toBe("pg001_t001.wav")
+    expect(body.entry.model).toBe("gemini-2.5-flash-preview-tts")
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+
+    const [firstUrl] = fetchMock.mock.calls[0]
+    const [secondUrl] = fetchMock.mock.calls[1]
+    expect(String(firstUrl)).toContain("gemini-2.5-pro-preview-tts")
+    expect(String(secondUrl)).toContain("gemini-2.5-flash-preview-tts")
+  })
+
+  it("falls back to OpenAI when both Gemini preview models return no audio", async () => {
+    const label = "gemini-audio-openai-fallback"
+    seedBook(label)
+
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            candidates: [
+              {
+                content: {
+                  parts: [{ text: "No audio returned for this request." }],
+                },
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            candidates: [
+              {
+                content: {
+                  parts: [{ text: "Still no audio returned for this request." }],
+                },
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(new Uint8Array([17, 18, 19, 20]), {
+          status: 200,
+          headers: { "Content-Type": "audio/wav" },
+        })
+      )
+
+    const app = createTTSRoutes(tmpDir, configPath)
+    const res = await app.request(`/books/${label}/tts/generate-one`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Gemini-API-Key": "gm-test",
+        "X-OpenAI-Key": "sk-test",
+      },
+      body: JSON.stringify({ textId: "pg001_t001", language: "en" }),
+    })
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.entry.fileName).toBe("pg001_t001.wav")
+    expect(body.entry.provider).toBe("openai")
+    expect(body.entry.model).toBe("gpt-4o-mini-tts")
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+
+    const [firstUrl] = fetchMock.mock.calls[0]
+    const [secondUrl] = fetchMock.mock.calls[1]
+    const [thirdUrl, thirdInit] = fetchMock.mock.calls[2]
+    expect(String(firstUrl)).toContain("gemini-2.5-pro-preview-tts")
+    expect(String(secondUrl)).toContain("gemini-2.5-flash-preview-tts")
+    expect(String(thirdUrl)).toBe("https://api.openai.com/v1/audio/speech")
+    expect(thirdInit?.headers).toMatchObject({
+      Authorization: "Bearer sk-test",
+      "Content-Type": "application/json",
+    })
+  })
+
   it("rejects single-item generation when the language is not routed to Gemini", async () => {
     writeConfig("openai")
     const label = "openai-audio"

--- a/apps/api/src/routes/tts.ts
+++ b/apps/api/src/routes/tts.ts
@@ -8,11 +8,17 @@ import {
   parseBookLabel,
   TTSOutput,
   type SpeechFileEntry,
+  type TTSProviderConfig,
   type TextCatalogEntry,
   type TextCatalogOutput,
 } from "@adt/types"
 import { openBookDb, createBookStorage } from "@adt/storage"
-import { createGeminiTTSSynthesizer, type LlmLogEntry } from "@adt/llm"
+import {
+  createAzureTTSSynthesizer,
+  createGeminiTTSSynthesizer,
+  createTTSSynthesizer,
+  type LlmLogEntry,
+} from "@adt/llm"
 import {
   getBaseLanguage,
   loadBookConfig,
@@ -32,6 +38,15 @@ const GenerateSingleTTSBody = z
     language: z.string().min(1),
   })
   .strict()
+
+const GEMINI_FLASH_PREVIEW_TTS_MODEL = "gemini-2.5-flash-preview-tts"
+const GEMINI_PRO_PREVIEW_TTS_MODEL = "gemini-2.5-pro-preview-tts"
+
+interface SingleItemFallbackAttempt {
+  provider: "openai" | "azure"
+  model: string
+  voice: string
+}
 
 function safeParseLabel(label: string): string {
   try {
@@ -182,6 +197,45 @@ function getTtsCompletionSummary(
   }
 }
 
+function getGeminiFallbackModel(model: string): string | null {
+  if (model === GEMINI_FLASH_PREVIEW_TTS_MODEL) {
+    return GEMINI_PRO_PREVIEW_TTS_MODEL
+  }
+  if (model === GEMINI_PRO_PREVIEW_TTS_MODEL) {
+    return GEMINI_FLASH_PREVIEW_TTS_MODEL
+  }
+  return null
+}
+
+function getSingleItemFallbackAttempts(options: {
+  openaiApiKey?: string
+  azureSpeechKey?: string
+  azureSpeechRegion?: string
+  language: string
+  providerConfigs: Record<string, TTSProviderConfig>
+  voiceMaps: ReturnType<typeof loadVoicesConfig>
+}): SingleItemFallbackAttempt[] {
+  const attempts: SingleItemFallbackAttempt[] = []
+
+  if (options.openaiApiKey) {
+    attempts.push({
+      provider: "openai",
+      model: resolveSpeechModel("openai", options.providerConfigs),
+      voice: resolveVoice("openai", options.language, options.voiceMaps),
+    })
+  }
+
+  if (options.azureSpeechKey && options.azureSpeechRegion) {
+    attempts.push({
+      provider: "azure",
+      model: resolveSpeechModel("azure", options.providerConfigs),
+      voice: resolveVoice("azure", options.language, options.voiceMaps),
+    })
+  }
+
+  return attempts
+}
+
 function appendSingleTtsLog(
   storage: ReturnType<typeof createBookStorage>,
   options: {
@@ -299,6 +353,9 @@ export function createTTSRoutes(booksDir: string, configPath?: string): Hono {
     }
 
     const geminiApiKey = c.req.header("X-Gemini-API-Key")?.trim()
+    const openaiApiKey = c.req.header("X-OpenAI-Key")?.trim()
+    const azureSpeechKey = c.req.header("X-Azure-Speech-Key")?.trim()
+    const azureSpeechRegion = c.req.header("X-Azure-Speech-Region")?.trim()
     if (!geminiApiKey) {
       throw new HTTPException(400, {
         message: "Gemini API key required. Set X-Gemini-API-Key header.",
@@ -322,7 +379,8 @@ export function createTTSRoutes(booksDir: string, configPath?: string): Hono {
         })
       }
 
-      const providerConfigs = config.speech?.providers ?? {}
+      const providerConfigs: Record<string, TTSProviderConfig> =
+        config.speech?.providers ?? {}
       const routing: ProviderRouting = {
         providers: providerConfigs,
         defaultProvider: config.speech?.default_provider ?? "openai",
@@ -359,23 +417,77 @@ export function createTTSRoutes(booksDir: string, configPath?: string): Hono {
         voiceMaps,
         config.speech?.voice
       )
+      const fallbackAttempts = getSingleItemFallbackAttempts({
+        openaiApiKey,
+        azureSpeechKey,
+        azureSpeechRegion,
+        language: normalizedLanguage,
+        providerConfigs,
+        voiceMaps,
+      })
+      const bookDir = path.join(path.resolve(booksDir), safeLabel)
+      const cacheDir = path.join(bookDir, ".cache")
 
       const startMs = Date.now()
-
-      try {
-        const entry = await generateSpeechFile({
+      const generateEntry = async (options: {
+        targetProvider: string
+        targetModel: string
+        targetVoice: string
+      }) =>
+        generateSpeechFile({
           textId: textEntry.id,
           text: textEntry.text,
           language: normalizedLanguage,
-          model,
-          voice,
+          model: options.targetModel,
+          voice: options.targetVoice,
           instructions: "",
           format,
-          bookDir: path.join(path.resolve(booksDir), safeLabel),
-          cacheDir: path.join(path.resolve(booksDir), safeLabel, ".cache"),
-          ttsSynthesizer: createGeminiTTSSynthesizer({ apiKey: geminiApiKey }),
-          provider,
+          bookDir,
+          cacheDir,
+          ttsSynthesizer:
+            options.targetProvider === "gemini"
+              ? createGeminiTTSSynthesizer({ apiKey: geminiApiKey })
+              : options.targetProvider === "azure"
+                ? createAzureTTSSynthesizer({
+                    subscriptionKey: azureSpeechKey!,
+                    region: azureSpeechRegion!,
+                  })
+                : createTTSSynthesizer(openaiApiKey),
+          provider: options.targetProvider,
         })
+
+      try {
+        let usedProvider = provider
+        let usedModel = model
+        let usedVoice = voice
+        let entry: Awaited<ReturnType<typeof generateEntry>>
+
+        try {
+          entry = await generateEntry({
+            targetProvider: provider,
+            targetModel: model,
+            targetVoice: voice,
+          })
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err)
+          const fallbackModel = getGeminiFallbackModel(model)
+          if (
+            fallbackModel &&
+            /did not include audio data/i.test(message)
+          ) {
+            console.warn(
+              `[tts] ${safeLabel}: retrying ${textEntry.id} with fallback Gemini model ${fallbackModel} after ${model} returned no audio`
+            )
+            usedModel = fallbackModel
+            entry = await generateEntry({
+              targetProvider: provider,
+              targetModel: fallbackModel,
+              targetVoice: voice,
+            })
+          } else {
+            throw err
+          }
+        }
 
         if (!entry) {
           throw new HTTPException(422, {
@@ -386,9 +498,9 @@ export function createTTSRoutes(booksDir: string, configPath?: string): Hono {
         appendSingleTtsLog(storage, {
           textId: textEntry.id,
           language: normalizedLanguage,
-          voice,
-          model,
-          provider,
+          voice: usedVoice,
+          model: usedModel,
+          provider: usedProvider,
           text: textEntry.text,
           durationMs: Date.now() - startMs,
           success: true,
@@ -437,6 +549,85 @@ export function createTTSRoutes(booksDir: string, configPath?: string): Hono {
         }
 
         const message = err instanceof Error ? err.message : String(err)
+        let fallbackFailureMessage = message
+
+        if (/did not include audio data/i.test(message)) {
+          for (const attempt of fallbackAttempts) {
+            try {
+              console.warn(
+                `[tts] ${safeLabel}: retrying ${textEntry.id} with fallback provider ${attempt.provider} after Gemini returned no audio`
+              )
+              const entry = await generateEntry({
+                targetProvider: attempt.provider,
+                targetModel: attempt.model,
+                targetVoice: attempt.voice,
+              })
+
+              if (!entry) {
+                throw new HTTPException(422, {
+                  message: `Text entry is not speakable: ${textEntry.id}`,
+                })
+              }
+
+              appendSingleTtsLog(storage, {
+                textId: textEntry.id,
+                language: normalizedLanguage,
+                voice: attempt.voice,
+                model: attempt.model,
+                provider: attempt.provider,
+                text: textEntry.text,
+                durationMs: Date.now() - startMs,
+                success: true,
+                cached: entry.cached,
+              })
+
+              const mergedEntries = mergeSpeechEntry(
+                getLatestTtsEntries(storage, normalizedLanguage),
+                entry,
+                languageEntries.map((item) => item.id)
+              )
+
+              const version = storage.putNodeData("tts", normalizedLanguage, {
+                entries: mergedEntries,
+                generatedAt: new Date().toISOString(),
+              })
+
+              const completion = getTtsCompletionSummary(
+                storage,
+                config,
+                sourceLanguage
+              )
+              if (completion.allComplete) {
+                storage.markStepCompleted("tts")
+              } else {
+                const currentStatus = storage
+                  .getStepRuns()
+                  .find((step) => step.step === "tts")?.status
+                if (currentStatus === "error") {
+                  storage.recordStepError(
+                    "tts",
+                    `${completion.remainingItems} Gemini audio item(s) still need generation.`
+                  )
+                }
+              }
+
+              return c.json({
+                entry,
+                version,
+                completed: completion.allComplete,
+                remainingItems: completion.remainingItems,
+              })
+            } catch (fallbackErr) {
+              if (fallbackErr instanceof HTTPException) {
+                throw fallbackErr
+              }
+              const fallbackMessage =
+                fallbackErr instanceof Error ? fallbackErr.message : String(fallbackErr)
+              fallbackFailureMessage = `${message}. Fallback ${attempt.provider} failed: ${fallbackMessage}`
+            }
+          }
+        }
+
         appendSingleTtsLog(storage, {
           textId: textEntry.id,
           language: normalizedLanguage,
@@ -447,15 +638,15 @@ export function createTTSRoutes(booksDir: string, configPath?: string): Hono {
           durationMs: Date.now() - startMs,
           success: false,
           cached: false,
-          error: message,
+          error: fallbackFailureMessage,
         })
         storage.recordStepError(
           "tts",
-          `Gemini audio generation failed for ${textEntry.id}: ${message}`
+          `Gemini audio generation failed for ${textEntry.id}: ${fallbackFailureMessage}`
         )
 
-        const status = /\(429\)|quota|rate limit/i.test(message) ? 429 : 502
-        return c.json({ error: message }, status)
+        const status = /\(429\)|quota|rate limit/i.test(fallbackFailureMessage) ? 429 : 502
+        return c.json({ error: fallbackFailureMessage }, status)
       }
     } finally {
       storage.close()

--- a/apps/api/src/services/stage-runner.test.ts
+++ b/apps/api/src/services/stage-runner.test.ts
@@ -389,7 +389,7 @@ speech:
     seedTextAndSpeechBook(booksDir, "gemini-tts-failure")
 
     generateSpeechFileMock.mockRejectedValueOnce(
-      new Error("Gemini TTS request failed (429): Quota exceeded")
+      new Error("Gemini TTS response did not include audio data")
     )
 
     const events: ProgressEvent[] = []
@@ -427,6 +427,76 @@ speech:
       const ttsStep = storage.getStepRuns().find((step) => step.step === "tts")
       expect(ttsStep?.status).toBe("error")
       expect(ttsStep?.error).toContain("Missing Gemini audio can be generated one by one")
+    } finally {
+      storage.close()
+    }
+  })
+
+  it("retries rate-limited Gemini TTS items and completes the step when a retry succeeds", async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "stage-runner-tts-"))
+    const booksDir = path.join(tmpDir, "books")
+    const promptsDir = path.join(tmpDir, "prompts")
+    const configPath = path.join(tmpDir, "config.yaml")
+    fs.mkdirSync(promptsDir, { recursive: true })
+    fs.writeFileSync(
+      configPath,
+      `text_types:
+  section_text: Main body text
+text_group_types:
+  paragraph: Paragraph
+speech:
+  default_provider: gemini
+  providers:
+    gemini:
+      languages:
+        - en
+`
+    )
+    seedTextAndSpeechBook(booksDir, "gemini-tts-retry")
+
+    generateSpeechFileMock
+      .mockRejectedValueOnce(
+        new Error(
+          "Gemini TTS request failed (429): Quota exceeded. Please retry in 0s."
+        )
+      )
+      .mockResolvedValueOnce(undefined)
+
+    const events: ProgressEvent[] = []
+    const runner = createStageRunner()
+    await runner.run(
+      "gemini-tts-retry",
+      {
+        booksDir,
+        apiKey: "sk-test",
+        geminiApiKey: "gm-test",
+        promptsDir,
+        configPath,
+        fromStage: "text-and-speech",
+        toStage: "text-and-speech",
+      },
+      { emit: (event) => events.push(event) }
+    )
+
+    expect(generateSpeechFileMock).toHaveBeenCalledTimes(2)
+    expect(
+      events.some(
+        (event) => event.type === "step-complete" && event.step === "tts"
+      )
+    ).toBe(true)
+    expect(
+      events.some(
+        (event) =>
+          event.type === "step-error" &&
+          event.step === "tts" &&
+          event.error.includes("Missing Gemini audio can be generated one by one")
+      )
+    ).toBe(false)
+
+    const storage = createBookStorage("gemini-tts-retry", booksDir)
+    try {
+      const ttsStep = storage.getStepRuns().find((step) => step.step === "tts")
+      expect(ttsStep?.status).toBe("done")
     } finally {
       storage.close()
     }

--- a/apps/api/src/services/stage-runner.ts
+++ b/apps/api/src/services/stage-runner.ts
@@ -88,6 +88,10 @@ import type {
 } from "./stage-service.js"
 
 const DEFAULT_METADATA_PAGES = 3
+const GEMINI_TTS_SAFE_REQUESTS_PER_MINUTE = 10
+const GEMINI_TTS_MAX_RATE_LIMIT_RETRIES = 2
+const GEMINI_TTS_DEFAULT_RETRY_DELAY_MS = 6_000
+const GEMINI_TTS_MAX_RETRY_DELAY_MS = 20_000
 
 class StepError extends Error {
   readonly step: StepName
@@ -101,6 +105,25 @@ class StepError extends Error {
 
 function toErrorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err)
+}
+
+function isGeminiTtsRateLimitMessage(message: string): boolean {
+  return /\(429\)|quota exceeded|rate limit|too many requests/i.test(message)
+}
+
+function parseGeminiRetryDelayMs(message: string): number | null {
+  const match = message.match(/retry in ([\d.]+)s/i)
+  if (!match) return null
+
+  const seconds = Number.parseFloat(match[1])
+  if (!Number.isFinite(seconds) || seconds < 0) return null
+
+  const baseMs = Math.ceil(seconds * 1000)
+  return Math.min(baseMs > 0 ? baseMs + 250 : 0, GEMINI_TTS_MAX_RETRY_DELAY_MS)
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
 function wrapStepError(step: StepName, err: unknown): never {
@@ -1592,6 +1615,22 @@ async function runTextAndSpeechStep(
     console.log(`[stage-run] ${label}: generating TTS for ${totalItems} entries across ${outputLanguages.length} languages (${outputLanguages.join(", ")})`)
     console.log(`[stage-run] ${label}: TTS routing — for each language: ${outputLanguages.map((l) => `${l}→${resolveProviderForLanguage(l, routing)}`).join(", ")}`)
 
+    const hasGeminiTts = outputLanguages.some(
+      (lang) => resolveProviderForLanguage(lang, routing) === "gemini"
+    )
+    const geminiTtsRequestsPerMinute = Math.min(
+      config.rate_limit?.requests_per_minute ?? GEMINI_TTS_SAFE_REQUESTS_PER_MINUTE,
+      GEMINI_TTS_SAFE_REQUESTS_PER_MINUTE
+    )
+    const geminiTtsRateLimiter = hasGeminiTts
+      ? createRateLimiter(geminiTtsRequestsPerMinute)
+      : undefined
+    if (geminiTtsRateLimiter) {
+      console.log(
+        `[stage-run] ${label}: Gemini TTS limiter active at ${geminiTtsRequestsPerMinute} req/min`
+      )
+    }
+
     const ttsResultsByLang = new Map<string, SpeechFileEntry[]>()
     for (const lang of outputLanguages) {
       ttsResultsByLang.set(lang, [])
@@ -1612,25 +1651,54 @@ async function runTextAndSpeechStep(
         const instructions = provider === "openai"
           ? resolveInstructions(item.language, instructionsMap)
           : ""
+        let attemptCount = 0
 
         console.log(`[stage-run] ${label}: TTS ${item.textId} → provider=${provider} voice=${voice} model=${providerModel} format=${outputFormat}`)
 
         try {
           const ttsSynthesizer = getSynthesizer(provider)
+          let entry: SpeechFileEntry | null
 
-          const entry = await generateSpeechFile({
-            textId: item.textId,
-            text: item.text,
-            language: item.language,
-            model: providerModel,
-            voice,
-            instructions,
-            format: outputFormat,
-            bookDir,
-            cacheDir,
-            ttsSynthesizer,
-            provider,
-          })
+          while (true) {
+            attemptCount++
+            try {
+              entry = await generateSpeechFile({
+                textId: item.textId,
+                text: item.text,
+                language: item.language,
+                model: providerModel,
+                voice,
+                instructions,
+                format: outputFormat,
+                bookDir,
+                cacheDir,
+                ttsSynthesizer,
+                rateLimiter: provider === "gemini" ? geminiTtsRateLimiter : undefined,
+                provider,
+              })
+              break
+            } catch (err) {
+              const msg = toErrorMessage(err)
+              if (
+                provider === "gemini" &&
+                isGeminiTtsRateLimitMessage(msg) &&
+                attemptCount <= GEMINI_TTS_MAX_RATE_LIMIT_RETRIES
+              ) {
+                const retryDelayMs =
+                  parseGeminiRetryDelayMs(msg) ??
+                  Math.min(
+                    GEMINI_TTS_DEFAULT_RETRY_DELAY_MS * attemptCount,
+                    GEMINI_TTS_MAX_RETRY_DELAY_MS
+                  )
+                console.warn(
+                  `[stage-run] ${label}: Gemini TTS rate limited for ${item.textId} (${item.language}); retrying ${attemptCount + 1}/${GEMINI_TTS_MAX_RATE_LIMIT_RETRIES + 1} in ${retryDelayMs}ms`
+                )
+                await sleep(retryDelayMs)
+                continue
+              }
+              throw err
+            }
+          }
 
           const durationMs = Date.now() - startMs
           const cached = entry?.cached ?? false
@@ -1645,7 +1713,7 @@ async function runTextAndSpeechStep(
             cacheHit: cached,
             success: true,
             errorCount: 0,
-            attempt: 1,
+            attempt: attemptCount,
             durationMs,
             messages: [{
               role: "user",
@@ -1685,7 +1753,7 @@ async function runTextAndSpeechStep(
             cacheHit: false,
             success: false,
             errorCount: 1,
-            attempt: 1,
+            attempt: Math.max(attemptCount, 1),
             durationMs,
             messages: [{
               role: "user",

--- a/apps/studio/src/api/client.ts
+++ b/apps/studio/src/api/client.ts
@@ -730,11 +730,20 @@ export const api = {
     label: string,
     textId: string,
     language: string,
-    geminiApiKey: string
+    credentials: {
+      geminiApiKey: string
+      openaiApiKey?: string
+      azure?: AzureCredentials
+    }
   ) =>
     request<GenerateSingleTTSResponse>(`/books/${label}/tts/generate-one`, {
       method: "POST",
-      headers: { "X-Gemini-API-Key": geminiApiKey },
+      headers: {
+        "X-Gemini-API-Key": credentials.geminiApiKey,
+        ...(credentials.openaiApiKey ? { "X-OpenAI-Key": credentials.openaiApiKey } : {}),
+        ...(credentials.azure?.key ? { "X-Azure-Speech-Key": credentials.azure.key } : {}),
+        ...(credentials.azure?.region ? { "X-Azure-Speech-Region": credentials.azure.region } : {}),
+      },
       body: JSON.stringify({ textId, language }),
     }),
 

--- a/apps/studio/src/components/pipeline/stages/TranslationsView.tsx
+++ b/apps/studio/src/components/pipeline/stages/TranslationsView.tsx
@@ -303,7 +303,13 @@ export function TranslationsView({ bookLabel, selectedPageId, onSelectPage }: { 
         bookLabel,
         variables.textId,
         variables.language,
-        geminiKey
+        {
+          geminiApiKey: geminiKey,
+          openaiApiKey: apiKey || undefined,
+          azure: azureKey && azureRegion
+            ? { key: azureKey, region: azureRegion }
+            : undefined,
+        }
       )
     },
     onMutate: (variables) => {

--- a/packages/llm/src/__tests__/speech.test.ts
+++ b/packages/llm/src/__tests__/speech.test.ts
@@ -74,6 +74,109 @@ describe("createGeminiTTSSynthesizer", () => {
     })
   })
 
+  it("finds Gemini audio when a text part appears before the audio part", async () => {
+    const pcmBytes = new Uint8Array([5, 6, 7, 8])
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          candidates: [
+            {
+              content: {
+                parts: [
+                  { text: "Audio generated successfully." },
+                  {
+                    inlineData: {
+                      mimeType: "audio/L16;rate=24000",
+                      data: Buffer.from(pcmBytes).toString("base64"),
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }
+      )
+    )
+
+    const synth = createGeminiTTSSynthesizer({ apiKey: "gm-test" })
+    const result = await synth.synthesize({
+      model: "gemini-2.5-pro-preview-tts",
+      voice: "Kore",
+      input: "Hello again",
+      responseFormat: "wav",
+    })
+
+    expect(Buffer.from(result.subarray(0, 4)).toString("ascii")).toBe("RIFF")
+    expect(result.byteLength).toBe(44 + pcmBytes.byteLength)
+  })
+
+  it("retries very short Gemini text with terminal punctuation when the first response has no audio", async () => {
+    const pcmBytes = new Uint8Array([9, 10, 11, 12])
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            candidates: [
+              {
+                content: {
+                  parts: [
+                    { text: "No audio returned for this request." },
+                  ],
+                },
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            candidates: [
+              {
+                content: {
+                  parts: [
+                    {
+                      inlineData: {
+                        mimeType: "audio/L16;rate=24000",
+                        data: Buffer.from(pcmBytes).toString("base64"),
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }
+        )
+      )
+
+    const synth = createGeminiTTSSynthesizer({ apiKey: "gm-test" })
+    const result = await synth.synthesize({
+      model: "gemini-2.5-pro-preview-tts",
+      voice: "Kore",
+      input: "یونیسف",
+      responseFormat: "wav",
+    })
+
+    expect(Buffer.from(result.subarray(0, 4)).toString("ascii")).toBe("RIFF")
+    expect(result.byteLength).toBe(44 + pcmBytes.byteLength)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body))).toMatchObject({
+      contents: [{ parts: [{ text: "یونیسف۔" }] }],
+    })
+  })
+
   it("rejects non-wav Gemini output requests", async () => {
     const synth = createGeminiTTSSynthesizer({ apiKey: "gm-test" })
 
@@ -87,5 +190,42 @@ describe("createGeminiTTSSynthesizer", () => {
     ).rejects.toThrow(/only supports wav output/i)
 
     expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("surfaces a useful summary when Gemini returns text but no audio", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    text: "The selected voice is unavailable for this request.",
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }
+      )
+    )
+
+    const synth = createGeminiTTSSynthesizer({ apiKey: "gm-test" })
+
+    await expect(
+      synth.synthesize({
+        model: "gemini-2.5-pro-preview-tts",
+        voice: "Kore",
+        input: "Hello world",
+        responseFormat: "wav",
+      })
+    ).rejects.toThrow(
+      /response did not include audio data\. Response summary: text="The selected voice is unavailable for this request\."/
+    )
   })
 })

--- a/packages/llm/src/speech.ts
+++ b/packages/llm/src/speech.ts
@@ -28,6 +28,23 @@ export interface GeminiTTSConfig {
   apiKey?: string
 }
 
+interface GeminiInlineData {
+  data?: string
+  mimeType?: string
+}
+
+interface GeminiGenerateContentPayload {
+  error?: { message?: string } | string
+  candidates?: Array<{
+    content?: {
+      parts?: Array<{
+        text?: string
+        inlineData?: GeminiInlineData
+      }>
+    }
+  }>
+}
+
 const GEMINI_PCM_SAMPLE_RATE = 24_000
 const GEMINI_PCM_CHANNELS = 1
 const GEMINI_PCM_BITS_PER_SAMPLE = 16
@@ -81,6 +98,76 @@ function wrapPcmAsWave(
   header.writeUInt32LE(dataSize, 40)
 
   return new Uint8Array(Buffer.concat([header, Buffer.from(pcmBytes)]))
+}
+
+function extractGeminiAudioData(
+  payload: GeminiGenerateContentPayload
+): string | null {
+  let fallbackAudioData: string | null = null
+
+  for (const candidate of payload.candidates ?? []) {
+    for (const part of candidate.content?.parts ?? []) {
+      const inlineData = part.inlineData
+      if (!inlineData?.data) continue
+
+      const mimeType = inlineData.mimeType?.toLowerCase()
+      if (mimeType?.startsWith("audio/")) {
+        return inlineData.data
+      }
+
+      if (!mimeType && !fallbackAudioData) {
+        fallbackAudioData = inlineData.data
+      }
+    }
+  }
+
+  return fallbackAudioData
+}
+
+function summarizeGeminiResponse(
+  payload: GeminiGenerateContentPayload
+): string | null {
+  const details: string[] = []
+
+  for (const candidate of payload.candidates ?? []) {
+    for (const part of candidate.content?.parts ?? []) {
+      const text = part.text?.trim()
+      if (text) {
+        details.push(`text="${text.slice(0, 160)}"`)
+        continue
+      }
+
+      const mimeType = part.inlineData?.mimeType?.trim()
+      if (mimeType) {
+        details.push(`inlineData mimeType=${mimeType}`)
+      } else if (part.inlineData?.data) {
+        details.push("inlineData without mimeType")
+      }
+    }
+  }
+
+  if (details.length === 0) {
+    return null
+  }
+
+  return details.slice(0, 3).join("; ")
+}
+
+function buildGeminiShortTextRetryInput(input: string): string | null {
+  const trimmed = input.trim()
+  if (!trimmed) return null
+
+  const codePointLength = Array.from(trimmed).length
+  if (codePointLength > 10) return null
+  if (/[.!?؟۔。！？।]$/u.test(trimmed)) return null
+
+  const suffix =
+    /[\u0600-\u08FF]/u.test(trimmed) ? "۔"
+      : /[\u0900-\u097F]/u.test(trimmed) ? "।"
+        : /[\u3040-\u30FF\u3400-\u9FFF]/u.test(trimmed) ? "。"
+          : "."
+
+  return `${trimmed}${suffix}`
 }
 
 /**
@@ -186,67 +273,75 @@ export function createGeminiTTSSynthesizer(
       }
 
       const url = `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(options.model)}:generateContent`
-      const response = await fetch(url, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "x-goog-api-key": resolvedApiKey,
-        },
-        body: JSON.stringify({
-          contents: [
-            {
-              parts: [
-                {
-                  text: options.input,
-                },
-              ],
-            },
-          ],
-          generationConfig: {
-            responseModalities: ["AUDIO"],
-            speechConfig: {
-              voiceConfig: {
-                prebuiltVoiceConfig: {
-                  voiceName: options.voice,
+      const synthesizeInput = async (inputText: string): Promise<GeminiGenerateContentPayload> => {
+        const response = await fetch(url, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "x-goog-api-key": resolvedApiKey,
+          },
+          body: JSON.stringify({
+            contents: [
+              {
+                parts: [
+                  {
+                    text: inputText,
+                  },
+                ],
+              },
+            ],
+            generationConfig: {
+              responseModalities: ["AUDIO"],
+              speechConfig: {
+                voiceConfig: {
+                  prebuiltVoiceConfig: {
+                    voiceName: options.voice,
+                  },
                 },
               },
             },
-          },
-        }),
-      })
+          }),
+        })
 
-      const responseText = await response.text()
-      const payload = (() => {
-        try {
-          return JSON.parse(responseText)
-        } catch {
-          return { error: responseText || response.statusText }
-        }
-      })() as {
-        error?: { message?: string } | string
-        candidates?: Array<{
-          content?: {
-            parts?: Array<{
-              inlineData?: {
-                data?: string
-              }
-            }>
+        const responseText = await response.text()
+        const payload = (() => {
+          try {
+            return JSON.parse(responseText)
+          } catch {
+            return { error: responseText || response.statusText }
           }
-        }>
+        })() as GeminiGenerateContentPayload
+
+        if (!response.ok) {
+          const message =
+            typeof payload.error === "string" ? payload.error
+              : payload.error?.message ?? response.statusText
+          throw new Error(
+            `Gemini TTS request failed (${response.status}): ${message || response.statusText}`
+          )
+        }
+
+        return payload
       }
 
-      if (!response.ok) {
-        const message =
-          typeof payload.error === "string" ? payload.error
-            : payload.error?.message ?? response.statusText
-        throw new Error(
-          `Gemini TTS request failed (${response.status}): ${message || response.statusText}`
-        )
-      }
+      let payload = await synthesizeInput(options.input)
+      let audioData = extractGeminiAudioData(payload)
 
-      const audioData = payload.candidates?.[0]?.content?.parts?.[0]?.inlineData?.data
       if (!audioData) {
-        throw new Error("Gemini TTS response did not include audio data")
+        const retryInput = buildGeminiShortTextRetryInput(options.input)
+        if (retryInput) {
+          payload = await synthesizeInput(retryInput)
+          audioData = extractGeminiAudioData(payload)
+        }
+      }
+
+      if (!audioData) {
+        const responseSummary = summarizeGeminiResponse(payload)
+        throw new Error(
+          responseSummary
+            ? `Gemini TTS response did not include audio data. Response summary: ${responseSummary}`
+            : "Gemini TTS response did not include audio data"
+        )
       }
 
       const pcmBytes = new Uint8Array(Buffer.from(audioData, "base64"))

--- a/packages/pipeline/src/__tests__/speech.test.ts
+++ b/packages/pipeline/src/__tests__/speech.test.ts
@@ -412,6 +412,43 @@ describe("generateSpeechFile", () => {
     expect(mockSynthesize).toHaveBeenCalledTimes(1) // Not called again
   })
 
+  it("only acquires the optional rate limiter when a real synth call is needed", async () => {
+    const rateLimiter = {
+      acquire: vi.fn().mockResolvedValue(undefined),
+    }
+
+    await generateSpeechFile({
+      textId: "p001_t001",
+      text: "Hello world",
+      language: "en",
+      model: "gpt-4o-mini-tts",
+      voice: "alloy",
+      instructions: "Speak cheerfully.",
+      format: "mp3",
+      bookDir,
+      cacheDir,
+      ttsSynthesizer: mockSynthesizer,
+      rateLimiter,
+    })
+
+    await generateSpeechFile({
+      textId: "p001_t001",
+      text: "Hello world",
+      language: "en",
+      model: "gpt-4o-mini-tts",
+      voice: "alloy",
+      instructions: "Speak cheerfully.",
+      format: "mp3",
+      bookDir,
+      cacheDir,
+      ttsSynthesizer: mockSynthesizer,
+      rateLimiter,
+    })
+
+    expect(rateLimiter.acquire).toHaveBeenCalledTimes(1)
+    expect(mockSynthesize).toHaveBeenCalledTimes(1)
+  })
+
   it("returns null for non-speakable text", async () => {
     const result = await generateSpeechFile({
       textId: "p001_t001",

--- a/packages/pipeline/src/speech.ts
+++ b/packages/pipeline/src/speech.ts
@@ -3,7 +3,7 @@ import path from "node:path"
 import crypto from "node:crypto"
 import yaml from "js-yaml"
 import type { SpeechFileEntry, TTSProviderConfig } from "@adt/types"
-import type { TTSSynthesizer } from "@adt/llm"
+import type { RateLimiter, TTSSynthesizer } from "@adt/llm"
 import { getBaseLanguage, normalizeLocale } from "./language-context.js"
 
 // ---------------------------------------------------------------------------
@@ -220,6 +220,7 @@ export interface GenerateSpeechFileOptions {
   bookDir: string
   cacheDir: string
   ttsSynthesizer: TTSSynthesizer
+  rateLimiter?: RateLimiter
   provider?: string
 }
 
@@ -242,6 +243,7 @@ export async function generateSpeechFile(
     bookDir,
     cacheDir,
     ttsSynthesizer,
+    rateLimiter,
     provider,
   } = options
 
@@ -295,6 +297,7 @@ export async function generateSpeechFile(
   }
 
   // Generate speech via shared LLM TTS client
+  await rateLimiter?.acquire()
   const audioBytes = await ttsSynthesizer.synthesize({
     model,
     voice,


### PR DESCRIPTION
## Summary
- harden Gemini TTS audio parsing and short-text retries for no-audio responses
- add manual single-item fallbacks from Gemini to OpenAI or Azure when Gemini returns no audio
- throttle and retry Gemini requests during bulk Text & Speech runs
- cover the new fallbacks and rate-limit behavior with regression tests

## Testing
- pnpm exec vitest run apps/api/src/routes/tts.test.ts apps/api/src/services/stage-runner.test.ts packages/llm/src/__tests__/speech.test.ts packages/pipeline/src/__tests__/speech.test.ts
- pnpm build