### PR TITLE
Add image replace-from-book option to storyboard section toolbar

### DIFF
--- a/apps/studio/src/components/pipeline/stages/storyboard/components/ReplaceFromBookDialog.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/ReplaceFromBookDialog.tsx
@@ -1,0 +1,148 @@
+import { useState } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { Check, ImagePlus, X, Search, Loader2 } from "lucide-react"
+import { api, BASE_URL } from "@/api/client"
+import { useLingui } from "@lingui/react/macro"
+
+interface ReplaceFromBookDialogProps {
+  bookLabel: string
+  currentImageId: string
+  onSelect: (imageId: string) => void
+  onClose: () => void
+}
+
+/**
+ * Dialog for picking an existing book image to replace the current one.
+ * Single-select variant of the image picker from AddImageDialog.
+ */
+export function ReplaceFromBookDialog({
+  bookLabel,
+  currentImageId,
+  onSelect,
+  onClose,
+}: ReplaceFromBookDialogProps) {
+  const { t } = useLingui()
+  const [filter, setFilter] = useState("")
+  const [selected, setSelected] = useState<string | null>(null)
+
+  const imagesQuery = useQuery({
+    queryKey: ["books", bookLabel, "images"],
+    queryFn: () => api.listBookImages(bookLabel),
+    staleTime: 30_000,
+  })
+
+  const selectableImages = imagesQuery.data?.images
+    .filter((img) => img.source !== "page")
+    .filter((img) => img.imageId !== currentImageId)
+    .filter((img) => !filter || img.imageId.toLowerCase().includes(filter.toLowerCase()))
+
+  return (
+    <div className="fixed inset-0 z-[100] bg-black/60 flex items-center justify-center p-8">
+      <div className="bg-background rounded-xl shadow-2xl w-full max-w-lg flex flex-col overflow-hidden max-h-[80vh]">
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-3.5 border-b shrink-0">
+          <div className="flex items-center gap-2">
+            <ImagePlus className="h-4 w-4 text-blue-500" />
+            <h2 className="text-sm font-semibold">{t`Replace from Book`}</h2>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="p-1 rounded hover:bg-accent transition-colors cursor-pointer"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto p-4 space-y-3">
+          <div className="relative">
+            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
+            <input
+              type="text"
+              value={filter}
+              onChange={(e) => setFilter(e.target.value)}
+              placeholder={t`Filter by image ID...`}
+              className="w-full text-sm border rounded-lg pl-8 pr-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500/30"
+              autoFocus
+            />
+          </div>
+
+          {imagesQuery.isLoading && (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+            </div>
+          )}
+
+          {selectableImages && selectableImages.length === 0 && (
+            <p className="text-center text-sm text-muted-foreground py-8">
+              {filter ? t`No images match your filter` : t`No other images in this book`}
+            </p>
+          )}
+
+          {selectableImages && selectableImages.length > 0 && (
+            <div className="grid grid-cols-3 gap-2">
+              {selectableImages.map((img) => {
+                const isSelected = selected === img.imageId
+                return (
+                  <button
+                    key={img.imageId}
+                    type="button"
+                    onClick={() => setSelected(isSelected ? null : img.imageId)}
+                    className={`group relative rounded border overflow-hidden bg-card flex flex-col items-center min-h-[60px] transition-all cursor-pointer ${
+                      isSelected
+                        ? "ring-2 ring-blue-500 border-blue-500"
+                        : "hover:ring-2 hover:ring-blue-500/50"
+                    }`}
+                  >
+                    {isSelected && (
+                      <div className="absolute top-1 right-1 z-10 h-5 w-5 rounded-full bg-blue-500 flex items-center justify-center">
+                        <Check className="h-3 w-3 text-white" />
+                      </div>
+                    )}
+                    <img
+                      src={`${BASE_URL}/books/${bookLabel}/images/${img.imageId}`}
+                      alt={img.imageId}
+                      className="max-w-full h-auto block"
+                      loading="lazy"
+                    />
+                    <div className="px-1.5 py-0.5 border-t bg-muted/30 w-full mt-auto">
+                      <span className="text-[9px] text-muted-foreground truncate block">
+                        {img.imageId}
+                      </span>
+                    </div>
+                  </button>
+                )
+              })}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-between px-5 py-3.5 border-t shrink-0">
+          <p className="text-[10px] text-muted-foreground">
+            {selected ? t`1 image selected` : t`Click an image to select`}
+          </p>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="text-xs font-medium rounded px-3 py-1.5 bg-muted hover:bg-accent transition-colors cursor-pointer"
+            >
+              {t`Cancel`}
+            </button>
+            <button
+              type="button"
+              onClick={() => selected && onSelect(selected)}
+              disabled={!selected}
+              className="flex items-center gap-1 text-xs font-medium rounded px-3 py-1.5 bg-blue-600 hover:bg-blue-500 text-white cursor-pointer transition-colors disabled:opacity-50"
+            >
+              <ImagePlus className="h-3 w-3" />
+              {t`Replace`}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/SectionEditToolbar.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/SectionEditToolbar.tsx
@@ -4,6 +4,7 @@ import {
   Crop,
   Eye,
   EyeOff,
+  ImagePlus,
   Pencil,
   Plus,
   Scissors,
@@ -979,6 +980,7 @@ export interface SectionEditToolbarProps {
   onCrop?: (dataId: string) => void
   onRecropFromPage?: (dataId: string) => void
   onReplace?: (dataId: string) => void
+  onReplaceFromBook?: (dataId: string) => void
   onAiImage?: (dataId: string) => void
   onSegment?: (dataId: string) => void
   segmenting?: boolean
@@ -1003,6 +1005,7 @@ export function SectionEditToolbar({
   onCrop,
   onRecropFromPage,
   onReplace,
+  onReplaceFromBook,
   onAiImage,
   onSegment,
   segmenting,
@@ -1011,7 +1014,9 @@ export function SectionEditToolbar({
 }: SectionEditToolbarProps) {
   const { t } = useLingui()
   const [cropMenuOpen, setCropMenuOpen] = useState(false)
+  const [replaceMenuOpen, setReplaceMenuOpen] = useState(false)
   const cropMenuRef = useRef<HTMLDivElement>(null)
+  const replaceMenuRef = useRef<HTMLDivElement>(null)
 
   // Close crop dropdown on outside click
   useEffect(() => {
@@ -1024,6 +1029,18 @@ export function SectionEditToolbar({
     document.addEventListener("mousedown", handler)
     return () => document.removeEventListener("mousedown", handler)
   }, [cropMenuOpen])
+
+  // Close replace dropdown on outside click
+  useEffect(() => {
+    if (!replaceMenuOpen) return
+    const handler = (e: MouseEvent) => {
+      if (replaceMenuRef.current && !replaceMenuRef.current.contains(e.target as Node)) {
+        setReplaceMenuOpen(false)
+      }
+    }
+    document.addEventListener("mousedown", handler)
+    return () => document.removeEventListener("mousedown", handler)
+  }, [replaceMenuOpen])
 
   if (!dataId) return null
 
@@ -1131,9 +1148,42 @@ export function SectionEditToolbar({
               </div>
             )}
             {onReplace && (
-              <button type="button" onClick={() => onReplace(dataId)} className="flex items-center gap-1 text-[10px] font-medium rounded px-2 py-1 bg-muted hover:bg-accent transition-colors cursor-pointer">
-                <Upload className="h-3 w-3" /><Trans>Replace</Trans>
-              </button>
+              <div className="relative inline-flex" ref={replaceMenuRef}>
+                <button type="button" onClick={() => onReplace(dataId)} className={`flex items-center gap-1 text-[10px] font-medium px-2 py-1 bg-muted hover:bg-accent transition-colors cursor-pointer ${onReplaceFromBook ? "rounded-l" : "rounded"}`}>
+                  <Upload className="h-3 w-3" /><Trans>Replace</Trans>
+                </button>
+                {onReplaceFromBook && (
+                  <>
+                    <button
+                      type="button"
+                      onClick={() => setReplaceMenuOpen(!replaceMenuOpen)}
+                      className="flex items-center text-[10px] font-medium rounded-r px-1 py-1 bg-muted hover:bg-accent transition-colors cursor-pointer border-l border-border"
+                    >
+                      <ChevronDown className="h-3 w-3" />
+                    </button>
+                    {replaceMenuOpen && (
+                      <div className="absolute top-full left-0 mt-1 z-50 bg-popover border rounded shadow-md py-1 min-w-[150px]">
+                        <button
+                          type="button"
+                          onClick={() => { setReplaceMenuOpen(false); onReplace(dataId) }}
+                          className="w-full text-left px-3 py-1.5 text-[10px] hover:bg-accent transition-colors cursor-pointer flex items-center gap-1.5"
+                        >
+                          <Upload className="h-3 w-3" />
+                          <Trans>Upload from Disk</Trans>
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => { setReplaceMenuOpen(false); onReplaceFromBook(dataId) }}
+                          className="w-full text-left px-3 py-1.5 text-[10px] hover:bg-accent transition-colors cursor-pointer flex items-center gap-1.5"
+                        >
+                          <ImagePlus className="h-3 w-3" />
+                          <Trans>Pick from Book</Trans>
+                        </button>
+                      </div>
+                    )}
+                  </>
+                )}
+              </div>
             )}
             {onAiImage && (
               <button type="button" onClick={() => onAiImage(dataId)} className="flex items-center gap-1 text-[10px] font-medium rounded px-2 py-1 bg-purple-100 hover:bg-purple-200 text-purple-700 transition-colors cursor-pointer">

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
@@ -16,6 +16,7 @@ import { SectionEditToolbar } from "./SectionEditToolbar"
 import { ImageCropDialog } from "./ImageCropDialog"
 import { AiImageDialog } from "./AiImageDialog"
 import { AddImageDialog } from "./AddImageDialog"
+import { ReplaceFromBookDialog } from "./ReplaceFromBookDialog"
 import { SegmentPreviewDialog, type SegmentRegion } from "./SegmentPreviewDialog"
 import { Input } from "@/components/ui/input"
 import { useLingui } from "@lingui/react/macro"
@@ -508,6 +509,7 @@ export function StoryboardSectionDetail({
 
   const fileInputRef = useRef<HTMLInputElement>(null)
   const replaceTargetRef = useRef<string | null>(null)
+  const [replaceFromBookTarget, setReplaceFromBookTarget] = useState<string | null>(null)
 
   // Image segmentation state
   const [segmenting, setSegmenting] = useState(false)
@@ -1712,6 +1714,61 @@ export function StoryboardSectionDetail({
     [bookLabel, pageId, pendingSectioning, page.sectioning, pendingRendering, page.rendering, sectionIndex]
   )
 
+  // Replace from book: open picker dialog
+  const handleReplaceFromBook = useCallback((dataId: string) => {
+    setReplaceFromBookTarget(dataId)
+    setSelectedElement(null)
+  }, [])
+
+  // Process replace-from-book selection: swap image in sectioning + rendering
+  const handleReplaceFromBookSelect = useCallback(
+    (newImageId: string) => {
+      const targetId = replaceFromBookTarget
+      if (!targetId) return
+      setReplaceFromBookTarget(null)
+
+      // Update sectioning
+      const sBase = pendingSectioning ?? page.sectioning
+      if (sBase) {
+        const updatedSectioning: SectioningData = {
+          ...sBase,
+          sections: sBase.sections.map((s, si) => {
+            if (si !== sectionIndex) return s
+            return {
+              ...s,
+              parts: s.parts.map((p) => {
+                if (p.type === "image" && p.imageId === targetId) {
+                  return { ...p, imageId: newImageId }
+                }
+                return p
+              }),
+            }
+          }),
+        }
+        setPendingSectioning(updatedSectioning)
+      }
+
+      // Update rendering HTML
+      const rBase = pendingRendering ?? page.rendering
+      if (rBase) {
+        const oldSrc = `${BASE_URL}/books/${bookLabel}/images/${targetId}`
+        const newSrc = `${BASE_URL}/books/${bookLabel}/images/${newImageId}`
+        const updatedRendering: RenderingData = {
+          ...rBase,
+          sections: rBase.sections.map((s) => {
+            if (s.sectionIndex !== sectionIndex) return s
+            let html = s.html
+            html = html.replace(new RegExp(`data-id="${escapeRegex(targetId)}"`, "g"), `data-id="${newImageId}"`)
+            html = html.replace(new RegExp(escapeRegex(oldSrc), "g"), newSrc)
+            return { ...s, html }
+          }),
+        }
+        setPendingRendering(updatedRendering)
+      }
+    },
+    [bookLabel, replaceFromBookTarget, pendingSectioning, page.sectioning, pendingRendering, page.rendering, sectionIndex]
+  )
+
   // Open AI image dialog for a specific image
   const handleAiImage = useCallback((dataId: string) => {
     setAiImageDialogTarget(dataId)
@@ -2556,6 +2613,7 @@ export function StoryboardSectionDetail({
           onCrop={selectedInfo.isImage && !storyboardRunning ? (dataId) => setCropTarget(dataId) : undefined}
           onRecropFromPage={selectedInfo.isImage && !storyboardRunning ? handleRecropFromPage : undefined}
           onReplace={selectedInfo.isImage && !storyboardRunning ? handleImageReplace : undefined}
+          onReplaceFromBook={selectedInfo.isImage && !storyboardRunning ? handleReplaceFromBook : undefined}
           onAiImage={selectedInfo.isImage && hasApiKey && !storyboardRunning ? handleAiImage : undefined}
           onSegment={selectedInfo.isImage && hasApiKey && !storyboardRunning ? handleSegment : undefined}
           segmenting={segmenting}
@@ -2655,6 +2713,16 @@ export function StoryboardSectionDetail({
         imageSrc={recropPageSrc ?? `${BASE_URL}/books/${bookLabel}/images/${cropTarget}`}
         onApply={handleCropApply}
         onClose={() => { setCropTarget(null); setRecropPageSrc(null) }}
+      />
+    )}
+
+    {/* Replace from book dialog */}
+    {replaceFromBookTarget && (
+      <ReplaceFromBookDialog
+        bookLabel={bookLabel}
+        currentImageId={replaceFromBookTarget}
+        onSelect={handleReplaceFromBookSelect}
+        onClose={() => setReplaceFromBookTarget(null)}
       />
     )}
 

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -795,6 +795,9 @@ msgstr "Clear model"
 msgid "Click \"Add Videos\" to upload MP4 or WebM files."
 msgstr "Click \"Add Videos\" to upload MP4 or WebM files."
 
+msgid "Click an image to select"
+msgstr "Click an image to select"
+
 msgid "Click images to select"
 msgstr "Click images to select"
 
@@ -2088,6 +2091,9 @@ msgstr "No matching sections"
 msgid "No metadata yet — run the pipeline to extract book details"
 msgstr "No metadata yet — run the pipeline to extract book details"
 
+msgid "No other images in this book"
+msgstr "No other images in this book"
+
 msgid "No page linked"
 msgstr "No page linked"
 
@@ -2542,6 +2548,9 @@ msgstr "Rendering this section..."
 
 msgid "Replace"
 msgstr "Replace"
+
+msgid "Replace from Book"
+msgstr "Replace from Book"
 
 msgid "Replace Video?"
 msgstr "Replace Video?"
@@ -3323,6 +3332,9 @@ msgstr "Upload a PDF to get started"
 
 msgid "Upload and assign sign language videos to book pages."
 msgstr "Upload and assign sign language videos to book pages."
+
+msgid "Upload from Disk"
+msgstr "Upload from Disk"
 
 msgid "Upload image"
 msgstr "Upload image"

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -795,6 +795,9 @@ msgstr "Borrar modelo"
 msgid "Click \"Add Videos\" to upload MP4 or WebM files."
 msgstr "Haga clic en \"Agregar Videos\" para cargar archivos MP4 o WebM."
 
+msgid "Click an image to select"
+msgstr "Haz clic en una imagen para seleccionar"
+
 msgid "Click images to select"
 msgstr "Haz clic en las imágenes para seleccionar"
 
@@ -2088,6 +2091,9 @@ msgstr "No hay secciones coincidentes"
 msgid "No metadata yet — run the pipeline to extract book details"
 msgstr "Aún no hay metadatos — ejecuta el pipeline para extraer los detalles del libro"
 
+msgid "No other images in this book"
+msgstr "No hay otras imágenes en este libro"
+
 msgid "No page linked"
 msgstr "No hay página vinculada"
 
@@ -2542,6 +2548,9 @@ msgstr "Renderizando esta sección..."
 
 msgid "Replace"
 msgstr "Reemplazar"
+
+msgid "Replace from Book"
+msgstr "Reemplazar del libro"
 
 msgid "Replace Video?"
 msgstr "¿Reemplazar Video?"
@@ -3323,6 +3332,9 @@ msgstr "Sube un PDF para comenzar"
 
 msgid "Upload and assign sign language videos to book pages."
 msgstr "Carga y asigna videos de lengua de señas a las páginas del libro."
+
+msgid "Upload from Disk"
+msgstr "Subir desde disco"
 
 msgid "Upload image"
 msgstr "Subir imagen"

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -795,6 +795,9 @@ msgstr "Limpar modelo"
 msgid "Click \"Add Videos\" to upload MP4 or WebM files."
 msgstr "Clique em \"Adicionar Vídeos\" para enviar arquivos MP4 ou WebM."
 
+msgid "Click an image to select"
+msgstr "Clique em uma imagem para selecionar"
+
 msgid "Click images to select"
 msgstr "Clique nas imagens para selecionar"
 
@@ -2088,6 +2091,9 @@ msgstr "Nenhuma seção correspondente"
 msgid "No metadata yet — run the pipeline to extract book details"
 msgstr "Ainda não há metadados — execute o pipeline para extrair os detalhes do livro"
 
+msgid "No other images in this book"
+msgstr "Nenhuma outra imagem neste livro"
+
 msgid "No page linked"
 msgstr "Nenhuma página vinculada"
 
@@ -2542,6 +2548,9 @@ msgstr "Renderizando esta seção..."
 
 msgid "Replace"
 msgstr "Substituir"
+
+msgid "Replace from Book"
+msgstr "Substituir do livro"
 
 msgid "Replace Video?"
 msgstr "Substituir Vídeo?"
@@ -3323,6 +3332,9 @@ msgstr "Envie um PDF para começar"
 
 msgid "Upload and assign sign language videos to book pages."
 msgstr "Envie e atribua vídeos de língua de sinais às páginas do livro."
+
+msgid "Upload from Disk"
+msgstr "Enviar do disco"
 
 msgid "Upload image"
 msgstr "Enviar imagem"


### PR DESCRIPTION
## Summary

- Adds a new "Replace from Book" option to the storyboard section image toolbar, allowing users to pick an existing book image as a replacement instead of uploading from disk
- Introduces a `ReplaceFromBookDialog` component with image browsing, filtering, and selection
- Converts the Replace button into a split-button dropdown with "Upload from Disk" and "Pick from Book" options
- Updates sectioning data and rendering HTML on selection, following the existing pending-state mutation pattern
- All new strings translated in en, es, and pt-BR

## Test plan

- [ ] Open a storyboard section with an image selected
- [ ] Verify the Replace button now shows a dropdown chevron
- [ ] Click "Pick from Book" and confirm the dialog shows available book images (excluding page-source images and the current image)
- [ ] Select an image and confirm it replaces the current one in both the section data and rendered preview
- [ ] Verify "Upload from Disk" still works as before
- [ ] Test the filter field in the dialog
- [ ] Verify translations appear correctly in es and pt-BR locales