### PR TITLE
Invalidate downstream pipeline data on storyboard and image edits

### DIFF
--- a/apps/api/src/routes/pages.test.ts
+++ b/apps/api/src/routes/pages.test.ts
@@ -632,4 +632,260 @@ describe("Page routes", () => {
       expect(res.status).toBe(404)
     })
   })
+
+  // ---------------------------------------------------------------------------
+  // Downstream data clearing tests
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Seed downstream pipeline data (image-captioning, text-catalog,
+   * text-catalog-translation, tts) and their step_runs so we can verify
+   * they get cleared after storyboard/image edits.
+   */
+  function seedDownstreamData(dir: string, bookLabel: string) {
+    const s = createBookStorage(bookLabel, dir)
+    try {
+      s.putNodeData("image-captioning", `${bookLabel}_p1`, {
+        captions: [{ imageId: "img1", reasoning: "test", caption: "A cat" }],
+      })
+      s.putNodeData("text-catalog", `${bookLabel}_p1`, {
+        entries: [{ id: "t1", text: "Hello" }],
+      })
+      s.putNodeData("text-catalog-translation", `${bookLabel}_p1`, {
+        locale: "es", entries: [{ id: "t1", text: "Hola" }],
+      })
+      s.putNodeData("tts", `${bookLabel}_p1`, {
+        entries: [{ id: "t1", url: "audio.mp3" }],
+      })
+      // Mark corresponding steps as completed
+      s.markStepCompleted("image-captioning")
+      s.markStepCompleted("text-catalog")
+      s.markStepCompleted("catalog-translation")
+      s.markStepCompleted("tts")
+    } finally {
+      s.close()
+    }
+  }
+
+  /** Assert that all caption + text-and-speech node data and step_runs were cleared. */
+  function expectAllDownstreamCleared(dir: string, bookLabel: string) {
+    const s = createBookStorage(bookLabel, dir)
+    try {
+      // Node data should be gone
+      expect(s.getLatestNodeData("image-captioning", `${bookLabel}_p1`)).toBeNull()
+      expect(s.getLatestNodeData("text-catalog", `${bookLabel}_p1`)).toBeNull()
+      expect(s.getLatestNodeData("text-catalog-translation", `${bookLabel}_p1`)).toBeNull()
+      expect(s.getLatestNodeData("tts", `${bookLabel}_p1`)).toBeNull()
+      // Step runs should be gone
+      const runs = s.getStepRuns()
+      const clearedSteps = ["image-captioning", "text-catalog", "catalog-translation", "tts"]
+      for (const step of clearedSteps) {
+        expect(runs.find((r) => r.step === step)).toBeUndefined()
+      }
+    } finally {
+      s.close()
+    }
+  }
+
+  /** Assert that text-and-speech (but NOT image-captioning) node data and step_runs were cleared. */
+  function expectTextAndSpeechCleared(dir: string, bookLabel: string) {
+    const s = createBookStorage(bookLabel, dir)
+    try {
+      // image-captioning should still exist
+      expect(s.getLatestNodeData("image-captioning", `${bookLabel}_p1`)).not.toBeNull()
+      // text-catalog, translations, tts should be gone
+      expect(s.getLatestNodeData("text-catalog", `${bookLabel}_p1`)).toBeNull()
+      expect(s.getLatestNodeData("text-catalog-translation", `${bookLabel}_p1`)).toBeNull()
+      expect(s.getLatestNodeData("tts", `${bookLabel}_p1`)).toBeNull()
+      // Step runs: image-captioning should remain, text steps should be gone
+      const runs = s.getStepRuns()
+      expect(runs.find((r) => r.step === "image-captioning")).toBeDefined()
+      for (const step of ["text-catalog", "catalog-translation", "tts"]) {
+        expect(runs.find((r) => r.step === step)).toBeUndefined()
+      }
+    } finally {
+      s.close()
+    }
+  }
+
+  describe("PUT /api/books/:label/pages/:pageId/sectioning clears downstream", () => {
+    it("clears caption + text-and-speech data on sectioning save", async () => {
+      seedDownstreamData(tmpDir, label)
+
+      const data = {
+        reasoning: "updated",
+        sections: [{
+          sectionId: `${label}_p1_sec001`,
+          sectionType: "content",
+          parts: [{
+            type: "text_group",
+            groupId: "g1",
+            groupType: "paragraph",
+            texts: [{ textId: "g1_tx001", textType: "section_text", text: "Updated text", isPruned: false }],
+            isPruned: false,
+          }],
+          backgroundColor: "#ffffff",
+          textColor: "#000000",
+          pageNumber: 1,
+          isPruned: false,
+        }],
+      }
+
+      const res = await app.request(
+        `/api/books/${label}/pages/${label}_p1/sectioning`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(data),
+        }
+      )
+
+      expect(res.status).toBe(200)
+      expectAllDownstreamCleared(tmpDir, label)
+    })
+  })
+
+  describe("PUT /api/books/:label/pages/:pageId/rendering clears downstream", () => {
+    it("clears caption + text-and-speech data on rendering save", async () => {
+      seedDownstreamData(tmpDir, label)
+
+      const data = {
+        sections: [{
+          sectionIndex: 0,
+          sectionType: "content",
+          reasoning: "updated render",
+          html: "<div>Updated</div>",
+        }],
+      }
+
+      const res = await app.request(
+        `/api/books/${label}/pages/${label}_p1/rendering`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(data),
+        }
+      )
+
+      expect(res.status).toBe(200)
+      expectAllDownstreamCleared(tmpDir, label)
+    })
+  })
+
+  describe("POST clone clears downstream", () => {
+    it("clears caption + text-and-speech data on section clone", async () => {
+      seedDownstreamData(tmpDir, label)
+
+      const res = await app.request(
+        `/api/books/${label}/pages/${label}_p1/sections/0/clone`,
+        { method: "POST" }
+      )
+
+      expect(res.status).toBe(200)
+      expectAllDownstreamCleared(tmpDir, label)
+    })
+  })
+
+  describe("POST delete clears downstream", () => {
+    it("clears caption + text-and-speech data on section delete", async () => {
+      // Need at least 2 sections so delete is valid
+      const s = createBookStorage(label, tmpDir)
+      try {
+        s.putNodeData("page-sectioning", `${label}_p1`, {
+          reasoning: "sectioned",
+          sections: [
+            {
+              sectionId: `${label}_p1_sec001`,
+              sectionType: "content",
+              parts: [],
+              backgroundColor: "#ffffff",
+              textColor: "#000000",
+              pageNumber: 1,
+              isPruned: false,
+            },
+            {
+              sectionId: `${label}_p1_sec002`,
+              sectionType: "content",
+              parts: [],
+              backgroundColor: "#ffffff",
+              textColor: "#000000",
+              pageNumber: 1,
+              isPruned: false,
+            },
+          ],
+        })
+        s.putNodeData("web-rendering", `${label}_p1`, {
+          sections: [
+            { sectionIndex: 0, sectionType: "content", reasoning: "r", html: "<div>A</div>" },
+            { sectionIndex: 1, sectionType: "content", reasoning: "r", html: "<div>B</div>" },
+          ],
+        })
+      } finally {
+        s.close()
+      }
+
+      seedDownstreamData(tmpDir, label)
+
+      const res = await app.request(
+        `/api/books/${label}/pages/${label}_p1/sections/1`,
+        { method: "DELETE" }
+      )
+
+      expect(res.status).toBe(200)
+      expectAllDownstreamCleared(tmpDir, label)
+    })
+  })
+
+  describe("POST crop (images) clears downstream", () => {
+    it("clears caption + text-and-speech data on image crop", async () => {
+      seedDownstreamData(tmpDir, label)
+
+      // Minimal valid PNG (1x1 pixel)
+      const pngHeader = Buffer.from([
+        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+        0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+        0x00, 0x00, 0x00, 0x01,
+        0x00, 0x00, 0x00, 0x01,
+        0x08, 0x02, 0x00, 0x00, 0x00,
+        0x90, 0x77, 0x53, 0xde,
+      ])
+
+      const formData = new FormData()
+      formData.append("image", new Blob([pngHeader], { type: "image/png" }), "crop.png")
+      formData.append("pageId", `${label}_p1`)
+      formData.append("sourceImageId", `${label}_p1_page`)
+
+      const res = await app.request(`/api/books/${label}/images`, {
+        method: "POST",
+        body: formData,
+      })
+
+      expect(res.status).toBe(200)
+      expectAllDownstreamCleared(tmpDir, label)
+    })
+  })
+
+  describe("PUT image-captioning clears text-and-speech downstream", () => {
+    it("clears text-catalog/translations/TTS but keeps image-captioning", async () => {
+      seedDownstreamData(tmpDir, label)
+
+      const data = {
+        captions: [{ imageId: "img1", reasoning: "updated", caption: "A dog" }],
+      }
+
+      const res = await app.request(
+        `/api/books/${label}/pages/${label}_p1/image-captioning`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(data),
+        }
+      )
+
+      expect(res.status).toBe(200)
+      // image-captioning was just saved (new version), so it should exist
+      // but text-catalog, translations, tts should be cleared
+      expectTextAndSpeechCleared(tmpDir, label)
+    })
+  })
 })

