### PR TITLE
Decouple extract and storyboard stages during book creation

### DIFF
--- a/apps/studio/src/routes/books.new.tsx
+++ b/apps/studio/src/routes/books.new.tsx
@@ -503,7 +503,7 @@ function AddBookPage() {
               await api.runStages(
                 book.label,
                 apiKey,
-                { fromStage: "extract", toStage: "storyboard" },
+                { fromStage: "extract", toStage: "extract" },
                 {
                   azure: { key: azureKey, region: azureRegion },
                   geminiApiKey: geminiKey,


### PR DESCRIPTION
## Summary

- Changes the `runStages` call in the new book creation flow to only run the `extract` stage instead of running from `extract` through `storyboard`
- This decouples the two pipeline stages so the storyboard stage must be triggered independently after extraction completes

## Test plan

- [ ] Create a new book and verify only the extract stage runs automatically
- [ ] Verify the storyboard stage can still be triggered manually after extraction