### PR TITLE
Add vector text grouping toggle for PDF extraction

### DIFF
--- a/apps/api/src/services/stage-runner.ts
+++ b/apps/api/src/services/stage-runner.ts
@@ -254,6 +254,7 @@ async function runExtractStep(
         startPage: config.start_page,
         endPage: config.end_page,
         spreadMode: config.spread_mode,
+        vectorTextGrouping: config.vector_text_grouping,
       },
       storage,
       progress

--- a/apps/studio/src/components/pipeline/stages/extract/ExtractSettings.tsx
+++ b/apps/studio/src/components/pipeline/stages/extract/ExtractSettings.tsx
@@ -41,6 +41,7 @@ export function ExtractSettings({ bookLabel, headerTarget, tab = "general" }: { 
   const [startPage, setStartPage] = useState("")
   const [endPage, setEndPage] = useState("")
   const [spreadMode, setSpreadMode] = useState(false)
+  const [vectorTextGrouping, setVectorTextGrouping] = useState(true)
   const [editingLanguage, setEditingLanguage] = useState("")
   const [textTypes, setTextTypes] = useState<Record<string, string>>({})
   const [prunedTextTypes, setPrunedTextTypes] = useState<Set<string>>(new Set())
@@ -75,6 +76,7 @@ export function ExtractSettings({ bookLabel, headerTarget, tab = "general" }: { 
     if (!bookConfigData) return
     const c = bookConfigData.config
     setSpreadMode(c.spread_mode === true)
+    setVectorTextGrouping(c.vector_text_grouping !== false)
     if (c.editing_language) setEditingLanguage(normalizeLocale(String(c.editing_language)))
     if (c.start_page != null) setStartPage(String(c.start_page))
     if (c.end_page != null) setEndPage(String(c.end_page))
@@ -162,6 +164,9 @@ export function ExtractSettings({ bookLabel, headerTarget, tab = "general" }: { 
     // Only write managed fields if touched or already in book config
     if (shouldWrite("spread_mode")) {
       overrides.spread_mode = spreadMode
+    }
+    if (shouldWrite("vector_text_grouping")) {
+      overrides.vector_text_grouping = vectorTextGrouping
     }
     if (shouldWrite("start_page")) {
       overrides.start_page = startPage.trim() ? Number(startPage) : undefined
@@ -302,6 +307,26 @@ export function ExtractSettings({ bookLabel, headerTarget, tab = "general" }: { 
             </div>
             <p className="text-xs text-muted-foreground mt-1.5">
               {t`Enable for scanned books where two pages appear on a single PDF page.`}
+            </p>
+          </div>
+
+          {/* Vector + Text Grouping */}
+          <div>
+            <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-3">
+              {t`Vector Extraction`}
+            </h3>
+            <div className="flex items-center gap-2">
+              <Switch
+                id="vector-text-grouping"
+                checked={vectorTextGrouping}
+                onCheckedChange={(v) => { setVectorTextGrouping(v); markDirty("vector_text_grouping") }}
+              />
+              <Label htmlFor="vector-text-grouping" className="text-sm font-normal">
+                {t`Include text overlays in vector groups`}
+              </Label>
+            </div>
+            <p className="text-xs text-muted-foreground mt-1.5">
+              {t`When enabled, text labels near vector images (e.g. chart dimensions, speech bubbles) are grouped together and extracted as raster crops. Disable to extract only the core vector shapes without text.`}
             </p>
           </div>
 

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -1441,6 +1441,9 @@ msgstr "Glossary Prompt"
 msgid "Go to book"
 msgstr "Go to book"
 
+msgid "Group text labels near vector images (e.g. chart dimensions, speech bubbles) and extract as raster crops. Disable to extract only the core vector shapes."
+msgstr "Group text labels near vector images (e.g. chart dimensions, speech bubbles) and extract as raster crops. Disable to extract only the core vector shapes."
+
 #~ msgid "Group Types"
 #~ msgstr "Group Types"
 
@@ -1542,6 +1545,9 @@ msgstr "Include in render"
 
 #~ msgid "Include section in render"
 #~ msgstr "Include section in render"
+
+msgid "Include text overlays in vector groups"
+msgstr "Include text overlays in vector groups"
 
 #~ msgid "Increase font size"
 #~ msgstr "Increase font size"
@@ -3203,6 +3209,9 @@ msgstr "Validation Errors ({0})"
 msgid "Variant:"
 msgstr "Variant:"
 
+msgid "Vector Extraction"
+msgstr "Vector Extraction"
+
 #. placeholder {0}: String(version)
 msgid "Version {0}"
 msgstr "Version {0}"
@@ -3254,6 +3263,9 @@ msgstr "What should the AI change?"
 
 msgid "When enabled, background colors from the styleguide are applied to the full page body."
 msgstr "When enabled, background colors from the styleguide are applied to the full page body."
+
+msgid "When enabled, text labels near vector images (e.g. chart dimensions, speech bubbles) are grouped together and extracted as raster crops. Disable to extract only the core vector shapes without text."
+msgstr "When enabled, text labels near vector images (e.g. chart dimensions, speech bubbles) are grouped together and extracted as raster crops. Disable to extract only the core vector shapes without text."
 
 msgid "Whole-book checks for packaged ADT output, plus reviewer findings captured from Preview."
 msgstr "Whole-book checks for packaged ADT output, plus reviewer findings captured from Preview."

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -1441,6 +1441,9 @@ msgstr "Prompt de glosario"
 msgid "Go to book"
 msgstr "Ir al libro"
 
+msgid "Group text labels near vector images (e.g. chart dimensions, speech bubbles) and extract as raster crops. Disable to extract only the core vector shapes."
+msgstr "Agrupa etiquetas de texto cerca de imágenes vectoriales (p. ej., dimensiones de gráficos, globos de diálogo) y las extrae como recortes rasterizados. Desactívelo para extraer solo las formas vectoriales principales."
+
 #~ msgid "Group Types"
 #~ msgstr "Tipos de grupo"
 
@@ -1542,6 +1545,9 @@ msgstr "Incluir en la renderización"
 
 #~ msgid "Include section in render"
 #~ msgstr "Incluir sección en la renderización"
+
+msgid "Include text overlays in vector groups"
+msgstr "Incluir superposiciones de texto en grupos vectoriales"
 
 #~ msgid "Increase font size"
 #~ msgstr "Aumentar tamaño de fuente"
@@ -3203,6 +3209,9 @@ msgstr "Errores de validación ({0})"
 msgid "Variant:"
 msgstr "Variante:"
 
+msgid "Vector Extraction"
+msgstr "Extracción vectorial"
+
 #. placeholder {0}: String(version)
 msgid "Version {0}"
 msgstr "Versión {0}"
@@ -3256,6 +3265,9 @@ msgstr "¿Qué debería cambiar la IA?"
 
 msgid "When enabled, background colors from the styleguide are applied to the full page body."
 msgstr "Cuando está activado, los colores de fondo de la guía de estilo se aplican al cuerpo completo de la página."
+
+msgid "When enabled, text labels near vector images (e.g. chart dimensions, speech bubbles) are grouped together and extracted as raster crops. Disable to extract only the core vector shapes without text."
+msgstr "Cuando está activado, las etiquetas de texto cercanas a imágenes vectoriales (p. ej. dimensiones de gráficos, globos de diálogo) se agrupan y extraen como recortes rasterizados. Desactive para extraer solo las formas vectoriales sin texto."
 
 msgid "Whole-book checks for packaged ADT output, plus reviewer findings captured from Preview."
 msgstr "Whole-book checks for packaged ADT output, plus reviewer findings captured from Preview."

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -1441,6 +1441,9 @@ msgstr "Prompt de glossário"
 msgid "Go to book"
 msgstr "Ir para o livro"
 
+msgid "Group text labels near vector images (e.g. chart dimensions, speech bubbles) and extract as raster crops. Disable to extract only the core vector shapes."
+msgstr "Agrupa rótulos de texto próximos a imagens vetoriais (por exemplo, dimensões de gráficos, balões de fala) e os extrai como recortes rasterizados. Desative para extrair apenas as formas vetoriais principais."
+
 #~ msgid "Group Types"
 #~ msgstr "Tipos de grupo"
 
@@ -1542,6 +1545,9 @@ msgstr "Incluir na renderização"
 
 #~ msgid "Include section in render"
 #~ msgstr "Incluir seção na renderização"
+
+msgid "Include text overlays in vector groups"
+msgstr "Incluir sobreposições de texto em grupos vetoriais"
 
 #~ msgid "Increase font size"
 #~ msgstr "Aumentar tamanho da fonte"
@@ -3203,6 +3209,9 @@ msgstr "Erros de validação ({0})"
 msgid "Variant:"
 msgstr "Variante:"
 
+msgid "Vector Extraction"
+msgstr "Extração vetorial"
+
 #. placeholder {0}: String(version)
 msgid "Version {0}"
 msgstr "Versão {0}"
@@ -3256,6 +3265,9 @@ msgstr "O que a IA deve alterar?"
 
 msgid "When enabled, background colors from the styleguide are applied to the full page body."
 msgstr "Quando ativado, as cores de fundo do guia de estilo são aplicadas ao corpo completo da página."
+
+msgid "When enabled, text labels near vector images (e.g. chart dimensions, speech bubbles) are grouped together and extracted as raster crops. Disable to extract only the core vector shapes without text."
+msgstr "Quando ativado, rótulos de texto próximos a imagens vetoriais (ex.: dimensões de gráficos, balões de fala) são agrupados e extraídos como recortes rasterizados. Desative para extrair apenas as formas vetoriais sem texto."
 
 msgid "Whole-book checks for packaged ADT output, plus reviewer findings captured from Preview."
 msgstr "Whole-book checks for packaged ADT output, plus reviewer findings captured from Preview."

--- a/apps/studio/src/routes/books.new.tsx
+++ b/apps/studio/src/routes/books.new.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useEffect } from "react"
+import { useLingui } from "@lingui/react/macro"
 import { createFileRoute, useNavigate, Link } from "@tanstack/react-router"
 import {
   Upload,
@@ -154,6 +155,7 @@ function AddBookPage() {
   const { data: existingBooks } = useBooks()
   const { apiKey, hasApiKey, azureKey, azureRegion, geminiKey } = useApiKey()
   const { openSettings } = useSettingsDialog()
+  const { t } = useLingui()
 
   const [step, setStep] = useState(1)
   const [submitError, setSubmitError] = useState<string | null>(null)
@@ -168,6 +170,7 @@ function AddBookPage() {
   const [spreadMode, setSpreadMode] = useState(false)
   const [imageCropping, setImageCropping] = useState(false)
   const [imageSegmentation, setImageSegmentation] = useState(false)
+  const [vectorTextGrouping, setVectorTextGrouping] = useState(true)
   const [segMinSide, setSegMinSide] = useState("")
 
   // Step 2 — Layout
@@ -310,6 +313,11 @@ function AddBookPage() {
       setSpreadMode(config.spread_mode)
     }
 
+    // Vector text grouping from preset
+    if (typeof config.vector_text_grouping === "boolean") {
+      setVectorTextGrouping(config.vector_text_grouping)
+    }
+
     // Sectioning mode from preset
     if (config.page_sectioning && typeof config.page_sectioning === "object") {
       const ps = config.page_sectioning as Record<string, unknown>
@@ -426,6 +434,7 @@ function AddBookPage() {
       configOverrides.output_languages = Array.from(outputLanguages)
     }
     configOverrides.spread_mode = spreadMode
+    configOverrides.vector_text_grouping = vectorTextGrouping
     configOverrides.apply_body_background = applyBodyBackground
     if (parsedStartPage !== undefined) {
       configOverrides.start_page = parsedStartPage
@@ -702,6 +711,21 @@ function AddBookPage() {
                         </p>
                       </div>
                     )}
+                  </div>
+                  <div className="space-y-1.5">
+                    <div className="flex items-center gap-2">
+                      <Switch
+                        id="vector-text-grouping"
+                        checked={vectorTextGrouping}
+                        onCheckedChange={setVectorTextGrouping}
+                      />
+                      <Label htmlFor="vector-text-grouping" className="text-xs">
+                        {t`Include text overlays in vector groups`}
+                      </Label>
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      {t`Group text labels near vector images (e.g. chart dimensions, speech bubbles) and extract as raster crops. Disable to extract only the core vector shapes.`}
+                    </p>
                   </div>
                 </div>
               )}

--- a/packages/pdf/src/extract.ts
+++ b/packages/pdf/src/extract.ts
@@ -28,6 +28,8 @@ export interface ExtractInput {
   endPage?: number;
   /** When true, merge pairs of pages as spreads (page 1 = cover, 2+3, 4+5, etc.) */
   spreadMode?: boolean;
+  /** When true, include text shapes in vector grouping to produce raster crops of vectors with text overlays. Defaults to true. */
+  vectorTextGrouping?: boolean;
 }
 
 export interface ExtractedPage {
@@ -137,7 +139,7 @@ export async function extractPdf(
   input: ExtractInput,
   onProgress?: (progress: ExtractProgress) => void
 ): Promise<ExtractResult> {
-  const { pdfBuffer, startPage = 1, endPage, spreadMode = false } = input;
+  const { pdfBuffer, startPage = 1, endPage, spreadMode = false, vectorTextGrouping = true } = input;
   validatePageRange(startPage, endPage);
 
   // Open PDF (suppressing mupdf stderr spam)
@@ -163,8 +165,8 @@ export async function extractPdf(
       const group = logicalGroups[g];
       const page =
         group.length === 2
-          ? await extractSpreadPage(doc, group[0], group[1])
-          : await extractPage(doc, group[0]);
+          ? await extractSpreadPage(doc, group[0], group[1], vectorTextGrouping)
+          : await extractPage(doc, group[0], vectorTextGrouping);
       pages.push(page);
 
       onProgress?.({ page: g + 1, totalPages: totalLogical });
@@ -173,7 +175,7 @@ export async function extractPdf(
   } else {
     const rangeSize = end - start;
     for (let i = start; i < end; i++) {
-      const page = await extractPage(doc, i);
+      const page = await extractPage(doc, i, vectorTextGrouping);
       pages.push(page);
 
       onProgress?.({ page: i - start + 1, totalPages: rangeSize });
@@ -198,7 +200,7 @@ export function extractPdfStream(
   input: ExtractInput,
   onProgress?: (progress: ExtractProgress) => void
 ): ExtractStreamResult {
-  const { pdfBuffer, startPage = 1, endPage, spreadMode = false } = input;
+  const { pdfBuffer, startPage = 1, endPage, spreadMode = false, vectorTextGrouping = true } = input;
   validatePageRange(startPage, endPage);
 
   const doc = openPdfFromBuffer(pdfBuffer);
@@ -218,8 +220,8 @@ export function extractPdfStream(
           const group = logicalGroups[g];
           const page =
             group.length === 2
-              ? await extractSpreadPage(doc, group[0], group[1])
-              : await extractPage(doc, group[0]);
+              ? await extractSpreadPage(doc, group[0], group[1], vectorTextGrouping)
+              : await extractPage(doc, group[0], vectorTextGrouping);
 
           onProgress?.({ page: g + 1, totalPages: totalLogical });
           yield page;
@@ -227,7 +229,7 @@ export function extractPdfStream(
       } else {
         const rangeSize = end - start;
         for (let i = start; i < end; i++) {
-          const page = await extractPage(doc, i);
+          const page = await extractPage(doc, i, vectorTextGrouping);
 
           onProgress?.({ page: i - start + 1, totalPages: rangeSize });
           yield page;
@@ -404,7 +406,7 @@ function extractPdfMetadata(doc: MupdfDocument): PdfMetadata {
   return metadata;
 }
 
-async function extractPage(doc: MupdfDocument, pageIndex: number): Promise<ExtractedPage> {
+async function extractPage(doc: MupdfDocument, pageIndex: number, vectorTextGrouping: boolean = true): Promise<ExtractedPage> {
   const pageNum = pageIndex + 1;
   const pageId = "pg" + String(pageNum).padStart(3, "0");
 
@@ -436,10 +438,10 @@ async function extractPage(doc: MupdfDocument, pageIndex: number): Promise<Extra
   const pdfPage = page as unknown as PDFPage;
   const allRasterImages = extractRasterImagesFromPdf(pdfDoc, pdfPage, pageId);
 
-  // Extract vector shapes and figure groups from SVG (text shapes participate in grouping)
+  // Extract vector shapes and figure groups from SVG (text shapes participate in grouping when enabled)
   const pageSvg = getPageSvg(page);
   const { images: figureImages, coveredRasterHashes, debug: extractionDebug } = await extractVectorImagesFromSvg(
-    pageSvg, pageId, allRasterImages.length, pagePngBuf, textShapes
+    pageSvg, pageId, allRasterImages.length, pagePngBuf, vectorTextGrouping ? textShapes : undefined
   );
 
   // Filter out raster images that are covered by figure groups (dedup)
@@ -464,7 +466,8 @@ async function extractPage(doc: MupdfDocument, pageIndex: number): Promise<Extra
 async function extractSpreadPage(
   doc: MupdfDocument,
   leftIndex: number,
-  rightIndex: number
+  rightIndex: number,
+  vectorTextGrouping: boolean = true,
 ): Promise<ExtractedPage> {
   const leftNum = leftIndex + 1;
   const rightNum = rightIndex + 1;
@@ -518,13 +521,13 @@ async function extractSpreadPage(
   const leftSvg = getPageSvg(leftPage);
   const rightSvg = getPageSvg(rightPage);
   const rasterCount = allLeftRaster.length + allRightRaster.length;
-  const leftResult = await extractVectorImagesFromSvg(leftSvg, pageId, rasterCount, leftPng, leftTextShapes);
+  const leftResult = await extractVectorImagesFromSvg(leftSvg, pageId, rasterCount, leftPng, vectorTextGrouping ? leftTextShapes : undefined);
   const rightResult = await extractVectorImagesFromSvg(
     rightSvg,
     pageId,
     rasterCount + leftResult.images.length,
     rightPng,
-    rightTextShapes,
+    vectorTextGrouping ? rightTextShapes : undefined,
   );
 
   // Merge covered hashes from both pages and filter raster images

--- a/packages/pipeline/src/pdf-extraction.ts
+++ b/packages/pipeline/src/pdf-extraction.ts
@@ -9,6 +9,7 @@ export interface ExtractOptions {
   startPage?: number
   endPage?: number
   spreadMode?: boolean
+  vectorTextGrouping?: boolean
 }
 
 export async function extractPDF(
@@ -16,7 +17,7 @@ export async function extractPDF(
   storage: Storage,
   progress: Progress
 ): Promise<void> {
-  const { pdfPath, startPage, endPage, spreadMode } = options
+  const { pdfPath, startPage, endPage, spreadMode, vectorTextGrouping } = options
 
   progress.emit({ type: "step-start", step: "extract" })
 
@@ -24,7 +25,7 @@ export async function extractPDF(
     const pdfBuffer = fs.readFileSync(pdfPath)
 
     const { pdfMetadata, pages } = extractPdfStream(
-      { pdfBuffer, startPage, endPage, spreadMode },
+      { pdfBuffer, startPage, endPage, spreadMode, vectorTextGrouping },
       (p) => {
         progress.emit({
           type: "step-progress",

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -127,6 +127,7 @@ export const AppConfig = z
     image_cropping: StepConfig.optional(),
     layout_type: LayoutType.optional(),
     spread_mode: z.boolean().optional(),
+    vector_text_grouping: z.boolean().optional(),
     apply_body_background: z.boolean().optional(),
     start_page: z.number().int().min(1).optional(),
     end_page: z.number().int().min(1).optional(),


### PR DESCRIPTION
## Summary

Adds a `vector_text_grouping` config option that controls whether text shapes near vector images are included when grouping and rasterizing vector figures during PDF extraction. When disabled, only the core vector shapes are extracted without text overlays. Defaults to `true`, preserving existing behavior.

The toggle is exposed in both the Extract settings panel and the new book wizard, with full i18n support (en, es, pt-BR).

## Test plan

- [ ] Create a new book with the toggle disabled and verify vector extraction excludes text overlays
- [ ] Toggle the setting in Extract settings for an existing book and re-run extraction
- [ ] Verify default behavior (toggle enabled) matches previous extraction results
- [ ] Check UI renders correctly in all three locales