### PR TITLE
Add automatic label deduplication for PDF imports

### DIFF
--- a/apps/studio/src/lib/label-validation.test.ts
+++ b/apps/studio/src/lib/label-validation.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest"
-import { isLabelFormatValid, isLabelDuplicate } from "./label-validation"
+import {
+  isLabelFormatValid,
+  isLabelDuplicate,
+  deduplicateLabel,
+} from "./label-validation"
 
 describe("isLabelFormatValid", () => {
   it("accepts valid labels", () => {
@@ -48,5 +52,31 @@ describe("isLabelDuplicate", () => {
 
   it("returns false for empty existing list", () => {
     expect(isLabelDuplicate("anything", [])).toBe(false)
+  })
+})
+
+describe("deduplicateLabel", () => {
+  it("returns original label when no duplicates", () => {
+    expect(deduplicateLabel("my-book", ["other-book"])).toBe("my-book")
+  })
+
+  it("returns original label when existing is undefined", () => {
+    expect(deduplicateLabel("my-book", undefined)).toBe("my-book")
+  })
+
+  it("appends -2 for first duplicate", () => {
+    expect(deduplicateLabel("my-book", ["my-book"])).toBe("my-book-2")
+  })
+
+  it("increments suffix when earlier suffixes are taken", () => {
+    expect(
+      deduplicateLabel("my-book", ["my-book", "my-book-2", "my-book-3"])
+    ).toBe("my-book-4")
+  })
+
+  it("finds first available gap", () => {
+    expect(deduplicateLabel("my-book", ["my-book", "my-book-2"])).toBe(
+      "my-book-3"
+    )
   })
 })

--- a/apps/studio/src/lib/label-validation.ts
+++ b/apps/studio/src/lib/label-validation.ts
@@ -11,3 +11,15 @@ export function isLabelDuplicate(
   if (!existingLabels) return false
   return existingLabels.includes(label)
 }
+
+export function deduplicateLabel(
+  label: string,
+  existingLabels: string[] | undefined
+): string {
+  if (!existingLabels || !existingLabels.includes(label)) return label
+  let suffix = 2
+  while (existingLabels.includes(`${label}-${suffix}`)) {
+    suffix++
+  }
+  return `${label}-${suffix}`
+}

--- a/apps/studio/src/routes/books.new.tsx
+++ b/apps/studio/src/routes/books.new.tsx
@@ -27,7 +27,11 @@ import {
 import { LanguagePicker } from "@/components/LanguagePicker"
 import { useSettingsDialog } from "@/routes/__root"
 import { useBooks, useCreateBook } from "@/hooks/use-books"
-import { isLabelFormatValid, isLabelDuplicate } from "@/lib/label-validation"
+import {
+  isLabelFormatValid,
+  isLabelDuplicate,
+  deduplicateLabel,
+} from "@/lib/label-validation"
 import { useApiKey } from "@/hooks/use-api-key"
 import { api } from "@/api/client"
 import { usePreset, useGlobalConfig, useStyleguides, useStyleguidePreview } from "@/hooks/use-presets"
@@ -343,7 +347,10 @@ function AddBookPage() {
   const handleFileSelect = (selected: File) => {
     setFile(selected)
     if (!label) {
-      setLabel(suggestLabel(selected.name))
+      const suggested = suggestLabel(selected.name)
+      setLabel(
+        deduplicateLabel(suggested, existingBooks?.map((b) => b.label))
+      )
     }
   }
 


### PR DESCRIPTION
## Summary
- Adds a `deduplicateLabel` utility that appends `-2`, `-3`, etc. when a suggested book label already exists
- Applies deduplication automatically when a PDF is selected in the new book form, so users don't have to manually rename
- Includes tests covering no-conflict, first duplicate, sequential duplicates, and gap-finding scenarios