### PR TITLE
Require 7-day minimum release age for pnpm packages

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
 packages:
   - "packages/*"
   - "apps/*"
+
+minimumReleaseAge: 10080


### PR DESCRIPTION
## Summary

Adds `minimumReleaseAge: 10080` to `pnpm-workspace.yaml` so pnpm will refuse to install any package version published less than 7 days ago. This mitigates supply chain attacks where malicious code is published and quickly consumed before detection.

## Test plan

- [ ] Run `pnpm install` and verify it completes successfully with existing lockfile
- [ ] Verify that attempting to install a very recently published package is blocked