### PR TITLE
Add inline text editing in storyboard sidebar

### DIFF
--- a/apps/studio/src/components/pipeline/stages/storyboard/components/SectionDataPanel.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/SectionDataPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback, type ReactNode } from "react"
+import { useState, useRef, useCallback, useEffect, type ReactNode } from "react"
 import {
   Copy,
   Eye,
@@ -57,6 +57,7 @@ interface SectionDataPanelProps {
   onDuplicateGroup: (partIndex: number) => void
   onDeleteGroup: (partIndex: number) => void
   onReorderParts: (fromIndex: number, toIndex: number) => void
+  onEditText: (partIndex: number, textIndex: number, newText: string) => void
   onMoveText: (
     fromPartIndex: number,
     textIndex: number,
@@ -133,6 +134,81 @@ function ImageCard({
   )
 }
 
+// -- Inline editable text --
+
+function EditableText({
+  value,
+  onCommit,
+}: {
+  value: string
+  onCommit: (newText: string) => void
+}) {
+  const { t } = useLingui()
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState(value)
+  // Guard against double-commit (Enter triggers blur when textarea is removed)
+  // and against committing on Escape (blur fires when editing is cancelled).
+  const cancelRef = useRef(false)
+
+  // Sync draft when value changes externally while not editing
+  useEffect(() => {
+    if (!editing) setDraft(value)
+  }, [value, editing])
+
+  const commit = useCallback(() => {
+    if (cancelRef.current) {
+      cancelRef.current = false
+      return
+    }
+    setEditing(false)
+    const trimmed = draft.trim()
+    if (trimmed && trimmed !== value) {
+      onCommit(trimmed)
+    } else {
+      setDraft(value)
+    }
+  }, [draft, value, onCommit])
+
+  if (!editing) {
+    return (
+      <span
+        className="leading-relaxed flex-1 min-w-0 text-xs cursor-text rounded px-0.5 -mx-0.5 hover:bg-accent/50 transition-colors"
+        onClick={() => {
+          setEditing(true)
+        }}
+        title={t`Click to edit`}
+      >
+        {value}
+      </span>
+    )
+  }
+
+  return (
+    <textarea
+      value={draft}
+      onChange={(e) => setDraft(e.target.value)}
+      onBlur={commit}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" && !e.shiftKey) {
+          e.preventDefault()
+          // Let blur handler do the commit — prevents double-fire
+          cancelRef.current = false
+          e.currentTarget.blur()
+        }
+        if (e.key === "Escape") {
+          // Discard edit — suppress the blur commit
+          cancelRef.current = true
+          setDraft(value)
+          setEditing(false)
+        }
+      }}
+      className="leading-relaxed flex-1 min-w-0 text-xs rounded border border-ring bg-background px-1 py-0.5 -mx-0.5 resize-none focus:outline-none focus:ring-1 focus:ring-ring"
+      rows={Math.max(2, Math.ceil(draft.length / 50))}
+      autoFocus
+    />
+  )
+}
+
 // -- Drag types --
 
 const DRAG_TYPE_GROUP = "application/x-group-index"
