### PR TITLE
docs: add Spanish developer guide and update English guide

### DIFF
--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -58,6 +58,12 @@ docker compose down
 
 Change the host port by setting `PORT=9000` in a `.env` file next to `docker-compose.yml`. See the [README](../README.md) for build-from-source instructions.
 
+To set the OpenAI API key at the server level (so users don't need to enter it in the UI):
+
+```bash
+docker run -p 8080:80 -v ./books:/app/books -e OPENAI_API_KEY=sk-... ghcr.io/unicef/adt-studio:latest
+```
+
 ### Option B — VPS / Bare Metal
 
 Build the project and run the two components separately using any process manager and static file server.
@@ -68,7 +74,7 @@ pnpm install && pnpm build
 
 # --- API server ---
 # With PM2:
-pm2 start apps/api/dist/index.js --name adt-api
+pm2 start apps/api/dist/api-server.mjs --name adt-api
 # With systemd: create a unit file pointing at the same entry point
 ```
 
@@ -303,7 +309,7 @@ HTML layout templates used by template-based render strategies (e.g., `two_colum
 
 ## 7. Developer Setup (Local)
 
-**Prerequisites**: [Node.js](https://nodejs.org/) >= 20, [pnpm](https://pnpm.io/) >= 9, and Playwright Chromium.
+**Prerequisites**: [Node.js](https://nodejs.org/) >= 22, [pnpm](https://pnpm.io/) 10.32.1 (via `corepack enable && corepack prepare pnpm@10.32.1 --activate`), and Playwright Chromium.
 
 ```bash
 git clone git@github.com:unicef/adt-studio.git
@@ -334,15 +340,43 @@ On first run, `pnpm dev` compiles all packages (~1 min). Subsequent runs use inc
 ```bash
 pnpm typecheck        # TypeScript strict mode check across all packages
 pnpm test             # Run all Vitest tests
-pnpm test:coverage    # Tests with coverage report
+pnpm test:watch       # Tests in watch mode
 pnpm lint             # ESLint across all packages
 pnpm build            # Full production build
 ```
 
 **Desktop app** (optional — requires [Rust](https://rustup.rs/)):
 ```bash
-pnpm dev:desktop      # Opens Tauri window pointing at the Vite dev server
+pnpm --filter @adt/api build:sidecar  # Required once before first run (and after API changes)
+pnpm dev                               # Terminal 1: start API + Studio dev servers
+pnpm dev:desktop                       # Terminal 2: opens Tauri window
 ```
+
+### Platform-specific notes
+
+**Windows:**
+- Use **PowerShell** or **Git Bash** (included with [Git for Windows](https://gitforwindows.org/)). Avoid CMD — it has issues with long paths.
+- `corepack enable` may require running PowerShell as Administrator.
+- Use [nvm-windows](https://github.com/coreybutler/nvm-windows) or [fnm](https://github.com/Schniz/fnm) (`winget install Schniz.fnm`) to manage Node.js versions. Note: `nvm-windows` is a different project from the Unix `nvm`.
+- For Docker: install [Docker Desktop](https://docs.docker.com/desktop/install/windows-install/) with WSL2 backend. Use `${PWD}/books` (PowerShell) instead of `./books` for volume mounts.
+- For long path issues: `git config --system core.longpaths true` (as Administrator).
+- For Tauri desktop builds: install [Visual Studio C++ Build Tools 2022](https://visualstudio.microsoft.com/visual-cpp-build-tools/) with the "Desktop development with C++" workload. WebView2 is preinstalled on Windows 10/11.
+
+**macOS:**
+- For Tauri desktop builds: install Xcode Command Line Tools: `xcode-select --install`.
+- Node.js can also be installed via Homebrew: `brew install node@22`.
+
+**Linux:**
+- For Tauri desktop builds (Debian/Ubuntu):
+  ```bash
+  sudo apt install libwebkit2gtk-4.1-dev build-essential libssl-dev \
+    libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
+  ```
+- To run Docker without `sudo`:
+  ```bash
+  sudo usermod -aG docker $USER
+  # Log out and back in for the group change to take effect
+  ```
 
 ---
 

--- a/docs/DEVELOPER-GUIDE_ES.md
+++ b/docs/DEVELOPER-GUIDE_ES.md
@@ -1,0 +1,525 @@
+# Guía de Instalación y Uso — ADT Studio
+
+ADT Studio es una aplicación de escritorio para la producción automatizada de libros digitales. Extrae contenido de archivos PDF, lo procesa mediante pipelines de LLM (modelos de lenguaje) y genera paquetes de salida formateados en HTML. Fue desarrollado para UNICEF con el objetivo de digitalizar libros de texto educativos.
+
+---
+
+## Tabla de Contenidos
+
+- [Sección 1: Desarrollo Local](#sección-1-desarrollo-local)
+  - [Requisitos Previos](#requisitos-previos)
+  - [Pasos de Instalación](#pasos-de-instalación)
+  - [Comandos Útiles](#comandos-útiles)
+  - [Desarrollo de Escritorio (Tauri) — Opcional](#desarrollo-de-escritorio-tauri--opcional)
+- [Sección 2: Docker](#sección-2-docker)
+  - [Requisitos Previos (Docker)](#requisitos-previos-docker)
+  - [Opción A: Imagen Combinada (Recomendado)](#opción-a-imagen-combinada-recomendado)
+  - [Opción B: Docker Compose (Dos Servicios)](#opción-b-docker-compose-dos-servicios)
+  - [Volúmenes y Persistencia de Datos](#volúmenes-y-persistencia-de-datos)
+- [Verificación y Primeros Pasos](#verificación-y-primeros-pasos)
+- [Solución de Problemas Comunes](#solución-de-problemas-comunes)
+- [Notas Específicas por Sistema Operativo](#notas-específicas-por-sistema-operativo)
+
+---
+
+## Sección 1: Desarrollo Local
+
+### Requisitos Previos
+
+| Software | Versión Requerida | Notas |
+|----------|-------------------|-------|
+| **Git** | Cualquier versión reciente | Para clonar el repositorio. En Windows: [Git for Windows](https://gitforwindows.org/) |
+| **Node.js** | **22 o superior** | Se recomienda usar un gestor de versiones (ver abajo) |
+| **pnpm** | **10.32.1** | Se instala con `corepack` (incluido en Node.js) |
+
+> **Windows:** Se recomienda usar **PowerShell** o **Git Bash** (incluido con Git for Windows) para ejecutar los comandos de esta guía. Los comandos `pnpm`, `node` y `git` funcionan en ambos. Evitar usar CMD (símbolo del sistema) ya que tiene limitaciones con rutas largas.
+
+#### Instalar Node.js 22
+
+##### macOS / Linux
+
+**Opción 1 — Con `nvm` (recomendado):**
+
+```bash
+# Instalar nvm (si no lo tienes)
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
+
+# Instalar y usar Node.js 22
+nvm install 22
+nvm use 22
+
+# Verificar versión
+node --version   # Debe mostrar v22.x.x
+```
+
+**Opción 2 — Con `fnm`:**
+
+```bash
+# Instalar fnm (si no lo tienes)
+curl -fsSL https://fnm.vercel.app/install | bash
+
+# Instalar y usar Node.js 22
+fnm install 22
+fnm use 22
+```
+
+##### Windows
+
+**Opción 1 — Con `fnm` (recomendado para Windows):**
+
+```powershell
+# Instalar fnm con winget
+winget install Schniz.fnm
+
+# Instalar y usar Node.js 22
+fnm install 22
+fnm use 22
+
+# Verificar versión
+node --version   # Debe mostrar v22.x.x
+```
+
+**Opción 2 — Con `nvm-windows`:**
+
+Descargar el instalador desde [nvm-windows](https://github.com/coreybutler/nvm-windows/releases) y ejecutarlo. Luego:
+
+```powershell
+nvm install 22
+nvm use 22
+```
+
+> **Importante:** `nvm-windows` es un proyecto diferente a `nvm` de Linux/macOS. No usar los comandos de instalación de `nvm` de Linux en Windows.
+
+##### Todas las plataformas
+
+**Instalación directa:**
+
+Descargar desde [nodejs.org](https://nodejs.org/) (versión 22 LTS o superior). El instalador está disponible para Windows, macOS y Linux.
+
+#### Instalar pnpm 10.32.1
+
+Node.js incluye `corepack`, que permite instalar gestores de paquetes como pnpm sin instalación manual:
+
+```bash
+# Habilitar corepack (en Windows puede requerir ejecutar PowerShell como Administrador)
+corepack enable
+
+# Preparar la versión exacta de pnpm
+corepack prepare pnpm@10.32.1 --activate
+
+# Verificar
+pnpm --version   # Debe mostrar 10.32.1
+```
+
+> **Windows:** Si `corepack enable` falla con un error de permisos, abrir PowerShell como Administrador (clic derecho > "Ejecutar como administrador") y ejecutar el comando nuevamente.
+
+### Pasos de Instalación
+
+#### 1. Clonar el repositorio
+
+```bash
+git clone https://github.com/unicef/adt-studio.git
+cd adt-studio
+```
+
+#### 2. Instalar dependencias
+
+```bash
+pnpm install
+```
+
+Este comando instala todas las dependencias del monorepo (paquetes compartidos y aplicaciones).
+
+#### 3. Instalar Playwright Chromium (para refinamiento visual)
+
+El pipeline de ADT Studio puede usar capturas de pantalla para refinar visualmente el HTML generado. Esto requiere el navegador Chromium de Playwright:
+
+```bash
+pnpm exec playwright install chromium
+```
+
+En Linux, si faltan dependencias del sistema operativo:
+
+```bash
+pnpm exec playwright install --with-deps chromium
+```
+
+> **Nota:** Este paso es opcional si solo se desea usar el pipeline sin refinamiento visual, pero se recomienda instalarlo para tener la funcionalidad completa.
+
+#### 4. Ejecutar en modo desarrollo
+
+```bash
+pnpm dev
+```
+
+Este comando hace lo siguiente automáticamente:
+
+1. **Compila todos los paquetes TypeScript** (`pnpm build` se ejecuta vía el script `predev`)
+2. **Inicia el servidor API** (Hono) en `http://localhost:3001`
+3. **Inicia la aplicación web** (Vite + React) en `http://localhost:5173`
+
+#### 5. Acceder a la aplicación
+
+Abrir el navegador en **http://localhost:5173**
+
+> **Nota sobre API Keys:** ADT Studio requiere una clave de API de OpenAI para procesar libros con LLMs. La clave se ingresa directamente desde la interfaz web de la aplicación. Alternativamente, para entornos de equipo o servidores compartidos, se puede configurar la variable de entorno `OPENAI_API_KEY` en el servidor — cuando está definida, los usuarios no necesitan ingresar la clave en la interfaz.
+
+### Comandos Útiles
+
+| Comando | Descripción |
+|---------|-------------|
+| `pnpm dev` | Inicia API + Studio en modo desarrollo (compila automáticamente) |
+| `pnpm dev:api` | Inicia solo el servidor API |
+| `pnpm dev:studio` | Inicia solo la interfaz web (Vite) |
+| `pnpm test` | Ejecuta los tests (Vitest) |
+| `pnpm test:watch` | Ejecuta tests en modo watch |
+| `pnpm typecheck` | Verificación de tipos TypeScript (modo estricto) |
+| `pnpm lint` | Ejecuta ESLint |
+| `pnpm build` | Compila todos los paquetes TypeScript |
+| `pnpm pipeline` | CLI: ejecuta el pipeline completo sobre un libro |
+| `pnpm pdf-extract` | CLI: extrae páginas de un PDF y genera un visor HTML |
+
+### Desarrollo de Escritorio (Tauri) — Opcional
+
+Para compilar la versión de escritorio (Windows/macOS/Linux), se necesitan requisitos adicionales según el sistema operativo:
+
+| Software | Versión | Instalación | Plataforma |
+|----------|---------|-------------|------------|
+| **Rust toolchain** | Última estable | [rustup.rs](https://rustup.rs/) | Todas |
+| **Visual Studio C++ Build Tools** | 2022+ | [Visual Studio Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) | Windows |
+| **WebView2** | Última | Preinstalado en Windows 10/11 | Windows |
+| **Xcode Command Line Tools** | Última | `xcode-select --install` | macOS |
+| **Dependencias de sistema** | — | `sudo apt install libwebkit2gtk-4.1-dev build-essential libssl-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev` | Linux (Debian/Ubuntu) |
+
+> **Nota:** La CLI de Tauri ya está incluida como dependencia de desarrollo del proyecto. No es necesario instalarla por separado.
+>
+> **Windows:** Al instalar Visual Studio Build Tools, asegurarse de seleccionar el componente "Desarrollo de escritorio con C++". Esto es necesario para compilar las dependencias nativas de Tauri/Rust.
+
+#### Pasos para desarrollo de escritorio
+
+```bash
+# 1. Compilar el sidecar (binario del API server + recursos)
+#    Solo es necesario ejecutarlo una vez, o cuando cambien los archivos del API
+pnpm --filter @adt/api build:sidecar
+
+# 2. En una terminal: iniciar los servidores de desarrollo
+pnpm dev
+
+# 3. En otra terminal: iniciar la ventana de escritorio de Tauri
+pnpm dev:desktop
+```
+
+#### Compilar el instalador de producción
+
+```bash
+# Genera el instalador completo (ejecuta build:sidecar automáticamente)
+pnpm build:desktop
+```
+
+El instalador se genera en `apps/desktop/src-tauri/target/release/`.
+
+---
+
+## Sección 2: Docker
+
+### Requisitos Previos (Docker)
+
+| Software | Versión Requerida | Notas |
+|----------|-------------------|-------|
+| **Docker** | Engine 20+ | [Instalar Docker](https://docs.docker.com/engine/install/) |
+| **Docker Compose** | v2+ | Incluido en Docker Desktop; en Linux puede requerir instalación separada |
+| **Git** | Cualquier versión reciente | Solo para clonar el repositorio |
+
+> **Nota:** No es necesario tener Node.js ni pnpm instalados para ejecutar con Docker. Todo está contenido en la imagen.
+>
+> **Windows:** Instalar [Docker Desktop para Windows](https://docs.docker.com/desktop/install/windows-install/). Requiere **WSL2** (Windows Subsystem for Linux 2) como backend. Docker Desktop lo configura automáticamente durante la instalación. Si WSL2 no está habilitado, seguir las [instrucciones de Microsoft](https://learn.microsoft.com/es-es/windows/wsl/install) antes de instalar Docker Desktop.
+
+### Opción A: Imagen Combinada (Recomendado)
+
+Esta opción ejecuta el API y la interfaz web en un solo contenedor. Es la forma más sencilla de usar ADT Studio.
+
+#### 1. Clonar el repositorio
+
+```bash
+git clone https://github.com/unicef/adt-studio.git
+cd adt-studio
+```
+
+#### 2. Construir la imagen
+
+```bash
+docker build --target app -t adt-studio .
+```
+
+> **Nota:** La primera compilación puede tardar varios minutos ya que descarga dependencias, compila TypeScript y descarga el navegador Chromium para renderizado de capturas.
+
+#### 3. Crear el directorio para libros
+
+```bash
+# macOS / Linux / Git Bash
+mkdir -p books
+
+# Windows (PowerShell)
+New-Item -ItemType Directory -Force -Path books
+```
+
+#### 4. Ejecutar el contenedor
+
+```bash
+# macOS / Linux / Git Bash
+docker run -p 8080:80 -v ./books:/app/books adt-studio
+
+# Windows (PowerShell) — usar ruta absoluta para volúmenes
+docker run -p 8080:80 -v ${PWD}/books:/app/books adt-studio
+
+# Windows (CMD)
+docker run -p 8080:80 -v %cd%/books:/app/books adt-studio
+```
+
+> **API Key del servidor:** Para configurar la clave de OpenAI a nivel de servidor (evita que cada usuario la ingrese manualmente), agregar la variable de entorno:
+> ```bash
+> docker run -p 8080:80 -v ./books:/app/books -e OPENAI_API_KEY=sk-... adt-studio
+> ```
+
+#### 5. Acceder a la aplicación
+
+Abrir el navegador en **http://localhost:8080**
+
+#### Cambiar el puerto
+
+Para usar un puerto diferente al 8080, cambiar el primer número:
+
+```bash
+docker run -p 3000:80 -v ./books:/app/books adt-studio
+```
+
+Esto haría accesible la aplicación en `http://localhost:3000`.
+
+### Opción B: Docker Compose (Dos Servicios)
+
+Esta opción ejecuta el API y la interfaz web como servicios separados, conectados por una red interna. Útil para desarrollo o si se necesita escalar los servicios de forma independiente.
+
+#### 1. Clonar el repositorio
+
+```bash
+git clone https://github.com/unicef/adt-studio.git
+cd adt-studio
+```
+
+#### 2. Configurar el puerto (opcional)
+
+```bash
+# macOS / Linux / Git Bash
+cp .env.example .env
+
+# Windows (PowerShell)
+Copy-Item .env.example .env
+
+# Editar .env si se desea cambiar el puerto (por defecto: 8080)
+# PORT=8080
+```
+
+#### 3. Construir e iniciar los servicios
+
+```bash
+docker compose up --build
+```
+
+Para ejecutar en segundo plano (modo daemon):
+
+```bash
+docker compose up --build -d
+```
+
+#### 4. Acceder a la aplicación
+
+Abrir el navegador en **http://localhost:8080** (o el puerto configurado en `.env`).
+
+#### 5. Detener los servicios
+
+```bash
+# Si se ejecutó en primer plano: Ctrl+C
+
+# Si se ejecutó en modo daemon:
+docker compose down
+```
+
+### Volúmenes y Persistencia de Datos
+
+| Volumen | Descripción | Requerido |
+|---------|-------------|-----------|
+| `./books:/app/books` | Datos de libros procesados (PDFs, imágenes, bases de datos SQLite) | **Sí** |
+| `./prompts:/app/prompts` | Plantillas de prompts LLM personalizadas | No (usa las incluidas por defecto) |
+| `./templates:/app/templates` | Plantillas HTML de layout personalizadas | No (usa las incluidas por defecto) |
+| `./config.yaml:/app/config.yaml` | Configuración global personalizada | No (usa la incluida por defecto) |
+
+> **Respaldo y migración:** Para respaldar o migrar un libro, copiar o comprimir el directorio `books/{label}/`. Contiene toda la información del libro (base de datos SQLite, imágenes extraídas, caché de LLM y configuración). Para migrar a otra instancia, simplemente copiar el directorio al `books/` de la nueva instalación.
+
+**Ejemplo con volúmenes opcionales (imagen combinada):**
+
+```bash
+# macOS / Linux / Git Bash
+docker run -p 8080:80 \
+  -v ./books:/app/books \
+  -v ./prompts:/app/prompts \
+  -v ./config.yaml:/app/config.yaml:ro \
+  adt-studio
+
+# Windows (PowerShell) — usar ` en lugar de \ para continuación de línea
+docker run -p 8080:80 `
+  -v ${PWD}/books:/app/books `
+  -v ${PWD}/prompts:/app/prompts `
+  -v ${PWD}/config.yaml:/app/config.yaml:ro `
+  adt-studio
+```
+
+**Ejemplo con volúmenes opcionales (Docker Compose):**
+
+Descomentar las líneas correspondientes en `docker-compose.yml`:
+
+```yaml
+volumes:
+  - ./books:/app/books
+  - ./prompts:/app/prompts           # descomentar
+  - ./templates:/app/templates:ro     # descomentar
+  - ./config.yaml:/app/config.yaml:ro # descomentar
+```
+
+---
+
+## Verificación y Primeros Pasos
+
+### Verificar que la aplicación está funcionando
+
+**Desde el navegador:** Acceder a la URL correspondiente (http://localhost:5173 para desarrollo local, http://localhost:8080 para Docker).
+
+**Desde la terminal (health check del API):**
+
+```bash
+# Desarrollo local
+curl http://localhost:3001/api/health
+
+# Docker
+curl http://localhost:8080/api/health
+
+# Windows (PowerShell, si curl no está disponible)
+Invoke-RestMethod http://localhost:8080/api/health
+```
+
+Si todo está correcto, la respuesta será un JSON con estado OK.
+
+### Primeros pasos con un libro
+
+1. Abrir la aplicación en el navegador
+2. Ingresar la clave de API de OpenAI cuando la aplicación lo solicite
+3. Hacer clic en **"Add Book"** (Agregar Libro)
+4. Completar el asistente: seleccionar el archivo PDF, asignar una etiqueta, definir el rango de páginas y otros parámetros
+5. La extracción del PDF comenzará automáticamente
+6. Una vez terminada, se mostrará el storyboard para revisión y edición
+
+---
+
+## Solución de Problemas Comunes
+
+### `pnpm: command not found`
+
+Asegurarse de que `corepack` está habilitado:
+
+```bash
+corepack enable
+corepack prepare pnpm@10.32.1 --activate
+```
+
+### Error de versión de Node.js
+
+ADT Studio requiere Node.js 22 o superior. Verificar con:
+
+```bash
+node --version
+```
+
+Si la versión es inferior a 22, actualizar usando `nvm`, `fnm` o descargando desde [nodejs.org](https://nodejs.org/).
+
+### Puerto en uso
+
+Si el puerto 5173 (desarrollo) u 8080 (Docker) ya está en uso:
+
+- **Desarrollo local:** Vite automáticamente intentará el siguiente puerto disponible y lo mostrará en la terminal.
+- **Docker:** Cambiar el puerto en el comando `docker run` o en el archivo `.env`.
+
+### Docker: error de permisos en `./books`
+
+Si el contenedor no puede escribir en el directorio `books/`:
+
+```bash
+# macOS / Linux — crear el directorio con los permisos adecuados
+mkdir -p books
+chmod 777 books
+```
+
+> **Windows:** Los problemas de permisos en volúmenes de Docker son menos comunes en Windows con Docker Desktop + WSL2. Si ocurren, verificar que la carpeta del proyecto esté dentro del filesystem de WSL2 o que Docker Desktop tenga permisos para compartir la unidad correspondiente (Settings > Resources > File Sharing).
+
+### Docker: la compilación es muy lenta
+
+La primera compilación descarga muchas dependencias y el navegador Chromium. Las compilaciones subsecuentes serán mucho más rápidas gracias al caché de capas de Docker. Si se necesita reconstruir sin caché:
+
+```bash
+docker build --no-cache --target app -t adt-studio .
+```
+
+### Windows: `corepack enable` falla con error de permisos
+
+Abrir PowerShell como Administrador y ejecutar:
+
+```powershell
+corepack enable
+```
+
+### Windows: rutas largas causan errores en `pnpm install`
+
+Si se encuentran errores relacionados con rutas de archivo demasiado largas, habilitar el soporte de rutas largas en Windows:
+
+```powershell
+# Ejecutar como Administrador
+git config --system core.longpaths true
+```
+
+También verificar que la política de rutas largas esté habilitada en el registro de Windows:
+
+```powershell
+# Ejecutar como Administrador
+New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
+```
+
+---
+
+## Notas Específicas por Sistema Operativo
+
+### Windows
+
+- **Shell recomendado:** PowerShell o Git Bash (incluido con [Git for Windows](https://gitforwindows.org/)). Evitar CMD.
+- **Docker:** Requiere [Docker Desktop](https://docs.docker.com/desktop/install/windows-install/) con backend WSL2.
+- **Rutas de volúmenes Docker:** Usar `${PWD}/books` (PowerShell) o `%cd%/books` (CMD) en lugar de `./books`.
+- **Continuación de línea:** En PowerShell usar `` ` `` en lugar de `\` para comandos multilínea.
+- **Tauri (escritorio):** Requiere [Visual Studio C++ Build Tools 2022](https://visualstudio.microsoft.com/visual-cpp-build-tools/) con el componente "Desarrollo de escritorio con C++".
+- **Permisos de corepack:** Puede requerir ejecutar PowerShell como Administrador para `corepack enable`.
+
+### macOS
+
+- **Docker:** Instalar [Docker Desktop para Mac](https://docs.docker.com/desktop/install/mac-install/) (disponible para Apple Silicon y Intel).
+- **Tauri (escritorio):** Requiere Xcode Command Line Tools: `xcode-select --install`.
+- **Gestor de versiones de Node:** `nvm` o `fnm` funcionan nativamente. También se puede usar `brew install node@22`.
+
+### Linux
+
+- **Docker:** Instalar [Docker Engine](https://docs.docker.com/engine/install/) + [Docker Compose plugin](https://docs.docker.com/compose/install/linux/). Docker Desktop también está disponible pero no es obligatorio.
+- **Tauri (escritorio — Debian/Ubuntu):**
+  ```bash
+  sudo apt install libwebkit2gtk-4.1-dev build-essential libssl-dev \
+    libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
+  ```
+- **Permisos de Docker sin root:**
+  ```bash
+  sudo usermod -aG docker $USER
+  # Cerrar sesión y volver a iniciar para que tome efecto
+  ```


### PR DESCRIPTION
## Summary

- **New file:** `docs/DEVELOPER-GUIDE_ES.md` — comprehensive step-by-step guide in Spanish for new developers, covering both local development and Docker setup with OS-specific instructions (Windows, macOS, Linux).
- **Updated:** `docs/DEVELOPER-GUIDE.md` (English) with content that was missing:
  - Platform-specific notes for Windows (PowerShell, corepack admin, nvm-windows, Docker Desktop/WSL2, long paths, VS C++ Build Tools), macOS (Xcode CLI Tools), and Linux (Tauri system deps, Docker without root)
  - `OPENAI_API_KEY` server-side example in Docker section
  - Fixed desktop dev section to include the required `build:sidecar` step before `dev:desktop`
  - Fixed outdated prerequisites (Node.js >= 20 → >= 22, pnpm >= 9 → 10.32.1)
  - Fixed non-existent `pnpm test:coverage` → `pnpm test:watch`
  - Fixed VPS entry point path (`index.js` → `api-server.mjs`)

## Test plan

- [ ] Verify all commands in the Spanish guide work on a clean machine (local dev flow)
- [ ] Verify Docker commands work (`docker build --target app`, `docker compose up`)
- [ ] Confirm no broken markdown links in either file