### PR TITLE
Add LLM-driven nested grouping and ordered parts rendering

### DIFF
--- a/apps/api/src/routes/adt-preview.ts
+++ b/apps/api/src/routes/adt-preview.ts
@@ -12,6 +12,7 @@ import {
   type TTSOutput,
   type TocGenerationOutput,
   type Quiz,
+  flattenTextParts,
 } from "@adt/types"
 import { createBookStorage, type Storage } from "@adt/storage"
 import {
@@ -285,8 +286,7 @@ function buildHeadingBasedToc(storage: Storage): Array<{ section_id: string; hre
       const sectionId = sectionMeta.sectionId ?? `${page.pageId}_sec${String(rs.sectionIndex + 1).padStart(3, "0")}`
 
       // Find first heading text in section parts
-      for (const part of sectionMeta.parts) {
-        if (part.type !== "text_group" || part.isPruned) continue
+      for (const part of flattenTextParts(sectionMeta.parts)) {
         let found = false
         for (const t of part.texts) {
           if (t.isPruned) continue

--- a/apps/api/src/routes/pages.ts
+++ b/apps/api/src/routes/pages.ts
@@ -4,7 +4,7 @@ import path from "node:path"
 import { z } from "zod"
 import { Hono } from "hono"
 import { HTTPException } from "hono/http-exception"
-import { parseBookLabel, TextClassificationOutput, ImageClassificationOutput, PageSectioningOutput, WebRenderingOutput, ImageCaptioningOutput, ImageSegmentRegion, DEFAULT_LLM_MAX_RETRIES } from "@adt/types"
+import { parseBookLabel, TextClassificationOutput, ImageClassificationOutput, PageSectioningOutput, WebRenderingOutput, ImageCaptioningOutput, ImageSegmentRegion, DEFAULT_LLM_MAX_RETRIES, type SectionPart, flattenImageParts } from "@adt/types"
 import { openBookDb } from "@adt/storage"
 import { createBookStorage } from "@adt/storage"
 import type { Storage } from "@adt/storage"
@@ -258,15 +258,20 @@ async function executeAiImageGeneration(params: AiImageGenParams): Promise<{
               const sectioning = parsed.data
               const si = params.sectionIndex
               if (si < sectioning.sections.length) {
+                const swapImageInParts = (parts: SectionPart[], targetId: string, replacementId: string): SectionPart[] =>
+                  parts.map((p) => {
+                    if (p.type === "image" && p.imageId === targetId) return { ...p, imageId: replacementId }
+                    if (p.type === "group") return { ...p, parts: swapImageInParts(p.parts, targetId, replacementId) }
+                    return p
+                  })
+
                 if (params.mode === "swap" && params.targetImageId) {
-                  const tid = params.targetImageId
-                  sectioning.sections[si].parts = sectioning.sections[si].parts.map((p) =>
-                    p.type === "image" && p.imageId === tid ? { ...p, imageId: newImageId } : p
+                  sectioning.sections[si].parts = swapImageInParts(
+                    sectioning.sections[si].parts, params.targetImageId, newImageId
                   )
                 } else if (params.mode === "add") {
-                  const alreadyExists = sectioning.sections[si].parts.some(
-                    (p) => p.type === "image" && p.imageId === newImageId
-                  )
+                  const alreadyExists = flattenImageParts(sectioning.sections[si].parts)
+                    .some((p) => p.imageId === newImageId)
                   if (!alreadyExists) {
                     sectioning.sections[si].parts.push({ type: "image", imageId: newImageId, isPruned: false })
                   }

--- a/apps/api/src/services/page-edit-service.test.ts
+++ b/apps/api/src/services/page-edit-service.test.ts
@@ -146,12 +146,12 @@ describe("page-edit-service", () => {
           context: {
             section_id: string
             section_type: string
-            images: Array<{ image_id: string }>
+            ordered_parts: Array<{ part_type: string; image_id?: string }>
           }
         }).context
         const sectionId = context.section_id
         const sectionType = context.section_type
-        const imageId = context.images[0]?.image_id
+        const imageId = context.ordered_parts.find((p) => p.part_type === "image")?.image_id
         return {
           object: {
             reasoning: "rerendered",

--- a/apps/api/src/services/page-edit-service.ts
+++ b/apps/api/src/services/page-edit-service.ts
@@ -5,7 +5,7 @@ import { createLLMModel, createPromptEngine } from "@adt/llm"
 import type { LLMModel } from "@adt/llm"
 import { renderPage, buildRenderStrategyResolver, createTemplateEngine, loadBookConfig, createScreenshotRenderer, runVisualReviewLoop, DEFAULT_VISUAL_REVIEW_MODEL_ID } from "@adt/pipeline"
 import type { VisualRefinementDeps } from "@adt/pipeline"
-import { PageSectioningOutput, WebRenderingOutput, webRenderingLLMSchema } from "@adt/types"
+import { PageSectioningOutput, WebRenderingOutput, webRenderingLLMSchema, flattenImageParts } from "@adt/types"
 import { loadStyleguideContent } from "./styleguide.js"
 
 export interface ReRenderOptions {
@@ -82,8 +82,8 @@ export async function reRenderPage(
     }
     // Add any images referenced in sections but not found on this page
     for (const section of sectioning.sections) {
-      for (const part of section.parts) {
-        if (part.type === "image" && !part.isPruned && !renderImages.has(part.imageId)) {
+      for (const part of flattenImageParts(section.parts)) {
+        if (!renderImages.has(part.imageId)) {
           const dims = storage.getImageDimensions(part.imageId)
           renderImages.set(part.imageId, { base64: storage.getImageBase64(part.imageId), width: dims?.width, height: dims?.height })
         }

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/SectionDataPanel.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/SectionDataPanel.tsx
@@ -1,15 +1,24 @@
-import { useState, useRef, useCallback, useEffect, type ReactNode } from "react"
+import { useState, useRef, useCallback, useEffect, useMemo, type ReactNode } from "react"
 import {
+  ArrowDown,
+  ArrowUp,
+  ChevronDown,
+  ChevronRight,
   Copy,
   Eye,
   EyeOff,
+  FolderOpen,
   GripVertical,
+  Image,
   ImagePlus,
   Layers,
   Loader2,
+  Minus,
+  PanelTop,
   Plus,
   RefreshCw,
   Trash2,
+  Type,
   X,
 } from "lucide-react"
 import { SectionActionsDropdown } from "./SectionActionsDropdown"
@@ -89,6 +98,14 @@ interface SectionDataPanelProps {
   hasApiKey: boolean
   showPrunedImages: boolean
   onToggleShowPrunedImages: () => void
+  // Layers panel
+  sectionHtml?: string
+  selectedDataId?: string
+  onSelectElement?: (dataId: string) => void
+  onMoveElement?: (dataId: string, direction: "up" | "down") => void
+  onReorderElement?: (dragSelector: string, dropSelector: string, position: "before" | "after" | "inside") => void
+  /** Set of data-ids that are pruned (hidden from output) */
+  prunedDataIds?: string[]
 }
 
 // -- ImageCard (inline) --
@@ -218,10 +235,574 @@ function EditableText({
   )
 }
 
+// ---------------------------------------------------------------------------
+// Layers panel — DOM tree view of the rendered section HTML
+// ---------------------------------------------------------------------------
+
+interface LayerNode {
+  tag: string
+  dataId: string | null
+  /** Stable identifier for drag-and-drop — uses dataId when available, otherwise a positional key */
+  layerKey: string
+  /** CSS selector that uniquely identifies this element in the parsed DOM */
+  cssSelector: string
+  label: string
+  textPreview: string
+  isImage: boolean
+  isContainer: boolean
+  children: LayerNode[]
+  hasPrevSibling: boolean
+  hasNextSibling: boolean
+  /** Index among visible siblings in this parent */
+  siblingIndex: number
+}
+
+/** Tags that are interesting to show in the layer tree */
+const LAYER_TAGS = new Set([
+  "div", "section", "article", "main", "aside", "nav", "header", "footer",
+  "p", "h1", "h2", "h3", "h4", "h5", "h6", "span", "a", "blockquote",
+  "figure", "figcaption", "img", "picture", "video", "audio",
+  "ul", "ol", "li", "table", "tr", "td", "th", "tbody", "thead",
+  "button", "input", "label", "form", "textarea", "select",
+])
+
+function buildLayerTree(html: string): LayerNode[] {
+  const parser = new DOMParser()
+  const doc = parser.parseFromString(html, "text/html")
+
+  // Start from #content wrapper if present, otherwise body
+  const root = doc.getElementById("content") ?? doc.body
+  const rootSelector = root.id ? `#${root.id}` : "body"
+  return buildChildren(root, rootSelector)
+}
+
+function buildChildren(parent: Element, parentSelector: string = ""): LayerNode[] {
+  const nodes: LayerNode[] = []
+  const childElements = Array.from(parent.children)
+
+  let visibleIdx = 0
+  for (let i = 0; i < childElements.length; i++) {
+    const el = childElements[i]
+    const tag = el.tagName.toLowerCase()
+
+    // Skip non-visual elements
+    if (tag === "script" || tag === "style" || tag === "link" || tag === "meta") continue
+
+    const dataId = el.getAttribute("data-id")
+    const isImg = tag === "img"
+    const isContainer = !dataId && LAYER_TAGS.has(tag) && el.children.length > 0
+
+    // Build a CSS selector: prefer data-id, fall back to nth-child
+    // eslint-disable-next-line lingui/no-unlocalized-strings -- CSS selector, not user-visible
+    const cssSelector = dataId ? `[data-id="${dataId}"]` : `${parentSelector} > :nth-child(${i + 1})`
+
+    const layerKey = dataId ?? `${parentSelector}/${visibleIdx}:${tag}`
+    const children = isContainer ? buildChildren(el, cssSelector) : []
+
+    // Build label — data-id or image filename
+    let label: string
+    if (dataId) {
+      label = dataId
+    } else if (isImg) {
+      const src = el.getAttribute("src") ?? ""
+      const fileName = src.split("/").pop() ?? ""
+      label = fileName || tag
+    } else {
+      label = tag
+    }
+
+    // Text preview — always show for any element with text content
+    const ownText = getOwnTextContent(el)
+    const textPreview = ownText.length > 50 ? ownText.slice(0, 50) + "…" : ownText
+
+    // Only include if it has a data-id, is a container with children, or is a known tag
+    if (dataId || children.length > 0 || LAYER_TAGS.has(tag)) {
+      nodes.push({
+        tag,
+        dataId,
+        layerKey,
+        cssSelector,
+        label,
+        textPreview,
+        isImage: isImg || (dataId?.includes("_im") ?? false),
+        isContainer,
+        children,
+        hasPrevSibling: visibleIdx > 0,
+        hasNextSibling: false, // patched below
+        siblingIndex: visibleIdx,
+      })
+      visibleIdx++
+    }
+  }
+  // Patch hasNextSibling
+  for (let i = 0; i < nodes.length - 1; i++) {
+    nodes[i].hasNextSibling = true
+  }
+  return nodes
+}
+
+/** Get the direct (non-child-element) text content of an element */
+function getOwnTextContent(el: Element): string {
+  let text = ""
+  for (const child of el.childNodes) {
+    if (child.nodeType === Node.TEXT_NODE) {
+      text += child.textContent ?? ""
+    }
+  }
+  // Fallback: if no direct text nodes, use full textContent (for leaf elements)
+  if (!text.trim() && el.children.length === 0) {
+    text = el.textContent ?? ""
+  }
+  return text.trim()
+}
+
+const DRAG_TYPE_LAYER = "application/x-layer-key"
+
+function LayerNodeRow({
+  node,
+  depth,
+  selectedDataId,
+  prunedDataIds,
+  expandedPaths,
+  toggleExpand,
+  onSelect,
+  onMove,
+  dragState,
+  onDragStart,
+  onDragEnd,
+  onDragOver,
+  onDrop,
+  disabled,
+}: {
+  node: LayerNode
+  depth: number
+  selectedDataId?: string
+  prunedDataIds?: Set<string>
+  expandedPaths: Set<string>
+  toggleExpand: (path: string) => void
+  onSelect?: (dataId: string) => void
+  onMove?: (dataId: string, direction: "up" | "down") => void
+  dragState: { dragKey: string | null; dropKey: string | null; dropPosition: "before" | "after" | "inside" | null }
+  onDragStart: (layerKey: string) => void
+  onDragEnd: () => void
+  onDragOver: (e: React.DragEvent, layerKey: string) => void
+  onDrop: (e: React.DragEvent, layerKey: string) => void
+  disabled?: boolean
+}) {
+  const { t } = useLingui()
+  const pathKey = node.layerKey
+  const isExpanded = expandedPaths.has(pathKey)
+  const isSelected = node.dataId != null && node.dataId === selectedDataId
+  const isPruned = node.dataId != null && (prunedDataIds?.has(node.dataId) ?? false)
+  const hasChildren = node.children.length > 0
+  const canMove = node.dataId != null && onMove && !disabled
+  const isDragging = dragState.dragKey === node.layerKey
+  const isDropTarget = dragState.dropKey === node.layerKey
+  const isDraggable = !disabled
+
+  return (
+    <>
+      <div
+        className={cn(
+          "flex items-center gap-1 py-0.5 pr-1 rounded text-[11px] transition-colors group/layer",
+          isSelected && !isDropTarget ? "bg-blue-100 text-blue-900" : !isDropTarget && "hover:bg-accent/50",
+          isDragging && "opacity-40",
+          isPruned && !isDragging && "opacity-40",
+          isDropTarget && dragState.dropPosition === "before" && "border-t-2 border-t-primary",
+          isDropTarget && dragState.dropPosition === "after" && "border-b-2 border-b-primary",
+          isDropTarget && dragState.dropPosition === "inside" && "bg-primary/10 ring-1 ring-primary rounded",
+          isDraggable ? "cursor-grab active:cursor-grabbing" : "cursor-default"
+        )}
+        style={{ paddingLeft: depth * 16 + 4 }}
+        draggable={isDraggable}
+        onDragStart={(e) => {
+          if (!isDraggable) { e.preventDefault(); return }
+          e.dataTransfer.setData(DRAG_TYPE_LAYER, node.layerKey)
+          e.dataTransfer.effectAllowed = "move"
+          onDragStart(node.layerKey)
+        }}
+        onDragEnd={onDragEnd}
+        onDragOver={(e) => onDragOver(e, node.layerKey)}
+        onDrop={(e) => onDrop(e, node.layerKey)}
+        onClick={() => {
+          if (node.dataId && onSelect) onSelect(node.dataId)
+        }}
+      >
+        {/* Expand/collapse toggle */}
+        {hasChildren ? (
+          <button
+            type="button"
+            onClick={(e) => { e.stopPropagation(); toggleExpand(pathKey) }}
+            className="p-0 shrink-0 cursor-pointer"
+          >
+            <ChevronRight className={`h-3 w-3 text-muted-foreground transition-transform ${isExpanded ? "rotate-90" : ""}`} />
+          </button>
+        ) : (
+          <span className="w-3 shrink-0">
+            <Minus className="h-3 w-3 text-muted-foreground/30" />
+          </span>
+        )}
+
+        {/* Icon */}
+        {node.isImage ? (
+          <Image className="h-3 w-3 text-green-600 shrink-0" />
+        ) : hasChildren ? (
+          <PanelTop className="h-3 w-3 text-orange-500 shrink-0" />
+        ) : (
+          <Type className="h-3 w-3 text-muted-foreground shrink-0" />
+        )}
+
+        {/* Tag name */}
+        <span className="text-[10px] font-mono text-muted-foreground shrink-0">{node.tag}</span>
+
+        {/* Label (data-id or tag) */}
+        <span className="text-[10px] font-mono text-muted-foreground/70 shrink-0 max-w-[80px] truncate">{node.label !== node.tag ? node.label : ""}</span>
+
+        {/* Text preview */}
+        {node.textPreview && (
+          <span className="truncate min-w-0 flex-1 text-[10px] text-muted-foreground/60 italic">{node.textPreview}</span>
+        )}
+        {!node.textPreview && <span className="flex-1" />}
+
+        {/* Pruned indicator */}
+        {isPruned && (
+          <span className="shrink-0" title={t`Pruned`}>
+            <EyeOff className="h-3 w-3 text-destructive" />
+          </span>
+        )}
+
+        {/* Move buttons — visible on hover, keep as fallback alongside drag */}
+        {canMove && (
+          <span className="flex items-center gap-0 shrink-0 opacity-0 group-hover/layer:opacity-100 transition-opacity">
+            <button
+              type="button"
+              onClick={(e) => { e.stopPropagation(); onMove(node.dataId!, "up") }}
+              disabled={!node.hasPrevSibling}
+              className="p-0.5 rounded hover:bg-accent transition-colors cursor-pointer disabled:opacity-20 disabled:cursor-default"
+              title={t`Move up`}
+            >
+              <ArrowUp className="h-3 w-3" />
+            </button>
+            <button
+              type="button"
+              onClick={(e) => { e.stopPropagation(); onMove(node.dataId!, "down") }}
+              disabled={!node.hasNextSibling}
+              className="p-0.5 rounded hover:bg-accent transition-colors cursor-pointer disabled:opacity-20 disabled:cursor-default"
+              title={t`Move down`}
+            >
+              <ArrowDown className="h-3 w-3" />
+            </button>
+          </span>
+        )}
+      </div>
+      {/* Children */}
+      {hasChildren && isExpanded && node.children.map((child, i) => (
+        <LayerNodeRow
+          key={child.layerKey}
+          node={child}
+          depth={depth + 1}
+          selectedDataId={selectedDataId}
+          prunedDataIds={prunedDataIds}
+          expandedPaths={expandedPaths}
+          toggleExpand={toggleExpand}
+          onSelect={onSelect}
+          onMove={onMove}
+          dragState={dragState}
+          onDragStart={onDragStart}
+          onDragEnd={onDragEnd}
+          onDragOver={onDragOver}
+          onDrop={onDrop}
+          disabled={disabled}
+        />
+      ))}
+    </>
+  )
+}
+
+function LayersPanel({
+  html,
+  selectedDataId,
+  prunedDataIds,
+  onSelect,
+  onMove,
+  onReorder,
+  disabled,
+}: {
+  html: string
+  selectedDataId?: string
+  prunedDataIds?: Set<string>
+  onSelect?: (dataId: string) => void
+  onMove?: (dataId: string, direction: "up" | "down") => void
+  /** Reorder: move drag element relative to drop element. "inside" appends into a container. */
+  onReorder?: (dragSelector: string, dropSelector: string, position: "before" | "after" | "inside") => void
+  disabled?: boolean
+}) {
+  const { t } = useLingui()
+  const tree = useMemo(() => buildLayerTree(html), [html])
+  const [expandedPaths, setExpandedPaths] = useState<Set<string>>(() => {
+    const paths = new Set<string>()
+    for (const node of tree) {
+      paths.add(node.layerKey)
+    }
+    return paths
+  })
+
+  type DropPosition = "before" | "after" | "inside"
+
+  const [dragState, setDragState] = useState<{
+    dragKey: string | null
+    dropKey: string | null
+    dropPosition: DropPosition | null
+  }>({ dragKey: null, dropKey: null, dropPosition: null })
+
+  // Build a lookup from layerKey -> node for resolving drag/drop
+  const nodeByKey = useMemo(() => {
+    const map = new Map<string, LayerNode>()
+    function walk(nodes: LayerNode[]) {
+      for (const n of nodes) {
+        map.set(n.layerKey, n)
+        walk(n.children)
+      }
+    }
+    walk(tree)
+    return map
+  }, [tree])
+
+  const toggleExpand = useCallback((path: string) => {
+    setExpandedPaths((prev) => {
+      const next = new Set(prev)
+      if (next.has(path)) next.delete(path)
+      else next.add(path)
+      return next
+    })
+  }, [])
+
+  const handleDragStart = useCallback((layerKey: string) => {
+    setDragState({ dragKey: layerKey, dropKey: null, dropPosition: null })
+  }, [])
+
+  const handleDragEnd = useCallback(() => {
+    setDragState({ dragKey: null, dropKey: null, dropPosition: null })
+  }, [])
+
+  // Compute drop position from mouse Y:
+  // - Container nodes: top 25% = before, middle 50% = inside, bottom 25% = after
+  // - Leaf nodes: top 50% = before, bottom 50% = after
+  const getDropPosition = useCallback((e: React.DragEvent, targetKey: string): DropPosition => {
+    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect()
+    const relY = (e.clientY - rect.top) / rect.height
+    const targetNode = nodeByKey.get(targetKey)
+    if (targetNode?.isContainer) {
+      if (relY < 0.25) return "before"
+      if (relY > 0.75) return "after"
+      return "inside"
+    }
+    return relY < 0.5 ? "before" : "after"
+  }, [nodeByKey])
+
+  const handleDragOver = useCallback((e: React.DragEvent, layerKey: string) => {
+    if (!e.dataTransfer.types.includes(DRAG_TYPE_LAYER)) return
+    e.preventDefault()
+    e.dataTransfer.dropEffect = "move"
+
+    const position = getDropPosition(e, layerKey)
+
+    setDragState((prev) => {
+      if (prev.dropKey === layerKey && prev.dropPosition === position) return prev
+      return { ...prev, dropKey: layerKey, dropPosition: position }
+    })
+  }, [getDropPosition])
+
+  const handleDrop = useCallback((e: React.DragEvent, dropLayerKey: string) => {
+    e.preventDefault()
+    const dragKey = e.dataTransfer.getData(DRAG_TYPE_LAYER)
+    if (!dragKey || dragKey === dropLayerKey) {
+      setDragState({ dragKey: null, dropKey: null, dropPosition: null })
+      return
+    }
+
+    const dragNode = nodeByKey.get(dragKey)
+    const dropNode = nodeByKey.get(dropLayerKey)
+    if (!dragNode || !dropNode || !onReorder) {
+      setDragState({ dragKey: null, dropKey: null, dropPosition: null })
+      return
+    }
+
+    const position = getDropPosition(e, dropLayerKey)
+
+    onReorder(dragNode.cssSelector, dropNode.cssSelector, position)
+    setDragState({ dragKey: null, dropKey: null, dropPosition: null })
+  }, [nodeByKey, onReorder, getDropPosition])
+
+  if (tree.length === 0) {
+    return (
+      <div className="px-4 py-8 text-center text-xs text-muted-foreground">
+        {t`No rendered HTML for this section`}
+      </div>
+    )
+  }
+
+  return (
+    <div className="px-2 py-2 space-y-0">
+      {tree.map((node) => (
+        <LayerNodeRow
+          key={node.layerKey}
+          node={node}
+          depth={0}
+          selectedDataId={selectedDataId}
+          prunedDataIds={prunedDataIds}
+          expandedPaths={expandedPaths}
+          toggleExpand={toggleExpand}
+          onSelect={onSelect}
+          onMove={onMove}
+          dragState={dragState}
+          onDragStart={handleDragStart}
+          onDragEnd={handleDragEnd}
+          onDragOver={handleDragOver}
+          onDrop={handleDrop}
+          disabled={disabled}
+        />
+      ))}
+    </div>
+  )
+}
+
 // -- Drag types --
 
 const DRAG_TYPE_GROUP = "application/x-group-index"
 const DRAG_TYPE_TEXT = "application/x-text-entry"
+
+// -- Nested group renderer --
+
+function GroupPartView({
+  group,
+  partIndex,
+  bookLabel,
+  showPrunedImages,
+  pipelineRunning,
+  onTogglePartPruned,
+  t,
+  depth = 0,
+}: {
+  group: import("@adt/types").SectionGroupPartType
+  partIndex: number
+  bookLabel: string
+  showPrunedImages: boolean
+  pipelineRunning?: boolean
+  onTogglePartPruned: (partIndex: number) => void
+  t: ReturnType<typeof useLingui>["t"]
+  depth?: number
+}) {
+  const [expanded, setExpanded] = useState(true)
+
+  // Color accents by groupType
+  const isOptionGroup = group.groupType === "option_group"
+  const isOption = group.groupType === "option"
+  const borderColor = isOptionGroup ? "border-violet-300" : isOption ? "border-amber-300" : "border-sky-300"
+  const headerBg = isOptionGroup ? "bg-violet-50" : isOption ? "bg-amber-50" : "bg-sky-50"
+  const iconColor = isOptionGroup ? "text-violet-500" : isOption ? "text-amber-500" : "text-sky-500"
+
+  // Compact mode: option with a single text_group containing one entry → show text inline
+  const compactText = isOption
+    && group.parts.length === 1
+    && group.parts[0].type === "text_group"
+    && group.parts[0].texts.length === 1
+    ? group.parts[0].texts[0]
+    : null
+
+  if (compactText) {
+    return (
+      <div className={cn("rounded border overflow-hidden flex items-center gap-1.5 px-3 py-1.5", borderColor, headerBg, group.isPruned && "opacity-40")}>
+        <FolderOpen className={cn("h-3 w-3 shrink-0", iconColor)} />
+        <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">{group.groupType}</span>
+        <span className={cn("text-xs flex-1 min-w-0 break-words", compactText.isPruned && "opacity-40")}>{compactText.text}</span>
+        {group.answer && (
+          <span className="shrink-0 text-[10px] font-medium text-amber-700 bg-amber-100 rounded px-1.5 py-0.5">{group.answer}</span>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <div className={cn("rounded border overflow-hidden", borderColor, group.isPruned && "opacity-40")} style={{ marginLeft: depth > 0 ? 0 : undefined }}>
+      {/* Group header */}
+      <div className={cn("px-3 py-1.5 border-b flex items-center gap-1.5", headerBg, borderColor)}>
+        <button type="button" onClick={() => setExpanded(!expanded)} className="p-0.5 rounded hover:bg-accent/50 transition-colors cursor-pointer">
+          {expanded ? <ChevronDown className="h-3 w-3 text-muted-foreground" /> : <ChevronRight className="h-3 w-3 text-muted-foreground" />}
+        </button>
+        <FolderOpen className={cn("h-3 w-3 shrink-0", iconColor)} />
+        <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">{group.groupType}</span>
+        {group.answer && (
+          <span className="text-[10px] font-medium text-amber-700 bg-amber-100 rounded px-1.5 py-0.5 ml-1">{group.answer}</span>
+        )}
+        <span className="text-[10px] text-muted-foreground/60 ml-auto">{group.parts.length}</span>
+        <button type="button" onClick={() => onTogglePartPruned(partIndex)} disabled={!!pipelineRunning} className="p-0.5 rounded hover:bg-accent transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-default" title={group.isPruned ? t`Include in render` : t`Exclude from render`}>
+          {group.isPruned ? <EyeOff className="h-3 w-3 text-muted-foreground" /> : <Eye className="h-3 w-3 text-muted-foreground" />}
+        </button>
+      </div>
+
+      {/* Group children */}
+      {expanded && (
+        <div className="pl-3 pr-1 py-1.5 space-y-1.5">
+          {group.reasoning && (
+            <div className="text-[10px] text-muted-foreground/70 italic px-1 py-0.5">{group.reasoning}</div>
+          )}
+          {group.parts.map((child, childIdx) => {
+            if (child.type === "text_group") {
+              return (
+                <div key={child.groupId} className={cn("rounded border overflow-hidden", child.isPruned && "opacity-40")}>
+                  <div className="px-2 py-1 bg-muted/30 border-b flex items-center gap-1">
+                    <Type className="h-2.5 w-2.5 text-blue-500 shrink-0" />
+                    <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">{child.groupType}</span>
+                  </div>
+                  <div className="divide-y">
+                    {child.texts.map((te) => (
+                      <div key={te.textId} className={cn("px-2 py-1 flex items-start gap-1.5 text-xs", te.isPruned && "opacity-40")}>
+                        <span className="shrink-0 text-[9px] font-medium text-muted-foreground bg-muted/50 rounded px-1 py-0.5">{te.textType}</span>
+                        <span className="flex-1 min-w-0 break-words">{te.text}</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )
+            }
+
+            if (child.type === "image") {
+              if (child.isPruned && !showPrunedImages) return null
+              return (
+                <div key={child.imageId} className={cn("rounded border overflow-hidden", child.isPruned && "opacity-40")}>
+                  <div className="px-2 py-1 bg-muted/30 border-b flex items-center gap-1">
+                    <Image className="h-2.5 w-2.5 text-green-600 shrink-0" />
+                    <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">{child.imageId}</span>
+                  </div>
+                  <ImageCard imageId={child.imageId} bookLabel={bookLabel} isPruned={child.isPruned} reason={child.reason} />
+                </div>
+              )
+            }
+
+            if (child.type === "group") {
+              return (
+                <GroupPartView
+                  key={child.groupId}
+                  group={child}
+                  partIndex={partIndex}
+                  bookLabel={bookLabel}
+                  showPrunedImages={showPrunedImages}
+                  pipelineRunning={pipelineRunning}
+                  onTogglePartPruned={onTogglePartPruned}
+                  t={t}
+                  depth={depth + 1}
+                />
+              )
+            }
+
+            return null
+          })}
+        </div>
+      )}
+    </div>
+  )
+}
 
 // -- Component --
 
@@ -271,14 +852,21 @@ export function SectionDataPanel({
   hasApiKey,
   showPrunedImages,
   onToggleShowPrunedImages,
+  sectionHtml,
+  selectedDataId,
+  onSelectElement,
+  onMoveElement,
+  onReorderElement,
+  prunedDataIds,
 }: SectionDataPanelProps) {
   const { t } = useLingui()
+  const [activeTab, setActiveTab] = useState<"content" | "layers" | "json">("content")
   const [rerenderOpen, setRerenderOpen] = useState(false)
   const [rerenderPrompt, setRerenderPrompt] = useState("")
   const parts = section.parts
 
-  const hasTextParts = parts.some((p) => p.type === "text_group")
-  const hasImageParts = parts.some((p) => p.type === "image")
+  const hasTextParts = parts.some((p) => p.type === "text_group" || (p.type === "group" && p.parts.some((c) => c.type === "text_group")))
+  const hasImageParts = parts.some((p) => p.type === "image" || (p.type === "group" && p.parts.some((c) => c.type === "image")))
 
   // -- Group drag state --
   const [dragGroupIdx, setDragGroupIdx] = useState<number | null>(null)
@@ -573,6 +1161,46 @@ export function SectionDataPanel({
         )}
       </div>
 
+      {/* Tab bar */}
+      <div className="flex border-b bg-muted/20">
+        <button
+          type="button"
+          onClick={() => setActiveTab("content")}
+          className={cn(
+            "flex-1 text-[10px] font-medium uppercase tracking-wider py-1.5 transition-colors cursor-pointer",
+            activeTab === "content"
+              ? "border-b-2 border-primary text-foreground"
+              : "text-muted-foreground hover:text-foreground"
+          )}
+        >
+          {t`Content`}
+        </button>
+        <button
+          type="button"
+          onClick={() => setActiveTab("layers")}
+          className={cn(
+            "flex-1 text-[10px] font-medium uppercase tracking-wider py-1.5 transition-colors cursor-pointer",
+            activeTab === "layers"
+              ? "border-b-2 border-primary text-foreground"
+              : "text-muted-foreground hover:text-foreground"
+          )}
+        >
+          {t`Layers`}
+        </button>
+        <button
+          type="button"
+          onClick={() => setActiveTab("json")}
+          className={cn(
+            "flex-1 text-[10px] font-medium uppercase tracking-wider py-1.5 transition-colors cursor-pointer",
+            activeTab === "json"
+              ? "border-b-2 border-primary text-foreground"
+              : "text-muted-foreground hover:text-foreground"
+          )}
+        >
+          {t`JSON`}
+        </button>
+      </div>
+
       {/* Pipeline running banner */}
       {pipelineRunning && (
         <div className="flex items-center gap-2 px-4 py-2 bg-violet-50 border-b text-xs text-violet-700">
@@ -581,276 +1209,220 @@ export function SectionDataPanel({
         </div>
       )}
 
-      {/* Panel body — scrollable */}
-      <div className="overflow-auto flex-1 px-4 py-3 space-y-5">
-        {/* Text groups */}
-        <div>
-          <h3 className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
-            <Layers className="h-3 w-3" />
-            {t`Text Groups`}
-          </h3>
-          {hasTextParts && (
-            <div>
-              {parts.map((p, partIndex) => {
-                if (p.type !== "text_group") return null
-                const isGroupDragging = dragGroupIdx === partIndex
-                const showDropLine = dropGroupSlot === `before:${partIndex}` && dragGroupIdx !== null && dragGroupIdx !== partIndex
-                return (
-                  <div key={p.groupId}>
-                    {/* Drop zone gap before each group */}
-                    <div
-                      className={`transition-all duration-150 ${dragGroupIdx !== null ? "py-1.5" : "py-1"}`}
-                      onDragOver={(e) => handleGapDragOver(e, partIndex)}
-                      onDrop={handleGroupDrop}
-                    >
-                      {showDropLine && (
-                        <div className="h-0.5 bg-primary rounded-full" />
-                      )}
-                    </div>
-                    <div
-                      className={`group/card rounded border overflow-hidden transition-all duration-150 ${
-                        p.isPruned ? "opacity-40" : ""
-                      } ${isGroupDragging ? "opacity-50 scale-[0.98]" : ""}`}
-                      onDragOver={(e) => handleGroupDragOver(e, partIndex)}
-                      onDrop={handleGroupDrop}
-                    >
-                    <div className="px-3 py-1.5 bg-muted/50 border-b flex items-center gap-1.5">
-                      {/* Drag handle — visible on hover */}
-                      <div
-                        draggable={!pipelineRunning}
-                        onDragStart={(e) => { if (pipelineRunning) { e.preventDefault(); return } handleGroupDragStart(e, partIndex) }}
-                        onDragEnd={handleGroupDragEnd}
-                        className={cn("p-0.5 -ml-1 rounded transition-colors opacity-0 group-hover/card:opacity-100", pipelineRunning ? "cursor-default opacity-30" : "cursor-grab active:cursor-grabbing hover:bg-accent")}
-                        title={pipelineRunning ? undefined : t`Drag to reorder`}
-                      >
-                        <GripVertical className="h-3 w-3 text-muted-foreground" />
-                      </div>
-                      {groupTypes ? (
-                        <Select
-                          value={p.groupType}
-                          onValueChange={(val) => onChangeGroupType(partIndex, val)}
-                          disabled={pipelineRunning}
-                        >
-                          <SelectTrigger className="h-5 text-[10px] font-semibold uppercase tracking-wider px-1.5 py-0 w-auto min-w-[60px] border-0 bg-transparent text-muted-foreground">
-                            <SelectValue>{p.groupType}</SelectValue>
-                          </SelectTrigger>
-                          <SelectContent>
-                            {Object.entries(groupTypes).map(([key, desc]) => (
-                              <SelectItem key={key} value={key} className="text-xs">
-                                {key}
-                                <span className="ml-1 text-muted-foreground text-[10px]">{desc}</span>
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                      ) : (
-                        <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                          {p.groupType}
-                        </span>
-                      )}
-                      <div className="ml-auto flex items-center gap-0.5">
-                        <button
-                          type="button"
-                          onClick={() => onDuplicateGroup(partIndex)}
-                          disabled={pipelineRunning}
-                          className="p-0.5 rounded hover:bg-accent transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-default"
-                          title={t`Duplicate group`}
-                        >
-                          <Copy className="h-3 w-3 text-muted-foreground" />
-                        </button>
-                        {p.isPruned && (
-                          <button
-                            type="button"
-                            onClick={() => onDeleteGroup(partIndex)}
-                            disabled={pipelineRunning}
-                            className="p-0.5 rounded hover:bg-red-100 transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-default"
-                            title={t`Delete group`}
-                          >
-                            <Trash2 className="h-3 w-3 text-red-600" />
-                          </button>
-                        )}
-                        <button
-                          type="button"
-                          onClick={() => onTogglePartPruned(partIndex)}
-                          disabled={pipelineRunning}
-                          className="p-0.5 rounded hover:bg-accent transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-default"
-                          title={
-                            p.isPruned
-                              ? t`Include in render`
-                              : t`Exclude from render`
-                          }
-                        >
-                          {p.isPruned ? (
-                            <EyeOff className="h-3 w-3 text-muted-foreground" />
-                          ) : (
-                            <Eye className="h-3 w-3 text-muted-foreground" />
-                          )}
-                        </button>
-                      </div>
-                    </div>
-                    <div
-                      className="divide-y"
-                      onDragOver={(e) =>
-                        handleGroupBodyDragOver(e, partIndex, p.texts.length)
-                      }
-                      onDrop={(e) =>
-                        handleGroupBodyDrop(e, partIndex, p.texts.length)
-                      }
-                    >
-                      {p.texts.length === 0 && (
-                        <div className="px-3 py-3 text-xs text-muted-foreground/50 italic text-center">
-                          {t`Empty group — drag text entries here`}
-                        </div>
-                      )}
-                      {p.texts.map((textEntry, ti) => {
-                        const isTextDragging =
-                          dragText?.partIndex === partIndex &&
-                          dragText?.textIndex === ti
-                        const isTextDropTarget =
-                          dropTarget?.partIndex === partIndex &&
-                          dropTarget?.textIndex === ti &&
-                          dragText !== null
-                        return (
-                          <div
-                            key={textEntry.textId}
-                            className={`group/text px-3 py-1.5 flex items-start gap-2 text-sm transition-all duration-150 ${
-                              textEntry.isPruned ? "opacity-40" : ""
-                            } ${isTextDragging ? "opacity-30 bg-muted/30" : ""} ${
-                              isTextDropTarget
-                                ? "border-t-2 !border-t-primary"
-                                : ""
-                            }`}
-                            onDragOver={(e) =>
-                              handleTextDragOver(e, partIndex, ti)
-                            }
-                            onDrop={(e) => handleTextDrop(e, partIndex, ti)}
-                          >
-                            {/* Drag handle — visible on hover */}
-                            <div
-                              draggable={!pipelineRunning}
-                              onDragStart={(e) => { if (pipelineRunning) { e.preventDefault(); return } handleTextDragStart(e, partIndex, ti) }}
-                              onDragEnd={handleTextDragEnd}
-                              className={cn("shrink-0 p-0.5 mt-0.5 rounded transition-colors opacity-0 group-hover/text:opacity-100", pipelineRunning ? "cursor-default opacity-30" : "cursor-grab active:cursor-grabbing hover:bg-accent")}
-                              title={pipelineRunning ? undefined : t`Drag to reorder or move to another group`}
-                            >
-                              <GripVertical className="h-3 w-3 text-muted-foreground/50" />
-                            </div>
-                            {textTypes ? (
-                              <Select
-                                value={textEntry.textType}
-                                onValueChange={(val) =>
-                                  onChangeTextType(partIndex, ti, val)
-                                }
-                                disabled={pipelineRunning}
-                              >
-                                <SelectTrigger className="shrink-0 h-5 text-[10px] font-medium px-1.5 py-0 w-auto min-w-[60px] border-0 bg-muted/50">
-                                  <SelectValue>{textEntry.textType}</SelectValue>
-                                </SelectTrigger>
-                                <SelectContent>
-                                  {Object.entries(textTypes).map(
-                                    ([key, desc]) => (
-                                      <SelectItem
-                                        key={key}
-                                        value={key}
-                                        className="text-xs"
-                                      >
-                                        {key}
-                                        <span className="ml-1 text-muted-foreground text-[10px]">
-                                          {desc}
-                                        </span>
-                                      </SelectItem>
-                                    )
-                                  )}
-                                </SelectContent>
-                              </Select>
-                            ) : (
-                              <span className="shrink-0 text-xs font-medium text-muted-foreground bg-muted/50 rounded px-1.5 py-0.5 text-center">
-                                {textEntry.textType}
-                              </span>
-                            )}
-                            <EditableText
-                              value={textEntry.text}
-                              onCommit={(newText) =>
-                                onEditText(partIndex, ti, newText)
-                              }
-                              disabled={pipelineRunning}
-                            />
-                            <div className="shrink-0 flex items-center gap-0.5 self-center opacity-0 group-hover/text:opacity-100 transition-opacity">
-                              <button
-                                type="button"
-                                onClick={() => onDuplicateTextEntry(partIndex, ti)}
-                                disabled={pipelineRunning}
-                                className="p-0.5 rounded hover:bg-accent transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-default"
-                                title={t`Duplicate text entry`}
-                              >
-                                <Copy className="h-3 w-3 text-muted-foreground" />
-                              </button>
-                              {textEntry.isPruned && (
-                                <button
-                                  type="button"
-                                  onClick={() => onDeleteTextEntry(partIndex, ti)}
-                                  disabled={pipelineRunning}
-                                  className="p-0.5 rounded hover:bg-red-100 transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-default"
-                                  title={t`Delete text entry`}
-                                >
-                                  <Trash2 className="h-3 w-3 text-red-600" />
-                                </button>
-                              )}
-                              <button
-                                type="button"
-                                onClick={() => onToggleTextPruned(partIndex, ti)}
-                                disabled={pipelineRunning}
-                                className="p-0.5 rounded hover:bg-accent transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-default"
-                                title={
-                                  textEntry.isPruned
-                                    ? t`Include in render`
-                                    : t`Exclude from render`
-                                }
-                              >
-                                {textEntry.isPruned ? (
-                                  <EyeOff className="h-3 w-3 text-muted-foreground" />
-                                ) : (
-                                  <Eye className="h-3 w-3 text-muted-foreground" />
-                                )}
-                              </button>
-                            </div>
-                          </div>
-                        )
-                      })}
-                    </div>
-                    </div>
-                  </div>
-                )
-              })}
-              {/* Drop zone after the last group */}
-              {dragGroupIdx !== null && (() => {
-                const lastTextGroupIdx = parts.reduce((last, p, i) => p.type === "text_group" ? i : last, -1)
-                const showDropLine = dropGroupSlot === `after:${lastTextGroupIdx}` && dragGroupIdx !== lastTextGroupIdx
-                return (
-                  <div
-                    className="py-1.5"
-                    onDragOver={(e) => {
-                      if (!e.dataTransfer.types.includes(DRAG_TYPE_GROUP)) return
-                      e.preventDefault()
-                      e.dataTransfer.dropEffect = "move"
-                      setDropGroupSlot(`after:${lastTextGroupIdx}`)
-                    }}
-                    onDrop={handleGroupDrop}
-                  >
-                    {showDropLine && (
-                      <div className="h-0.5 bg-primary rounded-full" />
-                    )}
-                  </div>
-                )
-              })()}
+      {/* Layers tab — scrollable */}
+      {activeTab === "layers" && (
+        <div className="overflow-auto flex-1">
+          {sectionHtml ? (
+            <LayersPanel
+              html={sectionHtml}
+              selectedDataId={selectedDataId}
+              prunedDataIds={prunedDataIds ? new Set(prunedDataIds) : undefined}
+              onSelect={onSelectElement}
+              onMove={onMoveElement}
+              onReorder={onReorderElement}
+              disabled={!!pipelineRunning}
+            />
+          ) : (
+            <div className="px-4 py-8 text-center text-xs text-muted-foreground">
+              {t`No rendered HTML for this section`}
             </div>
           )}
+        </div>
+      )}
+
+      {/* Content tab — scrollable */}
+      {activeTab === "content" && (
+      <div className="overflow-auto flex-1 px-4 py-3 space-y-2">
+        {/* Unified parts list — renders text_group, image, and group in document order */}
+        {parts.map((p, partIndex) => {
+          if (p.type === "text_group") {
+            const isGroupDragging = dragGroupIdx === partIndex
+            const showDropLine = dropGroupSlot === `before:${partIndex}` && dragGroupIdx !== null && dragGroupIdx !== partIndex
+            return (
+              <div key={p.groupId}>
+                {showDropLine && <div className="h-0.5 bg-primary rounded-full mb-1" />}
+                <div
+                  className={`group/card rounded border overflow-hidden transition-all duration-150 ${
+                    p.isPruned ? "opacity-40" : ""
+                  } ${isGroupDragging ? "opacity-50 scale-[0.98]" : ""}`}
+                  onDragOver={(e) => handleGroupDragOver(e, partIndex)}
+                  onDrop={handleGroupDrop}
+                >
+                  <div className="px-3 py-1.5 bg-muted/50 border-b flex items-center gap-1.5">
+                    <div
+                      draggable={!pipelineRunning}
+                      onDragStart={(e) => { if (pipelineRunning) { e.preventDefault(); return } handleGroupDragStart(e, partIndex) }}
+                      onDragEnd={handleGroupDragEnd}
+                      className={cn("p-0.5 -ml-1 rounded transition-colors opacity-0 group-hover/card:opacity-100", pipelineRunning ? "cursor-default opacity-30" : "cursor-grab active:cursor-grabbing hover:bg-accent")}
+                      title={pipelineRunning ? undefined : t`Drag to reorder`}
+                    >
+                      <GripVertical className="h-3 w-3 text-muted-foreground" />
+                    </div>
+                    <Type className="h-3 w-3 text-blue-500 shrink-0" />
+                    {groupTypes ? (
+                      <Select value={p.groupType} onValueChange={(val) => onChangeGroupType(partIndex, val)} disabled={pipelineRunning}>
+                        <SelectTrigger className="h-5 text-[10px] font-semibold uppercase tracking-wider px-1.5 py-0 w-auto min-w-[60px] border-0 bg-transparent text-muted-foreground">
+                          <SelectValue>{p.groupType}</SelectValue>
+                        </SelectTrigger>
+                        <SelectContent>
+                          {Object.entries(groupTypes).map(([key, desc]) => (
+                            <SelectItem key={key} value={key} className="text-xs">
+                              {key}
+                              <span className="ml-1 text-muted-foreground text-[10px]">{desc}</span>
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    ) : (
+                      <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">{p.groupType}</span>
+                    )}
+                    <div className="ml-auto flex items-center gap-0.5">
+                      <button type="button" onClick={() => onDuplicateGroup(partIndex)} disabled={pipelineRunning} className="p-0.5 rounded hover:bg-accent transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-default" title={t`Duplicate group`}>
+                        <Copy className="h-3 w-3 text-muted-foreground" />
+                      </button>
+                      {p.isPruned && (
+                        <button type="button" onClick={() => onDeleteGroup(partIndex)} disabled={pipelineRunning} className="p-0.5 rounded hover:bg-red-100 transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-default" title={t`Delete group`}>
+                          <Trash2 className="h-3 w-3 text-red-600" />
+                        </button>
+                      )}
+                      <button type="button" onClick={() => onTogglePartPruned(partIndex)} disabled={pipelineRunning} className="p-0.5 rounded hover:bg-accent transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-default" title={p.isPruned ? t`Include in render` : t`Exclude from render`}>
+                        {p.isPruned ? <EyeOff className="h-3 w-3 text-muted-foreground" /> : <Eye className="h-3 w-3 text-muted-foreground" />}
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    className="divide-y"
+                    onDragOver={(e) => handleGroupBodyDragOver(e, partIndex, p.texts.length)}
+                    onDrop={(e) => handleGroupBodyDrop(e, partIndex, p.texts.length)}
+                  >
+                    {p.texts.length === 0 && (
+                      <div className="px-3 py-3 text-xs text-muted-foreground/50 italic text-center">{t`Empty group — drag text entries here`}</div>
+                    )}
+                    {p.texts.map((textEntry, ti) => {
+                      const isTextDragging = dragText?.partIndex === partIndex && dragText?.textIndex === ti
+                      const isTextDropTarget = dropTarget?.partIndex === partIndex && dropTarget?.textIndex === ti && dragText !== null
+                      return (
+                        <div
+                          key={textEntry.textId}
+                          className={`group/text px-3 py-1.5 flex items-start gap-2 text-sm transition-all duration-150 ${textEntry.isPruned ? "opacity-40" : ""} ${isTextDragging ? "opacity-30 bg-muted/30" : ""} ${isTextDropTarget ? "border-t-2 !border-t-primary" : ""}`}
+                          onDragOver={(e) => handleTextDragOver(e, partIndex, ti)}
+                          onDrop={(e) => handleTextDrop(e, partIndex, ti)}
+                        >
+                          <div
+                            draggable={!pipelineRunning}
+                            onDragStart={(e) => { if (pipelineRunning) { e.preventDefault(); return } handleTextDragStart(e, partIndex, ti) }}
+                            onDragEnd={handleTextDragEnd}
+                            className={cn("shrink-0 p-0.5 mt-0.5 rounded transition-colors opacity-0 group-hover/text:opacity-100", pipelineRunning ? "cursor-default opacity-30" : "cursor-grab active:cursor-grabbing hover:bg-accent")}
+                            title={pipelineRunning ? undefined : t`Drag to reorder or move to another group`}
+                          >
+                            <GripVertical className="h-3 w-3 text-muted-foreground/50" />
+                          </div>
+                          {textTypes ? (
+                            <Select value={textEntry.textType} onValueChange={(val) => onChangeTextType(partIndex, ti, val)} disabled={pipelineRunning}>
+                              <SelectTrigger className="shrink-0 h-5 text-[10px] font-medium px-1.5 py-0 w-auto min-w-[60px] border-0 bg-muted/50">
+                                <SelectValue>{textEntry.textType}</SelectValue>
+                              </SelectTrigger>
+                              <SelectContent>
+                                {Object.entries(textTypes).map(([key, desc]) => (
+                                  <SelectItem key={key} value={key} className="text-xs">
+                                    {key}
+                                    <span className="ml-1 text-muted-foreground text-[10px]">{desc}</span>
+                                  </SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
+                          ) : (
+                            <span className="shrink-0 text-xs font-medium text-muted-foreground bg-muted/50 rounded px-1.5 py-0.5 text-center">{textEntry.textType}</span>
+                          )}
+                          <EditableText value={textEntry.text} onCommit={(newText) => onEditText(partIndex, ti, newText)} disabled={pipelineRunning} />
+                          <div className="shrink-0 flex items-center gap-0.5 self-center opacity-0 group-hover/text:opacity-100 transition-opacity">
+                            <button type="button" onClick={() => onDuplicateTextEntry(partIndex, ti)} disabled={pipelineRunning} className="p-0.5 rounded hover:bg-accent transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-default" title={t`Duplicate text entry`}>
+                              <Copy className="h-3 w-3 text-muted-foreground" />
+                            </button>
+                            {textEntry.isPruned && (
+                              <button type="button" onClick={() => onDeleteTextEntry(partIndex, ti)} disabled={pipelineRunning} className="p-0.5 rounded hover:bg-red-100 transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-default" title={t`Delete text entry`}>
+                                <Trash2 className="h-3 w-3 text-red-600" />
+                              </button>
+                            )}
+                            <button type="button" onClick={() => onToggleTextPruned(partIndex, ti)} disabled={pipelineRunning} className="p-0.5 rounded hover:bg-accent transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-default" title={textEntry.isPruned ? t`Include in render` : t`Exclude from render`}>
+                              {textEntry.isPruned ? <EyeOff className="h-3 w-3 text-muted-foreground" /> : <Eye className="h-3 w-3 text-muted-foreground" />}
+                            </button>
+                          </div>
+                        </div>
+                      )
+                    })}
+                  </div>
+                </div>
+              </div>
+            )
+          }
+
+          if (p.type === "image") {
+            if (p.isPruned && !showPrunedImages) return null
+            return (
+              <div key={p.imageId} className="group/card relative">
+                <div className={`rounded border overflow-hidden ${p.isPruned ? "opacity-40" : ""}`}>
+                  <div className="px-3 py-1.5 bg-muted/50 border-b flex items-center gap-1.5">
+                    <Image className="h-3 w-3 text-green-600 shrink-0" />
+                    <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">{p.imageId}</span>
+                    <div className="ml-auto">
+                      <button type="button" onClick={() => onTogglePartPruned(partIndex)} disabled={pipelineRunning} className="p-0.5 rounded hover:bg-accent transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-default" title={p.isPruned ? t`Include in render` : t`Exclude from render`}>
+                        {p.isPruned ? <EyeOff className="h-3 w-3 text-muted-foreground" /> : <Eye className="h-3 w-3 text-muted-foreground" />}
+                      </button>
+                    </div>
+                  </div>
+                  <ImageCard imageId={p.imageId} bookLabel={bookLabel} isPruned={p.isPruned} reason={p.reason} />
+                </div>
+              </div>
+            )
+          }
+
+          if (p.type === "group") {
+            return (
+              <GroupPartView
+                key={p.groupId}
+                group={p}
+                partIndex={partIndex}
+                bookLabel={bookLabel}
+                showPrunedImages={showPrunedImages}
+                pipelineRunning={pipelineRunning}
+                onTogglePartPruned={onTogglePartPruned}
+                t={t}
+              />
+            )
+          }
+
+          return null
+        })}
+
+        {/* Drop zone after the last part */}
+        {dragGroupIdx !== null && (() => {
+          const lastIdx = parts.length - 1
+          const showDropLine = dropGroupSlot === `after:${lastIdx}` && dragGroupIdx !== lastIdx
+          return (
+            <div
+              className="py-1.5"
+              onDragOver={(e) => {
+                if (!e.dataTransfer.types.includes(DRAG_TYPE_GROUP)) return
+                e.preventDefault()
+                e.dataTransfer.dropEffect = "move"
+                setDropGroupSlot(`after:${lastIdx}`)
+              }}
+              onDrop={handleGroupDrop}
+            >
+              {showDropLine && <div className="h-0.5 bg-primary rounded-full" />}
+            </div>
+          )
+        })()}
+
+        {/* Add group / Add image buttons */}
+        <div className="flex gap-2 pt-2">
           <button
             type="button"
             onClick={onAddGroup}
             disabled={pipelineRunning}
             className={cn(
-              "flex items-center justify-center gap-1.5 w-full rounded border border-dashed py-3 text-xs transition-colors mt-3",
+              "flex-1 flex items-center justify-center gap-1.5 rounded border border-dashed py-2.5 text-xs transition-colors",
               pipelineRunning
                 ? "border-muted-foreground/20 text-muted-foreground/50 cursor-default"
                 : "border-muted-foreground/30 hover:border-muted-foreground/60 text-muted-foreground hover:text-foreground cursor-pointer"
@@ -858,6 +1430,20 @@ export function SectionDataPanel({
           >
             <Plus className="h-3.5 w-3.5" />
             {t`Add Group`}
+          </button>
+          <button
+            type="button"
+            onClick={onAddImage}
+            disabled={pipelineRunning}
+            className={cn(
+              "flex-1 flex items-center justify-center gap-1.5 rounded border border-dashed py-2.5 text-xs transition-colors",
+              pipelineRunning
+                ? "border-muted-foreground/20 text-muted-foreground/50 cursor-default"
+                : "border-muted-foreground/30 hover:border-muted-foreground/60 text-muted-foreground hover:text-foreground cursor-pointer"
+            )}
+          >
+            <ImagePlus className="h-3.5 w-3.5" />
+            {t`Add Image`}
           </button>
         </div>
 
@@ -891,83 +1477,20 @@ export function SectionDataPanel({
             </div>
           </div>
         )}
-
-        {/* Images */}
-        <div>
-          <h3 className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
-            {t`Images`}
-            {hasImageParts &&
-              parts.some((p) => p.type === "image" && p.isPruned) && (
-                <button
-                  type="button"
-                  onClick={onToggleShowPrunedImages}
-                  className="ml-auto flex items-center gap-1 text-[10px] font-normal normal-case tracking-normal text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
-                  title={
-                    showPrunedImages
-                      ? t`Hide pruned images`
-                      : t`Show pruned images`
-                  }
-                >
-                  {showPrunedImages ? (
-                    <Eye className="h-3 w-3" />
-                  ) : (
-                    <EyeOff className="h-3 w-3" />
-                  )}
-                  {showPrunedImages ? t`Hide Pruned` : t`Show Pruned`}
-                </button>
-              )}
-          </h3>
-          {hasImageParts && (
-            <div className="grid grid-cols-2 gap-2 mb-2">
-              {parts.map((p, partIndex) => {
-                if (p.type !== "image") return null
-                if (p.isPruned && !showPrunedImages) return null
-                return (
-                  <div key={p.imageId} className="group relative">
-                    <ImageCard
-                      imageId={p.imageId}
-                      bookLabel={bookLabel}
-                      isPruned={p.isPruned}
-                      reason={p.reason}
-                    />
-                    <button
-                      type="button"
-                      onClick={() => onTogglePartPruned(partIndex)}
-                      disabled={pipelineRunning}
-                      className="absolute top-1 right-1 p-1 rounded bg-background/80 hover:bg-accent transition-colors cursor-pointer opacity-0 group-hover:opacity-100 disabled:opacity-30 disabled:cursor-default"
-                      title={
-                        p.isPruned
-                          ? t`Include in render`
-                          : t`Exclude from render`
-                      }
-                    >
-                      {p.isPruned ? (
-                        <EyeOff className="h-3.5 w-3.5 text-muted-foreground" />
-                      ) : (
-                        <Eye className="h-3.5 w-3.5 text-muted-foreground" />
-                      )}
-                    </button>
-                  </div>
-                )
-              })}
-            </div>
-          )}
-          <button
-            type="button"
-            onClick={onAddImage}
-            disabled={pipelineRunning}
-            className={cn(
-              "flex items-center justify-center gap-1.5 w-full rounded border border-dashed py-3 text-xs transition-colors",
-              pipelineRunning
-                ? "border-muted-foreground/20 text-muted-foreground/50 cursor-default"
-                : "border-muted-foreground/30 hover:border-muted-foreground/60 text-muted-foreground hover:text-foreground cursor-pointer"
-            )}
-          >
-            <ImagePlus className="h-3.5 w-3.5" />
-            {t`Add Image`}
-          </button>
-        </div>
       </div>
+      )}
+
+      {/* JSON tab — raw sectioning data */}
+      {activeTab === "json" && (
+      <div className="overflow-auto flex-1 p-2">
+        <pre className="text-[10px] leading-relaxed font-mono whitespace-pre-wrap break-all bg-muted/30 rounded p-3 select-text">
+          {JSON.stringify(section, (_key, value) => {
+            if (_key === "imageBase64") return undefined
+            return value
+          }, 2)}
+        </pre>
+      </div>
+      )}
     </div>
   )
 }

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/SectionEditToolbar.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/SectionEditToolbar.tsx
@@ -1,5 +1,7 @@
 import { useState, useRef, useEffect, useMemo, useCallback } from "react"
 import {
+  ArrowDown,
+  ArrowUp,
   ChevronDown,
   Crop,
   Eye,
@@ -984,6 +986,14 @@ export interface SectionEditToolbarProps {
   segmenting?: boolean
   onDelete?: (dataId: string) => void
   onClassesChange?: (dataId: string, classes: string[]) => void
+  /** Move element before its previous sibling within the same parent */
+  onMoveUp?: (dataId: string) => void
+  /** Move element after its next sibling within the same parent */
+  onMoveDown?: (dataId: string) => void
+  /** Whether the element can move up (has a previous sibling) */
+  canMoveUp?: boolean
+  /** Whether the element can move down (has a next sibling) */
+  canMoveDown?: boolean
 }
 
 export function SectionEditToolbar({
@@ -1008,6 +1018,10 @@ export function SectionEditToolbar({
   segmenting,
   onDelete,
   onClassesChange,
+  onMoveUp,
+  onMoveDown,
+  canMoveUp,
+  canMoveDown,
 }: SectionEditToolbarProps) {
   const { t } = useLingui()
   const [cropMenuOpen, setCropMenuOpen] = useState(false)
@@ -1063,6 +1077,20 @@ export function SectionEditToolbar({
           <span className="text-[10px] font-mono text-muted-foreground bg-muted/50 rounded px-1.5 py-0.5">
             &lt;{containerTagName ?? "div"}&gt;
           </span>
+          {(onMoveUp || onMoveDown) && (
+            <span className="flex items-center gap-0.5 ml-auto">
+              {onMoveUp && (
+                <button type="button" onClick={() => onMoveUp(dataId)} disabled={!canMoveUp} className="p-0.5 rounded hover:bg-accent transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-default" title={t`Move up`}>
+                  <ArrowUp className="h-3 w-3 text-muted-foreground" />
+                </button>
+              )}
+              {onMoveDown && (
+                <button type="button" onClick={() => onMoveDown(dataId)} disabled={!canMoveDown} className="p-0.5 rounded hover:bg-accent transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-default" title={t`Move down`}>
+                  <ArrowDown className="h-3 w-3 text-muted-foreground" />
+                </button>
+              )}
+            </span>
+          )}
         </div>
         {elementClasses && onClassesChange && (
           <div className="border-t pt-1">
@@ -1101,6 +1129,20 @@ export function SectionEditToolbar({
             </div>
           )}
           <div className="flex items-center gap-1 border-t pt-2 flex-wrap">
+            {(onMoveUp || onMoveDown) && (
+              <span className="flex items-center gap-0.5 mr-1">
+                {onMoveUp && (
+                  <button type="button" onClick={() => onMoveUp(dataId)} disabled={!canMoveUp} className="flex items-center gap-0.5 text-[10px] font-medium rounded px-1.5 py-1 bg-muted hover:bg-accent transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-default" title={t`Move up`}>
+                    <ArrowUp className="h-3 w-3" />
+                  </button>
+                )}
+                {onMoveDown && (
+                  <button type="button" onClick={() => onMoveDown(dataId)} disabled={!canMoveDown} className="flex items-center gap-0.5 text-[10px] font-medium rounded px-1.5 py-1 bg-muted hover:bg-accent transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-default" title={t`Move down`}>
+                    <ArrowDown className="h-3 w-3" />
+                  </button>
+                )}
+              </span>
+            )}
             {onCrop && (
               <div className="relative inline-flex" ref={cropMenuRef}>
                 <button type="button" onClick={() => onCrop(dataId)} className={`flex items-center gap-1 text-[10px] font-medium px-2 py-1 bg-muted hover:bg-accent transition-colors cursor-pointer ${onRecropFromPage ? "rounded-l" : "rounded"}`}>
@@ -1202,6 +1244,20 @@ export function SectionEditToolbar({
         <span className="flex items-center gap-0.5 text-[10px] text-blue-500">
           <Pencil className="h-2.5 w-2.5" /><Trans>Editing</Trans>
         </span>
+        {(onMoveUp || onMoveDown) && (
+          <span className="flex items-center gap-0.5">
+            {onMoveUp && (
+              <button type="button" onClick={() => onMoveUp(dataId)} disabled={!canMoveUp} className="p-0.5 rounded hover:bg-accent transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-default" title={t`Move up`}>
+                <ArrowUp className="h-3 w-3 text-muted-foreground" />
+              </button>
+            )}
+            {onMoveDown && (
+              <button type="button" onClick={() => onMoveDown(dataId)} disabled={!canMoveDown} className="p-0.5 rounded hover:bg-accent transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-default" title={t`Move down`}>
+                <ArrowDown className="h-3 w-3 text-muted-foreground" />
+              </button>
+            )}
+          </span>
+        )}
         {onDelete && (
           <button type="button" onClick={() => onDelete(dataId)} className="p-0.5 rounded hover:bg-red-100 transition-colors cursor-pointer" title={t`Remove this block`}>
             <Trash2 className="h-3 w-3 text-red-600" />

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/SectioningOverview.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/SectioningOverview.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useRef, useCallback } from "react"
 import { useQueries, useQueryClient, useMutation } from "@tanstack/react-query"
 import { api, BASE_URL, type PageSummaryItem, type PageDetail } from "@/api/client"
-import type { SectionPart, PageSection } from "@adt/types"
+import type { SectionPart, PageSection, SectionImagePart } from "@adt/types"
+import { flattenTextParts, flattenImageParts } from "@adt/types"
 import { invalidateStoryboardDependents } from "@/hooks/use-page-mutations"
 import {
   ChevronDown,
@@ -22,8 +23,8 @@ import { Trans } from "@lingui/react/macro"
 import { useLingui } from "@lingui/react/macro"
 import { cn } from "@/lib/utils"
 
-type DetailPanel = "preview" | "metadata" | "textGroups" | "images" | "prunedImages"
-const ALL_PANELS: DetailPanel[] = ["preview", "metadata", "textGroups", "images", "prunedImages"]
+type DetailPanel = "preview" | "metadata" | "content" | "prunedImages"
+const ALL_PANELS: DetailPanel[] = ["preview", "metadata", "content", "prunedImages"]
 
 interface SectioningOverviewProps {
   bookLabel: string
@@ -53,9 +54,8 @@ export function SectioningOverview({ bookLabel, pages, onNavigateToSection }: Se
   const panelLabels: Record<DetailPanel, string> = {
     preview: t`Preview`,
     metadata: t`Metadata`,
-    textGroups: t`Text Groups`,
-    images: t`Images`,
-    prunedImages: t`Pruned Images`,
+    content: t`Content`,
+    prunedImages: t`Pruned`,
   }
 
   // Fetch full page details for all pages that have sections
@@ -419,8 +419,6 @@ function PageSectionRows({
 
       {/* Section rows */}
       {sections.map((section, idx) => {
-        const textParts = section.parts.filter((p) => p.type === "text_group")
-        const imageParts = section.parts.filter((p) => p.type === "image")
         const isExpanded = expanded.has(idx)
 
         // Get rendering reasoning if available
@@ -437,8 +435,6 @@ function PageSectionRows({
             sectionCount={sections.length}
             hasPrevPage={hasPrevPage}
             hasNextPage={hasNextPage}
-            textParts={textParts}
-            imageParts={imageParts}
             isExpanded={isExpanded}
             onToggle={() => toggleSection(idx)}
             renderReasoning={renderSection?.reasoning}
@@ -462,6 +458,163 @@ function PageSectionRows({
 }
 
 // ---------------------------------------------------------------------------
+// Recursive parts mappers for image mutations inside nested groups
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Ordered, nested parts tree for the overview detail panel
+// ---------------------------------------------------------------------------
+
+function OverviewPartsTree({
+  parts,
+  showPruned,
+  bookLabel,
+  selectedImageId,
+  onImageClick,
+  depth = 0,
+}: {
+  parts: readonly SectionPart[]
+  showPruned: boolean
+  bookLabel: string
+  selectedImageId: string | null
+  onImageClick: (e: React.MouseEvent, img: { imageId: string; isPruned: boolean }) => void
+  depth?: number
+}) {
+  return (
+    <>
+      {parts.map((part, idx) => {
+        if (part.isPruned && !showPruned) return null
+
+        if (part.type === "text_group") {
+          return (
+            <div
+              key={part.groupId}
+              className={cn(
+                "border rounded p-2",
+                part.isPruned && "opacity-50 border-dashed",
+                depth > 0 && "ml-4"
+              )}
+            >
+              <div className="flex items-center gap-2 mb-1">
+                <span className="font-mono text-[10px] text-muted-foreground">{part.groupId}</span>
+                <span className="text-[10px] px-1 rounded bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400">
+                  {part.groupType}
+                </span>
+                {part.isPruned && (
+                  <span className="text-[10px] px-1 rounded bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400">
+                    <Trans>pruned</Trans>
+                  </span>
+                )}
+              </div>
+              <div className="space-y-0.5">
+                {part.texts.map((text) => (
+                  <div
+                    key={text.textId}
+                    className={cn(
+                      "flex gap-2 text-xs",
+                      text.isPruned && "opacity-40 line-through"
+                    )}
+                  >
+                    <span className="shrink-0 text-[10px] font-mono text-muted-foreground w-24">{text.textType}</span>
+                    <span className="text-foreground">{text.text}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )
+        }
+
+        if (part.type === "image") {
+          if (part.isPruned && !showPruned) return null
+          return (
+            <div
+              key={part.imageId}
+              className={cn(
+                "inline-flex border rounded p-1.5 flex-col items-center gap-1 cursor-pointer hover:ring-2 hover:ring-primary/50 transition-shadow",
+                part.isPruned && "opacity-50 border-dashed",
+                selectedImageId === part.imageId && "ring-2 ring-primary",
+                depth > 0 && "ml-4"
+              )}
+              onClick={(e) => onImageClick(e, part)}
+            >
+              <img
+                src={`${BASE_URL}/books/${bookLabel}/images/${part.imageId}`}
+                alt={part.imageId}
+                className="h-16 w-auto object-contain rounded"
+              />
+              <span className="text-[10px] font-mono text-muted-foreground">{part.imageId}</span>
+              {part.isPruned && (
+                <span className="text-[10px] text-amber-600"><Trans>pruned</Trans></span>
+              )}
+            </div>
+          )
+        }
+
+        // type === "group"
+        if (part.type === "group") {
+          return (
+            <div
+              key={part.groupId || `group-${idx}`}
+              className={cn(
+                "border rounded-lg p-2 border-violet-200 dark:border-violet-800 bg-violet-50/30 dark:bg-violet-950/10",
+                part.isPruned && "opacity-50 border-dashed",
+                depth > 0 && "ml-4"
+              )}
+            >
+              <div className="flex items-center gap-2 mb-1.5">
+                <span className="text-[10px] px-1.5 rounded bg-violet-100 dark:bg-violet-900/40 text-violet-700 dark:text-violet-400 font-medium">
+                  {part.groupType}
+                </span>
+                <span className="font-mono text-[10px] text-muted-foreground">{part.groupId}</span>
+                {part.isPruned && (
+                  <span className="text-[10px] px-1 rounded bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400">
+                    <Trans>pruned</Trans>
+                  </span>
+                )}
+              </div>
+              <div className="space-y-1.5">
+                <OverviewPartsTree
+                  parts={part.parts}
+                  showPruned={showPruned}
+                  bookLabel={bookLabel}
+                  selectedImageId={selectedImageId}
+                  onImageClick={onImageClick}
+                  depth={depth + 1}
+                />
+              </div>
+            </div>
+          )
+        }
+
+        return null
+      })}
+    </>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Recursive parts mappers for image mutations inside nested groups
+// ---------------------------------------------------------------------------
+
+function mapImageInParts(
+  parts: SectionPart[],
+  fn: (p: Extract<SectionPart, { type: "image" }>) => SectionPart | null,
+): SectionPart[] {
+  const result: SectionPart[] = []
+  for (const p of parts) {
+    if (p.type === "image") {
+      const mapped = fn(p)
+      if (mapped !== null) result.push(mapped)
+    } else if (p.type === "group") {
+      result.push({ ...p, parts: mapImageInParts(p.parts, fn) })
+    } else {
+      result.push(p)
+    }
+  }
+  return result
+}
+
+// ---------------------------------------------------------------------------
 // Individual section row with expandable detail
 // ---------------------------------------------------------------------------
 
@@ -472,8 +625,6 @@ function SectionRow({
   sectionCount,
   hasPrevPage,
   hasNextPage,
-  textParts,
-  imageParts,
   isExpanded,
   onToggle,
   renderReasoning,
@@ -496,8 +647,6 @@ function SectionRow({
   sectionCount: number
   hasPrevPage: boolean
   hasNextPage: boolean
-  textParts: SectionPart[]
-  imageParts: SectionPart[]
   isExpanded: boolean
   onToggle: () => void
   renderReasoning?: string
@@ -515,6 +664,8 @@ function SectionRow({
   onInvalidatePages: (...pageIds: string[]) => void
 }) {
   const { t } = useLingui()
+  const textParts = flattenTextParts(section.parts)
+  const imageParts = flattenImageParts(section.parts)
   const textCount = textParts.length
   const imageCount = imageParts.length
 
@@ -632,8 +783,6 @@ function SectionRow({
             <SectionDetail
               section={section}
               sectionIndex={sectionIndex}
-              textParts={textParts as Extract<SectionPart, { type: "text_group" }>[]}
-              imageParts={imageParts as Extract<SectionPart, { type: "image" }>[]}
               renderReasoning={renderReasoning}
               bookLabel={bookLabel}
               pageId={page.pageId}
@@ -657,8 +806,6 @@ function SectionRow({
 function SectionDetail({
   section,
   sectionIndex,
-  textParts,
-  imageParts,
   renderReasoning,
   bookLabel,
   pageId,
@@ -668,10 +815,8 @@ function SectionDetail({
   onNavigate,
   onInvalidatePages,
 }: {
-  section: { sectionId: string; sectionType: string; backgroundColor: string; textColor: string }
+  section: PageSection
   sectionIndex: number
-  textParts: Array<{ type: "text_group"; groupId: string; groupType: string; texts: Array<{ textId: string; textType: string; text: string; isPruned: boolean }>; isPruned: boolean }>
-  imageParts: Array<{ type: "image"; imageId: string; isPruned: boolean; reason?: string }>
   renderReasoning?: string
   bookLabel: string
   pageId: string
@@ -722,8 +867,8 @@ function SectionDetail({
           if (si !== sectionIndex) return s
           return {
             ...s,
-            parts: s.parts.map((p: SectionPart) =>
-              p.type === "image" && p.imageId === cropTarget ? { ...p, imageId: result.imageId } : p
+            parts: mapImageInParts(s.parts, (p) =>
+              p.imageId === cropTarget ? { ...p, imageId: result.imageId } : p
             ),
           }
         }),
@@ -767,8 +912,8 @@ function SectionDetail({
           if (si !== sectionIndex) return s
           return {
             ...s,
-            parts: s.parts.map((p: SectionPart) =>
-              p.type === "image" && p.imageId === targetId ? { ...p, imageId: result.imageId } : p
+            parts: mapImageInParts(s.parts, (p) =>
+              p.imageId === targetId ? { ...p, imageId: result.imageId } : p
             ),
           }
         }),
@@ -807,7 +952,7 @@ function SectionDetail({
         ...pageData.sectioning,
         sections: pageData.sectioning.sections.map((s: PageSection, si: number) => {
           if (si !== sectionIndex) return s
-          return { ...s, parts: s.parts.filter((p: SectionPart) => !(p.type === "image" && p.imageId === dataId)) }
+          return { ...s, parts: mapImageInParts(s.parts, (p) => p.imageId === dataId ? null : p) }
         }),
       }
       await api.updateSectioning(bookLabel, pageId, updated)
@@ -825,8 +970,8 @@ function SectionDetail({
           if (si !== sectionIndex) return s
           return {
             ...s,
-            parts: s.parts.map((p: SectionPart) =>
-              p.type === "image" && p.imageId === dataId ? { ...p, isPruned: !p.isPruned } : p
+            parts: mapImageInParts(s.parts, (p) =>
+              p.imageId === dataId ? { ...p, isPruned: !p.isPruned } : p
             ),
           }
         }),
@@ -907,87 +1052,23 @@ function SectionDetail({
           )}
 
           {/* Text groups */}
-          {visiblePanels.has("textGroups") && textParts.length > 0 && (
+          {/* Ordered content parts */}
+          {visiblePanels.has("content") && section.parts.length > 0 && (
             <div>
               <h4 className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider mb-1.5">
-                <Trans>Text Groups</Trans>
+                <Trans>Content</Trans>
               </h4>
-              <div className="space-y-2">
-                {textParts.map((part) => (
-                  <div
-                    key={part.groupId}
-                    className={cn(
-                      "border rounded p-2",
-                      part.isPruned && "opacity-50 border-dashed"
-                    )}
-                  >
-                    <div className="flex items-center gap-2 mb-1">
-                      <span className="font-mono text-[10px] text-muted-foreground">{part.groupId}</span>
-                      <span className="text-[10px] px-1 rounded bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400">
-                        {part.groupType}
-                      </span>
-                      {part.isPruned && (
-                        <span className="text-[10px] px-1 rounded bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400">
-                          <Trans>pruned</Trans>
-                        </span>
-                      )}
-                    </div>
-                    <div className="space-y-0.5">
-                      {part.texts.map((text) => (
-                        <div
-                          key={text.textId}
-                          className={cn(
-                            "flex gap-2 text-xs",
-                            text.isPruned && "opacity-40 line-through"
-                          )}
-                        >
-                          <span className="shrink-0 text-[10px] font-mono text-muted-foreground w-24">{text.textType}</span>
-                          <span className="text-foreground">{text.text}</span>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                ))}
+              <div className="space-y-1.5">
+                <OverviewPartsTree
+                  parts={section.parts}
+                  showPruned={visiblePanels.has("prunedImages")}
+                  bookLabel={bookLabel}
+                  selectedImageId={selectedImage?.imageId ?? null}
+                  onImageClick={handleImageClick}
+                />
               </div>
             </div>
           )}
-
-          {/* Images */}
-          {visiblePanels.has("images") && imageParts.length > 0 && (() => {
-            const showPruned = visiblePanels.has("prunedImages")
-            const filteredImages = showPruned ? imageParts : imageParts.filter((img) => !img.isPruned)
-            if (filteredImages.length === 0) return null
-            return (
-            <div>
-              <h4 className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider mb-1.5">
-                <Trans>Images</Trans>
-              </h4>
-              <div className="flex flex-wrap gap-2">
-                {filteredImages.map((img) => (
-                  <div
-                    key={img.imageId}
-                    className={cn(
-                      "border rounded p-1.5 flex flex-col items-center gap-1 cursor-pointer hover:ring-2 hover:ring-primary/50 transition-shadow",
-                      img.isPruned && "opacity-50 border-dashed",
-                      selectedImage?.imageId === img.imageId && "ring-2 ring-primary"
-                    )}
-                    onClick={(e) => handleImageClick(e, img)}
-                  >
-                    <img
-                      src={`${BASE_URL}/books/${bookLabel}/images/${img.imageId}`}
-                      alt={img.imageId}
-                      className="h-16 w-auto object-contain rounded"
-                    />
-                    <span className="text-[10px] font-mono text-muted-foreground">{img.imageId}</span>
-                    {img.isPruned && (
-                      <span className="text-[10px] text-amber-600"><Trans>pruned</Trans></span>
-                    )}
-                  </div>
-                ))}
-              </div>
-            </div>
-            )
-          })()}
         </div>
       </div>
 

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
@@ -916,6 +916,152 @@ export function StoryboardSectionDetail({
     [pendingRendering, page.rendering, sectionIndex]
   )
 
+  // Determine the "swap unit" for an element: the block-level node that should be
+  // reordered when the user moves the element up/down within its parent container.
+  function getSwapUnit(doc: Document, dataId: string): { unit: Element; parent: Element } | null {
+    const el = doc.querySelector(`[data-id="${dataId}"]`)
+    if (!el) return null
+
+    const blockParent = el.closest("div, p, figure, li, tr, section[data-section-id]")
+    const isSectionWrapper = blockParent?.getAttribute("data-section-id") != null
+    const isOuterContainer =
+      blockParent?.id === "content" || blockParent?.classList.contains("container")
+
+    let unit: Element
+    if (!blockParent || isSectionWrapper || isOuterContainer) {
+      unit = el
+    } else if (blockParent.querySelectorAll("[data-id]").length <= 1) {
+      // Block parent wraps only this element — swap the whole block
+      unit = blockParent
+    } else {
+      unit = el
+    }
+
+    const parent = unit.parentElement
+    if (!parent) return null
+    return { unit, parent }
+  }
+
+  // Compute whether the currently-selected element can move up/down.
+  const moveInfo = useMemo(() => {
+    if (!selectedElement) return null
+    const rBase = pendingRendering ?? page.rendering
+    if (!rBase) return null
+    const currentSection = getRenderedSectionByIndex(rBase, sectionIndex)
+    if (!currentSection?.html) return null
+
+    const parser = new DOMParser()
+    const doc = parser.parseFromString(currentSection.html, "text/html")
+    const info = getSwapUnit(doc, selectedElement.dataId)
+    if (!info) return null
+
+    return {
+      canMoveUp: info.unit.previousElementSibling !== null,
+      canMoveDown: info.unit.nextElementSibling !== null,
+    }
+  }, [selectedElement, pendingRendering, page.rendering, sectionIndex])
+
+  // Swap an element with its previous or next sibling in the rendered HTML.
+  const swapElementInRendering = useCallback(
+    (dataId: string, direction: "up" | "down") => {
+      const rBase = pendingRendering ?? page.rendering
+      if (!rBase) return
+      const currentSection = getRenderedSectionByIndex(rBase, sectionIndex)
+      if (!currentSection?.html) return
+
+      const parser = new DOMParser()
+      const doc = parser.parseFromString(currentSection.html, "text/html")
+      const info = getSwapUnit(doc, dataId)
+      if (!info) return
+
+      const { unit, parent } = info
+
+      if (direction === "up") {
+        const prev = unit.previousElementSibling
+        if (!prev) return
+        parent.insertBefore(unit, prev)
+      } else {
+        const next = unit.nextElementSibling
+        if (!next) return
+        parent.insertBefore(next, unit)
+      }
+
+      const newHtml = doc.body.innerHTML
+      const updated: RenderingData = {
+        ...rBase,
+        sections: rBase.sections.map((s) => {
+          if (s.sectionIndex !== sectionIndex) return s
+          return { ...s, html: newHtml }
+        }),
+      }
+      setPendingRendering(updated)
+    },
+    [pendingRendering, page.rendering, sectionIndex]
+  )
+
+  const handleMoveUp = useCallback(
+    (dataId: string) => swapElementInRendering(dataId, "up"),
+    [swapElementInRendering]
+  )
+
+  const handleMoveDown = useCallback(
+    (dataId: string) => swapElementInRendering(dataId, "down"),
+    [swapElementInRendering]
+  )
+
+  // Tags where child type matters — don't allow dropping arbitrary elements inside these
+  const STRICT_CHILD_TAGS = new Set(["table", "thead", "tbody", "tfoot", "tr", "ul", "ol", "dl", "select"])
+
+  // Reorder an element by drag-and-drop: move drag element before/after/inside drop element.
+  // Supports cross-container moves. Uses CSS selectors to identify elements.
+  const reorderElementInRendering = useCallback(
+    (dragSelector: string, dropSelector: string, position: "before" | "after" | "inside") => {
+      if (dragSelector === dropSelector) return
+      const rBase = pendingRendering ?? page.rendering
+      if (!rBase) return
+      const currentSection = getRenderedSectionByIndex(rBase, sectionIndex)
+      if (!currentSection?.html) return
+
+      const parser = new DOMParser()
+      const doc = parser.parseFromString(currentSection.html, "text/html")
+
+      const dragEl = doc.querySelector(dragSelector)
+      const dropEl = doc.querySelector(dropSelector)
+      if (!dragEl || !dropEl) return
+
+      // Prevent dropping an element inside itself (would create a cycle)
+      if (dragEl.contains(dropEl)) return
+
+      if (position === "inside") {
+        // Drop into a container — guard against structural tags
+        if (STRICT_CHILD_TAGS.has(dropEl.tagName.toLowerCase())) return
+        dropEl.appendChild(dragEl)
+      } else {
+        const targetParent = dropEl.parentElement
+        if (!targetParent) return
+        // Guard against inserting into structural containers
+        if (STRICT_CHILD_TAGS.has(targetParent.tagName.toLowerCase())) return
+
+        if (position === "before") {
+          targetParent.insertBefore(dragEl, dropEl)
+        } else {
+          targetParent.insertBefore(dragEl, dropEl.nextSibling)
+        }
+      }
+
+      const newHtml = doc.body.innerHTML
+      const updated: RenderingData = {
+        ...rBase,
+        sections: rBase.sections.map((s) => {
+          if (s.sectionIndex !== sectionIndex) return s
+          return { ...s, html: newHtml }
+        }),
+      }
+      setPendingRendering(updated)
+    },
+    [pendingRendering, page.rendering, sectionIndex]
+  )
+
   // Clone data-id elements in the rendered HTML and insert after the originals.
   // `mappings` is an array of { sourceDataId, newDataId } pairs.
   // For group duplication, pass all text entries of the source group mapped to new IDs.
@@ -2562,6 +2708,10 @@ export function StoryboardSectionDetail({
           onDelete={!storyboardRunning ? handleDeleteBlock : undefined}
           elementClasses={selectedElementClasses ?? undefined}
           onClassesChange={handleClassesChange}
+          onMoveUp={!storyboardRunning ? handleMoveUp : undefined}
+          onMoveDown={!storyboardRunning ? handleMoveDown : undefined}
+          canMoveUp={moveInfo?.canMoveUp}
+          canMoveDown={moveInfo?.canMoveDown}
         />
       )}
 
@@ -2631,6 +2781,16 @@ export function StoryboardSectionDetail({
         hasApiKey={hasApiKey}
         showPrunedImages={showPrunedImages}
         onToggleShowPrunedImages={() => setShowPrunedImages((v) => !v)}
+        sectionHtml={renderedSection?.html}
+        selectedDataId={selectedElement?.dataId}
+        onSelectElement={(dataId) => {
+          // Highlight in layers only — no floating toolbar (no rect info from layers panel)
+          setSelectedElement(dataId ? { dataId, rect: new DOMRect(), iframeTop: 0, iframeLeft: 0 } : null)
+          setSelectedElementClasses(dataId ? (previewFrameRef.current?.getElementClasses(dataId) ?? null) : null)
+        }}
+        onMoveElement={(dataId, dir) => swapElementInRendering(dataId, dir)}
+        onReorderElement={reorderElementInRendering}
+        prunedDataIds={prunedDataIds}
       />
       )}
 

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -1540,11 +1540,11 @@ msgstr "Header Text"
 msgid "Heading"
 msgstr "Heading"
 
-msgid "Hide Pruned"
-msgstr "Hide Pruned"
+#~ msgid "Hide Pruned"
+#~ msgstr "Hide Pruned"
 
-msgid "Hide pruned images"
-msgstr "Hide pruned images"
+#~ msgid "Hide pruned images"
+#~ msgstr "Hide pruned images"
 
 msgid "Higher values filter out simple or blank images."
 msgstr "Higher values filter out simple or blank images."
@@ -1612,8 +1612,8 @@ msgstr "Image unavailable"
 msgid "Image upload failed"
 msgstr "Image upload failed"
 
-msgid "Images"
-msgstr "Images"
+#~ msgid "Images"
+#~ msgstr "Images"
 
 msgid "Images only"
 msgstr "Images only"
@@ -1673,6 +1673,9 @@ msgstr "Items marked as needing changes for this reviewer session."
 msgid "Jane Reviewer"
 msgstr "Jane Reviewer"
 
+msgid "JSON"
+msgstr "JSON"
+
 msgid "KB"
 msgstr "KB"
 
@@ -1703,6 +1706,9 @@ msgstr "Languages"
 
 msgid "Last"
 msgstr "Last"
+
+msgid "Layers"
+msgstr "Layers"
 
 msgid "Leave empty if not required"
 msgstr "Leave empty if not required"
@@ -1956,6 +1962,12 @@ msgstr "moderate"
 msgid "Moderate"
 msgstr "Moderate"
 
+msgid "Move down"
+msgstr "Move down"
+
+msgid "Move up"
+msgstr "Move up"
+
 msgid "mp3"
 msgstr "mp3"
 
@@ -2108,6 +2120,9 @@ msgstr "No quizzes for this page"
 
 msgid "No rendered content for this section"
 msgstr "No rendered content for this section"
+
+msgid "No rendered HTML for this section"
+msgstr "No rendered HTML for this section"
 
 msgid "No review areas are currently flagged in this reviewer session."
 msgstr "No review areas are currently flagged in this reviewer session."
@@ -2419,8 +2434,8 @@ msgstr "pruned"
 msgid "Pruned"
 msgstr "Pruned"
 
-msgid "Pruned Images"
-msgstr "Pruned Images"
+#~ msgid "Pruned Images"
+#~ msgstr "Pruned Images"
 
 #. placeholder {0}: reason ?? ""
 msgid "Pruned: {0}"
@@ -2897,11 +2912,11 @@ msgstr "Show all text & speech"
 msgid "Show fewer"
 msgstr "Show fewer"
 
-msgid "Show Pruned"
-msgstr "Show Pruned"
+#~ msgid "Show Pruned"
+#~ msgstr "Show Pruned"
 
-msgid "Show pruned images"
-msgstr "Show pruned images"
+#~ msgid "Show pruned images"
+#~ msgstr "Show pruned images"
 
 msgid "Show reviewer validation"
 msgstr "Show reviewer validation"
@@ -3078,8 +3093,8 @@ msgstr "Text Classification Prompt"
 msgid "Text color: {0}"
 msgstr "Text color: {0}"
 
-msgid "Text Groups"
-msgstr "Text Groups"
+#~ msgid "Text Groups"
+#~ msgstr "Text Groups"
 
 msgid "Text Only"
 msgstr "Text Only"

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -1540,11 +1540,11 @@ msgstr "Texto de encabezado"
 msgid "Heading"
 msgstr "Título"
 
-msgid "Hide Pruned"
-msgstr "Ocultar eliminadas"
+#~ msgid "Hide Pruned"
+#~ msgstr "Ocultar eliminadas"
 
-msgid "Hide pruned images"
-msgstr "Ocultar imágenes eliminadas"
+#~ msgid "Hide pruned images"
+#~ msgstr "Ocultar imágenes eliminadas"
 
 msgid "Higher values filter out simple or blank images."
 msgstr "Valores más altos filtran imágenes simples o en blanco."
@@ -1612,8 +1612,8 @@ msgstr "Imagen no disponible"
 msgid "Image upload failed"
 msgstr "Image upload failed"
 
-msgid "Images"
-msgstr "Imágenes"
+#~ msgid "Images"
+#~ msgstr "Imágenes"
 
 msgid "Images only"
 msgstr "Solo imágenes"
@@ -1673,6 +1673,9 @@ msgstr "Items marked as needing changes for this reviewer session."
 msgid "Jane Reviewer"
 msgstr "Jane Reviewer"
 
+msgid "JSON"
+msgstr "JSON"
+
 msgid "KB"
 msgstr "KB"
 
@@ -1703,6 +1706,9 @@ msgstr "Idiomas"
 
 msgid "Last"
 msgstr "Última"
+
+msgid "Layers"
+msgstr "Capas"
 
 msgid "Leave empty if not required"
 msgstr "Dejar vacío si no es necesario"
@@ -1956,6 +1962,12 @@ msgstr "moderate"
 msgid "Moderate"
 msgstr "Moderate"
 
+msgid "Move down"
+msgstr "Mover abajo"
+
+msgid "Move up"
+msgstr "Mover arriba"
+
 msgid "mp3"
 msgstr "mp3"
 
@@ -2108,6 +2120,9 @@ msgstr "No hay quizzes para esta página"
 
 msgid "No rendered content for this section"
 msgstr "Sin contenido renderizado para esta sección"
+
+msgid "No rendered HTML for this section"
+msgstr "Sin HTML renderizado para esta sección"
 
 msgid "No review areas are currently flagged in this reviewer session."
 msgstr "No review areas are currently flagged in this reviewer session."
@@ -2419,8 +2434,8 @@ msgstr "eliminado"
 msgid "Pruned"
 msgstr "Eliminado"
 
-msgid "Pruned Images"
-msgstr "Imágenes eliminadas"
+#~ msgid "Pruned Images"
+#~ msgstr "Imágenes eliminadas"
 
 #. placeholder {0}: reason ?? ""
 msgid "Pruned: {0}"
@@ -2897,11 +2912,11 @@ msgstr "Mostrar todos los textos y audios"
 msgid "Show fewer"
 msgstr "Show fewer"
 
-msgid "Show Pruned"
-msgstr "Mostrar eliminadas"
+#~ msgid "Show Pruned"
+#~ msgstr "Mostrar eliminadas"
 
-msgid "Show pruned images"
-msgstr "Mostrar imágenes eliminadas"
+#~ msgid "Show pruned images"
+#~ msgstr "Mostrar imágenes eliminadas"
 
 msgid "Show reviewer validation"
 msgstr "Show reviewer validation"
@@ -3078,8 +3093,8 @@ msgstr "Prompt de clasificación de texto"
 msgid "Text color: {0}"
 msgstr "Color del texto: {0}"
 
-msgid "Text Groups"
-msgstr "Grupos de texto"
+#~ msgid "Text Groups"
+#~ msgstr "Grupos de texto"
 
 msgid "Text Only"
 msgstr "Solo texto"

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -1540,11 +1540,11 @@ msgstr "Texto de cabeçalho"
 msgid "Heading"
 msgstr "Título"
 
-msgid "Hide Pruned"
-msgstr "Ocultar removidas"
+#~ msgid "Hide Pruned"
+#~ msgstr "Ocultar removidas"
 
-msgid "Hide pruned images"
-msgstr "Ocultar imagens removidas"
+#~ msgid "Hide pruned images"
+#~ msgstr "Ocultar imagens removidas"
 
 msgid "Higher values filter out simple or blank images."
 msgstr "Valores mais altos filtram imagens simples ou em branco."
@@ -1612,8 +1612,8 @@ msgstr "Imagem indisponível"
 msgid "Image upload failed"
 msgstr "Image upload failed"
 
-msgid "Images"
-msgstr "Imagens"
+#~ msgid "Images"
+#~ msgstr "Imagens"
 
 msgid "Images only"
 msgstr "Somente imagens"
@@ -1673,6 +1673,9 @@ msgstr "Items marked as needing changes for this reviewer session."
 msgid "Jane Reviewer"
 msgstr "Jane Reviewer"
 
+msgid "JSON"
+msgstr "JSON"
+
 msgid "KB"
 msgstr "KB"
 
@@ -1703,6 +1706,9 @@ msgstr "Idiomas"
 
 msgid "Last"
 msgstr "Última"
+
+msgid "Layers"
+msgstr "Camadas"
 
 msgid "Leave empty if not required"
 msgstr "Deixe vazio se não for necessário"
@@ -1956,6 +1962,12 @@ msgstr "moderate"
 msgid "Moderate"
 msgstr "Moderate"
 
+msgid "Move down"
+msgstr "Mover para baixo"
+
+msgid "Move up"
+msgstr "Mover para cima"
+
 msgid "mp3"
 msgstr "mp3"
 
@@ -2108,6 +2120,9 @@ msgstr "Nenhum quiz para esta página"
 
 msgid "No rendered content for this section"
 msgstr "Sem conteúdo renderizado para esta seção"
+
+msgid "No rendered HTML for this section"
+msgstr "Sem HTML renderizado para esta seção"
 
 msgid "No review areas are currently flagged in this reviewer session."
 msgstr "No review areas are currently flagged in this reviewer session."
@@ -2419,8 +2434,8 @@ msgstr "removido"
 msgid "Pruned"
 msgstr "Removido"
 
-msgid "Pruned Images"
-msgstr "Imagens removidas"
+#~ msgid "Pruned Images"
+#~ msgstr "Imagens removidas"
 
 #. placeholder {0}: reason ?? ""
 msgid "Pruned: {0}"
@@ -2897,11 +2912,11 @@ msgstr "Mostrar todos os textos e áudios"
 msgid "Show fewer"
 msgstr "Show fewer"
 
-msgid "Show Pruned"
-msgstr "Mostrar removidas"
+#~ msgid "Show Pruned"
+#~ msgstr "Mostrar removidas"
 
-msgid "Show pruned images"
-msgstr "Mostrar imagens removidas"
+#~ msgid "Show pruned images"
+#~ msgstr "Mostrar imagens removidas"
 
 msgid "Show reviewer validation"
 msgstr "Show reviewer validation"
@@ -3078,8 +3093,8 @@ msgstr "Prompt de classificação de texto"
 msgid "Text color: {0}"
 msgstr "Cor do texto: {0}"
 
-msgid "Text Groups"
-msgstr "Grupos de texto"
+#~ msgid "Text Groups"
+#~ msgstr "Grupos de texto"
 
 msgid "Text Only"
 msgstr "Só texto"

--- a/packages/pipeline/src/__tests__/page-sectioning.test.ts
+++ b/packages/pipeline/src/__tests__/page-sectioning.test.ts
@@ -5,6 +5,8 @@ import {
   buildSectioningConfig,
   buildGroupSummaries,
   sectionPage,
+  structureActivityParts,
+  type GroupSummary,
 } from "../page-sectioning.js"
 
 describe("buildSectioningConfig", () => {
@@ -86,7 +88,7 @@ describe("buildSectioningConfig", () => {
 })
 
 describe("buildGroupSummaries", () => {
-  it("builds summaries from unpruned text entries", () => {
+  it("builds summaries with individual text entry IDs", () => {
     const textClassification: TextClassificationOutput = {
       reasoning: "test",
       groups: [
@@ -115,12 +117,17 @@ describe("buildGroupSummaries", () => {
       {
         groupId: "pg001_gp001",
         groupType: "paragraph",
-        text: "Hello world. More text.",
+        texts: [
+          { textId: "pg001_gp001_tx001", textType: "section_text", text: "Hello world." },
+          { textId: "pg001_gp001_tx002", textType: "section_text", text: "More text." },
+        ],
       },
       {
         groupId: "pg001_gp002",
         groupType: "heading",
-        text: "Chapter 1",
+        texts: [
+          { textId: "pg001_gp002_tx001", textType: "section_heading", text: "Chapter 1" },
+        ],
       },
     ])
   })
@@ -153,7 +160,7 @@ describe("buildGroupSummaries", () => {
     expect(summaries[0].groupId).toBe("pg001_gp002")
   })
 
-  it("excludes pruned texts within a group", () => {
+  it("excludes pruned texts but preserves correct IDs", () => {
     const textClassification: TextClassificationOutput = {
       reasoning: "test",
       groups: [
@@ -171,7 +178,14 @@ describe("buildGroupSummaries", () => {
 
     const summaries = buildGroupSummaries(textClassification)
     expect(summaries).toEqual([
-      { groupId: "pg001_gp001", groupType: "paragraph", text: "Body text" },
+      {
+        groupId: "pg001_gp001",
+        groupType: "paragraph",
+        texts: [
+          // tx002 because tx001 (pruned) is at index 0
+          { textId: "pg001_gp001_tx002", textType: "section_text", text: "Body text" },
+        ],
+      },
     ])
   })
 })
@@ -211,14 +225,14 @@ describe("sectionPage", () => {
       sections: [
         {
           section_type: "text_only",
-          part_ids: ["pg001_gp001"],
+          parts: ["pg001_gp001"],
           background_color: "#ffffff",
           text_color: "#000000",
           page_number: 1,
         },
         {
           section_type: "credits",
-          part_ids: ["pg001_gp002"],
+          parts: ["pg001_gp002"],
           background_color: "#f0f0f0",
           text_color: "#333333",
           page_number: null,
@@ -390,7 +404,7 @@ describe("sectionPage", () => {
       sections: [
         {
           section_type: "text_only",
-          part_ids: ["pg001_gp001"],
+          parts: ["pg001_gp001"],
           background_color: "#ffffff",
           text_color: "#000000",
           page_number: 1,
@@ -470,6 +484,129 @@ describe("sectionPage", () => {
     })
   })
 
+  it("expands LLM group objects into nested SectionParts", async () => {
+    // Simulate the LLM producing structured groups for a multiple choice section
+    const response = {
+      reasoning: "Multiple choice question",
+      sections: [
+        {
+          section_type: "activity_multiple_choice",
+          parts: [
+            "pg001_gp001",
+            "pg001_gp002_tx001",
+            {
+              group_type: "option_group",
+              items: [
+                { group_type: "option", items: ["pg001_gp002_tx002"] },
+                { group_type: "option", items: ["pg001_gp002_tx003"] },
+                { group_type: "option", items: ["pg001_gp002_tx004"] },
+              ],
+            },
+          ],
+          background_color: "#ffffff",
+          text_color: "#000000",
+          page_number: 1,
+        },
+      ],
+    }
+
+    const fakeLlm: LLMModel = {
+      generateObject: async <T>() =>
+        ({ object: response as T }) as GenerateObjectResult<T>,
+    }
+
+    const result = await sectionPage(
+      {
+        pageId: "pg001",
+        pageNumber: 1,
+        pageImageBase64: "base64img",
+        textClassification: {
+          reasoning: "test",
+          groups: [
+            {
+              groupId: "pg001_gp001",
+              groupType: "list",
+              texts: [
+                { textType: "instruction_text", text: "Choose the best answer.", isPruned: false },
+              ],
+              isPruned: false,
+            },
+            {
+              groupId: "pg001_gp002",
+              groupType: "other",
+              texts: [
+                { textType: "section_text", text: "Elena was taken to her grandfather.", isPruned: false },
+                { textType: "activity_option", text: "Elena's arrival", isPruned: false },
+                { textType: "activity_option", text: "Elena's journey", isPruned: false },
+                { textType: "activity_option", text: "Elena's costume", isPruned: false },
+              ],
+              isPruned: false,
+            },
+          ],
+        },
+        imageClassification: { images: [] },
+        images: [],
+      },
+      {
+        sectionTypes: [{ key: "activity_multiple_choice", description: "Multiple choice" }],
+        prunedSectionTypes: [],
+        promptName: "page_sectioning",
+        modelId: "openai:gpt-4o",
+      },
+      fakeLlm
+    )
+
+    const section = result.sections[0]
+    expect(section.sectionType).toBe("activity_multiple_choice")
+
+    // First part: instruction text_group (whole group referenced by group ID)
+    expect(section.parts[0]).toEqual({
+      type: "text_group",
+      groupId: "pg001_gp001",
+      groupType: "list",
+      texts: [
+        { textId: "pg001_gp001_tx001", textType: "instruction_text", text: "Choose the best answer.", isPruned: false },
+      ],
+      isPruned: false,
+    })
+
+    // Second part: individual text entry for the question
+    expect(section.parts[1]).toMatchObject({
+      type: "text_group",
+      groupId: "pg001_gp002_tx001_tg",
+      texts: [
+        { textId: "pg001_gp002_tx001", textType: "section_text", text: "Elena was taken to her grandfather." },
+      ],
+    })
+
+    // Third part: option_group wrapping 3 options
+    const optionGroup = section.parts[2]
+    expect(optionGroup.type).toBe("group")
+    if (optionGroup.type === "group") {
+      expect(optionGroup.groupType).toBe("option_group")
+      expect(optionGroup.parts).toHaveLength(3)
+
+      // Each option is a group wrapping a single-text text_group
+      for (const opt of optionGroup.parts) {
+        expect(opt.type).toBe("group")
+        if (opt.type === "group") {
+          expect(opt.groupType).toBe("option")
+          expect(opt.parts).toHaveLength(1)
+          expect(opt.parts[0].type).toBe("text_group")
+        }
+      }
+
+      // Verify option texts
+      const optionTexts = optionGroup.parts.map((opt) => {
+        if (opt.type === "group" && opt.parts[0].type === "text_group") {
+          return opt.parts[0].texts[0].text
+        }
+        return ""
+      })
+      expect(optionTexts).toEqual(["Elena's arrival", "Elena's journey", "Elena's costume"])
+    }
+  })
+
   it("throws when no section types configured", async () => {
     const fakeLlm: LLMModel = {
       generateObject: async <T>() =>
@@ -511,5 +648,156 @@ describe("sectionPage", () => {
         fakeLlm
       )
     ).rejects.toThrow("No section types configured")
+  })
+})
+
+describe("structureActivityParts", () => {
+  it("returns content sections unchanged", () => {
+    const parts: import("@adt/types").SectionPart[] = [
+      {
+        type: "text_group",
+        groupId: "tg1",
+        groupType: "paragraph",
+        texts: [{ textId: "t1", textType: "section_text", text: "Hello", isPruned: false }],
+        isPruned: false,
+      },
+      { type: "image", imageId: "img1", isPruned: false },
+    ]
+
+    const result = structureActivityParts("text_only", parts)
+    expect(result).toEqual(parts)
+  })
+
+  it("wraps all-option text_group entries into option_group", () => {
+    // Like pg012 word bank: a text_group where all entries are activity_option
+    const parts: import("@adt/types").SectionPart[] = [
+      {
+        type: "text_group",
+        groupId: "tg1",
+        groupType: "paragraph",
+        texts: [{ textId: "t1", textType: "instruction_text", text: "Fill in blanks", isPruned: false }],
+        isPruned: false,
+      },
+      {
+        type: "text_group",
+        groupId: "tg2",
+        groupType: "list",
+        texts: [
+          { textId: "t2", textType: "activity_option", text: "word1", isPruned: false },
+          { textId: "t3", textType: "activity_option", text: "word2", isPruned: false },
+        ],
+        isPruned: false,
+      },
+    ]
+
+    const result = structureActivityParts("activity_fill_in_the_blank", parts)
+    expect(result).toHaveLength(2)
+    expect(result[0].type).toBe("text_group") // instruction unchanged
+    expect(result[1].type).toBe("group")
+    if (result[1].type === "group") {
+      expect(result[1].groupType).toBe("option_group")
+      expect(result[1].parts).toHaveLength(2)
+      expect(result[1].parts[0].type).toBe("group")
+      if (result[1].parts[0].type === "group") {
+        expect(result[1].parts[0].groupType).toBe("option")
+      }
+    }
+  })
+
+  it("splits mixed text_group into question + options", () => {
+    // Like pg011: section_text + activity_option in same text_group
+    const parts: import("@adt/types").SectionPart[] = [
+      {
+        type: "text_group",
+        groupId: "tg1",
+        groupType: "other",
+        texts: [
+          { textId: "t1", textType: "section_text", text: "Question text", isPruned: false },
+          { textId: "t2", textType: "activity_option", text: "Option A", isPruned: false },
+          { textId: "t3", textType: "activity_option", text: "Option B", isPruned: false },
+        ],
+        isPruned: false,
+      },
+    ]
+
+    const result = structureActivityParts("activity_multiple_choice", parts)
+    expect(result).toHaveLength(2)
+
+    // First: question text_group with options removed
+    expect(result[0].type).toBe("text_group")
+    if (result[0].type === "text_group") {
+      expect(result[0].texts).toHaveLength(1)
+      expect(result[0].texts[0].textType).toBe("section_text")
+    }
+
+    // Second: option_group with 2 options
+    expect(result[1].type).toBe("group")
+    if (result[1].type === "group") {
+      expect(result[1].groupType).toBe("option_group")
+      expect(result[1].parts).toHaveLength(2)
+    }
+  })
+
+  it("preserves images between text parts", () => {
+    const parts: import("@adt/types").SectionPart[] = [
+      {
+        type: "text_group",
+        groupId: "tg1",
+        groupType: "other",
+        texts: [
+          { textId: "t1", textType: "activity_option", text: "Opt A", isPruned: false },
+          { textId: "t2", textType: "activity_option", text: "Opt B", isPruned: false },
+        ],
+        isPruned: false,
+      },
+      { type: "image", imageId: "img1", isPruned: false },
+      {
+        type: "text_group",
+        groupId: "tg2",
+        groupType: "other",
+        texts: [
+          { textId: "t3", textType: "activity_option", text: "Opt C", isPruned: false },
+        ],
+        isPruned: false,
+      },
+    ]
+
+    const result = structureActivityParts("activity_multiple_choice", parts)
+    // Options before image → option_group, then image, then another option_group
+    expect(result).toHaveLength(3)
+    expect(result[0].type).toBe("group") // option_group for Opt A, B
+    expect(result[1].type).toBe("image")
+    expect(result[2].type).toBe("group") // option_group for Opt C
+  })
+
+  it("handles pruned option entries gracefully", () => {
+    const parts: import("@adt/types").SectionPart[] = [
+      {
+        type: "text_group",
+        groupId: "tg1",
+        groupType: "other",
+        texts: [
+          { textId: "t1", textType: "activity_option", text: "Active", isPruned: false },
+          { textId: "t2", textType: "activity_option", text: "Pruned", isPruned: true },
+        ],
+        isPruned: false,
+      },
+    ]
+
+    const result = structureActivityParts("activity_true_false", parts)
+    // Pruned entries are excluded from option extraction; only the active option
+    // becomes an option group. Since no non-pruned non-option entries remain,
+    // the text_group is fully consumed.
+    expect(result).toHaveLength(1)
+
+    expect(result[0].type).toBe("group")
+    if (result[0].type === "group") {
+      expect(result[0].groupType).toBe("option_group")
+      expect(result[0].parts).toHaveLength(1)
+      // The single active option
+      if (result[0].parts[0].type === "group") {
+        expect(result[0].parts[0].groupType).toBe("option")
+      }
+    }
   })
 })

--- a/packages/pipeline/src/__tests__/web-rendering.test.ts
+++ b/packages/pipeline/src/__tests__/web-rendering.test.ts
@@ -166,6 +166,31 @@ function imagePart(imageId: string, isPruned = false) {
 }
 
 describe("renderPage", () => {
+  // Helper to extract flat texts from ordered_parts
+  function extractTextsFromParts(parts: unknown[]): Array<{ text_id: string; text_type: string; text: string }> {
+    const result: Array<{ text_id: string; text_type: string; text: string }> = []
+    for (const p of parts as Array<Record<string, unknown>>) {
+      if (p.part_type === "text_group") {
+        result.push(...(p.texts as Array<{ text_id: string; text_type: string; text: string }>))
+      } else if (p.part_type === "group") {
+        result.push(...extractTextsFromParts(p.parts as unknown[]))
+      }
+    }
+    return result
+  }
+
+  function extractImagesFromParts(parts: unknown[]): Array<{ image_id: string; image_base64: string }> {
+    const result: Array<{ image_id: string; image_base64: string }> = []
+    for (const p of parts as Array<Record<string, unknown>>) {
+      if (p.part_type === "image") {
+        result.push(p as unknown as { image_id: string; image_base64: string })
+      } else if (p.part_type === "group") {
+        result.push(...extractImagesFromParts(p.parts as unknown[]))
+      }
+    }
+    return result
+  }
+
   const htmlResponse = {
     reasoning: "test",
     content: '<div id="content" class="container"><section data-section-type="text_only" data-section-id="pg001_sec001"><p data-id="pg001_gp001_tx001">Hello</p></section></div>',
@@ -314,10 +339,7 @@ describe("renderPage", () => {
       fakeLlm
     )
 
-    const images = capturedContext?.images as Array<{
-      image_id: string
-      image_base64: string
-    }>
+    const images = extractImagesFromParts(capturedContext?.ordered_parts as unknown[])
     expect(images).toHaveLength(1)
     expect(images[0].image_id).toBe("pg001_im001")
     expect(images[0].image_base64).toBe("imagedata")
@@ -370,11 +392,7 @@ describe("renderPage", () => {
       fakeLlm
     )
 
-    const texts = capturedContext?.texts as Array<{
-      text_id: string
-      text_type: string
-      text: string
-    }>
+    const texts = extractTextsFromParts(capturedContext?.ordered_parts as unknown[])
     expect(texts).toHaveLength(2)
     expect(texts[0].text_id).toBe("pg001_gp001_tx001")
     expect(texts[1].text_id).toBe("pg001_gp001_tx002")
@@ -427,11 +445,7 @@ describe("renderPage", () => {
       fakeLlm
     )
 
-    const texts = capturedContext?.texts as Array<{
-      text_id: string
-      text_type: string
-      text: string
-    }>
+    const texts = extractTextsFromParts(capturedContext?.ordered_parts as unknown[])
     expect(texts).toHaveLength(2)
     expect(texts[0].text_id).toBe("pg001_gp001_tx002")
     expect(texts[1].text_id).toBe("pg001_gp001_tx003")
@@ -482,9 +496,7 @@ describe("renderPage", () => {
       fakeLlm
     )
 
-    const texts = capturedContext?.texts as Array<{
-      text_id: string
-    }>
+    const texts = extractTextsFromParts(capturedContext?.ordered_parts as unknown[])
     expect(texts).toHaveLength(1)
     expect(texts[0].text_id).toBe("pg001_gp001_tx001")
   })
@@ -1002,11 +1014,11 @@ describe("renderPage", () => {
     )
 
     // Only unpruned parts should be passed to the renderer
-    const texts = capturedContext?.texts as Array<{ text_id: string }>
+    const texts = extractTextsFromParts(capturedContext?.ordered_parts as unknown[])
     expect(texts).toHaveLength(1)
     expect(texts[0].text_id).toBe("pg001_gp001_tx001")
 
-    const images = capturedContext?.images as Array<{ image_id: string }>
+    const images = extractImagesFromParts(capturedContext?.ordered_parts as unknown[])
     expect(images).toHaveLength(0)
   })
 })

--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -58,8 +58,11 @@ export {
   sectionPage,
   buildSectioningConfig,
   buildGroupSummaries,
+  structureActivityParts,
   type SectioningConfig,
   type SectionPageInput,
+  type GroupSummary,
+  type TextEntrySummary,
 } from "./page-sectioning.js"
 export {
   renderPage,
@@ -69,6 +72,8 @@ export {
   type RenderPageInput,
   type RenderSectionInput,
   type SectionPart,
+  type GroupPart,
+  type NestedGroupPart,
   type TextInput,
   type ImageInput,
 } from "./web-rendering.js"

--- a/packages/pipeline/src/package-web.ts
+++ b/packages/pipeline/src/package-web.ts
@@ -17,7 +17,7 @@ import type {
   Quiz,
   ImageCaptioningOutput,
 } from "@adt/types"
-import { WebRenderingOutput as WebRenderingOutputSchema } from "@adt/types"
+import { WebRenderingOutput as WebRenderingOutputSchema, flattenImageParts, flattenTextParts } from "@adt/types"
 import type { Progress } from "./progress.js"
 import { nullProgress } from "./progress.js"
 import { getBaseLanguage, normalizeLocale } from "./language-context.js"
@@ -1117,18 +1117,12 @@ function loadImageCaptionMap(storage: Storage, pageId: string): Map<string, stri
 }
 
 function buildSectionImageAltMap(section: PageSection): Map<string, string> {
-  const imageParts = section.parts.filter(
-    (part): part is Extract<PageSection["parts"][number], { type: "image" }> =>
-      part.type === "image" && !part.isPruned,
-  )
+  const imageParts = flattenImageParts(section.parts)
   if (imageParts.length !== 1) {
     return new Map<string, string>()
   }
 
-  const textParts = section.parts.filter(
-    (part): part is Extract<PageSection["parts"][number], { type: "text_group" }> =>
-      part.type === "text_group" && !part.isPruned,
-  )
+  const textParts = flattenTextParts(section.parts)
 
   const associatedTexts = textParts
     .flatMap((part) => part.texts)
@@ -1150,8 +1144,7 @@ function applyDuplicateImageAltPolicy(
   const normalizedAltToFirstImageId = new Map<string, string>()
   const normalizedAltMap = new Map(altTextByImageId)
 
-  for (const part of section.parts) {
-    if (part.type !== "image" || part.isPruned) continue
+  for (const part of flattenImageParts(section.parts)) {
     const altText = normalizedAltMap.get(part.imageId)?.trim()
     if (!altText) continue
 
@@ -2148,9 +2141,7 @@ const HEADING_TEXT_TYPES = new Set([
 function findHeadingText(
   section: import("@adt/types").PageSection,
 ): { textId: string; text: string } | null {
-  for (const part of section.parts) {
-    if (part.type !== "text_group" || part.isPruned) continue
-    // Check if this is a heading group type OR contains heading text types
+  for (const part of flattenTextParts(section.parts)) {
     for (const t of part.texts) {
       if (t.isPruned) continue
       if (HEADING_TEXT_TYPES.has(t.textType)) {

--- a/packages/pipeline/src/page-sectioning.ts
+++ b/packages/pipeline/src/page-sectioning.ts
@@ -3,9 +3,14 @@ import type {
   ImageClassificationOutput,
   PageSectioningOutput,
   SectionPart,
+  SectionTextPart,
   AppConfig,
   TypeDef,
   SectioningMode,
+  SectionGroupPartType,
+  LLMSectionPart,
+  LLMPartGroup,
+  LLMPartGroupItem,
 } from "@adt/types"
 import {
   buildPageSectioningLLMSchema,
@@ -31,26 +36,135 @@ export interface SectionPageInput {
   images: Array<{ imageId: string; imageBase64: string }>
 }
 
+export interface TextEntrySummary {
+  textId: string
+  textType: string
+  text: string
+}
+
+export interface GroupSummary {
+  groupId: string
+  groupType: string
+  texts: TextEntrySummary[]
+}
+
 /**
- * Build concise group summaries from text classification, excluding pruned text entries.
- * Groups with no unpruned texts are omitted entirely.
+ * Build group summaries from text classification, exposing individual text
+ * entries with pre-assigned IDs so the LLM can reference either whole groups
+ * or individual text entries. Pruned groups and pruned text entries are excluded.
  */
 export function buildGroupSummaries(
   textClassification: TextClassificationOutput
-): Array<{ groupId: string; groupType: string; text: string }> {
+): GroupSummary[] {
   return textClassification.groups
     .map((g) => {
       if (g.isPruned) return null
-      const unprunedTexts = g.texts.filter((t) => !t.isPruned)
+      // Assign IDs based on index within the full group (including pruned)
+      // then filter to only unpruned entries for the LLM
+      const textsWithIds = g.texts.map((t, idx) => ({
+        textId: `${g.groupId}_tx${String(idx + 1).padStart(3, "0")}`,
+        textType: t.textType,
+        text: t.text,
+        isPruned: t.isPruned,
+      }))
+      const unprunedTexts = textsWithIds.filter((t) => !t.isPruned)
       if (unprunedTexts.length === 0) return null
 
       return {
         groupId: g.groupId,
         groupType: g.groupType,
-        text: unprunedTexts.map((t) => t.text).join(" "),
+        texts: unprunedTexts.map(({ textId, textType, text }) => ({
+          textId,
+          textType,
+          text,
+        })),
       }
     })
     .filter((g): g is NonNullable<typeof g> => g !== null)
+}
+
+// ---------------------------------------------------------------------------
+// Post-processing: restructure flat parts into groups for activity sections
+// ---------------------------------------------------------------------------
+
+/**
+ * Restructure flat parts into nested groups for activity sections.
+ * - Extracts `activity_option` entries from text_groups into `option` groups
+ * - Wraps consecutive options in an `option_group`
+ * - Splits mixed text_groups (question text + options) into separate parts
+ * Non-activity sections are returned unchanged.
+ */
+export function structureActivityParts(sectionType: string, parts: SectionPart[]): SectionPart[] {
+  if (!sectionType.startsWith("activity_")) return parts
+
+  const result: SectionPart[] = []
+  const pendingOptions: SectionGroupPartType[] = []
+
+  const flushOptions = () => {
+    if (pendingOptions.length === 0) return
+    // Use the first option's ID to derive the option_group ID
+    const firstOptId = pendingOptions[0].groupId
+    const grpId = firstOptId.replace(/_opt$/, "_optgrp")
+    result.push({
+      type: "group",
+      groupId: grpId,
+      groupType: "option_group",
+      parts: [...pendingOptions],
+      isPruned: false,
+    })
+    pendingOptions.length = 0
+  }
+
+  const makeOption = (entry: SectionTextPart["texts"][number], sourceGroupType: string): SectionGroupPartType => ({
+    type: "group",
+    groupId: `${entry.textId}_opt`,
+    groupType: "option",
+    parts: [{
+      type: "text_group" as const,
+      groupId: `${entry.textId}_tg`,
+      groupType: sourceGroupType,
+      texts: [entry],
+      isPruned: false,
+    }],
+    isPruned: entry.isPruned,
+  })
+
+  for (const part of parts) {
+    if (part.type !== "text_group") {
+      // Images and existing groups pass through; flush pending options first
+      flushOptions()
+      result.push(part)
+      continue
+    }
+
+    const nonPrunedEntries = part.texts.filter((t) => !t.isPruned)
+    const optionEntries = nonPrunedEntries.filter((t) => t.textType === "activity_option")
+    const nonOptionEntries = part.texts.filter((t) => t.textType !== "activity_option" || t.isPruned)
+
+    if (optionEntries.length === 0) {
+      // No options — keep text_group as-is
+      flushOptions()
+      result.push(part)
+    } else if (nonOptionEntries.filter((t) => !t.isPruned).length === 0) {
+      // ALL non-pruned entries are options — each becomes an option group
+      for (const entry of optionEntries) {
+        pendingOptions.push(makeOption(entry, part.groupType))
+      }
+    } else {
+      // MIXED — split: non-option entries stay in the text_group, options become groups
+      flushOptions()
+      result.push({
+        ...part,
+        texts: nonOptionEntries,
+      })
+      for (const entry of optionEntries) {
+        pendingOptions.push(makeOption(entry, part.groupType))
+      }
+    }
+  }
+
+  flushOptions()
+  return result
 }
 
 /**
@@ -62,7 +176,7 @@ export async function sectionPage(
   config: SectioningConfig,
   llmModel: LLMModel
 ): Promise<PageSectioningOutput> {
-  // Build group summaries (excludes pruned text entries)
+  // Build group summaries with individual text entry IDs
   const groupSummaries = buildGroupSummaries(input.textClassification)
 
   // Filter to un-pruned images
@@ -75,14 +189,15 @@ export async function sectionPage(
     (img) => !prunedImageIds.has(img.imageId)
   )
 
-  // Build valid part IDs for the schema
-  const validPartIds = [
+  // Build valid part IDs: group IDs, individual text entry IDs, and image IDs
+  const validPartIds = new Set([
     ...groupSummaries.map((g) => g.groupId),
+    ...groupSummaries.flatMap((g) => g.texts.map((t) => t.textId)),
     ...unprunedImages.map((img) => img.imageId),
-  ]
+  ])
 
   // If no parts to section, return empty result
-  if (validPartIds.length === 0) {
+  if (validPartIds.size === 0) {
     return { reasoning: "No content to section", sections: [] }
   }
 
@@ -97,7 +212,7 @@ export async function sectionPage(
     reasoning: string
     sections: Array<{
       section_type: string
-      part_ids: string[]
+      parts: LLMSectionPart[]
       background_color: string
       text_color: string
       page_number: number | null
@@ -115,7 +230,11 @@ export async function sectionPage(
       groups: groupSummaries.map((g) => ({
         group_id: g.groupId,
         group_type: g.groupType,
-        text: g.text,
+        texts: g.texts.map((t) => ({
+          text_id: t.textId,
+          text_type: t.textType,
+          text: t.text,
+        })),
       })),
       section_types: config.sectionTypes,
     },
@@ -129,50 +248,131 @@ export async function sectionPage(
     },
   })
 
-  // Build lookup maps for expanding part_ids into inline parts
+  // Build lookup maps for expanding IDs into inline parts
   const groupMap = new Map(
     input.textClassification.groups.map((g) => [g.groupId, g])
   )
+  // Map individual text entry IDs → { group, textIndex }
+  const textEntryMap = new Map<string, { groupId: string; textIdx: number }>()
+  for (const g of input.textClassification.groups) {
+    for (let i = 0; i < g.texts.length; i++) {
+      const textId = `${g.groupId}_tx${String(i + 1).padStart(3, "0")}`
+      textEntryMap.set(textId, { groupId: g.groupId, textIdx: i })
+    }
+  }
   const imageClassMap = new Map(
     input.imageClassification.images.map((img) => [img.imageId, img])
   )
 
-  // Track which parts get assigned to a section
-  const assignedPartIds = new Set<string>()
+  // Track which groups/text entries/images get assigned
+  const assignedGroupIds = new Set<string>()
+  const assignedTextEntryIds = new Set<string>()
+  const assignedImageIds = new Set<string>()
 
-  // Post-process: mark pruned sections, expand part_ids to inline parts
+  /** Expand a single string ID to a SectionPart */
+  const expandStringId = (id: string): SectionPart | null => {
+    // Check if it's a group ID
+    const group = groupMap.get(id)
+    if (group) {
+      assignedGroupIds.add(id)
+      return {
+        type: "text_group" as const,
+        groupId: group.groupId,
+        groupType: group.groupType,
+        texts: group.texts.map((t, tIdx) => ({
+          textId: `${group.groupId}_tx${String(tIdx + 1).padStart(3, "0")}`,
+          textType: t.textType,
+          text: t.text,
+          isPruned: t.isPruned,
+        })),
+        isPruned: group.isPruned,
+      }
+    }
+
+    // Check if it's an individual text entry ID
+    const entry = textEntryMap.get(id)
+    if (entry) {
+      assignedTextEntryIds.add(id)
+      assignedGroupIds.add(entry.groupId) // mark parent group as covered
+      const g = groupMap.get(entry.groupId)!
+      const t = g.texts[entry.textIdx]
+      return {
+        type: "text_group" as const,
+        groupId: `${id}_tg`,
+        groupType: g.groupType,
+        texts: [{
+          textId: id,
+          textType: t.textType,
+          text: t.text,
+          isPruned: t.isPruned,
+        }],
+        isPruned: t.isPruned,
+      }
+    }
+
+    // Must be an image ID
+    assignedImageIds.add(id)
+    const imgClass = imageClassMap.get(id)
+    return {
+      type: "image" as const,
+      imageId: id,
+      isPruned: false,
+      ...(imgClass?.reason ? { reason: imgClass.reason } : {}),
+    }
+  }
+
+  /** Expand an LLMPartGroupItem to SectionPart(s) */
+  const expandGroupItem = (item: LLMPartGroupItem): SectionPart[] => {
+    if (typeof item === "string") {
+      const part = expandStringId(item)
+      return part ? [part] : []
+    }
+    // Leaf group: { group_type, items: string[] }
+    const childParts: SectionPart[] = []
+    for (const childId of item.items) {
+      const part = expandStringId(childId)
+      if (part) childParts.push(part)
+    }
+    if (childParts.length === 0) return []
+    return [{
+      type: "group" as const,
+      groupId: `${item.items[0]}_grp`,
+      groupType: item.group_type,
+      parts: childParts,
+      isPruned: false,
+    }]
+  }
+
+  /** Expand an LLMSectionPart to SectionPart(s) */
+  const expandLLMPart = (llmPart: LLMSectionPart, sectionId: string, partIdx: number): SectionPart[] => {
+    if (typeof llmPart === "string") {
+      const part = expandStringId(llmPart)
+      return part ? [part] : []
+    }
+    // PartGroup: { group_type, items: (string | LeafGroup)[] }
+    const childParts: SectionPart[] = []
+    for (const item of llmPart.items) {
+      childParts.push(...expandGroupItem(item))
+    }
+    if (childParts.length === 0) return []
+    return [{
+      type: "group" as const,
+      groupId: `${sectionId}_grp${String(partIdx + 1).padStart(3, "0")}`,
+      groupType: llmPart.group_type,
+      parts: childParts,
+      isPruned: false,
+    }]
+  }
+
+  // Post-process: mark pruned sections, expand parts to inline SectionParts
   const prunedSet = new Set(config.prunedSectionTypes)
 
   const sections = result.object.sections.map((s, idx) => {
     const sectionId = `${input.pageId}_sec${String(idx + 1).padStart(3, "0")}`
-    // Expand part_ids to full SectionPart objects
-    const parts: SectionPart[] = s.part_ids.map((partId) => {
-      assignedPartIds.add(partId)
-
-      const group = groupMap.get(partId)
-      if (group) {
-        return {
-          type: "text_group" as const,
-          groupId: group.groupId,
-          groupType: group.groupType,
-          texts: group.texts.map((t, tIdx) => ({
-            textId: `${group.groupId}_tx${String(tIdx + 1).padStart(3, "0")}`,
-            textType: t.textType,
-            text: t.text,
-            isPruned: t.isPruned,
-          })),
-          isPruned: group.isPruned,
-        }
-      }
-
-      const imgClass = imageClassMap.get(partId)
-      return {
-        type: "image" as const,
-        imageId: partId,
-        isPruned: false,
-        ...(imgClass?.reason ? { reason: imgClass.reason } : {}),
-      }
-    })
+    const parts: SectionPart[] = []
+    for (let i = 0; i < s.parts.length; i++) {
+      parts.push(...expandLLMPart(s.parts[i], sectionId, i))
+    }
 
     return {
       sectionId,
@@ -197,39 +397,41 @@ export async function sectionPage(
     }
   }
 
-  // Replace segmented originals in-place with their segments.
-  // This keeps segments in the same position as the original image
-  // instead of appending them to the end of the section.
-  for (const section of sections) {
-    const expandedParts: SectionPart[] = []
-    for (const part of section.parts) {
-      if (part.type === "image" && segmentsBySource.has(part.imageId)) {
-        // Replace the original (now pruned) with its segments in-place
+  // Replace segmented originals in-place with their segments (recursive).
+  const expandSegments = (parts: SectionPart[]): SectionPart[] => {
+    const result: SectionPart[] = []
+    for (const part of parts) {
+      if (part.type === "group") {
+        result.push({ ...part, parts: expandSegments(part.parts) })
+      } else if (part.type === "image" && segmentsBySource.has(part.imageId)) {
         const segIds = segmentsBySource.get(part.imageId)!
         for (const segId of segIds) {
           const segClass = imageClassMap.get(segId)
-          expandedParts.push({
+          result.push({
             type: "image",
             imageId: segId,
             isPruned: segClass?.isPruned ?? false,
             ...(segClass?.reason ? { reason: segClass.reason } : {}),
           })
-          assignedPartIds.add(segId)
+          assignedImageIds.add(segId)
         }
-        // Keep the original as pruned
-        expandedParts.push({ ...part, isPruned: true, reason: "segmented" })
+        result.push({ ...part, isPruned: true, reason: "segmented" })
       } else {
-        expandedParts.push(part)
+        result.push(part)
       }
     }
-    section.parts = expandedParts
+    return result
+  }
+
+  for (const section of sections) {
+    section.parts = expandSegments(section.parts)
   }
 
   // Collect unassigned parts and add them to the last non-pruned section
   const unassignedParts: SectionPart[] = []
 
   for (const group of input.textClassification.groups) {
-    if (!assignedPartIds.has(group.groupId)) {
+    if (!assignedGroupIds.has(group.groupId)) {
       unassignedParts.push({
         type: "text_group",
         groupId: group.groupId,
@@ -246,7 +448,7 @@ export async function sectionPage(
   }
 
   for (const img of input.imageClassification.images) {
-    if (!assignedPartIds.has(img.imageId)) {
+    if (!assignedImageIds.has(img.imageId)) {
       unassignedParts.push({
         type: "image",
         imageId: img.imageId,
@@ -273,41 +475,85 @@ function validatePageSectioning(
   context: Record<string, unknown>
 ): ValidationResult {
   const r = result as {
-    sections: Array<{ section_type: string; part_ids: string[] }>
+    sections: Array<{ section_type: string; parts: LLMSectionPart[] }>
   }
   const sectionTypes = context.section_types as TypeDef[]
-  const groups = context.groups as Array<{ group_id: string }>
+  const groups = context.groups as Array<{
+    group_id: string
+    texts: Array<{ text_id: string }>
+  }>
   const images = context.images as Array<{ image_id: string }>
 
   const sectionTypeKeys = new Set(sectionTypes.map((s) => s.key))
+  // Valid IDs include group IDs, individual text entry IDs, and image IDs
   const validPartIds = new Set([
+    ...groups.map((g) => g.group_id),
+    ...groups.flatMap((g) => g.texts.map((t) => t.text_id)),
+    ...images.map((img) => img.image_id),
+  ])
+  // Group-or-image IDs only (for checking assignment coverage)
+  const topLevelIds = new Set([
     ...groups.map((g) => g.group_id),
     ...images.map((img) => img.image_id),
   ])
+  // Map text entry IDs → parent group ID
+  const textToGroup = new Map<string, string>()
+  for (const g of groups) {
+    for (const t of g.texts) {
+      textToGroup.set(t.text_id, g.group_id)
+    }
+  }
 
   const errors: string[] = []
-  const assignedIds = new Set<string>()
+  const assignedTopLevelIds = new Set<string>()
+
+  /** Recursively collect and validate all string IDs from an LLMSectionPart tree */
+  const collectIds = (part: LLMSectionPart): void => {
+    if (typeof part === "string") {
+      if (!validPartIds.has(part)) {
+        errors.push(
+          `Invalid part ID "${part}". Must be one of: ${[...validPartIds].join(", ")}`
+        )
+      }
+      // Track top-level coverage
+      if (topLevelIds.has(part)) {
+        assignedTopLevelIds.add(part)
+      }
+      const parentGroup = textToGroup.get(part)
+      if (parentGroup) {
+        assignedTopLevelIds.add(parentGroup)
+      }
+    } else {
+      // PartGroup or LeafGroup
+      for (const item of part.items) {
+        if (typeof item === "string") {
+          collectIds(item)
+        } else {
+          // Nested leaf group
+          for (const leafId of item.items) {
+            collectIds(leafId)
+          }
+        }
+      }
+    }
+  }
+
   for (const section of r.sections) {
     if (!sectionTypeKeys.has(section.section_type)) {
       errors.push(
         `Invalid section_type "${section.section_type}". Must be one of: ${sectionTypes.map((s) => s.key).join(", ")}`
       )
     }
-    for (const partId of section.part_ids) {
-      if (!validPartIds.has(partId)) {
-        errors.push(
-          `Invalid part_id "${partId}". Must be one of: ${[...validPartIds].join(", ")}`
-        )
-      }
-      assignedIds.add(partId)
+    for (const part of section.parts) {
+      collectIds(part)
     }
   }
 
-  // Ensure all parts are assigned to at least one section
-  const unassigned = [...validPartIds].filter((id) => !assignedIds.has(id))
+  // Ensure all top-level groups and images are covered
+  const unassigned = [...topLevelIds].filter((id) => !assignedTopLevelIds.has(id))
   if (unassigned.length > 0) {
     errors.push(
-      `Every part must be assigned to a section. Unassigned part_ids: ${unassigned.join(", ")}`
+      `Every group and image must be assigned to a section. Unassigned: ${unassigned.join(", ")}`
     )
   }
 

--- a/packages/pipeline/src/render-llm.ts
+++ b/packages/pipeline/src/render-llm.ts
@@ -3,7 +3,7 @@ import { webRenderingLLMSchema, activityAnswersLLMSchema } from "@adt/types"
 import type { LLMModel, ValidationResult } from "@adt/llm"
 import { validateSectionHtml } from "./validate-html.js"
 import { getViewportBreakpoints, type ScreenshotRenderer } from "./screenshot.js"
-import type { RenderConfig, RenderSectionInput, TextInput, ImageInput } from "./web-rendering.js"
+import type { RenderConfig, RenderSectionInput, ImageInput, SectionPart } from "./web-rendering.js"
 import { runVisualReviewLoop } from "./visual-review.js"
 
 /** Dependencies for the optional visual refinement loop. */
@@ -24,55 +24,40 @@ export interface VisualRefinementDeps {
  * - Validation allows activity_gen_* prefixed data-ids
  * - If config.answerPromptName is set, a second LLM call generates correct answers
  */
-export async function renderSectionLlm(
-  input: RenderSectionInput,
-  config: RenderConfig,
-  llmModel: LLMModel,
-  visualRefinement?: VisualRefinementDeps,
-): Promise<SectionRendering> {
-  const texts: TextInput[] = []
-  const images: ImageInput[] = []
+/** Recursively collect all images from parts (including nested groups). */
+function collectImages(parts: SectionPart[]): ImageInput[] {
+  const result: ImageInput[] = []
+  for (const part of parts) {
+    if (part.type === "image") result.push({ imageId: part.imageId, imageBase64: part.imageBase64, width: part.width, height: part.height })
+    else if (part.type === "nested_group") result.push(...collectImages(part.parts))
+  }
+  return result
+}
 
-  for (const part of input.parts) {
-    if (part.type === "group") {
-      texts.push(...part.texts)
-    } else {
-      images.push({ imageId: part.imageId, imageBase64: part.imageBase64, width: part.width, height: part.height })
+type OrderedPart =
+  | { part_type: "text_group"; group_id: string; group_type: string; texts: Array<{ text_id: string; text_type: string; text: string }> }
+  | { part_type: "image"; image_id: string; image_base64: string; width?: number; height?: number }
+  | { part_type: "group"; group_id: string; group_type: string; parts: OrderedPart[]; answer?: string; reasoning?: string }
+
+/** Build an image lookup map from parts (including nested groups). */
+function buildImageLookup(parts: SectionPart[]): Map<string, { base64: string; width?: number; height?: number }> {
+  const map = new Map<string, { base64: string; width?: number; height?: number }>()
+  for (const part of parts) {
+    if (part.type === "image") {
+      map.set(part.imageId, { base64: part.imageBase64, width: part.width, height: part.height })
+    } else if (part.type === "nested_group") {
+      for (const [k, v] of buildImageLookup(part.parts)) map.set(k, v)
     }
   }
+  return map
+}
 
-  const isActivity = config.renderType === "activity"
-  const taskType = isActivity ? "activity-rendering" : "web-rendering"
-
-  // Build structured groups (preserves groupId/groupType for prompts that need it)
-  const groups: Array<{
-    group_id: string
-    group_type: string
-    texts: Array<{ text_id: string; text_type: string; text: string }>
-  }> = []
-  for (const part of input.parts) {
+/** Recursively build ordered parts preserving nested group structure for the LLM prompt. */
+function buildOrderedParts(parts: SectionPart[], imgLookup: Map<string, { base64: string; width?: number; height?: number }>): OrderedPart[] {
+  const result: OrderedPart[] = []
+  for (const part of parts) {
     if (part.type === "group") {
-      groups.push({
-        group_id: part.groupId,
-        group_type: part.groupType,
-        texts: part.texts.map((t) => ({
-          text_id: t.textId,
-          text_type: t.textType,
-          text: t.text,
-        })),
-      })
-    }
-  }
-
-  // Build ordered parts list preserving document flow (text groups + images interleaved).
-  // This helps overlay prompts understand spatial relationships between content.
-  const orderedParts: Array<
-    | { part_type: "text_group"; group_id: string; group_type: string; texts: Array<{ text_id: string; text_type: string; text: string }> }
-    | { part_type: "image"; image_id: string }
-  > = []
-  for (const part of input.parts) {
-    if (part.type === "group") {
-      orderedParts.push({
+      result.push({
         part_type: "text_group",
         group_id: part.groupId,
         group_type: part.groupType,
@@ -82,32 +67,50 @@ export async function renderSectionLlm(
           text: t.text,
         })),
       })
-    } else {
-      orderedParts.push({
+    } else if (part.type === "image") {
+      result.push({
         part_type: "image",
         image_id: part.imageId,
+        image_base64: part.imageBase64,
+        ...(part.width != null ? { width: part.width } : {}),
+        ...(part.height != null ? { height: part.height } : {}),
+      })
+    } else if (part.type === "nested_group") {
+      result.push({
+        part_type: "group",
+        group_id: part.groupId,
+        group_type: part.groupType,
+        parts: buildOrderedParts(part.parts, imgLookup),
+        ...(part.answer ? { answer: part.answer } : {}),
+        ...(part.reasoning ? { reasoning: part.reasoning } : {}),
       })
     }
   }
+  return result
+}
+
+export async function renderSectionLlm(
+  input: RenderSectionInput,
+  config: RenderConfig,
+  llmModel: LLMModel,
+  visualRefinement?: VisualRefinementDeps,
+): Promise<SectionRendering> {
+  const images = collectImages(input.parts)
+
+  const isActivity = config.renderType === "activity"
+  const taskType = isActivity ? "activity-rendering" : "web-rendering"
+
+  // Build ordered parts — the canonical representation for all prompts.
+  // Preserves document flow and nested group structure (option_group → option → text).
+  const imgLookup = buildImageLookup(input.parts)
+  const orderedParts = buildOrderedParts(input.parts, imgLookup)
 
   const context = {
     label: input.label,
     page_image_base64: input.pageImageBase64,
     section_id: input.sectionId,
     section_type: input.sectionType,
-    texts: texts.map((t) => ({
-      text_id: t.textId,
-      text_type: t.textType,
-      text: t.text,
-    })),
-    groups,
     ordered_parts: orderedParts,
-    images: images.map((img) => ({
-      image_id: img.imageId,
-      image_base64: img.imageBase64,
-      ...(img.width != null && { width: img.width }),
-      ...(img.height != null && { height: img.height }),
-    })),
     styleguide: input.styleguide ?? "",
     viewports: getViewportBreakpoints(),
     _isActivity: isActivity,
@@ -223,21 +226,44 @@ export async function renderSectionLlm(
   }
 }
 
+/** Recursively collect text and image info from ordered parts for validation. */
+function collectValidationIds(
+  parts: OrderedPart[],
+  textIds: string[],
+  imageIds: string[],
+  textMap: Map<string, string>,
+): void {
+  for (const part of parts) {
+    if (part.part_type === "text_group") {
+      for (const t of part.texts) {
+        textIds.push(t.text_id)
+        textMap.set(t.text_id, t.text)
+      }
+    } else if (part.part_type === "image") {
+      imageIds.push(part.image_id)
+    } else if (part.part_type === "group") {
+      collectValidationIds(part.parts, textIds, imageIds, textMap)
+    }
+  }
+}
+
 function validateWebRendering(
   result: unknown,
   context: Record<string, unknown>
 ): ValidationResult {
   const r = result as { reasoning: string; content: string }
   const label = context.label as string
-  const texts = context.texts as Array<{ text_id: string; text: string }>
-  const images = context.images as Array<{ image_id: string }>
+  const parts = context.ordered_parts as OrderedPart[]
   const isActivity = context._isActivity as boolean | undefined
   const sectionId = context.section_id as string
   const sectionType = context.section_type as string
-  const allowedTextIds = texts.map((t) => t.text_id)
-  const allowedImageIds = images.map((img) => img.image_id)
+
+  const allowedTextIds: string[] = []
+  const allowedImageIds: string[] = []
+  const expectedTexts = new Map<string, string>()
+  collectValidationIds(parts, allowedTextIds, allowedImageIds, expectedTexts)
+
   const imageUrlPrefix = `/api/books/${label}/images`
-  const expectedTexts = new Map(texts.map((t) => [t.text_id, t.text]))
 
   const check = validateSectionHtml(
     r.content,

--- a/packages/pipeline/src/render-template.ts
+++ b/packages/pipeline/src/render-template.ts
@@ -1,7 +1,7 @@
 import { Liquid } from "liquidjs"
 import type { SectionRendering } from "@adt/types"
 import { validateSectionHtml } from "./validate-html.js"
-import type { RenderConfig, RenderSectionInput } from "./web-rendering.js"
+import type { RenderConfig, RenderSectionInput, SectionPart } from "./web-rendering.js"
 
 export interface TemplateEngine {
   render(templateName: string, context: Record<string, unknown>): Promise<string>
@@ -28,6 +28,63 @@ export function createTemplateEngine(templatesDir: string): TemplateEngine {
   }
 }
 
+/** Recursively map SectionParts to template-friendly objects. */
+function mapPartsForTemplate(parts: SectionPart[], imageUrlPrefix: string): unknown[] {
+  return parts.map((part) => {
+    if (part.type === "group") {
+      return {
+        type: "group",
+        group_id: part.groupId,
+        group_type: part.groupType,
+        texts: part.texts.map((t) => ({
+          text_id: t.textId,
+          text_type: t.textType,
+          text: t.text,
+        })),
+      }
+    }
+    if (part.type === "nested_group") {
+      return {
+        type: "nested_group",
+        group_id: part.groupId,
+        group_type: part.groupType,
+        parts: mapPartsForTemplate(part.parts, imageUrlPrefix),
+        ...(part.answer ? { answer: part.answer } : {}),
+        ...(part.reasoning ? { reasoning: part.reasoning } : {}),
+      }
+    }
+    const segMatch = part.imageId.match(/^(.+)_seg\d{3}_v\d+$/)
+    return {
+      type: "image",
+      image_id: part.imageId,
+      image_url: `${imageUrlPrefix}/${part.imageId}`,
+      is_segment: !!segMatch,
+      source_image_id: segMatch ? segMatch[1] : null,
+    }
+  })
+}
+
+/** Recursively collect text and image IDs from SectionParts for validation. */
+function collectIdsForValidation(
+  parts: SectionPart[],
+  allowedTextIds: string[],
+  allowedImageIds: string[],
+  expectedTexts: Map<string, string>,
+): void {
+  for (const part of parts) {
+    if (part.type === "group") {
+      for (const t of part.texts) {
+        allowedTextIds.push(t.textId)
+        expectedTexts.set(t.textId, t.text)
+      }
+    } else if (part.type === "image") {
+      allowedImageIds.push(part.imageId)
+    } else if (part.type === "nested_group") {
+      collectIdsForValidation(part.parts, allowedTextIds, allowedImageIds, expectedTexts)
+    }
+  }
+}
+
 /**
  * Render a single section using a Liquid template.
  * Deterministic — no LLM call, no retries. If validation fails, throws.
@@ -46,28 +103,7 @@ export async function renderSectionTemplate(
     text_color: input.textColor,
     label: input.label,
     image_url_prefix: imageUrlPrefix,
-    parts: input.parts.map((part) => {
-      if (part.type === "group") {
-        return {
-          type: "group",
-          group_id: part.groupId,
-          group_type: part.groupType,
-          texts: part.texts.map((t) => ({
-            text_id: t.textId,
-            text_type: t.textType,
-            text: t.text,
-          })),
-        }
-      }
-      const segMatch = part.imageId.match(/^(.+)_seg\d{3}_v\d+$/)
-      return {
-        type: "image",
-        image_id: part.imageId,
-        image_url: `${imageUrlPrefix}/${part.imageId}`,
-        is_segment: !!segMatch,
-        source_image_id: segMatch ? segMatch[1] : null,
-      }
-    }),
+    parts: mapPartsForTemplate(input.parts, imageUrlPrefix),
   }
 
   const html = await templateEngine.render(config.templateName, context)
@@ -76,16 +112,7 @@ export async function renderSectionTemplate(
   const allowedTextIds: string[] = []
   const allowedImageIds: string[] = []
   const expectedTexts = new Map<string, string>()
-  for (const part of input.parts) {
-    if (part.type === "group") {
-      for (const t of part.texts) {
-        allowedTextIds.push(t.textId)
-        expectedTexts.set(t.textId, t.text)
-      }
-    } else {
-      allowedImageIds.push(part.imageId)
-    }
-  }
+  collectIdsForValidation(input.parts, allowedTextIds, allowedImageIds, expectedTexts)
 
   const check = validateSectionHtml(
     html,

--- a/packages/pipeline/src/toc-generation.ts
+++ b/packages/pipeline/src/toc-generation.ts
@@ -1,5 +1,5 @@
 import type { AppConfig, TocEntry, TocGenerationOutput, PageSectioningOutput } from "@adt/types"
-import { tocLLMSchema, WebRenderingOutput, PageSectioningOutput as PageSectioningOutputSchema, DEFAULT_LLM_MAX_RETRIES } from "@adt/types"
+import { tocLLMSchema, WebRenderingOutput, PageSectioningOutput as PageSectioningOutputSchema, DEFAULT_LLM_MAX_RETRIES, flattenTextParts } from "@adt/types"
 import type { LLMModel } from "@adt/llm"
 import type { Storage, PageData } from "@adt/storage"
 import { buildLanguageContext } from "./language-context.js"
@@ -96,8 +96,8 @@ function collectHeadingsAndToc(
 
       const sectionId = section.sectionId ?? `${page.pageId}_sec${String(i + 1).padStart(3, "0")}`
 
-      for (const part of section.parts) {
-        if (part.type !== "text_group" || part.isPruned) continue
+      for (const part of flattenTextParts(section.parts)) {
+        let found = false
         for (const t of part.texts) {
           if (t.isPruned) continue
           if (HEADING_TEXT_TYPES.has(t.textType)) {
@@ -108,10 +108,11 @@ function collectHeadingsAndToc(
               textType: t.textType,
               pageNumber: section.pageNumber,
             })
-            break // one heading per section
+            found = true
+            break // one heading per text group
           }
         }
-        if (headings.length > 0 && headings[headings.length - 1].sectionId === sectionId) break
+        if (found) break // one heading per section
       }
     }
   }

--- a/packages/pipeline/src/web-rendering.ts
+++ b/packages/pipeline/src/web-rendering.ts
@@ -22,9 +22,27 @@ export interface ImageInput {
   height?: number
 }
 
+export interface GroupPart {
+  type: "group"
+  groupId: string
+  groupType: string
+  texts: TextInput[]
+}
+
+export interface NestedGroupPart {
+  type: "nested_group"
+  groupId: string
+  groupType: string
+  parts: SectionPart[]
+  answer?: string
+  reasoning?: string
+  metadata?: Record<string, unknown>
+}
+
 export type SectionPart =
-  | { type: "group"; groupId: string; groupType: string; texts: TextInput[] }
+  | GroupPart
   | { type: "image"; imageId: string; imageBase64: string; width?: number; height?: number }
+  | NestedGroupPart
 
 export interface VisualRefinementConfig {
   enabled: boolean
@@ -120,6 +138,20 @@ function expandParts(
       const imgData = images.get(part.imageId)
       if (imgData) {
         parts.push({ type: "image", imageId: part.imageId, imageBase64: imgData.base64, width: imgData.width, height: imgData.height })
+      }
+    } else if (part.type === "group") {
+      // Preserve nested group structure for the renderer
+      const childParts = expandParts(part.parts, images)
+      if (childParts.length > 0) {
+        parts.push({
+          type: "nested_group",
+          groupId: part.groupId,
+          groupType: part.groupType,
+          parts: childParts,
+          ...(part.answer ? { answer: part.answer } : {}),
+          ...(part.reasoning ? { reasoning: part.reasoning } : {}),
+          ...(part.metadata ? { metadata: part.metadata } : {}),
+        })
       }
     }
   }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -101,10 +101,18 @@ export {
   SectionTextEntry,
   SectionTextPart,
   SectionImagePart,
+  SectionGroupPart,
+  type SectionGroupPartType,
   SectionPart,
   PageSection,
   PageSectioningOutput,
   buildPageSectioningLLMSchema,
+  type LLMPartGroup,
+  type LLMPartGroupItem,
+  type LLMSectionPart,
+  flattenParts,
+  flattenImageParts,
+  flattenTextParts,
 } from "./page-sectioning.js"
 
 export {

--- a/packages/types/src/page-sectioning.ts
+++ b/packages/types/src/page-sectioning.ts
@@ -25,8 +25,41 @@ export const SectionImagePart = z.object({
 })
 export type SectionImagePart = z.infer<typeof SectionImagePart>
 
-export const SectionPart = z.discriminatedUnion("type", [SectionTextPart, SectionImagePart])
-export type SectionPart = z.infer<typeof SectionPart>
+/**
+ * A recursive group that nests other parts (text_group, image, or nested groups).
+ * Used to express structural roles within activity sections (e.g., question, option)
+ * and layout grouping in content sections.
+ */
+export const SectionGroupPart: z.ZodType<SectionGroupPartType> = z.object({
+  type: z.literal("group"),
+  groupId: z.string(),
+  groupType: z.string(),
+  parts: z.lazy(() => z.array(SectionPart)),
+  isPruned: z.boolean(),
+  answer: z.string().optional(),
+  reasoning: z.string().optional(),
+  metadata: z.record(z.unknown()).optional(),
+})
+
+export type SectionGroupPartType = {
+  type: "group"
+  groupId: string
+  groupType: string
+  parts: SectionPart[]
+  isPruned: boolean
+  answer?: string
+  reasoning?: string
+  metadata?: Record<string, unknown>
+}
+
+// Use z.union instead of z.discriminatedUnion because z.lazy is not compatible
+// with discriminatedUnion. The "type" field still acts as the discriminator at runtime.
+export const SectionPart: z.ZodType<SectionPart> = z.union([
+  SectionTextPart,
+  SectionImagePart,
+  SectionGroupPart,
+])
+export type SectionPart = SectionTextPart | SectionImagePart | SectionGroupPartType
 
 export const PageSection = z.object({
   sectionId: z.string(),
@@ -45,19 +78,74 @@ export const PageSectioningOutput = z.object({
 })
 export type PageSectioningOutput = z.infer<typeof PageSectioningOutput>
 
+// ---------------------------------------------------------------------------
+// Helpers — recursive part traversal
+// ---------------------------------------------------------------------------
+
+/**
+ * Recursively flatten a parts array, yielding all leaf parts (text_group and image)
+ * in document order. Groups are traversed depth-first; the group wrapper is not included.
+ */
+export function flattenParts(parts: readonly SectionPart[]): (SectionTextPart | SectionImagePart)[] {
+  const result: (SectionTextPart | SectionImagePart)[] = []
+  for (const part of parts) {
+    if (part.type === "group") {
+      result.push(...flattenParts(part.parts))
+    } else {
+      result.push(part)
+    }
+  }
+  return result
+}
+
+/**
+ * Recursively collect all non-pruned image parts from a parts tree.
+ */
+export function flattenImageParts(parts: readonly SectionPart[]): SectionImagePart[] {
+  return flattenParts(parts).filter(
+    (p): p is SectionImagePart => p.type === "image" && !p.isPruned,
+  )
+}
+
+/**
+ * Recursively collect all non-pruned text_group parts from a parts tree.
+ */
+export function flattenTextParts(parts: readonly SectionPart[]): SectionTextPart[] {
+  return flattenParts(parts).filter(
+    (p): p is SectionTextPart => p.type === "text_group" && !p.isPruned,
+  )
+}
+
 /**
  * Build an LLM-facing schema for page sectioning.
  * Enum fields use z.string() so invalid values are caught by our validate
  * callback (which feeds errors back to the LLM) instead of causing a
  * NoObjectGeneratedError that retries blindly.
+ *
+ * The `parts` array accepts:
+ * - Plain string IDs (group IDs, text entry IDs, or image IDs)
+ * - Group objects: `{ group_type, items }` where items can be string IDs
+ *   or nested group objects (max 2 levels: option_group → option → IDs)
  */
 export function buildPageSectioningLLMSchema() {
+  // Leaf group: { group_type, items: string[] }
+  const LeafGroup = z.object({
+    group_type: z.string(),
+    items: z.array(z.string()),
+  })
+
+  // Top-level group: { group_type, items: (string | LeafGroup)[] }
+  const PartGroup = z.object({
+    group_type: z.string(),
+    items: z.array(z.union([z.string(), LeafGroup])),
+  })
+
   return z.object({
     reasoning: z.string(),
     sections: z.array(
       z.object({
         section_type: z.string(),
-        part_ids: z.array(z.string()),
+        parts: z.array(z.union([z.string(), PartGroup])),
         background_color: z.string(),
         text_color: z.string(),
         page_number: z.number().int().nullable(),
@@ -65,3 +153,10 @@ export function buildPageSectioningLLMSchema() {
     ),
   })
 }
+
+/** Type for items in a PartGroup (output from LLM). */
+export type LLMPartGroupItem = string | { group_type: string; items: string[] }
+/** Type for a PartGroup (output from LLM). */
+export type LLMPartGroup = { group_type: string; items: LLMPartGroupItem[] }
+/** Type for a section part in LLM output — plain ID or group. */
+export type LLMSectionPart = string | LLMPartGroup

--- a/prompts/activity_fill_in_a_table.liquid
+++ b/prompts/activity_fill_in_a_table.liquid
@@ -110,13 +110,42 @@ This is the base64 image of the entire page from the textbook for context only.
 Section ID: {{ section_id }}
 Section type: {{ section_type }}
 
-{% for image in images %}
-Image ID: {{ image.image_id }}{% if image.width %} ({{ image.width }}×{{ image.height }}px){% endif %}
-{% image image.image_base64 %}
+Content parts (in document order):
+{% for part in ordered_parts %}
+{% if part.part_type == "text_group" %}
+[Group: {{ part.group_id }} | type: {{ part.group_type }}]
+{% for text in part.texts %}
+  - id: {{ text.text_id }} | type: {{ text.text_type }} | text: "{{ text.text }}"
 {% endfor %}
-
-Allowed text IDs and exact text values (must be copied verbatim):
-{% for text in texts %}
-- id: {{ text.text_id }} | type: {{ text.text_type }} | text: "{{ text.text }}"
+{% elsif part.part_type == "image" %}
+[Image: {{ part.image_id }}{% if part.width %} ({{ part.width }}×{{ part.height }}px){% endif %}]
+{% image part.image_base64 %}
+{% elsif part.part_type == "group" %}
+[{{ part.group_type }}: {{ part.group_id }}]
+{% for child in part.parts %}
+{% if child.part_type == "text_group" %}
+  [Group: {{ child.group_id }} | type: {{ child.group_type }}]
+{% for text in child.texts %}
+    - id: {{ text.text_id }} | type: {{ text.text_type }} | text: "{{ text.text }}"
+{% endfor %}
+{% elsif child.part_type == "image" %}
+  [Image: {{ child.image_id }}{% if child.width %} ({{ child.width }}×{{ child.height }}px){% endif %}]
+  {% image child.image_base64 %}
+{% elsif child.part_type == "group" %}
+  [{{ child.group_type }}: {{ child.group_id }}]
+{% for grandchild in child.parts %}
+{% if grandchild.part_type == "text_group" %}
+    [Group: {{ grandchild.group_id }} | type: {{ grandchild.group_type }}]
+{% for text in grandchild.texts %}
+      - id: {{ text.text_id }} | type: {{ text.text_type }} | text: "{{ text.text }}"
+{% endfor %}
+{% elsif grandchild.part_type == "image" %}
+    [Image: {{ grandchild.image_id }}{% if grandchild.width %} ({{ grandchild.width }}×{{ grandchild.height }}px){% endif %}]
+    {% image grandchild.image_base64 %}
+{% endif %}
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% endif %}
 {% endfor %}
 {% endchat %}

--- a/prompts/activity_fill_in_a_table_answers.liquid
+++ b/prompts/activity_fill_in_a_table_answers.liquid
@@ -109,16 +109,36 @@ IMPORTANT: The `answers` array MUST include ALL `data-activity-item` IDs found i
 This is the base64 image of the entire page from the textbook for context only.
 {% image page_image_base64 %}
 
-{% for image in images %}
-Image ID: {{ image.image_id }}{% if image.width %} ({{ image.width }}×{{ image.height }}px){% endif %}
-{% image image.image_base64 %}
-{% endfor %}
-
 Activity Type: {{ section_type }}
 
-Textbook Context:
-{% for text in texts %}
+Textbook Context (in document order):
+{% for part in ordered_parts %}
+{% if part.part_type == "text_group" %}
+{% for text in part.texts %}
 - {{ text.text }}
+{% endfor %}
+{% elsif part.part_type == "image" %}
+[Image: {{ part.image_id }}{% if part.width %} ({{ part.width }}×{{ part.height }}px){% endif %}]
+{% image part.image_base64 %}
+{% elsif part.part_type == "group" %}
+[{{ part.group_type }}]:
+{% for child in part.parts %}
+{% if child.part_type == "text_group" %}
+{% for text in child.texts %}
+  - {{ text.text }}
+{% endfor %}
+{% elsif child.part_type == "group" %}
+  [{{ child.group_type }}]:
+{% for grandchild in child.parts %}
+{% if grandchild.part_type == "text_group" %}
+{% for text in grandchild.texts %}
+    - {{ text.text }}
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% endif %}
 {% endfor %}
 
 Activity HTML:

--- a/prompts/activity_fill_in_the_blank.liquid
+++ b/prompts/activity_fill_in_the_blank.liquid
@@ -165,13 +165,42 @@ This is the base64 image of the entire page from the textbook for context only.
 Section ID: {{ section_id }}
 Section type: {{ section_type }}
 
-{% for image in images %}
-Image ID: {{ image.image_id }}{% if image.width %} ({{ image.width }}×{{ image.height }}px){% endif %}
-{% image image.image_base64 %}
+Content parts (in document order):
+{% for part in ordered_parts %}
+{% if part.part_type == "text_group" %}
+[Group: {{ part.group_id }} | type: {{ part.group_type }}]
+{% for text in part.texts %}
+  - id: {{ text.text_id }} | type: {{ text.text_type }} | text: "{{ text.text }}"
 {% endfor %}
-
-Allowed text IDs and exact text values (must be copied verbatim):
-{% for text in texts %}
-- id: {{ text.text_id }} | type: {{ text.text_type }} | text: "{{ text.text }}"
+{% elsif part.part_type == "image" %}
+[Image: {{ part.image_id }}{% if part.width %} ({{ part.width }}×{{ part.height }}px){% endif %}]
+{% image part.image_base64 %}
+{% elsif part.part_type == "group" %}
+[{{ part.group_type }}: {{ part.group_id }}]
+{% for child in part.parts %}
+{% if child.part_type == "text_group" %}
+  [Group: {{ child.group_id }} | type: {{ child.group_type }}]
+{% for text in child.texts %}
+    - id: {{ text.text_id }} | type: {{ text.text_type }} | text: "{{ text.text }}"
+{% endfor %}
+{% elsif child.part_type == "image" %}
+  [Image: {{ child.image_id }}{% if child.width %} ({{ child.width }}×{{ child.height }}px){% endif %}]
+  {% image child.image_base64 %}
+{% elsif child.part_type == "group" %}
+  [{{ child.group_type }}: {{ child.group_id }}]
+{% for grandchild in child.parts %}
+{% if grandchild.part_type == "text_group" %}
+    [Group: {{ grandchild.group_id }} | type: {{ grandchild.group_type }}]
+{% for text in grandchild.texts %}
+      - id: {{ text.text_id }} | type: {{ text.text_type }} | text: "{{ text.text }}"
+{% endfor %}
+{% elsif grandchild.part_type == "image" %}
+    [Image: {{ grandchild.image_id }}{% if grandchild.width %} ({{ grandchild.width }}×{{ grandchild.height }}px){% endif %}]
+    {% image grandchild.image_base64 %}
+{% endif %}
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% endif %}
 {% endfor %}
 {% endchat %}

--- a/prompts/activity_fill_in_the_blank_answers.liquid
+++ b/prompts/activity_fill_in_the_blank_answers.liquid
@@ -103,16 +103,36 @@ Provide correct text for each blank based on:
 This is the base64 image of the entire page from the textbook for context only.
 {% image page_image_base64 %}
 
-{% for image in images %}
-Image ID: {{ image.image_id }}{% if image.width %} ({{ image.width }}×{{ image.height }}px){% endif %}
-{% image image.image_base64 %}
-{% endfor %}
-
 Activity Type: {{ section_type }}
 
-Textbook Context:
-{% for text in texts %}
+Textbook Context (in document order):
+{% for part in ordered_parts %}
+{% if part.part_type == "text_group" %}
+{% for text in part.texts %}
 - {{ text.text }}
+{% endfor %}
+{% elsif part.part_type == "image" %}
+[Image: {{ part.image_id }}{% if part.width %} ({{ part.width }}×{{ part.height }}px){% endif %}]
+{% image part.image_base64 %}
+{% elsif part.part_type == "group" %}
+[{{ part.group_type }}]:
+{% for child in part.parts %}
+{% if child.part_type == "text_group" %}
+{% for text in child.texts %}
+  - {{ text.text }}
+{% endfor %}
+{% elsif child.part_type == "group" %}
+  [{{ child.group_type }}]:
+{% for grandchild in child.parts %}
+{% if grandchild.part_type == "text_group" %}
+{% for text in grandchild.texts %}
+    - {{ text.text }}
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% endif %}
 {% endfor %}
 
 Activity HTML:

--- a/prompts/activity_matching.liquid
+++ b/prompts/activity_matching.liquid
@@ -130,13 +130,42 @@ This is the base64 image of the entire page from the textbook for context only.
 Section ID: {{ section_id }}
 Section type: {{ section_type }}
 
-{% for image in images %}
-Image ID: {{ image.image_id }}{% if image.width %} ({{ image.width }}×{{ image.height }}px){% endif %}
-{% image image.image_base64 %}
+Content parts (in document order):
+{% for part in ordered_parts %}
+{% if part.part_type == "text_group" %}
+[Group: {{ part.group_id }} | type: {{ part.group_type }}]
+{% for text in part.texts %}
+  - id: {{ text.text_id }} | type: {{ text.text_type }} | text: "{{ text.text }}"
 {% endfor %}
-
-Allowed text IDs and exact text values (must be copied verbatim):
-{% for text in texts %}
-- id: {{ text.text_id }} | type: {{ text.text_type }} | text: "{{ text.text }}"
+{% elsif part.part_type == "image" %}
+[Image: {{ part.image_id }}{% if part.width %} ({{ part.width }}×{{ part.height }}px){% endif %}]
+{% image part.image_base64 %}
+{% elsif part.part_type == "group" %}
+[{{ part.group_type }}: {{ part.group_id }}]
+{% for child in part.parts %}
+{% if child.part_type == "text_group" %}
+  [Group: {{ child.group_id }} | type: {{ child.group_type }}]
+{% for text in child.texts %}
+    - id: {{ text.text_id }} | type: {{ text.text_type }} | text: "{{ text.text }}"
+{% endfor %}
+{% elsif child.part_type == "image" %}
+  [Image: {{ child.image_id }}{% if child.width %} ({{ child.width }}×{{ child.height }}px){% endif %}]
+  {% image child.image_base64 %}
+{% elsif child.part_type == "group" %}
+  [{{ child.group_type }}: {{ child.group_id }}]
+{% for grandchild in child.parts %}
+{% if grandchild.part_type == "text_group" %}
+    [Group: {{ grandchild.group_id }} | type: {{ grandchild.group_type }}]
+{% for text in grandchild.texts %}
+      - id: {{ text.text_id }} | type: {{ text.text_type }} | text: "{{ text.text }}"
+{% endfor %}
+{% elsif grandchild.part_type == "image" %}
+    [Image: {{ grandchild.image_id }}{% if grandchild.width %} ({{ grandchild.width }}×{{ grandchild.height }}px){% endif %}]
+    {% image grandchild.image_base64 %}
+{% endif %}
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% endif %}
 {% endfor %}
 {% endchat %}

--- a/prompts/activity_matching_answers.liquid
+++ b/prompts/activity_matching_answers.liquid
@@ -84,16 +84,36 @@ CRITICAL:
 This is the base64 image of the entire page from the textbook for context only.
 {% image page_image_base64 %}
 
-{% for image in images %}
-Image ID: {{ image.image_id }}{% if image.width %} ({{ image.width }}×{{ image.height }}px){% endif %}
-{% image image.image_base64 %}
-{% endfor %}
-
 Activity Type: {{ section_type }}
 
-Textbook Context:
-{% for text in texts %}
+Textbook Context (in document order):
+{% for part in ordered_parts %}
+{% if part.part_type == "text_group" %}
+{% for text in part.texts %}
 - {{ text.text }}
+{% endfor %}
+{% elsif part.part_type == "image" %}
+[Image: {{ part.image_id }}{% if part.width %} ({{ part.width }}×{{ part.height }}px){% endif %}]
+{% image part.image_base64 %}
+{% elsif part.part_type == "group" %}
+[{{ part.group_type }}]:
+{% for child in part.parts %}
+{% if child.part_type == "text_group" %}
+{% for text in child.texts %}
+  - {{ text.text }}
+{% endfor %}
+{% elsif child.part_type == "group" %}
+  [{{ child.group_type }}]:
+{% for grandchild in child.parts %}
+{% if grandchild.part_type == "text_group" %}
+{% for text in grandchild.texts %}
+    - {{ text.text }}
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% endif %}
 {% endfor %}
 
 Activity HTML:

--- a/prompts/activity_multiple_choice.liquid
+++ b/prompts/activity_multiple_choice.liquid
@@ -117,13 +117,42 @@ This is the base64 image of the entire page from the textbook for context only.
 Section ID: {{ section_id }}
 Section type: {{ section_type }}
 
-{% for image in images %}
-Image ID: {{ image.image_id }}{% if image.width %} ({{ image.width }}×{{ image.height }}px){% endif %}
-{% image image.image_base64 %}
+Content parts (in document order):
+{% for part in ordered_parts %}
+{% if part.part_type == "text_group" %}
+[Group: {{ part.group_id }} | type: {{ part.group_type }}]
+{% for text in part.texts %}
+  - id: {{ text.text_id }} | type: {{ text.text_type }} | text: "{{ text.text }}"
 {% endfor %}
-
-Allowed text IDs and exact text values (must be copied verbatim):
-{% for text in texts %}
-- id: {{ text.text_id }} | type: {{ text.text_type }} | text: "{{ text.text }}"
+{% elsif part.part_type == "image" %}
+[Image: {{ part.image_id }}{% if part.width %} ({{ part.width }}×{{ part.height }}px){% endif %}]
+{% image part.image_base64 %}
+{% elsif part.part_type == "group" %}
+[{{ part.group_type }}: {{ part.group_id }}]
+{% for child in part.parts %}
+{% if child.part_type == "text_group" %}
+  [Group: {{ child.group_id }} | type: {{ child.group_type }}]
+{% for text in child.texts %}
+    - id: {{ text.text_id }} | type: {{ text.text_type }} | text: "{{ text.text }}"
+{% endfor %}
+{% elsif child.part_type == "image" %}
+  [Image: {{ child.image_id }}{% if child.width %} ({{ child.width }}×{{ child.height }}px){% endif %}]
+  {% image child.image_base64 %}
+{% elsif child.part_type == "group" %}
+  [{{ child.group_type }}: {{ child.group_id }}]
+{% for grandchild in child.parts %}
+{% if grandchild.part_type == "text_group" %}
+    [Group: {{ grandchild.group_id }} | type: {{ grandchild.group_type }}]
+{% for text in grandchild.texts %}
+      - id: {{ text.text_id }} | type: {{ text.text_type }} | text: "{{ text.text }}"
+{% endfor %}
+{% elsif grandchild.part_type == "image" %}
+    [Image: {{ grandchild.image_id }}{% if grandchild.width %} ({{ grandchild.width }}×{{ grandchild.height }}px){% endif %}]
+    {% image grandchild.image_base64 %}
+{% endif %}
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% endif %}
 {% endfor %}
 {% endchat %}

--- a/prompts/activity_multiple_choice_answers.liquid
+++ b/prompts/activity_multiple_choice_answers.liquid
@@ -81,16 +81,36 @@ CRITICAL:
 This is the base64 image of the entire page from the textbook for context only.
 {% image page_image_base64 %}
 
-{% for image in images %}
-Image ID: {{ image.image_id }}{% if image.width %} ({{ image.width }}×{{ image.height }}px){% endif %}
-{% image image.image_base64 %}
-{% endfor %}
-
 Activity Type: {{ section_type }}
 
-Textbook Context:
-{% for text in texts %}
+Textbook Context (in document order):
+{% for part in ordered_parts %}
+{% if part.part_type == "text_group" %}
+{% for text in part.texts %}
 - {{ text.text }}
+{% endfor %}
+{% elsif part.part_type == "image" %}
+[Image: {{ part.image_id }}{% if part.width %} ({{ part.width }}×{{ part.height }}px){% endif %}]
+{% image part.image_base64 %}
+{% elsif part.part_type == "group" %}
+[{{ part.group_type }}]:
+{% for child in part.parts %}
+{% if child.part_type == "text_group" %}
+{% for text in child.texts %}
+  - {{ text.text }}
+{% endfor %}
+{% elsif child.part_type == "group" %}
+  [{{ child.group_type }}]:
+{% for grandchild in child.parts %}
+{% if grandchild.part_type == "text_group" %}
+{% for text in grandchild.texts %}
+    - {{ text.text }}
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% endif %}
 {% endfor %}
 
 Activity HTML:

--- a/prompts/activity_open_ended_answer.liquid
+++ b/prompts/activity_open_ended_answer.liquid
@@ -121,13 +121,42 @@ This is the base64 image of the entire page from the textbook for context only.
 Section ID: {{ section_id }}
 Section type: {{ section_type }}
 
-{% for image in images %}
-Image ID: {{ image.image_id }}{% if image.width %} ({{ image.width }}×{{ image.height }}px){% endif %}
-{% image image.image_base64 %}
+Content parts (in document order):
+{% for part in ordered_parts %}
+{% if part.part_type == "text_group" %}
+[Group: {{ part.group_id }} | type: {{ part.group_type }}]
+{% for text in part.texts %}
+  - id: {{ text.text_id }} | type: {{ text.text_type }} | text: "{{ text.text }}"
 {% endfor %}
-
-Allowed text IDs and exact text values (must be copied verbatim):
-{% for text in texts %}
-- id: {{ text.text_id }} | type: {{ text.text_type }} | text: "{{ text.text }}"
+{% elsif part.part_type == "image" %}
+[Image: {{ part.image_id }}{% if part.width %} ({{ part.width }}×{{ part.height }}px){% endif %}]
+{% image part.image_base64 %}
+{% elsif part.part_type == "group" %}
+[{{ part.group_type }}: {{ part.group_id }}]
+{% for child in part.parts %}
+{% if child.part_type == "text_group" %}
+  [Group: {{ child.group_id }} | type: {{ child.group_type }}]
+{% for text in child.texts %}
+    - id: {{ text.text_id }} | type: {{ text.text_type }} | text: "{{ text.text }}"
+{% endfor %}
+{% elsif child.part_type == "image" %}
+  [Image: {{ child.image_id }}{% if child.width %} ({{ child.width }}×{{ child.height }}px){% endif %}]
+  {% image child.image_base64 %}
+{% elsif child.part_type == "group" %}
+  [{{ child.group_type }}: {{ child.group_id }}]
+{% for grandchild in child.parts %}
+{% if grandchild.part_type == "text_group" %}
+    [Group: {{ grandchild.group_id }} | type: {{ grandchild.group_type }}]
+{% for text in grandchild.texts %}
+      - id: {{ text.text_id }} | type: {{ text.text_type }} | text: "{{ text.text }}"
+{% endfor %}
+{% elsif grandchild.part_type == "image" %}
+    [Image: {{ grandchild.image_id }}{% if grandchild.width %} ({{ grandchild.width }}×{{ grandchild.height }}px){% endif %}]
+    {% image grandchild.image_base64 %}
+{% endif %}
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% endif %}
 {% endfor %}
 {% endchat %}

--- a/prompts/activity_sorting.liquid
+++ b/prompts/activity_sorting.liquid
@@ -104,13 +104,42 @@ This is the base64 image of the entire page from the textbook for context only.
 Section ID: {{ section_id }}
 Section type: {{ section_type }}
 
-{% for image in images %}
-Image ID: {{ image.image_id }}{% if image.width %} ({{ image.width }}×{{ image.height }}px){% endif %}
-{% image image.image_base64 %}
+Content parts (in document order):
+{% for part in ordered_parts %}
+{% if part.part_type == "text_group" %}
+[Group: {{ part.group_id }} | type: {{ part.group_type }}]
+{% for text in part.texts %}
+  - id: {{ text.text_id }} | type: {{ text.text_type }} | text: "{{ text.text }}"
 {% endfor %}
-
-Allowed text IDs and exact text values (must be copied verbatim):
-{% for text in texts %}
-- id: {{ text.text_id }} | type: {{ text.text_type }} | text: "{{ text.text }}"
+{% elsif part.part_type == "image" %}
+[Image: {{ part.image_id }}{% if part.width %} ({{ part.width }}×{{ part.height }}px){% endif %}]
+{% image part.image_base64 %}
+{% elsif part.part_type == "group" %}
+[{{ part.group_type }}: {{ part.group_id }}]
+{% for child in part.parts %}
+{% if child.part_type == "text_group" %}
+  [Group: {{ child.group_id }} | type: {{ child.group_type }}]
+{% for text in child.texts %}
+    - id: {{ text.text_id }} | type: {{ text.text_type }} | text: "{{ text.text }}"
+{% endfor %}
+{% elsif child.part_type == "image" %}
+  [Image: {{ child.image_id }}{% if child.width %} ({{ child.width }}×{{ child.height }}px){% endif %}]
+  {% image child.image_base64 %}
+{% elsif child.part_type == "group" %}
+  [{{ child.group_type }}: {{ child.group_id }}]
+{% for grandchild in child.parts %}
+{% if grandchild.part_type == "text_group" %}
+    [Group: {{ grandchild.group_id }} | type: {{ grandchild.group_type }}]
+{% for text in grandchild.texts %}
+      - id: {{ text.text_id }} | type: {{ text.text_type }} | text: "{{ text.text }}"
+{% endfor %}
+{% elsif grandchild.part_type == "image" %}
+    [Image: {{ grandchild.image_id }}{% if grandchild.width %} ({{ grandchild.width }}×{{ grandchild.height }}px){% endif %}]
+    {% image grandchild.image_base64 %}
+{% endif %}
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% endif %}
 {% endfor %}
 {% endchat %}

--- a/prompts/activity_sorting_answers.liquid
+++ b/prompts/activity_sorting_answers.liquid
@@ -69,16 +69,36 @@ CRITICAL:
 This is the base64 image of the entire page from the textbook for context only.
 {% image page_image_base64 %}
 
-{% for image in images %}
-Image ID: {{ image.image_id }}{% if image.width %} ({{ image.width }}×{{ image.height }}px){% endif %}
-{% image image.image_base64 %}
-{% endfor %}
-
 Activity Type: {{ section_type }}
 
-Textbook Context:
-{% for text in texts %}
+Textbook Context (in document order):
+{% for part in ordered_parts %}
+{% if part.part_type == "text_group" %}
+{% for text in part.texts %}
 - {{ text.text }}
+{% endfor %}
+{% elsif part.part_type == "image" %}
+[Image: {{ part.image_id }}{% if part.width %} ({{ part.width }}×{{ part.height }}px){% endif %}]
+{% image part.image_base64 %}
+{% elsif part.part_type == "group" %}
+[{{ part.group_type }}]:
+{% for child in part.parts %}
+{% if child.part_type == "text_group" %}
+{% for text in child.texts %}
+  - {{ text.text }}
+{% endfor %}
+{% elsif child.part_type == "group" %}
+  [{{ child.group_type }}]:
+{% for grandchild in child.parts %}
+{% if grandchild.part_type == "text_group" %}
+{% for text in grandchild.texts %}
+    - {{ text.text }}
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% endif %}
 {% endfor %}
 
 Activity HTML:

--- a/prompts/activity_true_false.liquid
+++ b/prompts/activity_true_false.liquid
@@ -130,13 +130,42 @@ This is the base64 image of the entire page from the textbook for context only.
 Section ID: {{ section_id }}
 Section type: {{ section_type }}
 
-{% for image in images %}
-Image ID: {{ image.image_id }}{% if image.width %} ({{ image.width }}×{{ image.height }}px){% endif %}
-{% image image.image_base64 %}
+Content parts (in document order):
+{% for part in ordered_parts %}
+{% if part.part_type == "text_group" %}
+[Group: {{ part.group_id }} | type: {{ part.group_type }}]
+{% for text in part.texts %}
+  - id: {{ text.text_id }} | type: {{ text.text_type }} | text: "{{ text.text }}"
 {% endfor %}
-
-Allowed text IDs and exact text values (must be copied verbatim):
-{% for text in texts %}
-- id: {{ text.text_id }} | type: {{ text.text_type }} | text: "{{ text.text }}"
+{% elsif part.part_type == "image" %}
+[Image: {{ part.image_id }}{% if part.width %} ({{ part.width }}×{{ part.height }}px){% endif %}]
+{% image part.image_base64 %}
+{% elsif part.part_type == "group" %}
+[{{ part.group_type }}: {{ part.group_id }}]
+{% for child in part.parts %}
+{% if child.part_type == "text_group" %}
+  [Group: {{ child.group_id }} | type: {{ child.group_type }}]
+{% for text in child.texts %}
+    - id: {{ text.text_id }} | type: {{ text.text_type }} | text: "{{ text.text }}"
+{% endfor %}
+{% elsif child.part_type == "image" %}
+  [Image: {{ child.image_id }}{% if child.width %} ({{ child.width }}×{{ child.height }}px){% endif %}]
+  {% image child.image_base64 %}
+{% elsif child.part_type == "group" %}
+  [{{ child.group_type }}: {{ child.group_id }}]
+{% for grandchild in child.parts %}
+{% if grandchild.part_type == "text_group" %}
+    [Group: {{ grandchild.group_id }} | type: {{ grandchild.group_type }}]
+{% for text in grandchild.texts %}
+      - id: {{ text.text_id }} | type: {{ text.text_type }} | text: "{{ text.text }}"
+{% endfor %}
+{% elsif grandchild.part_type == "image" %}
+    [Image: {{ grandchild.image_id }}{% if grandchild.width %} ({{ grandchild.width }}×{{ grandchild.height }}px){% endif %}]
+    {% image grandchild.image_base64 %}
+{% endif %}
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% endif %}
 {% endfor %}
 {% endchat %}

--- a/prompts/activity_true_false_answers.liquid
+++ b/prompts/activity_true_false_answers.liquid
@@ -69,16 +69,36 @@ CRITICAL:
 This is the base64 image of the entire page from the textbook for context only.
 {% image page_image_base64 %}
 
-{% for image in images %}
-Image ID: {{ image.image_id }}{% if image.width %} ({{ image.width }}×{{ image.height }}px){% endif %}
-{% image image.image_base64 %}
-{% endfor %}
-
 Activity Type: {{ section_type }}
 
-Textbook Context:
-{% for text in texts %}
+Textbook Context (in document order):
+{% for part in ordered_parts %}
+{% if part.part_type == "text_group" %}
+{% for text in part.texts %}
 - {{ text.text }}
+{% endfor %}
+{% elsif part.part_type == "image" %}
+[Image: {{ part.image_id }}{% if part.width %} ({{ part.width }}×{{ part.height }}px){% endif %}]
+{% image part.image_base64 %}
+{% elsif part.part_type == "group" %}
+[{{ part.group_type }}]:
+{% for child in part.parts %}
+{% if child.part_type == "text_group" %}
+{% for text in child.texts %}
+  - {{ text.text }}
+{% endfor %}
+{% elsif child.part_type == "group" %}
+  [{{ child.group_type }}]:
+{% for grandchild in child.parts %}
+{% if grandchild.part_type == "text_group" %}
+{% for text in grandchild.texts %}
+    - {{ text.text }}
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% endif %}
 {% endfor %}
 
 Activity HTML:

--- a/prompts/page_sectioning.liquid
+++ b/prompts/page_sectioning.liquid
@@ -41,12 +41,13 @@ CLASSIFICATION RULES (use these to disambiguate activity types):
 - activity_other is a last resort — only use it when the learning mechanic itself is truly unique (e.g., free drawing, crafts, physical movement) and no other activity type applies.
 
 RULES:
-- ONLY use IDs that are explicitly listed below in "Text groups" and "Image" entries. Do NOT invent or generate new IDs.
+- ONLY use IDs that are explicitly listed below in "Content parts". Do NOT invent or generate new IDs.
+- You can reference a whole text group by its group ID (e.g., "pg001_gp001") or an individual text entry by its text ID (e.g., "pg001_gp001_tx001"). Both are valid.
 {% if sectioning_mode == "page" %}
 - Create EXACTLY ONE section containing ALL listed group IDs and ALL listed image IDs
 - Choose the single most appropriate section type for the page as a whole
 - ALL listed group IDs and ALL listed image IDs must be assigned to this one section
-- If no image IDs are listed below, do NOT include any image IDs in part_ids
+- If no image IDs are listed below, do NOT include any image IDs in parts
 {% elsif sectioning_mode == "dynamic" %}
 - DEFAULT: Keep all content in a SINGLE section. Prefer one section per page.
 - SPLIT the page into multiple sections when ANY of these conditions are true:
@@ -70,6 +71,31 @@ RULES:
 - Extract page number if visible (headers, footers, margins). Use null if none found
 - For background_color: hex code of predominant background. Default #ffffff
 - For text_color: hex code of predominant text color. Must contrast with background. Default #000000
+
+PARTS FORMAT:
+Each section's "parts" array accepts:
+- Plain string IDs: group IDs, text entry IDs, or image IDs. Use group IDs when the entire group belongs together. Use individual text entry IDs when you need to pair specific texts with images.
+- Group objects for structured pairing: `{ "group_type": "<type>", "items": [...] }` where items are string IDs or nested group objects.
+
+For CONTENT sections: list group IDs and image IDs as plain strings. Example:
+  "parts": ["pg001_gp001", "pg001_im001", "pg001_gp002"]
+
+For ACTIVITY sections where items need pairing (e.g., sorting where each option has a label + image):
+  Use group objects to pair related content. Example for a sorting activity:
+  "parts": [
+    "pg001_gp001",
+    { "group_type": "option_group", "items": [
+      { "group_type": "option", "items": ["pg001_gp002_tx001", "pg001_im001"] },
+      { "group_type": "option", "items": ["pg001_gp002_tx002", "pg001_im002"] }
+    ]}
+  ]
+  This pairs each text label with its corresponding image in an option.
+
+GROUPING GUIDELINES:
+- For multiple choice: wrap answer choices in an option_group, each choice as an option. If a choice has both text and an image, group them together.
+- For sorting/matching: pair each item's label text with its associated image in an option, then wrap all options in an option_group.
+- For content sections: no grouping needed — just list IDs as strings.
+- Only create groups when the content genuinely needs structural pairing for rendering.
 {% endchat %}
 
 {% chat role: "user" %}
@@ -81,16 +107,21 @@ Image {{ image.image_id }}:
 {% image image.imageBase64 %}
 {% endfor %}
 
-Text groups:
+Content parts:
 {% for group in groups %}
-- {{ group.group_id }} ({{ group.group_type }}): {{ group.text }}
+Group {{ group.group_id }} ({{ group.group_type }}):
+{% for text in group.texts %}
+  - {{ text.text_id }} ({{ text.text_type }}): {{ text.text }}
+{% endfor %}
 {% endfor %}
 
 {% if sectioning_mode == "page" %}
 Please place ALL content into a single section.
 {% elsif sectioning_mode == "dynamic" %}
 Keep this page as a single section UNLESS it contains multiple separate activities OR multiple multiple-choice/true-false questions. Split when activities have different types, different instructions, or are visually separate on the page — even if they share the same activity type. Each multiple-choice or true/false question gets its own section.
+For activity sections with paired content (e.g., sorting options with text labels and images), use group objects to structure the pairing.
 {% else %}
 Please organize these into sections.
+For activity sections with paired content (e.g., sorting options with text labels and images), use group objects to structure the pairing.
 {% endif %}
 {% endchat %}

--- a/prompts/web_generation_html.liquid
+++ b/prompts/web_generation_html.liquid
@@ -43,11 +43,6 @@ Page image for context:
 Section ID: {{ section_id }}
 Section type: {{ section_type }}
 
-{% for image in images %}
-Image ID: {{ image.image_id }}
-{% image image.image_base64 %}
-{% endfor %}
-
 Content parts (in document order):
 {% for part in ordered_parts %}
 {% if part.part_type == "text_group" %}
@@ -56,7 +51,34 @@ Content parts (in document order):
   - id: {{ text.text_id }} | type: {{ text.text_type }} | text: "{{ text.text }}"
 {% endfor %}
 {% elsif part.part_type == "image" %}
-[Image: {{ part.image_id }}]
+[Image: {{ part.image_id }}{% if part.width %} ({{ part.width }}×{{ part.height }}px){% endif %}]
+{% image part.image_base64 %}
+{% elsif part.part_type == "group" %}
+[{{ part.group_type }}: {{ part.group_id }}]
+{% for child in part.parts %}
+{% if child.part_type == "text_group" %}
+  [Group: {{ child.group_id }} | type: {{ child.group_type }}]
+{% for text in child.texts %}
+    - id: {{ text.text_id }} | type: {{ text.text_type }} | text: "{{ text.text }}"
+{% endfor %}
+{% elsif child.part_type == "image" %}
+  [Image: {{ child.image_id }}{% if child.width %} ({{ child.width }}×{{ child.height }}px){% endif %}]
+  {% image child.image_base64 %}
+{% elsif child.part_type == "group" %}
+  [{{ child.group_type }}: {{ child.group_id }}]
+{% for grandchild in child.parts %}
+{% if grandchild.part_type == "text_group" %}
+    [Group: {{ grandchild.group_id }} | type: {{ grandchild.group_type }}]
+{% for text in grandchild.texts %}
+      - id: {{ text.text_id }} | type: {{ text.text_type }} | text: "{{ text.text }}"
+{% endfor %}
+{% elsif grandchild.part_type == "image" %}
+    [Image: {{ grandchild.image_id }}{% if grandchild.width %} ({{ grandchild.width }}×{{ grandchild.height }}px){% endif %}]
+    {% image grandchild.image_base64 %}
+{% endif %}
+{% endfor %}
+{% endif %}
+{% endfor %}
 {% endif %}
 {% endfor %}
 {% if user_instructions != "" %}

--- a/prompts/web_generation_html_old.liquid
+++ b/prompts/web_generation_html_old.liquid
@@ -47,14 +47,28 @@ This is the base64 image of the entire page from the textbook for context only.
 
 The section type for this section is: {{ section_type }}.
 
-{% for image in images %}
-ID of the following image is: {{ image.image_id }}.
-{% image image.image_base64 %}
-{% endfor %}
-
-The following are text for the section to use for web asset generation. You may use it verbatim or modify it as needed.
-{% for text in texts %}
+Content parts (in document order):
+{% for part in ordered_parts %}
+{% if part.part_type == "text_group" %}
+{% for text in part.texts %}
 id: {{ text.text_id }} text type: {{ text.text_type }}.
 text: {{ text.text }}
+{% endfor %}
+{% elsif part.part_type == "image" %}
+ID of the following image is: {{ part.image_id }}.
+{% image part.image_base64 %}
+{% elsif part.part_type == "group" %}
+{% for child in part.parts %}
+{% if child.part_type == "text_group" %}
+{% for text in child.texts %}
+id: {{ text.text_id }} text type: {{ text.text_type }}.
+text: {{ text.text }}
+{% endfor %}
+{% elsif child.part_type == "image" %}
+ID of the following image is: {{ child.image_id }}.
+{% image child.image_base64 %}
+{% endif %}
+{% endfor %}
+{% endif %}
 {% endfor %}
 {% endchat %}

--- a/prompts/web_generation_html_overlay.liquid
+++ b/prompts/web_generation_html_overlay.liquid
@@ -269,20 +269,42 @@ Page image for context (use this to determine EXACT positions for each text grou
 Section ID: {{ section_id }}
 Section type: {{ section_type }}
 
-{% for image in images %}
-Image ID: {{ image.image_id }}
-{% image image.image_base64 %}
-{% endfor %}
-
 Page content in DOCUMENT FLOW ORDER (top-to-bottom as they appear on the page).
 Use this ordering plus the page image to determine the vertical position of each group:
 {% for part in ordered_parts %}
-{% if part.part_type == "image" %}
-[IMAGE: {{ part.image_id }}]
-{% else %}
+{% if part.part_type == "text_group" %}
 [TEXT GROUP: {{ part.group_id }} ({{ part.group_type }})]
 {% for text in part.texts %}
   - id: {{ text.text_id }} | type: {{ text.text_type }} | text: "{{ text.text }}"
+{% endfor %}
+{% elsif part.part_type == "image" %}
+[IMAGE: {{ part.image_id }}{% if part.width %} ({{ part.width }}×{{ part.height }}px){% endif %}]
+{% image part.image_base64 %}
+{% elsif part.part_type == "group" %}
+[{{ part.group_type }}: {{ part.group_id }}]
+{% for child in part.parts %}
+{% if child.part_type == "text_group" %}
+  [TEXT GROUP: {{ child.group_id }} ({{ child.group_type }})]
+{% for text in child.texts %}
+    - id: {{ text.text_id }} | type: {{ text.text_type }} | text: "{{ text.text }}"
+{% endfor %}
+{% elsif child.part_type == "image" %}
+  [IMAGE: {{ child.image_id }}{% if child.width %} ({{ child.width }}×{{ child.height }}px){% endif %}]
+  {% image child.image_base64 %}
+{% elsif child.part_type == "group" %}
+  [{{ child.group_type }}: {{ child.group_id }}]
+{% for grandchild in child.parts %}
+{% if grandchild.part_type == "text_group" %}
+    [TEXT GROUP: {{ grandchild.group_id }} ({{ grandchild.group_type }})]
+{% for text in grandchild.texts %}
+      - id: {{ text.text_id }} | type: {{ text.text_type }} | text: "{{ text.text }}"
+{% endfor %}
+{% elsif grandchild.part_type == "image" %}
+    [IMAGE: {{ grandchild.image_id }}{% if grandchild.width %} ({{ grandchild.width }}×{{ grandchild.height }}px){% endif %}]
+    {% image grandchild.image_base64 %}
+{% endif %}
+{% endfor %}
+{% endif %}
 {% endfor %}
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
## Summary

- **Structured page sectioning**: Replace flat `part_ids` with a `parts` union schema (`string | PartGroup`) so the LLM can output nested groups directly (e.g., `option_group > option > text + image`), eliminating the heuristic `structureActivityParts()` post-processing
- **Ordered parts as canonical representation**: Use `ordered_parts` as the single source of truth for rendering, removing redundant flat `texts`, `images`, `groups` arrays from the LLM rendering context. All 16 prompt templates updated to consume `ordered_parts` with nested group support
- **Preserve nested group structure**: Introduce `NestedGroupPart` in web rendering to carry group structure through to the LLM renderer instead of flattening it
- **Individual text entry IDs in sectioning**: Expose per-text-entry IDs (e.g., `pg014_gp009_tx001`) to the sectioning LLM so it can pair specific texts with images in structured groups
- **UI improvements**: Add JSON inspection tab to section data panel, replace separate Text Groups/Images panels in storyboard overview with a unified ordered Content view showing nested group structure

## Test plan
- [x] All 929 tests pass
- [x] TypeScript typecheck clean
- [x] i18n extraction — 0 missing translations
- [ ] Manual: run sectioning on an activity page (e.g., sorting with image+text options) and verify the JSON tab shows nested groups
- [ ] Manual: verify storyboard overview shows parts in document order with nested group indentation