### PR TITLE
Sort extracted images to show unpruned before pruned

### DIFF
--- a/apps/studio/src/components/pipeline/stages/extract/components/ExtractPageDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/extract/components/ExtractPageDetail.tsx
@@ -351,9 +351,9 @@ export function ExtractPageDetail({
         {/* Other extracted images (excluding the page image) */}
         {(() => {
           const pageImageId = `${pageId}_page`
-          const extractedImages = imageClassData?.images.filter(
+          const extractedImages = (imageClassData?.images.filter(
             (img) => img.imageId !== pageImageId
-          ) ?? []
+          ) ?? []).sort((a, b) => Number(a.isPruned) - Number(b.isPruned))
           if (extractedImages.length === 0) return null
           return (
             <div className="grid grid-cols-2 gap-2 items-start">


### PR DESCRIPTION
## Summary

Sorts the extracted images grid on the Extract page detail view so that unpruned (active) images appear before pruned ones. This makes it easier to see which images are still included at a glance without scrolling past pruned items.