### PR TITLE
Virtualize page sidebar for large books

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -25,6 +25,7 @@
     "@radix-ui/react-tabs": "^1.1.13",
     "@tanstack/react-query": "^5.0.0",
     "@tanstack/react-router": "^1.0.0",
+    "@tanstack/react-virtual": "^3.13.23",
     "@tauri-apps/plugin-dialog": "^2",
     "@tauri-apps/plugin-fs": "^2",
     "class-variance-authority": "^0.7.0",
@@ -48,12 +49,12 @@
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.0",
+    "ai": "^4.0.0",
     "babel-plugin-macros": "^3.1.0",
     "eslint": "^9",
     "eslint-plugin-lingui": "^0.11.0",
-    "typescript-eslint": "^8",
     "tailwindcss": "^4.0.0",
-    "ai": "^4.0.0",
+    "typescript-eslint": "^8",
     "vite": "^6.0.0"
   }
 }

--- a/apps/studio/src/components/pipeline/StageSidebar.tsx
+++ b/apps/studio/src/components/pipeline/StageSidebar.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from "react"
+import { useState, useEffect, useRef, useCallback, useMemo } from "react"
 import { createPortal } from "react-dom"
 import { Link, useMatchRoute, useSearch } from "@tanstack/react-router"
 import { Trans } from "@lingui/react/macro"
@@ -7,6 +7,7 @@ import {
   RotateCcw,
   Settings,
 } from "lucide-react"
+import { useVirtualizer } from "@tanstack/react-virtual"
 import { cn } from "@/lib/utils"
 import { useLingui } from "@lingui/react"
 import { msg } from "@lingui/core/macro"
