### PR TITLE
Add group-level pruning for text groups

### DIFF
--- a/apps/api/src/routes/pages.test.ts
+++ b/apps/api/src/routes/pages.test.ts
@@ -61,6 +61,7 @@ describe("Page routes", () => {
             texts: [
               { textType: "paragraph", text: "Hello world", isPruned: false },
             ],
+            isPruned: false,
           },
         ],
       })
@@ -207,6 +208,7 @@ describe("Page routes", () => {
             texts: [
               { textType: "paragraph", text: "Updated text", isPruned: false },
             ],
+            isPruned: false,
           },
         ],
       }

--- a/apps/studio/src/api/client.ts
+++ b/apps/studio/src/api/client.ts
@@ -166,6 +166,7 @@ export interface PageDetail {
       groupId: string
       groupType: string
       texts: Array<{ textType: string; text: string; isPruned: boolean }>
+      isPruned: boolean
     }>
   } | null
   imageClassification: {

--- a/apps/studio/src/components/pipeline/stages/extract/components/ExtractPageDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/extract/components/ExtractPageDetail.tsx
@@ -247,6 +247,17 @@ export function ExtractPageDetail({
     })
   }
 
+  const toggleGroupPrune = (groupId: string) => {
+    const base = pendingTextData ?? page?.textClassification
+    if (!base) return
+    setPendingTextData({
+      ...base,
+      groups: base.groups.map((g) =>
+        g.groupId === groupId ? { ...g, isPruned: !g.isPruned } : g
+      ),
+    })
+  }
+
   const toggleImagePrune = (imageId: string) => {
     const base = pendingImageData ?? page?.imageClassification
     if (!base) return
@@ -411,11 +422,26 @@ export function ExtractPageDetail({
                 const maxTypeLen = Math.max(...group.texts.map((tx) => tx.textType.length), 0)
                 const colWidth = `${Math.max(maxTypeLen * 0.65 + 1.5, 4)}em`
                 return (
-                  <div key={group.groupId} className="rounded border overflow-hidden">
-                    <div className="px-3 py-1.5 bg-muted/50 border-b flex items-center gap-1.5">
+                  <div key={group.groupId} className={`rounded border overflow-hidden ${group.isPruned ? "opacity-40" : ""}`}>
+                    <div className="px-3 py-1.5 bg-muted/50 border-b flex items-center gap-1.5 group/grp">
                       <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
                         {getTextGroupLabel(group.groupType)}
                       </span>
+                      <button
+                        type="button"
+                        onClick={() => toggleGroupPrune(group.groupId)}
+                        className={`shrink-0 flex items-center justify-center w-5 h-5 rounded-full cursor-pointer transition-colors ${
+                          group.isPruned
+                            ? "bg-destructive hover:bg-destructive/80"
+                            : "opacity-0 group-hover/grp:opacity-100 bg-black/30 hover:bg-black/50"
+                        }`}
+                        title={group.isPruned ? t`Unprune group` : t`Prune group`}
+                      >
+                        {group.isPruned
+                          ? <EyeOff className="h-3 w-3 text-white" />
+                          : <Eye className="h-3 w-3 text-white" />
+                        }
+                      </button>
                     </div>
                     <div className="divide-y">
                       {group.texts.map((tx, i) => (

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -2351,6 +2351,9 @@ msgstr "Prune"
 msgid "Prune element"
 msgstr "Prune element"
 
+msgid "Prune group"
+msgstr "Prune group"
+
 msgid "Prune image"
 msgstr "Prune image"
 
@@ -3222,6 +3225,9 @@ msgstr "Unknown step slug: {step}"
 
 msgid "Unknown step: {step}"
 msgstr "Unknown step: {step}"
+
+msgid "Unprune group"
+msgstr "Unprune group"
 
 msgid "Unprune image"
 msgstr "Unprune image"

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -2351,6 +2351,9 @@ msgstr "Eliminar"
 msgid "Prune element"
 msgstr "Eliminar elemento"
 
+msgid "Prune group"
+msgstr "Eliminar grupo"
+
 msgid "Prune image"
 msgstr "Eliminar imagen"
 
@@ -3222,6 +3225,9 @@ msgstr "Slug de etapa desconocido: {0}"
 
 msgid "Unknown step: {step}"
 msgstr "Paso desconocido: {0}"
+
+msgid "Unprune group"
+msgstr "Restaurar grupo"
 
 msgid "Unprune image"
 msgstr "Restaurar imagen"

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -2351,6 +2351,9 @@ msgstr "Remover"
 msgid "Prune element"
 msgstr "Remover elemento"
 
+msgid "Prune group"
+msgstr "Remover grupo"
+
 msgid "Prune image"
 msgstr "Remover imagem"
 
@@ -3222,6 +3225,9 @@ msgstr "Slug de etapa desconhecido: {0}"
 
 msgid "Unknown step: {step}"
 msgstr "Etapa desconhecida: {0}"
+
+msgid "Unprune group"
+msgstr "Restaurar grupo"
 
 msgid "Unprune image"
 msgstr "Restaurar imagem"

--- a/packages/pipeline/src/__tests__/page-sectioning.test.ts
+++ b/packages/pipeline/src/__tests__/page-sectioning.test.ts
@@ -97,6 +97,7 @@ describe("buildGroupSummaries", () => {
             { textType: "section_text", text: "Hello world.", isPruned: false },
             { textType: "section_text", text: "More text.", isPruned: false },
           ],
+          isPruned: false,
         },
         {
           groupId: "pg001_gp002",
@@ -104,6 +105,7 @@ describe("buildGroupSummaries", () => {
           texts: [
             { textType: "section_heading", text: "Chapter 1", isPruned: false },
           ],
+          isPruned: false,
         },
       ],
     }
@@ -133,6 +135,7 @@ describe("buildGroupSummaries", () => {
           texts: [
             { textType: "header_text", text: "Header", isPruned: true },
           ],
+          isPruned: false,
         },
         {
           groupId: "pg001_gp002",
@@ -140,6 +143,7 @@ describe("buildGroupSummaries", () => {
           texts: [
             { textType: "section_text", text: "Body text", isPruned: false },
           ],
+          isPruned: false,
         },
       ],
     }
@@ -160,6 +164,7 @@ describe("buildGroupSummaries", () => {
             { textType: "page_number", text: "42", isPruned: true },
             { textType: "section_text", text: "Body text", isPruned: false },
           ],
+          isPruned: false,
         },
       ],
     }
@@ -244,6 +249,7 @@ describe("sectionPage", () => {
                   isPruned: false,
                 },
               ],
+              isPruned: false,
             },
             {
               groupId: "pg001_gp002",
@@ -255,6 +261,7 @@ describe("sectionPage", () => {
                   isPruned: false,
                 },
               ],
+              isPruned: false,
             },
           ],
         },
@@ -347,6 +354,7 @@ describe("sectionPage", () => {
                   isPruned: false,
                 },
               ],
+              isPruned: false,
             },
           ],
         },
