### PR TITLE
Add text alignment controls to storyboard toolbar

### DIFF
--- a/apps/studio/src/components/pipeline/stages/BookPreviewFrame.tsx
+++ b/apps/studio/src/components/pipeline/stages/BookPreviewFrame.tsx
@@ -16,12 +16,18 @@ function previewAssetsUrl(bookLabel: string): string {
  *  The iframe is scaled down via CSS transform to fit the actual panel width. */
 const RENDER_WIDTH = 1280
 
+export type Alignment = "left" | "center" | "right"
+
 export interface BookPreviewFrameHandle {
   /** Get the iframe element's bounding rect in the viewport */
   getIframeRect: () => DOMRect | null
   /** Regenerate Tailwind CSS including the given extra HTML, then inject into iframe.
    *  Use after AI edits introduce new Tailwind classes not yet in the DB. */
   refreshCss: (extraHtml: string) => Promise<void>
+  /** Read the current text alignment of a data-id element in the iframe. */
+  getElementAlignment: (dataId: string) => Alignment
+  /** Change the text alignment of a data-id element. */
+  changeAlignment: (dataId: string, alignment: Alignment) => void
 }
 
 export interface BookPreviewFrameProps {
@@ -39,6 +45,8 @@ export interface BookPreviewFrameProps {
   onSelectElement?: (dataId: string, rect: DOMRect) => void
   /** Called when a text element is edited (blur/Enter after contenteditable) */
   onTextChanged?: (dataId: string, newText: string, fullHtml: string) => void
+  /** Called when text alignment is changed on a data-id element via changeAlignment() */
+  onAlignmentChanged?: (dataId: string, alignment: Alignment, fullHtml: string) => void
   /** When true (default), applies data-background-color to the iframe body */
   applyBodyBackground?: boolean
 }
@@ -63,6 +71,7 @@ export const BookPreviewFrame = forwardRef<BookPreviewFrameHandle, BookPreviewFr
   changedElements,
   onSelectElement,
   onTextChanged,
+  onAlignmentChanged,
   applyBodyBackground,
 }, ref) {
   const iframeRef = useRef<HTMLIFrameElement>(null)
@@ -70,8 +79,50 @@ export const BookPreviewFrame = forwardRef<BookPreviewFrameHandle, BookPreviewFr
 
   const assetsPrefix = previewAssetsUrl(bookLabel)
 
+  function extractFullHtml(): string {
+    const doc = iframeRef.current?.contentDocument
+    if (!doc?.body) return ""
+    const wrapper = doc.getElementById("content")
+    if (wrapper) {
+      const cls = (wrapper.getAttribute("class") || "").trim()
+      return cls ? wrapper.outerHTML : wrapper.innerHTML
+    }
+    return doc.body.innerHTML
+  }
+
+  function detectAlignment(el: Element): Alignment {
+    const cl = el.classList
+    if (cl.contains("text-center")) return "center"
+    if (cl.contains("text-right")) return "right"
+    return "left"
+  }
+
   useImperativeHandle(ref, () => ({
     getIframeRect: () => iframeRef.current?.getBoundingClientRect() ?? null,
+    getElementAlignment: (dataId: string): Alignment => {
+      const doc = iframeRef.current?.contentDocument
+      if (!doc) return "left"
+      const el = doc.querySelector(`[data-id="${CSS.escape(dataId)}"]`)
+      if (!el) return "left"
+      return detectAlignment(el)
+    },
+    changeAlignment: (dataId: string, alignment: Alignment) => {
+      const doc = iframeRef.current?.contentDocument
+      if (!doc) return
+      const el = doc.querySelector(`[data-id="${CSS.escape(dataId)}"]`) as HTMLElement | null
+      if (!el) return
+      el.classList.remove("text-left", "text-center", "text-right")
+      el.classList.add(`text-${alignment}`)
+      // Temporarily strip the selection outline so it doesn't get baked into the stored HTML
+      const savedOutline = el.style.outline
+      const savedOffset = el.style.outlineOffset
+      el.style.outline = ""
+      el.style.outlineOffset = ""
+      const fullHtml = extractFullHtml()
+      el.style.outline = savedOutline
+      el.style.outlineOffset = savedOffset
+      callbacksRef.current.onAlignmentChanged?.(dataId, alignment, fullHtml)
+    },
     refreshCss: async (extraHtml: string) => {
       const doc = iframeRef.current?.contentDocument
       if (!doc?.head) return
@@ -247,8 +298,8 @@ ${interactiveScript}
   )
 
   // Listen for postMessage from iframe
-  const callbacksRef = useRef({ onSelectElement, onTextChanged })
-  callbacksRef.current = { onSelectElement, onTextChanged }
+  const callbacksRef = useRef({ onSelectElement, onTextChanged, onAlignmentChanged })
+  callbacksRef.current = { onSelectElement, onTextChanged, onAlignmentChanged }
 
   const handleMessage = useCallback((e: MessageEvent) => {
     const iframe = iframeRef.current

--- a/apps/studio/src/components/pipeline/stages/SectionEditToolbar.tsx
+++ b/apps/studio/src/components/pipeline/stages/SectionEditToolbar.tsx
@@ -1,4 +1,5 @@
-import { Crop, Eye, EyeOff, Pencil, Scissors, Sparkles, Trash2, Type, Upload } from "lucide-react"
+import { AlignCenter, AlignLeft, AlignRight, Crop, Eye, EyeOff, Pencil, Scissors, Sparkles, Trash2, Type, Upload } from "lucide-react"
+import type { Alignment } from "./BookPreviewFrame"
 import {
   Select,
   SelectContent,
@@ -42,6 +43,10 @@ export interface SectionEditToolbarProps {
   segmenting?: boolean
   /** Called when delete/remove block is requested */
   onDelete?: (dataId: string) => void
+  /** Current text alignment of the selected element */
+  currentAlignment?: Alignment
+  /** Called when text alignment is changed */
+  onChangeAlignment?: (dataId: string, alignment: Alignment) => void
 }
 
 /**
@@ -66,9 +71,17 @@ export function SectionEditToolbar({
   onSegment,
   segmenting,
   onDelete,
+  currentAlignment,
+  onChangeAlignment,
 }: SectionEditToolbarProps) {
   const { t } = useLingui()
   if (!dataId) return null
+
+  const ALIGN_OPTIONS = [
+    { value: "left" as Alignment, Icon: AlignLeft, label: () => t`Align left` },
+    { value: "center" as Alignment, Icon: AlignCenter, label: () => t`Align center` },
+    { value: "right" as Alignment, Icon: AlignRight, label: () => t`Align right` },
+  ]
 
   if (isImage) {
     // Image popover: positioned ABOVE the element (card height ~110px: thumbnail 48 + info + padding + actions)
@@ -221,6 +234,25 @@ export function SectionEditToolbar({
             {textType}
           </span>
         )
+      )}
+
+      {onChangeAlignment && (
+        <>
+          <span className="border-l h-4 mx-0.5" />
+          <div className="flex items-center">
+            {ALIGN_OPTIONS.map(({ value, Icon, label }) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => onChangeAlignment(dataId, value)}
+                className={`p-0.5 rounded transition-colors cursor-pointer ${currentAlignment === value ? "bg-accent text-accent-foreground" : "hover:bg-muted text-muted-foreground"}`}
+                title={label()}
+              >
+                <Icon className="h-3 w-3" />
+              </button>
+            ))}
+          </div>
+        </>
       )}
 
       <span className="flex items-center gap-0.5 text-[10px] text-blue-500">

--- a/apps/studio/src/components/pipeline/stages/StoryboardSectionDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/StoryboardSectionDetail.tsx
@@ -1292,6 +1292,31 @@ export function StoryboardSectionDetail({
     [parts, pendingSectioning, page.sectioning, sectionIndex]
   )
 
+  // Handle toolbar alignment change — delegates to BookPreviewFrame imperative method
+  const handleToolbarAlignment = useCallback(
+    (dataId: string, alignment: "left" | "center" | "right") => {
+      previewFrameRef.current?.changeAlignment(dataId, alignment)
+    },
+    []
+  )
+
+  // Handle alignment change callback from BookPreviewFrame
+  const handleAlignmentChanged = useCallback(
+    (_dataId: string, _alignment: string, fullHtml: string) => {
+      if (!page.rendering) return
+      const base = pendingRendering ?? page.rendering
+      const updated: RenderingData = {
+        ...base,
+        sections: base.sections.map((s) => {
+          if (s.sectionIndex !== sectionIndex) return s
+          return { ...s, html: fullHtml }
+        }),
+      }
+      setPendingRendering(updated)
+    },
+    [page.rendering, pendingRendering, sectionIndex]
+  )
+
   // Handle crop apply: upload cropped image, update sectioning + rendering HTML
   const handleCropApply = useCallback(
     async (blob: Blob) => {
@@ -1762,6 +1787,7 @@ export function StoryboardSectionDetail({
       textType: textEntry?.textType,
       isPruned: isImage ? imagePart?.isPruned ?? false : textEntry?.isPruned ?? false,
       imageSrc: isImage ? `${BASE_URL}/books/${bookLabel}/images/${dataId}` : undefined,
+      alignment: !isImage ? previewFrameRef.current?.getElementAlignment(dataId) ?? "left" : undefined,
     }
   }
 
@@ -1982,6 +2008,7 @@ export function StoryboardSectionDetail({
                   changedElements={changedElements}
                   onSelectElement={handleSelectElement}
                   onTextChanged={handleTextChanged}
+                  onAlignmentChanged={handleAlignmentChanged}
                   applyBodyBackground={applyBodyBackground}
                 />
             )}
@@ -2239,6 +2266,8 @@ export function StoryboardSectionDetail({
           onSegment={selectedInfo.isImage && hasApiKey ? handleSegment : undefined}
           segmenting={segmenting}
           onDelete={handleDeleteBlock}
+          currentAlignment={selectedInfo.alignment}
+          onChangeAlignment={!selectedInfo.isImage ? handleToolbarAlignment : undefined}
         />
       )}
 

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -289,6 +289,15 @@ msgstr "AI sees the current image and modifies it"
 msgid "AIza..."
 msgstr "AIza..."
 
+msgid "Align center"
+msgstr "Align center"
+
+msgid "Align left"
+msgstr "Align left"
+
+msgid "Align right"
+msgstr "Align right"
+
 msgid "All sections have been deleted"
 msgstr "All sections have been deleted"
 

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -289,6 +289,15 @@ msgstr "La IA ve la imagen actual y la modifica"
 msgid "AIza..."
 msgstr "AIza..."
 
+msgid "Align center"
+msgstr "Alinear al centro"
+
+msgid "Align left"
+msgstr "Alinear a la izquierda"
+
+msgid "Align right"
+msgstr "Alinear a la derecha"
+
 msgid "All sections have been deleted"
 msgstr "Todas las secciones han sido eliminadas"
 

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -289,6 +289,15 @@ msgstr "A IA vê a imagem atual e a modifica"
 msgid "AIza..."
 msgstr "AIza..."
 
+msgid "Align center"
+msgstr "Alinhar ao centro"
+
+msgid "Align left"
+msgstr "Alinhar à esquerda"
+
+msgid "Align right"
+msgstr "Alinhar à direita"
+
 msgid "All sections have been deleted"
 msgstr "Todas as seções foram excluídas"
 


### PR DESCRIPTION
## Summary

Adds left/center/right text alignment buttons to the storyboard section edit toolbar, giving users deterministic control over text alignment within rendered elements — no LLM re-render required.

- **AlignLeft / AlignCenter / AlignRight** icon buttons appear in the floating text toolbar (between the text-type selector and the "Editing" indicator) when a text element is selected
- Toggling alignment modifies `text-left` / `text-center` / `text-right` Tailwind classes directly on the `data-id` element inside the iframe
- The active alignment is highlighted in the toolbar based on the element's current classes
- Changes follow the same `pendingRendering` dirty-state pattern as inline text editing — save/discard bar appears, versioning is preserved
- Text elements only — alignment buttons are not shown for image elements
- Selection outline is temporarily stripped before extracting HTML to prevent the blue border from being persisted into stored rendering data
- All 3 locales fully translated (en, es, pt-BR)

## Files changed

| File | Change |
|------|--------|
| `BookPreviewFrame.tsx` | `Alignment` type export, `extractFullHtml()` / `detectAlignment()` helpers, `getElementAlignment` / `changeAlignment` imperative methods, `onAlignmentChanged` prop + callback ref |
| `SectionEditToolbar.tsx` | `AlignLeft`/`AlignCenter`/`AlignRight` imports, `currentAlignment` + `onChangeAlignment` props, alignment button group in text toolbar |
| `StoryboardSectionDetail.tsx` | `handleToolbarAlignment` + `handleAlignmentChanged` callbacks, `alignment` field in `selectedInfo`, wiring to both `SectionEditToolbar` and `BookPreviewFrame` |
| `en.po` / `es.po` / `pt-BR.po` | 3 new translated strings each ("Align left/center/right") |

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` — all 783 tests pass
- [x] `pnpm lint` — no errors (eslint suppressions updated for CSS class strings)
- [x] `pnpm --filter @adt/studio extract` — 0 missing translations
- [x] Open a book with storyboard data, click a text element → alignment buttons appear in the toolbar
- [x] Click left/center/right → text alignment changes visually in the preview
- [x] Save/discard bar appears (dirty state); saving persists alignment, discarding reverts
- [ ] Alignment buttons do NOT appear when an image element is selected
- [ ] No blue outline border persisted in saved HTML after alignment change