### PR TITLE
Fix MCQ validation, styling, consistency, and add multi-group support

### DIFF
--- a/assets/adt/modules/activities/multiple_choice.js
+++ b/assets/adt/modules/activities/multiple_choice.js
@@ -325,11 +325,6 @@ const selectOption = (option) => {
     groupOptions.forEach(opt => {
         opt.setAttribute('aria-checked', 'false');
         setOptionState(opt, 'default');
-        const feedback = opt.querySelector('.feedback-container');
-        if (feedback) {
-            feedback.classList.add('hidden');
-            feedback.classList.remove('bg-white', 'rounded-md', 'px-3', 'py-2', 'mt-3');
-        }
     });
 
     selectClickedOption(option);
@@ -361,27 +356,11 @@ const clearGroupValidationStyling = (groupName) => {
     const groupOptions = getOptionsForGroup(groupName);
     groupOptions.forEach(option => {
         option.removeAttribute('aria-invalid');
-
-        const feedback = option.querySelector('.feedback-container');
-        if (feedback) {
-            feedback.classList.add('hidden');
-            feedback.classList.remove('bg-white', 'rounded-md', 'px-3', 'py-2', 'mt-3');
-
-            const feedbackIcon = feedback.querySelector('.feedback-icon');
-            const feedbackText = feedback.querySelector('.feedback-text');
-
-            if (feedbackIcon) {
-                feedbackIcon.className = 'feedback-icon';
-                feedbackIcon.textContent = '';
-            }
-            if (feedbackText) {
-                feedbackText.className = 'feedback-text';
-                feedbackText.textContent = '';
-            }
-        }
-
+        option.querySelector('.result-mark')?.remove();
         setOptionState(option, 'default');
     });
+    // Remove summary banner — score changed, will be recalculated on next submit
+    document.querySelector('.mcq-summary-banner')?.remove();
 };
 
 /**
@@ -395,27 +374,12 @@ const clearAllValidationStyling = () => {
 
     document.querySelectorAll(".activity-option").forEach(option => {
         option.removeAttribute('aria-invalid');
-
-        const feedback = option.querySelector('.feedback-container');
-        if (feedback) {
-            feedback.classList.add('hidden');
-            feedback.classList.remove('bg-white', 'rounded-md', 'px-3', 'py-2', 'mt-3');
-
-            const feedbackIcon = feedback.querySelector('.feedback-icon');
-            const feedbackText = feedback.querySelector('.feedback-text');
-
-            if (feedbackIcon) {
-                feedbackIcon.className = 'feedback-icon';
-                feedbackIcon.textContent = '';
-            }
-            if (feedbackText) {
-                feedbackText.className = 'feedback-text';
-                feedbackText.textContent = '';
-            }
-        }
-
+        option.querySelector('.result-mark')?.remove();
         setOptionState(option, 'default');
     });
+
+    // Remove inline summary banner
+    document.querySelector('.mcq-summary-banner')?.remove();
 
     const validationResults = document.getElementById('validation-results-announcement');
     if (validationResults) {
@@ -476,7 +440,10 @@ export const checkMultipleChoice = () => {
         const isCorrect = raw === true || raw === "true";
 
         styleSelectedOption(state.selectedOption, isCorrect);
-        showFeedback(state.selectedOption, isCorrect);
+        showResultMark(state.selectedOption, isCorrect);
+        if (section) {
+            showInlineSummary(section, { correct: isCorrect ? 1 : 0, total: 1, allCorrect: isCorrect });
+        }
         recordAttemptResult(isCorrect);
         if (typeof updateResetButtonVisibility === 'function') {
             updateResetButtonVisibility();
@@ -502,6 +469,9 @@ export const checkMultipleChoice = () => {
         // Check each group — answered groups get correct/incorrect feedback,
         // unanswered groups are marked as skipped (incorrect).
         let allCorrect = true;
+        let correctCount = 0;
+        const totalGroups = allGroupNames.size;
+
         for (const groupName of allGroupNames) {
             const selectedOption = selectedByGroup.get(groupName);
 
@@ -511,9 +481,11 @@ export const checkMultipleChoice = () => {
                 const isCorrect = raw === true || raw === "true";
 
                 styleSelectedOption(selectedOption, isCorrect);
-                showFeedback(selectedOption, isCorrect);
+                showResultMark(selectedOption, isCorrect);
 
-                if (!isCorrect) {
+                if (isCorrect) {
+                    correctCount++;
+                } else {
                     allCorrect = false;
                 }
             } else {
@@ -527,12 +499,15 @@ export const checkMultipleChoice = () => {
                     const isAnswer = raw === true || raw === "true";
                     if (isAnswer) {
                         setOptionState(opt, 'correct');
-                        showFeedback(opt, true);
+                        showResultMark(opt, true);
                     }
                 }
             }
         }
 
+        if (section) {
+            showInlineSummary(section, { correct: correctCount, total: totalGroups, allCorrect });
+        }
         recordAttemptResult(allCorrect);
         if (typeof updateResetButtonVisibility === 'function') {
             updateResetButtonVisibility();
@@ -545,57 +520,71 @@ export const checkMultipleChoice = () => {
     }
 };
 
+/**
+ * Show an inline summary banner at the bottom of the activity section.
+ * Replaces the toast popup for better accessibility — persistent, in-context,
+ * and announced to screen readers via aria-live.
+ */
+const showInlineSummary = (section, { correct, total, allCorrect }) => {
+    // Remove any existing banner
+    section.querySelector('.mcq-summary-banner')?.remove();
+
+    const banner = document.createElement('div');
+    banner.className = 'mcq-summary-banner mt-8 rounded-xl px-6 py-4 flex items-center gap-3 shadow-sm';
+    banner.setAttribute('role', 'status');
+    banner.setAttribute('aria-live', 'polite');
+
+    if (allCorrect) {
+        banner.classList.add('bg-green-50', 'border', 'border-green-200');
+        banner.innerHTML = `
+            <span class="text-2xl" aria-hidden="true">🎉</span>
+            <span class="text-green-800 font-semibold text-lg">${translateText('multiple-choice-correct-answer')}</span>
+        `;
+    } else {
+        banner.classList.add('bg-amber-50', 'border', 'border-amber-200');
+        const scoreText = total > 1
+            ? `${correct} / ${total}`
+            : '';
+        banner.innerHTML = `
+            <span class="text-2xl" aria-hidden="true">🔄</span>
+            <div class="flex flex-col">
+                ${scoreText ? `<span class="text-amber-900 font-semibold text-lg">${scoreText}</span>` : ''}
+                <span class="text-amber-800 text-base">${translateText('multiple-choice-try-again')}</span>
+            </div>
+        `;
+    }
+
+    section.appendChild(banner);
+
+    // Smooth scroll so the banner is visible
+    banner.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+};
+
 const styleSelectedOption = (option, isCorrect) => {
     setOptionState(option, isCorrect ? 'correct' : 'incorrect');
     option.setAttribute('aria-invalid', isCorrect ? 'false' : 'true');
 };
 
 /**
- * Show visual feedback on an option. Pure display — no side effects.
+ * Show a ✓ or ✗ result badge overlaid on the option.
+ * Works universally regardless of option content (text, images, cards).
  */
-const showFeedback = (option, isCorrect) => {
-    const feedbackContainer = option.querySelector('.feedback-container');
+const showResultMark = (option, isCorrect) => {
+    // Remove any existing mark first
+    option.querySelector('.result-mark')?.remove();
 
-    if (!feedbackContainer) {
-        console.warn('Feedback container not found for option:', option);
-        return;
+    const mark = document.createElement('div');
+    mark.className = 'result-mark absolute top-2 right-2 w-8 h-8 rounded-full flex items-center justify-center text-white text-lg font-bold shadow-md';
+    mark.classList.add(isCorrect ? 'bg-green-500' : 'bg-red-400');
+    mark.textContent = isCorrect ? '✓' : '✗';
+    mark.setAttribute('aria-label', isCorrect ? 'Correct' : 'Incorrect');
+
+    // Ensure the option is positioned so the badge can be absolutely placed
+    if (!['relative', 'absolute', 'fixed', 'sticky'].includes(getComputedStyle(option).position)) {
+        option.classList.add('relative');
     }
 
-    const feedbackIcon = feedbackContainer.querySelector('.feedback-icon');
-    const feedbackText = feedbackContainer.querySelector('.feedback-text');
-
-    if (!feedbackIcon || !feedbackText) {
-        console.warn('Feedback children missing for option:', option);
-        return;
-    }
-
-    feedbackContainer.classList.remove('hidden');
-
-    // Ensure feedback is always readable regardless of parent background color.
-    // Use an opaque background with proper contrast for accessibility (WCAG AA).
-    feedbackContainer.classList.add('bg-white', 'rounded-md', 'px-3', 'py-2', 'mt-3');
-
-    const dataExplanation = option.getAttribute('data-explanation');
-    const globalExplanation = window?.multipleChoiceExplanations?.[getActivityItem(option)];
-    const explanation = dataExplanation || globalExplanation;
-
-    if (isCorrect) {
-        feedbackIcon.className = 'feedback-icon hidden';
-        feedbackIcon.textContent = '';
-
-        feedbackText.className = 'feedback-text text-lg font-semibold text-green-800';
-        feedbackText.textContent = explanation || translateText('multiple-choice-correct-answer');
-
-        feedbackContainer.setAttribute('role', 'status');
-        feedbackContainer.setAttribute('aria-live', 'polite');
-    } else {
-        feedbackIcon.className = 'feedback-icon hidden';
-        feedbackIcon.textContent = '';
-        feedbackText.className = 'feedback-text text-lg font-semibold text-red-800';
-        feedbackText.textContent = explanation || translateText('multiple-choice-try-again');
-
-        feedbackContainer.setAttribute('role', 'alert');
-    }
+    option.appendChild(mark);
 };
 
 /**

--- a/assets/adt/modules/activities/multiple_choice.js
+++ b/assets/adt/modules/activities/multiple_choice.js
@@ -8,6 +8,101 @@ import { isTypingTarget } from './shortcut-utils.js';
 
 let multipleChoiceShortcutHandler = null;
 
+// --- Per-group selection tracking ---
+// Maps radio name → selected .activity-option element
+const selectedByGroup = new Map();
+
+// --- Color classes toggled by state (never touch structural/layout classes) ---
+const CIRCLE_BORDER_NEUTRALS = [
+    'border-gray-300', 'border-gray-400',
+    'border-stone-300', 'border-stone-400',
+    'border-neutral-300', 'border-slate-300',
+];
+const CIRCLE_BORDER_STATES = ['border-blue-500', 'border-green-500', 'border-red-500'];
+const CIRCLE_BGS   = ['bg-white', 'bg-blue-500', 'bg-green-500', 'bg-red-500'];
+const CIRCLE_TEXTS  = ['text-gray-500', 'text-white'];
+
+const ALL_CIRCLE_COLORS = [...CIRCLE_BORDER_NEUTRALS, ...CIRCLE_BORDER_STATES, ...CIRCLE_BGS, ...CIRCLE_TEXTS];
+
+const OPTION_RINGS = ['ring-2', 'ring-blue-500', 'ring-green-500', 'ring-red-500'];
+const OPTION_BGS   = ['bg-green-50', 'bg-red-50'];
+
+/**
+ * Find the radio-circle element inside an option.
+ */
+const findCircle = (option) => {
+    const byClass = option.querySelector('.option-letter');
+    if (byClass) return byClass;
+
+    const candidates = option.querySelectorAll('.rounded-full');
+    for (const el of candidates) {
+        if (el.closest('.feedback-container')) continue;
+        if (el.tagName === 'INPUT') continue;
+        if (el.classList.contains('border-2') || el.classList.contains('border')) {
+            return el;
+        }
+    }
+    return null;
+};
+
+/**
+ * Non-destructive state setter: only toggles color classes on the radio circle
+ * element and ring/bg classes on the label. Structural classes are never touched.
+ */
+const setOptionState = (option, stateName) => {
+    const circleEl = findCircle(option);
+    if (circleEl && !isLetterHidden(option)) {
+        circleEl.classList.remove(...ALL_CIRCLE_COLORS);
+
+        if (stateName === 'selected') {
+            circleEl.classList.add('border-blue-500', 'bg-blue-500', 'text-white');
+        } else if (stateName === 'correct') {
+            circleEl.classList.add('border-green-500', 'bg-green-500', 'text-white');
+        } else if (stateName === 'incorrect') {
+            circleEl.classList.add('border-red-500', 'bg-red-500', 'text-white');
+        } else {
+            circleEl.classList.add('border-gray-300', 'bg-white', 'text-gray-500');
+        }
+    }
+
+    option.classList.remove(...OPTION_RINGS, ...OPTION_BGS, 'selected-option');
+
+    if (stateName === 'selected') {
+        option.classList.add('ring-2', 'ring-blue-500', 'selected-option');
+    } else if (stateName === 'correct') {
+        option.classList.add('ring-2', 'ring-green-500', 'bg-green-50');
+    } else if (stateName === 'incorrect') {
+        option.classList.add('ring-2', 'ring-red-500', 'bg-red-50');
+    }
+};
+
+/**
+ * Get the radio group name for an option element.
+ */
+const getGroupName = (option) => {
+    const input = option.querySelector('input[type="radio"]');
+    return input?.getAttribute('name') || 'default';
+};
+
+/**
+ * Get all distinct radio group names within a section.
+ */
+const getGroupNames = (section) => {
+    const names = new Set();
+    section.querySelectorAll('.activity-option input[type="radio"]').forEach(input => {
+        const name = input.getAttribute('name');
+        if (name) names.add(name);
+    });
+    return names;
+};
+
+/**
+ * Get all .activity-option elements that belong to a specific radio group name.
+ */
+const getOptionsForGroup = (groupName) => {
+    return [...document.querySelectorAll('.activity-option')].filter(opt => getGroupName(opt) === groupName);
+};
+
 const restoreSubmitButtonToValidate = () => {
     const submitButton = document.getElementById("submit-button");
     if (!submitButton || submitButton.dataset.submitState !== 'retry') {
@@ -30,7 +125,20 @@ const restoreSubmitButtonToValidate = () => {
 };
 
 export const prepareMultipleChoice = (section) => {
-    restorePreviousSelection(section); // Restaurar selección previa
+    // Clear stale group selections from previous pages
+    selectedByGroup.clear();
+
+    // Self-healing: if the LLM didn't add .activity-option to labels containing
+    // radio inputs, find them and tag them so the rest of the JS works.
+    if (!section.querySelector('.activity-option')) {
+        section.querySelectorAll('label').forEach((label) => {
+            if (label.querySelector('input[type="radio"]')) {
+                label.classList.add('activity-option');
+            }
+        });
+    }
+
+    restorePreviousSelection(section);
 
     const activityOptions = section.querySelectorAll(".activity-option");
 
@@ -44,15 +152,13 @@ export const prepareMultipleChoice = (section) => {
     section.querySelectorAll(".activity-option").forEach((option) => {
         option.addEventListener("click", () => selectOption(option));
 
-        // Keyboard event handling - Enter and Space trigger option selection
         option.addEventListener("keydown", (e) => {
             if (e.key === "Enter" || e.key === " ") {
-                e.preventDefault(); // Prevent scrolling on space
+                e.preventDefault();
                 selectOption(option);
             }
         });
 
-        // Set proper ARIA attributes
         const optionLetter = option.querySelector('.option-letter')?.textContent || '';
         const imgAlt = option.querySelector('img')?.alt || '';
         const shadowInput = option.querySelector('input[type="radio"]');
@@ -60,44 +166,55 @@ export const prepareMultipleChoice = (section) => {
             shadowInput.setAttribute('tabindex', '-1');
         }
 
-        // Create a more descriptive label that includes the image description
         option.setAttribute('aria-label', `Option ${optionLetter}: ${imgAlt}`);
         option.setAttribute('role', 'radio');
         option.setAttribute('aria-checked', 'false');
 
-
-        // Add hover effect classes
         option.classList.add(
             'cursor-pointer',
-            'transition-all',
+            'transition-shadow',
             'duration-200',
             'hover:shadow-md',
             'focus:outline-none',
             'focus:ring-2',
             'focus:ring-blue-500',
-            'focus:ring-opacity-50'
+            'focus:ring-opacity-50',
+            'rounded-lg'
         );
-
-        // Style option label
-        const label = option.querySelector("span");
-        if (label) {
-            label.classList.add(
-                'px-4',
-                'py-2',
-                'rounded-full',
-                'font-medium',
-                'transition-colors',
-                'duration-200'
-            );
-        }
     });
 
-    // Set proper radiogroup role on the container
-    const radioGroup = section.querySelector('[role="group"]');
-    if (radioGroup) {
-        radioGroup.setAttribute('role', 'radiogroup');
-        radioGroup.setAttribute('aria-labelledby', 'question-label');
+    // Set proper radiogroup role on containers.
+    // For multi-group pages, each group's parent should be a radiogroup.
+    const groupNames = getGroupNames(section);
+    if (groupNames.size <= 1) {
+        // Single group — use existing logic
+        let radioGroup = section.querySelector('[role="group"]') || section.querySelector('[role="radiogroup"]');
+        if (!radioGroup) {
+            const firstOption = section.querySelector('.activity-option');
+            if (firstOption) {
+                radioGroup = firstOption.parentElement;
+            }
+        }
+        if (radioGroup) {
+            radioGroup.setAttribute('role', 'radiogroup');
+            radioGroup.setAttribute('aria-labelledby', 'question-label');
+        }
+    } else {
+        // Multiple groups — tag each group's parent as a radiogroup
+        for (const name of groupNames) {
+            const groupOptions = getOptionsForGroup(name);
+            if (groupOptions.length > 0) {
+                const parent = groupOptions[0].parentElement;
+                if (parent && !parent.getAttribute('role')) {
+                    parent.setAttribute('role', 'radiogroup');
+                }
+            }
+        }
+    }
 
+    // Shortcut hint
+    const radioGroup = section.querySelector('[role="radiogroup"]');
+    if (radioGroup) {
         let shortcutHint = radioGroup.querySelector('.quiz-shortcut-hint');
         if (!shortcutHint) {
             shortcutHint = document.createElement('p');
@@ -105,48 +222,52 @@ export const prepareMultipleChoice = (section) => {
             shortcutHint.setAttribute('aria-live', 'polite');
             radioGroup.prepend(shortcutHint);
         }
-
         shortcutHint.textContent = translateText('quiz-shortcut-hint');
     }
 
-    // Allow digit keys (1-9) to select options, Enter to submit
-    const options = [...section.querySelectorAll(".activity-option")];
-    const keyHandler = (e) => {
-        if (isTypingTarget(e.target)) {
-            return;
-        }
-
-        const digit = parseInt(e.key, 10);
-        if (digit >= 1 && digit <= options.length) {
-            e.preventDefault();
-            selectOption(options[digit - 1]);
-        } else if (e.key === "Enter") {
-            const submitButton = document.getElementById("submit-button");
-            if (submitButton) {
-                e.preventDefault();
-                submitButton.click();
-            }
-        }
-    };
-    // Remove any previous handler before adding a new one
+    // Always clean up previous keyboard handler before potentially adding a new one
     if (multipleChoiceShortcutHandler) {
         document.removeEventListener("keydown", multipleChoiceShortcutHandler);
+        multipleChoiceShortcutHandler = null;
     }
-    multipleChoiceShortcutHandler = keyHandler;
-    document.addEventListener("keydown", multipleChoiceShortcutHandler);
+
+    // Keyboard shortcuts — only for single-group pages (ambiguous for multi-group)
+    if (groupNames.size <= 1) {
+        const options = [...section.querySelectorAll(".activity-option")];
+        const keyHandler = (e) => {
+            if (isTypingTarget(e.target)) {
+                return;
+            }
+
+            const digit = parseInt(e.key, 10);
+            if (digit >= 1 && digit <= options.length) {
+                e.preventDefault();
+                selectOption(options[digit - 1]);
+            } else if (e.key === "Enter") {
+                const submitButton = document.getElementById("submit-button");
+                if (submitButton) {
+                    e.preventDefault();
+                    submitButton.click();
+                }
+            }
+        };
+        multipleChoiceShortcutHandler = keyHandler;
+        document.addEventListener("keydown", multipleChoiceShortcutHandler);
+    }
 };
+
 const saveSelectionState = (option) => {
     const activityId = location.pathname
         .substring(location.pathname.lastIndexOf("/") + 1)
         .split(".")[0];
 
-    const areaId = option.closest("[data-area-id]")?.getAttribute("data-area-id") || "default";
-    const storageKey = `${activityId}_${areaId}_multipleChoice`;
+    const groupName = getGroupName(option);
+    const storageKey = `${activityId}_${groupName}_multipleChoice`;
 
     const selectedData = {
         question: option.getAttribute("data-activity-item"),
         value: option.querySelector('input[type="radio"]').value,
-        areaId: areaId
+        groupName,
     };
 
     localStorage.setItem(storageKey, JSON.stringify(selectedData));
@@ -157,21 +278,28 @@ const restorePreviousSelection = (section) => {
         .substring(location.pathname.lastIndexOf("/") + 1)
         .split(".")[0];
 
-    const areaId = section.querySelector("[data-area-id]")?.getAttribute("data-area-id") || "default";
-    const storageKey = `${activityId}_${areaId}_multipleChoice`;
+    const groupNames = getGroupNames(section);
 
-    const savedSelection = localStorage.getItem(storageKey);
-    if (savedSelection) {
-        const { value } = JSON.parse(savedSelection);
+    for (const groupName of groupNames) {
+        const storageKey = `${activityId}_${groupName}_multipleChoice`;
+        const savedSelection = localStorage.getItem(storageKey);
 
-        const selectedOption = [...section.querySelectorAll(".activity-option")].find(option =>
-            option.querySelector('input[type="radio"]').value === value
-        );
+        if (savedSelection) {
+            const { value } = JSON.parse(savedSelection);
+            const selectedOption = [...section.querySelectorAll(".activity-option")].find(option =>
+                option.querySelector('input[type="radio"]')?.value === value
+            );
 
-        if (selectedOption) {
-            selectClickedOption(selectedOption);
-            setState('selectedOption', selectedOption);
+            if (selectedOption) {
+                selectClickedOption(selectedOption);
+                selectedByGroup.set(groupName, selectedOption);
+            }
         }
+    }
+
+    // Keep legacy state.selectedOption pointing at the last restored option
+    if (selectedByGroup.size > 0) {
+        setState('selectedOption', [...selectedByGroup.values()].pop());
     }
 };
 
@@ -184,49 +312,29 @@ const isLetterHidden = (option) => {
     );
 };
 
-const setLetterAppearance = (option, circleClasses, letterClasses) => {
-    const letterElement = option.querySelector('.option-letter');
-    const circle = letterElement?.parentElement;
-
-    if (!letterElement || !circle) {
-        return;
-    }
-
-    if (isLetterHidden(option)) {
-        circle.className = 'option-letter-wrapper sr-only';
-        letterElement.className = 'option-letter sr-only';
-        return;
-    }
-
-    if (circleClasses) {
-        circle.className = circleClasses;
-    }
-
-    if (letterClasses) {
-        letterElement.className = letterClasses;
-    }
-};
-
-
 const selectOption = (option) => {
-    // Clear all validation styling before selecting a new option
-    clearAllValidationStyling();
+    const groupName = getGroupName(option);
 
-    const activityItem = getActivityItem(option);
+    // Only clear validation styling for THIS group, not all groups
+    clearGroupValidationStyling(groupName);
 
-    const radioGroup = option.closest('[role="radiogroup"]') || option.closest('[role="group"]');
-    if (!radioGroup) {
-        return;
-    }
+    // Reset only options in the same radio group
+    const groupOptions = getOptionsForGroup(groupName);
+    groupOptions.forEach(opt => {
+        opt.setAttribute('aria-checked', 'false');
+        setOptionState(opt, 'default');
+        const feedback = opt.querySelector('.feedback-container');
+        if (feedback) {
+            feedback.classList.add('hidden');
+            feedback.classList.remove('bg-white', 'rounded-md', 'px-3', 'py-2', 'mt-3');
+        }
+    });
 
-    resetOptions(radioGroup);
     selectClickedOption(option);
+    selectedByGroup.set(groupName, option);
+    // Keep legacy single-option state for backward compatibility
     setState('selectedOption', option);
 
-    // Update ARIA attributes
-    radioGroup.querySelectorAll('.activity-option').forEach(opt => {
-        opt.setAttribute('aria-checked', 'false');
-    });
     option.setAttribute('aria-checked', 'true');
 
     // Announce selection to screen readers
@@ -240,36 +348,23 @@ const selectOption = (option) => {
         }, 1000);
     }
 
-    // Guardar en localStorage
     saveSelectionState(option);
-
     restoreSubmitButtonToValidate();
-
-    const shortcutHint = radioGroup?.querySelector('.quiz-shortcut-hint');
-    if (shortcutHint) {
-        shortcutHint.textContent = translateText('quiz-shortcut-hint');
-    }
 };
 
-// New function to clear all validation styling
-const clearAllValidationStyling = () => {
-    // Reset all validation marks
-    document.querySelectorAll(".validation-mark").forEach(mark => {
-        mark.classList.add('hidden');
-        mark.textContent = '';
-    });
-
-    // Reset all option containers
-    document.querySelectorAll(".activity-option").forEach(option => {
-        option.classList.remove('bg-green-50', 'bg-red-50');
+/**
+ * Clear validation styling only for options in a specific radio group.
+ */
+const clearGroupValidationStyling = (groupName) => {
+    const groupOptions = getOptionsForGroup(groupName);
+    groupOptions.forEach(option => {
         option.removeAttribute('aria-invalid');
 
-        // Reset all feedback containers
         const feedback = option.querySelector('.feedback-container');
         if (feedback) {
             feedback.classList.add('hidden');
+            feedback.classList.remove('bg-white', 'rounded-md', 'px-3', 'py-2', 'mt-3');
 
-            // Clear feedback content
             const feedbackIcon = feedback.querySelector('.feedback-icon');
             const feedbackText = feedback.querySelector('.feedback-text');
 
@@ -277,51 +372,53 @@ const clearAllValidationStyling = () => {
                 feedbackIcon.className = 'feedback-icon';
                 feedbackIcon.textContent = '';
             }
-
             if (feedbackText) {
                 feedbackText.className = 'feedback-text';
                 feedbackText.textContent = '';
             }
         }
-        
-        // Reset the letter appearance
-        setLetterAppearance(
-            option,
-            'w-8 h-8 aspect-square rounded-full border-2 border-gray-300 flex items-center justify-center',
-            'option-letter text-gray-500'
-        );
 
-        option.classList.remove('selected-option');
+        setOptionState(option, 'default');
+    });
+};
+
+/**
+ * Clear all validation styling across all groups (used on full reset).
+ */
+const clearAllValidationStyling = () => {
+    document.querySelectorAll(".validation-mark").forEach(mark => {
+        mark.classList.add('hidden');
+        mark.textContent = '';
     });
 
-    // Announce change to screen readers
+    document.querySelectorAll(".activity-option").forEach(option => {
+        option.removeAttribute('aria-invalid');
+
+        const feedback = option.querySelector('.feedback-container');
+        if (feedback) {
+            feedback.classList.add('hidden');
+            feedback.classList.remove('bg-white', 'rounded-md', 'px-3', 'py-2', 'mt-3');
+
+            const feedbackIcon = feedback.querySelector('.feedback-icon');
+            const feedbackText = feedback.querySelector('.feedback-text');
+
+            if (feedbackIcon) {
+                feedbackIcon.className = 'feedback-icon';
+                feedbackIcon.textContent = '';
+            }
+            if (feedbackText) {
+                feedbackText.className = 'feedback-text';
+                feedbackText.textContent = '';
+            }
+        }
+
+        setOptionState(option, 'default');
+    });
+
     const validationResults = document.getElementById('validation-results-announcement');
     if (validationResults) {
         validationResults.textContent = translateText('selection-changed-resubmit');
     }
-};
-
-const resetOptions = (radioGroup) => {
-    radioGroup.querySelectorAll(".activity-option").forEach((opt) => {
-        // Reset aria attributes
-        opt.setAttribute('aria-checked', 'false');
-
-        setLetterAppearance(
-            opt,
-            'w-8 h-8 aspect-square rounded-full border-2 border-gray-300 flex items-center justify-center',
-            'option-letter text-gray-500'
-        );
-
-        // Reset option container
-        opt.classList.remove('bg-green-50', 'bg-red-50');
-    opt.classList.remove('selected-option');
-
-        // Hide feedback
-        const feedback = opt.querySelector('.feedback-container');
-        if (feedback) {
-            feedback.classList.add('hidden');
-        }
-    });
 };
 
 const selectClickedOption = (option) => {
@@ -330,16 +427,8 @@ const selectClickedOption = (option) => {
         input.checked = true;
     }
 
-    // Update ARIA state
     option.setAttribute('aria-checked', 'true');
-
-    setLetterAppearance(
-        option,
-        'w-8 h-8 aspect-square rounded-full border-2 border-blue-500 bg-blue-500 flex items-center justify-center',
-        'option-letter text-white'
-    );
-
-    option.classList.add('selected-option');
+    setOptionState(option, 'selected');
 };
 
 const getActivityItem = (element) => {
@@ -363,55 +452,93 @@ const getActivityItem = (element) => {
 };
 
 export const checkMultipleChoice = () => {
-    if (!state.selectedOption) {
-        // Add announcement for screen readers
-        const announcement = document.getElementById('validation-results-announcement');
-        if (announcement) {
-            announcement.setAttribute('aria-live', 'assertive');
-            announcement.textContent = translateText("select-option-first");
-            setTimeout(() => {
-                announcement.textContent = '';
-            }, 3000);
+    // Collect all groups that have a selection
+    const section = document.querySelector('[data-section-type="activity_multiple_choice"]');
+    const allGroupNames = section ? getGroupNames(section) : new Set();
+    const isSingleGroup = allGroupNames.size <= 1;
+
+    if (isSingleGroup) {
+        // --- Single group: original behavior ---
+        if (!state.selectedOption) {
+            const announcement = document.getElementById('validation-results-announcement');
+            if (announcement) {
+                announcement.setAttribute('aria-live', 'assertive');
+                announcement.textContent = translateText("select-option-first");
+                setTimeout(() => { announcement.textContent = ''; }, 3000);
+            }
+            return;
         }
 
-        return;
-    }
+        const dataActivityItem = getActivityItem(state.selectedOption);
+        const raw = correctAnswers[dataActivityItem];
+        const isCorrect = raw === true || raw === "true";
 
-    const input = state.selectedOption.querySelector('input[type="radio"]');
-    const dataActivityItem = getActivityItem(state.selectedOption);
-    const isCorrect = correctAnswers[dataActivityItem];
+        styleSelectedOption(state.selectedOption, isCorrect);
+        showFeedback(state.selectedOption, isCorrect);
+        recordAttemptResult(isCorrect);
+        if (typeof updateResetButtonVisibility === 'function') {
+            updateResetButtonVisibility();
+        }
+        updateSubmitButtonAndToast(
+            isCorrect,
+            translateText("next-activity"),
+            ActivityTypes.MULTIPLE_CHOICE
+        );
+    } else {
+        // --- Multi-group: check all groups ---
+        // Ensure every group has a selection
+        const unansweredGroups = [];
+        for (const groupName of allGroupNames) {
+            if (!selectedByGroup.has(groupName)) {
+                unansweredGroups.push(groupName);
+            }
+        }
 
-    styleSelectedOption(state.selectedOption, isCorrect);
-    showFeedback(state.selectedOption, isCorrect);
-    // Add this line to update reset button visibility
-    if (typeof updateResetButtonVisibility === 'function') {
-        updateResetButtonVisibility();
+        if (unansweredGroups.length > 0) {
+            const announcement = document.getElementById('validation-results-announcement');
+            if (announcement) {
+                announcement.setAttribute('aria-live', 'assertive');
+                announcement.textContent = translateText("select-option-first");
+                setTimeout(() => { announcement.textContent = ''; }, 3000);
+            }
+            return;
+        }
+
+        // Check each group
+        let allCorrect = true;
+        for (const [groupName, selectedOption] of selectedByGroup) {
+            const dataActivityItem = getActivityItem(selectedOption);
+            const raw = correctAnswers[dataActivityItem];
+            const isCorrect = raw === true || raw === "true";
+
+            styleSelectedOption(selectedOption, isCorrect);
+            showFeedback(selectedOption, isCorrect);
+
+            if (!isCorrect) {
+                allCorrect = false;
+            }
+        }
+
+        recordAttemptResult(allCorrect);
+        if (typeof updateResetButtonVisibility === 'function') {
+            updateResetButtonVisibility();
+        }
+        updateSubmitButtonAndToast(
+            allCorrect,
+            translateText("next-activity"),
+            ActivityTypes.MULTIPLE_CHOICE
+        );
     }
-    updateSubmitButtonAndToast(
-        isCorrect,
-        translateText("next-activity"),
-        ActivityTypes.MULTIPLE_CHOICE
-    );
 };
 
 const styleSelectedOption = (option, isCorrect) => {
-    option.classList.remove('selected-option');
-
-    setLetterAppearance(
-        option,
-        `w-8 h-8 aspect-square rounded-full border-2 flex items-center justify-center ${isCorrect
-            ? 'border-green-500 bg-green-500 text-white'
-            : 'border-red-500 bg-red-500 text-white'
-            }`,
-        'option-letter text-white'
-    );
-
-    option.classList.add(isCorrect ? 'bg-green-50' : 'bg-red-50');
-
-    // Update ARIA for feedback status
+    setOptionState(option, isCorrect ? 'correct' : 'incorrect');
     option.setAttribute('aria-invalid', isCorrect ? 'false' : 'true');
 };
 
+/**
+ * Show visual feedback on an option. Pure display — no side effects.
+ */
 const showFeedback = (option, isCorrect) => {
     const feedbackContainer = option.querySelector('.feedback-container');
 
@@ -430,6 +557,38 @@ const showFeedback = (option, isCorrect) => {
 
     feedbackContainer.classList.remove('hidden');
 
+    // Ensure feedback is always readable regardless of parent background color.
+    // Use an opaque background with proper contrast for accessibility (WCAG AA).
+    feedbackContainer.classList.add('bg-white', 'rounded-md', 'px-3', 'py-2', 'mt-3');
+
+    const dataExplanation = option.getAttribute('data-explanation');
+    const globalExplanation = window?.multipleChoiceExplanations?.[getActivityItem(option)];
+    const explanation = dataExplanation || globalExplanation;
+
+    if (isCorrect) {
+        feedbackIcon.className = 'feedback-icon hidden';
+        feedbackIcon.textContent = '';
+
+        feedbackText.className = 'feedback-text text-lg font-semibold text-green-800';
+        feedbackText.textContent = explanation || translateText('multiple-choice-correct-answer');
+
+        feedbackContainer.setAttribute('role', 'status');
+        feedbackContainer.setAttribute('aria-live', 'polite');
+    } else {
+        feedbackIcon.className = 'feedback-icon hidden';
+        feedbackIcon.textContent = '';
+        feedbackText.className = 'feedback-text text-lg font-semibold text-red-800';
+        feedbackText.textContent = explanation || translateText('multiple-choice-try-again');
+
+        feedbackContainer.setAttribute('role', 'alert');
+    }
+};
+
+/**
+ * Record attempt, play sound, track completion, and send email.
+ * Called once per submit regardless of number of groups.
+ */
+const recordAttemptResult = (isCorrect) => {
     const activityId = location.pathname
         .substring(location.pathname.lastIndexOf("/") + 1)
         .split(".")[0];
@@ -445,28 +604,9 @@ const showFeedback = (option, isCorrect) => {
     intentCount++;
     localStorage.setItem(key, intentCount.toString());
 
-    const dataExplanation = option.getAttribute('data-explanation');
-    const globalExplanation = window?.multipleChoiceExplanations?.[getActivityItem(option)];
-    const explanation = dataExplanation || globalExplanation;
-
     if (isCorrect) {
-        feedbackIcon.className = 'feedback-icon hidden';
-        feedbackIcon.textContent = '';
-
-        feedbackText.className = 'feedback-text text-lg font-semibold text-green-800';
-        if (explanation) {
-            feedbackText.textContent = explanation;
-        } else {
-            feedbackText.textContent = translateText('multiple-choice-correct-answer');
-        }
-        
-        // Set ARIA attributes for feedback
-        feedbackContainer.setAttribute('role', 'status');
-        feedbackContainer.setAttribute('aria-live', 'polite');
-
         playActivitySound('success');
 
-        // Recuperar el arreglo de actividades completadas del localStorage
         const storedActivities = localStorage.getItem("completedActivities");
         let completedActivities = storedActivities ? JSON.parse(storedActivities) : [];
 
@@ -474,30 +614,13 @@ const showFeedback = (option, isCorrect) => {
         const timeDone = new Date().toLocaleString("es-ES");
         const newActivityId = `${activityId}-${namePage}-${intentCount}-${timeDone}`;
 
-        // Remover cualquier entrada anterior con el mismo activityId
         completedActivities = completedActivities.filter(id => !id.startsWith(`${activityId}-`));
-
-        // Agregar la nueva entrada actualizada
         completedActivities.push(newActivityId);
-
-        // Guardar en localStorage
         localStorage.setItem("completedActivities", JSON.stringify(completedActivities));
 
         localStorage.setItem("namePage", document.querySelector("h1")?.innerText ?? "unknown_page");
         executeMail(ActivityTypes.MULTIPLE_CHOICE);
     } else {
-        feedbackIcon.className = 'feedback-icon hidden';
-        feedbackIcon.textContent = '';
-        feedbackText.className = 'feedback-text text-lg font-semibold text-red-800';
-        if (explanation) {
-            feedbackText.textContent = explanation;
-        } else {
-            feedbackText.textContent = translateText('multiple-choice-try-again');
-        }
-        
-        // Set ARIA attributes for feedback
-        feedbackContainer.setAttribute('role', 'alert');
-
         playActivitySound('error');
     }
 };

--- a/assets/adt/modules/activities/multiple_choice.js
+++ b/assets/adt/modules/activities/multiple_choice.js
@@ -138,15 +138,17 @@ export const prepareMultipleChoice = (section) => {
         });
     }
 
-    restorePreviousSelection(section);
-
     const activityOptions = section.querySelectorAll(".activity-option");
 
-    // Remove any previous event listeners
+    // Remove any previous event listeners by cloning nodes.
+    // This must happen BEFORE restorePreviousSelection so that restored
+    // references in selectedByGroup point to the live DOM nodes.
     activityOptions.forEach((option) => {
         const newOption = option.cloneNode(true);
         option.parentNode.replaceChild(newOption, option);
     });
+
+    restorePreviousSelection(section);
 
     // Add new event listeners
     section.querySelectorAll(".activity-option").forEach((option) => {
@@ -486,15 +488,8 @@ export const checkMultipleChoice = () => {
         );
     } else {
         // --- Multi-group: check all groups ---
-        // Ensure every group has a selection
-        const unansweredGroups = [];
-        for (const groupName of allGroupNames) {
-            if (!selectedByGroup.has(groupName)) {
-                unansweredGroups.push(groupName);
-            }
-        }
-
-        if (unansweredGroups.length > 0) {
+        // Require at least one selection before allowing submit
+        if (selectedByGroup.size === 0) {
             const announcement = document.getElementById('validation-results-announcement');
             if (announcement) {
                 announcement.setAttribute('aria-live', 'assertive');
@@ -504,18 +499,37 @@ export const checkMultipleChoice = () => {
             return;
         }
 
-        // Check each group
+        // Check each group — answered groups get correct/incorrect feedback,
+        // unanswered groups are marked as skipped (incorrect).
         let allCorrect = true;
-        for (const [groupName, selectedOption] of selectedByGroup) {
-            const dataActivityItem = getActivityItem(selectedOption);
-            const raw = correctAnswers[dataActivityItem];
-            const isCorrect = raw === true || raw === "true";
+        for (const groupName of allGroupNames) {
+            const selectedOption = selectedByGroup.get(groupName);
 
-            styleSelectedOption(selectedOption, isCorrect);
-            showFeedback(selectedOption, isCorrect);
+            if (selectedOption) {
+                const dataActivityItem = getActivityItem(selectedOption);
+                const raw = correctAnswers[dataActivityItem];
+                const isCorrect = raw === true || raw === "true";
 
-            if (!isCorrect) {
+                styleSelectedOption(selectedOption, isCorrect);
+                showFeedback(selectedOption, isCorrect);
+
+                if (!isCorrect) {
+                    allCorrect = false;
+                }
+            } else {
+                // Unanswered group — highlight the correct option so the student
+                // can see what they missed.
                 allCorrect = false;
+                const groupOptions = getOptionsForGroup(groupName);
+                for (const opt of groupOptions) {
+                    const itemId = getActivityItem(opt);
+                    const raw = correctAnswers[itemId];
+                    const isAnswer = raw === true || raw === "true";
+                    if (isAnswer) {
+                        setOptionState(opt, 'correct');
+                        showFeedback(opt, true);
+                    }
+                }
             }
         }
 

--- a/packages/pipeline/src/web-rendering.ts
+++ b/packages/pipeline/src/web-rendering.ts
@@ -3,6 +3,7 @@ import {
   type AppConfig,
   type SectionRendering,
   type WebRenderingOutput,
+  webRenderingLLMSchema,
   DEFAULT_LLM_MAX_RETRIES,
 } from "@adt/types"
 import type { LLMModel } from "@adt/llm"
@@ -195,6 +196,58 @@ export async function renderPage(
     }
 
     sections.push(rendering)
+  }
+
+  // --- Activity consistency pass ---
+  // When a page has 2+ activity sections of the same type, the LLM may produce
+  // visually inconsistent HTML across them.  Use the first rendered section of
+  // each activity type as the "reference style" and rewrite subsequent ones to
+  // match its structure/classes while preserving their own content.
+  const CONSISTENCY_PROMPT = "activity_multiple_choice_consistency"
+  const activityTypes = new Set(
+    sections
+      .filter((s) => s.sectionType.startsWith("activity_"))
+      .map((s) => s.sectionType)
+  )
+
+  for (const actType of activityTypes) {
+    const group = sections.filter((s) => s.sectionType === actType)
+    if (group.length < 2) continue
+
+    const referenceHtml = group[0].html
+    const config = resolveConfig(actType)
+
+    for (let g = 1; g < group.length; g++) {
+      const target = group[g]
+      try {
+        const result = await getLLMModel(llmModel, config.modelId).generateObject<{
+          reasoning: string
+          content: string
+        }>({
+          schema: webRenderingLLMSchema,
+          prompt: CONSISTENCY_PROMPT,
+          context: {
+            reference_html: referenceHtml,
+            target_html: target.html,
+          },
+          maxRetries: config.maxRetries,
+          maxTokens: 16384,
+          temperature: 0.1,
+          timeoutMs: config.timeoutMs,
+          log: {
+            taskType: "activity-consistency",
+            pageId: input.pageId,
+            promptName: CONSISTENCY_PROMPT,
+          },
+        })
+        target.html = result.object.content
+      } catch (err) {
+        // If consistency pass fails, keep the original HTML — it's better than nothing
+        console.warn(
+          `Activity consistency pass failed for section ${target.sectionIndex}: ${err}`
+        )
+      }
+    }
   }
 
   return { sections }

--- a/prompts/activity_multiple_choice.liquid
+++ b/prompts/activity_multiple_choice.liquid
@@ -35,7 +35,28 @@ Use this exact outer shell:
 7. Do not output visible raw text outside an element that has a valid provided `data-id`. The only exception is single-digit numbers used as option markers.
 8. No markdown, no code fences in `content`, and no additional top-level fields.
 
-## Multiple Choice — Required Interactive Elements
+## Step 1: Determine Question Structure (CRITICAL — do this BEFORE writing any HTML)
+
+Analyze the page image, the provided images, and the instruction text to determine how many **independent questions** this activity contains and how many **options per question**.
+
+### Counting rules
+1. Look at the **page image layout** — how are images and content visually grouped? Rows, columns, grids, pairs?
+2. Count the provided images. If there are N images and the activity involves **comparing or choosing between image pairs** (e.g., big vs small, correct vs incorrect, before vs after), then you have **N/2 questions with 2 options each**, not 1 question with N options.
+3. If images are arranged in **rows of 2** on the page (side by side), each row is almost certainly one question with 2 image options.
+4. If images are arranged in a **grid of 4+** and the student picks ONE, that is 1 question with multiple options.
+5. The instruction text describes the **task** (e.g., "circle the big picture"), NOT the question count. Do not let it mislead you — always verify against the visual layout.
+
+### Radio group assignment
+- Each independent question gets its own unique radio `name` (e.g., `question-1`, `question-2`, …).
+- Option numbering (inside `.option-letter`) restarts at 1 for each question group.
+- If the page has only one question, use a single `name` for all options.
+
+### State your analysis in `reasoning`
+Your `reasoning` field MUST include: how many questions you identified, how many options per question, and why (e.g., "8 images in 4 rows of 2 → 4 binary-choice questions, each comparing big vs small").
+
+## Step 2: Build the HTML
+
+### Multiple Choice — Required Interactive Elements
 
 Each answer option MUST use this exact interactive structure. You have full creative freedom on layout and styling for everything else (non-interactive content, images, question text, etc.), but every selectable option MUST contain these elements exactly:
 
@@ -74,8 +95,11 @@ Each answer option MUST use this exact interactive structure. You have full crea
 - Styling, spacing, and typography for non-interactive elements
 - Whether option content is text, images, or both
 
+### Image card options
+When each option is primarily an image (image-based choices), present each option as a visual card — the image is the main content inside the `<label>`. For **binary image comparison** activities (2 options per question), display each question's options side by side (e.g., `grid grid-cols-2 gap-4`) so both images are visible simultaneously for comparison. Each card/label gets its own `<img>` with `data-id` — do NOT put multiple images inside the same option.
+
 ### Image sizing rule
-For image-based choices, compute each option image's width as a **percentage of the widest option image** and set `style="width:X%"`. Do NOT use fixed pixel widths.
+For image-based choices, compute each option image's width as a **percentage of the widest option image** within that question group and set `style="width:X%"`. Do NOT use fixed pixel widths.
 {% endchat %}
 
 {% chat role: "user" %}

--- a/prompts/activity_multiple_choice.liquid
+++ b/prompts/activity_multiple_choice.liquid
@@ -33,85 +33,53 @@ Use this exact outer shell:
 5. Every image ID used in HTML must be from the provided image list.
 6. Text for each text ID must match the provided text exactly (no paraphrasing, no punctuation/case changes).
 7. Do not output visible raw text outside an element that has a valid provided `data-id`. The only exception is single-digit numbers used as option markers.
-8. Use sequential numbers (1, 2, 3, …) as option markers inside the `.option-letter` element. Do not use letters (A, B, C) as they are not language-neutral.
-9. No markdown, no code fences in `content`, and no additional top-level fields.
+8. No markdown, no code fences in `content`, and no additional top-level fields.
 
-## Multiple Choice Structure
-- Render option rows with radio inputs (`type="radio"`), one shared `name` per question group.
-- Each radio input must include:
-  - `class="sr-only"`
-  - `tabindex="0"`
-  - unique `data-activity-item` value within the section (for answer checking)
-  - descriptive `aria-label`
-- Keep feedback containers present and hidden by default.
-- Image-based choices are valid and encouraged when provided images are the actual options.
-- For image choices, place the option image inside the clickable `<label>` and set `data-id` on `<img>` using a provided image ID.
-- If there are not enough text IDs for per-option visible labels, keep options image-only and use `aria-label` for accessibility.
-- IMPORTANT: Preserve relative image sizes for image-based choices. When pixel dimensions are provided, compute each option image's width as a **percentage of the widest option image** and set `style="width:X%"`. For example, if images are 400px and 200px wide, use `style="width:100%"` and `style="width:50%"`. Also add `class="h-auto rounded"`. Do NOT use `w-full` or fixed pixel widths. This ensures both images scale proportionally when the container shrinks.
+## Multiple Choice — Required Interactive Elements
 
-## Example Pattern (ID placeholders only - replace with provided IDs)
+Each answer option MUST use this exact interactive structure. You have full creative freedom on layout and styling for everything else (non-interactive content, images, question text, etc.), but every selectable option MUST contain these elements exactly:
+
 ```html
-<section class="section mb-8" data-section-type="SECTION_TYPE_FROM_INPUT" data-section-id="SECTION_ID_FROM_INPUT">
-  <div class="questions grow space-y-4" role="group">
-    <div class="mb-4 bg-green-100 rounded-lg p-4">
-      <p data-id="TEXT_ID_FROM_INPUT">EXACT_TEXT_FROM_INPUT</p>
-    </div>
-
-    <div class="option-container">
-      <label class="activity-option flex items-start gap-4 p-4 rounded-lg hover:bg-gray-50 cursor-pointer">
-        <div class="flex-shrink-0">
-          <div class="w-8 h-8 aspect-square rounded-full border-2 border-gray-300 flex items-center justify-center text-gray-500 option-letter">
-            1
-          </div>
-        </div>
-        <div class="flex-grow">
-          <input type="radio" name="question-group-1" value="item-1" data-activity-item="item-1" class="sr-only" tabindex="0" aria-label="Option" />
-          <div class="text-gray-700" data-id="TEXT_ID_FROM_INPUT">EXACT_TEXT_FROM_INPUT</div>
-          <div class="feedback-container mt-2 hidden">
-            <div class="flex items-center gap-2">
-              <span class="feedback-icon w-5 h-5 rounded-full flex items-center justify-center text-sm"></span>
-              <span class="feedback-text text-sm font-medium"></span>
-            </div>
-          </div>
-        </div>
-      </label>
+<label class="activity-option ...YOUR_STYLING_CLASSES...">
+  <div class="...">
+    <div class="w-10 h-10 rounded-full border-2 border-gray-300 bg-white flex items-center justify-center text-gray-500 text-sm font-medium option-letter">NUMBER</div>
+  </div>
+  <div class="flex-grow min-w-0">
+    <input type="radio" name="QUESTION_GROUP" value="ITEM_ID" data-activity-item="ITEM_ID" class="sr-only" tabindex="0" aria-label="DESCRIPTION" />
+    <!-- Option content: text element with data-id, and/or image with data-id -->
+    <div class="feedback-container mt-2 hidden">
+      <div class="flex items-center gap-2">
+        <span class="feedback-icon w-5 h-5 rounded-full flex items-center justify-center text-sm"></span>
+        <span class="feedback-text text-sm font-medium"></span>
+      </div>
     </div>
   </div>
-</section>
+</label>
 ```
 
-## Example Pattern: Image-Based Choices (allowed)
-```html
-<section class="section mb-8" data-section-type="SECTION_TYPE_FROM_INPUT" data-section-id="SECTION_ID_FROM_INPUT">
-  <div class="questions grow space-y-4" role="group">
-    <p data-id="TEXT_ID_FROM_INPUT">EXACT_TEXT_FROM_INPUT</p>
+### Required attributes (do NOT change):
+- `class="activity-option"` on the `<label>` (you may add additional classes)
+- `class="option-letter"` on the number circle div (you may add additional classes)
+- `class="sr-only"` on the radio `<input>`
+- `data-activity-item="ITEM_ID"` on the radio `<input>` — unique per option
+- `class="feedback-container mt-2 hidden"` on the feedback wrapper
+- `class="feedback-icon ..."` and `class="feedback-text ..."` on the feedback children
+- Sequential numbers (1, 2, 3, …) inside `.option-letter` — not letters (A, B, C)
+- One shared `name` attribute per question group on all radio inputs
 
-    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-      <label class="activity-option flex items-start gap-4 p-4 rounded-lg border border-gray-200 hover:bg-gray-50 cursor-pointer">
-        <div class="flex-shrink-0">
-          <div class="w-8 h-8 aspect-square rounded-full border-2 border-gray-300 flex items-center justify-center text-gray-500 option-letter">
-            1
-          </div>
-        </div>
-        <div class="flex-grow">
-          <input type="radio" name="question-group-1" value="item-1" data-activity-item="item-1" class="sr-only" tabindex="0" aria-label="Option 1" />
-          <img data-id="IMAGE_ID_FROM_INPUT" src="images/IMAGE_FILE.png" alt="Option image" style="width:100%" class="h-auto rounded" />
-          <div class="feedback-container mt-2 hidden">
-            <div class="flex items-center gap-2">
-              <span class="feedback-icon w-5 h-5 rounded-full flex items-center justify-center text-sm"></span>
-              <span class="feedback-text text-sm font-medium"></span>
-            </div>
-          </div>
-        </div>
-      </label>
-    </div>
-  </div>
-</section>
-```
+### You decide:
+- Overall page layout (single column, two column grid, etc.)
+- How to present question/instruction text and passage content
+- How to arrange images (inline, grid, etc.)
+- Styling, spacing, and typography for non-interactive elements
+- Whether option content is text, images, or both
+
+### Image sizing rule
+For image-based choices, compute each option image's width as a **percentage of the widest option image** and set `style="width:X%"`. Do NOT use fixed pixel widths.
 {% endchat %}
 
 {% chat role: "user" %}
-This is the base64 image of the entire page from the textbook for context only.
+This is the base64 image of the entire page from the textbook for context.
 {% image page_image_base64 %}
 
 Section ID: {{ section_id }}

--- a/prompts/activity_multiple_choice_answers.liquid
+++ b/prompts/activity_multiple_choice_answers.liquid
@@ -41,8 +41,8 @@ The `answers` field is REQUIRED and must be a JSON array, never null or missing.
 
 ### Activity Structure:
 - **Radio inputs**: Each option has `data-activity-item="<item_id>"` (e.g., "item-1", "item-2", "item-3")
-- **One correct answer**: Only one option should be marked as correct per question
-- **Multiple questions**: If there are multiple questions, provide answers for all
+- **Question groups**: Options sharing the same radio `name` attribute belong to one question group. Each group has exactly ONE correct answer (`true`).
+- **Multiple questions**: A single section may contain multiple question groups (different `name` attributes). Provide answers for ALL options across ALL groups.
 
 ### Your Task:
 For each question, identify which option (by its `data-activity-item` value) is the correct answer based on the context.

--- a/prompts/activity_multiple_choice_consistency.liquid
+++ b/prompts/activity_multiple_choice_consistency.liquid
@@ -1,0 +1,40 @@
+{% chat role: "system" %}
+You are a frontend engineer ensuring visual consistency across a set of activity pages.
+
+## Task
+You are given a **reference HTML** (the first page in a series) and a **target HTML** (a subsequent page). Both are multiple-choice activities from the same textbook page. The target must be rewritten so its **structure, classes, and styling match the reference exactly**, while keeping the target's own content (text, images, IDs, attributes).
+
+## Required Output Contract
+Return valid JSON with exactly two fields:
+```json
+{
+  "reasoning": "1-2 sentence explanation in English of what you changed",
+  "content": "THE_REWRITTEN_HTML"
+}
+```
+
+## Rules
+1. **Match the reference structure exactly**: same wrapper divs, same CSS classes, same grid/flex layout, same spacing utilities, same color classes, same border-radius, same text sizes.
+2. **Preserve ALL target content**: every `data-id`, `data-activity-item`, `data-section-type`, `data-section-id`, text content, image `src`, `aria-label`, radio `name`/`value` — these must remain exactly as in the target.
+3. **Preserve the number of options**: if the target has 3 options and the reference has 4, keep 3. Only the styling/structure changes.
+4. **Copy the reference's class lists verbatim** onto the corresponding elements in the target. For example, if the reference passage container has `class="bg-amber-50 rounded-2xl p-6 space-y-3"`, the target's passage container must use those exact classes.
+5. **Do NOT add or remove content elements** — only restructure/restyle existing ones.
+6. **Do NOT invent new IDs or attributes.**
+7. If the reference has a two-column grid layout, the target must too. If the reference uses a specific option row structure (flex, gap, border classes), replicate it exactly.
+8. The `#content` wrapper and outer shell must match the reference.
+9. If the target already matches the reference, return it unchanged.
+{% endchat %}
+
+{% chat role: "user" %}
+## Reference HTML (match this style exactly)
+```html
+{{ reference_html }}
+```
+
+## Target HTML (rewrite to match reference style)
+```html
+{{ target_html }}
+```
+
+Rewrite the target HTML so its structure and styling match the reference. Keep all target content intact.
+{% endchat %}


### PR DESCRIPTION
## Summary
- Fix answer validation bug where string `"false"` was treated as truthy, causing all options to show as correct
- Replace destructive `className` replacement (`setLetterAppearance`) with non-destructive `classList` toggling (`setOptionState`) to prevent layout instability when selecting/validating options
- Add self-healing JS that auto-patches missing `.activity-option` classes and `role="radiogroup"` attributes on LLM-generated HTML
- Simplify MCQ prompt to a minimal functional skeleton, giving the LLM creative freedom on non-interactive elements while locking down required interactive structure
- Add cross-page visual consistency pass: a second LLM call rewrites subsequent activity sections to match the first section's styling
- Add accessible feedback display with opaque `bg-white` background for WCAG AA contrast compliance
- Support multiple question groups per page with per-group selection tracking, validation, and localStorage persistence
- Extract side effects (sound, email, attempt counter) into `recordAttemptResult` so they fire once per submit, not once per group

## Test plan
- [ ] Generate MCQ pages and verify correct/incorrect feedback displays properly
- [ ] Verify radio button selection doesn't cause layout shifts
- [ ] Generate multi-section MCQ pages and verify visual consistency across sections
- [ ] Test pages with multiple question groups — each group should track independently
- [ ] Verify keyboard shortcuts (1-9) work on single-group pages and are disabled on multi-group pages
- [ ] Check feedback text contrast on various background colors