### PR TITLE
Rename storyboard overview labels and make section preview clickable

### DIFF
--- a/apps/studio/src/components/pipeline/stages/storyboard/StoryboardView.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/StoryboardView.tsx
@@ -141,7 +141,7 @@ export function StoryboardView({ bookLabel, selectedPageId: selectedPageIdProp, 
         overviewMode ? "bg-white/30 text-white" : "bg-white/15 hover:bg-white/25 text-white/70"
       }`}
       onClick={() => setOverviewMode((v) => !v)}
-      title={t`Sectioning Overview`}
+      title={t`Overview`}
     >
       <Table2 className="h-3.5 w-3.5" />
     </button>
@@ -186,7 +186,7 @@ export function StoryboardView({ bookLabel, selectedPageId: selectedPageIdProp, 
       setExtra(
         <>
           <span className="text-white/40 text-sm">/</span>
-          <span className="text-sm font-medium">{t`Sectioning Overview`}</span>
+          <span className="text-sm font-medium">{t`Overview`}</span>
           <div className="ml-auto flex gap-1">
             {overviewToggle}
           </div>

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/SectioningOverview.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/SectioningOverview.tsx
@@ -829,7 +829,12 @@ function SectionDetail({
             <h4 className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider mb-1.5">
               <Trans>Preview</Trans>
             </h4>
-            <div className="w-[200px] h-[260px] border rounded overflow-hidden bg-white relative">
+            <button
+              type="button"
+              className="w-[200px] h-[260px] border rounded overflow-hidden bg-white relative cursor-pointer hover:ring-2 hover:ring-violet-400 transition-shadow"
+              onClick={() => onNavigate?.()}
+              title={t`Edit this section`}
+            >
               <iframe
                 src={previewSrc}
                 title={t`Section preview`}
@@ -842,7 +847,7 @@ function SectionDetail({
                 }}
                 sandbox="allow-same-origin"
               />
-            </div>
+            </button>
           </div>
         )}
 

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
@@ -2215,14 +2215,14 @@ export function StoryboardSectionDetail({
         type="button"
         onClick={() => setPanelOpen((v) => !v)}
         className="flex items-center gap-1 px-2 py-1 rounded bg-white/10 hover:bg-white/20 transition-colors cursor-pointer shrink-0"
-        title={panelOpen ? t`Close section data` : t`Open section data`}
+        title={panelOpen ? t`Close edit panel` : t`Open edit panel`}
       >
         {panelOpen ? (
           <PanelRightClose className="h-3.5 w-3.5" />
         ) : (
           <PanelRightOpen className="h-3.5 w-3.5" />
         )}
-        <span className="text-[10px]">{t`Section Data`}</span>
+        <span className="text-[10px]">{t`Edit`}</span>
         {dirty && <span className="w-1.5 h-1.5 rounded-full bg-amber-400" title={t`Unsaved changes`} />}
       </button>
       {navigationArrows}

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -762,8 +762,11 @@ msgstr "Clone failed"
 msgid "Close"
 msgstr "Close"
 
-msgid "Close section data"
-msgstr "Close section data"
+msgid "Close edit panel"
+msgstr "Close edit panel"
+
+#~ msgid "Close section data"
+#~ msgstr "Close section data"
 
 msgid "Collapse accessibility summary"
 msgstr "Collapse accessibility summary"
@@ -1138,6 +1141,9 @@ msgstr "Edit the Liquid/HTML template below. Changes are saved when you click Sa
 
 msgid "Edit this image"
 msgstr "Edit this image"
+
+msgid "Edit this section"
+msgstr "Edit this section"
 
 msgid "Editing"
 msgstr "Editing"
@@ -2079,14 +2085,17 @@ msgstr "Open a page to review"
 msgid "Open a page to see page-level findings"
 msgstr "Open a page to see page-level findings"
 
+msgid "Open edit panel"
+msgstr "Open edit panel"
+
 msgid "Open page preview for {pageId}"
 msgstr "Open page preview for {pageId}"
 
 msgid "Open Preview"
 msgstr "Open Preview"
 
-msgid "Open section data"
-msgstr "Open section data"
+#~ msgid "Open section data"
+#~ msgstr "Open section data"
 
 msgid "Open Validation"
 msgstr "Open Validation"
@@ -2129,6 +2138,9 @@ msgstr "Output Tokens"
 
 msgid "Overall page note"
 msgstr "Overall page note"
+
+msgid "Overview"
+msgstr "Overview"
 
 msgid "Package and preview the final ADT web application."
 msgstr "Package and preview the final ADT web application."
@@ -2624,8 +2636,8 @@ msgstr "Section {0} — {1}"
 msgid "Section {0} (pruned)"
 msgstr "Section {0} (pruned)"
 
-msgid "Section Data"
-msgstr "Section Data"
+#~ msgid "Section Data"
+#~ msgstr "Section Data"
 
 msgid "Section Heading"
 msgstr "Section Heading"
@@ -2654,8 +2666,8 @@ msgstr "Section Types"
 msgid "Sectioning Mode"
 msgstr "Sectioning Mode"
 
-msgid "Sectioning Overview"
-msgstr "Sectioning Overview"
+#~ msgid "Sectioning Overview"
+#~ msgstr "Sectioning Overview"
 
 msgid "Sectioning Reasoning"
 msgstr "Sectioning Reasoning"

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -762,8 +762,11 @@ msgstr "Clone failed"
 msgid "Close"
 msgstr "Close"
 
-msgid "Close section data"
-msgstr "Cerrar datos de sección"
+msgid "Close edit panel"
+msgstr "Cerrar panel de edición"
+
+#~ msgid "Close section data"
+#~ msgstr "Cerrar datos de sección"
 
 msgid "Collapse accessibility summary"
 msgstr "Collapse accessibility summary"
@@ -1138,6 +1141,9 @@ msgstr "Edita la plantilla Liquid/HTML a continuación. Los cambios se guardan c
 
 msgid "Edit this image"
 msgstr "Editar esta imagen"
+
+msgid "Edit this section"
+msgstr "Editar esta sección"
 
 msgid "Editing"
 msgstr "Editando"
@@ -2079,14 +2085,17 @@ msgstr "Open a page to review"
 msgid "Open a page to see page-level findings"
 msgstr "Open a page to see page-level findings"
 
+msgid "Open edit panel"
+msgstr "Abrir panel de edición"
+
 msgid "Open page preview for {pageId}"
 msgstr "Abrir vista previa de la página {0}"
 
 msgid "Open Preview"
 msgstr "Open Preview"
 
-msgid "Open section data"
-msgstr "Abrir datos de sección"
+#~ msgid "Open section data"
+#~ msgstr "Abrir datos de sección"
 
 msgid "Open Validation"
 msgstr "Open Validation"
@@ -2129,6 +2138,9 @@ msgstr "Tokens de salida"
 
 msgid "Overall page note"
 msgstr "Overall page note"
+
+msgid "Overview"
+msgstr "Vista general"
 
 msgid "Package and preview the final ADT web application."
 msgstr "Empaqueta y previsualiza la aplicación web ADT final."
@@ -2624,8 +2636,8 @@ msgstr "Sección {0} — {1}"
 msgid "Section {0} (pruned)"
 msgstr "Sección {0} (eliminada)"
 
-msgid "Section Data"
-msgstr "Datos de sección"
+#~ msgid "Section Data"
+#~ msgstr "Datos de sección"
 
 msgid "Section Heading"
 msgstr "Título de sección"
@@ -2654,8 +2666,8 @@ msgstr "Tipos de sección"
 msgid "Sectioning Mode"
 msgstr "Modo de sección"
 
-msgid "Sectioning Overview"
-msgstr "Vista general de secciones"
+#~ msgid "Sectioning Overview"
+#~ msgstr "Vista general de secciones"
 
 msgid "Sectioning Reasoning"
 msgstr "Razonamiento de sección"

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -762,8 +762,11 @@ msgstr "Clone failed"
 msgid "Close"
 msgstr "Close"
 
-msgid "Close section data"
-msgstr "Fechar dados da seção"
+msgid "Close edit panel"
+msgstr "Fechar painel de edição"
+
+#~ msgid "Close section data"
+#~ msgstr "Fechar dados da seção"
 
 msgid "Collapse accessibility summary"
 msgstr "Collapse accessibility summary"
@@ -1138,6 +1141,9 @@ msgstr "Edite o template Liquid/HTML abaixo. As alterações são salvas quando 
 
 msgid "Edit this image"
 msgstr "Editar esta imagem"
+
+msgid "Edit this section"
+msgstr "Editar esta seção"
 
 msgid "Editing"
 msgstr "Editando"
@@ -2079,14 +2085,17 @@ msgstr "Open a page to review"
 msgid "Open a page to see page-level findings"
 msgstr "Open a page to see page-level findings"
 
+msgid "Open edit panel"
+msgstr "Abrir painel de edição"
+
 msgid "Open page preview for {pageId}"
 msgstr "Abrir pré-visualização da página {0}"
 
 msgid "Open Preview"
 msgstr "Open Preview"
 
-msgid "Open section data"
-msgstr "Abrir dados da seção"
+#~ msgid "Open section data"
+#~ msgstr "Abrir dados da seção"
 
 msgid "Open Validation"
 msgstr "Open Validation"
@@ -2129,6 +2138,9 @@ msgstr "Tokens de saída"
 
 msgid "Overall page note"
 msgstr "Overall page note"
+
+msgid "Overview"
+msgstr "Visão geral"
 
 msgid "Package and preview the final ADT web application."
 msgstr "Empacota e pré-visualiza a aplicação web ADT final."
@@ -2624,8 +2636,8 @@ msgstr "Seção {0} — {1}"
 msgid "Section {0} (pruned)"
 msgstr "Seção {0} (removida)"
 
-msgid "Section Data"
-msgstr "Dados da seção"
+#~ msgid "Section Data"
+#~ msgstr "Dados da seção"
 
 msgid "Section Heading"
 msgstr "Cabeçalho da seção"
@@ -2654,8 +2666,8 @@ msgstr "Tipos de seção"
 msgid "Sectioning Mode"
 msgstr "Modo de seção"
 
-msgid "Sectioning Overview"
-msgstr "Visão geral das seções"
+#~ msgid "Sectioning Overview"
+#~ msgstr "Visão geral das seções"
 
 msgid "Sectioning Reasoning"
 msgstr "Raciocínio de seção"


### PR DESCRIPTION
## Summary
- Simplifies storyboard UI labels: "Sectioning Overview" → "Overview", "Section Data" → "Edit", "Open/Close section data" → "Open/Close edit panel"
- Makes the section preview thumbnail in the overview clickable, navigating to the section detail view
- Updates all locale files (en, es, pt-BR) with translations for new strings

## Test plan
- [ ] Open the storyboard view and verify the overview toggle button shows "Overview"
- [ ] Verify the breadcrumb shows "Overview" instead of "Sectioning Overview"
- [ ] In section detail, verify the panel toggle says "Edit" and tooltip says "Open/Close edit panel"
- [ ] In the sectioning overview, click a section preview thumbnail and verify it navigates to that section
- [ ] Switch locale to es and pt-BR and verify translated labels appear correctly