--- a/apps/api/src/routes/pages.ts
+++ b/apps/api/src/routes/pages.ts
@@ -7,6 +7,7 @@ import { HTTPException } from "hono/http-exception"
 import { parseBookLabel, TextClassificationOutput, ImageClassificationOutput, PageSectioningOutput, WebRenderingOutput, ImageCaptioningOutput, ImageSegmentRegion, DEFAULT_LLM_MAX_RETRIES } from "@adt/types"
 import { openBookDb } from "@adt/storage"
 import { createBookStorage } from "@adt/storage"
+import type { Storage } from "@adt/storage"
 import { reRenderPage, aiEditSection } from "../services/page-edit-service.js"
 import type { TaskService } from "../services/task-service.js"
 import { segmentPageImages, getSegmentedImageId, loadBookConfig, applyCrop, generateStyleguide, buildStyleguideGenerationConfig } from "@adt/pipeline"
@@ -267,7 +268,7 @@ async function executeAiImageGeneration(params: AiImageGenParams): Promise<{
                     sectioning.sections[si].parts.push({ type: "image", imageId: newImageId, isPruned: false })
                   }
                 }
-                storage.putNodeData("page-sectioning", pageId, sectioning)
+                saveStoryboardNode(storage, "page-sectioning", pageId, sectioning)
               }
             }
           }