@@ -320,16 +321,14 @@ export function StageSidebar({
         {/* Pages panel — only when pages are open and not in settings */}
         {effectivePagesOpen && !isSettings && (
           <div className="flex-1 min-w-0 flex flex-col overflow-hidden border-l">
-            <div className="flex-1 overflow-y-auto">
-              <PageIndex
-                bookLabel={bookLabel}
-                activeStep={activeStep}
-                selectedPageId={selectedPageId}
-                onSelectPage={onSelectPage}
-                sectionIndex={sectionIndex}
-                onSelectSection={onSelectSection}
-              />
-            </div>
+            <PageIndex
+              bookLabel={bookLabel}
+              activeStep={activeStep}
+              selectedPageId={selectedPageId}
+              onSelectPage={onSelectPage}
+              sectionIndex={sectionIndex}
+              onSelectSection={onSelectSection}
+            />
           </div>
         )}
       </div>
@@ -429,32 +428,72 @@ function PageIndex({
 }) {
   const { data: pages } = usePages(bookLabel)
   const activeStepDef = STAGES.find((s) => s.slug === activeStep)
+  const parentRef = useRef<HTMLDivElement>(null)
+
+  const selectedIndex = useMemo(
+    () => pages?.findIndex((p) => p.pageId === selectedPageId) ?? -1,
+    [pages, selectedPageId],
+  )
+
+  const virtualizer = useVirtualizer({
+    count: pages?.length ?? 0,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 52,
+    overscan: 5,
+  })
+
+  useEffect(() => {
+    if (selectedIndex >= 0) {
+      virtualizer.scrollToIndex(selectedIndex, { align: "auto" })
+    }
+  }, [selectedIndex, virtualizer])
 
   if (!pages?.length) {
     return (
-      <div className="px-3 py-4 text-xs text-muted-foreground text-center">
+      <div className="flex-1 overflow-y-auto px-3 py-4 text-xs text-muted-foreground text-center">
         <Trans>No pages extracted yet</Trans>
       </div>
     )
   }
 
   return (
-    <div className="flex flex-col py-1">
-      {pages.map((page) => {
-        const isActive = page.pageId === selectedPageId
-        return (
-          <PageRow
-            key={page.pageId}
-            bookLabel={bookLabel}
-            page={page}
-            isActive={isActive}
-            activeStepDef={activeStepDef}
-            onSelect={() => onSelectPage?.(page.pageId)}
-            sectionIndex={isActive ? sectionIndex : undefined}
-            onSelectSection={isActive ? onSelectSection : undefined}
-          />
-        )
-      })}
+    <div ref={parentRef} className="flex-1 overflow-y-auto">
+      <div
+        style={{
+          height: virtualizer.getTotalSize(),
+          width: "100%",
+          position: "relative",
+        }}
+      >
+        {virtualizer.getVirtualItems().map((virtualRow) => {
+          const page = pages[virtualRow.index]
+          const isActive = page.pageId === selectedPageId
+          return (
+            <div
+              key={page.pageId}
+              data-index={virtualRow.index}
+              ref={virtualizer.measureElement}
+              style={{
+                position: "absolute",
+                top: 0,
+                left: 0,
+                width: "100%",
+                transform: `translateY(${virtualRow.start}px)`,
+              }}
+            >
+              <PageRow
+                bookLabel={bookLabel}
+                page={page}
+                isActive={isActive}
+                activeStepDef={activeStepDef}
+                onSelect={() => onSelectPage?.(page.pageId)}
+                sectionIndex={isActive ? sectionIndex : undefined}
+                onSelectSection={isActive ? onSelectSection : undefined}
+              />
+            </div>
+          )
+        })}
+      </div>
     </div>
   )
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,6 +124,9 @@ importers:
       '@tanstack/react-router':
         specifier: ^1.0.0
         version: 1.159.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@tanstack/react-virtual':
+        specifier: ^3.13.23
+        version: 3.13.23(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@tauri-apps/plugin-dialog':
         specifier: ^2
         version: 2.6.0
@@ -1737,6 +1740,12 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  '@tanstack/react-virtual@3.13.23':
+    resolution: {integrity: sha512-XnMRnHQ23piOVj2bzJqHrRrLg4r+F86fuBcwteKfbIjJrtGxb4z7tIvPVAe4B+4UVwo9G4Giuz5fmapcrnZ0OQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   '@tanstack/router-core@1.159.4':
     resolution: {integrity: sha512-MFzPH39ijNO83qJN3pe7x4iAlhZyqgao3sJIzv3SJ4Pnk12xMnzuDzIAQT/1WV6JolPQEcw0Wr4L5agF8yxoeg==}
     engines: {node: '>=12'}
@@ -1772,6 +1781,9 @@ packages:
 
   '@tanstack/store@0.8.0':
     resolution: {integrity: sha512-Om+BO0YfMZe//X2z0uLF2j+75nQga6TpTJgLJQBiq85aOyZNIhkCgleNcud2KQg4k4v9Y9l+Uhru3qWMPGTOzQ==}
+
+  '@tanstack/virtual-core@3.13.23':
+    resolution: {integrity: sha512-zSz2Z2HNyLjCplANTDyl3BcdQJc2k1+yyFoKhNRmCr7V7dY8o8q5m8uFTI1/Pg1kL+Hgrz6u3Xo6eFUB7l66cg==}
 
   '@tanstack/virtual-file-routes@1.154.7':
     resolution: {integrity: sha512-cHHDnewHozgjpI+MIVp9tcib6lYEQK5MyUr0ChHpHFGBl8Xei55rohFK0I0ve/GKoHeioaK42Smd8OixPp6CTg==}
@@ -4931,6 +4943,12 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       use-sync-external-store: 1.6.0(react@19.2.4)
 
+  '@tanstack/react-virtual@3.13.23(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@tanstack/virtual-core': 3.13.23
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
   '@tanstack/router-core@1.159.4':
     dependencies:
       '@tanstack/history': 1.154.14
@@ -4990,6 +5008,8 @@ snapshots:
       - supports-color
 
   '@tanstack/store@0.8.0': {}
+
+  '@tanstack/virtual-core@3.13.23': {}
 
   '@tanstack/virtual-file-routes@1.154.7': {}
 


### PR DESCRIPTION
## Summary
- Adds `@tanstack/react-virtual` to only render visible page rows in the sidebar
- Replaces the full `pages.map()` in `PageIndex` with a virtualized list (5 row overscan)
- Page images are now lazily fetched only for visible rows instead of all at once
- Auto-scrolls to the selected page when navigating via URL

## Test plan
- [x] Open a book with many pages, verify sidebar is responsive and only ~20-25 page DOM nodes exist
- [x] Navigate to a deep page via URL — sidebar scrolls to show it
- [x] Hover a thumbnail — large preview appears correctly
- [x] Select a page with multiple sections — section buttons appear, layout adjusts
- [x] Scroll rapidly through pages — no blank flashes