### PR TITLE
Add empty-state screens for pruned books and storyboard-dependent stages

### DIFF
--- a/apps/studio/eslint-suppressions.json
+++ b/apps/studio/eslint-suppressions.json
@@ -44,11 +44,6 @@
       "count": 3
     }
   },
-  "src/components/pipeline/stages/PreviewView.tsx": {
-    "lingui/no-unlocalized-strings": {
-      "count": 7
-    }
-  },
   "src/components/pipeline/stages/storyboard/components/BookPreviewFrame.tsx": {
     "lingui/no-unlocalized-strings": {
       "count": 2

--- a/apps/studio/eslint.config.js
+++ b/apps/studio/eslint.config.js
@@ -131,10 +131,11 @@ export default [
             "*.info",
             "*.debug",
 
-            // --- Error constructors ---
+            // --- Error constructors & state error setters ---
             "Error",
             "TypeError",
             "RangeError",
+            "setError",
 
             // --- Module system ---
             "require",

--- a/apps/studio/src/components/pipeline/stages/ExportView.tsx
+++ b/apps/studio/src/components/pipeline/stages/ExportView.tsx
@@ -1,12 +1,18 @@
-import { FileDown, Loader2, BookOpen, AlertCircle, GraduationCap } from "lucide-react"
+import { FileDown, Loader2, BookOpen, GraduationCap } from "lucide-react"
 import { Trans } from "@lingui/react/macro"
 import { Button } from "@/components/ui/button"
 import { useBookRun } from "@/hooks/use-book-run"
 import { useExportWatcher } from "@/hooks/use-export-watcher"
+import { usePages } from "@/hooks/use-pages"
+import { StoryboardRequired, AllPagesPruned } from "./StageEmptyStates"
 
 export function ExportView({ bookLabel }: { bookLabel: string }) {
   const { startExport, isPreparing, preparingFormat, error } = useExportWatcher()
   const { stageState } = useBookRun()
+  const { data: pages } = usePages(bookLabel)
+  const allPagesPruned = pages && pages.length > 0
+    ? pages.every((p) => p.sectionCount > 0 && p.prunedSections.length >= p.sectionCount)
+    : false
   const storyboardDone = stageState("storyboard") === "done"
 
   const adtError = error?.format === "book" ? error.message : null
@@ -14,19 +20,11 @@ export function ExportView({ bookLabel }: { bookLabel: string }) {
   const webpubError = error?.format === "webpub" ? error.message : null
 
   if (!storyboardDone) {
-    return (
-      <div className="p-6 max-w-xl flex flex-col items-center gap-3 text-center">
-        <AlertCircle className="w-8 h-8 text-muted-foreground/50" />
-        <p className="text-sm text-muted-foreground">
-          <Trans>A storyboard must be built before exporting.</Trans>
-        </p>
-        <p className="text-sm text-muted-foreground">
-          <Trans>Run the pipeline through at least the</Trans>{" "}
-          <span className="font-medium text-foreground"><Trans>Storyboard</Trans></span>{" "}
-          <Trans>stage first.</Trans>
-        </p>
-      </div>
-    )
+    return <StoryboardRequired action="exporting" />
+  }
+
+  if (allPagesPruned) {
+    return <AllPagesPruned context="export" />
   }
 
   return (

--- a/apps/studio/src/components/pipeline/stages/PreviewView.tsx
+++ b/apps/studio/src/components/pipeline/stages/PreviewView.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from "react"
 import type { AccessibilityFinding } from "@adt/types"
-import { Loader2, AlertCircle } from "lucide-react"
+import { Loader2 } from "lucide-react"
+import { Trans } from "@lingui/react/macro"
+import { useLingui } from "@lingui/react/macro"
 import { useQueryClient } from "@tanstack/react-query"
 import { useNavigate, useSearch } from "@tanstack/react-router"
 import { api, getAdtUrl } from "@/api/client"
@@ -8,6 +10,8 @@ import { useDebugPanelState } from "@/components/debug/debug-panel-state"
 import { useAccessibilityAssessment } from "@/hooks/use-debug"
 import { useReviewerValidationCatalog } from "@/hooks/use-reviewer-validation"
 import { useBookRun } from "@/hooks/use-book-run"
+import { usePages } from "@/hooks/use-pages"
+import { StoryboardRequired, AllPagesPruned } from "./StageEmptyStates"
 import { useBookTasks } from "@/hooks/use-book-tasks"
 import {
   findAccessibilityPage,
@@ -23,12 +27,17 @@ const HIGHLIGHT_SEVERITY_ATTR = "data-adt-a11y-hover-severity"
 const HIGHLIGHT_PAGE_ATTR = "data-adt-a11y-hover-page"
 
 export function PreviewView({ bookLabel }: { bookLabel: string }) {
+  const { t } = useLingui()
   const queryClient = useQueryClient()
   const navigate = useNavigate()
   const search = useSearch({ strict: false }) as { previewHref?: string }
   const { stageState } = useBookRun()
   const { isTaskRunning, getTask } = useBookTasks(bookLabel)
   const storyboardDone = stageState("storyboard") === "done"
+  const { data: pages } = usePages(bookLabel)
+  const allPagesPruned = pages && pages.length > 0
+    ? pages.every((p) => p.sectionCount > 0 && p.prunedSections.length >= p.sectionCount)
+    : false
   const iframeRef = useRef<HTMLIFrameElement>(null)
   const ranRef = useRef(false)
   const { panelOpen } = useDebugPanelState()
@@ -224,25 +233,18 @@ export function PreviewView({ bookLabel }: { bookLabel: string }) {
   }, [bookLabel, currentPreviewPage.href, navigate, navigatePreviewToHref, ready, search.previewHref])
 
   if (!storyboardDone) {
-    return (
-      <div className="p-6 max-w-xl flex flex-col items-center gap-3 text-center">
-        <AlertCircle className="w-8 h-8 text-muted-foreground/50" />
-        <p className="text-sm text-muted-foreground">
-          A storyboard must be built before previewing.
-        </p>
-        <p className="text-sm text-muted-foreground">
-          Run the pipeline through
-          at least the <span className="font-medium text-foreground">Storyboard</span> stage first.
-        </p>
-      </div>
-    )
+    return <StoryboardRequired action="previewing" />
+  }
+
+  if (allPagesPruned) {
+    return <AllPagesPruned context="preview" />
   }
 
   if (packaging) {
     return (
       <div className="flex items-center justify-center py-12 text-muted-foreground">
         <Loader2 className="w-4 h-4 animate-spin mr-2" />
-        <span className="text-sm">Packaging preview...</span>
+        <span className="text-sm"><Trans>Packaging preview...</Trans></span>
       </div>
     )
   }
@@ -264,7 +266,7 @@ export function PreviewView({ bookLabel }: { bookLabel: string }) {
           ref={iframeRef}
           src={`${getAdtUrl(bookLabel)}/v-${version}/`}
           className="h-full w-full border-0"
-          title="ADT Preview"
+          title={t`ADT Preview`}
           onLoad={syncCurrentPreviewPage}
         />
 
@@ -357,6 +359,7 @@ function ensureHighlightStyles(doc: Document): void {
   if (doc.getElementById(HIGHLIGHT_STYLE_ID)) return
   const style = doc.createElement("style")
   style.id = HIGHLIGHT_STYLE_ID
+  /* eslint-disable lingui/no-unlocalized-strings */
   style.textContent = `
     [${HIGHLIGHT_ATTR}="true"] {
       outline-width: 2px !important;
@@ -425,6 +428,7 @@ function ensureHighlightStyles(doc: Document): void {
       box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.92), 0 0 0 6px rgba(107, 114, 128, 0.2);
     }
   `
+  /* eslint-enable lingui/no-unlocalized-strings */
   doc.head.appendChild(style)
 }
 

--- a/apps/studio/src/components/pipeline/stages/StageEmptyStates.tsx
+++ b/apps/studio/src/components/pipeline/stages/StageEmptyStates.tsx
@@ -2,7 +2,17 @@ import { AlertCircle, FileX2 } from "lucide-react"
 import { Trans } from "@lingui/react/macro"
 import { useLingui } from "@lingui/react/macro"
 
-type StageAction = "previewing" | "exporting" | "running validation" | "adding sign language videos"
+type StageAction =
+  | "previewing"
+  | "exporting"
+  | "running validation"
+  | "adding sign language videos"
+  | "generating quizzes"
+  | "generating captions"
+  | "generating glossary"
+  | "generating table of contents"
+  | "translating"
+  | "generating speech"
 
 export function StoryboardRequired({ action }: { action: StageAction }) {
   const { t } = useLingui()
@@ -12,6 +22,12 @@ export function StoryboardRequired({ action }: { action: StageAction }) {
     "exporting": t`exporting`,
     "running validation": t`running validation`,
     "adding sign language videos": t`adding sign language videos`,
+    "generating quizzes": t`generating quizzes`,
+    "generating captions": t`generating captions`,
+    "generating glossary": t`generating glossary`,
+    "generating table of contents": t`generating table of contents`,
+    "translating": t`translating`,
+    "generating speech": t`generating speech`,
   }
 
   const translatedAction = actionLabels[action]

--- a/apps/studio/src/components/pipeline/stages/StageEmptyStates.tsx
+++ b/apps/studio/src/components/pipeline/stages/StageEmptyStates.tsx
@@ -1,0 +1,61 @@
+import { AlertCircle, FileX2 } from "lucide-react"
+import { Trans } from "@lingui/react/macro"
+import { useLingui } from "@lingui/react/macro"
+
+type StageAction = "previewing" | "exporting" | "running validation" | "adding sign language videos"
+
+export function StoryboardRequired({ action }: { action: StageAction }) {
+  const { t } = useLingui()
+
+  const actionLabels: Record<StageAction, string> = {
+    "previewing": t`previewing`,
+    "exporting": t`exporting`,
+    "running validation": t`running validation`,
+    "adding sign language videos": t`adding sign language videos`,
+  }
+
+  const translatedAction = actionLabels[action]
+
+  return (
+    <div className="h-full flex items-center justify-center">
+      <div className="flex flex-col items-center gap-3 max-w-sm text-center px-6">
+        <AlertCircle className="w-8 h-8 text-muted-foreground/50" />
+        <p className="text-sm text-muted-foreground">
+          <Trans>A storyboard must be built before {translatedAction}.</Trans>
+        </p>
+        <p className="text-sm text-muted-foreground">
+          <Trans>Run the pipeline through at least the <span className="font-medium text-foreground">Storyboard</span> stage first.</Trans>
+        </p>
+      </div>
+    </div>
+  )
+}
+
+type EmptyContext = "preview" | "export"
+
+export function AllPagesPruned({ context }: { context: EmptyContext }) {
+  const { t } = useLingui()
+
+  const titles: Record<EmptyContext, string> = {
+    "preview": t`No pages to preview`,
+    "export": t`Nothing to export`,
+  }
+
+  return (
+    <div className="h-full flex items-center justify-center">
+      <div className="flex flex-col items-center gap-4 max-w-sm text-center px-6">
+        <div className="rounded-full bg-muted/60 p-4">
+          <FileX2 className="w-7 h-7 text-muted-foreground/60" />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <p className="text-sm font-medium text-foreground">
+            {titles[context]}
+          </p>
+          <p className="text-[13px] leading-relaxed text-muted-foreground">
+            <Trans>All pages in this book have been pruned or have no content to render. Return to the <span className="font-medium text-foreground">Extract</span> stage to adjust pruning settings, then re-run the pipeline.</Trans>
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/studio/src/components/pipeline/stages/ValidationView.tsx
+++ b/apps/studio/src/components/pipeline/stages/ValidationView.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
-import { AlertCircle, Loader2, RotateCcw, ShieldCheck } from "lucide-react"
+import { Loader2, RotateCcw, ShieldCheck } from "lucide-react"
 import { useNavigate, useSearch } from "@tanstack/react-router"
 import { Trans, useLingui } from "@lingui/react/macro"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
@@ -10,6 +10,7 @@ import { useBookTasks } from "@/hooks/use-book-tasks"
 import { AccessibilityOverviewTab } from "@/components/validation/AccessibilityValidationTabs"
 import { ReviewerValidationSummaryTab } from "@/components/validation/ReviewerValidationSummaryTab"
 import { useReviewerValidationCatalog } from "@/hooks/use-reviewer-validation"
+import { StoryboardRequired } from "./StageEmptyStates"
 
 const VALIDATION_TABS = new Set([
   "accessibility-summary",
@@ -84,19 +85,7 @@ export function ValidationView({ bookLabel }: { bookLabel: string }) {
   }, [getTask, pendingPackagingTaskId, t])
 
   if (!storyboardDone) {
-    return (
-      <div className="flex max-w-xl flex-col items-center gap-3 p-6 text-center">
-        <AlertCircle className="h-8 w-8 text-muted-foreground/50" />
-        <p className="text-sm text-muted-foreground">
-          <Trans>A storyboard must be built before running validation.</Trans>
-        </p>
-        <p className="text-sm text-muted-foreground">
-          <Trans>
-            Run the pipeline through at least the <span className="font-medium text-foreground">Storyboard</span> stage first.
-          </Trans>
-        </p>
-      </div>
-    )
+    return <StoryboardRequired action="running validation" />
   }
 
   const packaging = isSubmittingPackage || pendingPackagingTaskId !== null || isTaskRunning("package-adt")

--- a/apps/studio/src/components/pipeline/stages/captions/CaptionsView.tsx
+++ b/apps/studio/src/components/pipeline/stages/captions/CaptionsView.tsx
@@ -6,6 +6,7 @@ import type { PageDetail, VersionEntry } from "@/api/client"
 import { usePages, usePage } from "@/hooks/use-pages"
 import { useStepHeader } from "../../components/StepViewRouter"
 import { useBookRun } from "@/hooks/use-book-run"
+import { StoryboardRequired } from "../StageEmptyStates"
 import { useApiKey } from "@/hooks/use-api-key"
 import { invalidateStoryboardDependents } from "@/hooks/use-page-mutations"
 import { StageRunCard } from "../../components/StageRunCard"
@@ -344,6 +345,7 @@ export function CaptionsView({ bookLabel, selectedPageId, onSelectPage }: { book
   const { setExtra } = useStepHeader()
   const { stageState, queueRun } = useBookRun()
   const { apiKey, hasApiKey } = useApiKey()
+  const storyboardDone = stageState("storyboard") === "done"
   const captionsState = stageState("captions")
   const captionsDone = captionsState === "done"
   const captionsRunning = captionsState === "running" || captionsState === "queued"
@@ -415,6 +417,10 @@ export function CaptionsView({ bookLabel, selectedPageId, onSelectPage }: { book
     )
     return () => setExtra(null)
   }, [pages, totalImages, displayPages.length, setExtra, selectedPageId, selectedPageSummary?.pageNumber, selectedPageSummary?.sectionCount, hasSections, sectionIndex, setSectionIndex])
+
+  if (!storyboardDone) {
+    return <StoryboardRequired action="generating captions" />
+  }
 
   if (!showRunCard && isLoading) {
     return (

--- a/apps/studio/src/components/pipeline/stages/glossary/GlossaryView.tsx
+++ b/apps/studio/src/components/pipeline/stages/glossary/GlossaryView.tsx
@@ -7,6 +7,7 @@ import type { GlossaryOutput, VersionEntry } from "@/api/client"
 import { useGlossary } from "@/hooks/use-glossary"
 import { useStepHeader } from "../../components/StepViewRouter"
 import { useBookRun } from "@/hooks/use-book-run"
+import { StoryboardRequired } from "../StageEmptyStates"
 import { useApiKey } from "@/hooks/use-api-key"
 import { StageRunCard } from "../../components/StageRunCard"
 import { useLingui } from "@lingui/react/macro"
@@ -137,6 +138,7 @@ export function GlossaryView({ bookLabel }: { bookLabel: string }) {
   const { setExtra } = useStepHeader()
   const { stageState, queueRun } = useBookRun()
   const { apiKey, hasApiKey } = useApiKey()
+  const storyboardDone = stageState("storyboard") === "done"
   const glossaryState = stageState("glossary")
   const glossaryDone = glossaryState === "done"
   const glossaryRunning = glossaryState === "running" || glossaryState === "queued"
@@ -202,6 +204,10 @@ export function GlossaryView({ bookLabel }: { bookLabel: string }) {
         item.word === word ? { ...item, definition: newDefinition } : item
       ),
     })
+  }
+
+  if (!storyboardDone) {
+    return <StoryboardRequired action="generating glossary" />
   }
 
   if (!showRunCard && isLoading) {

--- a/apps/studio/src/components/pipeline/stages/quizzes/QuizzesView.tsx
+++ b/apps/studio/src/components/pipeline/stages/quizzes/QuizzesView.tsx
@@ -8,6 +8,7 @@ import { usePageImage } from "@/hooks/use-pages"
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog"
 import { useStepHeader } from "../../components/StepViewRouter"
 import { useBookRun } from "@/hooks/use-book-run"
+import { StoryboardRequired } from "../StageEmptyStates"
 import { useApiKey } from "@/hooks/use-api-key"
 import { StageRunCard } from "../../components/StageRunCard"
 import { getRequestedPageId, getQuizImageRenderState } from "./lib/quizzes-image-state"
@@ -277,6 +278,7 @@ export function QuizzesView({ bookLabel, selectedPageId }: { bookLabel: string; 
   const { setExtra } = useStepHeader()
   const { stageState, queueRun } = useBookRun()
   const { apiKey, hasApiKey } = useApiKey()
+  const storyboardDone = stageState("storyboard") === "done"
   const quizzesState = stageState("quizzes")
   const quizzesDone = quizzesState === "done"
   const quizzesRunning = quizzesState === "running" || quizzesState === "queued"
@@ -372,6 +374,10 @@ export function QuizzesView({ bookLabel, selectedPageId }: { bookLabel: string; 
           : q
       ),
     })
+  }
+
+  if (!storyboardDone) {
+    return <StoryboardRequired action="generating quizzes" />
   }
 
   if (!showRunCard && isLoading) {

--- a/apps/studio/src/components/pipeline/stages/sign-language/SignLanguageView.tsx
+++ b/apps/studio/src/components/pipeline/stages/sign-language/SignLanguageView.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useRef, useState } from "react"
 import { Trans, useLingui } from "@lingui/react/macro"
 import { msg } from "@lingui/core/macro"
-import { Upload, Trash2, Video, AlertCircle, Loader2, ArrowUp, ArrowDown, X } from "lucide-react"
+import { Upload, Trash2, Video, Loader2, ArrowUp, ArrowDown, X } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import {
   Select,
@@ -17,6 +17,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog"
 import { useBookRun } from "@/hooks/use-book-run"
+import { StoryboardRequired } from "../StageEmptyStates"
 import { usePages } from "@/hooks/use-pages"
 import {
   useSignLanguageVideos,
@@ -72,19 +73,7 @@ export function SignLanguageView({ bookLabel }: { bookLabel: string }) {
   }, [sortField])
 
   if (!storyboardDone) {
-    return (
-      <div className="p-6 max-w-xl flex flex-col items-center gap-3 text-center">
-        <AlertCircle className="w-8 h-8 text-muted-foreground/50" />
-        <p className="text-sm text-muted-foreground">
-          <Trans>A storyboard must be built before adding sign language videos.</Trans>
-        </p>
-        <p className="text-sm text-muted-foreground">
-          <Trans>Run the pipeline through at least the</Trans>{" "}
-          <span className="font-medium text-foreground"><Trans>Storyboard</Trans></span>{" "}
-          <Trans>stage first.</Trans>
-        </p>
-      </div>
-    )
+    return <StoryboardRequired action="adding sign language videos" />
   }
 
   function handleUpload() {

--- a/apps/studio/src/components/pipeline/stages/toc/TocView.tsx
+++ b/apps/studio/src/components/pipeline/stages/toc/TocView.tsx
@@ -7,6 +7,7 @@ import type { TocGenerationOutput, TocEntry, TocSection, VersionEntry } from "@/
 import { useToc } from "@/hooks/use-toc"
 import { useStepHeader } from "../../components/StepViewRouter"
 import { useBookRun } from "@/hooks/use-book-run"
+import { StoryboardRequired } from "../StageEmptyStates"
 import { useApiKey } from "@/hooks/use-api-key"
 import { StageRunCard } from "../../components/StageRunCard"
 
@@ -240,6 +241,7 @@ export function TocView({ bookLabel }: { bookLabel: string }) {
   const { setExtra } = useStepHeader()
   const { stageState, queueRun } = useBookRun()
   const { apiKey, hasApiKey } = useApiKey()
+  const storyboardDone = stageState("storyboard") === "done"
   const tocState = stageState("toc")
   const tocDone = tocState === "done"
   const tocRunning = tocState === "running" || tocState === "queued"
@@ -353,6 +355,10 @@ export function TocView({ bookLabel }: { bookLabel: string }) {
     const newLevel = Math.max(1, Math.min(3, entry.level + delta))
     if (newLevel === entry.level) return
     updateEntry(id, { level: newLevel })
+  }
+
+  if (!storyboardDone) {
+    return <StoryboardRequired action="generating table of contents" />
   }
 
   if (!showRunCard && isLoading) {

--- a/apps/studio/src/components/pipeline/stages/translations/TranslationsView.tsx
+++ b/apps/studio/src/components/pipeline/stages/translations/TranslationsView.tsx
@@ -8,6 +8,7 @@ import { useActiveConfig } from "@/hooks/use-debug"
 import { useBook } from "@/hooks/use-books"
 import { useStepHeader } from "../../components/StepViewRouter"
 import { useBookRun } from "@/hooks/use-book-run"
+import { StoryboardRequired } from "../StageEmptyStates"
 import { useBookTasks } from "@/hooks/use-book-tasks"
 import { useApiKey } from "@/hooks/use-api-key"
 import { StageRunCard } from "../../components/StageRunCard"
@@ -178,6 +179,7 @@ export function TranslationsView({ bookLabel, stageSlug = "translate", selectedP
   const { stageState, queueRun, error: runError } = useBookRun()
   const { isTaskRunning } = useBookTasks(bookLabel)
   const { apiKey, hasApiKey, azureKey, azureRegion, geminiKey } = useApiKey()
+  const storyboardDone = stageState("storyboard") === "done"
   const translateState = stageState("translate")
   const speechState = stageState("speech")
   const activeState = isSpeechStage ? speechState : translateState
@@ -554,6 +556,10 @@ export function TranslationsView({ bookLabel, stageSlug = "translate", selectedP
     )
     return () => setExtra(null)
   }, [catalog, t, displayEntries.length, outputLanguages.length, selectedLang, translationVersion, saving, dirty, bookLabel, isSourceLang, totalAudioFiles, selectedPageId, currentLanguageUsesGemini, generatedAudioCount, missingAudioCount, hasApiKey, isRunning, apiKey, queueRun, stageSlug, isSpeechStage, handleDeleteTTS, audioLang, transcribeAllMutation, isTaskRunning])
+
+  if (!storyboardDone) {
+    return <StoryboardRequired action={isSpeechStage ? "generating speech" : "translating"} />
+  }
 
   if (!showRunCard && isLoading) {
     return (

--- a/apps/studio/src/components/pipeline/stages/translations/TranslationsView.tsx
+++ b/apps/studio/src/components/pipeline/stages/translations/TranslationsView.tsx
@@ -557,19 +557,6 @@ export function TranslationsView({ bookLabel, stageSlug = "translate", selectedP
     return () => setExtra(null)
   }, [catalog, t, displayEntries.length, outputLanguages.length, selectedLang, translationVersion, saving, dirty, bookLabel, isSourceLang, totalAudioFiles, selectedPageId, currentLanguageUsesGemini, generatedAudioCount, missingAudioCount, hasApiKey, isRunning, apiKey, queueRun, stageSlug, isSpeechStage, handleDeleteTTS, audioLang, transcribeAllMutation, isTaskRunning])
 
-  if (!storyboardDone) {
-    return <StoryboardRequired action={isSpeechStage ? "generating speech" : "translating"} />
-  }
-
-  if (!showRunCard && isLoading) {
-    return (
-      <div className="flex items-center justify-center py-12 text-muted-foreground">
-        <Loader2 className="w-4 h-4 animate-spin mr-2" />
-        <span className="text-sm">{t`Loading text catalog...`}</span>
-      </div>
-    )
-  }
-
   // Resolve speech config summary for display
   const speechSummary = useMemo(() => {
     if (!speechConfig || typeof speechConfig !== "object") {
@@ -583,6 +570,19 @@ export function TranslationsView({ bookLabel, stageSlug = "translate", selectedP
     const providerModel = providers?.[provider]?.model as string | undefined
     return { provider, voice, model: providerModel ?? model ?? "gpt-4o-mini-tts" }
   }, [speechConfig])
+
+  if (!storyboardDone) {
+    return <StoryboardRequired action={isSpeechStage ? "generating speech" : "translating"} />
+  }
+
+  if (!showRunCard && isLoading) {
+    return (
+      <div className="flex items-center justify-center py-12 text-muted-foreground">
+        <Loader2 className="w-4 h-4 animate-spin mr-2" />
+        <span className="text-sm">{t`Loading text catalog...`}</span>
+      </div>
+    )
+  }
 
   if (showRunCard || !catalog || entries.length === 0) {
     return (

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -295,14 +295,17 @@ msgstr "A separator page between sections."
 msgid "A sorting activity."
 msgstr "A sorting activity."
 
-msgid "A storyboard must be built before adding sign language videos."
-msgstr "A storyboard must be built before adding sign language videos."
+msgid "A storyboard must be built before {translatedAction}."
+msgstr "A storyboard must be built before {translatedAction}."
 
-msgid "A storyboard must be built before exporting."
-msgstr "A storyboard must be built before exporting."
+#~ msgid "A storyboard must be built before adding sign language videos."
+#~ msgstr "A storyboard must be built before adding sign language videos."
 
-msgid "A storyboard must be built before running validation."
-msgstr "A storyboard must be built before running validation."
+#~ msgid "A storyboard must be built before exporting."
+#~ msgstr "A storyboard must be built before exporting."
+
+#~ msgid "A storyboard must be built before running validation."
+#~ msgstr "A storyboard must be built before running validation."
 
 msgid "A table-filling activity."
 msgstr "A table-filling activity."
@@ -462,14 +465,17 @@ msgstr "Add Videos"
 msgid "Add your first book"
 msgstr "Add your first book"
 
+msgid "adding sign language videos"
+msgstr "adding sign language videos"
+
 msgid "Additional Languages"
 msgstr "Additional Languages"
 
 msgid "ADT Export"
 msgstr "ADT Export"
 
-#~ msgid "ADT Preview"
-#~ msgstr "ADT Preview"
+msgid "ADT Preview"
+msgstr "ADT Preview"
 
 msgid "Affected pages"
 msgstr "Affected pages"
@@ -525,6 +531,9 @@ msgstr "All Categories"
 
 msgid "All issues and manual review items"
 msgstr "All issues and manual review items"
+
+msgid "All pages in this book have been pruned or have no content to render. Return to the <0>Extract</0> stage to adjust pruning settings, then re-run the pipeline."
+msgstr "All pages in this book have been pruned or have no content to render. Return to the <0>Extract</0> stage to adjust pruning settings, then re-run the pipeline."
 
 msgid "All sections have been deleted"
 msgstr "All sections have been deleted"
@@ -1384,6 +1393,9 @@ msgstr "Export the complete Accessible Digital Textbook as a ZIP archive. Includ
 msgid "Export WebPub"
 msgstr "Export WebPub"
 
+msgid "exporting"
+msgstr "exporting"
+
 msgid "Exporting..."
 msgstr "Exporting..."
 
@@ -2196,6 +2208,9 @@ msgstr "No pages extracted yet"
 msgid "No pages extracted yet. Run the pipeline to extract content."
 msgstr "No pages extracted yet. Run the pipeline to extract content."
 
+msgid "No pages to preview"
+msgstr "No pages to preview"
+
 msgid "No PDF"
 msgstr "No PDF"
 
@@ -2258,6 +2273,9 @@ msgstr "Not detected"
 
 msgid "Not reviewed"
 msgstr "Not reviewed"
+
+msgid "Nothing to export"
+msgstr "Nothing to export"
 
 msgid "Number of pages of content to include per quiz question."
 msgstr "Number of pages of content to include per quiz question."
@@ -2355,8 +2373,8 @@ msgstr "Packaging"
 msgid "Packaging failed"
 msgstr "Packaging failed"
 
-#~ msgid "Packaging preview..."
-#~ msgstr "Packaging preview..."
+msgid "Packaging preview..."
+msgstr "Packaging preview..."
 
 msgid "Packaging validation results..."
 msgstr "Packaging validation results..."
@@ -2487,6 +2505,9 @@ msgstr "Preview linked page"
 
 msgid "Preview of the HTML/CSS patterns used for LLM-generated pages."
 msgstr "Preview of the HTML/CSS patterns used for LLM-generated pages."
+
+msgid "previewing"
+msgstr "previewing"
 
 msgid "Processing metadata…"
 msgstr "Processing metadata…"
@@ -2760,8 +2781,8 @@ msgstr "Rewriting the story of this section..."
 msgid "Run {stageLabel}"
 msgstr "Run {stageLabel}"
 
-msgid "Run the pipeline through at least the"
-msgstr "Run the pipeline through at least the"
+#~ msgid "Run the pipeline through at least the"
+#~ msgstr "Run the pipeline through at least the"
 
 msgid "Run the pipeline through at least the <0>Storyboard</0> stage first."
 msgstr "Run the pipeline through at least the <0>Storyboard</0> stage first."
@@ -2771,6 +2792,9 @@ msgstr "Run whole-book validation checks and configure accessibility assessment 
 
 msgid "Run-only tags"
 msgstr "Run-only tags"
+
+msgid "running validation"
+msgstr "running validation"
 
 msgid "Running Validation..."
 msgstr "Running Validation..."
@@ -3077,8 +3101,8 @@ msgstr "Spread Mode"
 msgid "Sprinkling some digital fairy dust..."
 msgstr "Sprinkling some digital fairy dust..."
 
-msgid "stage first."
-msgstr "stage first."
+#~ msgid "stage first."
+#~ msgstr "stage first."
 
 msgid "Standalone Text"
 msgstr "Standalone Text"

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -1570,17 +1570,32 @@ msgstr "Generate word timestamps"
 msgid "Generates the interactive HTML for this activity type."
 msgstr "Generates the interactive HTML for this activity type."
 
+msgid "generating captions"
+msgstr "generating captions"
+
+msgid "generating glossary"
+msgstr "generating glossary"
+
 msgid "Generating Glossary..."
 msgstr "Generating Glossary..."
 
 msgid "Generating image..."
 msgstr "Generating image..."
 
+msgid "generating quizzes"
+msgstr "generating quizzes"
+
 msgid "Generating Quizzes..."
 msgstr "Generating Quizzes..."
 
+msgid "generating speech"
+msgstr "generating speech"
+
 msgid "Generating Speech..."
 msgstr "Generating Speech..."
+
+msgid "generating table of contents"
+msgstr "generating table of contents"
 
 #~ msgid "Generating Text & Speech..."
 #~ msgstr "Generating Text & Speech..."
@@ -3410,6 +3425,9 @@ msgstr "Track reviewer progress and review findings captured from Preview."
 
 msgid "Translate the book content to output languages."
 msgstr "Translate the book content to output languages."
+
+msgid "translating"
+msgstr "translating"
 
 msgid "Translating languages..."
 msgstr "Translating languages..."

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -1570,17 +1570,32 @@ msgstr "Generar marcas de tiempo por palabra"
 msgid "Generates the interactive HTML for this activity type."
 msgstr "Genera el HTML interactivo para este tipo de actividad."
 
+msgid "generating captions"
+msgstr "generar subtítulos"
+
+msgid "generating glossary"
+msgstr "generar glosario"
+
 msgid "Generating Glossary..."
 msgstr "Generando glosario..."
 
 msgid "Generating image..."
 msgstr "Generando imagen..."
 
+msgid "generating quizzes"
+msgstr "generar cuestionarios"
+
 msgid "Generating Quizzes..."
 msgstr "Generando cuestionarios..."
 
+msgid "generating speech"
+msgstr "generar voz"
+
 msgid "Generating Speech..."
 msgstr "Generando voz..."
+
+msgid "generating table of contents"
+msgstr "generar tabla de contenidos"
 
 #~ msgid "Generating Text & Speech..."
 #~ msgstr "Generando texto y voz..."
@@ -3410,6 +3425,9 @@ msgstr "Track reviewer progress and review findings captured from Preview."
 
 msgid "Translate the book content to output languages."
 msgstr "Traducir el contenido del libro a los idiomas de salida."
+
+msgid "translating"
+msgstr "traducir"
 
 msgid "Translating languages..."
 msgstr "Traduciendo idiomas..."

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -295,14 +295,17 @@ msgstr "Una página separadora entre secciones."
 msgid "A sorting activity."
 msgstr "Una actividad de ordenamiento."
 
-msgid "A storyboard must be built before adding sign language videos."
-msgstr "Se debe crear un guion gráfico antes de agregar videos de lengua de señas."
+msgid "A storyboard must be built before {translatedAction}."
+msgstr "Se debe crear un storyboard antes de {translatedAction}."
 
-msgid "A storyboard must be built before exporting."
-msgstr "Se debe crear un storyboard antes de exportar."
+#~ msgid "A storyboard must be built before adding sign language videos."
+#~ msgstr "Se debe crear un guion gráfico antes de agregar videos de lengua de señas."
 
-msgid "A storyboard must be built before running validation."
-msgstr "A storyboard must be built before running validation."
+#~ msgid "A storyboard must be built before exporting."
+#~ msgstr "Se debe crear un storyboard antes de exportar."
+
+#~ msgid "A storyboard must be built before running validation."
+#~ msgstr "A storyboard must be built before running validation."
 
 msgid "A table-filling activity."
 msgstr "Una actividad de completar tablas."
@@ -462,14 +465,17 @@ msgstr "Agregar Videos"
 msgid "Add your first book"
 msgstr "Agrega tu primer libro"
 
+msgid "adding sign language videos"
+msgstr "agregar videos de lengua de señas"
+
 msgid "Additional Languages"
 msgstr "Idiomas adicionales"
 
 msgid "ADT Export"
 msgstr "Exportación ADT"
 
-#~ msgid "ADT Preview"
-#~ msgstr "Vista previa ADT"
+msgid "ADT Preview"
+msgstr "Vista previa ADT"
 
 msgid "Affected pages"
 msgstr "Affected pages"
@@ -525,6 +531,9 @@ msgstr "All Categories"
 
 msgid "All issues and manual review items"
 msgstr "Todos los problemas y elementos de revisión manual"
+
+msgid "All pages in this book have been pruned or have no content to render. Return to the <0>Extract</0> stage to adjust pruning settings, then re-run the pipeline."
+msgstr "Todas las páginas de este libro han sido eliminadas o no tienen contenido para mostrar. Vuelva a la etapa <0>Extract</0> para ajustar la configuración de eliminación y vuelva a ejecutar el pipeline."
 
 msgid "All sections have been deleted"
 msgstr "Todas las secciones han sido eliminadas"
@@ -1384,6 +1393,9 @@ msgstr "Exporta el Libro de Texto Digital Accesible completo como un archivo ZIP
 msgid "Export WebPub"
 msgstr "Exportar WebPub"
 
+msgid "exporting"
+msgstr "exportar"
+
 msgid "Exporting..."
 msgstr "Exportando..."
 
@@ -2196,6 +2208,9 @@ msgstr "Ninguna página extraída aún"
 msgid "No pages extracted yet. Run the pipeline to extract content."
 msgstr "Aún no se extrajeron páginas. Ejecuta el pipeline para extraer el contenido."
 
+msgid "No pages to preview"
+msgstr "No hay páginas para previsualizar"
+
 msgid "No PDF"
 msgstr "Sin PDF"
 
@@ -2258,6 +2273,9 @@ msgstr "No detectado"
 
 msgid "Not reviewed"
 msgstr "Not reviewed"
+
+msgid "Nothing to export"
+msgstr "Nada para exportar"
 
 msgid "Number of pages of content to include per quiz question."
 msgstr "Número de páginas de contenido a incluir por pregunta de quiz."
@@ -2355,8 +2373,8 @@ msgstr "Empaquetando"
 msgid "Packaging failed"
 msgstr "Packaging failed"
 
-#~ msgid "Packaging preview..."
-#~ msgstr "Empaquetando vista previa..."
+msgid "Packaging preview..."
+msgstr "Empaquetando vista previa..."
 
 msgid "Packaging validation results..."
 msgstr "Packaging validation results..."
@@ -2487,6 +2505,9 @@ msgstr "Vista previa de la página vinculada"
 
 msgid "Preview of the HTML/CSS patterns used for LLM-generated pages."
 msgstr "Vista previa de los patrones HTML/CSS usados para páginas generadas por LLM."
+
+msgid "previewing"
+msgstr "previsualizar"
 
 msgid "Processing metadata…"
 msgstr "Procesando metadatos…"
@@ -2760,17 +2781,20 @@ msgstr "Reescribiendo la historia de esta sección..."
 msgid "Run {stageLabel}"
 msgstr "Ejecutar {0}"
 
-msgid "Run the pipeline through at least the"
-msgstr "Ejecuta el pipeline al menos hasta la etapa"
+#~ msgid "Run the pipeline through at least the"
+#~ msgstr "Ejecuta el pipeline al menos hasta la etapa"
 
 msgid "Run the pipeline through at least the <0>Storyboard</0> stage first."
-msgstr "Run the pipeline through at least the <0>Storyboard</0> stage first."
+msgstr "Ejecute el pipeline al menos hasta la etapa <0>Storyboard</0> primero."
 
 msgid "Run whole-book validation checks and configure accessibility assessment settings."
 msgstr "Run whole-book validation checks and configure accessibility assessment settings."
 
 msgid "Run-only tags"
 msgstr "Run-only tags"
+
+msgid "running validation"
+msgstr "ejecutar la validación"
 
 msgid "Running Validation..."
 msgstr "Running Validation..."
@@ -3077,8 +3101,8 @@ msgstr "Modo de páginas dobles"
 msgid "Sprinkling some digital fairy dust..."
 msgstr "Espolvoreando un poco de polvo mágico digital..."
 
-msgid "stage first."
-msgstr "primero."
+#~ msgid "stage first."
+#~ msgstr "primero."
 
 msgid "Standalone Text"
 msgstr "Texto independiente"

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -1570,17 +1570,32 @@ msgstr "Gerar marcações de tempo por palavra"
 msgid "Generates the interactive HTML for this activity type."
 msgstr "Gera o HTML interativo para este tipo de atividade."
 
+msgid "generating captions"
+msgstr "gerar legendas"
+
+msgid "generating glossary"
+msgstr "gerar glossário"
+
 msgid "Generating Glossary..."
 msgstr "Gerando glossário..."
 
 msgid "Generating image..."
 msgstr "Gerando imagem..."
 
+msgid "generating quizzes"
+msgstr "gerar questionários"
+
 msgid "Generating Quizzes..."
 msgstr "Gerando questionários..."
 
+msgid "generating speech"
+msgstr "gerar áudio"
+
 msgid "Generating Speech..."
 msgstr "Gerando voz..."
+
+msgid "generating table of contents"
+msgstr "gerar índice"
 
 #~ msgid "Generating Text & Speech..."
 #~ msgstr "Gerando texto e fala..."
@@ -3410,6 +3425,9 @@ msgstr "Track reviewer progress and review findings captured from Preview."
 
 msgid "Translate the book content to output languages."
 msgstr "Traduzir o conteúdo do livro para os idiomas de saída."
+
+msgid "translating"
+msgstr "traduzir"
 
 msgid "Translating languages..."
 msgstr "Traduzindo idiomas..."

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -295,14 +295,17 @@ msgstr "Uma página separadora entre seções."
 msgid "A sorting activity."
 msgstr "Uma atividade de ordenação."
 
-msgid "A storyboard must be built before adding sign language videos."
-msgstr "Um storyboard deve ser criado antes de adicionar vídeos de língua de sinais."
+msgid "A storyboard must be built before {translatedAction}."
+msgstr "É necessário criar um storyboard antes de {translatedAction}."
 
-msgid "A storyboard must be built before exporting."
-msgstr "É necessário criar um storyboard antes de exportar."
+#~ msgid "A storyboard must be built before adding sign language videos."
+#~ msgstr "Um storyboard deve ser criado antes de adicionar vídeos de língua de sinais."
 
-msgid "A storyboard must be built before running validation."
-msgstr "A storyboard must be built before running validation."
+#~ msgid "A storyboard must be built before exporting."
+#~ msgstr "É necessário criar um storyboard antes de exportar."
+
+#~ msgid "A storyboard must be built before running validation."
+#~ msgstr "A storyboard must be built before running validation."
 
 msgid "A table-filling activity."
 msgstr "Uma atividade de preenchimento de tabela."
@@ -462,14 +465,17 @@ msgstr "Adicionar Vídeos"
 msgid "Add your first book"
 msgstr "Adicione seu primeiro livro"
 
+msgid "adding sign language videos"
+msgstr "adicionar vídeos de língua de sinais"
+
 msgid "Additional Languages"
 msgstr "Idiomas adicionais"
 
 msgid "ADT Export"
 msgstr "Exportação ADT"
 
-#~ msgid "ADT Preview"
-#~ msgstr "Prévia ADT"
+msgid "ADT Preview"
+msgstr "Prévia ADT"
 
 msgid "Affected pages"
 msgstr "Affected pages"
@@ -525,6 +531,9 @@ msgstr "All Categories"
 
 msgid "All issues and manual review items"
 msgstr "Todos os problemas e itens de revisão manual"
+
+msgid "All pages in this book have been pruned or have no content to render. Return to the <0>Extract</0> stage to adjust pruning settings, then re-run the pipeline."
+msgstr "Todas as páginas deste livro foram removidas ou não têm conteúdo para exibir. Volte à etapa <0>Extract</0> para ajustar as configurações de remoção e execute o pipeline novamente."
 
 msgid "All sections have been deleted"
 msgstr "Todas as seções foram excluídas"
@@ -1384,6 +1393,9 @@ msgstr "Exporte o Accessible Digital Textbook completo como um arquivo ZIP. Incl
 msgid "Export WebPub"
 msgstr "Exportar WebPub"
 
+msgid "exporting"
+msgstr "exportar"
+
 msgid "Exporting..."
 msgstr "Exportando..."
 
@@ -2196,6 +2208,9 @@ msgstr "Nenhuma página extraída ainda"
 msgid "No pages extracted yet. Run the pipeline to extract content."
 msgstr "Nenhuma página extraída ainda. Execute o pipeline para extrair o conteúdo."
 
+msgid "No pages to preview"
+msgstr "Nenhuma página para previsualizar"
+
 msgid "No PDF"
 msgstr "Sem PDF"
 
@@ -2258,6 +2273,9 @@ msgstr "Não detectado"
 
 msgid "Not reviewed"
 msgstr "Not reviewed"
+
+msgid "Nothing to export"
+msgstr "Nada para exportar"
 
 msgid "Number of pages of content to include per quiz question."
 msgstr "Número de páginas de conteúdo a incluir por questão de quiz."
@@ -2355,8 +2373,8 @@ msgstr "Empacotando"
 msgid "Packaging failed"
 msgstr "Packaging failed"
 
-#~ msgid "Packaging preview..."
-#~ msgstr "Empacotando prévia..."
+msgid "Packaging preview..."
+msgstr "Empacotando prévia..."
 
 msgid "Packaging validation results..."
 msgstr "Packaging validation results..."
@@ -2487,6 +2505,9 @@ msgstr "Visualizar página vinculada"
 
 msgid "Preview of the HTML/CSS patterns used for LLM-generated pages."
 msgstr "Pré-visualização dos padrões HTML/CSS usados para páginas geradas por LLM."
+
+msgid "previewing"
+msgstr "previsualizar"
 
 msgid "Processing metadata…"
 msgstr "Processando metadados…"
@@ -2760,17 +2781,20 @@ msgstr "Reescrevendo a história desta seção..."
 msgid "Run {stageLabel}"
 msgstr "Executar {0}"
 
-msgid "Run the pipeline through at least the"
-msgstr "Execute o pipeline pelo menos até a etapa"
+#~ msgid "Run the pipeline through at least the"
+#~ msgstr "Execute o pipeline pelo menos até a etapa"
 
 msgid "Run the pipeline through at least the <0>Storyboard</0> stage first."
-msgstr "Run the pipeline through at least the <0>Storyboard</0> stage first."
+msgstr "Execute o pipeline pelo menos até a etapa <0>Storyboard</0> primeiro."
 
 msgid "Run whole-book validation checks and configure accessibility assessment settings."
 msgstr "Run whole-book validation checks and configure accessibility assessment settings."
 
 msgid "Run-only tags"
 msgstr "Run-only tags"
+
+msgid "running validation"
+msgstr "executar a validação"
 
 msgid "Running Validation..."
 msgstr "Running Validation..."
@@ -3077,8 +3101,8 @@ msgstr "Modo de páginas duplas"
 msgid "Sprinkling some digital fairy dust..."
 msgstr "Salpicando um pouco de pó mágico digital..."
 
-msgid "stage first."
-msgstr "primeiro."
+#~ msgid "stage first."
+#~ msgstr "primeiro."
 
 msgid "Standalone Text"
 msgstr "Texto independente"


### PR DESCRIPTION
Closes #273

## Summary

- Extracted reusable `StoryboardRequired` and `AllPagesPruned` empty-state components from inline implementations scattered across Preview, Export, Validation, and Sign Language views into a shared `StageEmptyStates.tsx` module
- Added user-friendly empty states for Preview and Export when all pages have been pruned, replacing the raw `{"error":"ADT has no pages"}` JSON error
- Extended the `StoryboardRequired` guard to all remaining pipeline stages that depend on a completed storyboard: **Captions, Glossary, Quizzes, ToC, Translate, and Speech**

## Future improvement

Once we have dedicated landing pages for each pipeline step, we can replace these empty-state screens with informative landing pages that explain what the step does. Instead of blocking the entire view, we would just disable the run button and show a message indicating the storyboard needs to be run first — giving users better context about each stage while still preventing premature execution.

## Test plan

- [ ] Open a book where **all pages have been pruned** — verify Preview and Export show the new empty-state screen instead of a JSON error
- [ ] Open a book that has **not run the storyboard** yet — navigate to each dependent stage (Captions, Glossary, Quizzes, ToC, Translate, Speech) and verify the "Storyboard required" empty state is shown
- [ ] Run the storyboard, then verify each stage loads its normal content
- [ ] Check all three locales (en, pt-BR, es) render translated empty-state messages