@@ -158,6 +234,7 @@ export function SectionDataPanel({
   onToggleTextPruned,
   onDeleteTextEntry,
   onDuplicateTextEntry,
+  onEditText,
   onAddGroup,
   onDuplicateGroup,
   onDeleteGroup,
@@ -735,9 +812,12 @@ export function SectionDataPanel({
                                 {textEntry.textType}
                               </span>
                             )}
-                            <span className="leading-relaxed flex-1 min-w-0 text-xs">
-                              {textEntry.text}
-                            </span>
+                            <EditableText
+                              value={textEntry.text}
+                              onCommit={(newText) =>
+                                onEditText(partIndex, ti, newText)
+                              }
+                            />
                             <div className="shrink-0 flex items-center gap-0.5 self-center opacity-0 group-hover/text:opacity-100 transition-opacity">
                               <button
                                 type="button"

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
@@ -573,6 +573,7 @@ export function StoryboardSectionDetail({
 
   const discardSectioning = () => {
     setPendingSectioning(null)
+    setPendingRendering(null)
     needsRerenderRef.current = false
   }
 
@@ -938,6 +939,73 @@ export function StoryboardSectionDetail({
       }),
     }
     setPendingSectioning(updated)
+  }
+
+  // Edit text content for a specific text entry (from sidebar)
+  const editText = (partIndex: number, textIndex: number, newText: string) => {
+    // 1. Update sectioning data
+    const sBase = pendingSectioning ?? page.sectioning
+    if (!sBase) return
+    const updatedSectioning: SectioningData = {
+      ...sBase,
+      sections: sBase.sections.map((s, si) => {
+        if (si !== sectionIndex) return s
+        return {
+          ...s,
+          parts: s.parts.map((p, pi) => {
+            if (pi !== partIndex || p.type !== "text_group") return p
+            return {
+              ...p,
+              texts: p.texts.map((t, ti) => {
+                if (ti !== textIndex) return t
+                return { ...t, text: newText }
+              }),
+            }
+          }),
+        }
+      }),
+    }
+    setPendingSectioning(updatedSectioning)
+
+    // 2. Forward-propagate to rendering HTML if available
+    const rBase = pendingRendering ?? page.rendering
+    if (rBase) {
+      const currentSection = getRenderedSectionByIndex(rBase, sectionIndex)
+      if (currentSection?.html) {
+        // Resolve the actual data-id from the HTML (may differ from positional
+        // index after delete/duplicate operations that shift the texts array).
+        const part = sBase.sections[sectionIndex]?.parts[partIndex]
+        if (part?.type === "text_group") {
+          const actualIds = resolveGroupDataIds(part.groupId)
+          const textId = actualIds[textIndex]
+          if (!textId) {
+            needsRerenderRef.current = true
+            return
+          }
+          const parser = new DOMParser()
+          const doc = parser.parseFromString(currentSection.html, "text/html")
+          const el = doc.querySelector(`[data-id="${textId}"]`)
+          if (el) {
+            el.textContent = newText
+            const updatedHtml = doc.body.innerHTML
+            const updatedRendering: RenderingData = {
+              ...rBase,
+              sections: rBase.sections.map((s) => {
+                if (s.sectionIndex !== sectionIndex) return s
+                return { ...s, html: updatedHtml }
+              }),
+            }
+            setPendingRendering(updatedRendering)
+          } else {
+            // Element not found in HTML — need re-render to sync
+            needsRerenderRef.current = true
+          }
+        }
+      }
+    } else {
+      // No rendering data — need re-render to sync
+      needsRerenderRef.current = true
+    }
   }
 
   // Change group type for a specific text group
@@ -2265,6 +2333,7 @@ export function StoryboardSectionDetail({
         onToggleTextPruned={toggleTextPruned}
         onDeleteTextEntry={deleteTextEntry}
         onDuplicateTextEntry={duplicateTextEntry}
+        onEditText={editText}
         onAddGroup={addGroup}
         onDuplicateGroup={duplicateGroup}
         onDeleteGroup={deleteGroup}

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -697,6 +697,9 @@ msgstr "Clear language"
 msgid "Click images to select"
 msgstr "Click images to select"
 
+msgid "Click to edit"
+msgstr "Click to edit"
+
 msgid "Click to pick a style reference image"
 msgstr "Click to pick a style reference image"
 

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -697,6 +697,9 @@ msgstr "Borrar idioma"
 msgid "Click images to select"
 msgstr "Haz clic en las imágenes para seleccionar"
 
+msgid "Click to edit"
+msgstr "Haz clic para editar"
+
 msgid "Click to pick a style reference image"
 msgstr "Haz clic para elegir una imagen de referencia de estilo"
 

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -697,6 +697,9 @@ msgstr "Limpar idioma"
 msgid "Click images to select"
 msgstr "Clique nas imagens para selecionar"
 
+msgid "Click to edit"
+msgstr "Clique para editar"
+
 msgid "Click to pick a style reference image"
 msgstr "Clique para escolher uma imagem de referência de estilo"
 


### PR DESCRIPTION
## Summary
- Adds an `EditableText` component that lets users click on text entries in the section data panel to edit them in-place via a textarea
- Updates both sectioning data and forward-propagates changes to the rendered HTML preview, using `resolveGroupDataIds` for correct element targeting after delete/duplicate operations
- Includes i18n strings for all three locales (en, es, pt-BR)

## Test plan
- [ ] Click a text entry in the sidebar — verify it becomes an editable textarea
- [ ] Edit text, press Enter — verify sectioning data and HTML preview both update
- [ ] Press Escape while editing — verify the edit is discarded
- [ ] Delete or duplicate a text entry, then edit another — verify the correct element updates in the preview