@@ -409,6 +417,7 @@ describe("sectionPage", () => {
               texts: [
                 { textType: "section_text", text: "Body", isPruned: false },
               ],
+              isPruned: false,
             },
             {
               groupId: "pg001_gp002",
@@ -416,6 +425,7 @@ describe("sectionPage", () => {
               texts: [
                 { textType: "header_text", text: "Header", isPruned: true },
               ],
+              isPruned: false,
             },
           ],
         },
@@ -485,6 +495,7 @@ describe("sectionPage", () => {
                     isPruned: false,
                   },
                 ],
+                isPruned: false,
               },
             ],
           },

--- a/packages/pipeline/src/__tests__/translation.test.ts
+++ b/packages/pipeline/src/__tests__/translation.test.ts
@@ -23,6 +23,7 @@ const sampleClassification: TextClassificationOutput = {
         { textType: "section_text", text: "Hello world", isPruned: false },
         { textType: "instruction_text", text: "Read this aloud.", isPruned: false },
       ],
+      isPruned: false,
     },
   ],
 }
@@ -180,6 +181,7 @@ describe("translation", () => {
           groupId: "pg001_gp001",
           groupType: "paragraph",
           texts: [],
+          isPruned: false,
         },
       ],
     }

--- a/packages/pipeline/src/page-sectioning.ts
+++ b/packages/pipeline/src/page-sectioning.ts
@@ -40,6 +40,7 @@ export function buildGroupSummaries(
 ): Array<{ groupId: string; groupType: string; text: string }> {
   return textClassification.groups
     .map((g) => {
+      if (g.isPruned) return null
       const unprunedTexts = g.texts.filter((t) => !t.isPruned)
       if (unprunedTexts.length === 0) return null
 
@@ -160,7 +161,7 @@ export async function sectionPage(
             text: t.text,
             isPruned: t.isPruned,
           })),
-          isPruned: false,
+          isPruned: group.isPruned,
         }
       }
 

--- a/packages/pipeline/src/text-classification.ts
+++ b/packages/pipeline/src/text-classification.ts
@@ -82,6 +82,7 @@ export async function classifyPageText(
       text: t.text,
       isPruned: prunedSet.has(t.text_type),
     })),
+    isPruned: false,
   }))
 
   return {

--- a/packages/types/src/text-classification.ts
+++ b/packages/types/src/text-classification.ts
@@ -11,6 +11,7 @@ export const TextGroup = z.object({
   groupId: z.string(),
   groupType: z.string(),
   texts: z.array(TextEntry),
+  isPruned: z.boolean().default(false),
 })
 export type TextGroup = z.infer<typeof TextGroup>
 


### PR DESCRIPTION
## Summary

- Adds `isPruned` boolean to the `TextGroup` schema, allowing entire text groups to be pruned (not just individual text entries)
- Pipeline logic in `buildGroupSummaries` skips pruned groups early and `sectionPage` preserves the group-level prune flag
- UI toggle button (eye/eye-off icon) on each group header lets users prune/unprune whole groups, with visual feedback (reduced opacity)
- All locales (en, es, pt-BR) updated with new "Prune group" / "Unprune group" strings
- Test fixtures updated across the board to include the new field

## Test plan

- [ ] Verify pruning a group hides it from storyboard output
- [ ] Verify the toggle button appears on hover and persists when pruned
- [ ] Verify existing per-text pruning still works independently
- [ ] Run `pnpm test` to confirm all tests pass