@@ -305,7 +306,7 @@ async function executeAiImageGeneration(params: AiImageGenParams): Promise<{
                 }
                 return { ...s, html }
               })
-              storage.putNodeData("web-rendering", pageId, rendering)
+              saveStoryboardNode(storage, "web-rendering", pageId, rendering)
             }
           }
         } finally {
@@ -321,6 +322,27 @@ async function executeAiImageGeneration(params: AiImageGenParams): Promise<{
   } finally {
     db.close()
   }
+}
+
+/** Clear caption + downstream text-and-speech data when images change. */
+function clearCaptionData(storage: Storage): void {
+  storage.clearNodesByType(["image-captioning", "text-catalog", "text-catalog-translation", "tts"])
+  storage.clearStepRuns(["image-captioning", "text-catalog", "catalog-translation", "tts"])
+}
+
+/**
+ * Save storyboard node data and clear stale downstream data.
+ * Use for all user-initiated storyboard saves (NOT pipeline stage runs).
+ */
+function saveStoryboardNode(
+  storage: Storage,
+  node: "page-sectioning" | "web-rendering",
+  itemId: string,
+  data: unknown
+): number {
+  const version = storage.putNodeData(node, itemId, data)
+  clearCaptionData(storage)
+  return version
 }
 
 export function createPageRoutes(
@@ -642,7 +664,7 @@ export function createPageRoutes(
         throw new HTTPException(404, { message: `Page not found: ${pageId}` })
       }
 
-      const version = storage.putNodeData("page-sectioning", pageId, parsed.data)
+      const version = saveStoryboardNode(storage, "page-sectioning", pageId, parsed.data)
       return c.json({ version })
     } finally {
       storage.close()
@@ -670,7 +692,7 @@ export function createPageRoutes(
         throw new HTTPException(404, { message: `Page not found: ${pageId}` })
       }
 
-      const version = storage.putNodeData("web-rendering", pageId, parsed.data)
+      const version = saveStoryboardNode(storage, "web-rendering", pageId, parsed.data)
       return c.json({ version })
     } finally {
       storage.close()
@@ -699,6 +721,9 @@ export function createPageRoutes(
       }
 
       const version = storage.putNodeData("image-captioning", pageId, parsed.data)
+      // Caption change cascades to text-catalog/translations/TTS
+      storage.clearNodesByType(["text-catalog", "text-catalog-translation", "tts"])
+      storage.clearStepRuns(["text-catalog", "catalog-translation", "tts"])
       return c.json({ version })
     } finally {
       storage.close()
@@ -866,7 +891,7 @@ export function createPageRoutes(
                   s.sectionIndex === idx ? { ...s, html: result.html } : s
                 ),
               }
-              storage.putNodeData("web-rendering", pageId, updated)
+              saveStoryboardNode(storage, "web-rendering", pageId, updated)
             }
           } finally {
             storage.close()
@@ -989,9 +1014,9 @@ export function createPageRoutes(
         }
         updatedRendering = { sections: shifted }
       }
-      const sectioningVersion = storage.putNodeData("page-sectioning", pageId, updatedSectioning)
+      const sectioningVersion = saveStoryboardNode(storage, "page-sectioning", pageId, updatedSectioning)
       if (updatedRendering) {
-        renderingVersion = storage.putNodeData("web-rendering", pageId, updatedRendering)
+        renderingVersion = saveStoryboardNode(storage, "web-rendering", pageId, updatedRendering)
       }
 
       return c.json({
@@ -1129,9 +1154,9 @@ export function createPageRoutes(
         updatedRendering = { sections: shifted }
       }
 
-      const sectioningVersion = storage.putNodeData("page-sectioning", pageId, updatedSectioning)
+      const sectioningVersion = saveStoryboardNode(storage, "page-sectioning", pageId, updatedSectioning)
       if (updatedRendering) {
-        renderingVersion = storage.putNodeData("web-rendering", pageId, updatedRendering)
+        renderingVersion = saveStoryboardNode(storage, "web-rendering", pageId, updatedRendering)
       }
 
       return c.json({
@@ -1236,9 +1261,9 @@ export function createPageRoutes(
         updatedRendering = { sections: shifted }
       }
 
-      const sectioningVersion = storage.putNodeData("page-sectioning", pageId, updatedSectioning)
+      const sectioningVersion = saveStoryboardNode(storage, "page-sectioning", pageId, updatedSectioning)
       if (updatedRendering) {
-        renderingVersion = storage.putNodeData("web-rendering", pageId, updatedRendering)
+        renderingVersion = saveStoryboardNode(storage, "web-rendering", pageId, updatedRendering)
       }
 
       return c.json({
@@ -1430,6 +1455,14 @@ export function createPageRoutes(
         [newImageId, pageId, `images/${filename}`, hash, width, height, "crop"]
       )
 
+      // Clear caption data since the image content changed
+      const storage = createBookStorage(safeLabel, booksDir)
+      try {
+        clearCaptionData(storage)
+      } finally {
+        storage.close()
+      }
+
       return c.json({ imageId: newImageId, width, height })
     } finally {
       db.close()
@@ -1507,6 +1540,14 @@ export function createPageRoutes(
          VALUES (?, ?, ?, ?, ?, ?, 'upload')`,
         [newImageId, pageId, `images/${filename}`, hash, width, height]
       )
+
+      // Clear caption data since a new image was added
+      const storage = createBookStorage(safeLabel, booksDir)
+      try {
+        clearCaptionData(storage)
+      } finally {
+        storage.close()
+      }
 
       return c.json({ imageId: newImageId, width, height })
     } finally {
@@ -1674,6 +1715,7 @@ export function createPageRoutes(
         })
       }
 
+      clearCaptionData(storage)
       return c.json({ segments })
     } catch (err) {
       console.error(`[segment/apply] Error applying segmentation for ${imageId}:`, err)

--- a/apps/api/src/services/page-edit-service.ts
+++ b/apps/api/src/services/page-edit-service.ts
@@ -190,6 +190,8 @@ export async function reRenderPage(
     if (visualRefinement) {
       await visualRefinement.screenshotRenderer.close()
     }
+    storage.clearNodesByType(["image-captioning", "text-catalog", "text-catalog-translation", "tts"])
+    storage.clearStepRuns(["image-captioning", "text-catalog", "catalog-translation", "tts"])
     storage.close()
     // Restore previous key
     if (previousKey !== undefined) {

--- a/apps/studio/src/components/pipeline/stages/captions/CaptionsView.tsx
+++ b/apps/studio/src/components/pipeline/stages/captions/CaptionsView.tsx
@@ -7,6 +7,7 @@ import { usePages, usePage } from "@/hooks/use-pages"
 import { useStepHeader } from "../../components/StepViewRouter"
 import { useBookRun } from "@/hooks/use-book-run"
 import { useApiKey } from "@/hooks/use-api-key"
+import { invalidateStoryboardDependents } from "@/hooks/use-page-mutations"
 import { StageRunCard } from "../../components/StageRunCard"
 import { useSectionNav } from "@/routes/books.$label"
 import { Trans } from "@lingui/react/macro"
@@ -241,6 +242,7 @@ function PageCaptions({
     await api.updateImageCaptioning(bookLabel, pageId, pending)
     setPending(null)
     await queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "pages", pageId] })
+    invalidateStoryboardDependents(queryClient, bookLabel)
     await minDelay
     setSaving(false)
   }

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
@@ -8,6 +8,7 @@ import type { PageDetail, VersionEntry } from "@/api/client"
 import { useApiKey } from "@/hooks/use-api-key"
 import { useActiveConfig } from "@/hooks/use-debug"
 import { useBookTasks } from "@/hooks/use-book-tasks"
+import { invalidateStoryboardDependents } from "@/hooks/use-page-mutations"
 import { useStepHeader } from "../../../components/StepViewRouter"
 import { BookPreviewFrame, type BookPreviewFrameHandle } from "./BookPreviewFrame"
 import { SectionEditToolbar } from "./SectionEditToolbar"
@@ -557,6 +558,7 @@ export function StoryboardSectionDetail({
       setPendingRendering(null)
       needsRerenderRef.current = false
       await queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "pages", pageId] })
+      invalidateStoryboardDependents(queryClient, bookLabel)
       await minDelay
 
       // Only re-render when changes require LLM (e.g., unprune, type change, reorder)
@@ -601,6 +603,7 @@ export function StoryboardSectionDetail({
       setPendingRendering(null)
       setPendingSectioning(null)
       await queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "pages", pageId] })
+      invalidateStoryboardDependents(queryClient, bookLabel)
       await minDelay
     } catch (err) {
       setAiError(err instanceof Error ? err.message : t`Save failed`)
@@ -617,6 +620,7 @@ export function StoryboardSectionDetail({
       const result = await api.cloneSection(bookLabel, pageId, sectionIndex)
       await queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "pages", pageId] })
       await queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "pages"] })
+      invalidateStoryboardDependents(queryClient, bookLabel)
       onNavigateSection?.(result.clonedSectionIndex)
     } catch (err) {
       setAiError(err instanceof Error ? err.message : t`Clone failed`)
@@ -633,6 +637,7 @@ export function StoryboardSectionDetail({
       const result = await api.mergeSection(bookLabel, pageId, sectionIndex, direction)
       await queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "pages", pageId] })
       await queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "pages"] })
+      invalidateStoryboardDependents(queryClient, bookLabel)
       onNavigateSection?.(result.mergedSectionIndex)
 
       // Auto re-render the merged section so the LLM generates proper HTML for the combined content
@@ -659,6 +664,7 @@ export function StoryboardSectionDetail({
       const result = await api.deleteSection(bookLabel, pageId, sectionIndex)
       await queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "pages", pageId] })
       await queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "pages"] })
+      invalidateStoryboardDependents(queryClient, bookLabel)
       onNavigateSection?.(Math.max(0, Math.min(sectionIndex, result.remainingSections - 1)))
     } catch (err) {
       setAiError(err instanceof Error ? err.message : t`Delete failed`)

--- a/apps/studio/src/hooks/use-book-run.ts
+++ b/apps/studio/src/hooks/use-book-run.ts
@@ -12,6 +12,7 @@ import { STEP_TO_STAGE, PIPELINE, getStageClearOrder } from "@adt/types"
 import type { StageName } from "@adt/types"
 import { isStageComplete } from "./run-state"
 import { bookTasksKey } from "./use-book-tasks"
+import { invalidateStoryboardDependents } from "./use-page-mutations"
 
 // ---------------------------------------------------------------------------
 // Types
@@ -259,6 +260,9 @@ export function useBookRunStatus(label: string): BookRunContextValue {
           }
           if ((completedTask?.kind === "image-generate" || completedTask?.kind === "re-render" || completedTask?.kind === "ai-edit") && completedTask.pageId) {
             queryClient.invalidateQueries({ queryKey: ["books", label, "pages", completedTask.pageId] })
+          }
+          if (completedTask?.kind === "re-render" || completedTask?.kind === "ai-edit" || completedTask?.kind === "image-generate") {
+            invalidateStoryboardDependents(queryClient, label)
           }
           // Always refetch tasks so we pick up the final state even if we missed start
           queryClient.invalidateQueries({ queryKey: bookTasksKey(label) })

--- a/apps/studio/src/hooks/use-page-mutations.ts
+++ b/apps/studio/src/hooks/use-page-mutations.ts
@@ -1,5 +1,13 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query"
+import type { QueryClient } from "@tanstack/react-query"
 import { api } from "@/api/client"
+
+/** Invalidate text-catalog, TTS, and step-status queries after storyboard changes. */
+export function invalidateStoryboardDependents(queryClient: QueryClient, label: string): void {
+  queryClient.invalidateQueries({ queryKey: ["books", label, "text-catalog"] })
+  queryClient.invalidateQueries({ queryKey: ["books", label, "tts"] })
+  queryClient.invalidateQueries({ queryKey: ["books", label, "step-status"] })
+}
 
 export function useSaveTextClassification(label: string, pageId: string) {
   const queryClient = useQueryClient()
@@ -27,6 +35,7 @@ export function useSaveSectioning(label: string, pageId: string) {
     mutationFn: (data: unknown) => api.updateSectioning(label, pageId, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["books", label, "pages", pageId] })
+      invalidateStoryboardDependents(queryClient, label)
     },
   })
 }
@@ -38,6 +47,7 @@ export function useReRenderPage(label: string, pageId: string) {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["books", label, "pages", pageId] })
       queryClient.invalidateQueries({ queryKey: ["books", label, "pages"] })
+      invalidateStoryboardDependents(queryClient, label)
     },
   })
 }


### PR DESCRIPTION
## Summary

- **Centralized API clearing**: `saveStoryboardNode()` wrapper clears captions + text-catalog/translations/TTS after all user-initiated storyboard saves (sectioning, rendering, clone, merge, delete, AI edit, AI image insert). `clearCaptionData()` helper covers direct image operations (crop, upload, segment/apply).
- **Caption edit cascade**: Manual caption edits (`PUT image-captioning`) now clear downstream text-catalog/translations/TTS.
- **Re-render clearing**: `reRenderPage()` clears caption + text-and-speech data in its finally block.
- **Frontend invalidation**: New `invalidateStoryboardDependents()` helper invalidates text-catalog, TTS, and step-status queries from all storyboard save paths, caption saves, and task-complete handlers.
- **Tests**: 6 new tests verifying downstream data clearing for sectioning save, rendering save, clone, delete, image crop, and caption edit.

## Test plan

- [x] `pnpm test` — all 898 tests pass
- [x] Manual: edit storyboard text inline → save → TTS/text-catalog step status resets to idle
- [x] Manual: prune a text element → save → TTS/text-catalog step status resets to idle
- [x] Manual: crop/upload/generate image → captions step status resets to idle
- [x] Manual: edit caption text → text-catalog/TTS step status resets to idle