### PR TITLE
Fixed-layout EPUB rendering for illustrated storybooks

### DIFF
--- a/apps/adt-runtime/src/features/audio/lib/word-highlight.ts
+++ b/apps/adt-runtime/src/features/audio/lib/word-highlight.ts
@@ -23,19 +23,89 @@ import {
   createApproximateWordTimestamps,
   type WordTimestamp,
 } from "@/features/audio/lib/tokenizer"
+import { parseSegments, styleToInline, type Segment } from "@/shared/lib/fl-segments"
 
 const ORIGINAL_HTML_ATTR = "data-tts-original-html"
 const WORD_HIGHLIGHT_CLASS = "bg-yellow-300"
 const BLOCK_HIGHLIGHT_CLASS = "tts-active-block"
 
 /**
+ * Fixed-layout word wrap: tokenise across the concatenated `data-segments`
+ * text, then for each word emit a `<span data-word-index="N">` containing
+ * the per-segment styled `<span style="…">` slices that overlap the word's
+ * character range. Preserves the styled-run structure (coloured letters,
+ * mixed fonts, contrast strokes) the renderer baked in.
+ */
+function wrapWordsFromSegments(element: HTMLElement, segments: Segment[]): boolean {
+  const plan = buildWordRenderPlan(segments.map((s) => s.text).join(""))
+  if (!plan.some((s) => s.type === "word")) return false
+
+  const doc = element.ownerDocument
+  const segOffsets: number[] = []
+  let cursor = 0
+  for (const s of segments) {
+    segOffsets.push(cursor)
+    cursor += s.text.length
+  }
+
+  const buildPieces = (start: number, end: number): HTMLSpanElement[] => {
+    const out: HTMLSpanElement[] = []
+    for (let i = 0; i < segments.length; i++) {
+      const segStart = segOffsets[i]
+      const segEnd = segStart + segments[i].text.length
+      if (segEnd <= start) continue
+      if (segStart >= end) break
+      const slice = segments[i].text.slice(
+        Math.max(start, segStart) - segStart,
+        Math.min(end, segEnd) - segStart,
+      )
+      if (!slice.length) continue
+      const span = doc.createElement("span")
+      const styleStr = styleToInline(segments[i].style)
+      if (styleStr) span.setAttribute("style", styleStr)
+      span.appendChild(doc.createTextNode(slice))
+      out.push(span)
+    }
+    return out
+  }
+
+  const fragment = doc.createDocumentFragment()
+  let charCursor = 0
+  for (const seg of plan) {
+    if (seg.type === "separator") {
+      if (seg.text.length > 0) fragment.appendChild(doc.createTextNode(seg.text))
+      charCursor += seg.text.length
+      continue
+    }
+    const start = charCursor
+    const end = start + seg.text.length
+    const wrap = doc.createElement("span")
+    wrap.setAttribute("data-word-index", String(seg.wordIndex))
+    for (const piece of buildPieces(start, end)) wrap.appendChild(piece)
+    fragment.appendChild(wrap)
+    charCursor = end
+  }
+  element.replaceChildren(fragment)
+  return true
+}
+
+/**
  * Wrap each whitespace-separated word inside `element` with a span carrying
  * `data-word-index="N"`. Idempotent — calling twice on the same element
- * is a no-op.
+ * is a no-op. When the element carries `data-segments` (fixed-layout
+ * paragraphs with per-run styling), the styled-span structure is preserved
+ * inside each word wrap.
  */
 export function wrapWordsForElement(element: HTMLElement, text: string): void {
   if (element.hasAttribute(ORIGINAL_HTML_ATTR)) return
   element.setAttribute(ORIGINAL_HTML_ATTR, element.innerHTML)
+
+  const segments = parseSegments(element.getAttribute("data-segments"))
+  if (segments && segments.length > 0) {
+    if (wrapWordsFromSegments(element, segments)) return
+    element.removeAttribute(ORIGINAL_HTML_ATTR)
+    return
+  }
 
   const plan = buildWordRenderPlan(text)
   // No matchable words (pure punctuation, empty string) — leave the element

--- a/apps/adt-runtime/src/features/language/runtime/i18n.ts
+++ b/apps/adt-runtime/src/features/language/runtime/i18n.ts
@@ -14,6 +14,7 @@ import {
   translationsAtom,
   videoFilesAtom,
 } from "@/features/language/state/language.atoms"
+import { rebuildSegmentedInnerHtml } from "@/shared/lib/fl-segments"
 
 async function safeJsonFetch<T = unknown>(
   url: string,
@@ -147,15 +148,20 @@ export function applyTranslationsToDOM(
     elements.forEach((el) => {
       if (el.tagName === "IMG") {
         el.setAttribute("alt", text)
-      } else {
-        if ((el as HTMLElement).hasAttribute("data-tts-original-html")) {
-          ;(el as HTMLElement).setAttribute(
-            "data-tts-original-html",
-            renderedHtml,
-          )
-        }
-        ;(el as HTMLElement).innerHTML = renderedHtml
+        return
       }
+      // Fixed-layout paragraphs carry per-run styling on `data-segments`.
+      // Rebuild the styled-span tree from that JSON so font-family, color,
+      // size, weight, and stroke survive the text swap — straight innerHTML
+      // assignment would flatten them.
+      const segmentsAttr = (el as HTMLElement).getAttribute("data-segments")
+      const html = segmentsAttr
+        ? rebuildSegmentedInnerHtml(segmentsAttr, renderedHtml)
+        : renderedHtml
+      if ((el as HTMLElement).hasAttribute("data-tts-original-html")) {
+        ;(el as HTMLElement).setAttribute("data-tts-original-html", html)
+      }
+      ;(el as HTMLElement).innerHTML = html
     })
 
     const placeholders = document.querySelectorAll(
@@ -173,6 +179,17 @@ export function applyTranslationsToDOM(
   if (titleMeta) {
     const id = titleMeta.getAttribute("content")
     if (id && translations[id]) document.title = translations[id]
+  }
+
+  // Re-run fixed-layout auto-fit after rebuilding segment spans — the new
+  // elements have no `data-adt-fs` cache and the translated content has a
+  // different length than the source, so an earlier auto-fit pass against
+  // the original spans no longer reflects the rendered DOM. Double-rAF so
+  // we measure after the browser has laid out the new innerHTML.
+  const runAutoFit = (window as Window & { __adtRunAutoFit?: () => void })
+    .__adtRunAutoFit
+  if (typeof runAutoFit === "function") {
+    requestAnimationFrame(() => requestAnimationFrame(() => runAutoFit()))
   }
 }
 

--- a/apps/adt-runtime/src/shared/lib/fl-segments.ts
+++ b/apps/adt-runtime/src/shared/lib/fl-segments.ts
@@ -1,0 +1,90 @@
+/**
+ * Fixed-layout paragraph segment helpers.
+ *
+ * FL `[data-id]` paragraphs carry per-run styling on `data-segments` — JSON
+ * mirroring `SectionTextSegment` in `@adt/types`. Two consumers in this
+ * runtime walk that JSON:
+ *
+ *   - `features/audio/lib/word-highlight.ts` rebuilds nested styled spans
+ *     inside each word wrapper during read-aloud, so word highlighting
+ *     doesn't flatten the renderer's per-run colour / font / size.
+ *
+ *   - `features/language/runtime/i18n.ts` rebuilds the styled span tree
+ *     after a translation swap (which otherwise pastes plain text into
+ *     `innerHTML`).
+ */
+
+export interface Segment {
+  text: string
+  style?: Record<string, string>
+}
+
+export function parseSegments(attr: string | null): Segment[] | null {
+  if (!attr) return null
+  try {
+    const parsed: unknown = JSON.parse(attr)
+    if (!Array.isArray(parsed)) return null
+    const out: Segment[] = []
+    for (const s of parsed) {
+      if (!s || typeof s !== "object" || typeof (s as Segment).text !== "string") return null
+      out.push({ text: (s as Segment).text, style: (s as Segment).style })
+    }
+    return out
+  } catch {
+    return null
+  }
+}
+
+export function styleToInline(style: Record<string, string> | undefined): string {
+  if (!style) return ""
+  return Object.entries(style)
+    .map(([k, v]) => `${k}:${v}`)
+    .join(";")
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;")
+}
+
+/**
+ * Build the inner HTML for a `[data-id][data-segments]` paragraph from a
+ * (possibly translated) text string. When the swapped text matches the
+ * segment concatenation (i.e. we're rendering the source language), every
+ * styled run is preserved verbatim. When it differs (translation), we fall
+ * back to a single run carrying the first segment's style — full per-run
+ * styling preservation across translation is a known follow-up.
+ *
+ * `<br>` tags inside the swapped text are passed through unescaped so
+ * line breaks survive; everything else is HTML-escaped.
+ */
+export function rebuildSegmentedInnerHtml(
+  segmentsAttr: string | null,
+  translatedHtml: string,
+): string {
+  const segments = parseSegments(segmentsAttr)
+  if (!segments || segments.length === 0) return translatedHtml
+
+  const normalize = (s: string): string =>
+    s.replace(/<br\s*\/?>/gi, " ").replace(/\s+/g, " ").trim()
+  const sourceConcat = segments.map((s) => s.text).join("")
+  const runs: Segment[] =
+    normalize(sourceConcat) === normalize(translatedHtml)
+      ? segments
+      : [{ text: translatedHtml, style: segments[0].style }]
+
+  return runs
+    .map((seg) => {
+      const html = seg.text
+        .split(/(<br\s*\/?>)/i)
+        .map((part) => (/^<br\s*\/?>$/i.test(part) ? part : escapeHtml(part)))
+        .join("")
+      const styleStr = styleToInline(seg.style)
+      return styleStr ? `<span style="${styleStr}">${html}</span>` : html
+    })
+    .join("")
+}

--- a/apps/api/src/routes/adt-preview.ts
+++ b/apps/api/src/routes/adt-preview.ts
@@ -33,6 +33,7 @@ import {
   buildPreferredImageAltMap,
   rewriteImageUrls,
   convertLatexToMathml,
+  isFixedLayoutBook,
 } from "@adt/pipeline"
 
 // ---------------------------------------------------------------------------
@@ -401,6 +402,7 @@ function buildPreviewConfig(
   webAssetsDir: string,
   speechConfig?: SpeechConfig,
   configuredOutputLanguages?: string[],
+  fixedLayout?: boolean,
 ) {
   const glossary = getGlossary(storage)
   const hasGlossary = glossary !== undefined && glossary.items.length > 0
@@ -485,6 +487,7 @@ function buildPreviewConfig(
       trackerUrl: "",
       srcUrl: "",
     },
+    ...(fixedLayout ? { fixedLayout: true } : {}),
   }
 }
 
@@ -545,6 +548,7 @@ export function createAdtPreviewRoutes(
         webAssetsDir,
         bookConfig.speech,
         bookConfig.output_languages,
+        isFixedLayoutBook(bookConfig),
       )
     })
     c.header("Content-Type", "application/json")

--- a/apps/api/src/routes/books.ts
+++ b/apps/api/src/routes/books.ts
@@ -19,6 +19,7 @@ import {
   exportWebpub,
   exportScorm,
   exportAdt,
+  exportEpub,
   type ExportFeatures,
   type ExportDefaultSettings,
   type ExportResult,
@@ -209,7 +210,7 @@ export function createBookRoutes(
   // POST /books/:label/prepare-export — Rebuild adt/ (and webpub/ if needed) before download
   app.post("/books/:label/prepare-export", async (c) => {
     const { label } = c.req.param()
-    const format = (c.req.query("format") ?? "project") as "project" | "webpub" | "scorm" | "adt"
+    const format = (c.req.query("format") ?? "project") as "project" | "webpub" | "scorm" | "adt" | "epub"
     let features: ExportFeatures | undefined
     let defaultSettings: ExportDefaultSettings | undefined
     const hasBody = (c.req.header("content-length") ?? "0") !== "0"
@@ -266,6 +267,27 @@ export function createBookRoutes(
       return c.body(result.stream)
     })
   }
+
+  // GET /books/:label/export-epub — Download book as EPUB 3
+  app.get("/books/:label/export-epub", async (c) => {
+    const { label } = c.req.param()
+    try {
+      const result = await exportEpub(label, booksDir)
+      c.header("Content-Type", "application/epub+zip")
+      const encodedName = encodeURIComponent(result.filename)
+      c.header(
+        "Content-Disposition",
+        `attachment; filename="${result.safeFilename}"; filename*=UTF-8''${encodedName}`
+      )
+      return c.body(result.stream)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      if (message.includes("Book not found")) {
+        throw new HTTPException(404, { message })
+      }
+      throw new HTTPException(400, { message })
+    }
+  })
 
   // GET /books/:label/images — List all images in a book
   app.get("/books/:label/images", (c) => {

--- a/apps/api/src/routes/package.ts
+++ b/apps/api/src/routes/package.ts
@@ -12,6 +12,7 @@ import {
   runAccessibilityAssessment,
   runBrowserAccessibilityAssessment,
   mergeAccessibilityResults,
+  isFixedLayoutBook,
 } from "@adt/pipeline"
 import type { Storage } from "@adt/storage"
 import type { TaskService } from "../services/task-service.js"
@@ -199,6 +200,7 @@ async function runPackaging(
       webAssetsDir,
       applyBodyBackground: config.apply_body_background,
       speechConfig: config.speech,
+      fixedLayout: isFixedLayoutBook(config),
     })
 
     const baseAccessibility = await runAccessibilityAssessment({

--- a/apps/api/src/routes/pages.ts
+++ b/apps/api/src/routes/pages.ts
@@ -36,6 +36,13 @@ interface PageDetail {
   imageCropping: unknown | null
   rendering: unknown | null
   imageCaptioning: unknown | null
+  /** Per-image metadata for this page (dimensions, optional PDF-point placement bounds). */
+  imagesMeta: Array<{
+    imageId: string
+    width: number
+    height: number
+    bounds?: { x: number; y: number; width: number; height: number }
+  }>
   versions: {
     sectioning: number | null
     imageClassification: number | null
@@ -570,6 +577,32 @@ export function createPageRoutes(
         if (parsed.success) sectioningTreeForUI = parsed.data
       }
 
+      // Per-image meta (width/height/bounds) — sourced directly from the
+      // images table rather than node_data so it reflects the latest state.
+      const imageMetaRows = db.all(
+        "SELECT image_id, width, height, bounds_x, bounds_y, bounds_w, bounds_h FROM images WHERE page_id = ? ORDER BY image_id",
+        [pageId]
+      ) as Array<{
+        image_id: string
+        width: number
+        height: number
+        bounds_x: number | null
+        bounds_y: number | null
+        bounds_w: number | null
+        bounds_h: number | null
+      }>
+      const imagesMeta: PageDetail["imagesMeta"] = imageMetaRows.map((r) => {
+        const meta: PageDetail["imagesMeta"][number] = {
+          imageId: r.image_id,
+          width: r.width,
+          height: r.height,
+        }
+        if (r.bounds_x !== null && r.bounds_y !== null && r.bounds_w !== null && r.bounds_h !== null) {
+          meta.bounds = { x: r.bounds_x, y: r.bounds_y, width: r.bounds_w, height: r.bounds_h }
+        }
+        return meta
+      })
+
       const result: PageDetail = {
         pageId: page.page_id,
         pageNumber: page.page_number,
@@ -579,6 +612,7 @@ export function createPageRoutes(
         imageCropping: imageCroppingNode?.data ?? null,
         rendering: renderingNode?.data ?? null,
         imageCaptioning: imageCaptioningNode?.data ?? null,
+        imagesMeta,
         versions: {
           sectioning: sectioningNode?.version ?? null,
           imageClassification: imageClassNode?.version ?? null,

--- a/apps/api/src/services/export-service.test.ts
+++ b/apps/api/src/services/export-service.test.ts
@@ -4,7 +4,7 @@ import os from "node:os"
 import path from "node:path"
 import { openBookDb, createBookStorage } from "@adt/storage"
 import { unzipSync } from "fflate"
-import { prepareExport, exportProject, exportWebpub } from "./export-service.js"
+import { prepareExport, exportProject, exportAdt, exportWebpub, exportEpub } from "./export-service.js"
 
 let tmpDir: string
 let webAssetsDir: string
@@ -347,5 +347,271 @@ describe("exportWebpub", () => {
 
     await expect(prepareExport("missing-assets", "webpub", tmpDir, path.join(tmpDir, "no-assets")))
       .rejects.toThrow("Web assets directory not found")
+  })
+})
+
+describe("exportEpub", () => {
+  it("produces a valid EPUB ZIP with required structure", async () => {
+    createBookWithMetadata("epub-test", "Test Book")
+    addPagesAndRenderings("epub-test", 2)
+
+    await prepareExport("epub-test", "epub", tmpDir, webAssetsDir)
+    const result = await exportEpub("epub-test", tmpDir)
+    expect(result.filename).toBe("Test Book.epub")
+    expect(result.safeFilename).toBe("epub-test.epub")
+
+    const buf = await streamToBuffer(result.stream)
+    const files = unzipSync(buf)
+    expect(files["mimetype"]).toBeDefined()
+    expect(new TextDecoder().decode(files["mimetype"])).toBe("application/epub+zip")
+    expect(files["META-INF/container.xml"]).toBeDefined()
+    expect(files["OEBPS/content.opf"]).toBeDefined()
+    expect(files["OEBPS/toc.xhtml"]).toBeDefined()
+    expect(files["OEBPS/toc.ncx"]).toBeDefined()
+  })
+
+  it("includes content pages as HTML files from ADT package", async () => {
+    createBookWithMetadata("epub-pages", "Pages Book")
+    addPagesAndRenderings("epub-pages", 2)
+
+    await prepareExport("epub-pages", "epub", tmpDir, webAssetsDir)
+    const result = await exportEpub("epub-pages", tmpDir)
+    const buf = await streamToBuffer(result.stream)
+    const files = unzipSync(buf)
+
+    // Should have content pages in OEBPS/ (copied from adt/)
+    const htmlFiles = Object.keys(files).filter(f =>
+      f.startsWith("OEBPS/") && (f.endsWith(".html") || f.endsWith(".xhtml")) &&
+      !f.includes("toc.") && !f.includes("content/")
+    )
+    expect(htmlFiles.length).toBeGreaterThanOrEqual(2)
+
+    // Content should be proper HTML documents
+    const content = new TextDecoder().decode(files[htmlFiles[0]])
+    expect(content).toContain("<!DOCTYPE html>")
+  })
+
+  it("includes content pages in OPF manifest and spine", async () => {
+    createBookWithMetadata("epub-opf", "OPF Test")
+    addPagesAndRenderings("epub-opf", 2)
+
+    await prepareExport("epub-opf", "epub", tmpDir, webAssetsDir)
+    const result = await exportEpub("epub-opf", tmpDir)
+    const buf = await streamToBuffer(result.stream)
+    const files = unzipSync(buf)
+    const opf = new TextDecoder().decode(files["OEBPS/content.opf"])
+
+    expect(opf).toContain('version="3.0"')
+    expect(opf).toContain("<dc:title>OPF Test</dc:title>")
+    expect(opf).toContain("<dc:language>en</dc:language>")
+    expect(opf).toContain("<dc:creator>Author</dc:creator>")
+    // Spine entries
+    expect(opf).toContain("itemref idref=")
+  })
+
+  it("falls back to label when metadata has no title", async () => {
+    createTestDb("epub-no-title")
+    addPages("epub-no-title", 1)
+
+    await prepareExport("epub-no-title", "epub", tmpDir, webAssetsDir)
+    const result = await exportEpub("epub-no-title", tmpDir)
+    expect(result.filename).toBe("epub-no-title.epub")
+    expect(result.safeFilename).toBe("epub-no-title.epub")
+  })
+
+  it("throws for non-existent book", async () => {
+    await expect(exportEpub("ghost", tmpDir)).rejects.toThrow("not found")
+  })
+
+  it("reflowable EPUB does not include rendition:layout metadata", async () => {
+    createBookWithMetadata("epub-reflow", "Reflowable Book")
+    addPagesAndRenderings("epub-reflow", 1)
+
+    await prepareExport("epub-reflow", "epub", tmpDir, webAssetsDir)
+    const result = await exportEpub("epub-reflow", tmpDir)
+    const buf = await streamToBuffer(result.stream)
+    const files = unzipSync(buf)
+    const opf = new TextDecoder().decode(files["OEBPS/content.opf"])
+
+    expect(opf).not.toContain("rendition:layout")
+    expect(opf).not.toContain("pre-paginated")
+  })
+})
+
+describe("exportEpub — fixed-layout", () => {
+  function createFixedLayoutBook(label: string, title: string): void {
+    const bookDir = path.join(tmpDir, label)
+    fs.mkdirSync(bookDir, { recursive: true })
+    fs.mkdirSync(path.join(bookDir, "images"), { recursive: true })
+    const db = openBookDb(path.join(bookDir, `${label}.db`))
+    db.run(
+      "INSERT INTO node_data (node, item_id, version, data) VALUES (?, ?, ?, ?)",
+      [
+        "metadata",
+        "book",
+        1,
+        JSON.stringify({
+          title,
+          authors: ["Illustrator"],
+          publisher: null,
+          language_code: "en",
+          cover_page_number: 1,
+          reasoning: "test",
+        }),
+      ]
+    )
+    db.close()
+
+    // Write config.yaml registering a fixed_layout render strategy as the
+    // default (this is what triggers fixed-layout output).
+    fs.writeFileSync(
+      path.join(bookDir, "config.yaml"),
+      "default_render_strategy: fixed_layout\nrender_strategies:\n  fixed_layout:\n    render_type: fixed_layout\n"
+    )
+  }
+
+  function addFixedLayoutPages(label: string, count: number): void {
+    const storage = createBookStorage(label, tmpDir)
+    try {
+      for (let i = 1; i <= count; i++) {
+        const pageId = `${label}_p${i}`
+        const sectionId = `${pageId}_sec001`
+        storage.putExtractedPage({
+          pageId,
+          pageNumber: i,
+          text: `Page ${i} text`,
+          pageImage: {
+            imageId: `${pageId}_page`,
+            buffer: Buffer.from("fake-png"),
+            format: "png",
+            hash: `hash${i}`,
+            width: 800,
+            height: 600,
+          },
+          images: [],
+        })
+
+        // Positioned text output (sub-product of the extract step)
+        storage.putNodeData("positioned-text", pageId, {
+          paragraphs: [
+            {
+              top: 100,
+              left: 144,
+              lineHeight: 96,
+              html: '<span style="font-family:Palatino,serif;font-size:48.0pt;color:#000000">Hello World</span>',
+            },
+          ],
+          pageWidth: 400,
+          pageHeight: 300,
+          renderWidth: 800,
+          renderHeight: 600,
+        })
+
+        // Fixed-layout sectioning (one section per page) — tree shape with
+        // a sidecar `placement` map for the PDF coordinates.
+        storage.putNodeData("page-sectioning", pageId, {
+          reasoning: "Fixed-layout mode",
+          sections: [
+            {
+              sectionId,
+              sectionType: "fixed-layout-page",
+              nodes: [
+                { nodeId: `${pageId}_page`, role: "image", isPruned: false },
+              ],
+              placement: {
+                [`${pageId}_page`]: {
+                  bounds: { x: 0, y: 0, width: 400, height: 300 },
+                },
+              },
+              viewport: { width: 400, height: 300 },
+              backgroundColor: "#ffffff",
+              textColor: "#000000",
+              pageNumber: i,
+              isPruned: false,
+            },
+          ],
+        })
+
+        // Fixed-layout rendered HTML (page image + positioned text overlay)
+        storage.putNodeData("web-rendering", pageId, {
+          sections: [
+            {
+              sectionIndex: 0,
+              sectionType: "fixed-layout-page",
+              reasoning: "Fixed-layout",
+              html: `<div id="content" style="position:relative;width:400px;height:300px;margin:0 auto;overflow:hidden">
+  <img src="/api/books/${label}/images/${pageId}_page" alt="" data-id="${pageId}_page" style="position:absolute;top:0;left:0;width:100%;height:100%"/>
+  <div class="text-overlay" style="position:absolute;top:0;left:0;width:100%;height:100%">
+    <p data-id="${pageId}_p000" style="position:absolute;top:50px;left:72px;line-height:48px"><span style="font-family:Palatino,serif;font-size:48px;color:#000000">Hello World</span></p>
+  </div>
+</div>`,
+            },
+          ],
+        })
+      }
+    } finally {
+      storage.close()
+    }
+  }
+
+  it("produces EPUB with pre-paginated rendition metadata", async () => {
+    createFixedLayoutBook("fl-epub", "Storybook")
+    addFixedLayoutPages("fl-epub", 2)
+
+    await prepareExport("fl-epub", "epub", tmpDir, webAssetsDir)
+    const result = await exportEpub("fl-epub", tmpDir)
+    const buf = await streamToBuffer(result.stream)
+    const files = unzipSync(buf)
+    const opf = new TextDecoder().decode(files["OEBPS/content.opf"])
+
+    expect(opf).toContain("rendition:layout")
+    expect(opf).toContain("pre-paginated")
+    expect(opf).toContain("rendition:spread")
+    expect(opf).toContain("none")
+  })
+
+  it("content pages have fixed viewport meta", async () => {
+    createFixedLayoutBook("fl-viewport", "Viewport Book")
+    addFixedLayoutPages("fl-viewport", 1)
+
+    await prepareExport("fl-viewport", "epub", tmpDir, webAssetsDir)
+    const result = await exportEpub("fl-viewport", tmpDir)
+    const buf = await streamToBuffer(result.stream)
+    const files = unzipSync(buf)
+
+    const htmlFiles = Object.keys(files).filter(f =>
+      f.startsWith("OEBPS/") && (f.endsWith(".html") || f.endsWith(".xhtml")) &&
+      !f.includes("toc.") && !f.includes("content/")
+    )
+    expect(htmlFiles.length).toBeGreaterThanOrEqual(1)
+
+    const html = new TextDecoder().decode(files[htmlFiles[0]])
+    // Fixed-layout pages have viewport matching page dimensions (1x)
+    expect(html).toContain("width=400")
+    expect(html).toContain("height=300")
+    expect(html).not.toContain("device-width")
+  })
+
+  it("content pages contain positioned text with data-id attributes", async () => {
+    createFixedLayoutBook("fl-text", "Text Overlay Book")
+    addFixedLayoutPages("fl-text", 1)
+
+    await prepareExport("fl-text", "epub", tmpDir, webAssetsDir)
+    const result = await exportEpub("fl-text", tmpDir)
+    const buf = await streamToBuffer(result.stream)
+    const files = unzipSync(buf)
+
+    const htmlFiles = Object.keys(files).filter(f =>
+      f.startsWith("OEBPS/") && (f.endsWith(".html") || f.endsWith(".xhtml")) &&
+      !f.includes("toc.") && !f.includes("content/")
+    )
+    const html = new TextDecoder().decode(files[htmlFiles[0]])
+
+    // Should contain positioned text spans with data-id for TTS/accessibility
+    expect(html).toContain("data-id=")
+    expect(html).toContain("Hello")
+    expect(html).toContain("World")
+    // Page image should be present
+    expect(html).toContain("_page")
   })
 })

--- a/apps/api/src/services/export-service.ts
+++ b/apps/api/src/services/export-service.ts
@@ -4,7 +4,7 @@ import { Zip, ZipDeflate, ZipPassThrough } from "fflate"
 import { HTTPException } from "hono/http-exception"
 import { parseBookLabel } from "@adt/types"
 import { createBookStorage } from "@adt/storage"
-import { packageAdtWeb, packageWebpub, loadBookConfig, normalizeLocale } from "@adt/pipeline"
+import { packageAdtWeb, packageWebpub, packageEpub, loadBookConfig, normalizeLocale, isFixedLayoutBook } from "@adt/pipeline"
 
 /** File extensions that are already compressed — skip deflation to save CPU */
 const COMPRESSED_EXTS = new Set([
@@ -74,7 +74,7 @@ export interface ExportDefaultSettings {
  */
 export async function prepareExport(
   label: string,
-  format: "project" | "webpub" | "scorm" | "adt",
+  format: "project" | "webpub" | "scorm" | "adt" | "epub",
   booksDir: string,
   webAssetsDir: string,
   configPath?: string,
@@ -158,12 +158,15 @@ export async function prepareExport(
       features,
       defaultSettings: mergedDefaultSettings,
       lockedSettings: config.locked_settings,
+      fixedLayout: isFixedLayoutBook(config),
     }
 
     await packageAdtWeb(storage, opts)
 
     if (format === "webpub") {
       packageWebpub(storage, opts)
+    } else if (format === "epub") {
+      packageEpub(storage, opts)
     }
   } finally {
     storage.close()
@@ -260,6 +263,46 @@ export async function exportAdt(
     stream: createZipStream(adtDir),
     filename: `${title}-adt.zip`,
     safeFilename: `${safeLabel}-adt.zip`,
+  }
+}
+
+export interface EpubExportResult {
+  stream: ReadableStream<Uint8Array>
+  filename: string
+  safeFilename: string
+}
+
+export async function exportEpub(
+  label: string,
+  booksDir: string,
+): Promise<EpubExportResult> {
+  const safeLabel = parseBookLabel(label)
+  const resolvedDir = path.resolve(booksDir)
+  const bookDir = path.join(resolvedDir, safeLabel)
+
+  if (!fs.existsSync(bookDir)) {
+    throw new Error(`Book not found: ${safeLabel}`)
+  }
+
+  let title = safeLabel
+  const storage = createBookStorage(safeLabel, resolvedDir)
+  try {
+    const metadataRow = storage.getLatestNodeData("metadata", "book")
+    const metadata = metadataRow?.data as { title?: string | null } | null
+    title = metadata?.title ?? safeLabel
+  } finally {
+    storage.close()
+  }
+
+  const epubDir = path.join(bookDir, "epub")
+  if (!fs.existsSync(epubDir)) {
+    throw new Error("EPUB directory not found — run prepare-export first")
+  }
+
+  return {
+    stream: createZipStream(epubDir),
+    filename: `${title}.epub`,
+    safeFilename: `${safeLabel}.epub`,
   }
 }
 

--- a/apps/api/src/services/stage-runner.ts
+++ b/apps/api/src/services/stage-runner.ts
@@ -63,6 +63,7 @@ import {
   getSegmentedImageId,
   createScreenshotRenderer,
   DEFAULT_VISUAL_REVIEW_MODEL_ID,
+  isFixedLayoutBook,
 } from "@adt/pipeline"
 import type { PageSectioningConfig, TranslationConfig, QuizPageInput, ProviderRouting, MeaningfulnessConfig, CroppingConfig, SegmentationConfig, VisualRefinementDeps } from "@adt/pipeline"
 import { loadStyleguideContent } from "./styleguide.js"
@@ -426,6 +427,7 @@ async function runExtractStep(
         endPage: config.end_page,
         spreadMode: config.spread_mode,
         vectorTextGrouping: config.vector_text_grouping,
+        fixedLayout: isFixedLayoutBook(config),
       },
       storage,
       progress
@@ -841,6 +843,23 @@ async function runStoryboardStep(
     const pages = storage.getPages()
     const totalPages = pages.length
     const effectiveConcurrency = config.concurrency ?? 32
+
+    if (isFixedLayoutBook(config)) {
+      // Fixed-layout: both sectioning and rendering happen here, driven
+      // off the positioned-text + image-filtering data the extract step
+      // already wrote. No LLM call. Emit start/complete for both steps so
+      // the progress UI mirrors the reflowable flow's two-step shape.
+      console.log(`[stage-run] ${label}: fixed-layout rendering for ${totalPages} pages`)
+      progress.emit({ type: "step-start", step: "page-sectioning" })
+      progress.emit({ type: "step-start", step: "web-rendering" })
+      const { processFixedLayoutPages } = await import("@adt/pipeline")
+      const imageUrlPrefix = `/api/books/${label}/images`
+      processFixedLayoutPages(storage, imageUrlPrefix)
+      progress.emit({ type: "step-complete", step: "page-sectioning" })
+      progress.emit({ type: "step-complete", step: "web-rendering" })
+      console.log(`[stage-run] ${label}: fixed-layout rendering complete`)
+      return
+    }
 
     console.log(
       `[stage-run] ${label}: rendering storyboard for ${totalPages} pages (concurrency=${effectiveConcurrency})`

--- a/apps/studio/src/api/client.ts
+++ b/apps/studio/src/api/client.ts
@@ -9,6 +9,7 @@ import type {
   ReviewerValidationSection,
   ReviewerValidationSession,
 } from "@adt/types"
+import type { ExportFormat } from "@/components/pipeline/stages/export/export-formats"
 
 export type { BookSummary, BookDetail }
 
@@ -235,6 +236,13 @@ export interface PageDetail {
   imageCaptioning: {
     captions: Array<{ imageId: string; reasoning: string; caption: string }>
   } | null
+  /** Per-image metadata (dimensions + optional PDF-point placement bounds). */
+  imagesMeta: Array<{
+    imageId: string
+    width: number
+    height: number
+    bounds?: { x: number; y: number; width: number; height: number }
+  }>
   versions: {
     imageClassification: number | null
     imageCropping: number | null
@@ -1134,7 +1142,7 @@ export const api = {
 
   prepareExport: (
     label: string,
-    format: "project" | "webpub" | "scorm" | "adt" = "project",
+    format: ExportFormat = "project",
     features?: { glossary?: boolean; readAloud?: boolean; quizzes?: boolean; signLanguage?: boolean; languages?: string[] },
     defaultSettings?: {
       dockLayout?: { width?: "compact" | "full"; position?: "top" | "bottom"; align?: "center" | "spread" }
@@ -1193,6 +1201,26 @@ export const api = {
     }
     const buf = await res.arrayBuffer()
     return new Blob([buf], { type: "application/zip" })
+  },
+
+  exportEpub: async (label: string): Promise<Blob | null> => {
+    if (!isDesktop()) {
+      triggerDirectDownload(`${BASE_URL}/books/${label}/export-epub`)
+      return null
+    }
+    const url = `${BASE_URL}/books/${label}/export-epub`
+    const res = await fetch(url, {
+      method: "GET",
+      headers: { Accept: "application/epub+zip" },
+      mode: "cors",
+      signal: AbortSignal.timeout(300_000),
+    })
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({ error: res.statusText }))
+      throw new Error(body.error ?? `EPUB export failed: ${res.status}`)
+    }
+    const buf = await res.arrayBuffer()
+    return new Blob([buf], { type: "application/epub+zip" })
   },
 
   exportScorm: async (label: string): Promise<Blob | null> => {

--- a/apps/studio/src/components/pipeline/stages/PreviewView.tsx
+++ b/apps/studio/src/components/pipeline/stages/PreviewView.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback, useMemo } from "react"
+import { useState, useEffect, useRef, useCallback, useMemo, type CSSProperties } from "react"
 import type { AccessibilityFinding } from "@adt/types"
 import { Loader2 } from "lucide-react"
 import { Trans } from "@lingui/react/macro"
@@ -34,7 +34,15 @@ export function PreviewView({ bookLabel }: { bookLabel: string }) {
   const storyboardDone = stageState("storyboard") === "done"
   const { allPruned } = useAllPagesPruned(bookLabel)
   const iframeRef = useRef<HTMLIFrameElement>(null)
+  const wrapperRef = useRef<HTMLDivElement>(null)
   const ranRef = useRef(false)
+  // Fixed-layout pages render at their native pixel viewport (e.g.
+  // 1587×1224) which usually exceeds the studio preview pane. Detect the
+  // page's intrinsic size from the iframe body's inline width/height and
+  // CSS-scale the iframe to fit, mirroring the storyboard preview.
+  // null = reflowable (no scaling).
+  const [fixedLayoutSize, setFixedLayoutSize] = useState<{ width: number; height: number } | null>(null)
+  const [availableWidth, setAvailableWidth] = useState(0)
   const { panelOpen } = useDebugPanelState()
   const [isSubmittingPackage, setIsSubmittingPackage] = useState(false)
   const [pendingTaskId, setPendingTaskId] = useState<string | null>(null)
@@ -117,11 +125,42 @@ export function PreviewView({ bookLabel }: { bookLabel: string }) {
       const signLanguageEnabled =
         iframe.contentDocument.querySelector("#sl-quick-toggle-button, #sign-language-video") !== null
 
+      // Detect fixed-layout pages — `package-web.ts` emits inline
+      // `style="...width:Wpx;height:Hpx..."` on `<body>` for fixed-layout
+      // page HTML. Parse those values; null otherwise.
+      const body = iframe.contentDocument.body
+      const w = parsePxStyle(body?.style.width)
+      const h = parsePxStyle(body?.style.height)
+      setFixedLayoutSize(w !== null && h !== null ? { width: w, height: h } : null)
+
       setCurrentPreviewPage({ sectionId, href, title, hasImages, hasActivity, signLanguageEnabled })
     } catch {
+      setFixedLayoutSize(null)
       setCurrentPreviewPage({ sectionId: null, href: null, title: null, hasImages: false, hasActivity: false, signLanguageEnabled: false })
     }
   }, [])
+
+  // Track wrapper width so the scale recomputes when the panel resizes
+  // (debug panel toggle, window resize, sidebar collapse, etc.). Depends
+  // on `ready` because the wrapper only renders once packaging is done —
+  // without that dep the effect runs once on mount when the wrapper
+  // doesn't exist yet, ref is null, and the observer never attaches.
+  useEffect(() => {
+    if (!ready) return
+    const el = wrapperRef.current
+    if (!el) return
+    setAvailableWidth(el.getBoundingClientRect().width)
+    const ro = new ResizeObserver((entries) => {
+      const entry = entries[0]
+      if (entry) setAvailableWidth(entry.contentRect.width)
+    })
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [ready])
+
+  const scale = fixedLayoutSize && availableWidth > 0
+    ? Math.min(1, availableWidth / fixedLayoutSize.width)
+    : 1
 
   const packaging = isSubmittingPackage || isTaskRunning("package-adt")
 
@@ -267,15 +306,39 @@ export function PreviewView({ bookLabel }: { bookLabel: string }) {
   }
 
   if (ready) {
+    // Fixed-layout: render the iframe at the page's native pixel
+    // dimensions and CSS-scale it via transform so it fits the wrapper
+    // width without horizontal scroll. The sizing div takes the *scaled*
+    // dimensions (the iframe's layout box stays at native size despite
+    // the transform, so we wrap it to keep page layout honest).
+    // Reflowable: iframe fills the wrapper as before.
+    const iframeStyle: CSSProperties = fixedLayoutSize
+      ? {
+          width: fixedLayoutSize.width,
+          height: fixedLayoutSize.height,
+          transform: `scale(${scale})`,
+          transformOrigin: "0 0",
+        }
+      : { width: "100%", height: "100%" }
+    const sizerStyle: CSSProperties = fixedLayoutSize
+      ? {
+          width: fixedLayoutSize.width * scale,
+          height: fixedLayoutSize.height * scale,
+          overflow: "hidden",
+        }
+      : { width: "100%", height: "100%" }
     return (
-      <div className="relative h-full w-full bg-muted/20">
-        <iframe
-          ref={iframeRef}
-          src={`${getAdtUrl(bookLabel)}/v-${version}/`}
-          className="h-full w-full border-0"
-          title="ADT Preview"
-          onLoad={syncCurrentPreviewPage}
-        />
+      <div ref={wrapperRef} className="relative h-full w-full bg-muted/20 overflow-auto">
+        <div style={sizerStyle}>
+          <iframe
+            ref={iframeRef}
+            src={`${getAdtUrl(bookLabel)}/v-${version}/`}
+            className="border-0"
+            style={iframeStyle}
+            title="ADT Preview"
+            onLoad={syncCurrentPreviewPage}
+          />
+        </div>
 
         <PreviewAccessibilityCard
           label={bookLabel}
@@ -320,6 +383,13 @@ export function PreviewView({ bookLabel }: { bookLabel: string }) {
   }
 
   return null
+}
+
+/** Parse a pixel value (e.g. "1587px") to a number, or null for missing/non-px values. */
+function parsePxStyle(value: string | undefined): number | null {
+  if (!value) return null
+  const match = /^(\d+(?:\.\d+)?)px$/.exec(value.trim())
+  return match ? parseFloat(match[1]) : null
 }
 
 function deriveReviewPageId(sectionId: string | null, href: string | null): string | null {

--- a/apps/studio/src/components/pipeline/stages/export/components/ExportPreview.tsx
+++ b/apps/studio/src/components/pipeline/stages/export/components/ExportPreview.tsx
@@ -4,6 +4,7 @@ import {
   ArrowDownToLine,
   BarChart3,
   Bookmark,
+  BookText,
   Check,
   ChevronLeft,
   ChevronRight,
@@ -95,6 +96,20 @@ const FORMAT_VISUALS: Record<ExportFormat, FormatVisual> = {
     footerHint: (
       <Trans>
         Distribute through Readium-compatible reading apps and libraries.
+      </Trans>
+    ),
+  },
+  epub: {
+    accent: "bg-purple-600",
+    accentSoft: "bg-purple-50",
+    accentText: "text-purple-700",
+    accentBorder: "border-purple-200",
+    Icon: BookText,
+    eyebrow: <Trans>EPUB 3</Trans>,
+    tagline: <Trans>Standard e-book for readers &amp; libraries</Trans>,
+    footerHint: (
+      <Trans>
+        Open in any EPUB 3 reader, e-reader, or accessibility tool.
       </Trans>
     ),
   },

--- a/apps/studio/src/components/pipeline/stages/export/components/FormatPicker.tsx
+++ b/apps/studio/src/components/pipeline/stages/export/components/FormatPicker.tsx
@@ -3,7 +3,7 @@ import { cn } from "@/lib/utils"
 import { buildExportFormatConfig, type ExportFormat } from "../export-formats"
 import type { useLingui } from "@lingui/react/macro"
 
-const FORMAT_ORDER: ExportFormat[] = ["project", "adt", "scorm", "webpub"]
+const FORMAT_ORDER: ExportFormat[] = ["project", "adt", "scorm", "webpub", "epub"]
 
 export function FormatPicker({
   selected,

--- a/apps/studio/src/components/pipeline/stages/export/export-formats.ts
+++ b/apps/studio/src/components/pipeline/stages/export/export-formats.ts
@@ -1,8 +1,8 @@
 import { msg } from "@lingui/core/macro"
 import type { LucideIcon } from "lucide-react"
-import { FileDown, Globe, GraduationCap } from "lucide-react"
+import { FileDown, Globe, GraduationCap, BookText } from "lucide-react"
 
-export type ExportFormat = "project" | "webpub" | "scorm" | "adt"
+export type ExportFormat = "project" | "webpub" | "scorm" | "adt" | "epub"
 
 export interface FormatConfig {
   icon: LucideIcon
@@ -47,6 +47,13 @@ export const EXPORT_FORMAT_CONFIG: Record<ExportFormat, Omit<FormatConfig, "labe
     borderColor: "border-blue-200",
     buttonClass: "bg-blue-600 hover:bg-blue-700 text-white",
   },
+  epub: {
+    icon: BookText,
+    textColor: "text-purple-600",
+    bgLight: "bg-purple-50",
+    borderColor: "border-purple-200",
+    buttonClass: "bg-purple-600 hover:bg-purple-700 text-white",
+  },
 }
 
 /**
@@ -74,6 +81,12 @@ export function buildExportFormatConfig(t: (msg: any) => string): Record<ExportF
       ...EXPORT_FORMAT_CONFIG.webpub,
       label: t(msg`WebPub Export`),
       description: t(msg`Readium Web Publication format for standards-based digital distribution platforms.`),
+      badge: t(msg`Beta`),
+    },
+    epub: {
+      ...EXPORT_FORMAT_CONFIG.epub,
+      label: t(msg`EPUB Export`),
+      description: t(msg`Standard EPUB 3 file for e-readers, reading apps, and accessibility tools. Interactive features (quizzes, TTS) work in readers that support JavaScript.`),
       badge: t(msg`Beta`),
     },
   }

--- a/apps/studio/src/components/pipeline/stages/extract/components/ExtractPageDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/extract/components/ExtractPageDetail.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useRef, useCallback } from "react"
-import { AlertTriangle, Check, Crop, Eye, EyeOff, FileText, Image, ImageOff, Layers, Loader2, ChevronDown, X } from "lucide-react"
+import { useState, useEffect, useRef, useCallback, useMemo } from "react"
+import { AlertTriangle, Check, Crop, Eye, EyeOff, FileText, Image, ImageOff, Layers, Loader2, ChevronDown, Square, X } from "lucide-react"
 import { useQueryClient } from "@tanstack/react-query"
 import { usePage, usePageImage } from "@/hooks/use-pages"
 import { api, BASE_URL } from "@/api/client"
@@ -129,7 +129,7 @@ function VersionPicker({
   )
 }
 
-function ImageCard({ imageId, bookLabel, isPruned, reason, onTogglePrune, onRecrop, cacheBust }: { imageId: string; bookLabel: string; isPruned?: boolean; reason?: string; onTogglePrune?: () => void; onRecrop?: () => void; cacheBust?: number }) {
+function ImageCard({ imageId, bookLabel, isPruned, reason, bounds, onTogglePrune, onRecrop, cacheBust }: { imageId: string; bookLabel: string; isPruned?: boolean; reason?: string; bounds?: { x: number; y: number; width: number; height: number }; onTogglePrune?: () => void; onRecrop?: () => void; cacheBust?: number }) {
   const { t } = useLingui()
   const [dimensions, setDimensions] = useState<{ w: number; h: number } | null>(null)
   // eslint-disable-next-line lingui/no-unlocalized-strings
@@ -140,6 +140,14 @@ function ImageCard({ imageId, bookLabel, isPruned, reason, onTogglePrune, onRecr
       className={`relative rounded border overflow-hidden bg-card flex flex-col items-center min-h-[80px] ${isPruned ? "opacity-40" : ""}`}
       title={isPruned && reason ? t`Pruned: ${reason}` : undefined}
     >
+      {bounds && (
+        <div
+          className="absolute top-1 left-1 z-10 flex items-center justify-center w-5 h-5 rounded-full bg-black/30 text-white"
+          title={t`Position ${Math.round(bounds.x)}, ${Math.round(bounds.y)} → ${Math.round(bounds.width)}×${Math.round(bounds.height)} pt`}
+        >
+          <Square className="h-3 w-3" />
+        </div>
+      )}
       <div className="absolute top-1 right-1 z-10 flex items-center gap-1">
         {onRecrop && (
           <button
@@ -268,6 +276,15 @@ export function ExtractPageDetail({
   const imageClassData = pendingImageData ?? page?.imageClassification ?? null
   const imageDirty = pendingImageData != null
 
+  // Lookup for per-image page-placement bounds (when available from extract)
+  const boundsByImageId = useMemo(() => {
+    const map = new Map<string, { x: number; y: number; width: number; height: number }>()
+    for (const meta of page?.imagesMeta ?? []) {
+      if (meta.bounds) map.set(meta.imageId, meta.bounds)
+    }
+    return map
+  }, [page?.imagesMeta])
+
   const toggleImagePrune = (imageId: string) => {
     const base = pendingImageData ?? page?.imageClassification
     if (!base) return
@@ -394,6 +411,7 @@ export function ExtractPageDetail({
                     bookLabel={bookLabel}
                     isPruned={img.isPruned}
                     reason={img.reason}
+                    bounds={boundsByImageId.get(img.imageId)}
                     onTogglePrune={() => toggleImagePrune(img.imageId)}
                     onRecrop={!storyboardRunning ? () => handleRecropFromPage(img.imageId) : undefined}
                     cacheBust={cacheBust}

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/BookPreviewFrame.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/BookPreviewFrame.tsx
@@ -47,6 +47,11 @@ function parsePxStyle(value: string | undefined): number | null {
   return match ? parseFloat(match[1]) : null
 }
 
+// Upper bound for upscaling fixed-layout pages so small-page PDFs fill the
+// preview panel instead of rendering boxed. 2× keeps rasterised assets from
+// getting unacceptably soft while still filling the panel for typical books.
+const FL_MAX_SCALE = 2
+
 export interface BookPreviewFrameHandle {
   /** Get the iframe element's bounding rect in the viewport */
   getIframeRect: () => DOMRect | null
@@ -610,12 +615,13 @@ ${selectors}:hover {
   }, [])
 
   // Fixed-layout: scale off the page viewport so content fills the preview
-  // area (capped at 1× — no upscaling beyond the source resolution).
+  // area, upscaling small pages (PDFs whose natural width is below the panel)
+  // up to FL_MAX_SCALE so they don't render boxed with side whitespace.
   // Reflowable: fit to the device-frame base width, desktop capped at 1× and
   // mobile/tablet grown up to a target visible width for legibility.
   useEffect(() => {
     if (fixedLayoutSize) {
-      setScale(Math.min(1, availableWidth / fixedLayoutSize.width))
+      setScale(Math.min(FL_MAX_SCALE, availableWidth / fixedLayoutSize.width))
       return
     }
     const fitScale = Math.max(0, availableWidth / baseWidth)

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/BookPreviewFrame.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/BookPreviewFrame.tsx
@@ -40,6 +40,13 @@ function previewAssetsUrl(bookLabel: string): string {
  *  actual panel width. */
 const DEFAULT_RENDER_WIDTH = 1280
 
+/** Parse a pixel value (e.g. "612px") to a number, or null for non-px values. */
+function parsePxStyle(value: string | undefined): number | null {
+  if (!value) return null
+  const match = /^(\d+(?:\.\d+)?)px$/.exec(value.trim())
+  return match ? parseFloat(match[1]) : null
+}
+
 export interface BookPreviewFrameHandle {
   /** Get the iframe element's bounding rect in the viewport */
   getIframeRect: () => DOMRect | null
@@ -93,8 +100,9 @@ export interface BookPreviewFrameProps {
  * Renders section HTML in an iframe that matches the final book output structure.
  * Uses the same CSS, fonts, and body layout as the preview so rendering is pixel-identical.
  *
- * The iframe always renders at a fixed desktop-width viewport (RENDER_WIDTH) then
- * scales down via CSS transform to fit the available panel width. This ensures
+ * The iframe renders reflowable content at a fixed desktop-width viewport
+ * (DEFAULT_RENDER_WIDTH) — fixed-layout pages render at their own pixel
+ * dimensions — then scales via CSS transform to fit the available panel width. This ensures
  * responsive breakpoints, overlay positions, and image sizing match the preview.
  *
  * When `editable` is true, injects interactive scripts that allow clicking and
@@ -212,6 +220,14 @@ export const BookPreviewFrame = forwardRef<BookPreviewFrameHandle, BookPreviewFr
   const [iframeReady, setIframeReady] = useState(false)
   const [scale, setScale] = useState(1)
   const [contentHeight, setContentHeight] = useState(800)
+  /**
+   * When the page is fixed-layout, `#content` has explicit pixel width/height
+   * (viewport coords from the renderer). Scaling off these instead of the
+   * fixed `DEFAULT_RENDER_WIDTH` makes the content fill the available preview area.
+   * null for reflowable pages.
+   */
+  const [fixedLayoutSize, setFixedLayoutSize] = useState<{ width: number; height: number } | null>(null)
+  const [availableWidth, setAvailableWidth] = useState(DEFAULT_RENDER_WIDTH)
   const readyRef = useRef(false)
   const latestHtmlRef = useRef("")
   const sanitizedHtmlRef = useRef("")
@@ -255,6 +271,14 @@ export const BookPreviewFrame = forwardRef<BookPreviewFrameHandle, BookPreviewFr
     originalTextsRef.current = map
   }, [sanitizedHtml])
 
+  // Auto-fit script — loaded by URL from the shared assets/adt/auto-fit.js
+  // so studio storyboard, packaged-book pages, and PreviewView all run
+  // the same code. (We can't inline a per-page script in storyboard
+  // anyway because DOMPurify strips the <script> tags before innerHTML
+  // injection.) The shared script exposes window.__adtRunAutoFit so
+  // injectContent can trigger another pass after content swaps.
+  // eslint-disable-next-line lingui/no-unlocalized-strings
+  const autoFitScript = `<script src="${assetsPrefix}/assets/auto-fit.js"></script>`
   // Stable shell — loaded once, never changes.
   // Mirrors the preview's renderPageHtml output: same CSS, fonts, body classes.
   const srcdoc = useMemo(
@@ -274,9 +298,13 @@ export const BookPreviewFrame = forwardRef<BookPreviewFrameHandle, BookPreviewFr
 </head>
 <body class="min-h-screen flex items-center justify-center">
 ${INTERACTIVE_SCRIPT}
+${autoFitScript}
 </body>
 </html>`,
-    [assetsPrefix]
+    // autoFitScript embeds assetsPrefix; INTERACTIVE_SCRIPT/INTERACTIVE_STYLES
+    // are stable module constants. Re-memoise the shell only when the prefix
+    // (and thus the auto-fit script URL) changes.
+    [assetsPrefix, autoFitScript]
   )
 
   // Listen for postMessage from iframe
@@ -284,17 +312,24 @@ ${INTERACTIVE_SCRIPT}
   callbacksRef.current = { onSelectElement, onTextChanged }
 
   const handleMessage = useCallback((e: MessageEvent) => {
+    const iframe = iframeRef.current
+    if (!iframe || e.source !== iframe.contentWindow) return
     const data = e.data ?? {}
     if (typeof data !== "object" || !data.type) return
-    const { type, dataId, rect, newText, tagName } = data
+    const { type, dataId, rect, newText, editedInnerHtml, tagName } = data
     if (type === "select" || type === "select-image" || type === "select-container") {
       callbacksRef.current.onSelectElement?.(dataId, rect, tagName)
     } else if (type === "text-changed") {
-      // Reconstruct fullHtml from original LaTeX HTML so MathML doesn't leak
-      // into the data model. If reconstruction fails (parse error, missing
-      // data-id) we drop the edit — the iframe's `fullHtml` would carry
-      // rendered MathML that must never reach persistence.
-      const reconstructed = reconstructHtmlWithEdit(sanitizedHtmlRef.current, dataId, newText)
+      // Splice the edited element's innerHTML into the original LaTeX-form HTML
+      // so the edited element keeps the styled child spans contentEditable
+      // preserved (e.g. fixed-layout colour runs), while non-edited siblings
+      // stay in LaTeX form (not MathML). Drop the edit if reconstruction fails
+      // — the iframe's rendered MathML must never reach persistence.
+      const reconstructed = reconstructHtmlWithEdit(
+        sanitizedHtmlRef.current,
+        dataId,
+        editedInnerHtml ?? newText,
+      )
       if (reconstructed === null) {
         console.warn(
           `[adt] Text edit dropped for data-id=${dataId} — could not reconstruct from source HTML.`,
@@ -319,6 +354,17 @@ ${INTERACTIVE_SCRIPT}
   function measureHeight() {
     const doc = iframeRef.current?.contentDocument
     if (!doc?.body) return
+    // Fixed-layout detection: `#content` with explicit pixel width + height.
+    // Our fixed-layout renderer emits `<div id="content" style="...width:Wpx;height:Hpx...">`.
+    const contentEl = doc.getElementById("content") as HTMLElement | null
+    const styleW = contentEl ? parsePxStyle(contentEl.style.width) : null
+    const styleH = contentEl ? parsePxStyle(contentEl.style.height) : null
+    if (contentEl && styleW !== null && styleH !== null) {
+      setFixedLayoutSize({ width: styleW, height: styleH })
+      return
+    }
+
+    setFixedLayoutSize(null)
     const main = doc.querySelector("main")
     const h = (main ?? doc.body).scrollHeight
     if (h > 0) setContentHeight(h)
@@ -330,8 +376,12 @@ ${INTERACTIVE_SCRIPT}
     const doc = iframe?.contentDocument
     if (!doc?.body) return
 
-    // Preserve the interactive script if present
-    const scriptEl = doc.body.querySelector("script")
+    // Preserve the interactive + auto-fit shell scripts. They were
+    // injected once into the srcdoc body and would be wiped when we
+    // replace innerHTML below; the appended copies don't re-execute
+    // (script re-insertion doesn't run them) but they keep the DOM
+    // structure consistent with what the shell expects.
+    const scriptEls = Array.from(doc.body.querySelectorAll("script"))
     const normalizedHtml = promoteFirstHeadingToH1(newHtml)
     // Mirror the packaged page shell closely: a page-level <main> containing
     // either the existing #content wrapper or a generated one.
@@ -339,8 +389,8 @@ ${INTERACTIVE_SCRIPT}
     const hasOwnWrapper = /^\s*<div\b[^>]*\bid="content"/.test(normalizedHtml)
     const contentHtml = hasOwnWrapper ? normalizedHtml : `<div id="content">${normalizedHtml}</div>`
     doc.body.innerHTML = hasOwnMain ? normalizedHtml : `<main class="w-full">${contentHtml}</main>`
-    if (scriptEl) {
-      doc.body.appendChild(scriptEl)
+    for (const s of scriptEls) {
+      doc.body.appendChild(s)
     }
 
     // Inject original LaTeX texts so startEditing can swap MathML → LaTeX
@@ -360,6 +410,34 @@ ${INTERACTIVE_SCRIPT}
     // Force synchronous reflow so the browser repaints the scaled iframe
     // immediately after innerHTML changes (fixes delayed style rendering).
     void doc.body.offsetHeight
+
+    // Trigger the shell-level auto-fit on the freshly injected content.
+    // The function was defined once when the iframe shell loaded; we call
+    // it via rAF so layout for the new innerHTML has flushed.
+    //
+    // We need TWO passes (mirroring auto-fit.js's own initial-load schedule):
+    //   1. Immediately after layout, in case fonts are already loaded.
+    //   2. After document.fonts.ready resolves for the just-injected content.
+    //
+    // The shell parses with an empty body, so its first fonts.ready resolves
+    // *before* any text is on the page — auto-fit.js's own post-fonts-ready
+    // hook therefore runs against an empty body and never re-fires for the
+    // injected content. Without the explicit second pass here, auto-fit
+    // measures against fallback-font metrics (Times for Palatino, etc.) and
+    // shrinks paragraphs that fit fine in the actual rendered font.
+    const runFit = () => {
+      const w = iframe?.contentWindow as (Window & { __adtRunAutoFit?: () => void }) | null
+      if (typeof w?.__adtRunAutoFit !== "function") {
+        // eslint-disable-next-line no-console, lingui/no-unlocalized-strings
+        console.warn("[BookPreviewFrame] __adtRunAutoFit is not defined on iframe contentWindow — auto-fit script did not load/execute. assetsPrefix:", assetsPrefix)
+        return
+      }
+      w.__adtRunAutoFit()
+    }
+    requestAnimationFrame(runFit)
+    if (doc.fonts?.ready) {
+      doc.fonts.ready.then(() => requestAnimationFrame(runFit))
+    }
 
     // Measure after fonts + images settle
     requestAnimationFrame(() => {
@@ -420,6 +498,28 @@ ${INTERACTIVE_SCRIPT}
     if (doc.documentElement) doc.documentElement.style.overflow = value
     if (doc.body) doc.body.style.overflow = value
   }, [deviceView, iframeReady])
+
+  // Fixed-layout pages overlay positioned text on top of full-page images
+  // via DOM order. The editable-mode `img[data-id] { z-index: 1 }` rule (used
+  // for image-selection outlines in reflowable books) would lift those images
+  // above the text and bury it — neutralise the z-index for fixed-layout pages.
+  useEffect(() => {
+    const doc = iframeRef.current?.contentDocument
+    if (!doc?.head) return
+    const styleId = "adt-fixed-layout-styles"
+    let styleEl = doc.getElementById(styleId) as HTMLStyleElement | null
+    if (!fixedLayoutSize) {
+      styleEl?.remove()
+      return
+    }
+    if (!styleEl) {
+      styleEl = doc.createElement("style")
+      styleEl.id = styleId
+      doc.head.appendChild(styleEl)
+    }
+    // eslint-disable-next-line lingui/no-unlocalized-strings
+    styleEl.textContent = `body[data-editable="true"] img[data-id] { z-index: auto; }`
+  }, [fixedLayoutSize, iframeReady])
 
   // Inject/update pruned element styles into the iframe
   useEffect(() => {
@@ -494,10 +594,8 @@ ${selectors}:hover {
   const targetVisibleWidth = getTargetVisibleWidth(deviceView)
   const baseWidth = frame.chromeWidth
 
-  // Compute the scale factor. The chrome (when present) is rendered at its
-  // full logical size; we then `transform: scale()` the entire wrapper so it
-  // fits the canvas. Desktop is capped at 1×; mobile/tablet grow up to a
-  // target visible width for legibility.
+  // Track the wrapper width; the scale effect below recomputes scale from it,
+  // branching on mode (fixed-layout page vs reflowable / device-frame).
   useEffect(() => {
     const wrapper = wrapperRef.current
     if (!wrapper) return
@@ -505,17 +603,28 @@ ${selectors}:hover {
     const ro = new ResizeObserver((entries) => {
       const entry = entries[0]
       if (!entry) return
-      const availableWidth = entry.contentRect.width
-      const fitScale = Math.max(0, availableWidth / baseWidth)
-      const cap =
-        deviceView === "desktop" || deviceView === undefined
-          ? 1
-          : targetVisibleWidth / baseWidth
-      setScale(Math.min(cap, fitScale))
+      setAvailableWidth(entry.contentRect.width)
     })
     ro.observe(wrapper)
     return () => ro.disconnect()
-  }, [baseWidth, targetVisibleWidth, deviceView])
+  }, [])
+
+  // Fixed-layout: scale off the page viewport so content fills the preview
+  // area (capped at 1× — no upscaling beyond the source resolution).
+  // Reflowable: fit to the device-frame base width, desktop capped at 1× and
+  // mobile/tablet grown up to a target visible width for legibility.
+  useEffect(() => {
+    if (fixedLayoutSize) {
+      setScale(Math.min(1, availableWidth / fixedLayoutSize.width))
+      return
+    }
+    const fitScale = Math.max(0, availableWidth / baseWidth)
+    const cap =
+      deviceView === "desktop" || deviceView === undefined
+        ? 1
+        : targetVisibleWidth / baseWidth
+    setScale(Math.min(cap, fitScale))
+  }, [availableWidth, fixedLayoutSize, baseWidth, targetVisibleWidth, deviceView])
 
   // Ref callback so the iframe re-initializes whenever the conditional
   // device-frame branch swaps it out (toggling Desktop ↔ Mobile ↔ Tablet
@@ -555,20 +664,25 @@ ${selectors}:hover {
     }
   }, [])
 
-  const visibleWidth = Math.round(renderWidth * scale)
+  const visibleWidth = Math.round((fixedLayoutSize?.width ?? renderWidth) * scale)
   useEffect(() => {
     onVisibleWidthChange?.(visibleWidth)
   }, [visibleWidth, onVisibleWidthChange])
 
-  // Mobile/tablet keep their fixed device-screen height (the chrome is meant
-  // to look like a real phone/tablet). Desktop has no chrome — making the
-  // iframe content-tall avoids the dead space `min-h-screen flex items-center`
-  // produces when a section is shorter than the canvas.
+  // Fixed-layout pages carry explicit pixel dimensions and ignore device
+  // chrome. Reflowable: mobile/tablet keep their fixed device-screen height
+  // (the chrome is meant to look like a real phone/tablet); desktop has no
+  // chrome — making the iframe content-tall avoids the dead space
+  // `min-h-screen flex items-center` produces when a section is shorter than
+  // the canvas.
   const isDesktop = !deviceView || deviceView === "desktop"
-  const iframeHeight = isDesktop ? contentHeight : frame.screenHeight
-  const visibleHeight = isDesktop
-    ? contentHeight * scale
-    : frame.chromeHeight * scale
+  const iframeWidth = fixedLayoutSize?.width ?? frame.screenWidth
+  const iframeHeight = fixedLayoutSize?.height ?? (isDesktop ? contentHeight : frame.screenHeight)
+  const visibleHeight = fixedLayoutSize
+    ? fixedLayoutSize.height * scale
+    : isDesktop
+      ? contentHeight * scale
+      : frame.chromeHeight * scale
 
   const iframeNode = (
     <iframe
@@ -576,7 +690,7 @@ ${selectors}:hover {
       srcDoc={srcdoc}
       className="block"
       style={{
-        width: frame.screenWidth,
+        width: iframeWidth,
         height: iframeHeight,
         border: "none",
       }}
@@ -609,7 +723,7 @@ ${selectors}:hover {
         ) : (
           <div
             style={{
-              width: frame.screenWidth,
+              width: iframeWidth,
               height: iframeHeight,
               overflow: "hidden",
             }}

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/iframe-html.ts
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/iframe-html.ts
@@ -22,20 +22,23 @@ export function demoteFirstHeadingIfPromoted(
   )
 }
 
-// Apply a text edit to the original (LaTeX) HTML by replacing the textContent
-// of the element matching the given data-id. Returns the reconstructed wrapper
-// HTML, or null if the element was not found.
+// Apply a text edit to the original (LaTeX) HTML by splicing the iframe's
+// edited innerHTML into the element matching the given data-id. Using innerHTML
+// (rather than `textContent = newText`) preserves the inner span structure that
+// contentEditable kept intact while the user typed — e.g. fixed-layout
+// paragraphs whose words are wrapped in differently coloured `<span>`s. Returns
+// the reconstructed wrapper HTML, or null if the element was not found.
 export function reconstructHtmlWithEdit(
   originalHtml: string,
   dataId: string,
-  newText: string
+  editedInnerHtml: string
 ): string | null {
   try {
     const parser = new DOMParser()
     const doc = parser.parseFromString(`<div id="__root">${originalHtml}</div>`, "text/html")
     const el = doc.querySelector(`[data-id="${CSS.escape(dataId)}"]`)
     if (!el) return null
-    el.textContent = newText
+    el.innerHTML = editedInnerHtml
     const wrapper = doc.getElementById("content") ?? doc.getElementById("__root")
     if (!wrapper) return null
     const cls = wrapper.getAttribute("class")?.trim()

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/iframe-interactive.ts
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/iframe-interactive.ts
@@ -123,6 +123,11 @@ export const INTERACTIVE_SCRIPT = `<script>
       type: 'text-changed',
       dataId: dataId,
       newText: newText,
+      // The element's edited innerHTML — contentEditable preserves any existing
+      // styled child spans (e.g. fixed-layout colour runs) as the user types
+      // within them. The parent splices this into the original LaTeX-form HTML
+      // so non-edited siblings keep LaTeX (not MathML).
+      editedInnerHtml: el.innerHTML,
       fullHtml: fullHtml
     }, '*');
   }

--- a/apps/studio/src/components/wizard/BookCreationWizard.tsx
+++ b/apps/studio/src/components/wizard/BookCreationWizard.tsx
@@ -275,11 +275,15 @@ export function BookCreationWizard() {
   }
   const previewWidth = currentStep === 2 ? getPreviewWidth(renderStrategy) : 650
 
+  const isFixedLayout = values.renderStrategy === "fixed_layout"
+
   function renderPreviewContent({mobileMode}: {mobileMode: boolean} = {mobileMode: false}) {
     if (currentStep === 1) return <PdfCoverPreview file={file} width={650} height={812} />
     if (currentStep === 2) return <LayoutPreview strategy={renderStrategy} />
-    if (currentStep === 3)
+    if (currentStep === 3) {
+      if (isFixedLayout) return <PdfCoverPreview file={file} width={650} height={812} />
       return <ImageProcessingPreviewPane focus={previewFocus} mobile={mobileMode} />
+    }
     if (currentStep === 4)
       return <LanguagesPreviewPane editingLanguage={editingLanguage} outputLanguages={outputLanguages} />
     if (currentStep === 5)

--- a/apps/studio/src/components/wizard/bookCreationConfig.ts
+++ b/apps/studio/src/components/wizard/bookCreationConfig.ts
@@ -37,6 +37,20 @@ export function buildConfigOverrides(values: WizardFormValues): Record<string, u
       max_side: values.imageFilterMaxSide,
       cropping: values.imageCropping,
       segmentation: values.imageSegmentation,
+      // Fixed-layout treats every extracted image as positioned page content
+      // (speech bubbles, decorative strips, captions all matter visually).
+      // Override the size / complexity / meaningfulness filters so nothing is
+      // pruned at extract time except the full-page render itself (handled
+      // separately by image-filtering's `_page` rule). The book config is
+      // honest about what will run; users can flip any of these back on in
+      // Extract Settings. `max_side: undefined` makes js-yaml omit the key
+      // entirely, so the pipeline's max-side check is skipped.
+      ...(values.renderStrategy === "fixed_layout" && {
+        min_side: 0,
+        max_side: undefined,
+        min_stddev: 0,
+        meaningfulness: false,
+      }),
     },
   }
 

--- a/apps/studio/src/components/wizard/constants.ts
+++ b/apps/studio/src/components/wizard/constants.ts
@@ -4,6 +4,7 @@ import {
   BookOpen,
   AlignLeft,
   SlidersHorizontal,
+  Image,
 } from "lucide-react";
 import type { MessageDescriptor } from "@lingui/core";
 import { msg } from "@lingui/core/macro";
@@ -88,6 +89,13 @@ export const RENDER_STRATEGIES = [
     Icon: TwoColumnStoryStrategyIcon,
     title: msg`Two Columns Story`,
     description: msg`Perfect for children's books, pairing large images with minimal text.`,
+    category: "template",
+  },
+  {
+    id: "fixed_layout",
+    Icon: Image,
+    title: msg`Fixed Layout`,
+    description: msg`Page image as background with positioned text overlay. Preserves the original page composition; ideal for illustrated storybooks.`,
     category: "template",
   },
 ] as const satisfies readonly RenderStrategyOption[];
@@ -318,7 +326,7 @@ export const PRESETS: PresetConfig[] = [
     bgColor: "bg-amber-500/5",
     title: msg`Storybook`,
     description: msg`Large images, narrative flow. Best for illustrated books with high-fidelity TTS voices.`,
-    renderStrategies: ["llm", "llm-overlay", "two_column", "two_column_story"],
+    renderStrategies: ["llm", "llm-overlay", "two_column", "two_column_story", "fixed_layout"],
     recommendedStrategies: ["llm-overlay", "two_column_story"],
     recommendedFor: [
       msg`Illustrated children's books`,
@@ -373,6 +381,9 @@ export const PRESETS: PresetConfig[] = [
             max_retries: 25,
             timeout: 180,
           },
+        },
+        fixed_layout: {
+          render_type: "fixed_layout",
         },
       },
       section_render_strategies: {},

--- a/apps/studio/src/components/wizard/step0preset/PresetGrid.tsx
+++ b/apps/studio/src/components/wizard/step0preset/PresetGrid.tsx
@@ -20,7 +20,7 @@ export function PresetGrid({ selected, onSelect }: PresetGridProps) {
       <div
         role="radiogroup"
         aria-labelledby="preset-step-heading"
-        className="w-full max-w-[1280px] grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-4 px-4 sm:px-6 overflow-auto py-1"
+        className="w-full max-w-[1280px] grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 px-4 sm:px-6 overflow-auto py-1"
       >
         {PRESETS.map((preset) => (
           <PresetCard

--- a/apps/studio/src/components/wizard/step0preset/PresetGrid.tsx
+++ b/apps/studio/src/components/wizard/step0preset/PresetGrid.tsx
@@ -20,7 +20,7 @@ export function PresetGrid({ selected, onSelect }: PresetGridProps) {
       <div
         role="radiogroup"
         aria-labelledby="preset-step-heading"
-        className="w-full max-w-[1280px] grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 px-4 sm:px-6 overflow-auto py-1"
+        className="w-full max-w-[1280px] grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-4 px-4 sm:px-6 overflow-auto py-1"
       >
         {PRESETS.map((preset) => (
           <PresetCard

--- a/apps/studio/src/components/wizard/step2LayoutOptions/LayoutPreview.tsx
+++ b/apps/studio/src/components/wizard/step2LayoutOptions/LayoutPreview.tsx
@@ -13,6 +13,7 @@ const STRATEGY_WIDTHS: Record<RenderStrategyId, number> = {
   single_column: 650,
   two_column: 650,
   two_column_story: 980,
+  fixed_layout: 650,
 }
 
 export function getPreviewWidth(strategy: string): number {
@@ -480,6 +481,23 @@ function TwoColumnStoryPreview() {
   )
 }
 
+function FixedLayoutPreview() {
+  return (
+    <div className="relative flex h-full min-h-0 items-center justify-center px-2 py-4 @min-[420px]:px-3 @min-[420px]:py-6 @min-[540px]:px-5 @min-[620px]:px-[30px] @min-[620px]:py-[66px]">
+      <div className="relative h-full max-h-[444px] w-full max-w-[440px]">
+        <img
+          alt=""
+          src="/previews/two-column-story.png"
+          className="pointer-events-none absolute inset-0 h-full w-full object-contain"
+        />
+        <div className="absolute left-[8%] top-[58%] right-[8%] rounded-md bg-white/85 px-3 py-2 text-center text-[11px] font-semibold leading-snug tracking-[0.3px] text-[#0a0a0a] shadow-sm @min-[420px]:px-4 @min-[420px]:py-2.5 @min-[420px]:text-xs @min-[480px]:text-sm @min-[540px]:px-5 @min-[540px]:py-3 @min-[540px]:text-base @min-[620px]:text-lg @min-[760px]:text-xl">
+          <Trans>This is Pip! He has a wiggly tail.</Trans>
+        </div>
+      </div>
+    </div>
+  )
+}
+
 // ─── Registry & export ──────────────────────────────────────────────────────
 
 const STRATEGY_PREVIEWS: Record<RenderStrategyId, React.FC> = {
@@ -488,6 +506,7 @@ const STRATEGY_PREVIEWS: Record<RenderStrategyId, React.FC> = {
   single_column: SingleColumnPreview,
   two_column: TwoColumnPreview,
   two_column_story: TwoColumnStoryPreview,
+  fixed_layout: FixedLayoutPreview,
 }
 
 const RENDER_STRATEGY_LABEL = msg`Render Strategy`

--- a/apps/studio/src/components/wizard/step3ContentProcessing/index.tsx
+++ b/apps/studio/src/components/wizard/step3ContentProcessing/index.tsx
@@ -89,6 +89,7 @@ export function Step3() {
   const { i18n } = useLingui()
   const recommendations = usePresetRecommendations()
   const selectedPresetId = useStore(form.store, (s) => s.values.selectedPreset)
+  const renderStrategy = useStore(form.store, (s) => s.values.renderStrategy)
   const preset = PRESETS.find((p) => p.id === selectedPresetId)
   const accent = getPresetAccent(selectedPresetId)
   // eslint-disable-next-line lingui/no-unlocalized-strings -- ImageProcessingPreviewFocus key
@@ -101,6 +102,29 @@ export function Step3() {
   const segmentationMinSide = useStore(form.store, (s) => s.values.segmentationMinSide)
   const imageFilterMinSide = useStore(form.store, (s) => s.values.imageFilterMinSide)
   const imageFilterMaxSide = useStore(form.store, (s) => s.values.imageFilterMaxSide)
+
+  if (renderStrategy === "fixed_layout") {
+    return (
+      <div className="flex w-full flex-col gap-4 p-8">
+        <div
+          className="rounded-lg border border-dashed px-5 py-6"
+          style={{ borderColor: accent.bg, backgroundColor: `${accent.bg}0d` }}
+        >
+          <h3 className="text-sm font-semibold text-[#0a0a0a]">
+            <Trans>No content processing needed</Trans>
+          </h3>
+          <p className="mt-2 text-sm text-[#525252]">
+            <Trans>
+              Fixed-layout books use the original page images as backgrounds with positioned text extracted from the PDF. Activities detection, figure extraction, and image cropping or segmentation don't apply to this layout.
+            </Trans>
+          </p>
+          <p className="mt-2 text-sm text-[#525252]">
+            <Trans>Click Next to continue to language settings.</Trans>
+          </p>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div className="flex w-full flex-col gap-8 p-8">

--- a/apps/studio/src/components/wizard/steps.ts
+++ b/apps/studio/src/components/wizard/steps.ts
@@ -46,10 +46,7 @@ export const STEPS: StepDef[] = [
     description: msg`Choose how the content should be formatted.`,
     component: Step2,
     hasRequiredFields: true,
-    isValid: (v) =>
-      v.renderStrategy !== "" &&
-      v.pageGrouping !== "" &&
-      v.sectioningMode !== "",
+    isValid: (v) => v.renderStrategy !== "" && v.pageGrouping !== "" && v.sectioningMode !== "",
     scrollToFirstInvalid: (v) => {
       if (!v.renderStrategy) return "wizard-render-strategy"
       if (!v.pageGrouping) return "wizard-page-grouping"

--- a/apps/studio/src/hooks/use-export-watcher.ts
+++ b/apps/studio/src/hooks/use-export-watcher.ts
@@ -8,8 +8,7 @@ import { isElectron } from "@/lib/utils"
 import { useBookTasks } from "./use-book-tasks"
 import type { ExportFeatureToggles } from "./use-export-features"
 import type { CapturedSettings } from "./use-preview-settings-listener"
-
-type ExportFormat = "project" | "webpub" | "scorm" | "adt"
+import type { ExportFormat } from "@/components/pipeline/stages/export/export-formats"
 
 interface PendingExport {
   taskId: string
@@ -129,6 +128,8 @@ async function triggerExportDownload(
     blob = await api.exportProject(label)
   } else if (format === "webpub") {
     blob = await api.exportWebpub(label)
+  } else if (format === "epub") {
+    blob = await api.exportEpub(label)
   } else if (format === "scorm") {
     blob = await api.exportScorm(label)
   } else {
@@ -147,6 +148,7 @@ async function triggerExportDownload(
     webpub: { ext: "webpub", suffix: "", filterName: i18n._(msg`WebPub`) },
     scorm: { ext: "zip", suffix: "-scorm", filterName: i18n._(msg`SCORM Package`) },
     adt: { ext: "zip", suffix: "-adt", filterName: i18n._(msg`ADT Package`) },
+    epub: { ext: "epub", suffix: "", filterName: i18n._(msg`EPUB`) },
   }
   /* eslint-enable lingui/no-unlocalized-strings */
   const meta = formatMeta[format]

--- a/apps/studio/src/lib/render-strategy.ts
+++ b/apps/studio/src/lib/render-strategy.ts
@@ -7,9 +7,12 @@ type RenderStrategyMap = Record<string, RenderStrategyLike>
 export function listSelectableRenderStrategies(
   strategies: RenderStrategyMap
 ): string[] {
-  return Object.keys(strategies).filter(
-    (name) => strategies[name]?.render_type !== "activity"
-  )
+  return Object.keys(strategies).filter((name) => {
+    const type = strategies[name]?.render_type
+    // `activity` strategies are auto-assigned to matching section types.
+    // `fixed_layout` is a book-wide rendering mode, not a per-section override.
+    return type !== "activity" && type !== "fixed_layout"
+  })
 }
 
 export function chooseDefaultRenderStrategyFallback(

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -1352,6 +1352,9 @@ msgstr "Click an image to select"
 msgid "Click images to select"
 msgstr "Click images to select"
 
+msgid "Click Next to continue to language settings."
+msgstr "Click Next to continue to language settings."
+
 msgid "Click to edit"
 msgstr "Click to edit"
 
@@ -2060,6 +2063,15 @@ msgstr "Enter a valid project name"
 #~ msgid "Enter hex color and press Enter"
 #~ msgstr "Enter hex color and press Enter"
 
+msgid "EPUB"
+msgstr "EPUB"
+
+msgid "EPUB 3"
+msgstr "EPUB 3"
+
+msgid "EPUB Export"
+msgstr "EPUB Export"
+
 msgid "Error"
 msgstr "Error"
 
@@ -2276,6 +2288,9 @@ msgstr "Fixed Layout"
 
 msgid "Fixed two-column template layout"
 msgstr "Fixed two-column template layout"
+
+msgid "Fixed-layout books use the original page images as backgrounds with positioned text extracted from the PDF. Activities detection, figure extraction, and image cropping or segmentation don't apply to this layout."
+msgstr "Fixed-layout books use the original page images as backgrounds with positioned text extracted from the PDF. Activities detection, figure extraction, and image cropping or segmentation don't apply to this layout."
 
 msgid "flagged"
 msgstr "flagged"
@@ -3332,6 +3347,9 @@ msgstr "No changes flagged on this page"
 msgid "No colors found"
 msgstr "No colors found"
 
+msgid "No content processing needed"
+msgstr "No content processing needed"
+
 msgid "No cover available"
 msgstr "No cover available"
 
@@ -3596,6 +3614,9 @@ msgstr "Open a page to see page-level findings"
 msgid "Open edit panel"
 msgstr "Open edit panel"
 
+msgid "Open in any EPUB 3 reader, e-reader, or accessibility tool."
+msgstr "Open in any EPUB 3 reader, e-reader, or accessibility tool."
+
 msgid "Open page preview for {pageId}"
 msgstr "Open page preview for {pageId}"
 
@@ -3782,6 +3803,9 @@ msgstr "Page Grouping Mode"
 msgid "Page image"
 msgstr "Page image"
 
+msgid "Page image as background with positioned text overlay. Preserves the original page composition; ideal for illustrated storybooks."
+msgstr "Page image as background with positioned text overlay. Preserves the original page composition; ideal for illustrated storybooks."
+
 msgid "Page Mode"
 msgstr "Page Mode"
 
@@ -3954,6 +3978,13 @@ msgstr "Portuguese (BR)"
 
 msgid "Position"
 msgstr "Position"
+
+#. placeholder {0}: Math.round(bounds.x)
+#. placeholder {1}: Math.round(bounds.y)
+#. placeholder {2}: Math.round(bounds.width)
+#. placeholder {3}: Math.round(bounds.height)
+msgid "Position {0}, {1} → {2}×{3} pt"
+msgstr "Position {0}, {1} → {2}×{3} pt"
 
 msgid "Práticas de Alfabetização e de Matemática"
 msgstr "Práticas de Alfabetização e de Matemática"
@@ -5053,6 +5084,12 @@ msgstr "Sprinkling some digital fairy dust..."
 msgid "Standard"
 msgstr "Standard"
 
+msgid "Standard e-book for readers & libraries"
+msgstr "Standard e-book for readers & libraries"
+
+msgid "Standard EPUB 3 file for e-readers, reading apps, and accessibility tools. Interactive features (quizzes, TTS) work in readers that support JavaScript."
+msgstr "Standard EPUB 3 file for e-readers, reading apps, and accessibility tools. Interactive features (quizzes, TTS) work in readers that support JavaScript."
+
 msgid "Start"
 msgstr "Start"
 
@@ -5421,6 +5458,9 @@ msgstr "This is <0>ADT Studio</0>."
 
 msgid "This is a preview of the options you have selected for your book, each option affects the preview in a different way."
 msgstr "This is a preview of the options you have selected for your book, each option affects the preview in a different way."
+
+msgid "This is Pip! He has a wiggly tail."
+msgstr "This is Pip! He has a wiggly tail."
 
 msgid "This is Pip! He is a happy caramel dog with a very wiggly tail. Pip loves the green grass, the bright yellow sun, and making new friends in his garden."
 msgstr "This is Pip! He is a happy caramel dog with a very wiggly tail. Pip loves the green grass, the bright yellow sun, and making new friends in his garden."

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -1352,6 +1352,9 @@ msgstr "Haz clic en una imagen para seleccionar"
 msgid "Click images to select"
 msgstr "Haz clic en las imágenes para seleccionar"
 
+msgid "Click Next to continue to language settings."
+msgstr "Haz clic en Siguiente para continuar con la configuración de idioma."
+
 msgid "Click to edit"
 msgstr "Haz clic para editar"
 
@@ -2060,6 +2063,15 @@ msgstr "Introduce un nombre de proyecto válido"
 #~ msgid "Enter hex color and press Enter"
 #~ msgstr "Ingresa un color hex y presiona Enter"
 
+msgid "EPUB"
+msgstr "EPUB"
+
+msgid "EPUB 3"
+msgstr "EPUB 3"
+
+msgid "EPUB Export"
+msgstr "Exportar EPUB"
+
 msgid "Error"
 msgstr "Error"
 
@@ -2276,6 +2288,9 @@ msgstr "Diseño Fijo"
 
 msgid "Fixed two-column template layout"
 msgstr "Plantilla de diseño fijo de dos columnas"
+
+msgid "Fixed-layout books use the original page images as backgrounds with positioned text extracted from the PDF. Activities detection, figure extraction, and image cropping or segmentation don't apply to this layout."
+msgstr "Los libros de diseño fijo usan las imágenes originales de las páginas como fondo con texto posicionado extraído del PDF. La detección de actividades, extracción de figuras, recorte o segmentación de imágenes no aplican a este diseño."
 
 msgid "flagged"
 msgstr "flagged"
@@ -3332,6 +3347,9 @@ msgstr "No changes flagged on this page"
 msgid "No colors found"
 msgstr "No se encontraron colores"
 
+msgid "No content processing needed"
+msgstr "No se necesita procesamiento de contenido"
+
 msgid "No cover available"
 msgstr "Portada no disponible"
 
@@ -3596,6 +3614,9 @@ msgstr "Open a page to see page-level findings"
 msgid "Open edit panel"
 msgstr "Abrir panel de edición"
 
+msgid "Open in any EPUB 3 reader, e-reader, or accessibility tool."
+msgstr "Ábrelo en cualquier lector EPUB 3, lector electrónico o herramienta de accesibilidad."
+
 msgid "Open page preview for {pageId}"
 msgstr "Abrir vista previa de la página {0}"
 
@@ -3782,6 +3803,9 @@ msgstr "Modo de Agrupación de Páginas"
 msgid "Page image"
 msgstr "Imagen de la página"
 
+msgid "Page image as background with positioned text overlay. Preserves the original page composition; ideal for illustrated storybooks."
+msgstr "Imagen de página como fondo con texto posicionado superpuesto. Preserva la composición original de la página; ideal para libros ilustrados."
+
 msgid "Page Mode"
 msgstr "Modo de Página"
 
@@ -3954,6 +3978,13 @@ msgstr "Portugués (BR)"
 
 msgid "Position"
 msgstr "Posición"
+
+#. placeholder {0}: Math.round(bounds.x)
+#. placeholder {1}: Math.round(bounds.y)
+#. placeholder {2}: Math.round(bounds.width)
+#. placeholder {3}: Math.round(bounds.height)
+msgid "Position {0}, {1} → {2}×{3} pt"
+msgstr "Posición {0}, {1} → {2}×{3} pt"
 
 msgid "Práticas de Alfabetização e de Matemática"
 msgstr "Prácticas de Alfabetización y Matemáticas"
@@ -5053,6 +5084,12 @@ msgstr "Espolvoreando un poco de polvo mágico digital..."
 msgid "Standard"
 msgstr "Estándar"
 
+msgid "Standard e-book for readers & libraries"
+msgstr "Libro electrónico estándar para lectores y bibliotecas"
+
+msgid "Standard EPUB 3 file for e-readers, reading apps, and accessibility tools. Interactive features (quizzes, TTS) work in readers that support JavaScript."
+msgstr "Archivo EPUB 3 estándar para lectores electrónicos, aplicaciones de lectura y herramientas de accesibilidad. Las funciones interactivas (cuestionarios, TTS) funcionan en lectores que admiten JavaScript."
+
 msgid "Start"
 msgstr "Inicio"
 
@@ -5421,6 +5458,9 @@ msgstr "Esto es <0>ADT Studio</0>."
 
 msgid "This is a preview of the options you have selected for your book, each option affects the preview in a different way."
 msgstr "Esta es una vista previa de las opciones que has seleccionado para tu libro, cada opción afecta la vista previa de una manera diferente."
+
+msgid "This is Pip! He has a wiggly tail."
+msgstr "¡Este es Pip! Tiene una cola que se mueve."
 
 msgid "This is Pip! He is a happy caramel dog with a very wiggly tail. Pip loves the green grass, the bright yellow sun, and making new friends in his garden."
 msgstr "¡Este es Pip! Es un perro caramelo feliz con una cola muy movida. A Pip le encanta el césped verde, el brillante sol amarillo y hacer nuevos amigos en su jardín."

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -1354,6 +1354,9 @@ msgstr "Cliquez sur une image pour la sélectionner"
 msgid "Click images to select"
 msgstr "Cliquez sur les images pour les sélectionner"
 
+msgid "Click Next to continue to language settings."
+msgstr "Cliquez sur Suivant pour passer aux paramètres de langue."
+
 msgid "Click to edit"
 msgstr "Cliquer pour modifier"
 
@@ -2062,6 +2065,15 @@ msgstr "Saisissez un nom de projet valide"
 #~ msgid "Enter hex color and press Enter"
 #~ msgstr "Saisissez une couleur hexadécimale et appuyez sur Entrée"
 
+msgid "EPUB"
+msgstr "EPUB"
+
+msgid "EPUB 3"
+msgstr "EPUB 3"
+
+msgid "EPUB Export"
+msgstr "Export EPUB"
+
 msgid "Error"
 msgstr "Erreur"
 
@@ -2278,6 +2290,9 @@ msgstr "Mise en page fixe"
 
 msgid "Fixed two-column template layout"
 msgstr "Mise en page fixe à deux colonnes"
+
+msgid "Fixed-layout books use the original page images as backgrounds with positioned text extracted from the PDF. Activities detection, figure extraction, and image cropping or segmentation don't apply to this layout."
+msgstr "Les livres à mise en page fixe utilisent les images de page d'origine comme arrière-plans avec le texte positionné extrait du PDF. La détection d'activités, l'extraction de figures et le rognage ou la segmentation d'images ne s'appliquent pas à cette mise en page."
 
 msgid "flagged"
 msgstr "signalé"
@@ -3334,6 +3349,9 @@ msgstr "Aucune modification signalée sur cette page"
 msgid "No colors found"
 msgstr "Aucune couleur trouvée"
 
+msgid "No content processing needed"
+msgstr "Aucun traitement de contenu nécessaire"
+
 msgid "No cover available"
 msgstr "Pas de couverture disponible"
 
@@ -3598,6 +3616,9 @@ msgstr "Ouvrir une page pour voir les résultats au niveau de la page"
 msgid "Open edit panel"
 msgstr "Ouvrir le panneau de modification"
 
+msgid "Open in any EPUB 3 reader, e-reader, or accessibility tool."
+msgstr "Ouvrez-le dans n'importe quelle liseuse EPUB 3 ou outil d'accessibilité."
+
 msgid "Open page preview for {pageId}"
 msgstr "Ouvrir l'aperçu de la page {pageId}"
 
@@ -3784,6 +3805,9 @@ msgstr "Mode de regroupement de pages"
 msgid "Page image"
 msgstr "Image de la page"
 
+msgid "Page image as background with positioned text overlay. Preserves the original page composition; ideal for illustrated storybooks."
+msgstr "Image de page en arrière-plan avec texte positionné en superposition. Préserve la composition originale de la page ; idéal pour les livres illustrés."
+
 msgid "Page Mode"
 msgstr "Mode de page"
 
@@ -3956,6 +3980,13 @@ msgstr "Portugais (BR)"
 
 msgid "Position"
 msgstr "Position"
+
+#. placeholder {0}: Math.round(bounds.x)
+#. placeholder {1}: Math.round(bounds.y)
+#. placeholder {2}: Math.round(bounds.width)
+#. placeholder {3}: Math.round(bounds.height)
+msgid "Position {0}, {1} → {2}×{3} pt"
+msgstr "Position {0}, {1} → {2}×{3} pt"
 
 msgid "Práticas de Alfabetização e de Matemática"
 msgstr "Práticas de Alfabetização e de Matemática"
@@ -5055,6 +5086,12 @@ msgstr "Saupoudrage de poussière de fée numérique..."
 msgid "Standard"
 msgstr "Standard"
 
+msgid "Standard e-book for readers & libraries"
+msgstr "Livre électronique standard pour liseuses et bibliothèques"
+
+msgid "Standard EPUB 3 file for e-readers, reading apps, and accessibility tools. Interactive features (quizzes, TTS) work in readers that support JavaScript."
+msgstr "Fichier EPUB 3 standard pour liseuses, applications de lecture et outils d'accessibilité. Les fonctions interactives (quiz, TTS) fonctionnent dans les lecteurs qui prennent en charge JavaScript."
+
 msgid "Start"
 msgstr "Démarrer"
 
@@ -5423,6 +5460,9 @@ msgstr "Voici <0>ADT Studio</0>."
 
 msgid "This is a preview of the options you have selected for your book, each option affects the preview in a different way."
 msgstr "Ceci est un aperçu des options que vous avez sélectionnées pour votre livre. Chaque option affecte l'aperçu de manière différente."
+
+msgid "This is Pip! He has a wiggly tail."
+msgstr "Voici Pip ! Il a une queue frétillante."
 
 msgid "This is Pip! He is a happy caramel dog with a very wiggly tail. Pip loves the green grass, the bright yellow sun, and making new friends in his garden."
 msgstr "Voici Pip ! C'est un joyeux chien caramel avec une queue très remuante. Pip adore l'herbe verte, le soleil jaune éclatant et se faire de nouveaux amis dans son jardin."

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -1352,6 +1352,9 @@ msgstr "Clique em uma imagem para selecionar"
 msgid "Click images to select"
 msgstr "Clique nas imagens para selecionar"
 
+msgid "Click Next to continue to language settings."
+msgstr "Clique em Avançar para continuar para as configurações de idioma."
+
 msgid "Click to edit"
 msgstr "Clique para editar"
 
@@ -2060,6 +2063,15 @@ msgstr "Insira um nome de projeto válido"
 #~ msgid "Enter hex color and press Enter"
 #~ msgstr "Digite uma cor hex e pressione Enter"
 
+msgid "EPUB"
+msgstr "EPUB"
+
+msgid "EPUB 3"
+msgstr "EPUB 3"
+
+msgid "EPUB Export"
+msgstr "Exportar EPUB"
+
 msgid "Error"
 msgstr "Erro"
 
@@ -2276,6 +2288,9 @@ msgstr "Layout Fixo"
 
 msgid "Fixed two-column template layout"
 msgstr "Layout fixo de duas colunas (template)"
+
+msgid "Fixed-layout books use the original page images as backgrounds with positioned text extracted from the PDF. Activities detection, figure extraction, and image cropping or segmentation don't apply to this layout."
+msgstr "Livros de layout fixo usam as imagens originais das páginas como fundo com texto posicionado extraído do PDF. Detecção de atividades, extração de figuras, recorte ou segmentação de imagens não se aplicam a este layout."
 
 msgid "flagged"
 msgstr "flagged"
@@ -3332,6 +3347,9 @@ msgstr "No changes flagged on this page"
 msgid "No colors found"
 msgstr "Nenhuma cor encontrada"
 
+msgid "No content processing needed"
+msgstr "Não é necessário processamento de conteúdo"
+
 msgid "No cover available"
 msgstr "Capa não disponível"
 
@@ -3596,6 +3614,9 @@ msgstr "Open a page to see page-level findings"
 msgid "Open edit panel"
 msgstr "Abrir painel de edição"
 
+msgid "Open in any EPUB 3 reader, e-reader, or accessibility tool."
+msgstr "Abra em qualquer leitor EPUB 3, leitor eletrônico ou ferramenta de acessibilidade."
+
 msgid "Open page preview for {pageId}"
 msgstr "Abrir pré-visualização da página {0}"
 
@@ -3782,6 +3803,9 @@ msgstr "Modo de agrupamento de páginas"
 msgid "Page image"
 msgstr "Imagem da página"
 
+msgid "Page image as background with positioned text overlay. Preserves the original page composition; ideal for illustrated storybooks."
+msgstr "Imagem da página como fundo com texto posicionado sobreposto. Preserva a composição original da página; ideal para livros ilustrados."
+
 msgid "Page Mode"
 msgstr "Modo de Página"
 
@@ -3954,6 +3978,13 @@ msgstr "Português (BR)"
 
 msgid "Position"
 msgstr "Posição"
+
+#. placeholder {0}: Math.round(bounds.x)
+#. placeholder {1}: Math.round(bounds.y)
+#. placeholder {2}: Math.round(bounds.width)
+#. placeholder {3}: Math.round(bounds.height)
+msgid "Position {0}, {1} → {2}×{3} pt"
+msgstr "Posição {0}, {1} → {2}×{3} pt"
 
 msgid "Práticas de Alfabetização e de Matemática"
 msgstr "Práticas de Alfabetização e de Matemática"
@@ -5053,6 +5084,12 @@ msgstr "Salpicando um pouco de pó mágico digital..."
 msgid "Standard"
 msgstr "Padrão"
 
+msgid "Standard e-book for readers & libraries"
+msgstr "E-book padrão para leitores e bibliotecas"
+
+msgid "Standard EPUB 3 file for e-readers, reading apps, and accessibility tools. Interactive features (quizzes, TTS) work in readers that support JavaScript."
+msgstr "Arquivo EPUB 3 padrão para leitores eletrônicos, aplicativos de leitura e ferramentas de acessibilidade. Recursos interativos (questionários, TTS) funcionam em leitores que suportam JavaScript."
+
 msgid "Start"
 msgstr "Início"
 
@@ -5421,6 +5458,9 @@ msgstr "Isto é o <0>ADT Studio</0>."
 
 msgid "This is a preview of the options you have selected for your book, each option affects the preview in a different way."
 msgstr "Esta é uma pré-visualização das opções que você selecionou para o seu livro, cada opção afeta a pré-visualização de uma maneira diferente."
+
+msgid "This is Pip! He has a wiggly tail."
+msgstr "Este é o Pip! Ele tem um rabo que balança."
 
 msgid "This is Pip! He is a happy caramel dog with a very wiggly tail. Pip loves the green grass, the bright yellow sun, and making new friends in his garden."
 msgstr "Este é o Pip! Ele é um cachorro caramelo feliz com um rabo muito agitado. Pip adora a grama verde, o sol amarelo brilhante e fazer novos amigos em seu jardim."

--- a/assets/adt/auto-fit.js
+++ b/assets/adt/auto-fit.js
@@ -1,0 +1,157 @@
+/**
+ * Auto-fit for fixed-layout text entries.
+ *
+ * Walks every `[data-adt-fit]` element and shrinks its inner
+ * `<span style="font-size:..">` runs until `scrollWidth <= clientWidth`
+ * and `scrollHeight <= clientHeight`. Two strategies in sequence:
+ *
+ * 1. Letter-spacing tightening (small, ≤ -0.02em). Handles the
+ *    millimetre-scale browser-vs-mupdf glyph metric drift without
+ *    visibly cramming characters.
+ * 2. Font-size shrink (98% → 50% in 2% steps). The dominant strategy —
+ *    a borderline 14%-too-wide title hits 86% font cleanly instead of
+ *    being crammed at full size.
+ *
+ * `data-adt-fs` and `data-adt-fit-ls` cache originals so re-runs
+ * (translation swap, content update) restart from a clean baseline.
+ *
+ * Briefly forces `overflow:visible` while measuring because some
+ * browsers cap `scrollHeight` on `overflow:hidden` boxes, which would
+ * let `fits()` falsely return true.
+ *
+ * Loaded by:
+ *   - Renderer (packages/pipeline/src/fixed-layout-rendering.ts) into
+ *     each fixed-layout page's HTML.
+ *   - Studio storyboard preview (apps/studio/.../BookPreviewFrame.tsx)
+ *     into the iframe shell, since DOMPurify strips per-page <script>
+ *     tags before innerHTML injection.
+ *
+ * Exposes `window.__adtRunAutoFit()` so callers that swap content
+ * (e.g. studio's `injectContent`) can trigger another pass after the
+ * new DOM is in place. Idempotent re-entry is safe.
+ */
+(function () {
+  function targets(el) {
+    var t = []
+    if (el.style.fontSize) t.push(el)
+    var inner = el.querySelectorAll('[style*="font-size"]')
+    for (var i = 0; i < inner.length; i++) t.push(inner[i])
+    return t
+  }
+
+  function fit(el) {
+    var ts = targets(el)
+    for (var i = 0; i < ts.length; i++) {
+      var t = ts[i]
+      if (!t.dataset.adtFs) t.dataset.adtFs = parseFloat(t.style.fontSize)
+      t.style.fontSize = t.dataset.adtFs + "px"
+    }
+    var origLs
+    if (el.dataset.adtFitLs !== undefined) {
+      origLs = parseFloat(el.dataset.adtFitLs)
+    } else {
+      var ls = getComputedStyle(el).letterSpacing
+      origLs = ls === "normal" ? 0 : parseFloat(ls) || 0
+      el.dataset.adtFitLs = origLs
+    }
+    el.style.letterSpacing = origLs ? origLs + "px" : "normal"
+    // Browsers report `scrollHeight` including each line's natural glyph
+    // extent — for a typical serif at line-height = font-size, that's
+    // ~1.2× per line (ascent + descent + lineGap). mupdf's geometric
+    // block bottom is the baseline of the last line, so a tight
+    // `bottom - top` undershoots the rendered extent by ~0.2× line-height
+    // per line. Tolerate that overhead, scaled by the estimated line count
+    // (clientHeight / line-height). One genuine extra wrapped line still
+    // overshoots tolerance by ~0.75× line-height, so true overflow is caught.
+    var lineHeightStr = getComputedStyle(el).lineHeight
+    var lineHeight = lineHeightStr === "normal"
+      ? parseFloat(getComputedStyle(el).fontSize) * 1.2
+      : parseFloat(lineHeightStr)
+    if (!Number.isFinite(lineHeight) || lineHeight <= 0) lineHeight = 16
+    function fits() {
+      var nLines = Math.max(1, Math.round(el.clientHeight / lineHeight))
+      var heightTolerance = nLines * lineHeight * 0.25
+      return (
+        el.scrollWidth <= el.clientWidth + 0.5 &&
+        el.scrollHeight <= el.clientHeight + heightTolerance
+      )
+    }
+    if (fits()) return
+    var refFs = 0
+    for (var ri = 0; ri < ts.length; ri++) {
+      var v = parseFloat(ts[ri].dataset.adtFs)
+      if (v > refFs) refFs = v
+    }
+    if (!refFs) refFs = parseFloat(getComputedStyle(el).fontSize)
+    // Step 1: small letter-spacing tightening (-0.02em max).
+    for (var k = 1; k <= 4; k++) {
+      el.style.letterSpacing = origLs - refFs * 0.005 * k + "px"
+      if (fits()) return
+    }
+    // Step 2: font-size shrink, dominant strategy (98% → 50%).
+    for (var s = 98; s >= 50; s -= 2) {
+      var scale = s / 100
+      for (var m = 0; m < ts.length; m++) {
+        ts[m].style.fontSize = parseFloat(ts[m].dataset.adtFs) * scale + "px"
+      }
+      el.style.letterSpacing = (origLs - refFs * 0.02) * scale + "px"
+      if (fits()) return
+    }
+    // Reached the floor without fitting — restore originals. Content
+    // that won't fit even at 50% is usually a browser font-fallback
+    // issue, not a translation-length issue. A barely-overflowing line
+    // at original size is more readable than a 5.75 px line that fits;
+    // the renderer keeps `overflow: visible` on text entries so the
+    // spill is shown, not clipped.
+    for (var rs = 0; rs < ts.length; rs++) {
+      ts[rs].style.fontSize = ts[rs].dataset.adtFs + "px"
+    }
+    el.style.letterSpacing = origLs ? origLs + "px" : "normal"
+  }
+
+  window.__adtRunAutoFit = function () {
+    var els = document.querySelectorAll("[data-adt-fit]")
+    for (var i = 0; i < els.length; i++) fit(els[i])
+  }
+
+  // Run schedule:
+  //   1. As soon as the DOM is ready (initial pass against whatever
+  //      font the browser has at parse time — typically a system
+  //      fallback while declared @font-face faces are still fetching).
+  //   2. After `document.fonts.ready` resolves, then double-rAF so the
+  //      browser paints the swapped font BEFORE we measure. Single rAF
+  //      fires *before* the next paint, which is enough to reflow
+  //      layout but can still return pre-swap metrics in some browsers.
+  //   3. Whenever the FontFaceSet finishes another batch of loads
+  //      (`loadingdone`) — handles fonts that finish after the initial
+  //      `fonts.ready` resolves (e.g. faces declared in stylesheets that
+  //      parsed late, or fonts referenced by content injected after
+  //      first paint). Without this listener, `fonts.ready` resolves
+  //      once and never re-fires, so any later swap leaves us measuring
+  //      against the pre-swap fallback.
+  //
+  // Each invocation is idempotent (caches originals on `data-adt-fs`
+  // / `data-adt-fit-ls`, resets to those before re-evaluating), so
+  // multiple runs converge to the same final result.
+  function runAfterPaint() {
+    requestAnimationFrame(function () {
+      requestAnimationFrame(window.__adtRunAutoFit)
+    })
+  }
+  function scheduleRuns() {
+    window.__adtRunAutoFit()
+    if (document.fonts) {
+      if (document.fonts.ready) {
+        document.fonts.ready.then(runAfterPaint)
+      }
+      if (document.fonts.addEventListener) {
+        document.fonts.addEventListener("loadingdone", runAfterPaint)
+      }
+    }
+  }
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", scheduleRuns)
+  } else {
+    scheduleRuns()
+  }
+})()

--- a/packages/pdf/src/__tests__/coincident-restyle.test.ts
+++ b/packages/pdf/src/__tests__/coincident-restyle.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from "vitest";
+import { _testing } from "../extract.js";
+
+const { restyleCoincidentVectorText } = _testing;
+
+type Para = Parameters<typeof restyleCoincidentVectorText>[0][number];
+type Op = Parameters<typeof restyleCoincidentVectorText>[1][number];
+
+const bb = (x0: number, y0: number, x1: number, y1: number) => ({ x0, y0, x1, y1 });
+
+// paragraph at top=100, lineHeight=20 → baseline 120
+const para = (segs: { text: string; style?: Record<string, string> }[]): Para =>
+  ({ top: 100, left: 50, lineHeight: 20, text: segs.map((s) => s.text).join(""), segments: segs }) as unknown as Para;
+
+const textOp = (seqno: number, runes: string, x: number, box: ReturnType<typeof bb>): Op =>
+  ({
+    seqno,
+    kind: "fillText",
+    bbox: box,
+    glyphs: [...runes].map((r, i) => ({ rune: r, x: x + i, y: 120 })),
+  }) as unknown as Op;
+
+const pathOp = (
+  seqno: number,
+  kind: "fillPath" | "strokePath",
+  geom: ReturnType<typeof bb>,
+  color: string,
+  strokeWidth?: number,
+): Op =>
+  ({ seqno, kind, bbox: geom, geomBbox: geom, color, alpha: 1, strokeWidth }) as unknown as Op;
+
+describe("restyleCoincidentVectorText", () => {
+  it("stroke-role: keeps the run's fill colour, adds faithful text-stroke from the PDF stroke", () => {
+    const segs = [
+      { text: "Look at the ", style: { color: "#000000" } },
+      { text: "white", style: { color: "#ffffff" } },
+    ];
+    const p = para(segs);
+    // segBox is now derived from the run's own glyph x-extent (not the
+    // whole op box). "white" glyphs sit at x=200..204; the stroke vector
+    // sits within that run's box.
+    const ops: Op[] = [
+      textOp(4, "Look at the ", 50, bb(50, 100, 180, 120)),
+      textOp(10, "white", 200, bb(200, 100, 320, 120)),
+      pathOp(5, "strokePath", bb(201, 102, 215, 118), "#000000", 4),
+    ];
+    const { consumed } = restyleCoincidentVectorText([p], ops);
+    expect(segs[1].style).toMatchObject({
+      color: "#ffffff",
+      "-webkit-text-stroke": "4px #000000",
+      "paint-order": "stroke fill",
+    });
+    expect(segs[0].style).toEqual({ color: "#000000" }); // untouched
+    expect([...consumed]).toEqual([5]);
+  });
+
+  it("fill-role: recolours the shim run to the vector fill colour, no stroke", () => {
+    const segs = [{ text: "h", style: { color: "#ffffff" } }];
+    const p = para(segs);
+    const ops: Op[] = [
+      textOp(10, "h", 60, bb(60, 100, 74, 120)),
+      pathOp(5, "fillPath", bb(61, 103, 73, 117), "#000000"),
+    ];
+    restyleCoincidentVectorText([p], ops);
+    expect(segs[0].style).toEqual({ color: "#000000" });
+    expect(segs[0].style!["-webkit-text-stroke"]).toBeUndefined();
+  });
+
+  it("mixed fill+stroke: adopts fill colour and adds the stroke", () => {
+    const segs = [{ text: "A", style: { color: "#ffffff" } }];
+    const p = para(segs);
+    const ops: Op[] = [
+      textOp(9, "A", 60, bb(60, 100, 80, 120)),
+      pathOp(5, "fillPath", bb(61, 102, 79, 118), "#112233"),
+      pathOp(6, "strokePath", bb(60, 101, 80, 119), "#445566", 2),
+    ];
+    restyleCoincidentVectorText([p], ops);
+    expect(segs[0].style).toMatchObject({
+      color: "#112233",
+      "-webkit-text-stroke": "2px #445566",
+      "paint-order": "stroke fill",
+    });
+  });
+
+  it("colour disagreement → faithful no-op, nothing consumed", () => {
+    const segs = [{ text: "x", style: { color: "#ffffff" } }];
+    const p = para(segs);
+    const ops: Op[] = [
+      textOp(9, "x", 60, bb(60, 100, 80, 120)),
+      pathOp(5, "fillPath", bb(61, 102, 70, 118), "#aaaaaa"),
+      pathOp(6, "fillPath", bb(70, 102, 79, 118), "#555555"),
+    ];
+    const { consumed } = restyleCoincidentVectorText([p], ops);
+    expect(segs[0].style).toEqual({ color: "#ffffff" });
+    expect(consumed.size).toBe(0);
+  });
+
+  it("path op outside the run box is not attributed to it", () => {
+    const segs = [{ text: "y", style: { color: "#ffffff" } }];
+    const p = para(segs);
+    const ops: Op[] = [
+      textOp(9, "y", 60, bb(60, 100, 80, 120)),
+      pathOp(5, "fillPath", bb(400, 400, 420, 420), "#000000"),
+    ];
+    const { consumed } = restyleCoincidentVectorText([p], ops);
+    expect(segs[0].style).toEqual({ color: "#ffffff" });
+    expect(consumed.size).toBe(0);
+  });
+
+  it("matches a run split across multiple coalesced ops (glyph alignment)", () => {
+    // A uniform-style heading is one coalesced op spanning many segments;
+    // here the run's glyphs arrive via two ops. The two-pointer glyph
+    // alignment still resolves the run's box and consumes its vector.
+    const segs = [{ text: "white", style: { color: "#ffffff" } }];
+    const p = para(segs);
+    const ops: Op[] = [
+      textOp(9, "whi", 60, bb(60, 100, 90, 120)),
+      textOp(10, "te", 90, bb(90, 100, 110, 120)),
+      pathOp(5, "strokePath", bb(61, 102, 100, 118), "#000000", 3),
+    ];
+    const { consumed } = restyleCoincidentVectorText([p], ops);
+    expect(segs[0].style).toMatchObject({
+      color: "#ffffff",
+      "-webkit-text-stroke": "3px #000000",
+    });
+    expect([...consumed]).toEqual([5]);
+  });
+});

--- a/packages/pdf/src/__tests__/extract-bounds.test.ts
+++ b/packages/pdf/src/__tests__/extract-bounds.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { extractPdf } from "../extract.js";
+import { createRasterOnlyTestPdf } from "./create-test-pdf.js";
+
+describe("extractPdf — per-image bounds", () => {
+  it("populates bounds on raster images with a PDF placement", async () => {
+    // Test PDF places a 30x30 native image at (100, 300) scaled to 200x200pt
+    // on a 612x792pt page. mupdf's preserve-images walker returns bboxes in
+    // top-left page coordinates, so the expected y is 792 - 300 - 200 = 292.
+    const pdfBuffer = createRasterOnlyTestPdf();
+    const result = await extractPdf({ pdfBuffer });
+
+    expect(result.pages).toHaveLength(1);
+    const page = result.pages[0];
+    expect(page.images.length).toBeGreaterThanOrEqual(1);
+
+    const raster = page.images.find((img) => img.renderMethod === "raster");
+    expect(raster).toBeDefined();
+    expect(raster!.bounds).toBeDefined();
+    expect(raster!.bounds!.x).toBeCloseTo(100, 0);
+    expect(raster!.bounds!.y).toBeCloseTo(292, 0);
+    expect(raster!.bounds!.width).toBeCloseTo(200, 0);
+    expect(raster!.bounds!.height).toBeCloseTo(200, 0);
+  });
+});

--- a/packages/pdf/src/__tests__/extract-raven.test.ts
+++ b/packages/pdf/src/__tests__/extract-raven.test.ts
@@ -42,15 +42,18 @@ describe("raven.pdf extraction", () => {
     expect(result.pages[0].text).toContain("Tony Lelliott");
   });
 
-  it("page 1 — extracts 2 images with correct hashes", () => {
+  it("page 1 — extracts 2 raster images with correct hashes", () => {
     const imgs = result.pages[0].images;
-    expect(imgs).toHaveLength(2);
-    expect(imgs[0].imageId).toBe("pg001_im001");
-    expect(imgs[0].hash).toBe("f7c69061b5fb89ed");
-    expect(imgs[0].width).toBe(546);
-    expect(imgs[0].height).toBe(546);
-    expect(imgs[1].imageId).toBe("pg001_im002");
-    expect(imgs[1].hash).toBe("14b8a1e04e930b83");
+    const rasters = imgs.filter((i) => i.renderMethod === "raster");
+    expect(rasters).toHaveLength(2);
+    expect(rasters[0].imageId).toBe("pg001_im001");
+    expect(rasters[0].hash).toBe("f7c69061b5fb89ed");
+    expect(rasters[0].width).toBe(546);
+    expect(rasters[0].height).toBe(546);
+    expect(rasters[1].imageId).toBe("pg001_im002");
+    // Hash reflects RGBA output (color + SMask alpha composited). Was
+    // opaque-black before SMask handling landed.
+    expect(rasters[1].hash).toBe("8965a2a0ee0f63ae");
   });
 
   // -- Page 2 --
@@ -66,11 +69,13 @@ describe("raven.pdf extraction", () => {
     expect(text).toContain("friends");
   });
 
-  it("page 2 — extracts 2 images with correct hashes", () => {
+  it("page 2 — extracts 2 raster images with correct hashes", () => {
     const imgs = result.pages[1].images;
-    expect(imgs).toHaveLength(2);
-    expect(imgs[0].hash).toBe("2bdb94c1a5f96fe7");
-    expect(imgs[1].hash).toBe("f7c69061b5fb89ed");
+    const rasters = imgs.filter((i) => i.renderMethod === "raster");
+    expect(rasters).toHaveLength(2);
+    // Hash reflects RGBA output (color + SMask alpha composited).
+    expect(rasters[0].hash).toBe("0e15f84a869b4f66");
+    expect(rasters[1].hash).toBe("f7c69061b5fb89ed");
   });
 
   // -- Page 3 --
@@ -85,10 +90,12 @@ describe("raven.pdf extraction", () => {
     expect(text).toContain("into the sky");
   });
 
-  it("page 3 — extracts 2 images with correct hashes", () => {
+  it("page 3 — extracts 2 raster images with correct hashes", () => {
     const imgs = result.pages[2].images;
-    expect(imgs).toHaveLength(2);
-    expect(imgs[0].hash).toBe("1aecee2cc36cd072");
-    expect(imgs[1].hash).toBe("b20ccebb2681ac27");
+    const rasters = imgs.filter((i) => i.renderMethod === "raster");
+    expect(rasters).toHaveLength(2);
+    // Hash reflects RGBA output (color + SMask alpha composited).
+    expect(rasters[0].hash).toBe("360de701626b47da");
+    expect(rasters[1].hash).toBe("b20ccebb2681ac27");
   });
 });

--- a/packages/pdf/src/__tests__/extract-stream-order.test.ts
+++ b/packages/pdf/src/__tests__/extract-stream-order.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Verifies that positioned-text drawItems are emitted in true PDF
+ * content-stream order, not mupdf's StructuredText reading-flow order.
+ *
+ * The regression this guards: a children's-book scene where speech bubbles
+ * are drawn (paths) BEFORE their text in the PDF stream — but mupdf's
+ * walker reorders blocks for reading flow, putting text before the small
+ * bubble paths in walker order. Naive seqno assignment from the walker
+ * then sorted text BEFORE bubbles, hiding text under opaque bubble fill.
+ *
+ * The fix uses a recording Device (`Page.run`) which fires once per
+ * content-stream operator in stream order, giving authoritative seqnos.
+ */
+import { describe, it, expect } from "vitest"
+import mupdf from "mupdf"
+import { extractPdf } from "../extract.js"
+
+/**
+ * Create a 1-page PDF with this drawing order:
+ *   1. White background rect (full page)
+ *   2. A black-stroked rectangle "bubble" at (50, 600) sized 200x60
+ *   3. Text "Inside bubble!" at the bubble's interior baseline
+ *   4. Text "Above bubble" at the top of the page
+ *
+ * The text is drawn AFTER the bubble in the stream, so the rendered EPUB
+ * must place text DOM-after the bubble image so it renders on top.
+ */
+function createBubbleScenarioPdf(): Buffer {
+  const doc = new mupdf.PDFDocument()
+
+  // Embed a simple Type1 font (Helvetica) for text rendering
+  const fontDict = doc.newDictionary()
+  fontDict.put("Type", doc.newName("Font"))
+  fontDict.put("Subtype", doc.newName("Type1"))
+  fontDict.put("BaseFont", doc.newName("Helvetica"))
+  fontDict.put("Encoding", doc.newName("WinAnsiEncoding"))
+  const fontObj = doc.addObject(fontDict)
+
+  const fonts = doc.newDictionary()
+  fonts.put("F1", fontObj)
+  const resourcesDict = doc.newDictionary()
+  resourcesDict.put("Font", fonts)
+  const resources = doc.addObject(resourcesDict)
+
+  // Content stream — order matters; this is the painter's order.
+  // PDF user space is y-up; on a 612x792 page:
+  //   - bubble at user-space (50..250, 600..660), i.e. visually upper area
+  //   - "Above bubble" text baseline at y=750 (very top)
+  //   - "Inside bubble!" text baseline at y=625 (inside the bubble)
+  const stream = `
+% 1. Full-page white background fill
+q
+1 1 1 rg
+0 0 612 792 re f
+Q
+% 2. Bubble outline drawn FIRST (so text drawn after it goes on top)
+q
+0 0 0 RG
+1 w
+50 600 200 60 re S
+Q
+% 3. Text drawn AFTER the bubble — must appear ON TOP in rendered output
+BT
+/F1 12 Tf
+60 625 Td
+(Inside bubble!) Tj
+ET
+BT
+/F1 12 Tf
+60 750 Td
+(Above bubble) Tj
+ET
+`
+  const buf = new mupdf.Buffer()
+  buf.writeLine(stream)
+  doc.insertPage(-1, doc.addPage([0, 0, 612, 792], 0, resources, buf))
+  return Buffer.from(doc.saveToBuffer("").asUint8Array())
+}
+
+describe("positioned-text draw order — stream-order recorder", () => {
+  it("emits bubble-text after its enclosing bubble shape", async () => {
+    const pdfBuffer = createBubbleScenarioPdf()
+    const result = await extractPdf({ pdfBuffer })
+
+    expect(result.pages).toHaveLength(1)
+    const page = result.pages[0]
+    const items = page.positionedText.drawItems
+    expect(items.length).toBeGreaterThan(0)
+
+    const insideIdx = items.findIndex(
+      (i) => i.kind === "paragraph" && i.text.includes("Inside bubble"),
+    )
+    const aboveIdx = items.findIndex(
+      (i) => i.kind === "paragraph" && i.text.includes("Above bubble"),
+    )
+    expect(insideIdx).toBeGreaterThanOrEqual(0)
+    expect(aboveIdx).toBeGreaterThanOrEqual(0)
+
+    // The bubble can be picked up either as a vector figure (an image item)
+    // or simply as path ops; in either case, EVERY image draw item that
+    // overlaps the "Inside bubble" text must come BEFORE that paragraph in
+    // the final draw order. This is the core invariant: text drawn on top
+    // of an image in the PDF stream renders DOM-after that image.
+    const insideItem = items[insideIdx]
+    if (insideItem.kind !== "paragraph") throw new Error("unreachable")
+    const textX = insideItem.left
+    const textY = insideItem.top + insideItem.lineHeight
+
+    for (let i = 0; i < items.length; i++) {
+      const it = items[i]
+      if (it.kind !== "image" || !it.bounds) continue
+      const b = it.bounds
+      const overlapsText =
+        textX >= b.x &&
+        textX <= b.x + b.width &&
+        textY >= b.y &&
+        textY <= b.y + b.height
+      if (overlapsText) {
+        expect(i).toBeLessThan(insideIdx)
+      }
+    }
+  })
+
+  it("matches each asHTML paragraph to a glyph-stream-order seqno", async () => {
+    const pdfBuffer = createBubbleScenarioPdf()
+    const result = await extractPdf({ pdfBuffer })
+
+    const items = result.pages[0].positionedText.drawItems
+    const paragraphs = items.filter((i) => i.kind === "paragraph")
+    // Both text strings should appear; both have unique textIds.
+    const ids = new Set(paragraphs.map((p) => (p.kind === "paragraph" ? p.textId : "")))
+    expect(ids.size).toBe(paragraphs.length)
+  })
+})

--- a/packages/pdf/src/__tests__/extract-stroke-ink.test.ts
+++ b/packages/pdf/src/__tests__/extract-stroke-ink.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { _testing } from "../extract.js";
+
+const { parseStrokeInkExtent, computeGroupInkBbox } = _testing;
+
+// computeGroupInkBbox only reads `.bbox` and `.svgElement`; the other
+// ShapeInfo fields are irrelevant to the ink-extent math.
+const shape = (bbox: [number, number, number, number], svgElement: string) =>
+  ({ bbox, svgElement }) as unknown as Parameters<typeof computeGroupInkBbox>[0][number];
+
+describe("parseStrokeInkExtent", () => {
+  it("returns 0 for a fill-only path (no stroke)", () => {
+    expect(parseStrokeInkExtent('<path d="M0 0H10V10Z" fill="#fff"/>')).toBe(0);
+  });
+
+  it('returns 0 for stroke="none" / "transparent"', () => {
+    expect(parseStrokeInkExtent('<path stroke="none" stroke-width="4"/>')).toBe(0);
+    expect(parseStrokeInkExtent('<path stroke="transparent" stroke-width="4"/>')).toBe(0);
+  });
+
+  it("returns half the stroke width when stroked, untransformed", () => {
+    expect(parseStrokeInkExtent('<path stroke="#000" stroke-width="3"/>')).toBe(1.5);
+  });
+
+  it("defaults stroke-width to 1 (SVG default) when stroke is set but width omitted", () => {
+    expect(parseStrokeInkExtent('<path stroke="#000"/>')).toBe(0.5);
+  });
+
+  it("scales stroke-width by the larger axis scale of the transform matrix", () => {
+    // matrix(2 0 0 3 0 0): sx=2, sy=3 → larger scale 3; half = 4*3/2 = 6
+    const e = '<path stroke="#000" stroke-width="4" transform="matrix(2 0 0 3 0 0)"/>';
+    expect(parseStrokeInkExtent(e)).toBe(6);
+  });
+
+  it("uses the rotation-inclusive column norm for skewed matrices", () => {
+    // matrix(3 4 0 1 ...): hypot(3,4)=5, hypot(0,1)=1 → scale 5; half = 2*5/2 = 5
+    const e = '<path stroke="#000" stroke-width="2" transform="matrix(3 4 0 1 10 10)"/>';
+    expect(parseStrokeInkExtent(e)).toBe(5);
+  });
+
+  it("applies the miter limit only when stroke-linejoin is explicitly miter", () => {
+    const round = '<path stroke="#000" stroke-width="2" stroke-linejoin="round"/>';
+    expect(parseStrokeInkExtent(round)).toBe(1); // half only
+
+    const miter =
+      '<path stroke="#000" stroke-width="2" stroke-linejoin="miter" stroke-miterlimit="4"/>';
+    expect(parseStrokeInkExtent(miter)).toBe(4); // half(1) * miterlimit(4)
+
+    // Omitted linejoin must NOT assume the SVG default (miter) — that would
+    // balloon every round-joined bubble. Half only.
+    const omitted = '<path stroke="#000" stroke-width="2"/>';
+    expect(parseStrokeInkExtent(omitted)).toBe(1);
+  });
+
+  it("defaults miterlimit to 4 when linejoin is miter but limit omitted", () => {
+    const e = '<path stroke="#000" stroke-width="2" stroke-linejoin="miter"/>';
+    expect(parseStrokeInkExtent(e)).toBe(4);
+  });
+});
+
+describe("computeGroupInkBbox", () => {
+  it("expands each shape's geometry bbox by its stroke half-width + AA guard", () => {
+    // Geometry [10,10,50,50], stroke-width 4 (half 2) + AA guard 1 on each
+    // side → [10-3, 10-3, 50+3, 50+3].
+    const g = [shape([10, 10, 50, 50], '<path stroke="#000" stroke-width="4"/>')];
+    expect(computeGroupInkBbox(g, 1, 1)).toEqual([7, 7, 53, 53]);
+  });
+
+  it("does not stroke-expand fill-only shapes (AA guard still applied)", () => {
+    const g = [shape([0, 0, 20, 20], '<path d="M0 0H20V20Z" fill="#abc"/>')];
+    expect(computeGroupInkBbox(g, 0.5, 0.5)).toEqual([-0.5, -0.5, 20.5, 20.5]);
+  });
+
+  it("unions per-shape ink boxes (a thin stroked shape can dominate one edge)", () => {
+    const g = [
+      shape([10, 10, 30, 30], '<path d="..." fill="#fff"/>'), // fill only
+      shape([28, 10, 30, 30], '<path stroke="#000" stroke-width="10"/>'), // half 5
+    ];
+    // fill box [10,10,30,30]; stroked box [28-5,10-5,30+5,30+5]=[23,5,35,35].
+    // union → [10, 5, 35, 35].
+    expect(computeGroupInkBbox(g, 0, 0)).toEqual([10, 5, 35, 35]);
+  });
+
+  it("uses per-axis AA guards (non-uniform page scale)", () => {
+    const g = [shape([0, 0, 10, 10], '<path d="..." fill="#000"/>')];
+    expect(computeGroupInkBbox(g, 2, 0.25)).toEqual([-2, -0.25, 12, 10.25]);
+  });
+});

--- a/packages/pdf/src/__tests__/figure-seqno-identity.test.ts
+++ b/packages/pdf/src/__tests__/figure-seqno-identity.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { _testing } from "../extract.js";
+
+const { stampFigureSeqnosFromOps } = _testing;
+
+// Minimal shapes of the real types; stampFigureSeqnosFromOps only reads
+// `shapeGeomBoxes` / `streamSeqno` on figures and `kind`/`seqno`/`geomBbox`
+// on ops.
+type Fig = Parameters<typeof stampFigureSeqnosFromOps>[0][number];
+type Op = Parameters<typeof stampFigureSeqnosFromOps>[1][number];
+
+const bb = (x0: number, y0: number, x1: number, y1: number) => ({ x0, y0, x1, y1 });
+const fillOp = (seqno: number, g: ReturnType<typeof bb>): Op =>
+  ({ seqno, kind: "fillPath", bbox: g, geomBbox: g }) as unknown as Op;
+const strokeOp = (
+  seqno: number,
+  geom: ReturnType<typeof bb>,
+  rendered: ReturnType<typeof bb>,
+): Op => ({ seqno, kind: "strokePath", bbox: rendered, geomBbox: geom }) as unknown as Op;
+const fig = (boxes: [number, number, number, number][] | undefined, fallback: number): Fig =>
+  ({ shapeGeomBoxes: boxes, streamSeqno: fallback }) as unknown as Fig;
+
+describe("stampFigureSeqnosFromOps — geometry identity", () => {
+  it("ties a stroked op to its figure by geometry bbox (rendered bbox spills outside)", () => {
+    // The bug case: a strokePath's rendered bbox is larger than the figure's
+    // geometry box (stroke inflation), so aggregate containment failed and the
+    // figure kept its unreliable SVG-order fallback (0). geomBbox matches.
+    const f = fig([[318, 452, 461, 509]], /* SVG-order fallback */ 0);
+    const ops: Op[] = [
+      fillOp(1, bb(-1, 43, 794, 1225)), // full-page background
+      strokeOp(5, bb(318, 452, 461, 509), bb(310, 444, 468, 516)), // "white" outline
+    ];
+    stampFigureSeqnosFromOps([f], ops);
+    expect(f.streamSeqno).toBe(5); // not 0 — drawn after the bg (seqno 1)
+  });
+
+  it("uses the minimum matching op seqno across a multi-shape figure", () => {
+    const f = fig([[10, 10, 20, 20], [30, 30, 50, 50]], 99);
+    const ops: Op[] = [
+      strokeOp(8, bb(30, 30, 50, 50), bb(28, 28, 52, 52)),
+      fillOp(3, bb(10, 10, 20, 20)),
+      fillOp(40, bb(999, 999, 1000, 1000)), // unrelated
+    ];
+    stampFigureSeqnosFromOps([f], ops);
+    expect(f.streamSeqno).toBe(3);
+  });
+
+  it("tolerates sub-pixel rounding (SVG export rounds to 2 decimals)", () => {
+    const f = fig([[100, 200, 140, 260]], 0);
+    stampFigureSeqnosFromOps([f], [fillOp(7, bb(100.4, 199.7, 140.3, 260.5))]);
+    expect(f.streamSeqno).toBe(7);
+  });
+
+  it("does not match a different path that merely overlaps the figure region", () => {
+    const f = fig([[100, 100, 200, 200]], 42);
+    // An op whose geometry is a big page rect overlapping the figure but with
+    // a clearly different extent must NOT be attributed to it.
+    stampFigureSeqnosFromOps([f], [fillOp(2, bb(0, 0, 800, 1200))]);
+    expect(f.streamSeqno).toBe(42); // unchanged fallback
+  });
+
+  it("keeps the SVG-order fallback when the figure has no shape boxes", () => {
+    const f = fig(undefined, 13);
+    stampFigureSeqnosFromOps([f], [fillOp(1, bb(0, 0, 10, 10))]);
+    expect(f.streamSeqno).toBe(13);
+  });
+});

--- a/packages/pdf/src/__tests__/positioned-text-clustering.test.ts
+++ b/packages/pdf/src/__tests__/positioned-text-clustering.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect } from "vitest"
+import { clusterParagraphsIntoBlocks, type AsHtmlParagraph } from "../positioned-text.js"
+
+type LineBbox = Parameters<typeof clusterParagraphsIntoBlocks>[1][number]
+
+const FONT_BODY = { "font-family": "MuseoSans,serif", "font-size": "11.5px" }
+const FONT_TITLE = { "font-family": "Chokle,serif", "font-size": "22px" }
+
+function makeParagraph(text: string, top: number, left: number, lineHeight = 11.5, style = FONT_BODY): AsHtmlParagraph {
+  return {
+    top,
+    left,
+    lineHeight,
+    text,
+    segments: [{ text, style }],
+  }
+}
+
+function makeLine(text: string, top: number, left: number, right: number, bottom: number): LineBbox {
+  return { top, left, right, bottom, text }
+}
+
+describe("clusterParagraphsIntoBlocks", () => {
+  it("clusters wrapped lines from one bubble into a single block", () => {
+    // Mirrors the Volcanoes book page 12 'Follow the evacuation plan / Move
+    // away from the volcano / as fast as possible.' bubble — three centred
+    // lines drawn as separate mupdf paragraphs.
+    const p1 = makeParagraph("Follow the evacuation plan. ", 387.2, 116.5)
+    const p2 = makeParagraph("Move away from the volcano ", 410.2, 112.9)
+    const p3 = makeParagraph("as fast as possible.", 433.2, 142.1)
+    const paragraphs = [p1, p2, p3]
+    const lines: LineBbox[] = [
+      makeLine("Follow the evacuation plan.", 386.1, 116.5, 273.9, 398.8),
+      makeLine("Move away from the volcano", 409.1, 112.9, 277.4, 421.8),
+      makeLine("as fast as possible.", 432.1, 142.1, 245.3, 444.8),
+    ]
+
+    clusterParagraphsIntoBlocks(paragraphs, lines)
+
+    expect(p1.blockId).toBeDefined()
+    expect(p1.blockId).toBe(p2.blockId)
+    expect(p2.blockId).toBe(p3.blockId)
+    expect(p1.blockBounds).toEqual({
+      x: 112.9,
+      y: 386.1,
+      width: 277.4 - 112.9,
+      height: 444.8 - 386.1,
+    })
+    expect(p3.blockBounds).toEqual(p1.blockBounds)
+  })
+
+  it("keeps adjacent bubbles in different blocks when their x-ranges don't overlap", () => {
+    const left1 = makeParagraph("as fast as possible.", 433.2, 142.1)
+    const right1 = makeParagraph("Try to stay out of low lying ", 418.1, 354.7)
+    const right2 = makeParagraph("areas such as valleys.", 441.1, 370.2)
+    const paragraphs = [left1, right1, right2]
+    const lines: LineBbox[] = [
+      makeLine("as fast as possible.", 432.1, 142.1, 245.3, 444.8),
+      makeLine("Try to stay out of low lying", 417.1, 354.7, 506.9, 429.7),
+      makeLine("areas such as valleys.", 440.1, 370.2, 488.4, 452.7),
+    ]
+
+    clusterParagraphsIntoBlocks(paragraphs, lines)
+
+    // Left bubble's last line gets its own block; right bubble's two lines join.
+    expect(left1.blockId).not.toBe(right1.blockId)
+    expect(right1.blockId).toBe(right2.blockId)
+    expect(right1.blockBounds).toEqual({
+      x: 354.7,
+      y: 417.1,
+      width: 506.9 - 354.7,
+      height: 452.7 - 417.1,
+    })
+  })
+
+  it("does not merge a heading with body text below it (different fonts)", () => {
+    const heading = makeParagraph("AND DURING A VOLCANIC ERUPTION?", 85.4, 58.4, 22.0, FONT_TITLE)
+    const body = makeParagraph("Follow the evacuation plan. ", 387.2, 116.5)
+    const paragraphs = [heading, body]
+    const lines: LineBbox[] = [
+      makeLine("AND DURING A VOLCANIC ERUPTION?", 81.3, 58.4, 416.4, 111.6),
+      makeLine("Follow the evacuation plan.", 386.1, 116.5, 273.9, 398.8),
+    ]
+
+    clusterParagraphsIntoBlocks(paragraphs, lines)
+
+    expect(heading.blockId).not.toBe(body.blockId)
+  })
+
+  it("clusters centred ragged-right lines whose left edges differ", () => {
+    // No horizontal overlap on left edges alone, but the visual centres
+    // line up — typical centred bubble text.
+    const p1 = makeParagraph("Watch out for falling ash and ", 111.1, 78.2)
+    const p2 = makeParagraph("rocks, lava, lahars, volcanic ", 134.1, 82.6)
+    const p3 = makeParagraph("gases and pyroclastic flows.", 157.1, 80.8)
+    const paragraphs = [p1, p2, p3]
+    const lines: LineBbox[] = [
+      makeLine("Watch out for falling ash and", 110.0, 78.2, 250.0, 122.6),
+      makeLine("rocks, lava, lahars, volcanic", 133.0, 82.6, 248.0, 145.6),
+      makeLine("gases and pyroclastic flows.", 156.0, 80.8, 246.0, 168.6),
+    ]
+
+    clusterParagraphsIntoBlocks(paragraphs, lines)
+
+    expect(p1.blockId).toBe(p2.blockId)
+    expect(p2.blockId).toBe(p3.blockId)
+  })
+
+  it("isolates a far-away paragraph from a preceding cluster", () => {
+    const top = makeParagraph("Watch out for falling ash and ", 111.1, 78.2)
+    const farBelow = makeParagraph("Did you know that the ", 307.0, 347.2)
+    const paragraphs = [top, farBelow]
+    const lines: LineBbox[] = [
+      makeLine("Watch out for falling ash and", 110.0, 78.2, 250.0, 122.6),
+      makeLine("Did you know that the", 306.0, 347.2, 480.0, 318.5),
+    ]
+
+    clusterParagraphsIntoBlocks(paragraphs, lines)
+
+    expect(top.blockId).not.toBe(farBelow.blockId)
+  })
+
+  it("merges lowercase-continuation lines into one mergedParagraphId", () => {
+    // "Move away from the volcano " (uppercase 'M') / "as fast as possible." (lowercase 'a')
+    const p1 = makeParagraph("Move away from the volcano ", 410.2, 112.9)
+    const p2 = makeParagraph("as fast as possible.", 433.2, 142.1)
+    const lines: LineBbox[] = [
+      makeLine("Move away from the volcano", 409.1, 112.9, 277.4, 421.8),
+      makeLine("as fast as possible.", 432.1, 142.1, 245.3, 444.8),
+    ]
+
+    clusterParagraphsIntoBlocks([p1, p2], lines)
+
+    expect(p1.mergedParagraphId).toBe(p2.mergedParagraphId)
+  })
+
+  it("splits at sentence boundaries inside the same block", () => {
+    // "Follow the evacuation plan." → period + uppercase "Move" → split
+    const p1 = makeParagraph("Follow the evacuation plan. ", 387.2, 116.5)
+    const p2 = makeParagraph("Move away from the volcano ", 410.2, 112.9)
+    const p3 = makeParagraph("as fast as possible.", 433.2, 142.1)
+    const lines: LineBbox[] = [
+      makeLine("Follow the evacuation plan.", 386.1, 116.5, 273.9, 398.8),
+      makeLine("Move away from the volcano", 409.1, 112.9, 277.4, 421.8),
+      makeLine("as fast as possible.", 432.1, 142.1, 245.3, 444.8),
+    ]
+
+    clusterParagraphsIntoBlocks([p1, p2, p3], lines)
+
+    // All three share a block (one bubble) but split into two merged paragraphs.
+    expect(p1.blockId).toBe(p2.blockId)
+    expect(p2.blockId).toBe(p3.blockId)
+    expect(p1.mergedParagraphId).not.toBe(p2.mergedParagraphId)
+    expect(p2.mergedParagraphId).toBe(p3.mergedParagraphId)
+  })
+
+  it("merges hyphen-wrapped words across lines", () => {
+    // "fast-" / "moving" — prev ends with '-' → continuation regardless of next case
+    const p1 = makeParagraph("super-", 100, 50)
+    const p2 = makeParagraph("Computers", 115, 50)
+    const lines: LineBbox[] = [
+      makeLine("super-", 99, 50, 90, 112),
+      makeLine("Computers", 114, 50, 110, 127),
+    ]
+
+    clusterParagraphsIntoBlocks([p1, p2], lines)
+
+    expect(p1.mergedParagraphId).toBe(p2.mergedParagraphId)
+  })
+
+  it("infers center alignment for centred bubble lines", () => {
+    const p1 = makeParagraph("Follow the evacuation plan. ", 387.2, 116.5)
+    const p2 = makeParagraph("Move away from the volcano ", 410.2, 112.9)
+    const p3 = makeParagraph("as fast as possible.", 433.2, 142.1)
+    const lines: LineBbox[] = [
+      makeLine("Follow the evacuation plan.", 386.1, 116.5, 273.9, 398.8),
+      makeLine("Move away from the volcano", 409.1, 112.9, 277.4, 421.8),
+      makeLine("as fast as possible.", 432.1, 142.1, 245.3, 444.8),
+    ]
+
+    clusterParagraphsIntoBlocks([p1, p2, p3], lines)
+
+    expect(p1.textAlign).toBe("center")
+    expect(p2.textAlign).toBe("center")
+    expect(p3.textAlign).toBe("center")
+  })
+
+  it("leaves textAlign undefined for left-flush body text", () => {
+    // All lines flush to the same left edge, varying right.
+    const p1 = makeParagraph("Lorem ipsum dolor sit amet, ", 100, 50)
+    const p2 = makeParagraph("consectetur adipiscing elit, ", 115, 50)
+    const p3 = makeParagraph("sed do eiusmod.", 130, 50)
+    const lines: LineBbox[] = [
+      makeLine("Lorem ipsum dolor sit amet,", 99, 50, 250, 112),
+      makeLine("consectetur adipiscing elit,", 114, 50, 240, 127),
+      makeLine("sed do eiusmod.", 129, 50, 160, 142),
+    ]
+
+    clusterParagraphsIntoBlocks([p1, p2, p3], lines)
+
+    expect(p1.textAlign).toBeUndefined()
+  })
+
+  it("namespaces ids by prefix so spread halves stay separate", () => {
+    const left1 = makeParagraph("Left line one", 100, 50)
+    const right1 = makeParagraph("Right line one", 100, 600)
+    const lines: LineBbox[] = [
+      makeLine("Left line one", 100, 50, 150, 112),
+    ]
+    const linesRight: LineBbox[] = [
+      makeLine("Right line one", 100, 600, 700, 112),
+    ]
+
+    clusterParagraphsIntoBlocks([left1], lines, "L")
+    clusterParagraphsIntoBlocks([right1], linesRight, "R")
+
+    expect(left1.blockId?.startsWith("L")).toBe(true)
+    expect(right1.blockId?.startsWith("R")).toBe(true)
+    expect(left1.blockId).not.toBe(right1.blockId)
+  })
+})

--- a/packages/pdf/src/__tests__/positioned-text-spacing.test.ts
+++ b/packages/pdf/src/__tests__/positioned-text-spacing.test.ts
@@ -1,0 +1,395 @@
+import { describe, it, expect } from "vitest"
+import {
+  cleanParagraphSpacing,
+  type AsHtmlParagraph,
+  type LineChar,
+} from "../positioned-text.js"
+
+interface SyntheticLine {
+  top: number
+  left: number
+  right: number
+  bottom: number
+  text: string
+  chars: LineChar[]
+}
+
+/**
+ * Build synthetic LineChar geometry from a simple `(char, advance)`
+ * recipe — `advance` is the cursor advance contributed by that character
+ * (i.e. the next character's origin = this character's origin + advance).
+ * For a normal letter this is its glyph width + any letter-spacing;
+ * for a zero-advance space this is 0.
+ */
+function chars(items: Array<[string, number]>): LineChar[] {
+  let x = 0
+  const out: LineChar[] = []
+  for (const [c, advance] of items) {
+    // qLeft = origin x; qRight = origin x + the character's own glyph width.
+    // For our purposes the "own glyph width" is the advance for letters
+    // (no extra letter-spacing) and 0 for zero-advance spaces.
+    const isSpace = c === " "
+    const ownWidth = isSpace ? advance : advance
+    out.push({ c, ox: x, qLeft: x, qRight: x + ownWidth })
+    x += advance
+  }
+  return out
+}
+
+/**
+ * Same as `chars` but encodes letter-spacing explicitly: each letter has
+ * its own `width` and a separate `track` value applied AFTER it. The
+ * letter occupies [ox, ox+width]; the next char's ox is at ox+width+track.
+ */
+function tracked(
+  items: Array<{ c: string; width: number; track?: number }>,
+): LineChar[] {
+  let x = 0
+  const out: LineChar[] = []
+  for (const it of items) {
+    const w = it.width
+    out.push({ c: it.c, ox: x, qLeft: x, qRight: x + w })
+    x += w + (it.track ?? 0)
+  }
+  return out
+}
+
+function makeLine(chars: LineChar[]): SyntheticLine {
+  const text = chars.map((c) => c.c).join("").replace(/\s+$/, "")
+  const left = chars[0]?.qLeft ?? 0
+  const right = chars[chars.length - 1]?.qRight ?? 0
+  return { top: 100, left, right, bottom: 112, text, chars }
+}
+
+function makeParagraph(text: string, segments?: AsHtmlParagraph["segments"]): AsHtmlParagraph {
+  return {
+    top: 100,
+    left: 0,
+    lineHeight: 12,
+    text,
+    segments: segments ?? [{ text, style: { "font-family": "Sans" } }],
+  }
+}
+
+describe("cleanParagraphSpacing", () => {
+  it("leaves a normal paragraph untouched (no zero-advance spaces)", () => {
+    // "Hi there" — letters with normal glyph widths, single real space (~3pt).
+    const c = chars([
+      ["H", 6],
+      ["i", 3],
+      [" ", 3],
+      ["t", 3],
+      ["h", 6],
+      ["e", 6],
+      ["r", 4],
+      ["e", 6],
+    ])
+    const line = makeLine(c)
+    const p = makeParagraph("Hi there")
+    cleanParagraphSpacing([p], [line])
+    expect(p.text).toBe("Hi there")
+    expect(p.segments).toEqual([{ text: "Hi there", style: { "font-family": "Sans" } }])
+  })
+
+  it("strips intra-word spaces whose advance ≤ paragraph letter-spacing", () => {
+    // "U n iversity" — letters at 22pt with ~3pt letter-spacing, single
+    // zero-advance spaces between U-n and n-i. Cluster advance (~3pt) is
+    // close to letter-spacing (3pt), so it strips.
+    // Build by tracking: letter widths ~10, track ~3 between letters of
+    // a tracked title. Then a zero-advance space sits between selected
+    // pairs, tracked exactly the same.
+    const charsArr: LineChar[] = []
+    let x = 0
+    function pushLetter(c: string, width: number, track: number) {
+      charsArr.push({ c, ox: x, qLeft: x, qRight: x + width })
+      x += width + track
+    }
+    function pushZeroSpace() {
+      // Zero-advance space placed at the cursor — qLeft == qRight, no advance.
+      charsArr.push({ c: " ", ox: x, qLeft: x, qRight: x })
+    }
+    pushLetter("U", 10, 3)
+    pushZeroSpace()
+    pushLetter("n", 8, 3)
+    pushZeroSpace()
+    pushLetter("i", 4, 3)
+    pushLetter("v", 8, 3)
+    pushLetter("e", 8, 0)
+
+    const line = makeLine(charsArr)
+    const p = makeParagraph("U n ive")
+    cleanParagraphSpacing([p], [line])
+    // Both intra-word spaces stripped.
+    expect(p.text).toBe("Unive")
+  })
+
+  it("collapses multi-space cluster at a real word boundary into one space", () => {
+    // "ity  of" — letterspaced "ity" finishes, then TWO zero-advance
+    // spaces wider than letter-spacing in total, then "of".
+    const charsArr: LineChar[] = []
+    let x = 0
+    function pushLetter(c: string, width: number, track: number) {
+      charsArr.push({ c, ox: x, qLeft: x, qRight: x + width })
+      x += width + track
+    }
+    function pushSpace(width: number) {
+      charsArr.push({ c: " ", ox: x, qLeft: x, qRight: x + width })
+      x += width
+    }
+    pushLetter("i", 4, 3)
+    pushLetter("t", 4, 3)
+    pushLetter("y", 8, 0)
+    pushSpace(3)
+    pushSpace(8) // Cluster total = 11pt — well above letter-spacing (3pt).
+    pushLetter("o", 8, 3)
+    pushLetter("f", 6, 0)
+
+    const line = makeLine(charsArr)
+    const p = makeParagraph("ity  of")
+    cleanParagraphSpacing([p], [line])
+    expect(p.text).toBe("ity of")
+  })
+
+  it("handles a mixed paragraph: intra-word strips, real boundary kept", () => {
+    // Sketch of "U n  of" — intra-word space U-n (1 zero-advance, narrow),
+    // then real word boundary "n→of" via 2 spaces totalling much more.
+    const charsArr: LineChar[] = []
+    let x = 0
+    function L(c: string, w: number, t: number) {
+      charsArr.push({ c, ox: x, qLeft: x, qRight: x + w })
+      x += w + t
+    }
+    function S(w: number) {
+      charsArr.push({ c: " ", ox: x, qLeft: x, qRight: x + w })
+      x += w
+    }
+    L("U", 10, 3)
+    S(0)        // narrow zero-advance space (intra-word artefact)
+    L("n", 8, 0)
+    S(3)        // first space at boundary
+    S(8)        // second space at boundary — together > letter-spacing
+    L("o", 8, 3)
+    L("f", 6, 0)
+
+    const line = makeLine(charsArr)
+    const p = makeParagraph("U n  of")
+    cleanParagraphSpacing([p], [line])
+    expect(p.text).toBe("Un of")
+  })
+
+  it("applies stripping to per-segment text (preserving style boundaries)", () => {
+    // "U n" but split across two styled segments: "U " styled red,
+    // "n" styled black. The space lives at the end of the first segment.
+    const charsArr: LineChar[] = []
+    let x = 0
+    charsArr.push({ c: "U", ox: x, qLeft: x, qRight: x + 10 })
+    x += 10 + 3
+    charsArr.push({ c: " ", ox: x, qLeft: x, qRight: x }) // zero-advance
+    charsArr.push({ c: "n", ox: x, qLeft: x, qRight: x + 8 })
+
+    const line = makeLine(charsArr)
+    const p: AsHtmlParagraph = {
+      top: 100,
+      left: 0,
+      lineHeight: 12,
+      text: "U n",
+      segments: [
+        { text: "U ", style: { color: "#ff0000" } },
+        { text: "n", style: { color: "#000000" } },
+      ],
+    }
+    cleanParagraphSpacing([p], [line])
+    expect(p.text).toBe("Un")
+    expect(p.segments).toEqual([
+      { text: "U", style: { color: "#ff0000" } },
+      { text: "n", style: { color: "#000000" } },
+    ])
+  })
+
+  it("keeps single space at a real boundary in plain (no letter-spacing) text", () => {
+    // Letter-spacing = 0 (medianLS = 0), threshold = max(0×1.6, 1) = 1pt.
+    // Real space of 2.4pt is well above → kept.
+    const c = chars([
+      ["a", 5],
+      [" ", 2.4],
+      ["b", 5],
+    ])
+    const line = makeLine(c)
+    const p = makeParagraph("a b")
+    cleanParagraphSpacing([p], [line])
+    expect(p.text).toBe("a b")
+  })
+})
+
+describe("cleanParagraphSpacing — per-font-run analysis (Volcanologists case)", () => {
+  /**
+   * Build chars where each letter has an explicit `width` and `track`
+   * (extra letter-spacing applied AFTER the glyph), and spaces have an
+   * explicit `width` that contributes to cursor advance. This produces
+   * realistic geometry where the per-run median letter-spacing reflects
+   * the title's actual typeset tracking.
+   */
+  function buildLine(
+    items: Array<{ c: string; width: number; track?: number; font: string }>,
+  ): LineChar[] {
+    let x = 0
+    const out: LineChar[] = []
+    for (const it of items) {
+      out.push({ c: it.c, ox: x, qLeft: x, qRight: x + it.width, font: it.font })
+      x += it.width + (it.track ?? 0)
+    }
+    return out
+  }
+
+  function L(c: string, width: number, track: number, font: string) {
+    return { c, width, track, font }
+  }
+  function S(width: number, font: string) {
+    return { c: " ", width, track: 0, font }
+  }
+
+  it("strips letter-spaced single spaces in a decorative font run", () => {
+    // Chokle@22 with ~3pt letter-tracking between every letter, fragment
+    // boundaries marked by single ~3pt-wide spaces — the Volcanologists
+    // pattern. Per-run median LS = 3pt, threshold = 4.8pt, single-space
+    // cluster (3pt) sub-threshold → strip.
+    const c = buildLine([
+      L("V", 7, 3, "Chokle@22"), L("o", 7, 3, "Chokle@22"),
+      S(3, "Chokle@22"),
+      L("l", 4, 3, "Chokle@22"), L("c", 6, 3, "Chokle@22"), L("a", 6, 3, "Chokle@22"),
+      S(3, "Chokle@22"),
+      L("n", 6, 3, "Chokle@22"),
+      S(3, "Chokle@22"),
+      L("o", 7, 3, "Chokle@22"),
+      S(3, "Chokle@22"),
+      L("l", 4, 3, "Chokle@22"), L("o", 7, 3, "Chokle@22"),
+      S(3, "Chokle@22"),
+      L("g", 7, 3, "Chokle@22"),
+      S(3, "Chokle@22"),
+      L("i", 4, 3, "Chokle@22"),
+      S(3, "Chokle@22"),
+      L("s", 6, 3, "Chokle@22"),
+      S(3, "Chokle@22"),
+      L("t", 5, 3, "Chokle@22"), L("s", 6, 0, "Chokle@22"),
+    ])
+    const line = makeLine(c)
+    const p = makeParagraph("Vo lca n o lo g i s ts")
+    cleanParagraphSpacing([p], [line])
+    expect(p.text).toBe("Volcanologists")
+  })
+
+  it("leaves a body-font run alone — even short fragments stay intact", () => {
+    // Body text: zero tracking, real spaces of 3pt. Per-run median LS = 0,
+    // threshold = 1pt, real-space cluster (3pt) supra-threshold → keep.
+    const c = buildLine([
+      L("a", 5, 0, "Body"), L("s", 5, 0, "Body"),
+      S(3, "Body"),
+      L("t", 4, 0, "Body"), L("w", 8, 0, "Body"), L("o", 6, 0, "Body"),
+      S(3, "Body"),
+      L("w", 8, 0, "Body"), L("e", 6, 0, "Body"), L("r", 4, 0, "Body"), L("e", 6, 0, "Body"),
+    ])
+    const line = makeLine(c)
+    const p = makeParagraph("as two were")
+    cleanParagraphSpacing([p], [line])
+    expect(p.text).toBe("as two were")
+  })
+
+  it("only strips spaces inside the decorative run of a mixed-font line", () => {
+    // Body (no tracking) | Chokle (3pt tracking) | Body (no tracking).
+    // Only the Chokle run's intra-word spaces should disappear; body-side
+    // word spaces and the font-transition space stay.
+    const c = buildLine([
+      L("a", 5, 0, "Body"), L("s", 5, 0, "Body"),
+      S(3, "Body"),
+      L("t", 4, 0, "Body"), L("w", 8, 0, "Body"), L("o", 6, 0, "Body"),
+      // Font-transition space — surrounded by Body 'o' and Chokle 'V',
+      // different fonts → kept regardless of cluster width.
+      S(3, "Body"),
+      L("V", 7, 3, "Chokle@22"), L("o", 7, 3, "Chokle@22"),
+      S(3, "Chokle@22"),
+      L("l", 4, 3, "Chokle@22"), L("c", 6, 3, "Chokle@22"), L("a", 6, 3, "Chokle@22"),
+      S(3, "Chokle@22"),
+      L("n", 6, 3, "Chokle@22"),
+      S(3, "Chokle@22"),
+      L("o", 7, 3, "Chokle@22"),
+      // Font-transition space — Chokle 'o' to Body 'w', different fonts → kept.
+      S(3, "Body"),
+      L("w", 8, 0, "Body"), L("e", 6, 0, "Body"), L("r", 4, 0, "Body"), L("e", 6, 0, "Body"),
+    ])
+    const line = makeLine(c)
+    const p = makeParagraph("as two Vo lca n o were")
+    cleanParagraphSpacing([p], [line])
+    expect(p.text).toBe("as two Volcano were")
+  })
+
+  it("strips when ≥60% of fragments are single-char even if metric ambiguous", () => {
+    // "L E A V E  N O  O N E  B E H I N D." — every letter separated by
+    // a single space, with double-spaces (TWO U+0020 chars) at word
+    // boundaries. A single accidental D→. pair gives a misleading
+    // non-zero medianLS that's below the actual single-space advances,
+    // so the metric alone would inconsistently strip/keep. The
+    // single-char-fragment ratio (15/16 ≈ 94%) catches it unambiguously.
+    // Single-space clusters → strip; double-space clusters → collapse to one.
+    const SP = (): { c: string; width: number; track?: number; font: string } =>
+      ({ c: " ", width: 4, track: 0, font: "Chokle@22" })
+    const c = buildLine([
+      L("L", 8, 0, "Chokle@22"), SP(),
+      L("E", 7, 0, "Chokle@22"), SP(),
+      L("A", 7, 0, "Chokle@22"), SP(),
+      L("V", 7, 0, "Chokle@22"), SP(),
+      L("E", 7, 0, "Chokle@22"), SP(), SP(),
+      L("N", 7, 0, "Chokle@22"), SP(),
+      L("O", 7, 0, "Chokle@22"), SP(), SP(),
+      L("O", 7, 0, "Chokle@22"), SP(),
+      L("N", 7, 0, "Chokle@22"), SP(),
+      L("E", 7, 0, "Chokle@22"), SP(), SP(),
+      L("B", 7, 0, "Chokle@22"), SP(),
+      L("E", 7, 0, "Chokle@22"), SP(),
+      L("H", 7, 0, "Chokle@22"), SP(),
+      L("I", 4, 0, "Chokle@22"), SP(),
+      L("N", 7, 0, "Chokle@22"), SP(),
+      L("D", 7, 2, "Chokle@22"),
+      L(".", 3, 0, "Chokle@22"),
+    ])
+    const line = makeLine(c)
+    const p = makeParagraph("L E A V E  N O  O N E  B E H I N D.")
+    cleanParagraphSpacing([p], [line])
+    expect(p.text).toBe("LEAVE NO ONE BEHIND.")
+  })
+
+  it("strips when run is entirely single-char fragments (medianLS=0)", () => {
+    // "e v a c u a t i o n" — every char is its own fragment, no
+    // consecutive non-space pairs. medianLS=0, threshold=1pt; without
+    // the fallback the 4pt-advance spaces would be kept.
+    const c = buildLine([
+      L("e", 6, 0, "Chokle@22"),
+      S(4, "Chokle@22"),
+      L("v", 7, 0, "Chokle@22"),
+      S(4, "Chokle@22"),
+      L("a", 6, 0, "Chokle@22"),
+      S(4, "Chokle@22"),
+      L("c", 6, 0, "Chokle@22"),
+      S(4, "Chokle@22"),
+      L("u", 6, 0, "Chokle@22"),
+    ])
+    const line = makeLine(c)
+    const p = makeParagraph("e v a c u")
+    cleanParagraphSpacing([p], [line])
+    expect(p.text).toBe("evacu")
+  })
+
+  it("keeps real word-spacing in a tracked font when cluster advance is wide enough", () => {
+    // Tracked Chokle@22 with median LS 3pt → threshold 4.8pt. A genuine
+    // word boundary inside this run (encoded as a wide ~10pt space)
+    // exceeds the threshold and stays.
+    const c = buildLine([
+      L("T", 7, 3, "Chokle@22"), L("h", 7, 3, "Chokle@22"), L("e", 7, 3, "Chokle@22"),
+      S(10, "Chokle@22"), // real word break, well above 4.8pt threshold
+      L("o", 7, 3, "Chokle@22"), L("n", 7, 3, "Chokle@22"), L("e", 7, 0, "Chokle@22"),
+    ])
+    const line = makeLine(c)
+    const p = makeParagraph("The one")
+    cleanParagraphSpacing([p], [line])
+    expect(p.text).toBe("The one")
+  })
+})

--- a/packages/pdf/src/__tests__/recorder-paint.test.ts
+++ b/packages/pdf/src/__tests__/recorder-paint.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import mupdf from "mupdf";
+import { recordPageStream } from "../page-stream-recorder.js";
+
+/** Minimal one-page PDF: a red filled rect and a blue stroked rect with a
+ *  known line width. Exercises the recorder's paint capture. */
+function paintTestPdf(): Buffer {
+  const doc = new mupdf.PDFDocument();
+  const stream = `
+q
+1 0 0 rg
+100 600 120 80 re f
+Q
+q
+0 0 1 RG
+7 w
+300 600 120 80 re S
+Q
+`;
+  const buf = new mupdf.Buffer();
+  buf.writeLine(stream);
+  const resources = doc.addObject(doc.newDictionary());
+  doc.insertPage(-1, doc.addPage([0, 0, 612, 792], 0, resources, buf));
+  return Buffer.from(doc.saveToBuffer("").asUint8Array());
+}
+
+describe("recorder paint capture", () => {
+  const doc = mupdf.Document.openDocument(paintTestPdf(), "application/pdf");
+  const ops = recordPageStream(doc.loadPage(0));
+  const fill = ops.find((o) => o.kind === "fillPath");
+  const stroke = ops.find((o) => o.kind === "strokePath");
+
+  it("captures fill colour and alpha on fillPath", () => {
+    expect(fill).toBeDefined();
+    expect(fill!.color).toBe("#ff0000");
+    expect(fill!.alpha).toBe(1);
+    expect(fill!.strokeWidth).toBeUndefined();
+  });
+
+  it("captures stroke colour, alpha and CTM-scaled width on strokePath", () => {
+    expect(stroke).toBeDefined();
+    expect(stroke!.color).toBe("#0000ff");
+    expect(stroke!.alpha).toBe(1);
+    // Page CTM is unscaled, so width ≈ the PDF `7 w` line width.
+    expect(stroke!.strokeWidth).toBeGreaterThan(0);
+    expect(stroke!.strokeWidth).toBeCloseTo(7, 1);
+  });
+
+  it("strokePath bbox is stroke-inflated; geomBbox is geometry-only", () => {
+    // The geometry rect is 120×80; the stroke (width 7) inflates the
+    // rendered bbox by ~half the width on each side, geomBbox stays tight.
+    const gW = stroke!.geomBbox.x1 - stroke!.geomBbox.x0;
+    const bW = stroke!.bbox.x1 - stroke!.bbox.x0;
+    expect(gW).toBeCloseTo(120, 0);
+    expect(bW).toBeGreaterThan(gW);
+  });
+});

--- a/packages/pdf/src/color-utils.ts
+++ b/packages/pdf/src/color-utils.ts
@@ -1,0 +1,30 @@
+/**
+ * mupdf colour → CSS hex conversion. Shared by structured-text styling
+ * (`positioned-text.ts`) and the page-stream recorder so a path op's paint
+ * and a text run's colour are derived identically.
+ */
+import { type Color } from "mupdf"
+
+/**
+ * Convert a mupdf Color (1, 3, or 4 floats in 0..1 — Gray / RGB / CMYK)
+ * to `#rrggbb`. CMYK uses the naive `r=(1-c)(1-k)` conversion (known
+ * limitation: ignores ICC profiles; matches what the rest of extraction
+ * does so colours stay consistent across text and vectors).
+ */
+export function colorToCss(color: Color): string {
+  let r: number, g: number, b: number
+  if (color.length === 1) {
+    r = g = b = color[0]
+  } else if (color.length === 3) {
+    [r, g, b] = color
+  } else {
+    // CMYK → naive conversion: r=(1-c)(1-k), g=(1-m)(1-k), b=(1-y)(1-k).
+    const [c, m, y, k] = color
+    r = (1 - c) * (1 - k)
+    g = (1 - m) * (1 - k)
+    b = (1 - y) * (1 - k)
+  }
+  const hex = (n: number) =>
+    Math.max(0, Math.min(255, Math.round(n * 255))).toString(16).padStart(2, "0")
+  return `#${hex(r)}${hex(g)}${hex(b)}`
+}

--- a/packages/pdf/src/extract.ts
+++ b/packages/pdf/src/extract.ts
@@ -5,16 +5,36 @@
  */
 
 import { createHash } from "crypto";
+import { PNG } from "pngjs";
 import mupdf, {
   type Document as MupdfDocument,
   type PDFDocument,
   type PDFPage,
   type PDFObject,
+  type Pixmap,
 } from "mupdf";
 import { cropPng, decodePng, stitchPngsHorizontally } from "./png-utils.js";
 import { extractTextFromStructuredText } from "./fm-sinhala.js";
 import type { RenderMethodValue } from "@adt/types";
 import { renderSvgToPng } from "./svg-render.js";
+import {
+  parsePageParagraphs,
+  parsePageParagraphsSpread,
+  type AsHtmlParagraph,
+  type ImageBounds,
+  type PageGeometry,
+} from "./positioned-text.js";
+import {
+  recordPageStream,
+  type StreamOp,
+  type ImageStreamOp,
+  type PathStreamOp,
+  type TextStreamOp,
+  type BBox as StreamBBox,
+  type ClipPath,
+  type PathCommand,
+} from "./page-stream-recorder.js";
+import type { DrawItem, PositionedTextOutput } from "@adt/types";
 
 // ============================================================================
 // Types
@@ -30,6 +50,14 @@ export interface ExtractInput {
   spreadMode?: boolean;
   /** When true, include text shapes in vector grouping to produce raster crops of vectors with text overlays. Defaults to true. */
   vectorTextGrouping?: boolean;
+  /**
+   * When true, run the metric-based positioned-text spacing cleanup
+   * (`cleanParagraphSpacing`) on extracted paragraphs. The pass strips
+   * letter-tracking artefacts ("V O L C A N O E S" → "VOLCANOES") that only
+   * matter for fixed-layout rendering — reflowable text comes from a
+   * separate path. Default false.
+   */
+  fixedLayout?: boolean;
 }
 
 export interface ExtractedPage {
@@ -38,6 +66,12 @@ export interface ExtractedPage {
   text: string;
   pageImage: ExtractedImage;
   images: ExtractedImage[];
+  /**
+   * Positioned text paragraphs and viewport dimensions, extracted from the
+   * PDF's structured text layer. Always populated so fixed-layout rendering
+   * has the data available regardless of when the strategy is configured.
+   */
+  positionedText: PositionedTextOutput;
   /** Debug info about figure grouping and render decisions */
   extractionDebug?: ExtractionDebugOutput;
 }
@@ -56,6 +90,52 @@ export interface ExtractedImage {
   hash: string;
   /** How this image was produced during extraction */
   renderMethod?: RenderMethod;
+  /**
+   * Placement on the page in PDF points (top-left origin). Populated for
+   * raster images that can be matched to a placement in the PDF's structured
+   * text. Undefined for vector figures and when no match is found.
+   */
+  bounds?: { x: number; y: number; width: number; height: number };
+  /**
+   * Zero-based draw order from the PDF's structured-text walker, shared with
+   * text paragraphs on the same page so fixed-layout rendering can restore
+   * z-stacking. Later items draw on top. Undefined for vector figures
+   * (which aren't visible to the walker).
+   */
+  drawOrder?: number;
+  /**
+   * Position of this image in the PDF content stream (painter's algorithm).
+   * Used by fixed-layout rendering to emit items in true draw order — later
+   * seqno renders on top. Transient: not persisted to the images table.
+   *   - Raster images: assigned by matching mupdf Device callbacks
+   *     (`fillImage` / `fillImageMask`) to extracted XObjects by native
+   *     dimensions, in stream order.
+   *   - Vector figures: assigned to the minimum seqno of `fillPath` /
+   *     `strokePath` ops that fall inside the figure's bounds.
+   */
+  streamSeqno?: number;
+  /**
+   * SVG path `d` attribute representing the active PDF clip applied to this
+   * image at draw time, in absolute viewport coordinates (PDF points,
+   * top-left origin — same space as `bounds`). Set only when the active
+   * clip meaningfully reduces the visible area of the image (≤95% overlap
+   * with the image's CTM bounds). The renderer translates these coords to
+   * the image's local origin when emitting `<clipPath>` markup.
+   */
+  clipPath?: string;
+  /**
+   * CSS `mix-blend-mode` value (e.g. "multiply") when the image was drawn
+   * under a non-Normal PDF blend mode at composite time. Common in
+   * watercolor storybooks: white backgrounds drawn under `/Multiply`
+   * effectively become transparent. Undefined when no special blending
+   * applies.
+   */
+  blendMode?: string;
+  /**
+   * Composed opacity (0..1) when the image's draw-time alpha or any
+   * enclosing transparency-group alpha is < 1. Undefined for fully opaque.
+   */
+  opacity?: number;
 }
 
 export interface PdfMetadata {
@@ -139,7 +219,7 @@ export async function extractPdf(
   input: ExtractInput,
   onProgress?: (progress: ExtractProgress) => void
 ): Promise<ExtractResult> {
-  const { pdfBuffer, startPage = 1, endPage, spreadMode = false, vectorTextGrouping = true } = input;
+  const { pdfBuffer, startPage = 1, endPage, spreadMode = false, vectorTextGrouping = true, fixedLayout = false } = input;
   validatePageRange(startPage, endPage);
 
   // Open PDF (suppressing mupdf stderr spam)
@@ -165,8 +245,8 @@ export async function extractPdf(
       const group = logicalGroups[g];
       const page =
         group.length === 2
-          ? await extractSpreadPage(doc, group[0], group[1], vectorTextGrouping)
-          : await extractPage(doc, group[0], vectorTextGrouping);
+          ? await extractSpreadPage(doc, group[0], group[1], vectorTextGrouping, fixedLayout)
+          : await extractPage(doc, group[0], vectorTextGrouping, fixedLayout);
       pages.push(page);
 
       onProgress?.({ page: g + 1, totalPages: totalLogical });
@@ -175,7 +255,7 @@ export async function extractPdf(
   } else {
     const rangeSize = end - start;
     for (let i = start; i < end; i++) {
-      const page = await extractPage(doc, i, vectorTextGrouping);
+      const page = await extractPage(doc, i, vectorTextGrouping, fixedLayout);
       pages.push(page);
 
       onProgress?.({ page: i - start + 1, totalPages: rangeSize });
@@ -200,7 +280,7 @@ export function extractPdfStream(
   input: ExtractInput,
   onProgress?: (progress: ExtractProgress) => void
 ): ExtractStreamResult {
-  const { pdfBuffer, startPage = 1, endPage, spreadMode = false, vectorTextGrouping = true } = input;
+  const { pdfBuffer, startPage = 1, endPage, spreadMode = false, vectorTextGrouping = true, fixedLayout = false } = input;
   validatePageRange(startPage, endPage);
 
   const doc = openPdfFromBuffer(pdfBuffer);
@@ -220,8 +300,8 @@ export function extractPdfStream(
           const group = logicalGroups[g];
           const page =
             group.length === 2
-              ? await extractSpreadPage(doc, group[0], group[1], vectorTextGrouping)
-              : await extractPage(doc, group[0], vectorTextGrouping);
+              ? await extractSpreadPage(doc, group[0], group[1], vectorTextGrouping, fixedLayout)
+              : await extractPage(doc, group[0], vectorTextGrouping, fixedLayout);
 
           onProgress?.({ page: g + 1, totalPages: totalLogical });
           yield page;
@@ -231,7 +311,7 @@ export function extractPdfStream(
       } else {
         const rangeSize = end - start;
         for (let i = start; i < end; i++) {
-          const page = await extractPage(doc, i, vectorTextGrouping);
+          const page = await extractPage(doc, i, vectorTextGrouping, fixedLayout);
 
           onProgress?.({ page: i - start + 1, totalPages: rangeSize });
           yield page;
@@ -320,6 +400,58 @@ function jpegDimensions(buf: Buffer): { width: number; height: number } {
 
 function pngDimensions(buf: Buffer): { width: number; height: number } {
   return { width: buf.readUInt32BE(16), height: buf.readUInt32BE(20) };
+}
+
+/**
+ * Combine a color pixmap with a grayscale alpha mask (from an image's SMask)
+ * into an RGBA PNG. PDF SMasks provide the transparency that
+ * `mupdf.Pixmap.toPixmap()` doesn't composite by itself, so without this step
+ * transparent regions come out as opaque black.
+ *
+ * If color and mask dimensions differ we fall back to sampling the mask at
+ * the matching position (nearest-neighbour), which handles the common case
+ * of a lower-resolution SMask.
+ */
+function compositeColorAndMask(color: Pixmap, mask: Pixmap): Buffer {
+  const width = color.getWidth();
+  const height = color.getHeight();
+  const colorComponents = color.getNumberOfComponents();
+  const colorAlpha = color.getAlpha();
+  const colorStride = colorComponents + (colorAlpha ? 1 : 0);
+  const colorPixels = color.getPixels();
+
+  const mWidth = mask.getWidth();
+  const mHeight = mask.getHeight();
+  const maskComponents = mask.getNumberOfComponents();
+  const maskAlpha = mask.getAlpha();
+  const maskStride = maskComponents + (maskAlpha ? 1 : 0);
+  const maskPixels = mask.getPixels();
+
+  const png = new PNG({ width, height });
+  for (let y = 0; y < height; y++) {
+    const my = mHeight === height ? y : Math.min(mHeight - 1, Math.round((y * mHeight) / height));
+    for (let x = 0; x < width; x++) {
+      const mx = mWidth === width ? x : Math.min(mWidth - 1, Math.round((x * mWidth) / width));
+      const srcIdx = (y * width + x) * colorStride;
+      const maskIdx = (my * mWidth + mx) * maskStride;
+      const dstIdx = (y * width + x) * 4;
+      // Color channels: grayscale → replicate, RGB → copy direct.
+      if (colorComponents === 1) {
+        const g = colorPixels[srcIdx];
+        png.data[dstIdx] = g;
+        png.data[dstIdx + 1] = g;
+        png.data[dstIdx + 2] = g;
+      } else {
+        png.data[dstIdx] = colorPixels[srcIdx];
+        png.data[dstIdx + 1] = colorPixels[srcIdx + 1];
+        png.data[dstIdx + 2] = colorPixels[srcIdx + 2];
+      }
+      // Alpha from mask: mupdf SMask pixmaps are typically grayscale with the
+      // value itself representing alpha (higher = more opaque).
+      png.data[dstIdx + 3] = maskPixels[maskIdx];
+    }
+  }
+  return PNG.sync.write(png);
 }
 
 /** Returns true if every pixel in the RGBA PNG is fully transparent (alpha === 0). */
@@ -424,7 +556,7 @@ function extractPdfMetadata(doc: MupdfDocument): PdfMetadata {
   return metadata;
 }
 
-async function extractPage(doc: MupdfDocument, pageIndex: number, vectorTextGrouping: boolean = true): Promise<ExtractedPage> {
+async function extractPage(doc: MupdfDocument, pageIndex: number, vectorTextGrouping: boolean = true, fixedLayout: boolean = false): Promise<ExtractedPage> {
   const pageNum = pageIndex + 1;
   const pageId = "pg" + String(pageNum).padStart(3, "0");
 
@@ -467,13 +599,445 @@ async function extractPage(doc: MupdfDocument, pageIndex: number, vectorTextGrou
     ? allRasterImages.filter(img => !coveredRasterHashes.has(img.hash))
     : allRasterImages;
 
+  // Stream-order assignment: run the page through a recording device so
+  // every draw op gets a true PDF content-stream seqno. mupdf's
+  // StructuredText walker is a layout reconstruction (reading flow, not
+  // stream order) so we cannot use it for z-order — but the device
+  // callbacks fire once per content-stream operator, in stream order, with
+  // fully-resolved CTMs. This is the canonical mupdf z-order primitive.
+  const recorder = runRecorderInViewport(page, pageBounds, 0, 0);
+  stampRasterPlacementsFromOps(rasterImages, recorder.ops);
+  stampFigureSeqnosFromOps(figureImages, recorder.ops);
+
+  const paragraphData = parsePageParagraphs(doc, pageIndex, 2, fixedLayout);
+  const positionedText = buildPositionedTextOutput(
+    pageId,
+    paragraphData,
+    rasterImages,
+    figureImages,
+    recorder.ops,
+  );
+
   return {
     pageId,
     pageNumber: pageNum,
     text,
     pageImage,
     images: [...rasterImages, ...figureImages],
+    positionedText,
     extractionDebug,
+  };
+}
+
+// ── Stream-order recorder integration ─────────────────────────────────
+
+/**
+ * Run the device recorder and translate every op's geometry into viewport
+ * space — i.e. the page's mupdf-normalized y-down coordinates with the
+ * page origin subtracted out and an optional `xShift` for spread
+ * right-pages. The recorder already returns y-down coords (mupdf flips PDF
+ * user-space internally before invoking device callbacks), so this is just
+ * an origin shift, not a coordinate-system flip.
+ *
+ * `seqnoShift` lets callers offset the spread's right-page seqnos past the
+ * left page so cross-page sort puts left-before-right.
+ */
+function runRecorderInViewport(
+  page: AnyPage,
+  pageBounds: number[],
+  xShift: number,
+  seqnoShift: number,
+): { ops: StreamOp[] } {
+  const pageOriginX = pageBounds[0];
+  const pageOriginY = pageBounds[1];
+  const rawOps = recordPageStream(page);
+  const dx = -pageOriginX + xShift;
+  const dy = -pageOriginY;
+  const shiftBBox = (b: StreamBBox): StreamBBox => ({
+    x0: b.x0 + dx,
+    y0: b.y0 + dy,
+    x1: b.x1 + dx,
+    y1: b.y1 + dy,
+  });
+  const shiftClipPaths = (clips: ClipPath[]): ClipPath[] =>
+    clips.map((c) => ({
+      evenOdd: c.evenOdd,
+      bbox: shiftBBox(c.bbox),
+      commands: c.commands.map((cmd): PathCommand => {
+        switch (cmd.op) {
+          case "M":
+          case "L":
+            return { op: cmd.op, x: cmd.x + dx, y: cmd.y + dy };
+          case "C":
+            return {
+              op: "C",
+              x1: cmd.x1 + dx,
+              y1: cmd.y1 + dy,
+              x2: cmd.x2 + dx,
+              y2: cmd.y2 + dy,
+              x3: cmd.x3 + dx,
+              y3: cmd.y3 + dy,
+            };
+          case "Z":
+            return cmd;
+        }
+      }),
+    }));
+  const ops: StreamOp[] = rawOps.map((op): StreamOp => {
+    const seqno = op.seqno + seqnoShift;
+    const activeClipBbox = op.activeClipBbox ? shiftBBox(op.activeClipBbox) : null;
+    if (op.kind === "image" || op.kind === "imageMask") {
+      return {
+        ...op,
+        seqno,
+        bbox: shiftBBox(op.bbox),
+        activeClipBbox,
+        activeClipPaths: shiftClipPaths(op.activeClipPaths),
+      };
+    }
+    if (op.kind === "fillText" || op.kind === "strokeText") {
+      return {
+        ...op,
+        seqno,
+        bbox: shiftBBox(op.bbox),
+        glyphs: op.glyphs.map((g) => ({
+          rune: g.rune,
+          x: g.x - pageOriginX + xShift,
+          y: g.y - pageOriginY,
+        })),
+        activeClipBbox,
+      };
+    }
+    // fillPath / strokePath / shade
+    return { ...op, seqno, bbox: shiftBBox(op.bbox), activeClipBbox };
+  });
+  return { ops };
+}
+
+type AnyPage = ReturnType<MupdfDocument["loadPage"]>;
+
+function bboxToImageBounds(b: StreamBBox): ImageBounds {
+  return { x: b.x0, y: b.y0, width: b.x1 - b.x0, height: b.y1 - b.y0 };
+}
+
+/** Serialize PathCommand[] to an SVG `d` attribute string in absolute coords. */
+function pathCommandsToSvgD(cmds: PathCommand[]): string {
+  const fmt = (n: number): string => {
+    // Round to 2 decimal places; strip trailing zeros / dot.
+    const s = n.toFixed(2);
+    return s.replace(/\.?0+$/, "");
+  };
+  const parts: string[] = [];
+  for (const c of cmds) {
+    switch (c.op) {
+      case "M":
+        parts.push(`M${fmt(c.x)} ${fmt(c.y)}`);
+        break;
+      case "L":
+        parts.push(`L${fmt(c.x)} ${fmt(c.y)}`);
+        break;
+      case "C":
+        parts.push(
+          `C${fmt(c.x1)} ${fmt(c.y1)} ${fmt(c.x2)} ${fmt(c.y2)} ${fmt(c.x3)} ${fmt(c.y3)}`,
+        );
+        break;
+      case "Z":
+        parts.push("Z");
+        break;
+    }
+  }
+  return parts.join("");
+}
+
+/** Pick the most-restrictive active clip for an image op, returning its SVG
+ *  `d` string in viewport coords — or undefined if no clip meaningfully
+ *  reduces the visible area. PDF semantics intersect the full clip stack;
+ *  the innermost is typically the binding constraint for storybook PDFs
+ *  (one clip-and-paint per image). If multiple clips are active, we score
+ *  each by how much it cuts into the image and pick the most restrictive. */
+function selectImageClipPath(op: ImageStreamOp): string | undefined {
+  if (op.activeClipPaths.length === 0) return undefined;
+  const imgArea =
+    Math.max(0, op.bbox.x1 - op.bbox.x0) *
+    Math.max(0, op.bbox.y1 - op.bbox.y0);
+  if (imgArea <= 0) return undefined;
+
+  let best: ClipPath | undefined;
+  let bestOverlap = Infinity;
+  for (const clip of op.activeClipPaths) {
+    if (clip.commands.length === 0) continue;
+    const ix0 = Math.max(clip.bbox.x0, op.bbox.x0);
+    const iy0 = Math.max(clip.bbox.y0, op.bbox.y0);
+    const ix1 = Math.min(clip.bbox.x1, op.bbox.x1);
+    const iy1 = Math.min(clip.bbox.y1, op.bbox.y1);
+    const interArea = Math.max(0, ix1 - ix0) * Math.max(0, iy1 - iy0);
+    const overlapRatio = interArea / imgArea;
+    if (overlapRatio < bestOverlap) {
+      bestOverlap = overlapRatio;
+      best = clip;
+    }
+  }
+  // Skip when the clip barely reduces the visible area (≥95% overlap means
+  // the clip is just the page or a containing region, not a meaningful crop).
+  if (!best || bestOverlap >= 0.95) return undefined;
+  return pathCommandsToSvgD(best.commands);
+}
+
+/**
+ * Match each `fillImage` / `fillImageMask` op to an extracted raster XObject
+ * by native pixel dimensions, consuming candidates in stream order. The
+ * matched raster gets its `streamSeqno` and its `bounds` (from the op's CTM)
+ * stamped on it.
+ *
+ * Multiple instances of the same image dimensions are paired in stream
+ * order — first op with WxH matches first remaining ExtractedImage with
+ * WxH. This is how mupdf placement order maps to XObject extraction order.
+ */
+function stampRasterPlacementsFromOps(
+  rasters: ExtractedImage[],
+  ops: StreamOp[],
+): void {
+  const byDim = new Map<string, ExtractedImage[]>();
+  for (const img of rasters) {
+    const key = `${img.width}x${img.height}`;
+    const arr = byDim.get(key) ?? [];
+    arr.push(img);
+    byDim.set(key, arr);
+  }
+  for (const op of ops) {
+    if (op.kind !== "image" && op.kind !== "imageMask") continue;
+    const candidates = byDim.get(`${op.nativeWidth}x${op.nativeHeight}`);
+    const matched = candidates?.shift();
+    if (!matched) continue;
+    matched.streamSeqno = op.seqno;
+    matched.bounds = bboxToImageBounds(op.bbox);
+    const clipD = selectImageClipPath(op);
+    if (clipD) matched.clipPath = clipD;
+    if (op.blendMode && op.blendMode !== "Normal") {
+      matched.blendMode = pdfBlendModeToCss(op.blendMode);
+    }
+    if (typeof op.alpha === "number" && op.alpha < 1) {
+      // Round to 3 decimal places — finer than display can reliably reproduce.
+      matched.opacity = Math.max(0, Math.round(op.alpha * 1000) / 1000);
+    }
+  }
+}
+
+/** Map mupdf's PDF BlendMode string to a CSS `mix-blend-mode` keyword.
+ *  PDF blend mode names are CamelCase ("ColorDodge"); CSS keywords are
+ *  kebab-case lowercase ("color-dodge"). Returns the input lowercased
+ *  with a hyphen between word boundaries. */
+function pdfBlendModeToCss(mode: string): string {
+  return mode
+    .replace(/([a-z])([A-Z])/g, "$1-$2")
+    .toLowerCase();
+}
+
+/**
+ * Stamp `streamSeqno` on each vector figure by finding the device path ops
+ * whose bounds fall inside the figure's overall bounds. The figure's seqno
+ * is the minimum of the matched ops' seqnos — the moment that figure
+ * begins drawing in the content stream.
+ *
+ * Why min, not e.g. mean: a figure is composed of several path ops drawn
+ * sequentially; seqno = first op preserves correct ordering relative to
+ * later ops that could draw on top of the figure (text, other figures).
+ */
+function stampFigureSeqnosFromOps(
+  figures: ExtractedImage[],
+  ops: StreamOp[],
+): void {
+  const pathOps: PathStreamOp[] = ops.filter(
+    (o): o is PathStreamOp => o.kind === "fillPath" || o.kind === "strokePath",
+  );
+  for (const fig of figures) {
+    if (!fig.bounds) continue;
+    const figBox: StreamBBox = {
+      x0: fig.bounds.x,
+      y0: fig.bounds.y,
+      x1: fig.bounds.x + fig.bounds.width,
+      y1: fig.bounds.y + fig.bounds.height,
+    };
+    let minSeqno = Infinity;
+    for (const op of pathOps) {
+      if (bboxContainedIn(op.bbox, figBox, /* tol */ 1)) {
+        if (op.seqno < minSeqno) minSeqno = op.seqno;
+      }
+    }
+    if (Number.isFinite(minSeqno)) fig.streamSeqno = minSeqno;
+  }
+}
+
+function bboxContainedIn(inner: StreamBBox, outer: StreamBBox, tol: number): boolean {
+  return (
+    inner.x0 >= outer.x0 - tol &&
+    inner.y0 >= outer.y0 - tol &&
+    inner.x1 <= outer.x1 + tol &&
+    inner.y1 <= outer.y1 + tol
+  );
+}
+
+/**
+ * For each asHTML paragraph, find the `fillText` op whose first glyph sits
+ * at the paragraph's anchor (left, top + lineHeight ≈ baseline). Returns
+ * the matched op's seqno, or null if no match.
+ *
+ * mupdf coalesces multiple asHTML paragraphs into a single `fillText` op
+ * when they share font/style — that's fine, all those paragraphs simply
+ * share the same stream seqno.
+ */
+function matchParagraphSeqno(
+  p: AsHtmlParagraph,
+  textOps: TextStreamOp[],
+): number | null {
+  // Both glyph and asHTML coords are in the page's y-down viewport. asHTML
+  // `top` is the top of the line box; the glyph baseline sits one
+  // line-height below.
+  const expectedX = p.left;
+  const expectedY = p.top + p.lineHeight;
+  let bestSeqno: number | null = null;
+  let bestDist = Infinity;
+  for (const op of textOps) {
+    for (const g of op.glyphs) {
+      const dx = Math.abs(g.x - expectedX);
+      const dy = Math.abs(g.y - expectedY);
+      if (dy < Math.max(p.lineHeight, 4) && dx < 4) {
+        const d = dx + dy * 2;
+        if (d < bestDist) {
+          bestDist = d;
+          bestSeqno = op.seqno;
+        }
+      }
+    }
+  }
+  return bestSeqno;
+}
+
+/**
+ * Assemble the final `PositionedTextOutput` from extracted images + vector
+ * figures + asHTML paragraphs, sorting everything by its true PDF
+ * content-stream seqno.
+ *
+ * - Each raster has its `streamSeqno` and `bounds` already stamped by
+ *   `stampRasterPlacementsFromOps`.
+ * - Each vector figure has its `streamSeqno` stamped by
+ *   `stampFigureSeqnosFromOps`.
+ * - Each paragraph gets its seqno here by matching its anchor to a
+ *   `fillText` op's first matching glyph. Paragraphs that share a fillText
+ *   op (mupdf coalesces same-font runs) get the same seqno; we add a tiny
+ *   index-based offset so they sort stably amongst themselves.
+ */
+function buildPositionedTextOutput(
+  pageId: string,
+  paragraphData: { paragraphs: AsHtmlParagraph[] } & PageGeometry,
+  rasterImages: ExtractedImage[],
+  vectorImages: ExtractedImage[],
+  ops: StreamOp[],
+): PositionedTextOutput {
+  type Item =
+    | {
+        seqno: number;
+        kind: "image";
+        imageId: string;
+        bounds: ImageBounds;
+        clipPath?: string;
+        blendMode?: string;
+        opacity?: number;
+      }
+    | {
+        seqno: number;
+        kind: "paragraph";
+        textId: string;
+        top: number;
+        left: number;
+        lineHeight: number;
+        segments: AsHtmlParagraph["segments"];
+        text: string;
+        blockId?: string;
+        blockBounds?: AsHtmlParagraph["blockBounds"];
+        mergedParagraphId?: string;
+        textAlign?: AsHtmlParagraph["textAlign"];
+      };
+  const items: Item[] = [];
+
+  for (const img of [...rasterImages, ...vectorImages]) {
+    if (!img.bounds || img.streamSeqno === undefined) continue;
+    items.push({
+      seqno: img.streamSeqno,
+      kind: "image",
+      imageId: img.imageId,
+      bounds: img.bounds,
+      clipPath: img.clipPath,
+      blendMode: img.blendMode,
+      opacity: img.opacity,
+    });
+  }
+
+  const textOps: TextStreamOp[] = ops.filter(
+    (o): o is TextStreamOp => o.kind === "fillText" || o.kind === "strokeText",
+  );
+  // Paragraphs not matched to a fillText op are pinned just past the last
+  // recorded op so they still sort above visual content. This is a safety
+  // net — when we can't unicode-decode glyphs (rare fonts/encodings the
+  // /ToUnicode CMap omits), we keep the paragraph but let it draw last.
+  const lastOpSeqno = ops.reduce((m, o) => Math.max(m, o.seqno), 0);
+
+  paragraphData.paragraphs.forEach((p, idx) => {
+    const matched = matchParagraphSeqno(p, textOps);
+    // Tiny per-paragraph offset breaks ties when multiple paragraphs share
+    // a fillText op (mupdf coalesces same-font runs); preserves asHTML
+    // emission order within a single op.
+    const seqno = (matched ?? lastOpSeqno + 1) + (idx + 1) * 1e-6;
+    items.push({
+      seqno,
+      kind: "paragraph",
+      textId: `${pageId}_p${String(idx).padStart(3, "0")}`,
+      top: p.top,
+      left: p.left,
+      lineHeight: p.lineHeight,
+      segments: p.segments,
+      text: p.text,
+      blockId: p.blockId,
+      blockBounds: p.blockBounds,
+      mergedParagraphId: p.mergedParagraphId,
+      textAlign: p.textAlign,
+    });
+  });
+
+  items.sort((a, b) => a.seqno - b.seqno);
+
+  const drawItems: DrawItem[] = items.map((i) => {
+    if (i.kind === "image") {
+      return {
+        kind: "image",
+        imageId: i.imageId,
+        bounds: i.bounds,
+        ...(i.clipPath ? { clipPath: i.clipPath } : {}),
+        ...(i.blendMode ? { blendMode: i.blendMode } : {}),
+        ...(typeof i.opacity === "number" ? { opacity: i.opacity } : {}),
+      };
+    }
+    return {
+      kind: "paragraph",
+      textId: i.textId,
+      top: i.top,
+      left: i.left,
+      lineHeight: i.lineHeight,
+      segments: i.segments,
+      text: i.text,
+      ...(i.blockId !== undefined ? { blockId: i.blockId } : {}),
+      ...(i.blockBounds !== undefined ? { blockBounds: i.blockBounds } : {}),
+      ...(i.mergedParagraphId !== undefined ? { mergedParagraphId: i.mergedParagraphId } : {}),
+      ...(i.textAlign !== undefined ? { textAlign: i.textAlign } : {}),
+    };
+  });
+
+  return {
+    drawItems,
+    pageWidth: paragraphData.pageWidth,
+    pageHeight: paragraphData.pageHeight,
+    renderWidth: paragraphData.renderWidth,
+    renderHeight: paragraphData.renderHeight,
   };
 }
 
@@ -486,6 +1050,7 @@ async function extractSpreadPage(
   leftIndex: number,
   rightIndex: number,
   vectorTextGrouping: boolean = true,
+  fixedLayout: boolean = false,
 ): Promise<ExtractedPage> {
   const leftNum = leftIndex + 1;
   const rightNum = rightIndex + 1;
@@ -539,6 +1104,7 @@ async function extractSpreadPage(
   const leftSvg = getPageSvg(leftPage);
   const rightSvg = getPageSvg(rightPage);
   const rasterCount = allLeftRaster.length + allRightRaster.length;
+  const leftPageWidthPt = leftBounds[2] - leftBounds[0];
   const leftResult = await extractVectorImagesFromSvg(leftSvg, pageId, rasterCount, leftPng, vectorTextGrouping ? leftTextShapes : undefined);
   const rightResult = await extractVectorImagesFromSvg(
     rightSvg,
@@ -546,6 +1112,7 @@ async function extractSpreadPage(
     rasterCount + leftResult.images.length,
     rightPng,
     vectorTextGrouping ? rightTextShapes : undefined,
+    leftPageWidthPt,
   );
 
   // Merge covered hashes from both pages and filter raster images
@@ -575,12 +1142,54 @@ async function extractSpreadPage(
     groups: [...leftResult.debug.groups, ...rightResult.debug.groups],
   };
 
+  // Fixed-layout places individual halves at their original positions, so no
+  // spread-level image stitching is needed — the two halves, each with their
+  // own PDF-point bounds, compose correctly on the rendered spread viewport.
+  const rasterImages = [...leftRaster, ...rightRaster];
+  const figureImages = [...leftResult.images, ...rightResult.images];
+
+  // Run the recorder on both pages, in viewport coords; right-page x is
+  // shifted by left page width so positions address the stitched spread,
+  // and right-page seqnos shift past left so cross-page sort puts left
+  // ahead of right (matches PDF reading order).
+  const leftRecorder = runRecorderInViewport(leftPage, leftBounds, 0, 0);
+  const leftMaxSeqno = leftRecorder.ops.reduce(
+    (m, o) => Math.max(m, o.seqno),
+    -1,
+  );
+  const rightRecorder = runRecorderInViewport(
+    rightPage,
+    rightBounds,
+    leftPageWidthPt,
+    leftMaxSeqno + 1,
+  );
+  const ops: StreamOp[] = [...leftRecorder.ops, ...rightRecorder.ops];
+  // Stamp seqnos on rasters/figures using the unified op list. We split by
+  // page when matching rasters so dim-tied images on different pages don't
+  // accidentally pair across the spread boundary.
+  stampRasterPlacementsFromOps(leftRaster, leftRecorder.ops);
+  stampRasterPlacementsFromOps(rightRaster, rightRecorder.ops);
+  stampFigureSeqnosFromOps(leftResult.images, leftRecorder.ops);
+  stampFigureSeqnosFromOps(rightResult.images, rightRecorder.ops);
+
+  const paragraphData = parsePageParagraphsSpread(doc, leftIndex, rightIndex, 2, fixedLayout);
+  const positionedText = buildPositionedTextOutput(
+    pageId,
+    paragraphData,
+    rasterImages,
+    figureImages,
+    ops,
+  );
+
+  const images: ExtractedImage[] = [...rasterImages, ...figureImages];
+
   return {
     pageId,
     pageNumber: leftNum,
     text,
     pageImage,
-    images: [...leftRaster, ...rightRaster, ...leftResult.images, ...rightResult.images],
+    images,
+    positionedText,
     extractionDebug,
   };
 }
@@ -668,7 +1277,16 @@ function extractRasterImagesFromPdf(
         // filter decoding, so we must not treat those as raw JPEG bytes.
         const isSingleFilter = filterNames.length === 1;
 
-        if (filterName === "DCTDecode" && isSingleFilter) {
+        // Soft-mask (SMask): the image dict points to a separate image that
+        // provides the alpha channel. mupdf's toPixmap() does NOT composite
+        // with the SMask, so any fast-path that bypasses mupdf (raw JPEG) or
+        // just reads the color channels will leave previously-transparent
+        // regions opaque black. Detect this up front so both branches handle
+        // it correctly.
+        const smaskObj = resolved.get("SMask");
+        const hasSMask = !smaskObj.isNull();
+
+        if (filterName === "DCTDecode" && isSingleFilter && !hasSMask) {
           // Check colorspace — CMYK JPEGs need conversion (browsers can't display them)
           const cs = resolved.get("ColorSpace");
           const isCmyk =
@@ -683,12 +1301,19 @@ function extractRasterImagesFromPdf(
             buf = Buffer.from(pixmap.asJPEG(90, true));
             format = "jpeg";
           } else {
-            // RGB/Gray JPEG: extract raw bytes directly
+            // RGB/Gray JPEG (no SMask): extract raw bytes directly
             buf = Buffer.from(streamObj.readRawStream().asUint8Array());
             format = "jpeg";
           }
+        } else if (hasSMask) {
+          // Composite color + soft-mask into an RGBA PNG.
+          const colorPixmap = doc.loadImage(streamObj).toPixmap();
+          const smaskStream = smaskObj.isIndirect() ? smaskObj : resolved.get("SMask");
+          const maskPixmap = doc.loadImage(smaskStream).toPixmap();
+          buf = compositeColorAndMask(colorPixmap, maskPixmap);
+          format = "png";
         } else {
-          // Multi-filter chains or non-JPEG: decode through mupdf → PNG
+          // Multi-filter chains or non-JPEG without SMask: decode through mupdf → PNG
           const image = doc.loadImage(streamObj);
           const pixmap = image.toPixmap();
           buf = Buffer.from(pixmap.asPNG());
@@ -1702,9 +2327,18 @@ function getPageSvg(
 
     const mediabox = page.getBounds();
     const device = writer.beginPage(mediabox);
-    page.run(device, mupdf.Matrix.identity);
+    try {
+      page.run(device, mupdf.Matrix.identity);
+    } finally {
+      // mupdf C requires close + drop on the per-page device before
+      // ending the page; otherwise it logs "dropping unclosed device"
+      // when the FinalizationRegistry eventually drops the WASM pointer.
+      device.close();
+      device.destroy();
+    }
     writer.endPage();
     writer.close();
+    writer.destroy();
 
     const svgContent = buf.asString();
     const pageWidth = mediabox[2] - mediabox[0];
@@ -1974,6 +2608,13 @@ interface FigureExtractionResult {
   images: ExtractedImage[];
   /** Hashes of raster images that are part of figure groups (for dedup with XObject extraction) */
   coveredRasterHashes: Set<string>;
+  /**
+   * Map from the hash of each SVG `<image>` element's decoded bytes to its
+   * SVG source-order seqno. Used by callers to assign `streamSeqno` on
+   * XObject-extracted rasters (matched by hash), yielding unified PDF
+   * content-stream order across rasters + vectors.
+   */
+  imageHashToSeqno: Map<string, number>;
   /** Debug info about grouping and render decisions */
   debug: ExtractionDebugOutput;
 }
@@ -1984,6 +2625,9 @@ async function extractVectorImagesFromSvg(
   startIndex: number,
   pagePngBuffer: Buffer,
   textShapes?: ShapeInfo[],
+  /** Added to every produced image's `bounds.x` so right-page figures in a
+   *  spread address the stitched viewport. Defaults to 0 (single page). */
+  xOffset: number = 0,
 ): Promise<FigureExtractionResult> {
   const images: ExtractedImage[] = [];
   const coveredRasterHashes = new Set<string>();
@@ -2024,13 +2668,27 @@ async function extractVectorImagesFromSvg(
   debug.totalShapes = allShapes.length;
   debug.totalTextShapes = textShapesIncluded;
 
-  if (allShapes.length === 0) return { images, coveredRasterHashes, debug };
+  // Map each SVG image shape's hash to its seqno so callers can stamp
+  // `streamSeqno` on the matching XObject-extracted rasters.
+  const imageHashToSeqno = new Map<string, number>();
+  for (const shape of allShapes) {
+    if (shape.isImage && shape.imageDataHash) {
+      imageHashToSeqno.set(shape.imageDataHash, shape.seqno);
+    }
+  }
 
-  // Filter out background shapes — large in either dimension (>75% of page).
-  // These are page-level fills/decorations that would merge unrelated groups.
+  if (allShapes.length === 0) return { images, coveredRasterHashes, imageHashToSeqno, debug };
+
+  // Split shapes into "normal" (participate in foreground grouping) and
+  // "background" (large page-fill shapes >75% of page in either dim).
+  // Backgrounds are kept aside because they'd merge unrelated foreground
+  // groups during spatial grouping; they're emitted as standalone figures
+  // at the end of this pass so fixed-layout rendering can render them below
+  // the foreground.
   const bgWidthThreshold = pageWidth * BACKGROUND_THRESHOLD;
   const bgHeightThreshold = pageHeight * BACKGROUND_THRESHOLD;
   const normalShapes: ShapeInfo[] = [];
+  const backgroundShapes: ShapeInfo[] = [];
 
   for (const shape of allShapes) {
     const [minX, minY, maxX, maxY] = shape.bbox;
@@ -2039,6 +2697,9 @@ async function extractVectorImagesFromSvg(
     if (w <= 0 || h <= 0) continue;
     if (w >= bgWidthThreshold || h >= bgHeightThreshold) {
       debug.backgroundsFiltered++;
+      // Non-text backgrounds become their own figures; text blocks that
+      // happen to be huge are discarded (would just be noise).
+      if (!shape.isText) backgroundShapes.push(shape);
       continue;
     }
     normalShapes.push(shape);
@@ -2157,10 +2818,45 @@ async function extractVectorImagesFromSvg(
       if (img) img.renderMethod = "vector";
     }
 
-    if (img) images.push(img);
+    if (img) {
+      // Record the figure's page placement in PDF points (top-left origin).
+      // Fixed-layout rendering reads these to position the figure on the page.
+      img.bounds = {
+        x: cropBbox[0] + xOffset,
+        y: cropBbox[1],
+        width: cropW,
+        height: cropH,
+      };
+      // Stream seqno = earliest-drawn shape in the group. Used by fixed-layout
+      // rendering to restore PDF content-stream order across all draw items.
+      img.streamSeqno = Math.min(...group.map((s) => s.seqno));
+      images.push(img);
+    }
   }
 
-  return { images, coveredRasterHashes, debug };
+  // Emit each background shape as its own figure — they're large page-fill
+  // shapes (purple sky, color-block strips) that got excluded from the
+  // foreground grouping but still need to render.
+  backgroundShapes.sort((a, b) => a.seqno - b.seqno);
+  for (const shape of backgroundShapes) {
+    imgIndex++;
+    const bgBbox = shape.bbox;
+    const bgW = bgBbox[2] - bgBbox[0];
+    const bgH = bgBbox[3] - bgBbox[1];
+    const img = await renderShapeGroup([shape], pageId, imgIndex, svgDefs, pageWidth, pageHeight, bgBbox);
+    if (!img) continue;
+    img.renderMethod = "vector";
+    img.bounds = {
+      x: bgBbox[0] + xOffset,
+      y: bgBbox[1],
+      width: bgW,
+      height: bgH,
+    };
+    img.streamSeqno = shape.seqno;
+    images.push(img);
+  }
+
+  return { images, coveredRasterHashes, imageHashToSeqno, debug };
 }
 
 // ============================================================================

--- a/packages/pdf/src/extract.ts
+++ b/packages/pdf/src/extract.ts
@@ -1916,6 +1916,58 @@ function applyMatrixTransformToBbox(
 }
 
 /**
+ * Half the rendered stroke width of an SVG element, in page points — i.e.
+ * how far the stroke ink extends beyond the path geometry on each side.
+ *
+ * `ShapeInfo.bbox` is the path *geometry* bbox; a stroke straddles the path
+ * centreline and reaches `stroke-width / 2` past the geometry, so cropping a
+ * figure to the geometry bbox shaves the outer half of its outline off (the
+ * speech-bubble outline-clipping reported on PR #285). Returns 0 for
+ * fill-only shapes so their bbox stays tight.
+ *
+ * stroke-width is authored in the element's pre-transform user units; the
+ * `transform="matrix(a b c d e f)"` scales it into page space. We take the
+ * larger axis scale so a non-uniform transform never under-expands.
+ *
+ * Miter joins can spike past `stroke-width / 2` (up to
+ * `stroke-miterlimit × half`). We apply that factor only when the element
+ * *explicitly* declares `stroke-linejoin="miter"`: mupdf emits the join
+ * explicitly, and assuming the SVG default (miter) for elements that omit it
+ * would balloon every round-joined bubble. Document-derived throughout — no
+ * arbitrary bleed.
+ */
+function parseStrokeInkExtent(svgElement: string): number {
+  const stroke = /\sstroke="([^"]*)"/.exec(svgElement)?.[1]?.trim();
+  if (!stroke || stroke === "none" || stroke === "transparent") return 0;
+
+  const widthRaw = /\sstroke-width="([^"]*)"/.exec(svgElement)?.[1];
+  // SVG default stroke-width is 1 when a stroke is set but width omitted.
+  const strokeWidth = widthRaw != null ? parseFloat(widthRaw) : 1;
+  if (!Number.isFinite(strokeWidth) || strokeWidth <= 0) return 0;
+
+  let scale = 1;
+  const matrix = /matrix\(([^)]+)\)/.exec(svgElement)?.[1];
+  if (matrix) {
+    const v = matrix.split(/[\s,]+/).map(parseFloat);
+    if (v.length === 6 && v.every(Number.isFinite)) {
+      const [a, b, c, d] = v;
+      scale = Math.max(Math.hypot(a, b), Math.hypot(c, d)) || 1;
+    }
+  }
+
+  let half = (strokeWidth * scale) / 2;
+
+  const linejoin = /\sstroke-linejoin="([^"]*)"/.exec(svgElement)?.[1];
+  if (linejoin === "miter") {
+    const mlRaw = /\sstroke-miterlimit="([^"]*)"/.exec(svgElement)?.[1];
+    const miterLimit = mlRaw != null ? parseFloat(mlRaw) : 4; // SVG default
+    if (Number.isFinite(miterLimit) && miterLimit > 1) half *= miterLimit;
+  }
+
+  return half;
+}
+
+/**
  * Extract shapes from SVG content.
  * Returns array of shapes with their bounding boxes (after applying transforms).
  * Tracks clip-path associations from parent <g> elements (including nested clips).
@@ -2180,6 +2232,41 @@ function computeGroupBbox(group: ShapeInfo[]): BBox {
     minY = Math.min(minY, y0);
     maxX = Math.max(maxX, x1);
     maxY = Math.max(maxY, y1);
+  }
+
+  return [minX, minY, maxX, maxY];
+}
+
+/**
+ * Group bbox grown to the figure's true *ink* extent: each shape's geometry
+ * bbox expanded by its own rendered stroke half-width (see
+ * {@link parseStrokeInkExtent}) plus a one-device-pixel anti-alias guard.
+ *
+ * `computeGroupBbox` returns the geometry union, which crops strokes and the
+ * rasteriser's 1px anti-alias fringe (the grey edge pixel visible one row in
+ * from a "clipped" outline). `aaGuardX/Y` are 1 device pixel expressed in
+ * page points (`1 / pageScale`) — measured from the page render, not an
+ * arbitrary constant.
+ */
+function computeGroupInkBbox(
+  group: ShapeInfo[],
+  aaGuardX: number,
+  aaGuardY: number,
+): BBox {
+  let minX = Infinity,
+    minY = Infinity,
+    maxX = -Infinity,
+    maxY = -Infinity;
+
+  for (const shape of group) {
+    const stroke = parseStrokeInkExtent(shape.svgElement);
+    const padX = stroke + aaGuardX;
+    const padY = stroke + aaGuardY;
+    const [x0, y0, x1, y1] = shape.bbox;
+    minX = Math.min(minX, x0 - padX);
+    minY = Math.min(minY, y0 - padY);
+    maxX = Math.max(maxX, x1 + padX);
+    maxY = Math.max(maxY, y1 + padY);
   }
 
   return [minX, minY, maxX, maxY];
@@ -2636,6 +2723,14 @@ async function extractVectorImagesFromSvg(
   const { svgContent, pageWidth, pageHeight } = svg;
   const svgDefs = `<defs>${svg.svgDefs}</defs>`;
 
+  // One device pixel of the page render expressed in page points
+  // (`1 / pageScale`) — the rasteriser's anti-alias fringe. Feeds
+  // computeGroupInkBbox so figure crops reach the figure's true ink extent
+  // instead of shaving stroked outlines (PR #285 speech-bubble clipping).
+  const pageDims = pngDimensions(pagePngBuffer);
+  const aaGuardX = pageDims.width > 0 ? pageWidth / pageDims.width : 0;
+  const aaGuardY = pageDims.height > 0 ? pageHeight / pageDims.height : 0;
+
   // Debug tracking
   const debug: ExtractionDebugOutput = {
     pageId,
@@ -2752,7 +2847,17 @@ async function extractVectorImagesFromSvg(
 
     const hasText = group.some(s => s.isText);
     const nonTextShapes = group.filter(s => !s.isText);
-    const cropBbox = bbox;
+    // Crop to the figure's true ink extent (geometry + per-shape stroke
+    // half-width + 1px AA), clamped to the page. The small-figure skip above
+    // intentionally stays on the geometry bbox so a stroke can't inflate a
+    // sub-threshold speck past MIN_VECTOR_DIMENSION.
+    const ink = computeGroupInkBbox(group, aaGuardX, aaGuardY);
+    const cropBbox: BBox = [
+      Math.max(0, ink[0]),
+      Math.max(0, ink[1]),
+      Math.min(pageWidth, ink[2]),
+      Math.min(pageHeight, ink[3]),
+    ];
 
     const cropW = cropBbox[2] - cropBbox[0];
     const cropH = cropBbox[3] - cropBbox[1];
@@ -2897,4 +3002,6 @@ export const _testing = {
   applyMatrixTransformToBbox,
   parseClipPathBounds,
   isPageLevelClip,
+  parseStrokeInkExtent,
+  computeGroupInkBbox,
 };

--- a/packages/pdf/src/extract.ts
+++ b/packages/pdf/src/extract.ts
@@ -599,9 +599,10 @@ async function extractPage(doc: MupdfDocument, pageIndex: number, vectorTextGrou
 
   // Extract vector shapes and figure groups from SVG (text shapes participate in grouping when enabled)
   const pageSvg = getPageSvg(page);
-  const { images: figureImages, coveredRasterHashes, debug: extractionDebug } = await extractVectorImagesFromSvg(
+  const { images: figureImagesRaw, coveredRasterHashes, debug: extractionDebug } = await extractVectorImagesFromSvg(
     pageSvg, pageId, allRasterImages.length, pagePngBuf, vectorTextGrouping ? textShapes : undefined
   );
+  let figureImages = figureImagesRaw;
 
   // Filter out raster images that are covered by figure groups (dedup)
   const rasterImages = coveredRasterHashes.size > 0
@@ -616,9 +617,16 @@ async function extractPage(doc: MupdfDocument, pageIndex: number, vectorTextGrou
   // fully-resolved CTMs. This is the canonical mupdf z-order primitive.
   const recorder = runRecorderInViewport(page, pageBounds, 0, 0);
   stampRasterPlacementsFromOps(rasterImages, recorder.ops);
-  stampFigureSeqnosFromOps(figureImages, recorder.ops);
 
   const paragraphData = parsePageParagraphs(doc, pageIndex, 2, fixedLayout);
+  // Fold hand-lettered vector paint into the duplicate selectable text
+  // run, then drop the now-duplicate vector shapes (re-rendering figures
+  // that only partially duplicate text). Figure seqnos are stamped after,
+  // so re-rendered survivors get their true content-stream order.
+  const { restyledBoxes } = restyleCoincidentVectorText(paragraphData.paragraphs, recorder.ops);
+  figureImages = await excludeConsumedFigureShapes(figureImages, restyledBoxes);
+  stampFigureSeqnosFromOps(figureImages, recorder.ops);
+
   const positionedText = buildPositionedTextOutput(
     pageId,
     paragraphData,
@@ -932,6 +940,184 @@ function matchParagraphSeqno(
   return bestSeqno;
 }
 
+type Segment = AsHtmlParagraph["segments"][number];
+
+/** A path op's geometry bbox is "inside" a text run's glyph box when it
+ *  sits within it, give or take `tol` (SVG export rounds to 2dp). */
+function geomInside(
+  inner: { x0: number; y0: number; x1: number; y1: number },
+  outer: { x0: number; y0: number; x1: number; y1: number },
+  tol: number,
+): boolean {
+  return (
+    inner.x0 >= outer.x0 - tol &&
+    inner.y0 >= outer.y0 - tol &&
+    inner.x1 <= outer.x1 + tol &&
+    inner.y1 <= outer.y1 + tol
+  );
+}
+
+/** Single dominant value of a string list, or null if no strict majority. */
+function majority(vals: string[]): string | null {
+  if (vals.length === 0) return null;
+  const counts = new Map<string, number>();
+  for (const v of vals) counts.set(v, (counts.get(v) ?? 0) + 1);
+  let best: string | null = null;
+  let bestN = 0;
+  for (const [v, n] of counts) if (n > bestN) (best = v), (bestN = n);
+  return bestN * 2 > vals.length ? best : null;
+}
+
+/**
+ * Restyle text runs that duplicate hand-lettered vector art, faithfully,
+ * from the vector's own paint — so the *selectable text* carries the
+ * visual the PDF intended and the duplicate vector can be dropped
+ * (translation / TTS / glossary all operate on clean text).
+ *
+ * mupdf opens a new `fillText` op on every graphics-state change
+ * (incl. fill colour / font) — exactly where `groupIntoSegments` splits
+ * runs — so a styled segment maps to a `fillText` op; that op's bbox is
+ * the run's extent in the same viewport space as path ops' `geomBbox`.
+ *
+ * For a segment whose run box contains path ops:
+ *  - all-`strokePath`  → the vector is the glyph's outline: keep the run's
+ *    fill colour, add a faithful `-webkit-text-stroke` from the stroke
+ *    op's colour + width (e.g. hollow "white").
+ *  - all-`fillPath`    → the vector IS the visible glyph and the run's
+ *    colour is an invisible shim: recolour the run to the fill colour,
+ *    no stroke (e.g. solid black hand-drawn `h`).
+ *  - mixed             → both.
+ *  - colour disagreement / no run match → leave untouched (safe no-op;
+ *    never worse than today).
+ *
+ * Returns the set of path-op seqnos consumed by a restyle, so a later
+ * pass can exclude the now-duplicate vector shapes.
+ */
+function restyleCoincidentVectorText(
+  paragraphs: AsHtmlParagraph[],
+  ops: StreamOp[],
+): { consumed: Set<number>; restyledBoxes: BBox[] } {
+  const consumed = new Set<number>();
+  // Glyph boxes of runs we restyled. A figure shape that sits inside one
+  // of these is the vector duplicate of already-restyled text and is
+  // excluded — robust to a glyph being one SVG shape but many recorder
+  // subpath ops (op-bbox equality isn't).
+  const restyledBoxes: BBox[] = [];
+  const pathOps = ops.filter(
+    (o): o is PathStreamOp => o.kind === "fillPath" || o.kind === "strokePath",
+  );
+  if (pathOps.length === 0) return { consumed, restyledBoxes };
+  const textOps = ops.filter(
+    (o): o is TextStreamOp => o.kind === "fillText" || o.kind === "strokeText",
+  );
+  const TOL = 1;
+  const isWs = (c: string): boolean => /\s/.test(c);
+
+  for (const p of paragraphs) {
+    if (!p.segments || p.segments.length === 0) continue;
+    const baseline = p.top + p.lineHeight;
+    // Glyphs on THIS paragraph's line, gathered across every text op and
+    // filtered by per-glyph y: a uniform-style heading is coalesced by
+    // mupdf into ONE op spanning multiple lines/segments, so an op can't
+    // be matched whole to a segment. Per-glyph y picks only this line's
+    // glyphs out of such an op.
+    const lineGlyphs: { rune: string; x: number }[] = [];
+    for (const op of textOps) {
+      for (const g of op.glyphs) {
+        if (Math.abs(g.y - baseline) < Math.max(p.lineHeight, 4)) {
+          lineGlyphs.push({ rune: g.rune, x: g.x });
+        }
+      }
+    }
+    if (lineGlyphs.length === 0) continue;
+    lineGlyphs.sort((a, b) => a.x - b.x);
+
+    // Align each segment to its own glyph sub-span by a whitespace-tolerant
+    // two-pointer walk (segments concatenate to the line text). The segment
+    // box is the extent of just its glyphs — works whether the run is its
+    // own op or part of a coalesced multi-segment op, and repeated letters
+    // map to successive glyphs (cursor advances), so each occurrence's
+    // coincident vector is consumed independently.
+    let gi = 0;
+    for (const seg of p.segments as Segment[]) {
+      const txt = seg.text;
+      const trimmedLen = txt.replace(/\s+$/, "").length;
+      const start = gi;
+      let si = 0;
+      while (si < txt.length && gi < lineGlyphs.length) {
+        const sc = txt[si];
+        const gc = lineGlyphs[gi].rune;
+        if (sc === gc) {
+          si++;
+          gi++;
+        } else if (isWs(sc)) {
+          si++; // segment whitespace absent from glyph stream
+        } else if (isWs(gc)) {
+          gi++; // extra whitespace glyph (letter-spacing artefact)
+        } else {
+          break; // real mismatch — give up on this segment
+        }
+      }
+      if (trimmedLen === 0 || si < trimmedLen) continue; // unmatched → skip
+      const segGlyphs = lineGlyphs.slice(start, gi);
+      if (segGlyphs.length === 0) continue;
+      const last = segGlyphs[segGlyphs.length - 1];
+      // A per-line y band proportional to lineHeight: tall enough for a
+      // decorative glyph's ascender / hand-drawn stroke overhang, but tied
+      // to THIS line — NOT the op's bbox (a uniform body block is one
+      // coalesced op whose bbox spans the whole multi-line paragraph;
+      // using it swallowed unrelated path ops and restyled body text).
+      const segBox = {
+        x0: segGlyphs[0].x,
+        // Next glyph's x bounds the run on the right; fall back to a rough
+        // em past the last glyph for the line's final segment.
+        x1: lineGlyphs[gi]?.x ?? last.x + p.lineHeight,
+        y0: p.top - 0.1 * p.lineHeight,
+        y1: p.top + 1.5 * p.lineHeight,
+      };
+
+      const hits = pathOps.filter((po) => geomInside(po.geomBbox, segBox, TOL));
+      if (hits.length === 0) continue;
+
+      const strokes = hits.filter((h) => h.kind === "strokePath");
+      const fills = hits.filter((h) => h.kind === "fillPath");
+      // Per-role colour majority. A fill colour differing from a stroke
+      // colour is normal (e.g. white fill + black outline) — only
+      // disagreement *within* a role is ambiguous and skipped.
+      const fillColor = fills.length ? majority(fills.map((f) => f.color)) : null;
+      const strokeColor = strokes.length ? majority(strokes.map((s) => s.color)) : null;
+      const style = (seg.style ??= {});
+      let applied = false;
+
+      if (fillColor) {
+        // Fill role: the vector is the visible glyph; adopt its colour.
+        style.color = fillColor;
+        applied = true;
+      }
+      if (strokeColor) {
+        // Stroke role: faithful outline from the PDF's own stroke.
+        const widths = strokes
+          .map((s) => s.strokeWidth ?? 0)
+          .filter((w) => w > 0)
+          .sort((a, b) => a - b);
+        const w = widths.length ? widths[widths.length >> 1] : 1;
+        style["-webkit-text-stroke"] = `${Math.max(1, Math.round(w))}px ${strokeColor}`;
+        style["paint-order"] = "stroke fill";
+        applied = true;
+      } else if (applied) {
+        // Pure fill role — clear any stale stroke styling.
+        delete style["-webkit-text-stroke"];
+        delete style["paint-order"];
+      }
+
+      if (!applied) continue; // ambiguous within a role → faithful no-op
+      for (const h of hits) consumed.add(h.seqno);
+      restyledBoxes.push([segBox.x0, segBox.y0, segBox.x1, segBox.y1]);
+    }
+  }
+  return { consumed, restyledBoxes };
+}
+
 /**
  * Assemble the final `PositionedTextOutput` from extracted images + vector
  * figures + asHTML paragraphs, sorting everything by its true PDF
@@ -1165,7 +1351,6 @@ async function extractSpreadPage(
   // spread-level image stitching is needed — the two halves, each with their
   // own PDF-point bounds, compose correctly on the rendered spread viewport.
   const rasterImages = [...leftRaster, ...rightRaster];
-  const figureImages = [...leftResult.images, ...rightResult.images];
 
   // Run the recorder on both pages, in viewport coords; right-page x is
   // shifted by left page width so positions address the stitched spread,
@@ -1183,15 +1368,25 @@ async function extractSpreadPage(
     leftMaxSeqno + 1,
   );
   const ops: StreamOp[] = [...leftRecorder.ops, ...rightRecorder.ops];
-  // Stamp seqnos on rasters/figures using the unified op list. We split by
-  // page when matching rasters so dim-tied images on different pages don't
-  // accidentally pair across the spread boundary.
+  // Rasters: stamp per page so dim-tied images on different pages don't
+  // pair across the spread boundary.
   stampRasterPlacementsFromOps(leftRaster, leftRecorder.ops);
   stampRasterPlacementsFromOps(rightRaster, rightRecorder.ops);
-  stampFigureSeqnosFromOps(leftResult.images, leftRecorder.ops);
-  stampFigureSeqnosFromOps(rightResult.images, rightRecorder.ops);
 
   const paragraphData = parsePageParagraphsSpread(doc, leftIndex, rightIndex, 2, fixedLayout);
+  // Fold hand-lettered vector paint into the duplicate selectable text run
+  // and drop the now-duplicate vector shapes (per-figure xOffset/svgDefs
+  // is carried in the re-render context, so a single pass spans both
+  // halves). Figure seqnos are stamped after, over the unified op list:
+  // geometry identity is position-exact, so right-page shape boxes
+  // (xOffset-shifted) only coincide with right-page ops.
+  const { restyledBoxes } = restyleCoincidentVectorText(paragraphData.paragraphs, ops);
+  const figureImages = await excludeConsumedFigureShapes(
+    [...leftResult.images, ...rightResult.images],
+    restyledBoxes,
+  );
+  stampFigureSeqnosFromOps(figureImages, ops);
+
   const positionedText = buildPositionedTextOutput(
     pageId,
     paragraphData,
@@ -1443,6 +1638,27 @@ interface ShapeInfo {
   /** Character count of the text content (only set when isText is true) */
   textLength?: number;
 }
+
+/**
+ * Per-vector-figure context for re-rendering a *subset* of its shapes when
+ * some are excluded as text duplicates (Option A phase 4, seam (a)).
+ * `group` is index-aligned with the figure's `shapeGeomBoxes`. Keyed by
+ * the figure object in a WeakMap so it's transient and never persisted.
+ */
+interface FigureRenderCtx {
+  group: ShapeInfo[];
+  svgDefs: string;
+  pageWidth: number;
+  pageHeight: number;
+  xOffset: number;
+  aaGuardX: number;
+  aaGuardY: number;
+  /** Group contained raster image shapes → it was page-cropped from the
+   *  composited page render; its pixels can't be reconstructed from the
+   *  SVG shape subset, so it must never be re-rendered vector-only. */
+  hadImages: boolean;
+}
+const figureRenderCtx = new WeakMap<ExtractedImage, FigureRenderCtx>();
 
 /**
  * Compute the exact bounding box of a cubic Bezier curve.
@@ -2967,6 +3183,22 @@ async function extractVectorImagesFromSvg(
         s.bbox[2] + xOffset,
         s.bbox[3],
       ]);
+      // Keep what's needed to re-render a surviving subset if some of this
+      // figure's shapes are later excluded as text duplicates. Captured for
+      // page-crop figures too: a decorative-letter bubble is page-crop only
+      // because the invisible duplicate text joined the group; once those
+      // shapes are excluded the survivors are pure vector and re-render
+      // cleanly (no baked-in ghost glyph).
+      figureRenderCtx.set(img, {
+        group,
+        svgDefs,
+        pageWidth,
+        pageHeight,
+        xOffset,
+        aaGuardX,
+        aaGuardY,
+        hadImages: hasImages,
+      });
       images.push(img);
     }
   }
@@ -3000,6 +3232,127 @@ async function extractVectorImagesFromSvg(
   }
 
   return { images, coveredRasterHashes, imageHashToSeqno, debug };
+}
+
+/**
+ * Drop vector figure shapes that `restyleCoincidentVectorText` consumed
+ * (their paint was folded into the duplicate selectable text run), so the
+ * figure isn't double-rendered over the text it duplicates.
+ *
+ * - no shapes consumed → figure unchanged.
+ * - all shapes consumed → figure dropped (e.g. colouring `im002`, the
+ *   whole "white" outline).
+ * - some consumed → re-render the surviving shapes only, preserving the
+ *   figure's `imageId` (e.g. Volcanoes `im003`: keep the bubble, drop the
+ *   hand-lettered glyphs). Re-render mirrors the original vector-figure
+ *   build (same `computeGroupInkBbox` + page clamp + bounds/boxes).
+ *
+ * A figure shape is consumed when it sits inside an already-restyled
+ * run's glyph box (the vector duplicate of that run). Coincidence uses a
+ * ≥70%-of-shape-area overlap, not strict containment / op-bbox equality:
+ * a hand-lettered glyph is one SVG shape but many recorder subpath ops
+ * and may slightly overhang the font-metrics box, while a bubble outline
+ * barely intersects a small letter run box so it's never wrongly flagged.
+ * Figures whose survivors include a raster image (illustration panels)
+ * are kept whole; re-rendering them vector-only would drop the art.
+ */
+async function excludeConsumedFigureShapes(
+  figures: ExtractedImage[],
+  restyledBoxes: BBox[],
+): Promise<ExtractedImage[]> {
+  if (restyledBoxes.length === 0) return figures;
+  const MIN_INSIDE = 0.7;
+  const boxConsumed = (b: BBox): boolean => {
+    const area = Math.max(0, b[2] - b[0]) * Math.max(0, b[3] - b[1]);
+    if (area <= 0) return false;
+    return restyledBoxes.some((r) => {
+      const ix = Math.max(0, Math.min(b[2], r[2]) - Math.max(b[0], r[0]));
+      const iy = Math.max(0, Math.min(b[3], r[3]) - Math.max(b[1], r[1]));
+      return (ix * iy) / area >= MIN_INSIDE;
+    });
+  };
+
+  const out: ExtractedImage[] = [];
+  for (const fig of figures) {
+    const boxes = fig.shapeGeomBoxes;
+    if (!boxes || boxes.length === 0) {
+      out.push(fig);
+      continue;
+    }
+    const flags = boxes.map((b) => boxConsumed(b));
+    const n = flags.filter(Boolean).length;
+    if (n === 0) {
+      out.push(fig);
+      continue;
+    }
+    if (n === boxes.length) continue; // whole figure duplicates text → drop
+
+    const ctx = figureRenderCtx.get(fig);
+    if (!ctx) {
+      out.push(fig); // no re-render context — keep whole (safe)
+      continue;
+    }
+    // A figure built from a group that contained raster images is a crop
+    // of the composited page render — its illustration can't be rebuilt
+    // from the SVG shape subset, so re-rendering it vector-only destroys
+    // the artwork. Keep such figures whole (conservative; an illustration
+    // panel that also bakes a heading keeps a ghost — accepted). Only
+    // raster-free figures (decorative-letter bubbles, true vector figures)
+    // re-render cleanly.
+    if (ctx.hadImages) {
+      out.push(fig);
+      continue;
+    }
+    const survivingGroup = ctx.group.filter((_, i) => !flags[i]);
+    const survivingNonText = survivingGroup.filter((s) => !s.isText);
+    if (survivingNonText.length === 0) continue;
+    if (survivingNonText.some((s) => s.isImage)) {
+      out.push(fig);
+      continue;
+    }
+
+    const ink = computeGroupInkBbox(
+      survivingGroup,
+      ctx.aaGuardX,
+      ctx.aaGuardY,
+    );
+    const cropBbox: BBox = [
+      Math.max(0, ink[0]),
+      Math.max(0, ink[1]),
+      Math.min(ctx.pageWidth, ink[2]),
+      Math.min(ctx.pageHeight, ink[3]),
+    ];
+    const re = await renderShapeGroup(
+      survivingNonText,
+      fig.pageId,
+      0,
+      ctx.svgDefs,
+      ctx.pageWidth,
+      ctx.pageHeight,
+      cropBbox,
+    );
+    if (!re) continue;
+    re.imageId = fig.imageId; // preserve id — downstream keys on it
+    re.pageId = fig.pageId;
+    re.renderMethod = "vector";
+    re.bounds = {
+      x: cropBbox[0] + ctx.xOffset,
+      y: cropBbox[1],
+      width: cropBbox[2] - cropBbox[0],
+      height: cropBbox[3] - cropBbox[1],
+    };
+    // Fallback z-order; re-stamped from recorder ops after exclusion.
+    re.streamSeqno = Math.min(...survivingGroup.map((s) => s.seqno));
+    re.shapeGeomBoxes = survivingGroup.map((s): BBox => [
+      s.bbox[0] + ctx.xOffset,
+      s.bbox[1],
+      s.bbox[2] + ctx.xOffset,
+      s.bbox[3],
+    ]);
+    figureRenderCtx.set(re, { ...ctx, group: survivingGroup });
+    out.push(re);
+  }
+  return out;
 }
 
 // ============================================================================
@@ -3043,4 +3396,5 @@ export const _testing = {
   parseStrokeInkExtent,
   computeGroupInkBbox,
   stampFigureSeqnosFromOps,
+  restyleCoincidentVectorText,
 };

--- a/packages/pdf/src/extract.ts
+++ b/packages/pdf/src/extract.ts
@@ -110,10 +110,19 @@ export interface ExtractedImage {
    *   - Raster images: assigned by matching mupdf Device callbacks
    *     (`fillImage` / `fillImageMask`) to extracted XObjects by native
    *     dimensions, in stream order.
-   *   - Vector figures: assigned to the minimum seqno of `fillPath` /
-   *     `strokePath` ops that fall inside the figure's bounds.
+   *   - Vector figures: assigned to the minimum seqno of the recorder
+   *     path ops whose geometry bbox matches one of this figure's
+   *     constituent shape bboxes (see `shapeGeomBoxes`).
    */
   streamSeqno?: number;
+  /**
+   * Geometry bboxes of this vector figure's constituent SVG shapes, in the
+   * same coordinate space as recorder ops (page coords + spread xOffset).
+   * `stampFigureSeqnosFromOps` matches recorder path ops to a figure by
+   * exact geometry identity against these, not aggregate containment.
+   * Transient: vector figures only; not persisted.
+   */
+  shapeGeomBoxes?: BBox[];
   /**
    * SVG path `d` attribute representing the active PDF clip applied to this
    * image at draw time, in absolute viewport coordinates (PDF points,
@@ -709,6 +718,15 @@ function runRecorderInViewport(
       };
     }
     // fillPath / strokePath / shade
+    if (op.kind === "fillPath" || op.kind === "strokePath") {
+      return {
+        ...op,
+        seqno,
+        bbox: shiftBBox(op.bbox),
+        geomBbox: shiftBBox(op.geomBbox),
+        activeClipBbox,
+      };
+    }
     return { ...op, seqno, bbox: shiftBBox(op.bbox), activeClipBbox };
   });
   return { ops };
@@ -834,14 +852,24 @@ function pdfBlendModeToCss(mode: string): string {
 }
 
 /**
- * Stamp `streamSeqno` on each vector figure by finding the device path ops
- * whose bounds fall inside the figure's overall bounds. The figure's seqno
- * is the minimum of the matched ops' seqnos — the moment that figure
- * begins drawing in the content stream.
+ * Stamp `streamSeqno` on each vector figure with its true PDF
+ * content-stream position, by tying recorder path ops back to the figure
+ * by exact geometry identity.
  *
- * Why min, not e.g. mean: a figure is composed of several path ops drawn
- * sequentially; seqno = first op preserves correct ordering relative to
- * later ops that could draw on top of the figure (text, other figures).
+ * Each figure carries `shapeGeomBoxes` — the geometry bboxes of its
+ * constituent SVG shapes, in recorder space. A recorder path op is the
+ * same draw as one of those shapes iff their geometry bboxes coincide
+ * (same path, same CTM, same page space → identical geometry extent;
+ * `geomBbox` excludes stroke inflation so a stroked op still matches its
+ * shape). The figure's seqno is the minimum seqno over matched ops — the
+ * moment it begins drawing — which preserves z-order against later ops
+ * (text, other figures) that draw on top of it.
+ *
+ * This replaces the previous aggregate bbox-containment heuristic, which
+ * silently failed for stroked figures (a strokePath's rendered bounds
+ * spill outside the figure's geometry box, so containment never matched
+ * and the figure kept an unreliable SVG-document-order seqno — drawing it
+ * behind content it should sit on top of).
  */
 function stampFigureSeqnosFromOps(
   figures: ExtractedImage[],
@@ -850,31 +878,22 @@ function stampFigureSeqnosFromOps(
   const pathOps: PathStreamOp[] = ops.filter(
     (o): o is PathStreamOp => o.kind === "fillPath" || o.kind === "strokePath",
   );
+  // SVG export rounds coords to 2 decimals; getBounds is full precision.
+  const TOL = 1;
+  const eq = (a: number, b: number): boolean => Math.abs(a - b) <= TOL;
   for (const fig of figures) {
-    if (!fig.bounds) continue;
-    const figBox: StreamBBox = {
-      x0: fig.bounds.x,
-      y0: fig.bounds.y,
-      x1: fig.bounds.x + fig.bounds.width,
-      y1: fig.bounds.y + fig.bounds.height,
-    };
+    const boxes = fig.shapeGeomBoxes;
+    if (!boxes || boxes.length === 0) continue; // keeps SVG-order fallback
     let minSeqno = Infinity;
     for (const op of pathOps) {
-      if (bboxContainedIn(op.bbox, figBox, /* tol */ 1)) {
-        if (op.seqno < minSeqno) minSeqno = op.seqno;
-      }
+      const g = op.geomBbox;
+      const hit = boxes.some(
+        (b) => eq(g.x0, b[0]) && eq(g.y0, b[1]) && eq(g.x1, b[2]) && eq(g.y1, b[3]),
+      );
+      if (hit && op.seqno < minSeqno) minSeqno = op.seqno;
     }
     if (Number.isFinite(minSeqno)) fig.streamSeqno = minSeqno;
   }
-}
-
-function bboxContainedIn(inner: StreamBBox, outer: StreamBBox, tol: number): boolean {
-  return (
-    inner.x0 >= outer.x0 - tol &&
-    inner.y0 >= outer.y0 - tol &&
-    inner.x1 <= outer.x1 + tol &&
-    inner.y1 <= outer.y1 + tol
-  );
 }
 
 /**
@@ -2932,9 +2951,22 @@ async function extractVectorImagesFromSvg(
         width: cropW,
         height: cropH,
       };
-      // Stream seqno = earliest-drawn shape in the group. Used by fixed-layout
-      // rendering to restore PDF content-stream order across all draw items.
+      // Fallback z-order: earliest SVG-document-order shape. mupdf's SVG
+      // export order is NOT stream order, so this is unreliable on its own —
+      // stampFigureSeqnosFromOps overrides it with the true content-stream
+      // seqno by matching recorder path ops to the per-shape geometry boxes
+      // below. The fallback only survives for groups with no matching path
+      // op (e.g. pure raster/text page-crops).
       img.streamSeqno = Math.min(...group.map((s) => s.seqno));
+      // Per-shape geometry bboxes in recorder space (page coords + spread
+      // xOffset, matching `img.bounds.x`). Used for exact op→figure
+      // identity instead of brittle aggregate bbox containment.
+      img.shapeGeomBoxes = group.map((s): BBox => [
+        s.bbox[0] + xOffset,
+        s.bbox[1],
+        s.bbox[2] + xOffset,
+        s.bbox[3],
+      ]);
       images.push(img);
     }
   }
@@ -2957,7 +2989,13 @@ async function extractVectorImagesFromSvg(
       width: bgW,
       height: bgH,
     };
-    img.streamSeqno = shape.seqno;
+    img.streamSeqno = shape.seqno; // SVG-order fallback; overridden below.
+    img.shapeGeomBoxes = [[
+      bgBbox[0] + xOffset,
+      bgBbox[1],
+      bgBbox[2] + xOffset,
+      bgBbox[3],
+    ]];
     images.push(img);
   }
 
@@ -3004,4 +3042,5 @@ export const _testing = {
   isPageLevelClip,
   parseStrokeInkExtent,
   computeGroupInkBbox,
+  stampFigureSeqnosFromOps,
 };

--- a/packages/pdf/src/page-stream-recorder.ts
+++ b/packages/pdf/src/page-stream-recorder.ts
@@ -90,7 +90,14 @@ export interface ImageStreamOp extends BaseStreamOp {
 
 export interface PathStreamOp extends BaseStreamOp {
   kind: "fillPath" | "strokePath"
+  /** Rendered bounds: stroke-inflated for `strokePath`, geometry for
+   *  `fillPath`. Used for spatial queries / placement. */
   bbox: BBox
+  /** Geometry-only bounds (path outline, no stroke inflation). Identical
+   *  to `bbox` for `fillPath`. Used to associate an op with the SVG shape
+   *  that produced it by exact geometry identity — a stroked op's `bbox`
+   *  is larger than its shape's geometry, so `bbox` can't be matched. */
+  geomBbox: BBox
 }
 
 export interface TextStreamOp extends BaseStreamOp {
@@ -140,10 +147,12 @@ export function recordPageStream(page: AnyPage): StreamOp[] {
 
   const device = new mupdf.Device({
     fillPath(path, _evenOdd, ctm /*, _cs, _color, _alpha */) {
+      const geom = rectToBBox(path.getBounds(NO_STROKE, ctm))
       ops.push({
         seqno: seqno++,
         kind: "fillPath",
-        bbox: rectToBBox(path.getBounds(NO_STROKE, ctm)),
+        bbox: geom,
+        geomBbox: geom,
         activeClipBbox: activeClipBbox(),
       })
     },
@@ -152,6 +161,9 @@ export function recordPageStream(page: AnyPage): StreamOp[] {
         seqno: seqno++,
         kind: "strokePath",
         bbox: rectToBBox(path.getBounds(stroke, ctm)),
+        // Geometry bounds without stroke inflation — matches the SVG
+        // shape's bbox so the op can be tied back to its figure.
+        geomBbox: rectToBBox(path.getBounds(NO_STROKE, ctm)),
         activeClipBbox: activeClipBbox(),
       })
     },

--- a/packages/pdf/src/page-stream-recorder.ts
+++ b/packages/pdf/src/page-stream-recorder.ts
@@ -1,0 +1,412 @@
+/**
+ * Page stream recorder — records every drawing operation a PDF page emits in
+ * the order they appear in the content stream.
+ *
+ * mupdf's StructuredText walker reorders blocks for reading flow, which loses
+ * the original z-order. The SVG output preserves draw order but mixes glyph
+ * paths with vector paths and renders text into post-pass `<text>` blocks.
+ * Neither is a clean source of stream-order data for our needs.
+ *
+ * Instead we run the page through a custom `Device` via `Page.run`. mupdf
+ * invokes our callbacks once per content-stream operator, in stream order,
+ * with the fully-resolved CTM. That gives us authoritative z-order with
+ * per-op clip stack visibility — the canonical PDF imaging model.
+ *
+ * The recorder is page-scoped and stateless across pages: callers run it
+ * once per page and consume the resulting `StreamOp[]`.
+ */
+import mupdf, {
+  type BlendMode,
+  type Document as MupdfDocument,
+  type Matrix as MupdfMatrix,
+  type StrokeState,
+} from "mupdf"
+
+// mupdf's path/text getBounds() typings require a StrokeState, but the
+// runtime accepts null for unstroked-bound queries. Cast at call sites.
+const NO_STROKE = null as unknown as StrokeState
+
+/** Axis-aligned bounding box in PDF user space (y-up, bottom-left origin). */
+export interface BBox {
+  x0: number
+  y0: number
+  x1: number
+  y1: number
+}
+
+/** Single glyph emission with its baseline origin in PDF user space. */
+export interface Glyph {
+  rune: string
+  x: number
+  y: number
+}
+
+/** A single path command in absolute (post-CTM) coordinates. */
+export type PathCommand =
+  | { op: "M"; x: number; y: number }
+  | { op: "L"; x: number; y: number }
+  | { op: "C"; x1: number; y1: number; x2: number; y2: number; x3: number; y3: number }
+  | { op: "Z" }
+
+/** Captured clip path: full geometry + bbox for fast tests. */
+export interface ClipPath {
+  commands: PathCommand[]
+  bbox: BBox
+  /** True if mupdf passed the even-odd flag (only meaningful for fillPath
+   *  clips; clipStrokePath, clipText, clipImageMask are non-zero by definition). */
+  evenOdd: boolean
+}
+
+interface BaseStreamOp {
+  /** Monotonically-increasing sequence number assigned in stream order. */
+  seqno: number
+  /** Innermost active clip bbox at the time the op fired, or null. Useful for
+   *  recovering the visible region of an image that mupdf reports with full
+   *  CTM bounds but is actually clipped to a smaller area. */
+  activeClipBbox: BBox | null
+}
+
+export interface ImageStreamOp extends BaseStreamOp {
+  kind: "image" | "imageMask"
+  bbox: BBox
+  nativeWidth: number
+  nativeHeight: number
+  /** True when the underlying mupdf Image has an SMask attached. */
+  hasMask: boolean
+  /** Full active clip-path stack at the time this image was drawn, outermost
+   *  first. PDF clip semantics intersect all active clips; consumers may pick
+   *  the innermost / most-restrictive or apply the full stack. Empty when no
+   *  clip is active. */
+  activeClipPaths: ClipPath[]
+  /** Innermost active non-Normal blend mode at draw time, or "Normal" when
+   *  no blending applies. Watercolor storybooks frequently use "Multiply"
+   *  to make white image backgrounds behave as transparent over the page —
+   *  CSS `mix-blend-mode` reproduces this in HTML. */
+  blendMode: BlendMode
+  /** Composed alpha at draw time: product of every enclosing transparency
+   *  group's alpha and the per-op `alpha` argument. 1.0 when fully opaque. */
+  alpha: number
+}
+
+export interface PathStreamOp extends BaseStreamOp {
+  kind: "fillPath" | "strokePath"
+  bbox: BBox
+}
+
+export interface TextStreamOp extends BaseStreamOp {
+  kind: "fillText" | "strokeText"
+  bbox: BBox
+  glyphs: Glyph[]
+}
+
+export type StreamOp =
+  | ImageStreamOp
+  | PathStreamOp
+  | TextStreamOp
+
+type AnyPage = ReturnType<MupdfDocument["loadPage"]>
+
+/**
+ * Run `page` through a recording device; return draw ops in stream order.
+ *
+ * Clip-only ops (`clipPath`, `clipImageMask`, `popClip`, etc.) are tracked
+ * internally for the `activeClipBbox` field but not emitted, since they
+ * don't draw pixels themselves.
+ */
+export function recordPageStream(page: AnyPage): StreamOp[] {
+  const ops: StreamOp[] = []
+  const clipStack: ClipPath[] = []
+  const groupStack: { blendMode: BlendMode; alpha: number }[] = []
+  let seqno = 0
+
+  const activeClipBbox = (): BBox | null =>
+    clipStack.length > 0 ? clipStack[clipStack.length - 1].bbox : null
+  const activeClipPaths = (): ClipPath[] => clipStack.slice()
+  // Innermost non-Normal blend mode wins. PDF nests transparency groups but
+  // a single non-Normal blend mode in the stack determines the visual
+  // compositing — the inner one is the most relevant for the draw op.
+  const activeBlendMode = (): BlendMode => {
+    for (let i = groupStack.length - 1; i >= 0; i--) {
+      if (groupStack[i].blendMode !== "Normal") return groupStack[i].blendMode
+    }
+    return "Normal"
+  }
+  // Compose group alpha multiplicatively up the stack.
+  const composedAlpha = (perOpAlpha: number): number => {
+    let a = perOpAlpha
+    for (const g of groupStack) a *= g.alpha
+    return a
+  }
+
+  const device = new mupdf.Device({
+    fillPath(path, _evenOdd, ctm /*, _cs, _color, _alpha */) {
+      ops.push({
+        seqno: seqno++,
+        kind: "fillPath",
+        bbox: rectToBBox(path.getBounds(NO_STROKE, ctm)),
+        activeClipBbox: activeClipBbox(),
+      })
+    },
+    strokePath(path, stroke, ctm /*, _cs, _color, _alpha */) {
+      ops.push({
+        seqno: seqno++,
+        kind: "strokePath",
+        bbox: rectToBBox(path.getBounds(stroke, ctm)),
+        activeClipBbox: activeClipBbox(),
+      })
+    },
+    clipPath(path, evenOdd, ctm) {
+      clipStack.push({
+        commands: collectPathCommands(path, ctm),
+        bbox: rectToBBox(path.getBounds(NO_STROKE, ctm)),
+        evenOdd: !!evenOdd,
+      })
+    },
+    clipStrokePath(path, stroke, ctm) {
+      clipStack.push({
+        commands: collectPathCommands(path, ctm),
+        bbox: rectToBBox(path.getBounds(stroke, ctm)),
+        evenOdd: false,
+      })
+    },
+    fillText(text, ctm /*, _cs, _color, _alpha */) {
+      ops.push({
+        seqno: seqno++,
+        kind: "fillText",
+        bbox: rectToBBox(text.getBounds(NO_STROKE, ctm)),
+        glyphs: collectGlyphs(text, ctm),
+        activeClipBbox: activeClipBbox(),
+      })
+    },
+    strokeText(text, stroke, ctm /*, _cs, _color, _alpha */) {
+      ops.push({
+        seqno: seqno++,
+        kind: "strokeText",
+        bbox: rectToBBox(text.getBounds(stroke, ctm)),
+        glyphs: collectGlyphs(text, ctm),
+        activeClipBbox: activeClipBbox(),
+      })
+    },
+    clipText(text, ctm) {
+      // Text-shaped clips can't be expressed as a single path; we keep the
+      // bbox approximation so containment queries still work, but emit no
+      // commands. Visual fidelity for these is rare in storybook PDFs.
+      clipStack.push({
+        commands: [],
+        bbox: rectToBBox(text.getBounds(NO_STROKE, ctm)),
+        evenOdd: false,
+      })
+    },
+    clipStrokeText(text, stroke, ctm) {
+      clipStack.push({
+        commands: [],
+        bbox: rectToBBox(text.getBounds(stroke, ctm)),
+        evenOdd: false,
+      })
+    },
+    ignoreText() {
+      // No pixels drawn; ignore.
+    },
+    fillImage(image, ctm, alpha) {
+      ops.push({
+        seqno: seqno++,
+        kind: "image",
+        bbox: unitImageBbox(ctm),
+        nativeWidth: image.getWidth(),
+        nativeHeight: image.getHeight(),
+        hasMask: !!image.getMask(),
+        activeClipBbox: activeClipBbox(),
+        activeClipPaths: activeClipPaths(),
+        blendMode: activeBlendMode(),
+        alpha: composedAlpha(alpha ?? 1),
+      })
+    },
+    fillImageMask(image, ctm, _cs, _color, alpha) {
+      ops.push({
+        seqno: seqno++,
+        kind: "imageMask",
+        bbox: unitImageBbox(ctm),
+        nativeWidth: image.getWidth(),
+        nativeHeight: image.getHeight(),
+        hasMask: false,
+        activeClipBbox: activeClipBbox(),
+        activeClipPaths: activeClipPaths(),
+        blendMode: activeBlendMode(),
+        alpha: composedAlpha(alpha ?? 1),
+      })
+    },
+    clipImageMask(_image, ctm) {
+      // Image-mask clips: synthesize a unit-square path through the CTM so
+      // downstream code can apply a rectangular clip-path. The mask's pixel
+      // alpha shape is not available here, but the AABB is the correct
+      // outer bound and matches what most PDFs use these for (rectangular
+      // image crops dressed as masks).
+      const bbox = unitImageBbox(ctm)
+      clipStack.push({
+        commands: bboxToPathCommands(bbox),
+        bbox,
+        evenOdd: false,
+      })
+    },
+    popClip() {
+      clipStack.pop()
+    },
+    // Group / mask / tile / layer brackets are tracked-as-no-ops for now —
+    // they don't draw pixels themselves. Inner draw ops emit normally and
+    // the outer transparency/blend semantics are baked into the page render
+    // we already produce. Re-introduce when needed.
+    beginMask() {},
+    endMask() {},
+    beginGroup(_bbox, _cs, _isolated, _knockout, blendmode, alpha) {
+      groupStack.push({ blendMode: blendmode, alpha: alpha ?? 1 })
+    },
+    endGroup() {
+      groupStack.pop()
+    },
+    beginTile() {
+      return 0
+    },
+    endTile() {},
+    beginLayer() {},
+    endLayer() {},
+    close() {},
+  })
+
+  try {
+    page.run(device, mupdf.Matrix.identity as MupdfMatrix)
+  } finally {
+    // mupdf C requires `fz_close_device` before `fz_drop_device`; without
+    // the explicit close, mupdf logs "dropping unclosed device" when the
+    // FinalizationRegistry eventually drops the WASM pointer. We do both
+    // eagerly so resources release in deterministic order.
+    device.close()
+    device.destroy()
+  }
+  return ops
+}
+
+/** Convert mupdf Rect tuple to {x0,y0,x1,y1}. */
+function rectToBBox(r: [number, number, number, number]): BBox {
+  return { x0: r[0], y0: r[1], x1: r[2], y1: r[3] }
+}
+
+/** Compute the AABB of an image after applying its CTM. The image's natural
+ *  domain is [0,1]×[0,1]; the CTM maps that to page coordinates (post-CTM
+ *  the rect can be rotated/skewed, hence we take the AABB of the corners). */
+function unitImageBbox(ctm: number[]): BBox {
+  const corners = [
+    [0, 0],
+    [1, 0],
+    [1, 1],
+    [0, 1],
+  ].map(([x, y]) => transformPoint(ctm, x, y))
+  const xs = corners.map((p) => p[0])
+  const ys = corners.map((p) => p[1])
+  return {
+    x0: Math.min(...xs),
+    y0: Math.min(...ys),
+    x1: Math.max(...xs),
+    y1: Math.max(...ys),
+  }
+}
+
+function transformPoint(
+  ctm: number[],
+  x: number,
+  y: number,
+): [number, number] {
+  return [ctm[0] * x + ctm[2] * y + ctm[4], ctm[1] * x + ctm[3] * y + ctm[5]]
+}
+
+/** Walk a Path and collect its draw commands, applying the device CTM so the
+ *  resulting coordinates are in the same absolute (mupdf-internal y-down)
+ *  space that other ops report. */
+function collectPathCommands(
+  path: { walk: (w: object) => void },
+  ctm: number[],
+): PathCommand[] {
+  const cmds: PathCommand[] = []
+  const tx = (x: number, y: number): [number, number] => [
+    ctm[0] * x + ctm[2] * y + ctm[4],
+    ctm[1] * x + ctm[3] * y + ctm[5],
+  ]
+  path.walk({
+    moveTo(x: number, y: number) {
+      const [ax, ay] = tx(x, y)
+      cmds.push({ op: "M", x: ax, y: ay })
+    },
+    lineTo(x: number, y: number) {
+      const [ax, ay] = tx(x, y)
+      cmds.push({ op: "L", x: ax, y: ay })
+    },
+    curveTo(
+      x1: number,
+      y1: number,
+      x2: number,
+      y2: number,
+      x3: number,
+      y3: number,
+    ) {
+      const [ax1, ay1] = tx(x1, y1)
+      const [ax2, ay2] = tx(x2, y2)
+      const [ax3, ay3] = tx(x3, y3)
+      cmds.push({
+        op: "C",
+        x1: ax1,
+        y1: ay1,
+        x2: ax2,
+        y2: ay2,
+        x3: ax3,
+        y3: ay3,
+      })
+    },
+    closePath() {
+      cmds.push({ op: "Z" })
+    },
+  })
+  return cmds
+}
+
+/** Synthesize a closed rectangular path from a bbox (used for image-mask
+ *  clips, where the alpha shape isn't available but the AABB is the right
+ *  outer bound). */
+function bboxToPathCommands(b: BBox): PathCommand[] {
+  return [
+    { op: "M", x: b.x0, y: b.y0 },
+    { op: "L", x: b.x1, y: b.y0 },
+    { op: "L", x: b.x1, y: b.y1 },
+    { op: "L", x: b.x0, y: b.y1 },
+    { op: "Z" },
+  ]
+}
+
+/** Walk a Text object and collect each glyph's unicode + baseline origin.
+ *  The glyph trm passed to `showGlyph` is in PDF text-space (y-up); we
+ *  compose it with the device's outer ctm to get the absolute baseline
+ *  position in mupdf-internal y-down coords (top-left origin) — matching
+ *  the coord system of every other op the device emits. */
+function collectGlyphs(
+  text: { walk: (w: object) => void },
+  ctm: number[],
+): Glyph[] {
+  const glyphs: Glyph[] = []
+  text.walk({
+    showGlyph(
+      _font: unknown,
+      trm: number[],
+      _gid: number,
+      ucs: number,
+    ) {
+      // ucs <= 0 marks unmapped glyphs (e.g. ligatures missing /ToUnicode).
+      // Skip: they don't help paragraph matching and would push noise into
+      // diagnostics. The paragraph's text content comes from asHTML anyway.
+      if (ucs <= 0) return
+      const tx = trm[4]
+      const ty = trm[5]
+      const x = ctm[0] * tx + ctm[2] * ty + ctm[4]
+      const y = ctm[1] * tx + ctm[3] * ty + ctm[5]
+      glyphs.push({ rune: String.fromCharCode(ucs), x, y })
+    },
+  })
+  return glyphs
+}

--- a/packages/pdf/src/page-stream-recorder.ts
+++ b/packages/pdf/src/page-stream-recorder.ts
@@ -17,10 +17,13 @@
  */
 import mupdf, {
   type BlendMode,
+  type Color,
+  type ColorSpace,
   type Document as MupdfDocument,
   type Matrix as MupdfMatrix,
   type StrokeState,
 } from "mupdf"
+import { colorToCss } from "./color-utils.js"
 
 // mupdf's path/text getBounds() typings require a StrokeState, but the
 // runtime accepts null for unstroked-bound queries. Cast at call sites.
@@ -98,6 +101,13 @@ export interface PathStreamOp extends BaseStreamOp {
    *  that produced it by exact geometry identity — a stroked op's `bbox`
    *  is larger than its shape's geometry, so `bbox` can't be matched. */
   geomBbox: BBox
+  /** Paint colour as CSS hex (`#rrggbb`), from the op's colorspace+color. */
+  color: string
+  /** Composed alpha (per-op × transparency-group stack), 0..1. */
+  alpha: number
+  /** `strokePath` only: line width in transformed (page) space, i.e.
+   *  `StrokeState.getLineWidth()` scaled by the CTM. */
+  strokeWidth?: number
 }
 
 export interface TextStreamOp extends BaseStreamOp {
@@ -146,17 +156,19 @@ export function recordPageStream(page: AnyPage): StreamOp[] {
   }
 
   const device = new mupdf.Device({
-    fillPath(path, _evenOdd, ctm /*, _cs, _color, _alpha */) {
+    fillPath(path, _evenOdd, ctm, _cs: ColorSpace, color: Color, alpha: number) {
       const geom = rectToBBox(path.getBounds(NO_STROKE, ctm))
       ops.push({
         seqno: seqno++,
         kind: "fillPath",
         bbox: geom,
         geomBbox: geom,
+        color: colorToCss(color),
+        alpha: composedAlpha(alpha ?? 1),
         activeClipBbox: activeClipBbox(),
       })
     },
-    strokePath(path, stroke, ctm /*, _cs, _color, _alpha */) {
+    strokePath(path, stroke, ctm, _cs: ColorSpace, color: Color, alpha: number) {
       ops.push({
         seqno: seqno++,
         kind: "strokePath",
@@ -164,6 +176,9 @@ export function recordPageStream(page: AnyPage): StreamOp[] {
         // Geometry bounds without stroke inflation — matches the SVG
         // shape's bbox so the op can be tied back to its figure.
         geomBbox: rectToBBox(path.getBounds(NO_STROKE, ctm)),
+        color: colorToCss(color),
+        alpha: composedAlpha(alpha ?? 1),
+        strokeWidth: stroke.getLineWidth() * ctmScale(ctm),
         activeClipBbox: activeClipBbox(),
       })
     },
@@ -300,6 +315,14 @@ export function recordPageStream(page: AnyPage): StreamOp[] {
 /** Convert mupdf Rect tuple to {x0,y0,x1,y1}. */
 function rectToBBox(r: [number, number, number, number]): BBox {
   return { x0: r[0], y0: r[1], x1: r[2], y1: r[3] }
+}
+
+/** Scalar scale of a 2×3 affine CTM `[a,b,c,d,e,f]` — the larger of the
+ *  two axis norms, so a non-uniform transform never under-scales a stroke
+ *  width. Mirrors `parseStrokeInkExtent` in extract.ts. */
+function ctmScale(ctm: number[]): number {
+  const [a, b, c, d] = ctm
+  return Math.max(Math.hypot(a, b), Math.hypot(c, d)) || 1
 }
 
 /** Compute the AABB of an image after applying its CTM. The image's natural

--- a/packages/pdf/src/positioned-text.ts
+++ b/packages/pdf/src/positioned-text.ts
@@ -1,0 +1,1062 @@
+/**
+ * Positioned text extraction for fixed-layout rendering.
+ *
+ * Parses mupdf's `asHTML()` output into structured paragraphs. Each paragraph
+ * carries its viewport-space anchor (top-left origin), its line height, and
+ * a list of styled segments (one per styled run, with CSS-compatible styling
+ * preserved from mupdf's spans).
+ *
+ * Stream ordering for these paragraphs is assigned by the caller using the
+ * page-stream recorder — mupdf's StructuredText layout doesn't preserve
+ * draw order, so we don't try to extract z-order here.
+ */
+
+import {
+  type Color,
+  type Document as MupdfDocument,
+  type Font as MupdfFont,
+  type Page as MupdfPage,
+  type Rect,
+} from "mupdf"
+
+// ── Types ──────────────────────────────────────────────────────────
+
+/** Bounding box of an image on the page, in PDF points (top-left origin). */
+export interface ImageBounds {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+/** Structured styled-run inside a paragraph. */
+export interface RawTextSegment {
+  text: string
+  /** CSS-compatible style map. Font-size is normalized to viewport `px`. */
+  style?: Record<string, string>
+}
+
+/** Bounding box of a logical text block (union of its line bboxes). */
+export interface TextBlockBounds {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+/** A single asHTML paragraph parsed into viewport-coord position + segments. */
+export interface AsHtmlParagraph {
+  /** Top in viewport coordinates (PDF points, y-down, top-left origin). */
+  top: number
+  /** Left in viewport coordinates (PDF points). */
+  left: number
+  /** Line height in viewport coordinates (PDF points). */
+  lineHeight: number
+  /** Per-run styling. Concatenating `segments[].text` yields `text`. */
+  segments: RawTextSegment[]
+  /** Plain-text concatenation (convenience). */
+  text: string
+  /**
+   * Identifier of the visual text block this paragraph belongs to. Wrapped
+   * lines that came from the same speech bubble share `blockId`. Assigned
+   * by `clusterParagraphsIntoBlocks` after asHTML parsing. Stable per
+   * page (not globally unique — callers prefix with a page id if needed).
+   */
+  blockId?: string
+  /**
+   * Bounds of the whole block this paragraph belongs to (union of every
+   * member paragraph's line bbox). Identical for paragraphs sharing
+   * `blockId`. Used by translation flows to know how much room the
+   * original container had.
+   */
+  blockBounds?: TextBlockBounds
+  /**
+   * Identifier of the merged paragraph this line belongs to. Wrapped
+   * lines that the continuation heuristic decides are one logical
+   * paragraph share a `mergedParagraphId`; sentence boundaries inside
+   * the same block produce different ids. Same heuristic BookFusion's
+   * PDF reader uses for TTS chunking.
+   */
+  mergedParagraphId?: string
+  /**
+   * Inferred horizontal alignment of the block this paragraph belongs
+   * to ("center" or "right"). Absent when the block is left-aligned
+   * (the CSS default). Used by the renderer to set `text-align` on the
+   * merged-paragraph `<p>` so re-flowed translations stay visually
+   * centred / right-aligned.
+   */
+  textAlign?: "center" | "right"
+}
+
+/**
+ * One character recovered from `StructuredText.walk`. `qLeft`/`qRight`
+ * are the glyph-quad horizontal extent — for a normal printable glyph
+ * they straddle the rendered rectangle; for a U+0020 with zero glyph
+ * advance (the literal-letter-spacing artefact some PDFs emit between
+ * letters of a kerned title) the two are equal.
+ *
+ * Exported so tests can construct synthetic line data; internal callers
+ * just see it through `LineBbox.chars`.
+ */
+export interface LineChar {
+  c: string
+  /** Origin x in PDF points (where the glyph anchor sits). */
+  ox: number
+  /** Left edge of the glyph quad in PDF points. */
+  qLeft: number
+  /** Right edge of the glyph quad in PDF points. */
+  qRight: number
+  /**
+   * Font identity key — `"<fontname>@<size>"`. Used to detect runs of
+   * consecutive characters in the same font/size, which is how we
+   * recognise a decorative letter-spaced title sitting inside body text:
+   * within one font run, a string of ≥4 ≤3-char fragments separated by
+   * spaces is the broken-typesetting pattern.
+   */
+  font?: string
+}
+
+/** Per-line geometry recovered from `StructuredText.walk`. */
+interface LineBbox {
+  /** Top in PDF points. */
+  top: number
+  /** Left in PDF points. */
+  left: number
+  /** Bottom (top + height) in PDF points. */
+  bottom: number
+  /** Right (left + width) in PDF points. */
+  right: number
+  /** Plain text content of the line (trimmed of trailing whitespace). */
+  text: string
+  /**
+   * Per-character geometry — only set when the consumer asked for it
+   * (the metric-based space-stripping pass needs it). Trailing whitespace
+   * is preserved here even though `text` strips it, so character indices
+   * are stable.
+   */
+  chars?: LineChar[]
+}
+
+export interface PageGeometry {
+  /** Page width in PDF points (viewport). */
+  pageWidth: number
+  /** Page height in PDF points (viewport). */
+  pageHeight: number
+  /** Rendered width in pixels (at renderScale, typically 2x). */
+  renderWidth: number
+  /** Rendered height in pixels (at renderScale, typically 2x). */
+  renderHeight: number
+}
+
+/** Page info as stored in the pipeline storage. */
+export interface PositionedTextPageInfo {
+  pageId: string
+  pageNumber: number
+}
+
+// ── High-Level API ─────────────────────────────────────────────────
+
+/**
+ * Parse asHTML paragraphs from a single PDF page.
+ *
+ * Returns paragraphs in mupdf's asHTML emission order. That order is
+ * READING-FLOW (layout-reconstructed), NOT PDF stream order; callers that
+ * need draw-order seqnos must derive them from the page stream recorder.
+ *
+ * Each paragraph is annotated with a `blockId` + `blockBounds` derived
+ * from a layout-clustering pass over mupdf's per-line bboxes. Wrapped
+ * lines that came from the same speech bubble share a block id and the
+ * same bounds.
+ */
+export function parsePageParagraphs(
+  doc: MupdfDocument,
+  pageIndex: number,
+  renderScale = 2,
+  cleanSpacing = false,
+): { paragraphs: AsHtmlParagraph[] } & PageGeometry {
+  const page = doc.loadPage(pageIndex)
+  const bounds = page.getBounds() as Rect
+  const pageWidth = bounds[2] - bounds[0]
+  const pageHeight = bounds[3] - bounds[1]
+  const paragraphs = walkPageParagraphs(page)
+  // Per-character geometry is only needed by the metric-based
+  // space-stripping pass; skip it when not cleaning to avoid the
+  // overhead.
+  const lineBboxes = collectLineBboxes(page, cleanSpacing)
+  if (cleanSpacing) {
+    // Strip spurious U+0020 spaces (the literal-letter-spacing artefacts
+    // some PDFs emit between glyphs of a tracked-letterform word) before
+    // anything downstream uses paragraph text — clustering's
+    // continuation heuristic and rendered output both want the cleaned
+    // text. The decision is metric-based per paragraph (cluster advance
+    // vs. that paragraph's own letter-spacing), so plain text is left
+    // untouched. Reflowable text comes from a separate path
+    // (`extractTextFromStructuredText`) and isn't affected.
+    cleanParagraphSpacing(paragraphs, lineBboxes)
+  }
+  clusterParagraphsIntoBlocks(paragraphs, lineBboxes)
+  return {
+    paragraphs,
+    pageWidth,
+    pageHeight,
+    renderWidth: Math.round(pageWidth * renderScale),
+    renderHeight: Math.round(pageHeight * renderScale),
+  }
+}
+
+/**
+ * Parse asHTML paragraphs from a two-page spread, x-shifting right-page
+ * positions by the left page's width so they address the stitched
+ * spread viewport. Each paragraph is annotated with `blockId` /
+ * `blockBounds`; clustering runs after the x-shift so left and right
+ * pages remain in separate blocks even when their layout lines up.
+ */
+export function parsePageParagraphsSpread(
+  doc: MupdfDocument,
+  leftIndex: number,
+  rightIndex: number,
+  renderScale = 2,
+  cleanSpacing = false,
+): { paragraphs: AsHtmlParagraph[] } & PageGeometry {
+  const leftPage = doc.loadPage(leftIndex)
+  const rightPage = doc.loadPage(rightIndex)
+  const leftBounds = leftPage.getBounds() as Rect
+  const rightBounds = rightPage.getBounds() as Rect
+
+  const leftWidth = leftBounds[2] - leftBounds[0]
+  const leftHeight = leftBounds[3] - leftBounds[1]
+  const rightWidth = rightBounds[2] - rightBounds[0]
+  const rightHeight = rightBounds[3] - rightBounds[1]
+  const spreadWidth = leftWidth + rightWidth
+  const spreadHeight = Math.max(leftHeight, rightHeight)
+
+  const leftParagraphs = walkPageParagraphs(leftPage)
+  const rightParagraphs = walkPageParagraphs(rightPage)
+  const shifted = rightParagraphs.map((p) => ({ ...p, left: p.left + leftWidth }))
+
+  const leftLines = collectLineBboxes(leftPage, cleanSpacing)
+  // For the right page we shift `chars[].ox/qLeft/qRight` along with
+  // `left`/`right` so per-character geometry stays consistent in the
+  // spread coordinate space.
+  const rightLines = collectLineBboxes(rightPage, cleanSpacing).map((l) => ({
+    ...l,
+    left: l.left + leftWidth,
+    right: l.right + leftWidth,
+    chars: l.chars
+      ? l.chars.map((c) => ({ ...c, ox: c.ox + leftWidth, qLeft: c.qLeft + leftWidth, qRight: c.qRight + leftWidth }))
+      : undefined,
+  }))
+
+  if (cleanSpacing) {
+    // Strip spurious spaces before clustering so the continuation
+    // heuristic gets clean text. See `parsePageParagraphs`.
+    cleanParagraphSpacing(leftParagraphs, leftLines)
+    cleanParagraphSpacing(shifted, rightLines)
+  }
+
+  // Cluster left and right separately so paragraphs from the two physical
+  // pages never join the same block, even if the gap between them happens
+  // to look right (e.g. last-line-of-left bubble at the same y as
+  // first-line-of-right bubble).
+  clusterParagraphsIntoBlocks(leftParagraphs, leftLines, "L")
+  clusterParagraphsIntoBlocks(shifted, rightLines, "R")
+
+  return {
+    paragraphs: [...leftParagraphs, ...shifted],
+    pageWidth: spreadWidth,
+    pageHeight: spreadHeight,
+    renderWidth: Math.round(spreadWidth * renderScale),
+    renderHeight: Math.round(spreadHeight * renderScale),
+  }
+}
+
+/**
+ * Walk the structured-text tree to collect per-line bboxes (and, when
+ * `withChars` is set, per-character geometry too). mupdf's own "block"
+ * grouping is unreliable for illustrated layouts (it sometimes fuses
+ * unrelated columns and splits real bubbles), so we only consume the
+ * per-line bboxes — they're tight and trustworthy — and do our own
+ * clustering on top.
+ */
+function collectLineBboxes(page: MupdfPage, withChars = false): LineBbox[] {
+  const stext = page.toStructuredText()
+  const lines: LineBbox[] = []
+  let curBbox: Rect | null = null
+  let curChars: LineChar[] = []
+  stext.walk({
+    beginLine(bbox) {
+      curBbox = bbox
+      curChars = []
+    },
+    onChar(c, origin, font, size, quad) {
+      // origin/quad layouts can vary between mupdf-js versions: origin is
+      // a Point ([x, y] or {x, y}); quad is an 8-number flat array of the
+      // four corners. We're only after horizontal extent, so take the
+      // min/max of all four x components.
+      const ox = Array.isArray(origin) ? origin[0] : (origin as { x: number } | undefined)?.x ?? 0
+      const xs = [quad[0], quad[2], quad[4], quad[6]].filter(
+        (v): v is number => typeof v === "number",
+      )
+      const qLeft = xs.length > 0 ? Math.min(...xs) : ox
+      const qRight = xs.length > 0 ? Math.max(...xs) : ox
+      const fontName = font?.getName?.() ?? ""
+      const fontKey = `${fontName}@${size ?? ""}`
+      curChars.push({ c, ox, qLeft, qRight, font: fontKey })
+    },
+    endLine() {
+      if (!curBbox) return
+      // Drop overlapping glyph passes (stroke-then-fill) so line text
+      // matches what `walkPageParagraphs` produces — otherwise the
+      // matchLineBbox lookup in `clusterParagraphsIntoBlocks` fails
+      // ("yellow" line text vs "yellowyellow" deduped paragraph text)
+      // and paragraphs get no blockBounds, which disables auto-fit.
+      curChars = dedupOverlappingGlyphs(curChars)
+      const rawText = curChars.map((c) => c.c).join("")
+      const text = rawText.replace(/\s+$/, "")
+      if (!text) {
+        curBbox = null
+        return
+      }
+      const line: LineBbox = {
+        left: curBbox[0],
+        top: curBbox[1],
+        right: curBbox[2],
+        bottom: curBbox[3],
+        text,
+      }
+      if (withChars) line.chars = curChars.slice()
+      lines.push(line)
+      curBbox = null
+    },
+  })
+  return lines
+}
+
+// ── Spurious-space stripping (metric-based) ───────────────────────
+
+/**
+ * Strip U+0020 characters that are "letter-spacing artefacts" — spaces
+ * the PDF stream inserts between glyphs of a single visually-kerned word
+ * (e.g. mupdf returns `"U n iversity"` for a tracked "University") — while
+ * preserving real word-boundary spaces. The discriminator is *physical
+ * advance through a space cluster vs. the paragraph's prevailing
+ * letter-spacing*; no per-book convention is hard-coded.
+ *
+ * For each line we already collected per-character geometry for:
+ * 1. Compute the median letter-spacing — the gap from one non-space
+ *    glyph's right edge to the next non-space glyph's left edge across
+ *    pairs that have no space between them. This is the paragraph's
+ *    natural letter-tracking.
+ * 2. Identify maximal runs of consecutive U+0020 characters.
+ * 3. For each run, sum the widths of its space glyphs (its total
+ *    horizontal advance through the cluster).
+ * 4. If `clusterAdvance < max(medianLS × 1.6, 1pt)` the cluster is an
+ *    intra-word artefact → strip every character in it. Otherwise it's a
+ *    real word boundary → keep one space, drop the rest.
+ *
+ * The 1.6× multiplier handles fonts with slightly variable letter-spacing
+ * without false-positiving on tightly-set body text. The 1pt floor avoids
+ * a divide-by-zero edge case when letter-spacing rounds to 0 (then any
+ * space character is wider than zero and gets kept — exactly what we
+ * want for plain text).
+ *
+ * Returns the per-character strip mask for the caller to apply to the
+ * matching asHTML paragraph's text + segments.
+ */
+function computeStripMask(chars: LineChar[]): boolean[] {
+  const mask = new Array(chars.length).fill(false)
+  if (chars.length === 0) return mask
+
+  // 1. Group chars into physical font runs (consecutive characters with
+  //    the same font key) and compute each run's prevailing letter-
+  //    spacing. Mixed-font lines — body text + decorative title +
+  //    body text — would otherwise have their median washed out by
+  //    the body run's zero-tracking pairs, hiding the title run's real
+  //    ~3pt tracking. Per-run medians keep each context honest.
+  type Run = { start: number; end: number; medianLS: number }
+  const runs: Run[] = []
+  let s = 0
+  while (s < chars.length) {
+    let e = s + 1
+    while (e < chars.length && chars[e].font === chars[s].font) e++
+    const trackings: number[] = []
+    for (let k = s + 1; k < e; k++) {
+      if (chars[k].c === " " || chars[k - 1].c === " ") continue
+      const advance = chars[k].ox - chars[k - 1].ox
+      const prevWidth = chars[k - 1].qRight - chars[k - 1].qLeft
+      const tracking = advance - prevWidth
+      if (tracking >= 0 && tracking < 50) trackings.push(tracking)
+    }
+    trackings.sort((a, b) => a - b)
+    const medianLS =
+      trackings.length > 0 ? trackings[Math.floor(trackings.length / 2)] : 0
+    runs.push({ start: s, end: e, medianLS })
+    s = e
+  }
+  const runForIndex = (idx: number): Run | undefined =>
+    runs.find((r) => idx >= r.start && idx < r.end)
+
+  // 1b. Identify font runs that consist of mostly single-character
+  //     fragments separated by single spaces — the "L E A V E  N O  O N E
+  //     B E H I N D." or "e v a c u a t i o n t e n t s" pattern. Those
+  //     runs either have no consecutive non-space pairs to measure
+  //     (medianLS=0) or have a single accidental pair (D→.) that gives a
+  //     misleading non-zero median; either way the primary threshold
+  //     check straddles the real cluster advances and produces wrong
+  //     decisions per cluster. The shape itself — ≥4 single-char
+  //     fragments and ≥60% of fragments being single-char — is the
+  //     unambiguous signal: body text never produces that.
+  const stripAsLetterRun = new Set<number>()
+  for (const run of runs) {
+    let fragCount = 0
+    let singleCharCount = 0
+    let p = run.start
+    while (p < run.end) {
+      while (p < run.end && chars[p].c === " ") p++
+      const fragStart = p
+      while (p < run.end && chars[p].c !== " ") p++
+      const fragLen = p - fragStart
+      if (fragLen > 0) {
+        fragCount += 1
+        if (fragLen === 1) singleCharCount += 1
+      }
+    }
+    if (singleCharCount >= 4 && singleCharCount / fragCount >= 0.6) {
+      stripAsLetterRun.add(run.start)
+    }
+  }
+
+  // 2. Walk space clusters. The cluster's *real* advance is the cursor
+  //    distance from the first space to the next non-space — origin-to-
+  //    origin, telescoping through any number of spaces. The threshold
+  //    we compare against depends on context:
+  //
+  //    - Surrounding non-space chars share a font → use that run's
+  //      median letter-spacing (× 1.6, floored at 1pt). Cluster narrower
+  //      than that = letter-spacing artefact → strip.
+  //    - Surrounding chars are in different fonts → font transition,
+  //      almost certainly a real word boundary → keep.
+  //    - At line edge (no surrounding char on one side) → use the
+  //      adjacent run's threshold.
+  //    - Cluster sits inside a `stripAsLetterRun` font run → strip
+  //      (single-space) or collapse (multi-space) regardless of metric.
+  let i = 0
+  while (i < chars.length) {
+    if (chars[i].c !== " ") {
+      i++
+      continue
+    }
+    let j = i
+    while (j < chars.length && chars[j].c === " ") j++
+
+    const leftFont = i > 0 ? chars[i - 1].font : undefined
+    const rightFont = j < chars.length ? chars[j].font : undefined
+    const sameFontRun =
+      leftFont !== undefined && rightFont !== undefined && leftFont === rightFont
+    const surroundingRun = sameFontRun
+      ? runForIndex(i - 1)
+      : leftFont !== undefined && rightFont === undefined
+        ? runForIndex(i - 1)
+        : leftFont === undefined && rightFont !== undefined
+          ? runForIndex(j)
+          : undefined
+    const medianLS = surroundingRun?.medianLS ?? 0
+
+    // Letter-run fallback: fire when the cluster is bracketed by chars in
+    // a flagged single-char-fragment run. We require sameFontRun so we
+    // don't strip a font-transition space whose two sides happen to
+    // belong to different runs.
+    const inLetterRun =
+      sameFontRun &&
+      surroundingRun !== undefined &&
+      stripAsLetterRun.has(surroundingRun.start)
+
+    const stripThreshold = Math.max(medianLS * 1.6, 1)
+    const clusterAdvance =
+      j < chars.length
+        ? chars[j].ox - chars[i].ox
+        : chars[j - 1].qRight - chars[i].ox // trailing cluster fallback
+
+    const shouldStrip = clusterAdvance < stripThreshold || (inLetterRun && j - i === 1)
+
+    if (shouldStrip) {
+      for (let k = i; k < j; k++) mask[k] = true
+    } else if (j - i > 1) {
+      for (let k = i + 1; k < j; k++) mask[k] = true
+    }
+
+    i = j
+  }
+
+  return mask
+}
+
+/**
+ * Apply the strip mask to an asHTML paragraph in place: drop characters
+ * from `text` and from each segment's `text` when their position aligns
+ * with a stripped character in the line. We only touch the paragraph
+ * when its text matches the line text up to trailing whitespace (the
+ * common case); when they diverge we leave the paragraph untouched
+ * rather than risk corrupting style boundaries.
+ */
+function applyStripMaskToParagraph(p: AsHtmlParagraph, line: LineBbox): void {
+  if (!line.chars) return
+  const lineText = line.chars.map((c) => c.c).join("")
+  // Only proceed when paragraph text is a prefix of the line characters
+  // (asHTML often trims trailing whitespace differently than the walker).
+  // If they diverge mid-string we'd start dropping the wrong characters.
+  if (!lineText.startsWith(p.text) && !p.text.startsWith(lineText.replace(/\s+$/, ""))) return
+
+  const mask = computeStripMask(line.chars)
+
+  // Build cleaned text by walking p.text and consulting the mask at the
+  // matching index in lineText.
+  let newText = ""
+  for (let i = 0; i < p.text.length; i++) {
+    if (i < mask.length && p.text[i] === line.chars[i].c && mask[i]) continue
+    newText += p.text[i]
+  }
+  if (newText === p.text) return // Nothing to strip — leave segments alone.
+
+  // Apply same drop pattern to segments. Segment texts concatenate to
+  // p.text in order, so we track a global position and skip stripped
+  // indices per segment.
+  let pos = 0
+  const newSegments: RawTextSegment[] = []
+  for (const seg of p.segments) {
+    let segText = ""
+    for (let k = 0; k < seg.text.length; k++) {
+      const idx = pos + k
+      const stripHere =
+        idx < mask.length && mask[idx] && line.chars[idx].c === seg.text[k]
+      if (!stripHere) segText += seg.text[k]
+    }
+    newSegments.push(segText.length > 0 ? { ...seg, text: segText } : { ...seg, text: "" })
+    pos += seg.text.length
+  }
+
+  p.text = newText
+  // Drop fully-empty segments so we don't render zero-content spans.
+  p.segments = newSegments.filter((s) => s.text.length > 0)
+}
+
+/**
+ * Top-level pass: for each paragraph, find its matching line and apply
+ * metric-based space stripping. Modifies paragraphs in place. Exported
+ * so tests can drive it with synthetic data without spinning up mupdf.
+ */
+export function cleanParagraphSpacing(paragraphs: AsHtmlParagraph[], lines: { text: string; chars?: LineChar[]; top: number; left: number; right: number; bottom: number }[]): void {
+  for (const p of paragraphs) {
+    const matched = matchLineBbox(p, lines)
+    if (matched) applyStripMaskToParagraph(p, matched)
+  }
+}
+
+/**
+ * Walk the structured-text tree to extract paragraphs (one per line) with
+ * viewport (PDF point) coordinates + structured segments. Each line
+ * becomes one paragraph; consecutive characters that share font, size,
+ * and color collapse into one segment. Deduplicates paragraphs that share
+ * normalized text content at a close position (mupdf emits the same text
+ * from both text and vector layers for some PDFs).
+ *
+ * This is a single-pass walk that replaces the previous
+ * `asHTML()`-and-reparse approach: mupdf's `onChar` callback exposes the
+ * same data (font, size, color, position) directly, so no HTML round-trip
+ * is needed.
+ */
+function walkPageParagraphs(page: MupdfPage): AsHtmlParagraph[] {
+  const stext = page.toStructuredText()
+  const paragraphs: AsHtmlParagraph[] = []
+  const seen = new Map<string, number>()
+
+  let curBbox: Rect | null = null
+  let curChars: Array<{ c: string; ox: number; font: MupdfFont; size: number; color: Color }> = []
+
+  stext.walk({
+    beginLine(bbox) {
+      curBbox = bbox
+      curChars = []
+    },
+    onChar(c, origin, font, size, _quad, color) {
+      const ox = Array.isArray(origin) ? origin[0] : (origin as { x: number } | undefined)?.x ?? 0
+      curChars.push({ c, ox, font, size, color })
+    },
+    endLine() {
+      if (!curBbox || curChars.length === 0) {
+        curBbox = null
+        return
+      }
+      // Drop overlapping glyph passes — stroke-then-fill rendering (used
+      // for outlined-fill effects on decorative text like "yellow") emits
+      // each character twice at the same origin: once stroked, once
+      // filled. mupdf's StructuredText keeps both passes; concatenating
+      // them naively yields "yellowyellow". Dedup by (char, integer
+      // x-pt) keeps one occurrence; we replace the earlier instance with
+      // the later so the visual end-state (typically fill, drawn after
+      // stroke) wins on color/style.
+      curChars = dedupOverlappingGlyphs(curChars)
+
+      const rawText = curChars.map((ch) => ch.c).join("")
+      const text = rawText.replace(/\s+$/, "")
+      if (!text.trim()) {
+        curBbox = null
+        return
+      }
+
+      const segments = groupIntoSegments(curChars, rawText.length - text.length)
+      const topPt = curBbox[1]
+      const leftPt = curBbox[0]
+      // Use the max nominal font-size in the line as line-height —
+      // matches mupdf asHtml's convention and CSS's line-box model.
+      // The glyph-quad bbox height (`curBbox[3] - curBbox[1]`) overcounts
+      // for fonts with large ascender/descender extent (e.g. ComicSansMS
+      // glyphs at 48pt span ~67pt of quad), which inflates the rendered
+      // line-height past CSS's expectation and breaks the wrapped-line
+      // count vs block-bounds math.
+      let maxSize = 0
+      for (const ch of curChars) if (ch.size > maxSize) maxSize = ch.size
+      const lineHeightPt = maxSize > 0 ? maxSize : curBbox[3] - curBbox[1]
+
+      // Collapse repeated-numeral page numbers ("1616" → "16") for the dedup
+      // key only. The original text is kept as-is.
+      let dedupText = text
+      if (/^\d+$/.test(dedupText) && dedupText.length >= 2 && dedupText.length % 2 === 0) {
+        const half = dedupText.length / 2
+        if (dedupText.slice(0, half) === dedupText.slice(half)) {
+          dedupText = dedupText.slice(0, half)
+        }
+      }
+      const dedupKey = `${dedupText}|${Math.floor(topPt / 15)}|${Math.floor(leftPt / 15)}`
+
+      const paragraph: AsHtmlParagraph = {
+        top: topPt,
+        left: leftPt,
+        lineHeight: lineHeightPt,
+        segments,
+        text,
+      }
+
+      const existingIdx = seen.get(dedupKey)
+      if (existingIdx !== undefined) {
+        // Duplicate — prefer the one with non-black color (e.g. white page nums).
+        const hasColor = segments.some((s) => {
+          const colorStr = s.style?.color
+          return !!colorStr && !/^#?0{3}$|^#?0{6}$/.test(colorStr.replace(/\s/g, ""))
+        })
+        if (hasColor) paragraphs[existingIdx] = paragraph
+      } else {
+        seen.set(dedupKey, paragraphs.length)
+        paragraphs.push(paragraph)
+      }
+      curBbox = null
+    },
+  })
+
+  return paragraphs
+}
+
+/** Dedup glyphs that occupy the same `(char, x-pt)` slot — happens when a
+ *  PDF renders text with stroke-then-fill (or fill-then-stroke) for an
+ *  outline effect. The later occurrence wins so the fill (drawn last in
+ *  PDF stream order) carries through; segment style on the deduped char
+ *  reflects the visible end-state. */
+function dedupOverlappingGlyphs<T extends { c: string; ox: number }>(chars: T[]): T[] {
+  if (chars.length < 2) return chars
+  const seen = new Map<string, number>()
+  const out: T[] = []
+  for (const ch of chars) {
+    if (ch.c === " " || ch.c === "\t") {
+      out.push(ch)
+      continue
+    }
+    const key = `${ch.c}|${Math.round(ch.ox)}`
+    const existingIdx = seen.get(key)
+    if (existingIdx !== undefined) {
+      out[existingIdx] = ch
+      continue
+    }
+    seen.set(key, out.length)
+    out.push(ch)
+  }
+  return out
+}
+
+/** Group consecutive same-style chars into segments. `trailingTrim` drops
+ *  trailing whitespace chars from the last segment (matching `text` which
+ *  is right-trimmed). */
+function groupIntoSegments(
+  chars: Array<{ c: string; font: MupdfFont; size: number; color: Color }>,
+  trailingTrim: number,
+): RawTextSegment[] {
+  if (chars.length === 0) return []
+  const segments: RawTextSegment[] = []
+  const styleSig = (i: number) =>
+    `${chars[i].font.getName()}|${chars[i].size}|${colorToCss(chars[i].color)}|${chars[i].font.isBold()}|${chars[i].font.isItalic()}`
+
+  let segStart = 0
+  let curSig = styleSig(0)
+  for (let i = 1; i <= chars.length; i++) {
+    const sig = i < chars.length ? styleSig(i) : null
+    if (sig !== curSig) {
+      const segText = chars.slice(segStart, i).map((c) => c.c).join("")
+      if (segText) {
+        segments.push({
+          text: segText,
+          style: buildSegmentStyle(chars[segStart].font, chars[segStart].size, chars[segStart].color),
+        })
+      }
+      segStart = i
+      if (sig !== null) curSig = sig
+    }
+  }
+  // Right-trim trailing whitespace from the last segment.
+  if (trailingTrim > 0 && segments.length > 0) {
+    const last = segments[segments.length - 1]
+    last.text = last.text.replace(/\s+$/, "")
+    if (!last.text) segments.pop()
+  }
+  return segments
+}
+
+function buildSegmentStyle(font: MupdfFont, size: number, color: Color): Record<string, string> {
+  const style: Record<string, string> = {
+    "font-family": cssFontFamily(font),
+    "font-size": `${size}px`,
+    color: colorToCss(color),
+  }
+  if (font.isBold()) style["font-weight"] = "bold"
+  if (font.isItalic()) style["font-style"] = "italic"
+  return style
+}
+
+/** Convert a mupdf font name to a CSS font-family string. Strips PostScript
+ *  style suffixes (`-Roman`, `-Regular`, `-Bold`, etc.) and the foundry
+ *  prefix (e.g. `LT`, `MT`) that PDFs sometimes carry, then appends the
+ *  generic `serif` so unbundled fonts fall back to a serif terminal in the
+ *  renderer's `withBundledFallback` chain. */
+function cssFontFamily(font: MupdfFont): string {
+  let name = font.getName()
+  // PDF subset prefix is 6 uppercase letters + "+" + the real font name
+  // (e.g. "TXJRJH+Palatino"). Drop it so paragraphs that mupdf split
+  // into different subsets cluster as the same logical font — otherwise
+  // adjacent lines from one bubble end up in separate blocks because
+  // their fontKey differs only in subset tag.
+  if (/^[A-Z]{6}\+/.test(name)) name = name.slice(7)
+  // Strip PostScript style suffix.
+  const dash = name.indexOf("-")
+  if (dash > 0) name = name.slice(0, dash)
+  // Strip common foundry suffixes.
+  name = name.replace(/(MT|LT|PS|Pro|Std)$/g, "")
+  if (!name) name = "serif"
+  return `${name},serif`
+}
+
+/** Convert a mupdf Color (1, 3, or 4 floats in 0..1) to `#rrggbb`. */
+function colorToCss(color: Color): string {
+  let r: number, g: number, b: number
+  if (color.length === 1) {
+    r = g = b = color[0]
+  } else if (color.length === 3) {
+    [r, g, b] = color
+  } else {
+    // CMYK → naive conversion: r=(1-c)(1-k), g=(1-m)(1-k), b=(1-y)(1-k).
+    const [c, m, y, k] = color
+    r = (1 - c) * (1 - k)
+    g = (1 - m) * (1 - k)
+    b = (1 - y) * (1 - k)
+  }
+  const hex = (n: number) =>
+    Math.max(0, Math.min(255, Math.round(n * 255))).toString(16).padStart(2, "0")
+  return `#${hex(r)}${hex(g)}${hex(b)}`
+}
+
+// ── Block clustering ───────────────────────────────────────────────
+
+/**
+ * Each paragraph plus the line-bbox we matched it to (bottom/right are
+ * the only fields not already on the paragraph). Used internally during
+ * clustering; not exported because the final form everyone consumes is
+ * `AsHtmlParagraph.blockBounds`.
+ */
+interface ParagraphWithBbox {
+  paragraph: AsHtmlParagraph
+  /** Effective line bbox: tight when matched to a structured-text line, estimated otherwise. */
+  bbox: { left: number; top: number; right: number; bottom: number }
+  /** Primary font (family + size as a string key) for the paragraph. Empty when unknown. */
+  fontKey: string
+}
+
+/**
+ * Cluster paragraphs into visual blocks (e.g. one speech bubble = one
+ * block) and stamp `blockId` + `blockBounds` on each paragraph in place.
+ *
+ * Inputs:
+ * - `paragraphs` is the asHTML output (top/left/lineHeight per line; no width).
+ * - `lineBboxes` are mupdf's per-line bboxes from structured-text walk —
+ *   tight rectangles we use to recover each paragraph's true right/bottom.
+ *
+ * Algorithm:
+ * 1. For each paragraph, find the best-matching line bbox by `top` proximity
+ *    and a text-prefix match. Fall back to an estimated bbox when no line
+ *    matches (rare; happens when asHTML emits text the structured-text walker
+ *    didn't see, e.g. duplicated layers).
+ * 2. Sort paragraphs by top, then left.
+ * 3. Greedily assign each paragraph to an existing block when:
+ *    - same font (family + size),
+ *    - vertical gap from any existing line in the block to the candidate's
+ *      top is in [-0.5×lh, 1.6×lh] (handles both descenders and small
+ *      lineHeight-vs-leading mismatches), and
+ *    - rectangles overlap horizontally OR centers are within 30pt
+ *      (centred ragged-right text in bubbles).
+ *    Otherwise start a new block.
+ * 4. Compute each block's bounds as the union of its paragraphs' line bboxes.
+ *
+ * The optional `idPrefix` lets the spread variant keep left/right blocks in
+ * separate id namespaces — this function never invents cross-page blocks
+ * because clustering happens on each side's paragraphs separately.
+ */
+export function clusterParagraphsIntoBlocks(
+  paragraphs: AsHtmlParagraph[],
+  lineBboxes: LineBbox[],
+  idPrefix = "",
+): void {
+  if (paragraphs.length === 0) return
+
+  const enriched: ParagraphWithBbox[] = paragraphs.map((p) => {
+    const matched = matchLineBbox(p, lineBboxes)
+    const bbox = matched
+      ? { left: matched.left, top: matched.top, right: matched.right, bottom: matched.bottom }
+      : {
+          left: p.left,
+          top: p.top,
+          // Crude fallback: unknown width, height = lineHeight. Used only when
+          // no structured-text line matches (very rare in practice).
+          right: p.left + Math.max(p.text.length * 0.5 * p.lineHeight, p.lineHeight),
+          bottom: p.top + p.lineHeight,
+        }
+    return { paragraph: p, bbox, fontKey: paragraphFontKey(p) }
+  })
+
+  // Stable sort by top (primary) then left (secondary) so clustering
+  // sweeps top-to-bottom in reading order and gets a deterministic
+  // assignment for paragraphs at the same y.
+  const sorted = enriched.slice().sort((a, b) => {
+    if (a.bbox.top !== b.bbox.top) return a.bbox.top - b.bbox.top
+    return a.bbox.left - b.bbox.left
+  })
+
+  type Block = {
+    members: ParagraphWithBbox[]
+    /** Running union bounds — kept current as members join. */
+    union: { left: number; top: number; right: number; bottom: number }
+    fontKey: string
+    /** Median lineHeight across members; used as the vertical-gap budget. */
+    lineHeight: number
+  }
+  const blocks: Block[] = []
+
+  for (const item of sorted) {
+    const lh = item.paragraph.lineHeight
+    const join = blocks.find((b) => canJoinBlock(b, item))
+    if (join) {
+      join.members.push(item)
+      join.union = {
+        left: Math.min(join.union.left, item.bbox.left),
+        top: Math.min(join.union.top, item.bbox.top),
+        right: Math.max(join.union.right, item.bbox.right),
+        bottom: Math.max(join.union.bottom, item.bbox.bottom),
+      }
+      // Track running median-ish lineHeight by simple max — bubbles are
+      // usually uniform and we want the join budget to grow if a slightly
+      // taller line shows up rather than to shrink.
+      join.lineHeight = Math.max(join.lineHeight, lh)
+    } else {
+      blocks.push({
+        members: [item],
+        union: { ...item.bbox },
+        fontKey: item.fontKey,
+        lineHeight: lh,
+      })
+    }
+  }
+
+  blocks.forEach((block, idx) => {
+    const id = `${idPrefix}b${String(idx).padStart(3, "0")}`
+    const bounds: TextBlockBounds = {
+      x: block.union.left,
+      y: block.union.top,
+      width: block.union.right - block.union.left,
+      height: block.union.bottom - block.union.top,
+    }
+    const align = inferTextAlign(block.members, block.union)
+    // Sort members in visual reading order (top, then left) before running
+    // the continuation pass — clustering already touched these in some
+    // sweep order, but we want the continuation check to compare "the
+    // line above" with "the line below it" specifically.
+    const ordered = block.members
+      .slice()
+      .sort((a, b) => (a.bbox.top !== b.bbox.top ? a.bbox.top - b.bbox.top : a.bbox.left - b.bbox.left))
+
+    let mergedIdx = 0
+    let prevText: string | null = null
+    for (const m of ordered) {
+      const curText = m.paragraph.text
+      const startsNewParagraph = prevText === null || !isContinuation(prevText, curText)
+      if (startsNewParagraph) mergedIdx += 1
+      const mid = `${id}_p${String(mergedIdx).padStart(2, "0")}`
+      m.paragraph.blockId = id
+      m.paragraph.blockBounds = bounds
+      m.paragraph.mergedParagraphId = mid
+      if (align) m.paragraph.textAlign = align
+      prevText = curText
+    }
+  })
+}
+
+/**
+ * Decide whether `currentText` continues the line above (`prevText`).
+ * Mirrors BookFusion's PDF-reader TTS heuristic:
+ *
+ * 1. Previous line ends with a hyphen → wrapped word, treat as continuation.
+ * 2. Current line starts with a Unicode lowercase letter → mid-sentence
+ *    wrap, treat as continuation.
+ *
+ * Otherwise the lines are different paragraphs (sentence break, list
+ * item, new bubble line, etc.). Sharing a block (visual container) is
+ * decided separately; this just splits within a block.
+ */
+function isContinuation(prevText: string, currentText: string): boolean {
+  if (prevText.endsWith("-")) return true
+  const firstChar = currentText.match(/^\s*(\S)/)
+  if (firstChar && /\p{Ll}/u.test(firstChar[1])) return true
+  return false
+}
+
+/**
+ * Infer the horizontal alignment of a block from its member lines.
+ * Returns "center" / "right" when the block visibly aligns that way;
+ * undefined for left-aligned (CSS default).
+ *
+ * The check we want is "do all lines share the same horizontal centre?",
+ * which works even for ragged-right centred bubbles where the widest line
+ * is flush-left and a different shorter line defines the block's right
+ * edge (so the *block* centre is shifted away from the *visual* centre).
+ *
+ * - All line lefts within FLUSH of block.left → left (return undefined).
+ * - All line rights within FLUSH of block.right → "right".
+ * - All line centres within CENTER_TOL of the average line centre, and
+ *   at least one line has padding on both sides → "center".
+ * - Otherwise treat as left (CSS default).
+ */
+function inferTextAlign(
+  members: ParagraphWithBbox[],
+  blockUnion: { left: number; top: number; right: number; bottom: number },
+): "center" | "right" | undefined {
+  if (members.length < 2) return undefined
+  const FLUSH = 2 // pt — line edge counts as touching the block edge
+  const CENTER_TOL = 6 // pt — tolerance for "all line centres agree"
+
+  let maxLeftDelta = 0
+  let maxRightDelta = 0
+  let anyMeaningfulPadding = false
+  const lineCentres: number[] = []
+  for (const m of members) {
+    const leftDelta = m.bbox.left - blockUnion.left
+    const rightDelta = blockUnion.right - m.bbox.right
+    if (leftDelta > maxLeftDelta) maxLeftDelta = leftDelta
+    if (rightDelta > maxRightDelta) maxRightDelta = rightDelta
+    if (leftDelta > FLUSH && rightDelta > FLUSH) anyMeaningfulPadding = true
+    lineCentres.push((m.bbox.left + m.bbox.right) / 2)
+  }
+
+  if (maxLeftDelta < FLUSH) return undefined // left-flush — default
+  if (maxRightDelta < FLUSH) return "right"
+
+  const avgCentre = lineCentres.reduce((a, b) => a + b, 0) / lineCentres.length
+  const maxCentreDeviation = lineCentres.reduce(
+    (m, c) => Math.max(m, Math.abs(c - avgCentre)),
+    0,
+  )
+  if (maxCentreDeviation < CENTER_TOL && anyMeaningfulPadding) return "center"
+  return undefined
+}
+
+/**
+ * Decide whether `candidate` can extend `block`. Same font, vertical gap
+ * in lineHeight territory, and either horizontal overlap or close centres
+ * (centred bubble text). Reject if any check fails.
+ */
+function canJoinBlock(
+  block: { union: { left: number; top: number; right: number; bottom: number }; fontKey: string; lineHeight: number },
+  candidate: ParagraphWithBbox,
+): boolean {
+  if (block.fontKey !== candidate.fontKey) return false
+
+  const lh = Math.max(block.lineHeight, candidate.paragraph.lineHeight)
+  // Gap from the block's current bottom to the candidate's top. Allow a
+  // small negative gap (descenders / overlap) and up to 1.6×lineHeight
+  // forward (extra leading in some PDFs).
+  const verticalGap = candidate.bbox.top - block.union.bottom
+  if (verticalGap < -lh * 0.5 || verticalGap > lh * 1.6) return false
+
+  const overlapsHoriz =
+    candidate.bbox.left <= block.union.right && candidate.bbox.right >= block.union.left
+  if (overlapsHoriz) return true
+
+  // Centred ragged-right text — match centres within 30pt (≈ a typical
+  // bubble's half-width tolerance).
+  const candCentre = (candidate.bbox.left + candidate.bbox.right) / 2
+  const blockCentre = (block.union.left + block.union.right) / 2
+  return Math.abs(candCentre - blockCentre) <= 30
+}
+
+/**
+ * Match a paragraph to its mupdf structured-text line. Prefers text
+ * agreement (mupdf's asHTML and StructuredText agree on the actual run
+ * of characters even when their reported `top` values disagree — e.g.
+ * inside blocks with extra leading where asHTML's paragraph top is
+ * offset from the glyph cap-top by more than one lineHeight). When two
+ * lines share the same text (page numbers, repeated headers), `top`
+ * proximity disambiguates.
+ *
+ * Returns the best candidate, or null when the paragraph's text doesn't
+ * appear in the structured-text output at all.
+ */
+function matchLineBbox(p: AsHtmlParagraph, lines: LineBbox[]): LineBbox | null {
+  const target = p.text.trim()
+  if (!target) return null
+  let best: LineBbox | null = null
+  let bestScore = Infinity
+  for (const line of lines) {
+    const lineText = line.text.trim()
+    const exactMatch = lineText === target
+    const prefixMatch = !exactMatch && (lineText.startsWith(target) || target.startsWith(lineText))
+    if (!exactMatch && !prefixMatch) continue
+
+    // Among same-text candidates pick the one closest in y. asHTML and
+    // StructuredText sometimes disagree by more than one lineHeight, so
+    // we don't reject far-apart matches outright — but we do score them.
+    const dy = Math.abs(line.top - p.top)
+    const score = (exactMatch ? 0 : 50) + dy
+    if (score < bestScore) {
+      bestScore = score
+      best = line
+    }
+  }
+  return best
+}
+
+/**
+ * Build a stable identity key for a paragraph's primary font (family +
+ * size). Used by clustering to refuse to merge a heading into the body
+ * paragraph below it. Empty string when no font info is available — those
+ * paragraphs will only cluster among themselves.
+ */
+function paragraphFontKey(p: AsHtmlParagraph): string {
+  const seg = p.segments[0]
+  if (!seg?.style) return ""
+  const family = seg.style["font-family"] ?? ""
+  const size = seg.style["font-size"] ?? ""
+  return `${family}|${size}`
+}

--- a/packages/pdf/src/positioned-text.ts
+++ b/packages/pdf/src/positioned-text.ts
@@ -18,6 +18,7 @@ import {
   type Page as MupdfPage,
   type Rect,
 } from "mupdf"
+import { colorToCss } from "./color-utils.js"
 
 // ── Types ──────────────────────────────────────────────────────────
 
@@ -752,24 +753,6 @@ function cssFontFamily(font: MupdfFont): string {
   return `${name},serif`
 }
 
-/** Convert a mupdf Color (1, 3, or 4 floats in 0..1) to `#rrggbb`. */
-function colorToCss(color: Color): string {
-  let r: number, g: number, b: number
-  if (color.length === 1) {
-    r = g = b = color[0]
-  } else if (color.length === 3) {
-    [r, g, b] = color
-  } else {
-    // CMYK → naive conversion: r=(1-c)(1-k), g=(1-m)(1-k), b=(1-y)(1-k).
-    const [c, m, y, k] = color
-    r = (1 - c) * (1 - k)
-    g = (1 - m) * (1 - k)
-    b = (1 - y) * (1 - k)
-  }
-  const hex = (n: number) =>
-    Math.max(0, Math.min(255, Math.round(n * 255))).toString(16).padStart(2, "0")
-  return `#${hex(r)}${hex(g)}${hex(b)}`
-}
 
 // ── Block clustering ───────────────────────────────────────────────
 

--- a/packages/pipeline/package.json
+++ b/packages/pipeline/package.json
@@ -24,6 +24,7 @@
     "jsdom": "^27.0.0",
     "liquidjs": "^10.0.0",
     "playwright": "^1.50.0",
+    "pngjs": "^7.0.0",
     "postcss": "^8.5.0",
     "tailwindcss": "^4.0.0",
     "@tailwindcss/postcss": "^4.0.0",
@@ -35,7 +36,6 @@
     "@types/cli-progress": "^3.11.6",
     "@types/jsdom": "^27.0.0",
     "@types/pngjs": "^6.0.5",
-    "esbuild": "^0.25.12",
-    "pngjs": "^7.0.0"
+    "esbuild": "^0.25.12"
   }
 }

--- a/packages/pipeline/src/__tests__/fixed-layout-rendering.test.ts
+++ b/packages/pipeline/src/__tests__/fixed-layout-rendering.test.ts
@@ -379,12 +379,11 @@ describe("renderFixedLayoutPage", () => {
 
     expect(html).toContain('data-id="pg001_p000"')
     expect(html).toContain('data-id="pg001_p001"')
-    // Words are wrapped in per-word <span id>; check first + last word
-    // of each paragraph rather than the contiguous string.
-    expect(html).toContain(">I</span>")
-    expect(html).toContain(">girl.</span>")
-    expect(html).toContain(">My</span>")
-    expect(html).toContain(">Sue.</span>")
+    // Renderer emits a structural shell — one styled <span style> per
+    // segment, no per-word wrapping. Word ids are added downstream by
+    // wrapWordSpans (packaging) and wrapTextInSpans (live viewer).
+    expect(html).toContain(">I am a little girl.</span>")
+    expect(html).toContain(">My name is Sue.</span>")
   })
 
   it("emits width + text-align on a paragraph that carries blockBounds", () => {
@@ -700,78 +699,19 @@ describe("renderFixedLayoutPage", () => {
     ])
   })
 
-  it("wraps each word in <span id> derived from the paragraph nodeId", () => {
+  it("emits one styled <span> per segment as a structural shell (no word ids)", () => {
+    // The renderer produces a translation-friendly structural shell. Word
+    // ids — required by SMIL fragment refs and the in-viewer highlighter —
+    // are added downstream by wrapWordSpans (packaging) and wrapTextInSpans
+    // (live viewer), each consuming the data-segments JSON.
     const html = renderFixedLayoutPage(makeSection(), "/images").sections[0].html
-
-    // "I am a little girl." → 5 words → ids _w001 .. _w005 on pg001_p000.
-    // Each word span wraps the per-run <span style> fragment(s) (here a
-    // single styled run per word).
-    expect(html).toMatch(/<span id="pg001_p000_w001"><span style="[^"]*">I<\/span><\/span>/)
-    expect(html).toMatch(/<span id="pg001_p000_w002"><span style="[^"]*">am<\/span><\/span>/)
-    expect(html).toMatch(/<span id="pg001_p000_w003"><span style="[^"]*">a<\/span><\/span>/)
-    expect(html).toMatch(/<span id="pg001_p000_w004"><span style="[^"]*">little<\/span><\/span>/)
-    expect(html).toMatch(/<span id="pg001_p000_w005"><span style="[^"]*">girl\.<\/span><\/span>/)
-    // Numbering restarts per paragraph.
-    expect(html).toMatch(/<span id="pg001_p001_w001"><span style="[^"]*">My<\/span><\/span>/)
+    expect(html).not.toMatch(/<span id="pg001_p000_w\d+"/)
+    // Single styled <span> for the single-run paragraph.
+    expect(html).toMatch(/<span style="[^"]*">I am a little girl\.<\/span>/)
+    expect(html).toMatch(/<span style="[^"]*">My name is Sue\.<\/span>/)
   })
 
-  it("keeps whitespace between word spans (so word boxes stay tight)", () => {
-    const html = renderFixedLayoutPage(makeSection(), "/images").sections[0].html
-
-    // The space between "I" and "am" must sit OUTSIDE the word spans —
-    // otherwise word measurement (and any per-word styling later) picks up
-    // surrounding whitespace.
-    expect(html).toMatch(
-      /<span id="pg001_p000_w001"><span style="[^"]*">I<\/span><\/span> <span id="pg001_p000_w002"><span style="[^"]*">am<\/span><\/span>/,
-    )
-  })
-
-  it("keeps a word split across style runs as ONE word span wrapping the run fragments", () => {
-    // A single coloured letter inside a word ("la" + white "h" + "ars" →
-    // "lahars") must NOT produce one word id per fragment — Whisper emits
-    // one timestamp for the spoken word, so extra ids would force the
-    // SMIL/viewer count guard to fall back to block-level highlighting,
-    // and reusing one id across fragments is an epubcheck duplicate-id.
-    const baseStyle = { "font-family": "Palatino,serif", "font-size": "48px", color: "#000000" }
-    const whiteStyle = { ...baseStyle, color: "#ffffff" }
-    const section = sectionFixedLayoutPage({
-      pageId: "pg001",
-      pageNumber: 1,
-      viewport,
-      drawItems: [
-        { kind: "image", imageId: "pg001_im001", bounds: { x: 0, y: 0, width: 400, height: 300 } },
-        {
-          kind: "paragraph",
-          textId: "pg001_p000",
-          top: 100,
-          left: 72,
-          lineHeight: 48,
-          segments: [
-            { text: "the la", style: baseStyle },
-            { text: "h", style: whiteStyle },
-            { text: "ars came", style: baseStyle },
-          ],
-          text: "the lahars came",
-        },
-      ],
-      availableImageIds: new Set(["pg001_im001"]),
-    }).sections[0]
-
-    const html = renderFixedLayoutPage(section, "/images").sections[0].html
-
-    // "the" "lahars" "came" → exactly 3 word ids (the old per-fragment
-    // tokenisation would have produced 5: the / la / h / ars / came).
-    expect(html).toContain('<span id="pg001_p000_w001">')
-    expect(html).toContain('<span id="pg001_p000_w002">')
-    expect(html).toContain('<span id="pg001_p000_w003">')
-    expect(html).not.toContain("pg001_p000_w004")
-    // The split word is one `<span id>` wrapping the three styled fragments.
-    expect(html).toMatch(
-      /<span id="pg001_p000_w002"><span style="[^"]*color:#000000[^"]*">la<\/span><span style="[^"]*color:#ffffff[^"]*">h<\/span><span style="[^"]*color:#000000[^"]*">ars<\/span><\/span>/,
-    )
-  })
-
-  it("numbers words across segments within the same paragraph", () => {
+  it("preserves per-segment styling across multiple runs", () => {
     const palatinoBlackStyle = {
       "font-family": "Palatino,serif",
       "font-size": "48px",
@@ -803,20 +743,11 @@ describe("renderFixedLayoutPage", () => {
 
     const html = renderFixedLayoutPage(section, "/images").sections[0].html
 
-    // Sequential ids span across segment boundaries (no reset per styled run).
-    expect(html).toMatch(/<span id="pg001_p000_w001"><span style="[^"]*">There<\/span><\/span>/)
-    expect(html).toMatch(/<span id="pg001_p000_w002"><span style="[^"]*">are<\/span><\/span>/)
-    expect(html).toMatch(/<span id="pg001_p000_w003"><span style="[^"]*">long,<\/span><\/span>/)
-    expect(html).toMatch(/<span id="pg001_p000_w004"><span style="[^"]*">yellow<\/span><\/span>/)
-    expect(html).toMatch(/<span id="pg001_p000_w005"><span style="[^"]*">bookshelves\.<\/span><\/span>/)
-
-    // The per-word <span id> wraps the per-run <span style> fragment(s), so
-    // a word lying entirely in a coloured run keeps a single id and the
-    // run's style cascades to it. The trailing space stays outside the word
-    // span.
-    expect(html).toMatch(
-      /<span id="pg001_p000_w004"><span style="[^"]*color:#fff200[^"]*">yellow<\/span><\/span> /,
-    )
+    // One <span style> per source segment; mid-paragraph coloured run
+    // survives intact for the downstream word-wrap to see.
+    expect(html).toMatch(/<span style="[^"]*color:#000000[^"]*">There are long, <\/span>/)
+    expect(html).toMatch(/<span style="[^"]*color:#fff200[^"]*">yellow <\/span>/)
+    expect(html).toMatch(/<span style="[^"]*color:#000000[^"]*">bookshelves\.<\/span>/)
   })
 
   it("renders visible text (no transparent fallback)", () => {

--- a/packages/pipeline/src/__tests__/fixed-layout-rendering.test.ts
+++ b/packages/pipeline/src/__tests__/fixed-layout-rendering.test.ts
@@ -1,0 +1,987 @@
+import { describe, it, expect, afterEach } from "vitest"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { sectionFixedLayoutPage, renderFixedLayoutPage, contrastRatio, createBackgroundSampler, processFixedLayoutPages } from "../fixed-layout-rendering.js"
+import type { ContentNodeData, DrawItem, NodePlacement, PageSectioningSection, PositionedTextOutput } from "@adt/types"
+import type { ExtractedImage } from "@adt/pdf"
+import { createBookStorage } from "@adt/storage"
+import { PNG } from "pngjs"
+
+/** Find the first text leaf inside a section (no nested containers in fixed layout). */
+function firstTextLeaf(section: PageSectioningSection): ContentNodeData | undefined {
+  return section.nodes.find((n) => n.role === "text")
+}
+
+function textLeaves(section: PageSectioningSection): ContentNodeData[] {
+  return section.nodes.filter((n) => n.role === "text")
+}
+
+function imageLeaves(section: PageSectioningSection): ContentNodeData[] {
+  return section.nodes.filter((n) => n.role === "image")
+}
+
+function placementOf(section: PageSectioningSection, nodeId: string): NodePlacement | undefined {
+  return section.placement?.[nodeId]
+}
+
+describe("sectionFixedLayoutPage", () => {
+  const viewport = { width: 400, height: 300 }
+
+  it("produces one section per page with an image leaf for the background", () => {
+    const drawItems: DrawItem[] = [
+      { kind: "image", imageId: "pg001_im001", bounds: { x: 0, y: 0, width: 400, height: 300 } },
+    ]
+    const result = sectionFixedLayoutPage({
+      pageId: "pg001",
+      pageNumber: 1,
+      viewport,
+      drawItems,
+      availableImageIds: new Set(["pg001_im001"]),
+    })
+
+    expect(result.sections).toHaveLength(1)
+    const section = result.sections[0]
+    expect(section.sectionId).toBe("pg001_sec001")
+    expect(section.sectionType).toBe("fixed-layout-page")
+    expect(section.isPruned).toBe(false)
+    expect(section.pageNumber).toBe(1)
+    expect(section.viewport).toEqual(viewport)
+
+    expect(section.nodes).toHaveLength(1)
+    expect(section.nodes[0]).toEqual({
+      nodeId: "pg001_im001",
+      role: "image",
+      isPruned: false,
+    })
+    expect(placementOf(section, "pg001_im001")).toEqual({
+      bounds: { x: 0, y: 0, width: 400, height: 300 },
+    })
+  })
+
+  it("emits text leaves with their nodeId (textId) and position", () => {
+    const drawItems: DrawItem[] = [
+      { kind: "image", imageId: "pg001_im001", bounds: { x: 0, y: 0, width: 400, height: 300 } },
+      {
+        kind: "paragraph",
+        textId: "pg001_p000",
+        top: 100,
+        left: 72,
+        lineHeight: 48,
+        segments: [{ text: "hello", style: { color: "#000000" } }],
+        text: "hello",
+      },
+    ]
+    const result = sectionFixedLayoutPage({
+      pageId: "pg001",
+      pageNumber: 1,
+      viewport,
+      drawItems,
+      availableImageIds: new Set(["pg001_im001"]),
+    })
+    const section = result.sections[0]
+
+    const leaves = textLeaves(section)
+    expect(leaves).toHaveLength(1)
+    expect(leaves[0].nodeId).toBe("pg001_p000")
+    expect(leaves[0].text).toBe("hello")
+
+    const p = placementOf(section, "pg001_p000")!
+    expect(p.position).toEqual({ top: 100, left: 72, lineHeight: 48 })
+    expect(p.segments).toEqual([{ text: "hello", style: { color: "#000000" } }])
+  })
+
+  it("preserves draw order — later items appear later in nodes", () => {
+    const drawItems: DrawItem[] = [
+      { kind: "image", imageId: "pg001_im001", bounds: { x: 0, y: 0, width: 400, height: 300 } },
+      {
+        kind: "paragraph",
+        textId: "pg001_p000",
+        top: 50,
+        left: 50,
+        lineHeight: 20,
+        segments: [{ text: "under" }],
+        text: "under",
+      },
+      { kind: "image", imageId: "pg001_im002", bounds: { x: 10, y: 20, width: 30, height: 40 } },
+      {
+        kind: "paragraph",
+        textId: "pg001_p001",
+        top: 100,
+        left: 100,
+        lineHeight: 20,
+        segments: [{ text: "over" }],
+        text: "over",
+      },
+    ]
+    const result = sectionFixedLayoutPage({
+      pageId: "pg001",
+      pageNumber: 1,
+      viewport,
+      drawItems,
+      availableImageIds: new Set(["pg001_im001", "pg001_im002"]),
+    })
+
+    const nodes = result.sections[0].nodes
+    expect(nodes).toHaveLength(4)
+    expect(nodes[0]).toMatchObject({ nodeId: "pg001_im001", role: "image" })
+    expect(nodes[1]).toMatchObject({ nodeId: "pg001_p000", role: "text" })
+    expect(nodes[2]).toMatchObject({ nodeId: "pg001_im002", role: "image" })
+    expect(nodes[3]).toMatchObject({ nodeId: "pg001_p001", role: "text" })
+  })
+
+  it("merges consecutive same-mergedParagraphId draw items into one text leaf", () => {
+    // "Move away from the volcano" wrapping to "as fast as possible." — the
+    // continuation heuristic stamps both lines with the same mergedParagraphId.
+    // Sectioning collapses them into a single text leaf whose text joins
+    // the two lines with a single space.
+    const blockBounds = { x: 113, y: 410, width: 165, height: 35 }
+    const drawItems: DrawItem[] = [
+      {
+        kind: "paragraph",
+        textId: "pg001_p001",
+        top: 410,
+        left: 113,
+        lineHeight: 12,
+        segments: [{ text: "Move away from the volcano " }],
+        text: "Move away from the volcano ",
+        blockId: "b001",
+        blockBounds,
+        mergedParagraphId: "b001_p01",
+        textAlign: "center",
+      },
+      {
+        kind: "paragraph",
+        textId: "pg001_p002",
+        top: 433,
+        left: 142,
+        lineHeight: 12,
+        segments: [{ text: "as fast as possible." }],
+        text: "as fast as possible.",
+        blockId: "b001",
+        blockBounds,
+        mergedParagraphId: "b001_p01",
+        textAlign: "center",
+      },
+    ]
+    const result = sectionFixedLayoutPage({
+      pageId: "pg001",
+      pageNumber: 1,
+      viewport,
+      drawItems,
+      availableImageIds: new Set(),
+    })
+    const section = result.sections[0]
+
+    const leaves = textLeaves(section)
+    expect(leaves).toHaveLength(1)
+    expect(leaves[0].text).toBe("Move away from the volcano as fast as possible.")
+    const p = placementOf(section, leaves[0].nodeId)!
+    expect(p.position).toEqual({ top: 410, left: 113, lineHeight: 12 })
+    expect(p.textAlign).toBe("center")
+    expect(p.blockBounds).toEqual(blockBounds)
+  })
+
+  it("keeps sentence-boundary lines as separate leaves inside the same block", () => {
+    const blockBounds = { x: 113, y: 386, width: 165, height: 60 }
+    const drawItems: DrawItem[] = [
+      {
+        kind: "paragraph",
+        textId: "pg001_p001",
+        top: 387,
+        left: 116,
+        lineHeight: 12,
+        segments: [{ text: "Follow the evacuation plan. " }],
+        text: "Follow the evacuation plan. ",
+        blockId: "b001",
+        blockBounds,
+        mergedParagraphId: "b001_p01",
+      },
+      {
+        kind: "paragraph",
+        textId: "pg001_p002",
+        top: 410,
+        left: 113,
+        lineHeight: 12,
+        segments: [{ text: "Move away from the volcano " }],
+        text: "Move away from the volcano ",
+        blockId: "b001",
+        blockBounds,
+        mergedParagraphId: "b001_p02",
+      },
+    ]
+    const result = sectionFixedLayoutPage({
+      pageId: "pg001",
+      pageNumber: 1,
+      viewport,
+      drawItems,
+      availableImageIds: new Set(),
+    })
+
+    expect(textLeaves(result.sections[0])).toHaveLength(2)
+  })
+
+  it("joins hyphen-wrapped words without a space between", () => {
+    const drawItems: DrawItem[] = [
+      {
+        kind: "paragraph",
+        textId: "pg001_p001",
+        top: 100,
+        left: 50,
+        lineHeight: 12,
+        segments: [{ text: "super-" }],
+        text: "super-",
+        mergedParagraphId: "b001_p01",
+      },
+      {
+        kind: "paragraph",
+        textId: "pg001_p002",
+        top: 115,
+        left: 50,
+        lineHeight: 12,
+        segments: [{ text: "Computers" }],
+        text: "Computers",
+        mergedParagraphId: "b001_p01",
+      },
+    ]
+    const result = sectionFixedLayoutPage({
+      pageId: "pg001",
+      pageNumber: 1,
+      viewport,
+      drawItems,
+      availableImageIds: new Set(),
+    })
+
+    const leaves = textLeaves(result.sections[0])
+    expect(leaves).toHaveLength(1)
+    expect(leaves[0].text).toBe("super-Computers")
+  })
+
+  it("does not merge across an image draw-item even when ids match", () => {
+    const drawItems: DrawItem[] = [
+      {
+        kind: "paragraph",
+        textId: "pg001_p001",
+        top: 100,
+        left: 50,
+        lineHeight: 12,
+        segments: [{ text: "first " }],
+        text: "first ",
+        mergedParagraphId: "b001_p01",
+      },
+      { kind: "image", imageId: "pg001_im001", bounds: { x: 0, y: 0, width: 100, height: 100 } },
+      {
+        kind: "paragraph",
+        textId: "pg001_p002",
+        top: 115,
+        left: 50,
+        lineHeight: 12,
+        segments: [{ text: "second" }],
+        text: "second",
+        mergedParagraphId: "b001_p01",
+      },
+    ]
+    const result = sectionFixedLayoutPage({
+      pageId: "pg001",
+      pageNumber: 1,
+      viewport,
+      drawItems,
+      availableImageIds: new Set(["pg001_im001"]),
+    })
+
+    expect(textLeaves(result.sections[0])).toHaveLength(2)
+  })
+
+  it("drops image items whose imageId isn't available (pruned by filtering)", () => {
+    const drawItems: DrawItem[] = [
+      { kind: "image", imageId: "pg001_im001", bounds: { x: 0, y: 0, width: 400, height: 300 } },
+      { kind: "image", imageId: "pg001_im002", bounds: { x: 10, y: 20, width: 30, height: 40 } },
+    ]
+    const result = sectionFixedLayoutPage({
+      pageId: "pg001",
+      pageNumber: 1,
+      viewport,
+      drawItems,
+      availableImageIds: new Set(["pg001_im001"]), // im002 pruned
+    })
+    const section = result.sections[0]
+
+    const images = imageLeaves(section)
+    expect(images).toHaveLength(1)
+    expect(images[0].nodeId).toBe("pg001_im001")
+  })
+})
+
+describe("renderFixedLayoutPage", () => {
+  const viewport = { width: 400, height: 300 }
+
+  function makeSection(overrides: Partial<Parameters<typeof sectionFixedLayoutPage>[0]> = {}) {
+    const palatinoBlackStyle = {
+      "font-family": "Palatino,serif",
+      "font-size": "48px",
+      color: "#000000",
+    }
+    const defaultItems: DrawItem[] = [
+      { kind: "image", imageId: "pg001_im001", bounds: { x: 0, y: 0, width: 400, height: 300 } },
+      {
+        kind: "paragraph",
+        textId: "pg001_p000",
+        top: 100,
+        left: 72,
+        lineHeight: 48,
+        segments: [{ text: "I am a little girl.", style: palatinoBlackStyle }],
+        text: "I am a little girl.",
+      },
+      {
+        kind: "paragraph",
+        textId: "pg001_p001",
+        top: 158,
+        left: 72,
+        lineHeight: 48,
+        segments: [{ text: "My name is Sue.", style: palatinoBlackStyle }],
+        text: "My name is Sue.",
+      },
+    ]
+    return sectionFixedLayoutPage({
+      pageId: "pg001",
+      pageNumber: 1,
+      viewport,
+      drawItems: defaultItems,
+      availableImageIds: new Set(["pg001_im001"]),
+      ...overrides,
+    }).sections[0]
+  }
+
+  it("produces a single section with fixed-layout-page type", () => {
+    const result = renderFixedLayoutPage(makeSection(), "/images")
+
+    expect(result.sections).toHaveLength(1)
+    expect(result.sections[0].sectionType).toBe("fixed-layout-page")
+    expect(result.sections[0].sectionIndex).toBe(0)
+  })
+
+  it("includes viewport dimensions in the HTML", () => {
+    const html = renderFixedLayoutPage(makeSection(), "/images").sections[0].html
+
+    expect(html).toContain("width:400px")
+    expect(html).toContain("height:300px")
+  })
+
+  it("includes illustration image reference", () => {
+    const html = renderFixedLayoutPage(makeSection(), "/images").sections[0].html
+
+    expect(html).toContain('src="/images/pg001_im001"')
+    expect(html).toContain('data-id="pg001_im001"')
+  })
+
+  it("includes positioned paragraphs with data-id attributes", () => {
+    const html = renderFixedLayoutPage(makeSection(), "/images").sections[0].html
+
+    expect(html).toContain('data-id="pg001_p000"')
+    expect(html).toContain('data-id="pg001_p001"')
+    expect(html).toContain("I am a little girl.")
+    expect(html).toContain("My name is Sue.")
+  })
+
+  it("emits width + text-align on a paragraph that carries blockBounds", () => {
+    const blockBounds = { x: 113, y: 410, width: 165, height: 12 }
+    const drawItems: DrawItem[] = [
+      { kind: "image", imageId: "pg001_im001", bounds: { x: 0, y: 0, width: 400, height: 300 } },
+      {
+        kind: "paragraph",
+        textId: "pg001_p000",
+        top: 410,
+        left: 142,
+        lineHeight: 12,
+        segments: [{ text: "as fast as possible." }],
+        text: "as fast as possible.",
+        blockId: "b001",
+        blockBounds,
+        mergedParagraphId: "b001_p01",
+        textAlign: "center",
+      },
+    ]
+    const section = sectionFixedLayoutPage({
+      pageId: "pg001",
+      pageNumber: 1,
+      viewport,
+      drawItems,
+      availableImageIds: new Set(["pg001_im001"]),
+    }).sections[0]
+
+    const html = renderFixedLayoutPage(section, "/images").sections[0].html
+
+    // Renders at the block's left (113), not the line's left (142), so the
+    // line re-centres against the block's full width when translated.
+    expect(html).toContain("left:113px")
+    expect(html).toContain("width:165px")
+    expect(html).toContain("text-align:center")
+  })
+
+  it("pins height + data-adt-fit when blockBounds is set (overflow stays visible)", () => {
+    const blockBounds = { x: 184, y: 22, width: 40, height: 16 }
+    const drawItems: DrawItem[] = [
+      { kind: "image", imageId: "pg001_im001", bounds: { x: 0, y: 0, width: 400, height: 300 } },
+      {
+        kind: "paragraph",
+        textId: "pg001_p000",
+        top: 22,
+        left: 184,
+        lineHeight: 12,
+        segments: [{ text: "C O P E" }],
+        text: "C O P E",
+        blockId: "b000",
+        blockBounds,
+        mergedParagraphId: "b000_p01",
+      },
+    ]
+    const section = sectionFixedLayoutPage({
+      pageId: "pg001",
+      pageNumber: 1,
+      viewport,
+      drawItems,
+      availableImageIds: new Set(["pg001_im001"]),
+    }).sections[0]
+
+    const html = renderFixedLayoutPage(section, "/images").sections[0].html
+
+    expect(html).toContain('data-adt-fit="1"')
+    expect(html).toContain("height:16px")
+    // overflow stays visible on the text leaf's <p> — content that
+    // doesn't auto-fit overflows visibly rather than getting silently
+    // clipped. The page-level #content wrapper keeps overflow:hidden.
+    const pStyleMatch = html.match(/<p[^>]*data-id="pg001_p000"[^>]*style="([^"]*)"/)
+    expect(pStyleMatch).not.toBeNull()
+    expect(pStyleMatch![1]).not.toContain("overflow:")
+    // Script reference is injected once when at least one fit-target
+    // exists. Loaded by URL from the shared assets/adt/auto-fit.js so
+    // studio + EPUB + web export run identical code.
+    expect(html).toContain('<script src="./assets/auto-fit.js"></script>')
+    expect(html.match(/<script src="\.\/assets\/auto-fit\.js"><\/script>/g)?.length).toBe(1)
+  })
+
+  it("does not inject the auto-fit script when no leaf has blockBounds", () => {
+    const drawItems: DrawItem[] = [
+      { kind: "image", imageId: "pg001_im001", bounds: { x: 0, y: 0, width: 400, height: 300 } },
+      {
+        kind: "paragraph",
+        textId: "pg001_p000",
+        top: 100,
+        left: 72,
+        lineHeight: 24,
+        segments: [{ text: "legacy" }],
+        text: "legacy",
+      },
+    ]
+    const section = sectionFixedLayoutPage({
+      pageId: "pg001",
+      pageNumber: 1,
+      viewport,
+      drawItems,
+      availableImageIds: new Set(["pg001_im001"]),
+    }).sections[0]
+
+    const html = renderFixedLayoutPage(section, "/images").sections[0].html
+
+    expect(html).not.toContain("data-adt-fit")
+    expect(html).not.toContain("auto-fit.js")
+  })
+
+  it("appends Merriweather to font-family fallback chains for unbundled fonts", () => {
+    // MuseoSans / Chokle aren't bundled as @font-face rules; without the
+    // Merriweather fallback the spans render in system serif (Times)
+    // which has very different metrics than the PDF source — causing the
+    // auto-fit script to over-shrink.
+    const drawItems: DrawItem[] = [
+      { kind: "image", imageId: "pg001_im001", bounds: { x: 0, y: 0, width: 400, height: 300 } },
+      {
+        kind: "paragraph",
+        textId: "pg001_p000",
+        top: 100,
+        left: 50,
+        lineHeight: 12,
+        segments: [
+          { text: "Body text", style: { "font-family": "MuseoSans,serif", "font-size": "11.5px" } },
+          { text: "Title", style: { "font-family": "Chokle,serif", "font-size": "22px" } },
+        ],
+        text: "Body textTitle",
+      },
+    ]
+    const section = sectionFixedLayoutPage({
+      pageId: "pg001",
+      pageNumber: 1,
+      viewport: { width: 400, height: 300 },
+      drawItems,
+      availableImageIds: new Set(["pg001_im001"]),
+    }).sections[0]
+
+    const html = renderFixedLayoutPage(section, "/images").sections[0].html
+
+    // Merriweather inserted before the generic `serif` terminator.
+    expect(html).toContain("font-family:MuseoSans,Merriweather,serif")
+    expect(html).toContain("font-family:Chokle,Merriweather,serif")
+  })
+
+  it("leaves font-family untouched when Merriweather is already present", () => {
+    const drawItems: DrawItem[] = [
+      { kind: "image", imageId: "pg001_im001", bounds: { x: 0, y: 0, width: 400, height: 300 } },
+      {
+        kind: "paragraph",
+        textId: "pg001_p000",
+        top: 100,
+        left: 50,
+        lineHeight: 12,
+        segments: [
+          { text: "x", style: { "font-family": "Merriweather,serif", "font-size": "12px" } },
+        ],
+        text: "x",
+      },
+    ]
+    const section = sectionFixedLayoutPage({
+      pageId: "pg001",
+      pageNumber: 1,
+      viewport: { width: 400, height: 300 },
+      drawItems,
+      availableImageIds: new Set(["pg001_im001"]),
+    }).sections[0]
+
+    const html = renderFixedLayoutPage(section, "/images").sections[0].html
+
+    // No double-Merriweather.
+    expect(html).toContain("font-family:Merriweather,serif")
+    expect(html).not.toContain("Merriweather,Merriweather")
+  })
+
+  it("uses max segment font-size as line-height when segments mix sizes", () => {
+    // Narrative paragraph "Remember the warning signs." with body
+    // segments (11.5px) sandwiching a decorative 24px segment. mupdf
+    // reports lineHeight = 12 (the body run); without the override the
+    // 24px segment overflows that 12px line box.
+    const drawItems: DrawItem[] = [
+      { kind: "image", imageId: "pg001_im001", bounds: { x: 0, y: 0, width: 800, height: 400 } },
+      {
+        kind: "paragraph",
+        textId: "pg001_p000",
+        top: 140,
+        left: 37,
+        lineHeight: 12,
+        segments: [
+          { text: "Remember the", style: { "font-family": "MuseoSans,serif", "font-size": "11.5px" } },
+          { text: " warning signs.", style: { "font-family": "Chokle,serif", "font-size": "24px" } },
+        ],
+        text: "Remember the warning signs.",
+        blockId: "b000",
+        blockBounds: { x: 37, y: 140, width: 483, height: 28 },
+        mergedParagraphId: "b000_p01",
+      },
+    ]
+    const section = sectionFixedLayoutPage({
+      pageId: "pg001",
+      pageNumber: 1,
+      viewport: { width: 800, height: 400 },
+      drawItems,
+      availableImageIds: new Set(["pg001_im001"]),
+    }).sections[0]
+
+    const html = renderFixedLayoutPage(section, "/images").sections[0].html
+
+    // Effective line-height should be 24 (max segment fontSize), not 12.
+    const pStyleMatch = html.match(/<p[^>]*data-id="pg001_p000"[^>]*style="([^"]*)"/)
+    expect(pStyleMatch).not.toBeNull()
+    expect(pStyleMatch![1]).toContain("line-height:24px")
+    expect(pStyleMatch![1]).not.toContain("line-height:12px")
+  })
+
+  it("keeps mupdf-reported line-height for uniform segment sizes", () => {
+    const drawItems: DrawItem[] = [
+      { kind: "image", imageId: "pg001_im001", bounds: { x: 0, y: 0, width: 400, height: 300 } },
+      {
+        kind: "paragraph",
+        textId: "pg001_p000",
+        top: 100,
+        left: 72,
+        lineHeight: 24,
+        segments: [
+          { text: "I am a little girl.", style: { "font-family": "Palatino,serif", "font-size": "24px" } },
+        ],
+        text: "I am a little girl.",
+      },
+    ]
+    const section = sectionFixedLayoutPage({
+      pageId: "pg001",
+      pageNumber: 1,
+      viewport: { width: 400, height: 300 },
+      drawItems,
+      availableImageIds: new Set(["pg001_im001"]),
+    }).sections[0]
+
+    const html = renderFixedLayoutPage(section, "/images").sections[0].html
+
+    const pStyleMatch = html.match(/<p[^>]*data-id="pg001_p000"[^>]*style="([^"]*)"/)
+    expect(pStyleMatch).not.toBeNull()
+    expect(pStyleMatch![1]).toContain("line-height:24px")
+  })
+
+  it("falls back to legacy single-line rendering when blockBounds is absent", () => {
+    const drawItems: DrawItem[] = [
+      { kind: "image", imageId: "pg001_im001", bounds: { x: 0, y: 0, width: 400, height: 300 } },
+      {
+        kind: "paragraph",
+        textId: "pg001_p000",
+        top: 100,
+        left: 72,
+        lineHeight: 24,
+        segments: [{ text: "legacy" }],
+        text: "legacy",
+      },
+    ]
+    const section = sectionFixedLayoutPage({
+      pageId: "pg001",
+      pageNumber: 1,
+      viewport,
+      drawItems,
+      availableImageIds: new Set(["pg001_im001"]),
+    }).sections[0]
+
+    const html = renderFixedLayoutPage(section, "/images").sections[0].html
+
+    expect(html).toContain("left:72px")
+    expect(html).not.toContain("text-align:")
+    // No width / box-height / overflow rule when blockBounds isn't set —
+    // legacy leaves flow at their original line position. (`line-height`
+    // is fine; `height:` proper isn't.)
+    const pStyleMatch = html.match(/<p[^>]*data-id="pg001_p000"[^>]*style="([^"]*)"/)
+    expect(pStyleMatch).not.toBeNull()
+    expect(pStyleMatch![1]).not.toContain("width:")
+    expect(pStyleMatch![1]).not.toMatch(/(^|;)height:/)
+    expect(pStyleMatch![1]).not.toContain("overflow:")
+  })
+
+  it("preserves font styling from mupdf via leaf html", () => {
+    const html = renderFixedLayoutPage(makeSection(), "/images").sections[0].html
+
+    // Merriweather is auto-inserted before the generic serif terminator
+    // (it's the bundled font; without this insertion spans fall back to
+    // system serif).
+    expect(html).toContain("font-family:Palatino,Merriweather,serif")
+    expect(html).toContain("color:#000000")
+  })
+
+  it("places positions from section JSON as inline styles in viewport coords", () => {
+    const html = renderFixedLayoutPage(makeSection(), "/images").sections[0].html
+
+    expect(html).toContain("top:100px")
+    expect(html).toContain("left:72px")
+    expect(html).toContain("top:158px")
+  })
+
+  it("emits data-segments on <p> so the viewer can rebuild styling on text swap", () => {
+    const html = renderFixedLayoutPage(makeSection(), "/images").sections[0].html
+
+    // Each <p> should carry the JSON segments (HTML-escaped).
+    expect(html).toMatch(/<p data-id="pg001_p000" data-segments="[^"]+"/)
+    // Attribute value must contain the style keys (HTML-escaped JSON quotes).
+    expect(html).toContain("font-family")
+    expect(html).toContain("color")
+    // The attribute value decodes to valid JSON with the expected segment.
+    const match = html.match(/data-id="pg001_p000" data-segments="([^"]+)"/)
+    expect(match).not.toBeNull()
+    const decoded = match![1].replace(/&quot;/g, '"').replace(/&amp;/g, "&")
+    const parsed = JSON.parse(decoded)
+    expect(parsed).toEqual([
+      {
+        text: "I am a little girl.",
+        style: { "font-family": "Palatino,serif", "font-size": "48px", color: "#000000" },
+      },
+    ])
+  })
+
+  it("renders visible text (no transparent fallback)", () => {
+    const html = renderFixedLayoutPage(makeSection(), "/images").sections[0].html
+
+    expect(html).not.toContain("color:transparent")
+  })
+
+  it("adds contrast stroke for white text on light background", () => {
+    const section = makeSection({
+      drawItems: [
+        { kind: "image", imageId: "pg001_im001", bounds: { x: 0, y: 0, width: 400, height: 300 } },
+        {
+          kind: "paragraph",
+          textId: "pg001_p000",
+          top: 100,
+          left: 72,
+          lineHeight: 48,
+          segments: [
+            {
+              text: "white",
+              style: { "font-family": "Palatino,serif", "font-size": "48px", color: "#ffffff" },
+            },
+          ],
+          text: "white",
+        },
+      ],
+    })
+
+    const png = new PNG({ width: 800, height: 600 })
+    png.data.fill(255)
+    const pngBuffer = PNG.sync.write(png)
+    const sampler = createBackgroundSampler(pngBuffer)!
+
+    const html = renderFixedLayoutPage(section, "/images", {
+      backgroundSampler: sampler,
+      renderScale: 2,
+    }).sections[0].html
+
+    expect(html).toContain("-webkit-text-stroke")
+    expect(html).toContain("paint-order:stroke fill")
+    // Stroke must also appear inside `data-segments` so the runtime
+    // translation rebuild (`assets/adt/modules/translations.js`) re-emits
+    // spans with the stroke after a language switch / inline edit. Without
+    // this, low-contrast text becomes invisible against the page image
+    // again on the next swap.
+    const dataSegMatch = html.match(/data-segments="([^"]*)"/)
+    expect(dataSegMatch).not.toBeNull()
+    const decoded = dataSegMatch![1].replace(/&quot;/g, '"').replace(/&amp;/g, "&")
+    const parsed = JSON.parse(decoded) as Array<{ style: Record<string, string> }>
+    expect(parsed[0].style["-webkit-text-stroke"]).toMatch(/^\d+px /)
+    expect(parsed[0].style["paint-order"]).toBe("stroke fill")
+  })
+
+  it("emits an SVG clipPath and applies clip-path:url() to images carrying a PDF clip", () => {
+    const section = makeSection({
+      drawItems: [
+        {
+          kind: "image",
+          imageId: "pg001_im001",
+          bounds: { x: 100, y: 50, width: 200, height: 200 },
+          clipPath: "M150 100L250 100L250 200L150 200Z",
+        },
+      ],
+      availableImageIds: new Set(["pg001_im001"]),
+    })
+
+    const html = renderFixedLayoutPage(section, "/images").sections[0].html
+
+    // SVG <clipPath> defs reference the imageId.
+    expect(html).toContain('id="clip-pg001_im001"')
+    expect(html).toContain('clipPathUnits="userSpaceOnUse"')
+    // Path d carried verbatim, with a translate that subtracts the image's
+    // origin so userSpaceOnUse coords are image-local.
+    expect(html).toContain('d="M150 100L250 100L250 200L150 200Z"')
+    expect(html).toContain('transform="translate(-100,-50)"')
+    // The <img> picks up the clip-path style via the clip-{imageId} ref.
+    expect(html).toMatch(
+      /<img[^>]+style="[^"]*clip-path:url\(#clip-pg001_im001\)/,
+    )
+  })
+
+  it("omits clipPath markup when the source PDF didn't clip the image", () => {
+    const html = renderFixedLayoutPage(makeSection(), "/images").sections[0].html
+
+    expect(html).not.toContain("<clipPath")
+    expect(html).not.toContain("clip-path:url(")
+  })
+
+  it("emits mix-blend-mode and opacity for images drawn under a non-Normal PDF blend mode", () => {
+    const section = makeSection({
+      drawItems: [
+        {
+          kind: "image",
+          imageId: "pg001_im001",
+          bounds: { x: 0, y: 0, width: 200, height: 100 },
+          blendMode: "multiply",
+          opacity: 0.8,
+        },
+      ],
+      availableImageIds: new Set(["pg001_im001"]),
+    })
+
+    const html = renderFixedLayoutPage(section, "/images").sections[0].html
+    expect(html).toMatch(
+      /<img[^>]+style="[^"]*mix-blend-mode:multiply[^"]*"/,
+    )
+    expect(html).toMatch(/<img[^>]+style="[^"]*opacity:0\.8/)
+  })
+
+  it("omits blend-mode and opacity styles when not provided", () => {
+    const html = renderFixedLayoutPage(makeSection(), "/images").sections[0].html
+    expect(html).not.toContain("mix-blend-mode")
+    expect(html).not.toContain("opacity:")
+  })
+
+  it("does not add contrast stroke for black text on white background", () => {
+    const png = new PNG({ width: 800, height: 600 })
+    png.data.fill(255)
+    const pngBuffer = PNG.sync.write(png)
+    const sampler = createBackgroundSampler(pngBuffer)!
+
+    const html = renderFixedLayoutPage(makeSection(), "/images", {
+      backgroundSampler: sampler,
+      renderScale: 2,
+    }).sections[0].html
+
+    expect(html).not.toContain("-webkit-text-stroke")
+  })
+})
+
+describe("contrastRatio", () => {
+  it("returns 21:1 for black on white", () => {
+    const ratio = contrastRatio({ r: 0, g: 0, b: 0 }, { r: 255, g: 255, b: 255 })
+    expect(ratio).toBeCloseTo(21, 0)
+  })
+
+  it("returns 1:1 for same colors", () => {
+    const ratio = contrastRatio({ r: 128, g: 128, b: 128 }, { r: 128, g: 128, b: 128 })
+    expect(ratio).toBeCloseTo(1, 1)
+  })
+
+  it("detects insufficient contrast for white text on light gray", () => {
+    const ratio = contrastRatio({ r: 255, g: 255, b: 255 }, { r: 220, g: 220, b: 220 })
+    expect(ratio).toBeLessThan(3)
+  })
+})
+
+describe("processFixedLayoutPages", () => {
+  const tmpDirs: string[] = []
+  afterEach(() => {
+    for (const dir of tmpDirs) fs.rmSync(dir, { recursive: true, force: true })
+    tmpDirs.length = 0
+  })
+
+  function solidPngBuffer(width: number, height: number): Buffer {
+    const png = new PNG({ width, height })
+    png.data.fill(255)
+    return PNG.sync.write(png)
+  }
+
+  function makeImage(
+    imageId: string,
+    pageId: string,
+    width: number,
+    height: number,
+    bounds?: { x: number; y: number; width: number; height: number },
+  ): ExtractedImage {
+    const buffer = solidPngBuffer(width, height)
+    return {
+      imageId,
+      pageId,
+      buffer,
+      format: "png",
+      width,
+      height,
+      hash: "",
+      renderMethod: "raster",
+      bounds,
+    }
+  }
+
+  it("renders all positioned images and paragraphs in draw order", () => {
+    const booksRoot = fs.mkdtempSync(path.join(os.tmpdir(), "adt-fixlayout-test-"))
+    tmpDirs.push(booksRoot)
+
+    const storage = createBookStorage("test-book", booksRoot)
+    try {
+      const positionedText: PositionedTextOutput = {
+        drawItems: [
+          { kind: "image", imageId: "pg001_im001", bounds: { x: 50, y: 50, width: 300, height: 200 } },
+          { kind: "image", imageId: "pg001_im002", bounds: { x: 200, y: 100, width: 30, height: 20 } },
+        ],
+        pageWidth: 400,
+        pageHeight: 300,
+        renderWidth: 800,
+        renderHeight: 600,
+      }
+
+      storage.putExtractedPage({
+        pageId: "pg001",
+        pageNumber: 1,
+        text: "",
+        pageImage: makeImage("pg001_page", "pg001", 800, 600),
+        images: [
+          makeImage("pg001_im001", "pg001", 600, 400, { x: 50, y: 50, width: 300, height: 200 }),
+          makeImage("pg001_im002", "pg001", 60, 40, { x: 200, y: 100, width: 30, height: 20 }),
+        ],
+        positionedText,
+      })
+
+      storage.putNodeData("positioned-text", "pg001", positionedText)
+      storage.putNodeData("image-filtering", "pg001", {
+        images: [
+          { imageId: "pg001_page", isPruned: true, reason: "full-page render" },
+          { imageId: "pg001_im001", isPruned: false },
+          { imageId: "pg001_im002", isPruned: false },
+        ],
+      })
+
+      processFixedLayoutPages(storage, "/images")
+
+      const rendering = storage.getLatestNodeData("web-rendering", "pg001")
+      expect(rendering).not.toBeNull()
+      const html = (rendering!.data as { sections: Array<{ html: string }> }).sections[0].html
+
+      expect(html).toContain('data-id="pg001_im001"')
+      expect(html).toContain('data-id="pg001_im002"')
+      // Both images positioned at their bounds
+      expect(html).toMatch(/data-id="pg001_im002"[^>]*top:100px/)
+      expect(html).toMatch(/data-id="pg001_im002"[^>]*left:200px/)
+    } finally {
+      storage.close()
+    }
+  })
+
+  it("excludes images that image-filtering marked pruned", () => {
+    // Fixed-layout trusts image-filtering's pruning decisions: the wizard
+    // writes image_filters that disable size/complexity/meaningfulness
+    // filtering for these books, so in practice nothing gets pruned except
+    // the full-page render — but if something *did* get pruned (manual
+    // user prune, etc.) the renderer respects that.
+    const booksRoot = fs.mkdtempSync(path.join(os.tmpdir(), "adt-fixlayout-test-"))
+    tmpDirs.push(booksRoot)
+
+    const storage = createBookStorage("test-book", booksRoot)
+    try {
+      const positionedText: PositionedTextOutput = {
+        drawItems: [
+          { kind: "image", imageId: "pg001_im001", bounds: { x: 50, y: 50, width: 300, height: 200 } },
+          { kind: "image", imageId: "pg001_im002", bounds: { x: 200, y: 100, width: 30, height: 20 } },
+        ],
+        pageWidth: 400,
+        pageHeight: 300,
+        renderWidth: 800,
+        renderHeight: 600,
+      }
+
+      storage.putExtractedPage({
+        pageId: "pg001",
+        pageNumber: 1,
+        text: "",
+        pageImage: makeImage("pg001_page", "pg001", 800, 600),
+        images: [
+          makeImage("pg001_im001", "pg001", 600, 400, { x: 50, y: 50, width: 300, height: 200 }),
+          makeImage("pg001_im002", "pg001", 60, 40, { x: 200, y: 100, width: 30, height: 20 }),
+        ],
+        positionedText,
+      })
+
+      storage.putNodeData("positioned-text", "pg001", positionedText)
+      storage.putNodeData("image-filtering", "pg001", {
+        images: [
+          { imageId: "pg001_page", isPruned: true, reason: "full-page render" },
+          { imageId: "pg001_im001", isPruned: false },
+          { imageId: "pg001_im002", isPruned: true, reason: "not meaningful" },
+        ],
+      })
+
+      processFixedLayoutPages(storage, "/images")
+
+      const rendering = storage.getLatestNodeData("web-rendering", "pg001")!
+      const html = (rendering.data as { sections: Array<{ html: string }> }).sections[0].html
+
+      expect(html).toContain('data-id="pg001_im001"')
+      expect(html).not.toContain('data-id="pg001_im002"')
+    } finally {
+      storage.close()
+    }
+  })
+})

--- a/packages/pipeline/src/__tests__/fixed-layout-rendering.test.ts
+++ b/packages/pipeline/src/__tests__/fixed-layout-rendering.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach } from "vitest"
 import fs from "node:fs"
 import os from "node:os"
 import path from "node:path"
-import { sectionFixedLayoutPage, renderFixedLayoutPage, contrastRatio, createBackgroundSampler, processFixedLayoutPages } from "../fixed-layout-rendering.js"
+import { sectionFixedLayoutPage, renderFixedLayoutPage, processFixedLayoutPages } from "../fixed-layout-rendering.js"
 import type { ContentNodeData, DrawItem, NodePlacement, PageSectioningSection, PositionedTextOutput } from "@adt/types"
 import type { ExtractedImage } from "@adt/pdf"
 import { createBookStorage } from "@adt/storage"
@@ -756,52 +756,6 @@ describe("renderFixedLayoutPage", () => {
     expect(html).not.toContain("color:transparent")
   })
 
-  it("adds contrast stroke for white text on light background", () => {
-    const section = makeSection({
-      drawItems: [
-        { kind: "image", imageId: "pg001_im001", bounds: { x: 0, y: 0, width: 400, height: 300 } },
-        {
-          kind: "paragraph",
-          textId: "pg001_p000",
-          top: 100,
-          left: 72,
-          lineHeight: 48,
-          segments: [
-            {
-              text: "white",
-              style: { "font-family": "Palatino,serif", "font-size": "48px", color: "#ffffff" },
-            },
-          ],
-          text: "white",
-        },
-      ],
-    })
-
-    const png = new PNG({ width: 800, height: 600 })
-    png.data.fill(255)
-    const pngBuffer = PNG.sync.write(png)
-    const sampler = createBackgroundSampler(pngBuffer)!
-
-    const html = renderFixedLayoutPage(section, "/images", {
-      backgroundSampler: sampler,
-      renderScale: 2,
-    }).sections[0].html
-
-    expect(html).toContain("-webkit-text-stroke")
-    expect(html).toContain("paint-order:stroke fill")
-    // Stroke must also appear inside `data-segments` so the runtime
-    // translation rebuild (`assets/adt/modules/translations.js`) re-emits
-    // spans with the stroke after a language switch / inline edit. Without
-    // this, low-contrast text becomes invisible against the page image
-    // again on the next swap.
-    const dataSegMatch = html.match(/data-segments="([^"]*)"/)
-    expect(dataSegMatch).not.toBeNull()
-    const decoded = dataSegMatch![1].replace(/&quot;/g, '"').replace(/&amp;/g, "&")
-    const parsed = JSON.parse(decoded) as Array<{ style: Record<string, string> }>
-    expect(parsed[0].style["-webkit-text-stroke"]).toMatch(/^\d+px /)
-    expect(parsed[0].style["paint-order"]).toBe("stroke fill")
-  })
-
   it("emits an SVG clipPath and applies clip-path:url() to images carrying a PDF clip", () => {
     const section = makeSection({
       drawItems: [
@@ -864,36 +818,6 @@ describe("renderFixedLayoutPage", () => {
     expect(html).not.toContain("opacity:")
   })
 
-  it("does not add contrast stroke for black text on white background", () => {
-    const png = new PNG({ width: 800, height: 600 })
-    png.data.fill(255)
-    const pngBuffer = PNG.sync.write(png)
-    const sampler = createBackgroundSampler(pngBuffer)!
-
-    const html = renderFixedLayoutPage(makeSection(), "/images", {
-      backgroundSampler: sampler,
-      renderScale: 2,
-    }).sections[0].html
-
-    expect(html).not.toContain("-webkit-text-stroke")
-  })
-})
-
-describe("contrastRatio", () => {
-  it("returns 21:1 for black on white", () => {
-    const ratio = contrastRatio({ r: 0, g: 0, b: 0 }, { r: 255, g: 255, b: 255 })
-    expect(ratio).toBeCloseTo(21, 0)
-  })
-
-  it("returns 1:1 for same colors", () => {
-    const ratio = contrastRatio({ r: 128, g: 128, b: 128 }, { r: 128, g: 128, b: 128 })
-    expect(ratio).toBeCloseTo(1, 1)
-  })
-
-  it("detects insufficient contrast for white text on light gray", () => {
-    const ratio = contrastRatio({ r: 255, g: 255, b: 255 }, { r: 220, g: 220, b: 220 })
-    expect(ratio).toBeLessThan(3)
-  })
 })
 
 describe("processFixedLayoutPages", () => {

--- a/packages/pipeline/src/__tests__/fixed-layout-rendering.test.ts
+++ b/packages/pipeline/src/__tests__/fixed-layout-rendering.test.ts
@@ -379,8 +379,12 @@ describe("renderFixedLayoutPage", () => {
 
     expect(html).toContain('data-id="pg001_p000"')
     expect(html).toContain('data-id="pg001_p001"')
-    expect(html).toContain("I am a little girl.")
-    expect(html).toContain("My name is Sue.")
+    // Words are wrapped in per-word <span id>; check first + last word
+    // of each paragraph rather than the contiguous string.
+    expect(html).toContain(">I</span>")
+    expect(html).toContain(">girl.</span>")
+    expect(html).toContain(">My</span>")
+    expect(html).toContain(">Sue.</span>")
   })
 
   it("emits width + text-align on a paragraph that carries blockBounds", () => {
@@ -694,6 +698,125 @@ describe("renderFixedLayoutPage", () => {
         style: { "font-family": "Palatino,serif", "font-size": "48px", color: "#000000" },
       },
     ])
+  })
+
+  it("wraps each word in <span id> derived from the paragraph nodeId", () => {
+    const html = renderFixedLayoutPage(makeSection(), "/images").sections[0].html
+
+    // "I am a little girl." → 5 words → ids _w001 .. _w005 on pg001_p000.
+    // Each word span wraps the per-run <span style> fragment(s) (here a
+    // single styled run per word).
+    expect(html).toMatch(/<span id="pg001_p000_w001"><span style="[^"]*">I<\/span><\/span>/)
+    expect(html).toMatch(/<span id="pg001_p000_w002"><span style="[^"]*">am<\/span><\/span>/)
+    expect(html).toMatch(/<span id="pg001_p000_w003"><span style="[^"]*">a<\/span><\/span>/)
+    expect(html).toMatch(/<span id="pg001_p000_w004"><span style="[^"]*">little<\/span><\/span>/)
+    expect(html).toMatch(/<span id="pg001_p000_w005"><span style="[^"]*">girl\.<\/span><\/span>/)
+    // Numbering restarts per paragraph.
+    expect(html).toMatch(/<span id="pg001_p001_w001"><span style="[^"]*">My<\/span><\/span>/)
+  })
+
+  it("keeps whitespace between word spans (so word boxes stay tight)", () => {
+    const html = renderFixedLayoutPage(makeSection(), "/images").sections[0].html
+
+    // The space between "I" and "am" must sit OUTSIDE the word spans —
+    // otherwise word measurement (and any per-word styling later) picks up
+    // surrounding whitespace.
+    expect(html).toMatch(
+      /<span id="pg001_p000_w001"><span style="[^"]*">I<\/span><\/span> <span id="pg001_p000_w002"><span style="[^"]*">am<\/span><\/span>/,
+    )
+  })
+
+  it("keeps a word split across style runs as ONE word span wrapping the run fragments", () => {
+    // A single coloured letter inside a word ("la" + white "h" + "ars" →
+    // "lahars") must NOT produce one word id per fragment — Whisper emits
+    // one timestamp for the spoken word, so extra ids would force the
+    // SMIL/viewer count guard to fall back to block-level highlighting,
+    // and reusing one id across fragments is an epubcheck duplicate-id.
+    const baseStyle = { "font-family": "Palatino,serif", "font-size": "48px", color: "#000000" }
+    const whiteStyle = { ...baseStyle, color: "#ffffff" }
+    const section = sectionFixedLayoutPage({
+      pageId: "pg001",
+      pageNumber: 1,
+      viewport,
+      drawItems: [
+        { kind: "image", imageId: "pg001_im001", bounds: { x: 0, y: 0, width: 400, height: 300 } },
+        {
+          kind: "paragraph",
+          textId: "pg001_p000",
+          top: 100,
+          left: 72,
+          lineHeight: 48,
+          segments: [
+            { text: "the la", style: baseStyle },
+            { text: "h", style: whiteStyle },
+            { text: "ars came", style: baseStyle },
+          ],
+          text: "the lahars came",
+        },
+      ],
+      availableImageIds: new Set(["pg001_im001"]),
+    }).sections[0]
+
+    const html = renderFixedLayoutPage(section, "/images").sections[0].html
+
+    // "the" "lahars" "came" → exactly 3 word ids (the old per-fragment
+    // tokenisation would have produced 5: the / la / h / ars / came).
+    expect(html).toContain('<span id="pg001_p000_w001">')
+    expect(html).toContain('<span id="pg001_p000_w002">')
+    expect(html).toContain('<span id="pg001_p000_w003">')
+    expect(html).not.toContain("pg001_p000_w004")
+    // The split word is one `<span id>` wrapping the three styled fragments.
+    expect(html).toMatch(
+      /<span id="pg001_p000_w002"><span style="[^"]*color:#000000[^"]*">la<\/span><span style="[^"]*color:#ffffff[^"]*">h<\/span><span style="[^"]*color:#000000[^"]*">ars<\/span><\/span>/,
+    )
+  })
+
+  it("numbers words across segments within the same paragraph", () => {
+    const palatinoBlackStyle = {
+      "font-family": "Palatino,serif",
+      "font-size": "48px",
+      color: "#000000",
+    }
+    const yellowStyle = { ...palatinoBlackStyle, color: "#fff200" }
+    const section = sectionFixedLayoutPage({
+      pageId: "pg001",
+      pageNumber: 1,
+      viewport,
+      drawItems: [
+        { kind: "image", imageId: "pg001_im001", bounds: { x: 0, y: 0, width: 400, height: 300 } },
+        {
+          kind: "paragraph",
+          textId: "pg001_p000",
+          top: 100,
+          left: 72,
+          lineHeight: 48,
+          segments: [
+            { text: "There are long, ", style: palatinoBlackStyle },
+            { text: "yellow ", style: yellowStyle },
+            { text: "bookshelves.", style: palatinoBlackStyle },
+          ],
+          text: "There are long, yellow bookshelves.",
+        },
+      ],
+      availableImageIds: new Set(["pg001_im001"]),
+    }).sections[0]
+
+    const html = renderFixedLayoutPage(section, "/images").sections[0].html
+
+    // Sequential ids span across segment boundaries (no reset per styled run).
+    expect(html).toMatch(/<span id="pg001_p000_w001"><span style="[^"]*">There<\/span><\/span>/)
+    expect(html).toMatch(/<span id="pg001_p000_w002"><span style="[^"]*">are<\/span><\/span>/)
+    expect(html).toMatch(/<span id="pg001_p000_w003"><span style="[^"]*">long,<\/span><\/span>/)
+    expect(html).toMatch(/<span id="pg001_p000_w004"><span style="[^"]*">yellow<\/span><\/span>/)
+    expect(html).toMatch(/<span id="pg001_p000_w005"><span style="[^"]*">bookshelves\.<\/span><\/span>/)
+
+    // The per-word <span id> wraps the per-run <span style> fragment(s), so
+    // a word lying entirely in a coloured run keeps a single id and the
+    // run's style cascades to it. The trailing space stays outside the word
+    // span.
+    expect(html).toMatch(
+      /<span id="pg001_p000_w004"><span style="[^"]*color:#fff200[^"]*">yellow<\/span><\/span> /,
+    )
   })
 
   it("renders visible text (no transparent fallback)", () => {

--- a/packages/pipeline/src/__tests__/package-epub.test.ts
+++ b/packages/pipeline/src/__tests__/package-epub.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from "vitest"
+import { mirrorDataIdToId, wrapWordSpans } from "../package-epub.js"
+
+describe("mirrorDataIdToId", () => {
+  it("adds id= matching data-id when id is absent", () => {
+    const xhtml = `<h1 data-id="pg002_n0002" class="x">title</h1>`
+    expect(mirrorDataIdToId(xhtml)).toBe(
+      `<h1 data-id="pg002_n0002" class="x" id="pg002_n0002">title</h1>`,
+    )
+  })
+
+  it("leaves existing id attributes untouched", () => {
+    const xhtml = `<h1 id="page-heading" data-id="pg001_n0001">title</h1>`
+    expect(mirrorDataIdToId(xhtml)).toBe(xhtml)
+  })
+
+  it("ignores elements without data-id", () => {
+    const xhtml = `<p class="x">no anchor</p>`
+    expect(mirrorDataIdToId(xhtml)).toBe(xhtml)
+  })
+
+  it("does not touch word spans that already carry an id", () => {
+    // Fixed-layout renderer emits per-word spans like `<span id="…_w001">`
+    // (no data-id). They must be left alone.
+    const xhtml = `<span id="pg001_n0001_w001">Hello</span>`
+    expect(mirrorDataIdToId(xhtml)).toBe(xhtml)
+  })
+
+  it("handles multiple elements in one document", () => {
+    const xhtml = `<p data-id="a">A</p><p data-id="b">B</p>`
+    expect(mirrorDataIdToId(xhtml)).toBe(
+      `<p data-id="a" id="a">A</p><p data-id="b" id="b">B</p>`,
+    )
+  })
+
+  it("works on self-closing void elements (img/br)", () => {
+    const xhtml = `<img data-id="pg001_im001" src="x.png"/>`
+    expect(mirrorDataIdToId(xhtml)).toBe(
+      `<img data-id="pg001_im001" src="x.png" id="pg001_im001"/>`,
+    )
+  })
+
+  it("does not mistake id-suffixed attribute names for the id attribute", () => {
+    // Defensive: an attribute like `data-id="x"` already contains the
+    // substring `id=`. The regex must only match the standalone `id=` attr.
+    const xhtml = `<p data-id="pg002_n0002">title</p>`
+    expect(mirrorDataIdToId(xhtml)).toBe(
+      `<p data-id="pg002_n0002" id="pg002_n0002">title</p>`,
+    )
+  })
+})
+
+describe("wrapWordSpans", () => {
+  it("wraps each word inside [data-id] elements in <span id>", () => {
+    const html = `<html><body><p data-id="pg002_n0002">Hello world.</p></body></html>`
+    const out = wrapWordSpans(html)
+    expect(out).toContain(`<span id="pg002_n0002_w001">Hello</span>`)
+    expect(out).toContain(`<span id="pg002_n0002_w002">world</span>`)
+    // Trailing punctuation stays outside the word span.
+    expect(out).toContain(`</span>.</p>`)
+  })
+
+  it("preserves inline elements while wrapping the text they contain", () => {
+    const html =
+      `<html><body><p data-id="pg002_n0002">She walks <em>tall</em> and proud.</p></body></html>`
+    const out = wrapWordSpans(html)
+    expect(out).toContain(`<span id="pg002_n0002_w001">She</span>`)
+    expect(out).toContain(`<span id="pg002_n0002_w002">walks</span>`)
+    // The <em> wrapper is kept; the word inside gets its own id.
+    expect(out).toContain(`<em><span id="pg002_n0002_w003">tall</span></em>`)
+    expect(out).toContain(`<span id="pg002_n0002_w004">and</span>`)
+    expect(out).toContain(`<span id="pg002_n0002_w005">proud</span>`)
+  })
+
+  it("skips img[data-id] — image audio is not in the overlay pipeline", () => {
+    const html = `<html><body><img data-id="pg001_im001" src="x.png"></body></html>`
+    const out = wrapWordSpans(html)
+    expect(out).not.toContain(`pg001_im001_w`)
+  })
+
+  it("re-emits fixed-layout paragraphs from data-segments with word spans wrapping style runs", () => {
+    // The renderer emits a structural shell (styled segments, no word ids).
+    // Packaging consumes data-segments to wrap words, including the
+    // cross-style-run "lahars" case — one word span around two styled
+    // fragments.
+    const segments = [
+      { text: "the la", style: { color: "#000000" } },
+      { text: "h", style: { color: "#ffffff" } },
+      { text: "ars came", style: { color: "#000000" } },
+    ]
+    const dataSegments = JSON.stringify(segments).replace(/"/g, "&quot;")
+    const html =
+      `<html><body><p data-id="pg001_p000" data-segments="${dataSegments}">` +
+      `<span style="color:#000000">the la</span>` +
+      `<span style="color:#ffffff">h</span>` +
+      `<span style="color:#000000">ars came</span>` +
+      `</p></body></html>`
+    const out = wrapWordSpans(html)
+    expect(out).toContain(`<span id="pg001_p000_w001">`)
+    expect(out).toContain(`<span id="pg001_p000_w002">`)
+    expect(out).toContain(`<span id="pg001_p000_w003">`)
+    expect(out).not.toContain(`pg001_p000_w004`)
+    // "lahars" (w002) wraps three styled fragments straddling the runs.
+    expect(out).toMatch(
+      /<span id="pg001_p000_w002"><span style="color:#000000">la<\/span><span style="color:#ffffff">h<\/span><span style="color:#000000">ars<\/span><\/span>/,
+    )
+  })
+
+  it("applies the bundled font-family fallback to data-segments styles", () => {
+    // wrapBySegments must use the same styleMapToInline as the renderer so
+    // the exported EPUB renders fonts the same way the in-studio viewer
+    // does — `Palatino,serif` becomes `Palatino,Merriweather,serif` so a
+    // bundled face is available when the declared one isn't.
+    const segments = [
+      { text: "Hello", style: { "font-family": "Palatino,serif", color: "#000" } },
+    ]
+    const dataSegments = JSON.stringify(segments).replace(/"/g, "&quot;")
+    const html =
+      `<html><body><p data-id="pg001_p000" data-segments="${dataSegments}">` +
+      `<span style="font-family:Palatino,Merriweather,serif;color:#000">Hello</span>` +
+      `</p></body></html>`
+    const out = wrapWordSpans(html)
+    expect(out).toContain("font-family:Palatino,Merriweather,serif")
+  })
+
+  it("walks multiple [data-id] elements with independent word numbering", () => {
+    const html =
+      `<html><body><h1 data-id="pg001_n0001">Title here</h1><p data-id="pg001_n0002">Body.</p></body></html>`
+    const out = wrapWordSpans(html)
+    expect(out).toContain(`<span id="pg001_n0001_w001">Title</span>`)
+    expect(out).toContain(`<span id="pg001_n0001_w002">here</span>`)
+    expect(out).toContain(`<span id="pg001_n0002_w001">Body</span>`)
+  })
+
+  it("leaves elements without data-id untouched", () => {
+    const html = `<html><body><div><p>not anchored</p></div></body></html>`
+    const out = wrapWordSpans(html)
+    expect(out).toContain(`<p>not anchored</p>`)
+    expect(out).not.toContain(`<span id=`)
+  })
+
+  it("preserves attributes other than data-id verbatim", () => {
+    const html = `<html><body><p data-id="pg001_n0001" class="lead">Hi.</p></body></html>`
+    const out = wrapWordSpans(html)
+    expect(out).toContain(`class="lead"`)
+    expect(out).toContain(`data-id="pg001_n0001"`)
+    expect(out).toContain(`<span id="pg001_n0001_w001">Hi</span>`)
+  })
+})

--- a/packages/pipeline/src/__tests__/smil.test.ts
+++ b/packages/pipeline/src/__tests__/smil.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect } from "vitest"
+import { buildSmil, formatMediaDuration } from "../smil.js"
+
+const para = (
+  paragraphId: string,
+  audioPath: string,
+  wordIds: string[],
+  whisperWords: { word: string; start: number; end: number }[],
+  audioDuration?: number,
+) => ({
+  paragraphId,
+  audioPath,
+  audioDuration: audioDuration ?? (whisperWords.length > 0 ? whisperWords[whisperWords.length - 1].end : 0),
+  wordIds,
+  whisperWords,
+})
+
+describe("buildSmil", () => {
+  it("emits word-level <par> when source span count matches whisper word count", () => {
+    const result = buildSmil({
+      pageHref: "../pg001_sec001.xhtml",
+      paragraphs: [
+        para(
+          "pg001_p001",
+          "../en/audio/pg001_p001.mp3",
+          ["pg001_p001_w001", "pg001_p001_w002", "pg001_p001_w003"],
+          [
+            { word: "Hello", start: 0, end: 0.4 },
+            { word: "there", start: 0.4, end: 0.8 },
+            { word: "Pip", start: 0.8, end: 1.2 },
+          ],
+        ),
+      ],
+    })
+
+    expect(result).not.toBeNull()
+    expect(result!.xml).toContain('xmlns="http://www.w3.org/ns/SMIL"')
+    expect(result!.xml).toContain('xmlns:epub="http://www.idpf.org/2007/ops"')
+    expect(result!.xml).toContain('version="3.0"')
+    // One <par> per word with clipBegin/clipEnd carrying the whisper times.
+    expect(result!.xml).toContain('src="../pg001_sec001.xhtml#pg001_p001_w001"')
+    expect(result!.xml).toContain('clipBegin="0.000s" clipEnd="0.400s"')
+    expect(result!.xml).toContain('src="../pg001_sec001.xhtml#pg001_p001_w002"')
+    expect(result!.xml).toContain('clipBegin="0.400s" clipEnd="0.800s"')
+    expect(result!.xml).toContain('src="../pg001_sec001.xhtml#pg001_p001_w003"')
+    expect(result!.xml).toContain('clipBegin="0.800s" clipEnd="1.200s"')
+  })
+
+  it("falls back to a single paragraph-level <par> when counts diverge", () => {
+    const result = buildSmil({
+      pageHref: "../pg001_sec001.xhtml",
+      paragraphs: [
+        para(
+          "pg001_p002",
+          "../en/audio/pg001_p002.mp3",
+          ["pg001_p002_w001", "pg001_p002_w002", "pg001_p002_w003"], // 3 source words
+          [
+            { word: "twenty", start: 0, end: 0.3 }, // 4 whisper words — counts differ
+            { word: "three", start: 0.3, end: 0.6 },
+            { word: "in", start: 0.6, end: 0.7 },
+            { word: "all", start: 0.7, end: 1.0 },
+          ],
+          1.0,
+        ),
+      ],
+    })
+
+    expect(result).not.toBeNull()
+    // Exactly one <par> for this paragraph (paragraph-level fallback),
+    // no per-word fragment refs.
+    const parMatches = result!.xml.match(/<par id="/g) ?? []
+    expect(parMatches).toHaveLength(1)
+    expect(result!.xml).toContain('src="../pg001_sec001.xhtml#pg001_p002"')
+    expect(result!.xml).not.toContain("pg001_p002_w001")
+    // Paragraph-level still emits explicit clip bounds so EPUB readers and
+    // EPUBCheck don't have to infer audio duration from the file.
+    expect(result!.xml).toContain('clipBegin="0.000s" clipEnd="1.000s"')
+  })
+
+  it("falls back to paragraph-level when paragraph has no word ids", () => {
+    const result = buildSmil({
+      pageHref: "../pg001.xhtml",
+      paragraphs: [
+        para(
+          "pg001_p001",
+          "../en/audio/pg001_p001.mp3",
+          [], // empty word ids — reflowable / CJK / no whitespace tokenisation
+          [{ word: "你好", start: 0, end: 0.5 }],
+          0.5,
+        ),
+      ],
+    })
+
+    expect(result).not.toBeNull()
+    expect(result!.xml).toContain('src="../pg001.xhtml#pg001_p001"')
+    expect(result!.xml).toContain('clipBegin="0.000s" clipEnd="0.500s"')
+  })
+
+  it("skips paragraphs with no whisper data and excludes their duration", () => {
+    const result = buildSmil({
+      pageHref: "../pg001.xhtml",
+      paragraphs: [
+        para(
+          "pg001_p001",
+          "../en/audio/pg001_p001.mp3",
+          ["pg001_p001_w001"],
+          [{ word: "hello", start: 0, end: 0.5 }],
+          0.5,
+        ),
+        para(
+          "pg001_p002",
+          "../en/audio/pg001_p002.mp3",
+          ["pg001_p002_w001"],
+          [], // no whisper data — skipped
+          1.0,
+        ),
+      ],
+    })
+
+    expect(result).not.toBeNull()
+    expect(result!.xml).toContain("seq-pg001_p001")
+    expect(result!.xml).not.toContain("seq-pg001_p002")
+    // Total duration excludes the skipped paragraph.
+    expect(result!.durationSeconds).toBeCloseTo(0.5, 5)
+  })
+
+  it("returns null when no paragraph produces audio", () => {
+    const result = buildSmil({
+      pageHref: "../pg001.xhtml",
+      paragraphs: [para("pg001_p001", "../en/audio/pg001_p001.mp3", ["w001"], [], 0)],
+    })
+    expect(result).toBeNull()
+  })
+
+  it("returns null for an empty paragraphs list", () => {
+    const result = buildSmil({ pageHref: "../pg001.xhtml", paragraphs: [] })
+    expect(result).toBeNull()
+  })
+
+  it("emits one <seq> per paragraph in input order, with stable par ids", () => {
+    const result = buildSmil({
+      pageHref: "../pg001.xhtml",
+      paragraphs: [
+        para("pg001_p001", "../audio/a.mp3", ["w_a_001"], [{ word: "a", start: 0, end: 0.1 }]),
+        para("pg001_p002", "../audio/b.mp3", ["w_b_001"], [{ word: "b", start: 0, end: 0.2 }]),
+      ],
+    })
+    expect(result).not.toBeNull()
+    // Sequences appear in input order.
+    const seqOrder = (result!.xml.match(/seq id="seq-(pg001_p\d{3})"/g) ?? []).map((m) => m)
+    expect(seqOrder).toEqual([
+      'seq id="seq-pg001_p001"',
+      'seq id="seq-pg001_p002"',
+    ])
+    // Par ids are zero-padded and unique across sequences.
+    expect(result!.xml).toContain('par id="par0001"')
+    expect(result!.xml).toContain('par id="par0002"')
+  })
+
+  it("attaches epub:textref on <seq> pointing to the paragraph fragment", () => {
+    const result = buildSmil({
+      pageHref: "../pg001.xhtml",
+      paragraphs: [
+        para("pg001_p001", "../audio/a.mp3", ["w001"], [{ word: "a", start: 0, end: 0.1 }]),
+      ],
+    })
+    expect(result).not.toBeNull()
+    expect(result!.xml).toContain(
+      'epub:textref="../pg001.xhtml#pg001_p001"',
+    )
+  })
+
+  it("formats clock values with millisecond precision", () => {
+    const result = buildSmil({
+      pageHref: "../pg001.xhtml",
+      paragraphs: [
+        para(
+          "pg001_p001",
+          "../audio/a.mp3",
+          ["w001"],
+          [{ word: "a", start: 1.234567, end: 5.678901 }],
+        ),
+      ],
+    })
+    expect(result).not.toBeNull()
+    // Three decimal places — matches SMIL convention + epubcheck expectations.
+    expect(result!.xml).toContain('clipBegin="1.235s" clipEnd="5.679s"')
+  })
+
+  it("escapes XML special chars in ids and paths", () => {
+    const result = buildSmil({
+      pageHref: '../page&with"quote.xhtml',
+      paragraphs: [
+        para(
+          'p&id"001',
+          '../a&b.mp3',
+          ['p&id"001_w001'],
+          [{ word: "x", start: 0, end: 0.1 }],
+        ),
+      ],
+    })
+    expect(result).not.toBeNull()
+    expect(result!.xml).toContain("&amp;")
+    expect(result!.xml).toContain("&quot;")
+    expect(result!.xml).not.toContain('"&"')
+  })
+
+  it("aggregates audioDuration across all included paragraphs", () => {
+    const result = buildSmil({
+      pageHref: "../pg001.xhtml",
+      paragraphs: [
+        para("pg001_p001", "../a.mp3", ["w001"], [{ word: "a", start: 0, end: 0.5 }], 0.5),
+        para("pg001_p002", "../b.mp3", ["w001"], [{ word: "b", start: 0, end: 1.2 }], 1.2),
+      ],
+    })
+    expect(result).not.toBeNull()
+    expect(result!.durationSeconds).toBeCloseTo(1.7, 5)
+  })
+})
+
+describe("formatMediaDuration", () => {
+  it("formats seconds as PT{n}S with 3 decimals", () => {
+    expect(formatMediaDuration(12.345)).toBe("PT12.345S")
+    expect(formatMediaDuration(0)).toBe("PT0.000S")
+    expect(formatMediaDuration(123.4567)).toBe("PT123.457S")
+  })
+})

--- a/packages/pipeline/src/__tests__/word-tokenize.test.ts
+++ b/packages/pipeline/src/__tests__/word-tokenize.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest"
+import { tokenizeWords, extractWords, WORD_PATTERN } from "../word-tokenize.js"
+
+describe("tokenizeWords", () => {
+  it("preserves the original text losslessly across segments", () => {
+    const text = 'During lunch, she buys food. "Always."'
+    const segs = tokenizeWords(text)
+    expect(segs.map((s) => s.text).join("")).toBe(text)
+  })
+
+  it("splits punctuation off as separators", () => {
+    const segs = tokenizeWords("Hello, world.")
+    expect(segs).toEqual([
+      { type: "word", text: "Hello", start: 0, end: 5, wordIndex: 0 },
+      { type: "separator", text: ", ", start: 5, end: 7 },
+      { type: "word", text: "world", start: 7, end: 12, wordIndex: 1 },
+      { type: "separator", text: ".", start: 12, end: 13 },
+    ])
+  })
+
+  it("keeps contractions and curly-apostrophe contractions as single words", () => {
+    expect(extractWords("don't can't it's")).toEqual(["don't", "can't", "it's"])
+    expect(extractWords("don’t can’t it’s")).toEqual(["don’t", "can’t", "it’s"])
+  })
+
+  it("keeps hyphenated compounds as single words", () => {
+    expect(extractWords("well-known mother-in-law")).toEqual([
+      "well-known",
+      "mother-in-law",
+    ])
+  })
+
+  it("treats trailing punctuation after a contraction as a separator", () => {
+    // Regression guard: ensure the regex's optional contraction tail doesn't
+    // greedily swallow trailing punctuation.
+    expect(extractWords('"Always."')).toEqual(["Always"])
+  })
+
+  it("handles non-ASCII letters with marks (combining characters)", () => {
+    expect(extractWords("café Straße naïve")).toEqual(["café", "Straße", "naïve"])
+  })
+
+  it("returns an empty array for whitespace-only input", () => {
+    expect(extractWords("   \n  \t")).toEqual([])
+    const segs = tokenizeWords("   \n  \t")
+    expect(segs).toEqual([
+      { type: "separator", text: "   \n  \t", start: 0, end: 7 },
+    ])
+  })
+
+  it("returns nothing for empty input", () => {
+    expect(tokenizeWords("")).toEqual([])
+  })
+
+  it("assigns sequential wordIndex starting at 0", () => {
+    const segs = tokenizeWords("one two three")
+    const words = segs.filter((s) => s.type === "word")
+    expect(words.map((w) => (w as { wordIndex: number }).wordIndex)).toEqual([
+      0, 1, 2,
+    ])
+  })
+
+  it("uses a local regex instance so concurrent calls don't share lastIndex", () => {
+    // If we used WORD_PATTERN directly without cloning, the second call would
+    // resume from the first call's leftover .lastIndex.
+    const a = extractWords("alpha bravo")
+    const b = extractWords("charlie delta")
+    expect(a).toEqual(["alpha", "bravo"])
+    expect(b).toEqual(["charlie", "delta"])
+  })
+})
+
+describe("WORD_PATTERN parity with viewer runtime", () => {
+  // Mirrors `assets/adt/modules/tts_highlighter_utils.js`. If this drifts,
+  // SMIL fragment ids and Whisper word counts will disagree across sites.
+  it("uses the same regex source as the viewer runtime tokenizer", () => {
+    const viewerPattern = /[\p{L}\p{N}\p{M}]+(?:[’'-][\p{L}\p{N}\p{M}]+)*/gu
+    expect(WORD_PATTERN.source).toBe(viewerPattern.source)
+    expect(WORD_PATTERN.flags).toBe(viewerPattern.flags)
+  })
+})

--- a/packages/pipeline/src/fixed-layout-rendering.ts
+++ b/packages/pipeline/src/fixed-layout-rendering.ts
@@ -1,0 +1,743 @@
+/**
+ * Fixed-Layout Rendering
+ *
+ * Produces fixed-layout HTML pages for illustrated storybooks. Uses
+ * extracted illustration images as backgrounds with visible, styled
+ * positioned text from mupdf's asHTML() output.
+ *
+ * Sectioning emits a regular `PageSectioningOutput` (semantic tree of
+ * `ContentNodeData` leaves) plus a `placement` sidecar carrying the PDF
+ * coordinates, segment styling, blockBounds, etc. on
+ * `PageSectioningSection.placement[nodeId]`. Downstream steps
+ * (text-catalog, TTS, packageAdtWeb) walk the tree and ignore placement.
+ */
+
+import { PNG } from "pngjs"
+import type { Storage } from "@adt/storage"
+import type {
+  AppConfig,
+  ContentNodeData,
+  DrawItem,
+  ImageClassificationOutput,
+  NodePlacement,
+  PageSectioningOutput,
+  PageSectioningSection,
+  SectionTextSegment,
+  WebRenderingOutput,
+  PositionedTextOutput,
+} from "@adt/types"
+
+/**
+ * Whether the book should render as a fixed-layout EPUB.
+ *
+ * True if any section type resolves to a `fixed_layout`-typed render strategy.
+ * When any section is fixed-layout the whole book renders fixed-layout
+ * (consistent with the BookFusion reader's homogeneous-layout requirement;
+ * the EPUB spec allows mixed per-itemref but many readers don't support it
+ * cleanly).
+ */
+export function isFixedLayoutBook(config: AppConfig): boolean {
+  const strategies = config.render_strategies ?? {}
+  const candidateNames = new Set<string>()
+  if (config.default_render_strategy) candidateNames.add(config.default_render_strategy)
+  for (const name of Object.values(config.section_render_strategies ?? {})) {
+    candidateNames.add(name)
+  }
+  for (const name of candidateNames) {
+    if (strategies[name]?.render_type === "fixed_layout") return true
+  }
+  return false
+}
+
+// ── Background Sampling & Contrast ────────────────────────────────
+
+interface RGB { r: number; g: number; b: number }
+
+export interface BackgroundSampler {
+  /** Sample average RGB color in a region (render pixel coordinates). */
+  sample(x: number, y: number, width: number, height: number): RGB
+}
+
+/**
+ * Create a background sampler from a PNG image buffer.
+ * Returns null if the buffer can't be decoded.
+ */
+export function createBackgroundSampler(pngBuffer: Buffer): BackgroundSampler | null {
+  try {
+    const png = PNG.sync.read(pngBuffer)
+    const { data, width, height } = png
+    return {
+      sample(rx: number, ry: number, rw: number, rh: number): RGB {
+        // Clamp region to image bounds
+        const x0 = Math.max(0, Math.min(Math.round(rx), width - 1))
+        const y0 = Math.max(0, Math.min(Math.round(ry), height - 1))
+        const x1 = Math.max(x0 + 1, Math.min(Math.round(rx + rw), width))
+        const y1 = Math.max(y0 + 1, Math.min(Math.round(ry + rh), height))
+
+        let totalR = 0, totalG = 0, totalB = 0, count = 0
+        for (let y = y0; y < y1; y++) {
+          for (let x = x0; x < x1; x++) {
+            const idx = (y * width + x) * 4
+            totalR += data[idx]
+            totalG += data[idx + 1]
+            totalB += data[idx + 2]
+            count++
+          }
+        }
+
+        if (count === 0) return { r: 255, g: 255, b: 255 }
+        return {
+          r: Math.round(totalR / count),
+          g: Math.round(totalG / count),
+          b: Math.round(totalB / count),
+        }
+      },
+    }
+  } catch {
+    return null
+  }
+}
+
+/** sRGB → linear channel conversion */
+function linearize(srgb: number): number {
+  const c = srgb / 255
+  return c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4)
+}
+
+/** WCAG relative luminance */
+function relativeLuminance(c: RGB): number {
+  return 0.2126 * linearize(c.r) + 0.7152 * linearize(c.g) + 0.0722 * linearize(c.b)
+}
+
+/** WCAG contrast ratio (always ≥ 1) */
+export function contrastRatio(c1: RGB, c2: RGB): number {
+  const l1 = relativeLuminance(c1)
+  const l2 = relativeLuminance(c2)
+  const lighter = Math.max(l1, l2)
+  const darker = Math.min(l1, l2)
+  return (lighter + 0.05) / (darker + 0.05)
+}
+
+function parseHexColor(hex: string): RGB {
+  return {
+    r: parseInt(hex.slice(0, 2), 16),
+    g: parseInt(hex.slice(2, 4), 16),
+    b: parseInt(hex.slice(4, 6), 16),
+  }
+}
+
+/**
+ * Compute the stroke style (or null when contrast is sufficient) for a
+ * single text colour against a sampled background. Stroke direction is
+ * the opposite luminance to the background; width scales with font size.
+ */
+function computeStrokeForColor(
+  hex: string,
+  bgColor: RGB,
+  lineHeight: number,
+): { "-webkit-text-stroke": string; "paint-order": string } | null {
+  const textColor = parseHexColor(hex)
+  if (contrastRatio(textColor, bgColor) >= 3.0) return null
+  const bgLum = relativeLuminance(bgColor)
+  const strokeColor = bgLum > 0.5 ? "rgba(0,0,0,0.6)" : "rgba(255,255,255,0.6)"
+  const strokeWidth = Math.max(1, Math.round(lineHeight * 0.06))
+  return {
+    "-webkit-text-stroke": `${strokeWidth}px ${strokeColor}`,
+    "paint-order": "stroke fill",
+  }
+}
+
+/**
+ * Apply contrast strokes per segment by mutating the segment's `style` map.
+ * Returning the mutated segments lets the caller serialise them into
+ * `data-segments` so the runtime translation/rebuild path
+ * (`assets/adt/modules/translations.js`) emits spans with the stroke too.
+ * Spans whose colour already meets the WCAG AA large-text threshold (3:1)
+ * are passed through unchanged.
+ */
+function applyContrastStrokesToSegments(
+  segments: SectionTextSegment[] | undefined,
+  bgColor: RGB,
+  lineHeight: number,
+): SectionTextSegment[] | undefined {
+  if (!segments || segments.length === 0) return segments
+  return segments.map((seg) => {
+    const colorRaw = seg.style?.color
+    const colorMatch = colorRaw?.match(/^#([0-9a-fA-F]{6})$/)
+    if (!colorMatch) return seg
+    const stroke = computeStrokeForColor(colorMatch[1], bgColor, lineHeight)
+    if (!stroke) return seg
+    return { ...seg, style: { ...seg.style, ...stroke } }
+  })
+}
+
+// ── Fixed-Layout Page Sectioning ───────────────────────────────────
+
+/**
+ * Input shape for building a fixed-layout section. `drawItems` is the
+ * authoritative draw sequence from extraction — array order IS z-order.
+ * Image items are kept only when their `imageId` is in `availableImageIds`
+ * (i.e. the image survived image-filtering).
+ */
+export interface FixedLayoutSectionInput {
+  pageId: string
+  pageNumber: number
+  viewport: { width: number; height: number }
+  drawItems: DrawItem[]
+  /**
+   * Set of imageIds that passed image-filtering. Image draw-items whose
+   * imageId isn't in this set are dropped from the section.
+   */
+  availableImageIds: Set<string>
+}
+
+/**
+ * Produce a `PageSectioningOutput` for a fixed-layout page. The section's
+ * `nodes` array mirrors `drawItems` order — each kept image becomes a
+ * `role: "image"` leaf, each paragraph becomes a `role: "text"` leaf.
+ * Wrapped lines that share a `mergedParagraphId` are collapsed into a
+ * single text leaf with concatenated text + segments. Sentence boundaries
+ * inside the same speech bubble keep separate leaves.
+ *
+ * PDF coordinates, segment styling, blockBounds, blend/clip metadata, etc.
+ * live on `section.placement[nodeId]` (out-of-band) so the tree itself
+ * stays a clean semantic structure that downstream tree-walkers
+ * (text-catalog, validators) can process unchanged.
+ */
+export function sectionFixedLayoutPage(
+  input: FixedLayoutSectionInput,
+): PageSectioningOutput {
+  const { pageId, pageNumber, viewport, drawItems, availableImageIds } = input
+
+  const nodes: ContentNodeData[] = []
+  const placement: Record<string, NodePlacement> = {}
+  // State for the in-flight merge: the leaf we'd append to, its placement
+  // (mutable; same reference stored in `placement`), the merged-id of its
+  // trailing line, and that line's original text — we read the trailing
+  // text to decide hyphen vs. space joining.
+  let lastLeaf: ContentNodeData | null = null
+  let lastLeafPlacement: NodePlacement | null = null
+  let lastMergedId: string | undefined
+  let lastItemText: string | null = null
+
+  for (const item of drawItems) {
+    if (item.kind === "image") {
+      // An image breaks any in-flight text merge — even if the next text
+      // shares an id, appending past the image would reorder DOM.
+      lastLeaf = null
+      lastLeafPlacement = null
+      lastMergedId = undefined
+      lastItemText = null
+      if (!availableImageIds.has(item.imageId)) continue
+      nodes.push({
+        nodeId: item.imageId,
+        role: "image",
+        isPruned: false,
+      })
+      placement[item.imageId] = {
+        bounds: item.bounds,
+        ...(item.clipPath ? { clipPath: item.clipPath } : {}),
+        ...(item.blendMode ? { blendMode: item.blendMode } : {}),
+        ...(typeof item.opacity === "number" ? { opacity: item.opacity } : {}),
+      }
+      continue
+    }
+
+    const canMerge =
+      lastLeaf !== null &&
+      lastLeafPlacement !== null &&
+      lastItemText !== null &&
+      item.mergedParagraphId !== undefined &&
+      item.mergedParagraphId === lastMergedId
+    if (canMerge && lastLeaf && lastLeafPlacement && lastItemText !== null) {
+      appendContinuationLine(lastLeaf, lastLeafPlacement, item, lastItemText)
+      lastItemText = item.text
+      continue
+    }
+
+    const leaf: ContentNodeData = {
+      nodeId: item.textId,
+      role: "text",
+      isPruned: false,
+      text: item.text,
+    }
+    const leafPlacement: NodePlacement = {
+      position: {
+        top: Math.round(item.top),
+        left: Math.round(item.left),
+        lineHeight: Math.round(item.lineHeight),
+      },
+      ...(item.segments !== undefined ? { segments: item.segments } : {}),
+      ...(item.blockId !== undefined ? { blockId: item.blockId } : {}),
+      ...(item.blockBounds !== undefined ? { blockBounds: item.blockBounds } : {}),
+      ...(item.textAlign !== undefined ? { textAlign: item.textAlign } : {}),
+    }
+    nodes.push(leaf)
+    placement[item.textId] = leafPlacement
+    lastLeaf = leaf
+    lastLeafPlacement = leafPlacement
+    lastMergedId = item.mergedParagraphId
+    lastItemText = item.text
+  }
+
+  // Slice each block's height across the leaves that share it. Without
+  // this, multiple absolutely-positioned <p>s in one block all use the
+  // full block height (blockBounds.height) and stack with overlapping
+  // boxes — e.g. "LISTEN. PREPARE." and "STAY AWARE!" in the same
+  // bubble both get height:55, but their tops are 25 apart, so a 30 px
+  // overlap covers the second paragraph's content.
+  const byBlock = new Map<string, NodePlacement[]>()
+  for (const node of nodes) {
+    if (node.role !== "text") continue
+    const p = placement[node.nodeId]
+    if (!p?.blockId || !p.blockBounds || !p.position) continue
+    const list = byBlock.get(p.blockId)
+    if (list) list.push(p)
+    else byBlock.set(p.blockId, [p])
+  }
+  for (const list of byBlock.values()) {
+    if (list.length < 2) continue // single leaf — full blockBounds.height is correct.
+    list.sort((a, b) => a.position!.top - b.position!.top)
+    for (let i = 0; i < list.length; i++) {
+      const cur = list[i]
+      const next = list[i + 1]
+      const top = cur.position!.top
+      const bottom = next ? next.position!.top : cur.blockBounds!.y + cur.blockBounds!.height
+      // Floor at one lineHeight so degenerate slices still hold a line of
+      // text. The auto-fit script tolerates the ~0.2× per-line glyph
+      // overhead between scrollHeight and clientHeight, so we don't need
+      // to over-allocate the layout box here.
+      cur.renderHeight = Math.max(bottom - top, cur.position!.lineHeight)
+    }
+  }
+
+  const section: PageSectioningSection = {
+    sectionId: `${pageId}_sec001`,
+    sectionType: "fixed-layout-page",
+    nodes,
+    placement,
+    backgroundColor: "#ffffff",
+    textColor: "#000000",
+    pageNumber,
+    isPruned: false,
+    viewport,
+  }
+
+  return {
+    reasoning: "Fixed-layout mode: entire page is a single section; nodes are in PDF draw-sequence order so z-stacking is preserved by HTML DOM order. Wrapped lines that the continuation heuristic identified as one logical paragraph are collapsed into a single text leaf.",
+    sections: [section],
+  }
+}
+
+/**
+ * Append a continuation line to an existing text leaf. `prevLineText` is
+ * the untouched text of the line that ends the leaf — we test its tail
+ * for a hyphen to choose between hyphen-join (no separator, drop the
+ * boundary whitespace) and word-wrap join (single space between).
+ *
+ * Mutates `leaf.text` and `placement.segments` in place.
+ */
+function appendContinuationLine(
+  leaf: ContentNodeData,
+  placement: NodePlacement,
+  item: { text: string; segments?: SectionTextSegment[] },
+  prevLineText: string,
+): void {
+  const hyphenJoin = prevLineText.endsWith("-")
+  const currentText = leaf.text ?? ""
+
+  if (hyphenJoin) {
+    leaf.text = currentText.replace(/\s+$/, "") + item.text.replace(/^\s+/, "")
+    if (placement.segments && placement.segments.length > 0) {
+      const lastIdx = placement.segments.length - 1
+      placement.segments[lastIdx] = {
+        ...placement.segments[lastIdx],
+        text: placement.segments[lastIdx].text.replace(/\s+$/, ""),
+      }
+    }
+    if (item.segments && item.segments.length > 0) {
+      const trimmedFirst = {
+        ...item.segments[0],
+        text: item.segments[0].text.replace(/^\s+/, ""),
+      }
+      placement.segments = [...(placement.segments ?? []), trimmedFirst, ...item.segments.slice(1)]
+    }
+    return
+  }
+
+  // Word-wrap join: ensure exactly one space between the two lines. PDF
+  // lines often already have a trailing space on prev or a leading space
+  // on current; only insert one if neither side carries it.
+  const prevHasTrailing = /\s$/.test(currentText)
+  const currHasLeading = /^\s/.test(item.text)
+  const needsSpace = !prevHasTrailing && !currHasLeading
+
+  leaf.text = currentText + (needsSpace ? " " : "") + item.text
+  if (needsSpace && placement.segments && placement.segments.length > 0) {
+    const lastIdx = placement.segments.length - 1
+    placement.segments[lastIdx] = {
+      ...placement.segments[lastIdx],
+      text: placement.segments[lastIdx].text + " ",
+    }
+  }
+  if (item.segments) {
+    placement.segments = [...(placement.segments ?? []), ...item.segments]
+  }
+}
+
+/**
+ * Build the inner HTML for a paragraph `<p>` from structured segments.
+ * Emits one `<span>` per styled run (bare text for runs without styling
+ * to keep markup compact). Later slices will swap these spans for
+ * per-word spans with SMIL-referenceable IDs.
+ */
+function renderSegmentsToHtml(segments: SectionTextSegment[] | undefined): string {
+  if (!segments || segments.length === 0) return ""
+  const parts: string[] = []
+  for (const seg of segments) {
+    const styleStr = seg.style ? styleMapToInline(seg.style) : ""
+    const text = escapeHtml(seg.text)
+    if (styleStr) {
+      parts.push(`<span style="${styleStr}">${text}</span>`)
+    } else {
+      parts.push(text)
+    }
+  }
+  return parts.join("")
+}
+
+function styleMapToInline(style: Record<string, string>): string {
+  return Object.entries(style)
+    .map(([k, v]) => `${k}:${k === "font-family" ? withBundledFallback(v) : v}`)
+    .join(";")
+}
+
+/**
+ * Append `Merriweather` to a font-family chain so spans whose declared
+ * fonts (MuseoSans, Chokle, etc.) aren't bundled fall back to the
+ * actually-loaded Merriweather instead of system `serif`. Without this
+ * fallback, `document.fonts.ready` resolves immediately because no
+ * declared face is loading, and the auto-fit script then measures
+ * against system Times — giving widely different metrics than the
+ * source PDF, which causes over-shrinking.
+ *
+ * Already includes Merriweather (case-insensitive) → unchanged.
+ * Generic family terminator (serif/sans-serif/monospace/etc.) → insert
+ * Merriweather just before it. No generic terminator → append both.
+ */
+function withBundledFallback(fontFamily: string): string {
+  if (/\bmerriweather\b/i.test(fontFamily)) return fontFamily
+  const generics = /\b(serif|sans-serif|monospace|cursive|fantasy|system-ui)\b/i
+  const m = fontFamily.match(generics)
+  if (m) {
+    const idx = fontFamily.toLowerCase().lastIndexOf(m[0].toLowerCase())
+    return fontFamily.slice(0, idx) + "Merriweather," + fontFamily.slice(idx)
+  }
+  return fontFamily.replace(/\s*$/, "") + ",Merriweather,serif"
+}
+
+// ── Fixed-Layout Web Rendering ─────────────────────────────────────
+
+/**
+ * Produce fixed-layout HTML from a pre-built `PageSectioningSection`.
+ * Walks the section's `nodes` tree (image and text leaves) and looks up
+ * placement metadata in `section.placement[nodeId]`. Downstream edit /
+ * translation flows can mutate node text + placement and re-call this to
+ * get a correctly-positioned HTML output.
+ */
+export function renderFixedLayoutPage(
+  section: PageSectioningSection,
+  imageUrlPrefix: string,
+  options?: {
+    backgroundSampler?: BackgroundSampler
+    /** Scale for sampler coordinates — sampler operates in render-pixel
+     *  space (the original page image); section positions are in viewport
+     *  coordinates. Multiplying by `renderScale` converts back. */
+    renderScale?: number
+  },
+): WebRenderingOutput {
+  const viewport = section.viewport
+  if (!viewport) {
+    throw new Error(
+      `Fixed-layout section ${section.sectionId} is missing viewport dimensions`,
+    )
+  }
+  const placement = section.placement ?? {}
+  const sampler = options?.backgroundSampler
+  const renderScale = options?.renderScale ?? 1
+
+  // Emit every drawable leaf (image or text) as a direct sibling of
+  // `#content`, in section-node order. Tree order = PDF draw order = HTML
+  // DOM order = z-stacking, so later items naturally appear on top.
+  const elements: string[] = []
+  for (const node of section.nodes) {
+    if (node.isPruned) continue
+    const p = placement[node.nodeId]
+    if (node.role === "image") {
+      if (!p?.bounds) continue
+      const url = `${imageUrlPrefix}/${node.nodeId}`
+      const { x, y, width, height } = p.bounds
+      let imgStyle = `position:absolute;top:${Math.round(y)}px;left:${Math.round(x)}px;width:${Math.round(width)}px;height:${Math.round(height)}px`
+      // Apply the PDF clip path captured during extraction. The `d` string is
+      // in absolute viewport coords; we translate via `transform` on the
+      // <path> element so the inner coords stay readable for debugging,
+      // while userSpaceOnUse interprets them relative to the <img>'s box
+      // (top-left origin). EPUB3 readers (Apple Books, ADE, Thorium,
+      // Calibre) all support this combination.
+      if (p.clipPath) {
+        const clipId = `clip-${node.nodeId}`
+        elements.push(
+          `  <svg width="0" height="0" style="position:absolute" aria-hidden="true"><defs><clipPath id="${clipId}" clipPathUnits="userSpaceOnUse"><path d="${escapeHtmlAttr(p.clipPath)}" transform="translate(${-Math.round(x)},${-Math.round(y)})"/></clipPath></defs></svg>`,
+        )
+        imgStyle += `;clip-path:url(#${clipId})`
+      }
+      // PDF blend modes (commonly Multiply in watercolor storybooks) make
+      // image backgrounds composite as transparent. Reproduce via
+      // `mix-blend-mode`.
+      if (p.blendMode) {
+        imgStyle += `;mix-blend-mode:${p.blendMode}`
+      }
+      if (typeof p.opacity === "number" && p.opacity < 1) {
+        imgStyle += `;opacity:${p.opacity}`
+      }
+      elements.push(
+        `  <img src="${escapeHtml(url)}" alt="" data-id="${node.nodeId}" style="${imgStyle}"/>`)
+    } else if (node.role === "text") {
+      if (!p?.position) continue // Reflowable text leaves shouldn't appear in fixed-layout sections; skip defensively
+      const { top, lineHeight } = p.position
+      // When the leaf carries a block bounds (i.e. clustering ran and
+      // identified the visual container), render the paragraph spanning
+      // the full block width with the inferred text-align — this lets a
+      // translation re-flow inside the original bubble. Without
+      // blockBounds (legacy data), fall back to single-line legacy
+      // behaviour (anchor at the line's own left, no width constraint).
+      const renderLeft = p.blockBounds ? Math.round(p.blockBounds.x) : p.position.left
+      // When we have block geometry, pin the paragraph to the full block
+      // box (width + height) and tag it with data-adt-fit so the runtime
+      // auto-fit script can shrink letter-spacing/font-size to make the
+      // text actually fit. We deliberately leave overflow visible: cases
+      // we haven't characterised should overflow visibly so they're easy
+      // to spot rather than getting silently clipped. The auto-fit
+      // script's fits() check uses scrollHeight/scrollWidth which work
+      // regardless of overflow setting.
+      const widthRule = p.blockBounds ? `;width:${Math.round(p.blockBounds.width)}px` : ""
+      // renderHeight is stamped at sectioning when multiple leaves share
+      // a block (each gets its own slice of the block height); for blocks
+      // with a single leaf the full blockBounds.height is correct.
+      const heightValue = p.blockBounds
+        ? p.renderHeight !== undefined ? p.renderHeight : p.blockBounds.height
+        : undefined
+      const heightRule = heightValue !== undefined ? `;height:${Math.round(heightValue)}px` : ""
+      const alignRule = p.textAlign ? `;text-align:${p.textAlign}` : ""
+      // line-height needs to fit the LARGEST segment's font-size, not
+      // just mupdf's reported lineHeight (which it computes from the
+      // first/dominant run). Without this, mixed-size paragraphs like
+      // "Remember the warning signs." (11.5px body + 24px decorative)
+      // overflow their 12px line box and the auto-fit's blanket scale
+      // produces uneven results. Use the biggest segment fontSize when
+      // segments mix sizes; fall back to the leaf's lineHeight otherwise.
+      const effectiveLineHeight = pickEffectiveLineHeight(p.segments, lineHeight)
+      const style = `position:absolute;top:${top}px;left:${renderLeft}px;line-height:${effectiveLineHeight}px${widthRule}${heightRule}${alignRule}`
+
+      // Apply contrast strokes at the segment level (not on the rendered
+      // HTML afterwards) so the stroke style flows into both the inline
+      // `<span>` rendering AND the `data-segments` JSON. Without this, the
+      // runtime rebuild on language switch / inline edit re-emits spans
+      // from `data-segments` and drops the stroke — low-contrast text
+      // becomes invisible against the page background again.
+      let segments = p.segments
+      if (sampler) {
+        const sampleWidth = p.blockBounds ? p.blockBounds.width : lineHeight * 3
+        const bgColor = sampler.sample(
+          renderLeft * renderScale,
+          top * renderScale,
+          sampleWidth * renderScale,
+          lineHeight * renderScale,
+        )
+        segments = applyContrastStrokesToSegments(segments, bgColor, lineHeight)
+      }
+      const content = renderSegmentsToHtml(segments) || escapeHtml(node.text ?? "")
+
+      // `data-segments` carries the structured styling inline so the viewer
+      // can rebuild the styled span structure after any text swap (language
+      // switch, inline edit) without losing font / colour / size / stroke.
+      const segmentsAttr = segments && segments.length > 0
+        ? ` data-segments="${escapeHtmlAttr(JSON.stringify(segments))}"`
+        : ""
+      const fitAttr = p.blockBounds ? ` data-adt-fit="1"` : ""
+      elements.push(
+        `  <p data-id="${node.nodeId}"${segmentsAttr}${fitAttr} style="${style}">${content}</p>`)
+    }
+  }
+
+  const hasFitTargets = elements.some((el) => el.includes("data-adt-fit=\"1\""))
+  const fitScript = hasFitTargets ? `\n${FIT_SCRIPT}` : ""
+  const html = `<div id="content" style="position:relative;width:${viewport.width}px;height:${viewport.height}px;margin:0 auto;overflow:hidden">
+${elements.join("\n")}${fitScript}
+</div>`
+
+  return {
+    sections: [
+      {
+        sectionIndex: 0,
+        sectionType: "fixed-layout-page",
+        reasoning: "Fixed-layout: rendered from positioned section JSON (text + image bounds).",
+        html,
+      },
+    ],
+  }
+}
+
+// ── Batch Processing ───────────────────────────────────────────────
+
+/**
+ * Run fixed-layout sectioning + rendering for all pages.
+ * Stores results using the same node names as the reflowable pipeline.
+ */
+export function processFixedLayoutPages(
+  storage: Storage,
+  imageUrlPrefix: string,
+): void {
+  const pages = storage.getPages()
+
+  for (const page of pages) {
+    // Render whatever image-filtering left unpruned. The wizard writes
+    // `image_filters` values for fixed-layout books that disable size /
+    // complexity / LLM-meaningfulness pruning, so in practice every
+    // extracted image survives except the full-page render itself (which
+    // image-filtering always prunes — using it as a background would
+    // double-draw the page).
+    const allImages = storage.getPageImages(page.pageId)
+    const pageRender = allImages.find((img) => img.imageId.endsWith("_page"))
+    const classRow = storage.getLatestNodeData("image-filtering", page.pageId)
+    const classification = classRow ? (classRow.data as ImageClassificationOutput) : null
+    const availableImageIds = new Set(
+      classification
+        ? classification.images.filter((c) => !c.isPruned).map((c) => c.imageId)
+        : []
+    )
+
+    const posTextRow = storage.getLatestNodeData("positioned-text", page.pageId)
+    const positionedText = posTextRow ? (posTextRow.data as PositionedTextOutput) : null
+
+    // Viewport comes from the positioned-text extraction (authoritative PDF
+    // page dimensions). Fall back to the page render's pixel size only when
+    // no positioned text was extracted at all.
+    const viewport = positionedText
+      ? { width: Math.round(positionedText.pageWidth), height: Math.round(positionedText.pageHeight) }
+      : pageRender
+        ? { width: pageRender.width, height: pageRender.height }
+        : null
+    if (!viewport) continue
+    const renderScale = positionedText ? positionedText.renderWidth / positionedText.pageWidth : 1
+
+    const drawItems: DrawItem[] = positionedText?.drawItems ?? []
+
+    const sectioning = sectionFixedLayoutPage({
+      pageId: page.pageId,
+      pageNumber: page.pageNumber,
+      viewport,
+      drawItems,
+      availableImageIds,
+    })
+    storage.putNodeData("page-sectioning", page.pageId, sectioning)
+
+    // Contrast sampler: always built from the page render when available,
+    // regardless of how the page is composed visually. The page render is an
+    // accurate preview of the final composited page, so sampling it gives a
+    // correct answer to "what is under this text?" for stroke-contrast decisions.
+    let backgroundSampler: BackgroundSampler | undefined
+    if (pageRender) {
+      try {
+        const imgBase64 = storage.getImageBase64(pageRender.imageId)
+        const imgBuffer = Buffer.from(imgBase64, "base64")
+        const rawSampler = createBackgroundSampler(imgBuffer)
+        if (rawSampler) {
+          const imgW = pageRender.width
+          const imgH = pageRender.height
+          const viewportPxW = viewport.width * renderScale
+          const viewportPxH = viewport.height * renderScale
+          // Map render-pixel sampler coords (viewport × renderScale) to the
+          // page render image's pixel coords.
+          backgroundSampler = {
+            sample(rx, ry, rw, rh) {
+              const ix = rx * (imgW / viewportPxW)
+              const iy = ry * (imgH / viewportPxH)
+              const iw = rw * (imgW / viewportPxW)
+              const ih = rh * (imgH / viewportPxH)
+              if (ix + iw < 0 || iy + ih < 0 || ix > imgW || iy > imgH) {
+                return { r: 255, g: 255, b: 255 }
+              }
+              return rawSampler.sample(ix, iy, iw, ih)
+            },
+          }
+        }
+      } catch {
+        // Page render not available — skip contrast checking
+      }
+    }
+
+    const rendering = renderFixedLayoutPage(
+      sectioning.sections[0],
+      imageUrlPrefix,
+      { backgroundSampler, renderScale },
+    )
+    storage.putNodeData("web-rendering", page.pageId, rendering)
+  }
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Escape a JSON string for embedding inside a double-quoted HTML attribute.
+ * `&` and `"` are entity-encoded; browsers decode them when calling
+ * `.getAttribute()`, so `JSON.parse(el.getAttribute("data-segments"))` works.
+ */
+function escapeHtmlAttr(str: string): string {
+  return str.replace(/&/g, "&amp;").replace(/"/g, "&quot;")
+}
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+}
+
+/**
+ * Pick the line-height to apply on the paragraph `<p>`. mupdf's
+ * `position.lineHeight` is the line-height of the first/dominant
+ * run on that line, which is wrong for mixed-size paragraphs — a 24 px
+ * decorative segment inside an 11.5 px body line gets clipped/overflows
+ * the 12 px line box.
+ *
+ * Strategy: take the largest segment font-size when (a) segments are
+ * present and (b) at least one segment exceeds the fallback. Single-size
+ * segments and segments-without-fontSize fall through to `fallbackLineHeight`.
+ */
+function pickEffectiveLineHeight(
+  segments: SectionTextSegment[] | undefined,
+  fallbackLineHeight: number,
+): number {
+  if (!segments || segments.length === 0) return fallbackLineHeight
+  let maxFontSize = 0
+  for (const seg of segments) {
+    const fsRaw = seg.style?.["font-size"]
+    if (!fsRaw) continue
+    const fs = parseFloat(fsRaw)
+    if (!Number.isFinite(fs) || fs <= 0) continue
+    if (fs > maxFontSize) maxFontSize = fs
+  }
+  if (maxFontSize <= fallbackLineHeight) return fallbackLineHeight
+  return maxFontSize
+}
+
+/**
+ * `<script src>` reference to the shared auto-fit script. The actual
+ * logic lives in `assets/adt/auto-fit.js` so the same file is used in
+ * both packaged-book pages (loaded by URL) and the studio storyboard
+ * preview (loaded by URL into the iframe shell). Keeping a single
+ * source of truth avoids the drift we ran into with two inline copies.
+ */
+const FIT_SCRIPT = `<script src="./assets/auto-fit.js"></script>`

--- a/packages/pipeline/src/fixed-layout-rendering.ts
+++ b/packages/pipeline/src/fixed-layout-rendering.ts
@@ -26,6 +26,7 @@ import type {
   WebRenderingOutput,
   PositionedTextOutput,
 } from "@adt/types"
+import { escapeHtml } from "./package-web.js"
 
 /**
  * Whether the book should render as a fixed-layout EPUB.
@@ -709,14 +710,6 @@ export function processFixedLayoutPages(
  */
 function escapeHtmlAttr(str: string): string {
   return str.replace(/&/g, "&amp;").replace(/"/g, "&quot;")
-}
-
-function escapeHtml(str: string): string {
-  return str
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
 }
 
 /**

--- a/packages/pipeline/src/fixed-layout-rendering.ts
+++ b/packages/pipeline/src/fixed-layout-rendering.ts
@@ -387,22 +387,80 @@ function appendContinuationLine(
 
 /**
  * Build the inner HTML for a paragraph `<p>` from structured segments.
- * Emits one `<span>` per styled run (bare text for runs without styling
- * to keep markup compact). Later slices will swap these spans for
- * per-word spans with SMIL-referenceable IDs.
+ *
+ * Per-word `<span id="{paragraphId}_w{NNN}">` wrappers let SMIL
+ * media-overlay `<text src="…#…"/>` reference individual words for
+ * read-aloud sync (absent without `paragraphId`). Crucially, words are
+ * tokenised against the *concatenated* segment text — not each segment in
+ * isolation — so a word split across style runs (e.g. a single coloured
+ * letter mid-word) becomes ONE word span wrapping the per-run
+ * `<span style="…">` fragments, rather than one id per fragment. Reusing
+ * an id across fragments would be invalid (epubcheck duplicate-id), and
+ * the extra ids break the viewer/SMIL word-count guard (commit
+ * `ee752ded`). The boundary signal is free: whitespace lives *between*
+ * segments, so a segment whose first token follows a previous segment's
+ * last token with no whitespace between them continues the same word.
+ *
+ * Whitespace stays outside the word span so word measurement / contrast
+ * checks aren't affected by surrounding spaces.
+ *
+ * Note: this is whitespace tokenisation. Scripts that don't separate words
+ * by whitespace (Chinese, Japanese, Thai) won't get word-level granularity
+ * here — Whisper alignment is unreliable for those anyway.
+ *
+ * Mirror any change here in `assets/adt/modules/translations.js`
+ * (`rebuildSegmentedInnerHtml`), which re-emits this structure on language
+ * swap.
  */
-function renderSegmentsToHtml(segments: SectionTextSegment[] | undefined): string {
+function renderSegmentsToHtml(
+  segments: SectionTextSegment[] | undefined,
+  paragraphId?: string,
+): string {
   if (!segments || segments.length === 0) return ""
+
+  // Without per-word ids each segment is just one styled run — no need to
+  // track word boundaries across segments.
+  if (!paragraphId) {
+    return segments
+      .map((seg) => {
+        const content = escapeHtml(seg.text)
+        const styleStr = seg.style ? styleMapToInline(seg.style) : ""
+        return styleStr ? `<span style="${styleStr}">${content}</span>` : content
+      })
+      .join("")
+  }
+
   const parts: string[] = []
+  let wordIdx = 0
+  // Pieces of the word currently being assembled, each from one style run.
+  let wordPieces: { style?: Record<string, string>; text: string }[] = []
+  const flushWord = (): void => {
+    if (wordPieces.length === 0) return
+    wordIdx += 1
+    const wordId = `${paragraphId}_w${String(wordIdx).padStart(3, "0")}`
+    const inner = wordPieces
+      .map((pc) => {
+        const content = escapeHtml(pc.text)
+        const styleStr = pc.style ? styleMapToInline(pc.style) : ""
+        return styleStr ? `<span style="${styleStr}">${content}</span>` : content
+      })
+      .join("")
+    parts.push(`<span id="${wordId}">${inner}</span>`)
+    wordPieces = []
+  }
+
   for (const seg of segments) {
-    const styleStr = seg.style ? styleMapToInline(seg.style) : ""
-    const text = escapeHtml(seg.text)
-    if (styleStr) {
-      parts.push(`<span style="${styleStr}">${text}</span>`)
-    } else {
-      parts.push(text)
+    for (const tok of seg.text.split(/(\s+)/)) {
+      if (tok.length === 0) continue
+      if (/^\s+$/.test(tok)) {
+        flushWord()
+        parts.push(escapeHtml(tok))
+      } else {
+        wordPieces.push({ style: seg.style, text: tok })
+      }
     }
   }
+  flushWord()
   return parts.join("")
 }
 
@@ -556,7 +614,7 @@ export function renderFixedLayoutPage(
         )
         segments = applyContrastStrokesToSegments(segments, bgColor, lineHeight)
       }
-      const content = renderSegmentsToHtml(segments) || escapeHtml(node.text ?? "")
+      const content = renderSegmentsToHtml(segments, node.nodeId) || escapeHtml(node.text ?? "")
 
       // `data-segments` carries the structured styling inline so the viewer
       // can rebuild the styled span structure after any text swap (language

--- a/packages/pipeline/src/fixed-layout-rendering.ts
+++ b/packages/pipeline/src/fixed-layout-rendering.ts
@@ -388,83 +388,39 @@ function appendContinuationLine(
 /**
  * Build the inner HTML for a paragraph `<p>` from structured segments.
  *
- * Per-word `<span id="{paragraphId}_w{NNN}">` wrappers let SMIL
- * media-overlay `<text src="…#…"/>` reference individual words for
- * read-aloud sync (absent without `paragraphId`). Crucially, words are
- * tokenised against the *concatenated* segment text — not each segment in
- * isolation — so a word split across style runs (e.g. a single coloured
- * letter mid-word) becomes ONE word span wrapping the per-run
- * `<span style="…">` fragments, rather than one id per fragment. Reusing
- * an id across fragments would be invalid (epubcheck duplicate-id), and
- * the extra ids break the viewer/SMIL word-count guard (commit
- * `ee752ded`). The boundary signal is free: whitespace lives *between*
- * segments, so a segment whose first token follows a previous segment's
- * last token with no whitespace between them continues the same word.
+ * Emits one styled `<span style="…">` per run; nothing more. Word-level
+ * `<span id="…_wNNN">` wrappers — needed for EPUB 3 media-overlay
+ * `<text src="…#…"/>` references and for in-viewer read-aloud highlighting
+ * — are materialised by the consumers from `data-segments` JSON:
+ *   - EPUB packaging: `wrapWordSpans` in `package-epub.ts`
+ *   - Live viewer at audio playback: `wrapTextInSpans` in
+ *     `assets/adt/modules/tts_highlighter.js`
  *
- * Whitespace stays outside the word span so word measurement / contrast
- * checks aren't affected by surrounding spaces.
- *
- * Note: this is whitespace tokenisation. Scripts that don't separate words
- * by whitespace (Chinese, Japanese, Thai) won't get word-level granularity
- * here — Whisper alignment is unreliable for those anyway.
- *
- * Mirror any change here in `assets/adt/modules/translations.js`
- * (`rebuildSegmentedInnerHtml`), which re-emits this structure on language
- * swap.
+ * Keeping the renderer language-agnostic means a single XHTML page can be
+ * re-skinned across translations (the in-studio swap rebuilds segments
+ * via `rebuildSegmentedInnerHtml`) without invalidating word ids; the
+ * consumers regenerate them in the target language.
  */
 function renderSegmentsToHtml(
   segments: SectionTextSegment[] | undefined,
-  paragraphId?: string,
 ): string {
   if (!segments || segments.length === 0) return ""
-
-  // Without per-word ids each segment is just one styled run — no need to
-  // track word boundaries across segments.
-  if (!paragraphId) {
-    return segments
-      .map((seg) => {
-        const content = escapeHtml(seg.text)
-        const styleStr = seg.style ? styleMapToInline(seg.style) : ""
-        return styleStr ? `<span style="${styleStr}">${content}</span>` : content
-      })
-      .join("")
-  }
-
-  const parts: string[] = []
-  let wordIdx = 0
-  // Pieces of the word currently being assembled, each from one style run.
-  let wordPieces: { style?: Record<string, string>; text: string }[] = []
-  const flushWord = (): void => {
-    if (wordPieces.length === 0) return
-    wordIdx += 1
-    const wordId = `${paragraphId}_w${String(wordIdx).padStart(3, "0")}`
-    const inner = wordPieces
-      .map((pc) => {
-        const content = escapeHtml(pc.text)
-        const styleStr = pc.style ? styleMapToInline(pc.style) : ""
-        return styleStr ? `<span style="${styleStr}">${content}</span>` : content
-      })
-      .join("")
-    parts.push(`<span id="${wordId}">${inner}</span>`)
-    wordPieces = []
-  }
-
-  for (const seg of segments) {
-    for (const tok of seg.text.split(/(\s+)/)) {
-      if (tok.length === 0) continue
-      if (/^\s+$/.test(tok)) {
-        flushWord()
-        parts.push(escapeHtml(tok))
-      } else {
-        wordPieces.push({ style: seg.style, text: tok })
-      }
-    }
-  }
-  flushWord()
-  return parts.join("")
+  return segments
+    .map((seg) => {
+      const content = escapeHtml(seg.text)
+      const styleStr = seg.style ? styleMapToInline(seg.style) : ""
+      return styleStr ? `<span style="${styleStr}">${content}</span>` : content
+    })
+    .join("")
 }
 
-function styleMapToInline(style: Record<string, string>): string {
+/**
+ * Serialize a `data-segments` style map to an inline-style string with the
+ * bundled-font fallback applied to `font-family`. Exported so EPUB
+ * packaging (`package-epub.ts:wrapBySegments`) renders the same styled
+ * spans the in-studio viewer does.
+ */
+export function styleMapToInline(style: Record<string, string>): string {
   return Object.entries(style)
     .map(([k, v]) => `${k}:${k === "font-family" ? withBundledFallback(v) : v}`)
     .join(";")
@@ -614,7 +570,7 @@ export function renderFixedLayoutPage(
         )
         segments = applyContrastStrokesToSegments(segments, bgColor, lineHeight)
       }
-      const content = renderSegmentsToHtml(segments, node.nodeId) || escapeHtml(node.text ?? "")
+      const content = renderSegmentsToHtml(segments) || escapeHtml(node.text ?? "")
 
       // `data-segments` carries the structured styling inline so the viewer
       // can rebuild the styled span structure after any text swap (language

--- a/packages/pipeline/src/fixed-layout-rendering.ts
+++ b/packages/pipeline/src/fixed-layout-rendering.ts
@@ -12,7 +12,6 @@
  * (text-catalog, TTS, packageAdtWeb) walk the tree and ignore placement.
  */
 
-import { PNG } from "pngjs"
 import type { Storage } from "@adt/storage"
 import type {
   AppConfig,
@@ -48,128 +47,6 @@ export function isFixedLayoutBook(config: AppConfig): boolean {
     if (strategies[name]?.render_type === "fixed_layout") return true
   }
   return false
-}
-
-// ── Background Sampling & Contrast ────────────────────────────────
-
-interface RGB { r: number; g: number; b: number }
-
-export interface BackgroundSampler {
-  /** Sample average RGB color in a region (render pixel coordinates). */
-  sample(x: number, y: number, width: number, height: number): RGB
-}
-
-/**
- * Create a background sampler from a PNG image buffer.
- * Returns null if the buffer can't be decoded.
- */
-export function createBackgroundSampler(pngBuffer: Buffer): BackgroundSampler | null {
-  try {
-    const png = PNG.sync.read(pngBuffer)
-    const { data, width, height } = png
-    return {
-      sample(rx: number, ry: number, rw: number, rh: number): RGB {
-        // Clamp region to image bounds
-        const x0 = Math.max(0, Math.min(Math.round(rx), width - 1))
-        const y0 = Math.max(0, Math.min(Math.round(ry), height - 1))
-        const x1 = Math.max(x0 + 1, Math.min(Math.round(rx + rw), width))
-        const y1 = Math.max(y0 + 1, Math.min(Math.round(ry + rh), height))
-
-        let totalR = 0, totalG = 0, totalB = 0, count = 0
-        for (let y = y0; y < y1; y++) {
-          for (let x = x0; x < x1; x++) {
-            const idx = (y * width + x) * 4
-            totalR += data[idx]
-            totalG += data[idx + 1]
-            totalB += data[idx + 2]
-            count++
-          }
-        }
-
-        if (count === 0) return { r: 255, g: 255, b: 255 }
-        return {
-          r: Math.round(totalR / count),
-          g: Math.round(totalG / count),
-          b: Math.round(totalB / count),
-        }
-      },
-    }
-  } catch {
-    return null
-  }
-}
-
-/** sRGB → linear channel conversion */
-function linearize(srgb: number): number {
-  const c = srgb / 255
-  return c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4)
-}
-
-/** WCAG relative luminance */
-function relativeLuminance(c: RGB): number {
-  return 0.2126 * linearize(c.r) + 0.7152 * linearize(c.g) + 0.0722 * linearize(c.b)
-}
-
-/** WCAG contrast ratio (always ≥ 1) */
-export function contrastRatio(c1: RGB, c2: RGB): number {
-  const l1 = relativeLuminance(c1)
-  const l2 = relativeLuminance(c2)
-  const lighter = Math.max(l1, l2)
-  const darker = Math.min(l1, l2)
-  return (lighter + 0.05) / (darker + 0.05)
-}
-
-function parseHexColor(hex: string): RGB {
-  return {
-    r: parseInt(hex.slice(0, 2), 16),
-    g: parseInt(hex.slice(2, 4), 16),
-    b: parseInt(hex.slice(4, 6), 16),
-  }
-}
-
-/**
- * Compute the stroke style (or null when contrast is sufficient) for a
- * single text colour against a sampled background. Stroke direction is
- * the opposite luminance to the background; width scales with font size.
- */
-function computeStrokeForColor(
-  hex: string,
-  bgColor: RGB,
-  lineHeight: number,
-): { "-webkit-text-stroke": string; "paint-order": string } | null {
-  const textColor = parseHexColor(hex)
-  if (contrastRatio(textColor, bgColor) >= 3.0) return null
-  const bgLum = relativeLuminance(bgColor)
-  const strokeColor = bgLum > 0.5 ? "rgba(0,0,0,0.6)" : "rgba(255,255,255,0.6)"
-  const strokeWidth = Math.max(1, Math.round(lineHeight * 0.06))
-  return {
-    "-webkit-text-stroke": `${strokeWidth}px ${strokeColor}`,
-    "paint-order": "stroke fill",
-  }
-}
-
-/**
- * Apply contrast strokes per segment by mutating the segment's `style` map.
- * Returning the mutated segments lets the caller serialise them into
- * `data-segments` so the runtime translation/rebuild path
- * (`assets/adt/modules/translations.js`) emits spans with the stroke too.
- * Spans whose colour already meets the WCAG AA large-text threshold (3:1)
- * are passed through unchanged.
- */
-function applyContrastStrokesToSegments(
-  segments: SectionTextSegment[] | undefined,
-  bgColor: RGB,
-  lineHeight: number,
-): SectionTextSegment[] | undefined {
-  if (!segments || segments.length === 0) return segments
-  return segments.map((seg) => {
-    const colorRaw = seg.style?.color
-    const colorMatch = colorRaw?.match(/^#([0-9a-fA-F]{6})$/)
-    if (!colorMatch) return seg
-    const stroke = computeStrokeForColor(colorMatch[1], bgColor, lineHeight)
-    if (!stroke) return seg
-    return { ...seg, style: { ...seg.style, ...stroke } }
-  })
 }
 
 // ── Fixed-Layout Page Sectioning ───────────────────────────────────
@@ -463,13 +340,6 @@ function withBundledFallback(fontFamily: string): string {
 export function renderFixedLayoutPage(
   section: PageSectioningSection,
   imageUrlPrefix: string,
-  options?: {
-    backgroundSampler?: BackgroundSampler
-    /** Scale for sampler coordinates — sampler operates in render-pixel
-     *  space (the original page image); section positions are in viewport
-     *  coordinates. Multiplying by `renderScale` converts back. */
-    renderScale?: number
-  },
 ): WebRenderingOutput {
   const viewport = section.viewport
   if (!viewport) {
@@ -478,8 +348,6 @@ export function renderFixedLayoutPage(
     )
   }
   const placement = section.placement ?? {}
-  const sampler = options?.backgroundSampler
-  const renderScale = options?.renderScale ?? 1
 
   // Emit every drawable leaf (image or text) as a direct sibling of
   // `#content`, in section-node order. Tree order = PDF draw order = HTML
@@ -554,23 +422,7 @@ export function renderFixedLayoutPage(
       const effectiveLineHeight = pickEffectiveLineHeight(p.segments, lineHeight)
       const style = `position:absolute;top:${top}px;left:${renderLeft}px;line-height:${effectiveLineHeight}px${widthRule}${heightRule}${alignRule}`
 
-      // Apply contrast strokes at the segment level (not on the rendered
-      // HTML afterwards) so the stroke style flows into both the inline
-      // `<span>` rendering AND the `data-segments` JSON. Without this, the
-      // runtime rebuild on language switch / inline edit re-emits spans
-      // from `data-segments` and drops the stroke — low-contrast text
-      // becomes invisible against the page background again.
-      let segments = p.segments
-      if (sampler) {
-        const sampleWidth = p.blockBounds ? p.blockBounds.width : lineHeight * 3
-        const bgColor = sampler.sample(
-          renderLeft * renderScale,
-          top * renderScale,
-          sampleWidth * renderScale,
-          lineHeight * renderScale,
-        )
-        segments = applyContrastStrokesToSegments(segments, bgColor, lineHeight)
-      }
+      const segments = p.segments
       const content = renderSegmentsToHtml(segments) || escapeHtml(node.text ?? "")
 
       // `data-segments` carries the structured styling inline so the viewer
@@ -644,7 +496,6 @@ export function processFixedLayoutPages(
         ? { width: pageRender.width, height: pageRender.height }
         : null
     if (!viewport) continue
-    const renderScale = positionedText ? positionedText.renderWidth / positionedText.pageWidth : 1
 
     const drawItems: DrawItem[] = positionedText?.drawItems ?? []
 
@@ -657,45 +508,9 @@ export function processFixedLayoutPages(
     })
     storage.putNodeData("page-sectioning", page.pageId, sectioning)
 
-    // Contrast sampler: always built from the page render when available,
-    // regardless of how the page is composed visually. The page render is an
-    // accurate preview of the final composited page, so sampling it gives a
-    // correct answer to "what is under this text?" for stroke-contrast decisions.
-    let backgroundSampler: BackgroundSampler | undefined
-    if (pageRender) {
-      try {
-        const imgBase64 = storage.getImageBase64(pageRender.imageId)
-        const imgBuffer = Buffer.from(imgBase64, "base64")
-        const rawSampler = createBackgroundSampler(imgBuffer)
-        if (rawSampler) {
-          const imgW = pageRender.width
-          const imgH = pageRender.height
-          const viewportPxW = viewport.width * renderScale
-          const viewportPxH = viewport.height * renderScale
-          // Map render-pixel sampler coords (viewport × renderScale) to the
-          // page render image's pixel coords.
-          backgroundSampler = {
-            sample(rx, ry, rw, rh) {
-              const ix = rx * (imgW / viewportPxW)
-              const iy = ry * (imgH / viewportPxH)
-              const iw = rw * (imgW / viewportPxW)
-              const ih = rh * (imgH / viewportPxH)
-              if (ix + iw < 0 || iy + ih < 0 || ix > imgW || iy > imgH) {
-                return { r: 255, g: 255, b: 255 }
-              }
-              return rawSampler.sample(ix, iy, iw, ih)
-            },
-          }
-        }
-      } catch {
-        // Page render not available — skip contrast checking
-      }
-    }
-
     const rendering = renderFixedLayoutPage(
       sectioning.sections[0],
       imageUrlPrefix,
-      { backgroundSampler, renderScale },
     )
     storage.putNodeData("web-rendering", page.pageId, rendering)
   }

--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -198,6 +198,10 @@ export {
   type PipelineDAGResult,
 } from "./dag.js"
 export {
+  packageEpub,
+  type PackageEpubOptions,
+} from "./package-epub.js"
+export {
   packageAdtWeb,
   packageWebpub,
   computePackagingInputHash,
@@ -229,3 +233,4 @@ export {
   type BuildBrowserAccessibilityRecheckPlanOptions,
 } from "./browser-accessibility-assessment.js"
 export { mergeAccessibilityResults } from "./accessibility-assessment-shared.js"
+export { processFixedLayoutPages, isFixedLayoutBook } from "./fixed-layout-rendering.js"

--- a/packages/pipeline/src/package-epub.ts
+++ b/packages/pipeline/src/package-epub.ts
@@ -3,7 +3,16 @@ import path from "node:path"
 import { JSDOM } from "jsdom"
 import type { Storage } from "@adt/storage"
 import type { BookMetadata, TocGenerationOutput, WordTimestampOutput } from "@adt/types"
-import { type PackageAdtWebOptions, copyDirRecursive, injectWebpubStyles, htmlToXhtml, getWordTimestamps } from "./package-web.js"
+import { type PackageAdtWebOptions, copyDirRecursive, injectWebpubStyles, htmlToXhtml, getWordTimestamps, pad3 } from "./package-web.js"
+
+/**
+ * Canonical word-id format used by SMIL fragment refs, EPUB packaging
+ * word-spans, and the runtime viewer's word highlighting. Mirror in
+ * `assets/adt/modules/tts_highlighter_utils.js:wordIdFor`.
+ */
+function wordIdFor(dataId: string, idx: number): string {
+  return `${dataId}_w${pad3(idx)}`
+}
 import { buildSmil, formatMediaDuration, type SmilParagraph } from "./smil.js"
 import { tokenizeWords } from "./word-tokenize.js"
 import { styleMapToInline } from "./fixed-layout-rendering.js"
@@ -748,9 +757,8 @@ function wrapBySegments(
       continue
     }
     wordIdx += 1
-    const wordId = `${dataId}_w${String(wordIdx).padStart(3, "0")}`
     const wrap = doc.createElement("span")
-    wrap.setAttribute("id", wordId)
+    wrap.setAttribute("id", wordIdFor(dataId, wordIdx))
     for (const piece of buildPieces(tok.start, tok.end)) wrap.appendChild(piece)
     parent.appendChild(wrap)
   }
@@ -773,9 +781,8 @@ function wrapTextNodes(
           fragment.appendChild(doc.createTextNode(tok.text))
         } else {
           counter.idx += 1
-          const wordId = `${dataId}_w${String(counter.idx).padStart(3, "0")}`
           const span = doc.createElement("span")
-          span.setAttribute("id", wordId)
+          span.setAttribute("id", wordIdFor(dataId, counter.idx))
           span.appendChild(doc.createTextNode(tok.text))
           fragment.appendChild(span)
         }

--- a/packages/pipeline/src/package-epub.ts
+++ b/packages/pipeline/src/package-epub.ts
@@ -1,8 +1,10 @@
 import fs from "node:fs"
 import path from "node:path"
+import { JSDOM } from "jsdom"
 import type { Storage } from "@adt/storage"
-import type { BookMetadata, TocGenerationOutput } from "@adt/types"
-import { type PackageAdtWebOptions, copyDirRecursive, injectWebpubStyles, htmlToXhtml } from "./package-web.js"
+import type { BookMetadata, TocGenerationOutput, WordTimestampOutput } from "@adt/types"
+import { type PackageAdtWebOptions, copyDirRecursive, injectWebpubStyles, htmlToXhtml, getWordTimestamps } from "./package-web.js"
+import { buildSmil, formatMediaDuration, type SmilParagraph } from "./smil.js"
 
 export type PackageEpubOptions = PackageAdtWebOptions
 
@@ -86,6 +88,25 @@ export function packageEpub(
   fs.writeFileSync(pagesJsonPath, JSON.stringify(rawPages, null, 2))
 
   // ------------------------------------------------------------------
+  // SMIL media overlays (fixed-layout only)
+  // ------------------------------------------------------------------
+  // Word-level read-aloud sync. Per-page .smil files reference the word
+  // <span id> elements emitted by the renderer + whisper word timestamps.
+  // Generated before file enumeration so collectFiles picks them up into
+  // the OPF manifest automatically.
+  //
+  // Gated on the export dialog's read-aloud toggle (`features.readAloud`)
+  // — disabling audio also disables SMIL, since SMIL is just sync metadata
+  // for the audio. Word-level vs paragraph-level fallback inside the SMIL
+  // builder is gated by whether tts-timestamps exist in storage (which is
+  // in turn gated by `speech.word_highlighting` at speech-generation time)
+  // and by whether the page has per-word `<span id>` (only fixed-layout
+  // emits these; reflowable falls back to paragraph-level highlights).
+  const smilEntries = options.features?.readAloud !== false
+    ? generateSmilFiles(storage, oebpsDir, rawPages, language)
+    : []
+
+  // ------------------------------------------------------------------
   // Load metadata
   // ------------------------------------------------------------------
   const metadataRow = storage.getLatestNodeData("metadata", "book")
@@ -141,7 +162,17 @@ export function packageEpub(
   // OEBPS/content.opf
   fs.writeFileSync(
     path.join(oebpsDir, "content.opf"),
-    buildOpf({ title, authors, publisher, language, pageList, allFiles, coverHref, fixedLayout: options.fixedLayout }),
+    buildOpf({
+      title,
+      authors,
+      publisher,
+      language,
+      pageList,
+      allFiles,
+      coverHref,
+      fixedLayout: options.fixedLayout,
+      smilEntries,
+    }),
   )
 
   // OEBPS/toc.xhtml (EPUB 3 navigation document)
@@ -182,6 +213,7 @@ const EPUB_MIME_TYPES: Record<string, string> = {
   ".ttf": "font/ttf",
   ".otf": "font/otf",
   ".dic": "application/octet-stream",
+  ".smil": "application/smil+xml",
 }
 
 function collectFiles(
@@ -224,6 +256,108 @@ const CONTAINER_XML = `<?xml version="1.0" encoding="UTF-8"?>
   </rootfiles>
 </container>`
 
+interface SmilEntry {
+  /** Page href the SMIL file is bound to (e.g. `pg001_sec001.xhtml`). */
+  pageHref: string
+  /** Path to the SMIL inside OEBPS (e.g. `smil/pg001_sec001.smil`). */
+  smilHref: string
+  /** Sum of audio durations covered by the SMIL, in seconds. */
+  durationSeconds: number
+}
+
+/**
+ * Walk page XHTML files and emit per-page `.smil` documents. Mirrors the
+ * viewer's count-guard: word-level when source span count matches whisper
+ * word count, paragraph-level fallback otherwise.
+ */
+function generateSmilFiles(
+  storage: Storage,
+  oebpsDir: string,
+  pages: PageEntry[],
+  language: string,
+): SmilEntry[] {
+  const wts: WordTimestampOutput | undefined = getWordTimestamps(storage, language)
+  if (!wts || Object.keys(wts.entries ?? {}).length === 0) return []
+
+  const audiosJsonPath = path.join(oebpsDir, "content", "i18n", language, "audios.json")
+  if (!fs.existsSync(audiosJsonPath)) return []
+  const audiosMap = JSON.parse(fs.readFileSync(audiosJsonPath, "utf-8")) as Record<string, string>
+
+  const smilDir = path.join(oebpsDir, "smil")
+  fs.mkdirSync(smilDir, { recursive: true })
+
+  const entries: SmilEntry[] = []
+  for (const page of pages) {
+    if (!page.href.endsWith(".xhtml")) continue
+    const xhtmlPath = path.join(oebpsDir, page.href)
+    if (!fs.existsSync(xhtmlPath)) continue
+    const xhtml = fs.readFileSync(xhtmlPath, "utf-8")
+
+    const paragraphs: SmilParagraph[] = []
+    for (const p of parseParagraphs(xhtml)) {
+      const audioFile = audiosMap[p.paragraphId]
+      const tsEntry = wts.entries[p.paragraphId]
+      if (!audioFile || !tsEntry || tsEntry.words.length === 0) continue
+      paragraphs.push({
+        paragraphId: p.paragraphId,
+        // SMIL lives at OEBPS/smil/{file}; audio at OEBPS/content/i18n/{lang}/audio/{file}.
+        audioPath: `../content/i18n/${language}/audio/${audioFile}`,
+        audioDuration: tsEntry.duration,
+        wordIds: p.wordIds,
+        whisperWords: tsEntry.words.map((w) => ({ word: w.word, start: w.start, end: w.end })),
+      })
+    }
+    if (paragraphs.length === 0) continue
+
+    const smilFileName = `${page.section_id}.smil`
+    const result = buildSmil({
+      // SMIL is in `smil/`; pages are at OEBPS root.
+      pageHref: `../${page.href}`,
+      paragraphs,
+    })
+    if (!result) continue
+
+    fs.writeFileSync(path.join(smilDir, smilFileName), result.xml)
+    entries.push({
+      pageHref: page.href,
+      smilHref: `smil/${smilFileName}`,
+      durationSeconds: result.durationSeconds,
+    })
+  }
+  return entries
+}
+
+/**
+ * Walk the page DOM for any element with `data-id` (the same convention the
+ * text-catalog uses to find audio-bearing elements) and capture the word
+ * `<span id>` children inside. Reflowable pages typically use `<h1>`,
+ * `<p>`, `<li>`, `<td>` etc. — fixed-layout uses `<p>` exclusively. Both
+ * flow through the same SMIL builder; reflowable always lands on
+ * paragraph-level fallback because no word ids are emitted there.
+ *
+ * `<img>` elements are excluded — image audio (alt-text descriptions)
+ * doesn't currently flow through the EPUB media overlay pipeline. The
+ * paragraph-level fallback for reflowable highlights the whole text
+ * element, which is what readers expect for non-fixed content.
+ */
+function parseParagraphs(xhtml: string): Array<{ paragraphId: string; wordIds: string[] }> {
+  const dom = new JSDOM(xhtml, { contentType: "application/xhtml+xml" })
+  const doc = dom.window.document
+  const out: Array<{ paragraphId: string; wordIds: string[] }> = []
+  for (const el of doc.querySelectorAll("[data-id]")) {
+    if (el.tagName.toLowerCase() === "img") continue
+    const paragraphId = el.getAttribute("data-id")
+    if (!paragraphId) continue
+    const wordIds: string[] = []
+    for (const wordEl of el.querySelectorAll("span[id]")) {
+      const id = wordEl.getAttribute("id")
+      if (id && /_w\d+$/.test(id)) wordIds.push(id)
+    }
+    out.push({ paragraphId, wordIds })
+  }
+  return out
+}
+
 function buildOpf(opts: {
   title: string
   authors: string[]
@@ -233,8 +367,11 @@ function buildOpf(opts: {
   allFiles: Array<{ href: string; mediaType: string }>
   coverHref?: string
   fixedLayout?: boolean
+  smilEntries?: SmilEntry[]
 }): string {
-  const { title, authors, publisher, language, pageList, allFiles, coverHref, fixedLayout } = opts
+  const { title, authors, publisher, language, pageList, allFiles, coverHref, fixedLayout, smilEntries } = opts
+  const smilByPage = new Map<string, SmilEntry>()
+  for (const e of smilEntries ?? []) smilByPage.set(e.pageHref, e)
   const now = new Date().toISOString().replace(/\.\d{3}Z$/, "Z")
 
   // Metadata
@@ -258,6 +395,32 @@ function buildOpf(opts: {
     metaLines.push(`    <meta property="rendition:spread">none</meta>`)
   }
 
+  // SMIL manifest items get stable, predictable ids so spine itemrefs can
+  // reference them via `media-overlay`. Derived from the SMIL filename
+  // (which uses section_id) — using page href would collapse the cover /
+  // first-page case where href is `index.xhtml` rather than the section id.
+  const smilHrefToOverlayId = new Map<string, string>()
+  for (const e of smilEntries ?? []) {
+    const sectionId = e.smilHref.replace(/^smil\//, "").replace(/\.smil$/, "")
+    smilHrefToOverlayId.set(e.smilHref, `overlay-${sectionId}`)
+  }
+
+  // SMIL media overlay metadata. Per-overlay duration goes alongside the
+  // page metadata via `refines`; the total runs as a top-level
+  // `media:duration`. media:active-class names the CSS class an EPUB
+  // reader toggles on the active text element during playback.
+  if (smilEntries && smilEntries.length > 0) {
+    const totalDuration = smilEntries.reduce((s, e) => s + e.durationSeconds, 0)
+    metaLines.push(`    <meta property="media:duration">${formatMediaDuration(totalDuration)}</meta>`)
+    metaLines.push(`    <meta property="media:active-class">-epub-media-overlay-active</meta>`)
+    for (const e of smilEntries) {
+      const overlayId = smilHrefToOverlayId.get(e.smilHref)!
+      metaLines.push(
+        `    <meta property="media:duration" refines="#${escapeXml(overlayId)}">${formatMediaDuration(e.durationSeconds)}</meta>`,
+      )
+    }
+  }
+
   // Manifest — enumerate all files in OEBPS
   const manifestLines: string[] = [
     `    <item id="nav" href="toc.xhtml" media-type="application/xhtml+xml" properties="nav"/>`,
@@ -268,6 +431,13 @@ function buildOpf(opts: {
   const skipHrefs = new Set(["toc.xhtml", "toc.ncx", "content.opf"])
   const pageHrefs = new Set(pageList.map(p => p.href))
   const hrefToItemId = new Map<string, string>()
+  // Page href → SMIL overlay item id (for the `media-overlay` attribute on
+  // the content document's manifest item). EPUB 3 Media Overlays spec puts
+  // this association on the manifest, not the spine.
+  const pageHrefToOverlayId = new Map<string, string>()
+  for (const e of smilEntries ?? []) {
+    pageHrefToOverlayId.set(e.pageHref, smilHrefToOverlayId.get(e.smilHref)!)
+  }
   let itemIndex = 0
 
   for (const file of allFiles) {
@@ -275,20 +445,23 @@ function buildOpf(opts: {
 
     const itemId = file.href === coverHref
       ? "cover-image"
-      : `item-${++itemIndex}`
+      : smilHrefToOverlayId.get(file.href) ?? `item-${++itemIndex}`
     hrefToItemId.set(file.href, itemId)
 
     const props: string[] = []
     if (file.href === coverHref) props.push("cover-image")
     if (!fixedLayout && pageHrefs.has(file.href)) props.push("scripted")
     const propsAttr = props.length > 0 ? ` properties="${props.join(" ")}"` : ""
+    const overlayId = pageHrefToOverlayId.get(file.href)
+    const overlayAttr = overlayId ? ` media-overlay="${escapeXml(overlayId)}"` : ""
 
     manifestLines.push(
-      `    <item id="${escapeXml(itemId)}" href="${escapeXml(file.href)}" media-type="${file.mediaType}"${propsAttr}/>`,
+      `    <item id="${escapeXml(itemId)}" href="${escapeXml(file.href)}" media-type="${file.mediaType}"${propsAttr}${overlayAttr}/>`,
     )
   }
 
-  // Spine — reading order from pages.json
+  // Spine — reading order from pages.json. The media-overlay association
+  // lives on the manifest item (above), not on the spine itemref.
   const spineLines = pageList.map((page) => {
     const itemId = hrefToItemId.get(page.href) ?? escapeXml(page.section_id)
     return `    <itemref idref="${escapeXml(itemId)}"/>`

--- a/packages/pipeline/src/package-epub.ts
+++ b/packages/pipeline/src/package-epub.ts
@@ -5,6 +5,8 @@ import type { Storage } from "@adt/storage"
 import type { BookMetadata, TocGenerationOutput, WordTimestampOutput } from "@adt/types"
 import { type PackageAdtWebOptions, copyDirRecursive, injectWebpubStyles, htmlToXhtml, getWordTimestamps } from "./package-web.js"
 import { buildSmil, formatMediaDuration, type SmilParagraph } from "./smil.js"
+import { tokenizeWords } from "./word-tokenize.js"
+import { styleMapToInline } from "./fixed-layout-rendering.js"
 
 export type PackageEpubOptions = PackageAdtWebOptions
 
@@ -413,6 +415,10 @@ function buildOpf(opts: {
     const totalDuration = smilEntries.reduce((s, e) => s + e.durationSeconds, 0)
     metaLines.push(`    <meta property="media:duration">${formatMediaDuration(totalDuration)}</meta>`)
     metaLines.push(`    <meta property="media:active-class">-epub-media-overlay-active</meta>`)
+    // media:playback-active-class names the class added to the document
+    // currently being read aloud. Apple's Asset Guide lists it alongside
+    // media:active-class; emitting both is harmless on readers that ignore it.
+    metaLines.push(`    <meta property="media:playback-active-class">-epub-media-overlay-playing</meta>`)
     for (const e of smilEntries) {
       const overlayId = smilHrefToOverlayId.get(e.smilHref)!
       metaLines.push(
@@ -594,15 +600,210 @@ function escapeXml(str: string): string {
 }
 
 /**
+ * Mirror `data-id` to `id` on every element that has the former but not
+ * the latter. The renderer/LLM uses `data-id` as the semantic anchor for
+ * in-app TTS/audio mapping; EPUB readers only honour the standard `id`
+ * attribute when resolving SMIL `<text src="…#id"/>` fragment references.
+ * Without this pass, every paragraph-level media-overlay reference fails
+ * to resolve and Apple Books silently disables read-aloud.
+ *
+ * Implementation is a regex pass rather than a DOM round-trip so the
+ * output stays byte-equivalent to the htmlToXhtml() result outside the
+ * inserted `id=` attribute — important for tests and for not perturbing
+ * the existing well-formed XHTML.
+ */
+export function mirrorDataIdToId(xhtml: string): string {
+  // Captures: tag name, attrs, optional self-closing slash. Re-emits the
+  // slash at the end so `<img …/>` doesn't turn into `<img …/ id="x">`.
+  return xhtml.replace(
+    /<([a-zA-Z][\w-]*)((?:\s+[^>\s][^>]*?)?)(\s*\/?)>/g,
+    (match, tag, attrs, selfClose) => {
+      const dataIdMatch = attrs.match(/\sdata-id="([^"]+)"/)
+      if (!dataIdMatch) return match
+      if (/\sid\s*=/.test(attrs)) return match
+      return `<${tag}${attrs} id="${dataIdMatch[1]}"${selfClose}>`
+    },
+  )
+}
+
+/**
+ * Wrap every word inside `[data-id]` elements in
+ * `<span id="${dataId}_w${NNN}">…</span>` so SMIL `<text src="…#…_wNNN"/>`
+ * references resolve in EPUB readers. Uses the same Unicode tokenizer as
+ * the live viewer (`tokenizeWords` / `WORD_PATTERN`), so word counts agree
+ * with Whisper alignment and with runtime word highlighting.
+ *
+ * Two paths:
+ * - When the paragraph carries `data-segments` (fixed-layout), tokenise the
+ *   concatenated segment text and emit per-word spans that wrap per-segment
+ *   style fragments. Words that straddle style runs become ONE word span
+ *   containing two `<span style>` fragments (the "lahars" case) — required
+ *   for epubcheck (no duplicate ids) and for SMIL alignment (Whisper emits
+ *   one timestamp for the spoken word).
+ * - Otherwise (reflowable), walk text nodes and wrap each word, preserving
+ *   inline elements (`<em>`, `<strong>`, glossary spans) verbatim.
+ *
+ * `<img data-id="…">` is skipped: image audio (alt-text descriptions)
+ * doesn't currently flow through the EPUB media overlay pipeline.
+ *
+ * Runs on the HTML *before* `htmlToXhtml` so the subsequent XHTML
+ * normaliser handles void-tag closing for us — keeps this function from
+ * needing its own XML serializer.
+ */
+export function wrapWordSpans(html: string): string {
+  const dom = new JSDOM(html)
+  const doc = dom.window.document
+
+  for (const el of Array.from(doc.querySelectorAll("[data-id]"))) {
+    if (el.tagName.toLowerCase() === "img") continue
+    const dataId = el.getAttribute("data-id")
+    if (!dataId) continue
+
+    const segmentsAttr = el.getAttribute("data-segments")
+    if (segmentsAttr) {
+      wrapBySegments(el, dataId, segmentsAttr, doc)
+    } else {
+      const counter = { idx: 0 }
+      wrapTextNodes(el, dataId, counter, doc)
+    }
+  }
+
+  return dom.serialize()
+}
+
+/**
+ * Fixed-layout path: re-emit the paragraph's children from `data-segments`,
+ * tokenising the concatenated segment text and using positional overlap to
+ * split words across style runs where needed. Replaces the paragraph's
+ * existing inner DOM — caller has already filtered out `img[data-id]`.
+ */
+function wrapBySegments(
+  parent: Element,
+  dataId: string,
+  segmentsAttr: string,
+  doc: Document,
+): void {
+  let segments: { text?: string; style?: Record<string, string> }[]
+  try {
+    segments = JSON.parse(segmentsAttr)
+  } catch {
+    return
+  }
+  if (!Array.isArray(segments) || segments.length === 0) return
+
+  const concatText = segments.map((s) => s?.text ?? "").join("")
+  const segOffsets: number[] = []
+  {
+    let cursor = 0
+    for (const s of segments) {
+      segOffsets.push(cursor)
+      cursor += (s?.text ?? "").length
+    }
+  }
+
+  // Build the styled `<span>` pieces that cover [start, end) in concat
+  // coordinates. Each style run becomes one span; adjacent runs stay
+  // separate so the visual styling survives intact.
+  const buildPieces = (start: number, end: number): Element[] => {
+    const out: Element[] = []
+    for (let i = 0; i < segments.length; i++) {
+      const segStart = segOffsets[i]
+      const segText = segments[i]?.text ?? ""
+      const segEnd = segStart + segText.length
+      if (segEnd <= start) continue
+      if (segStart >= end) break
+      const slice = segText.slice(
+        Math.max(start, segStart) - segStart,
+        Math.min(end, segEnd) - segStart,
+      )
+      if (slice.length === 0) continue
+      const styleStr = segments[i]?.style ? styleMapToInline(segments[i].style!) : ""
+      if (styleStr) {
+        const span = doc.createElement("span")
+        span.setAttribute("style", styleStr)
+        span.appendChild(doc.createTextNode(slice))
+        out.push(span)
+      } else {
+        // Wrap unstyled text in a span so callers always get Element nodes;
+        // the only consumer (appendChild loop below) handles both.
+        const span = doc.createElement("span")
+        span.appendChild(doc.createTextNode(slice))
+        out.push(span)
+      }
+    }
+    return out
+  }
+
+  // Clear and re-emit.
+  while (parent.firstChild) parent.removeChild(parent.firstChild)
+
+  let wordIdx = 0
+  for (const tok of tokenizeWords(concatText)) {
+    if (tok.type === "separator") {
+      // Separators (whitespace, punctuation) emit bare so word boxes stay
+      // tight; surrounding glyphs don't inherit a segment's font metrics.
+      if (tok.text.length > 0) {
+        parent.appendChild(doc.createTextNode(tok.text))
+      }
+      continue
+    }
+    wordIdx += 1
+    const wordId = `${dataId}_w${String(wordIdx).padStart(3, "0")}`
+    const wrap = doc.createElement("span")
+    wrap.setAttribute("id", wordId)
+    for (const piece of buildPieces(tok.start, tok.end)) wrap.appendChild(piece)
+    parent.appendChild(wrap)
+  }
+}
+
+function wrapTextNodes(
+  parent: Element,
+  dataId: string,
+  counter: { idx: number },
+  doc: Document,
+): void {
+  // Snapshot children so the mutation below doesn't disturb iteration.
+  for (const child of Array.from(parent.childNodes)) {
+    if (child.nodeType === 3 /* TEXT_NODE */) {
+      const text = child.textContent ?? ""
+      if (text.length === 0) continue
+      const fragment = doc.createDocumentFragment()
+      for (const tok of tokenizeWords(text)) {
+        if (tok.type === "separator") {
+          fragment.appendChild(doc.createTextNode(tok.text))
+        } else {
+          counter.idx += 1
+          const wordId = `${dataId}_w${String(counter.idx).padStart(3, "0")}`
+          const span = doc.createElement("span")
+          span.setAttribute("id", wordId)
+          span.appendChild(doc.createTextNode(tok.text))
+          fragment.appendChild(span)
+        }
+      }
+      child.parentNode!.replaceChild(fragment, child)
+    } else if (child.nodeType === 1 /* ELEMENT_NODE */) {
+      // Recurse — inline tags (em, strong, glossary span…) wrap whole words
+      // in practice. A word that crosses an inline boundary would split
+      // across two word ids, mirroring the rare-case Whisper behaviour.
+      wrapTextNodes(child as Element, dataId, counter, doc)
+    }
+  }
+}
+
+/**
  * Convert an HTML content page to well-formed XHTML for EPUB 3.
  *
  * - Adds XML declaration and XHTML namespace
  * - Converts HTML to XML-safe markup (self-closing tags, etc.)
  * - Preserves all inline styles and content
+ * - Mirrors `data-id` to `id` so SMIL fragment refs resolve in EPUB readers
+ * - Wraps words in `<span id="…_wNNN">` so SMIL word-level fragments resolve
  */
 function convertPageToXhtml(html: string): string {
-  // Extract the content between <html> and </html>, converting the body
-  const xhtmlBody = htmlToXhtml(html)
+  // Wrap words first on raw HTML (JSDOM is forgiving there); subsequent
+  // htmlToXhtml normalises void-tag closing and entity references for the
+  // EPUB consumer. Then mirror data-id → id for paragraph-level fragments.
+  const xhtmlBody = mirrorDataIdToId(htmlToXhtml(wrapWordSpans(html)))
 
   // The htmlToXhtml parser strips the doctype and may mangle the html tag.
   // Rebuild a clean XHTML document with proper namespace.

--- a/packages/pipeline/src/package-epub.ts
+++ b/packages/pipeline/src/package-epub.ts
@@ -1,0 +1,459 @@
+import fs from "node:fs"
+import path from "node:path"
+import type { Storage } from "@adt/storage"
+import type { BookMetadata, TocGenerationOutput } from "@adt/types"
+import { type PackageAdtWebOptions, copyDirRecursive, injectWebpubStyles, htmlToXhtml } from "./package-web.js"
+
+export type PackageEpubOptions = PackageAdtWebOptions
+
+interface PageEntry {
+  section_id: string
+  href: string
+  page_number?: number
+}
+
+/** Files/dirs in adt/ root that are SCORM/offline-specific and not needed in EPUB. */
+const EPUB_SKIP = new Set(["imsmanifest.xml", "AGENTS.md"])
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Package an EPUB 3 from the existing ADT web package.
+ *
+ * Follows the same pattern as `packageWebpub`: copies `adt/` into
+ * `epub/OEBPS/`, injects reader-override styles, then layers EPUB-specific
+ * metadata files (OPF, NCX, container.xml, navigation document) on top.
+ *
+ * Requires `packageAdtWeb` to have been run first.
+ */
+export function packageEpub(
+  storage: Storage,
+  options: PackageEpubOptions,
+): void {
+  const { bookDir, title, language } = options
+
+  const adtDir = path.join(bookDir, "adt")
+  if (!fs.existsSync(adtDir)) {
+    throw new Error("ADT package not found — run packageAdtWeb first")
+  }
+
+  const epubDir = path.join(bookDir, "epub")
+  const oebpsDir = path.join(epubDir, "OEBPS")
+
+  // Clean previous build
+  if (fs.existsSync(epubDir)) fs.rmSync(epubDir, { recursive: true })
+
+  // Copy adt/ -> epub/OEBPS/, skipping SCORM-specific files
+  copyDirRecursive(adtDir, oebpsDir, EPUB_SKIP)
+
+  // Strip SCORM adapter from assets/
+  const scormJs = path.join(oebpsDir, "assets", "scorm.js")
+  if (fs.existsSync(scormJs)) fs.unlinkSync(scormJs)
+  const offlineJs = path.join(oebpsDir, "assets", "offline-preloader.js")
+  if (fs.existsSync(offlineJs)) fs.unlinkSync(offlineJs)
+
+  // Strip the web runtime bundle. EPUB readers provide TOC, page navigation,
+  // settings, and read-aloud playback (the latter via the SMIL media overlays
+  // generated below) natively, so the React dock chrome would just duplicate
+  // them. Audio + word highlighting comes from SMIL; glossary is planned as
+  // an EPUB dictionary in a follow-up.
+  stripRuntimeBundle(oebpsDir)
+
+  // Inject reader-override CSS
+  injectWebpubStyles(oebpsDir, { fixedLayout: options.fixedLayout })
+
+  // ------------------------------------------------------------------
+  // Convert content HTML pages to XHTML (required by EPUB 3 / Apple Books)
+  // ------------------------------------------------------------------
+  const pagesJsonPath = path.join(oebpsDir, "content", "pages.json")
+  const rawPages = JSON.parse(fs.readFileSync(pagesJsonPath, "utf-8")) as PageEntry[]
+  for (const page of rawPages) {
+    if (!page.href.endsWith(".html")) continue
+    const htmlPath = path.join(oebpsDir, page.href)
+    if (!fs.existsSync(htmlPath)) continue
+
+    const html = fs.readFileSync(htmlPath, "utf-8")
+    const xhtml = convertPageToXhtml(html)
+    const xhtmlHref = page.href.replace(/\.html$/, ".xhtml")
+
+    fs.writeFileSync(path.join(oebpsDir, xhtmlHref), xhtml)
+    fs.unlinkSync(htmlPath)
+    page.href = xhtmlHref
+  }
+  // Update pages.json with .xhtml hrefs
+  fs.writeFileSync(pagesJsonPath, JSON.stringify(rawPages, null, 2))
+
+  // ------------------------------------------------------------------
+  // Load metadata
+  // ------------------------------------------------------------------
+  const metadataRow = storage.getLatestNodeData("metadata", "book")
+  const metadata = metadataRow?.data as BookMetadata | undefined
+  const authors = metadata?.authors ?? []
+  const publisher = metadata?.publisher ?? undefined
+
+  const tocRow = storage.getLatestNodeData("toc-generation", "book")
+  const llmToc = tocRow?.data as TocGenerationOutput | undefined
+
+  // ------------------------------------------------------------------
+  // Read pages.json for reading order
+  // ------------------------------------------------------------------
+  const pagesPath = path.join(oebpsDir, "content", "pages.json")
+  const pageList = JSON.parse(fs.readFileSync(pagesPath, "utf-8")) as PageEntry[]
+
+  // ------------------------------------------------------------------
+  // Enumerate all files for OPF manifest
+  // ------------------------------------------------------------------
+  const allFiles: Array<{ href: string; mediaType: string }> = []
+  collectFiles(oebpsDir, oebpsDir, allFiles)
+
+  // ------------------------------------------------------------------
+  // Detect cover image
+  // ------------------------------------------------------------------
+  let coverHref: string | undefined
+  for (const name of ["cover.png", "cover.jpg", "cover.jpeg"]) {
+    if (fs.existsSync(path.join(oebpsDir, name))) {
+      coverHref = name
+      break
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // Write EPUB-specific files
+  // ------------------------------------------------------------------
+
+  // mimetype (must be first file in ZIP, uncompressed — export service handles this)
+  fs.writeFileSync(path.join(epubDir, "mimetype"), "application/epub+zip")
+
+  // META-INF/container.xml
+  fs.mkdirSync(path.join(epubDir, "META-INF"), { recursive: true })
+  fs.writeFileSync(path.join(epubDir, "META-INF", "container.xml"), CONTAINER_XML)
+
+  // META-INF/com.apple.ibooks.display-options.xml (Apple Books compatibility)
+  if (options.fixedLayout) {
+    fs.writeFileSync(
+      path.join(epubDir, "META-INF", "com.apple.ibooks.display-options.xml"),
+      IBOOKS_DISPLAY_OPTIONS,
+    )
+  }
+
+  // OEBPS/content.opf
+  fs.writeFileSync(
+    path.join(oebpsDir, "content.opf"),
+    buildOpf({ title, authors, publisher, language, pageList, allFiles, coverHref, fixedLayout: options.fixedLayout }),
+  )
+
+  // OEBPS/toc.xhtml (EPUB 3 navigation document)
+  fs.writeFileSync(
+    path.join(oebpsDir, "toc.xhtml"),
+    buildNavDocument(language, title, pageList, llmToc),
+  )
+
+  // OEBPS/toc.ncx (EPUB 2 fallback)
+  fs.writeFileSync(
+    path.join(oebpsDir, "toc.ncx"),
+    buildNcx(title, pageList),
+  )
+}
+
+// ---------------------------------------------------------------------------
+// File enumeration
+// ---------------------------------------------------------------------------
+
+const EPUB_MIME_TYPES: Record<string, string> = {
+  ".xhtml": "application/xhtml+xml",
+  ".html": "text/html",
+  ".css": "text/css",
+  ".js": "application/javascript",
+  ".json": "application/json",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".svg": "image/svg+xml",
+  ".webp": "image/webp",
+  ".mp3": "audio/mpeg",
+  ".mp4": "video/mp4",
+  ".ogg": "audio/ogg",
+  ".wav": "audio/wav",
+  ".woff": "font/woff",
+  ".woff2": "font/woff2",
+  ".ttf": "font/ttf",
+  ".otf": "font/otf",
+  ".dic": "application/octet-stream",
+}
+
+function collectFiles(
+  baseDir: string,
+  dir: string,
+  out: Array<{ href: string; mediaType: string }>,
+): void {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      collectFiles(baseDir, fullPath, out)
+    } else if (entry.isFile()) {
+      const relPath = path.relative(baseDir, fullPath).replace(/\\/g, "/")
+      const ext = path.extname(entry.name).toLowerCase()
+      out.push({
+        href: relPath,
+        mediaType: EPUB_MIME_TYPES[ext] ?? "application/octet-stream",
+      })
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// EPUB structural documents
+// ---------------------------------------------------------------------------
+
+const IBOOKS_DISPLAY_OPTIONS = `<?xml version="1.0" encoding="UTF-8"?>
+<display_options>
+  <platform name="*">
+    <option name="specified-fonts">true</option>
+    <option name="fixed-layout">true</option>
+    <option name="open-to-spread">false</option>
+  </platform>
+</display_options>`
+
+const CONTAINER_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>`
+
+function buildOpf(opts: {
+  title: string
+  authors: string[]
+  publisher?: string
+  language: string
+  pageList: PageEntry[]
+  allFiles: Array<{ href: string; mediaType: string }>
+  coverHref?: string
+  fixedLayout?: boolean
+}): string {
+  const { title, authors, publisher, language, pageList, allFiles, coverHref, fixedLayout } = opts
+  const now = new Date().toISOString().replace(/\.\d{3}Z$/, "Z")
+
+  // Metadata
+  const metaLines: string[] = [
+    `    <dc:identifier>urn:uuid:${crypto.randomUUID()}</dc:identifier>`,
+    `    <dc:title>${escapeXml(title)}</dc:title>`,
+    `    <dc:language>${escapeXml(language)}</dc:language>`,
+    `    <meta property="dcterms:modified">${now}</meta>`,
+  ]
+  for (const author of authors) {
+    metaLines.push(`    <dc:creator>${escapeXml(author)}</dc:creator>`)
+  }
+  if (publisher) {
+    metaLines.push(`    <dc:publisher>${escapeXml(publisher)}</dc:publisher>`)
+  }
+  if (coverHref) {
+    metaLines.push(`    <meta name="cover" content="cover-image"/>`)
+  }
+  if (fixedLayout) {
+    metaLines.push(`    <meta property="rendition:layout">pre-paginated</meta>`)
+    metaLines.push(`    <meta property="rendition:spread">none</meta>`)
+  }
+
+  // Manifest — enumerate all files in OEBPS
+  const manifestLines: string[] = [
+    `    <item id="nav" href="toc.xhtml" media-type="application/xhtml+xml" properties="nav"/>`,
+    `    <item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml"/>`,
+  ]
+
+  // Track IDs to avoid duplicates (toc.xhtml and toc.ncx are already listed)
+  const skipHrefs = new Set(["toc.xhtml", "toc.ncx", "content.opf"])
+  const pageHrefs = new Set(pageList.map(p => p.href))
+  const hrefToItemId = new Map<string, string>()
+  let itemIndex = 0
+
+  for (const file of allFiles) {
+    if (skipHrefs.has(file.href)) continue
+
+    const itemId = file.href === coverHref
+      ? "cover-image"
+      : `item-${++itemIndex}`
+    hrefToItemId.set(file.href, itemId)
+
+    const props: string[] = []
+    if (file.href === coverHref) props.push("cover-image")
+    if (!fixedLayout && pageHrefs.has(file.href)) props.push("scripted")
+    const propsAttr = props.length > 0 ? ` properties="${props.join(" ")}"` : ""
+
+    manifestLines.push(
+      `    <item id="${escapeXml(itemId)}" href="${escapeXml(file.href)}" media-type="${file.mediaType}"${propsAttr}/>`,
+    )
+  }
+
+  // Spine — reading order from pages.json
+  const spineLines = pageList.map((page) => {
+    const itemId = hrefToItemId.get(page.href) ?? escapeXml(page.section_id)
+    return `    <itemref idref="${escapeXml(itemId)}"/>`
+  })
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="pub-id"${fixedLayout ? ` prefix="rendition: http://www.idpf.org/vocab/rendition/#"` : ""}>
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+${metaLines.join("\n")}
+  </metadata>
+  <manifest>
+${manifestLines.join("\n")}
+  </manifest>
+  <spine toc="ncx">
+${spineLines.join("\n")}
+  </spine>
+</package>`
+}
+
+function buildNavDocument(
+  language: string,
+  title: string,
+  pageList: PageEntry[],
+  llmToc?: TocGenerationOutput,
+): string {
+  let tocItems: string
+
+  if (llmToc && llmToc.entries.length > 0) {
+    // Use LLM-generated TOC — map sectionIds to page hrefs
+    const sectionMap = new Map(pageList.map((p) => [p.section_id, p.href]))
+    tocItems = llmToc.entries
+      .map((e) => {
+        const href = sectionMap.get(e.sectionId)
+        if (!href) return ""
+        const indent = "      " + "  ".repeat(Math.max(0, e.level - 1))
+        return `${indent}<li><a href="${escapeXml(href)}">${escapeXml(e.title)}</a></li>`
+      })
+      .filter(Boolean)
+      .join("\n")
+  } else {
+    // Fallback: one entry per page
+    tocItems = pageList
+      .map((p) => {
+        const label = p.page_number != null ? `Page ${p.page_number}` : p.section_id
+        return `      <li><a href="${escapeXml(p.href)}">${escapeXml(label)}</a></li>`
+      })
+      .join("\n")
+  }
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" lang="${escapeXml(language)}">
+<head>
+  <meta charset="UTF-8"/>
+  <title>${escapeXml(title)}</title>
+</head>
+<body>
+  <nav epub:type="toc" id="toc">
+    <h1>Table of Contents</h1>
+    <ol>
+${tocItems}
+    </ol>
+  </nav>
+</body>
+</html>`
+}
+
+function buildNcx(title: string, pageList: PageEntry[]): string {
+  const navPoints = pageList
+    .map((p, i) => {
+      const label = p.page_number != null ? `Page ${p.page_number}` : p.section_id
+      return `    <navPoint id="navpoint-${i + 1}" playOrder="${i + 1}">
+      <navLabel><text>${escapeXml(label)}</text></navLabel>
+      <content src="${escapeXml(p.href)}"/>
+    </navPoint>`
+    })
+    .join("\n")
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/" version="2005-1">
+  <head>
+    <meta name="dtb:depth" content="1"/>
+    <meta name="dtb:totalPageCount" content="0"/>
+    <meta name="dtb:maxPageNumber" content="0"/>
+  </head>
+  <docTitle><text>${escapeXml(title)}</text></docTitle>
+  <navMap>
+${navPoints}
+  </navMap>
+</ncx>`
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Remove `base.bundle.{min,local}.js` and the `<script>` tags that load them
+ * from every page. EPUB readers handle nav/settings/playback natively, so
+ * the React runtime would only duplicate them.
+ */
+function stripRuntimeBundle(oebpsDir: string): void {
+  for (const name of ["base.bundle.min.js", "base.bundle.local.js", "base.bundle.min.js.map"]) {
+    const p = path.join(oebpsDir, "assets", name)
+    if (fs.existsSync(p)) fs.unlinkSync(p)
+  }
+  const SCRIPT_RE = /\s*<script\b[^>]*src=["'][^"']*base\.bundle\.(min|local)\.js[^"']*["'][^>]*>\s*<\/script>/g
+  const walk = (dir: string): void => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const fullPath = path.join(dir, entry.name)
+      if (entry.isDirectory()) {
+        walk(fullPath)
+      } else if (entry.isFile() && /\.(html|xhtml)$/.test(entry.name)) {
+        const content = fs.readFileSync(fullPath, "utf-8")
+        const stripped = content.replace(SCRIPT_RE, "")
+        if (stripped !== content) fs.writeFileSync(fullPath, stripped)
+      }
+    }
+  }
+  walk(oebpsDir)
+}
+
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;")
+}
+
+/**
+ * Convert an HTML content page to well-formed XHTML for EPUB 3.
+ *
+ * - Adds XML declaration and XHTML namespace
+ * - Converts HTML to XML-safe markup (self-closing tags, etc.)
+ * - Preserves all inline styles and content
+ */
+function convertPageToXhtml(html: string): string {
+  // Extract the content between <html> and </html>, converting the body
+  const xhtmlBody = htmlToXhtml(html)
+
+  // The htmlToXhtml parser strips the doctype and may mangle the html tag.
+  // Rebuild a clean XHTML document with proper namespace.
+  // Extract lang attribute from original
+  const langMatch = html.match(/lang="([^"]*)"/)
+  const lang = langMatch ? langMatch[1] : "en"
+
+  // Extract <head> content (between <head> and </head>)
+  const headMatch = xhtmlBody.match(/<head[^>]*>([\s\S]*?)<\/head>/)
+  const headContent = headMatch ? headMatch[1] : ""
+
+  // Extract <body> with attributes and content
+  const bodyMatch = xhtmlBody.match(/<body([^>]*)>([\s\S]*?)<\/body>/)
+  const bodyAttrs = bodyMatch ? bodyMatch[1] : ""
+  const bodyContent = bodyMatch ? bodyMatch[2] : ""
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="${escapeXml(lang)}">
+<head>
+${headContent}
+</head>
+<body${bodyAttrs}>
+${bodyContent}
+</body>
+</html>`
+}

--- a/packages/pipeline/src/package-web.ts
+++ b/packages/pipeline/src/package-web.ts
@@ -2458,7 +2458,7 @@ export function copyDirRecursive(
   }
 }
 
-function escapeHtml(s: string): string {
+export function escapeHtml(s: string): string {
   return s
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")

--- a/packages/pipeline/src/package-web.ts
+++ b/packages/pipeline/src/package-web.ts
@@ -100,7 +100,7 @@ function collectDirectoryFingerprint(dirPath: string, prefix = ""): Array<[strin
   return entries
 }
 
-function getWordTimestamps(
+export function getWordTimestamps(
   storage: Storage,
   language: string,
 ): WordTimestampOutput | undefined {
@@ -948,6 +948,14 @@ body {
 }
 .text-overlay p {
   position: absolute !important;
+}
+
+/* SMIL media-overlay active class — declared in the OPF as
+   media:active-class. EPUB readers toggle this on the active text
+   element during read-aloud playback. */
+.-epub-media-overlay-active {
+  background: rgba(255, 235, 59, 0.4);
+  border-radius: 0.15em;
 }
 </style>`
 

--- a/packages/pipeline/src/package-web.ts
+++ b/packages/pipeline/src/package-web.ts
@@ -66,6 +66,7 @@ export interface PackageAdtWebOptions {
     reduceMotion?: boolean
   }
   lockedSettings?: ("dockLayout" | "theme" | "iconSize" | "reduceMotion")[]
+  fixedLayout?: boolean
 }
 
 interface PageEntry {
@@ -212,6 +213,7 @@ export async function packageAdtWeb(
     features,
     defaultSettings,
     lockedSettings,
+    fixedLayout,
   } = options
   const language = normalizeLocale(rawLanguage)
   const outputLanguages = Array.from(new Set(rawOutputLanguages.map((code) => normalizeLocale(code))))
@@ -340,6 +342,17 @@ export async function packageAdtWeb(
 
           const headingText = sectionMeta ? findHeadingText(sectionMeta) : null
 
+          // For fixed-layout pages, extract viewport from the rendered content div.
+          // Viewport matches content dimensions (2x render scale) exactly — no
+          // transform needed, Apple Books scales the viewport to fit the screen.
+          let fixedViewport: { width: number; height: number } | undefined
+          if (fixedLayout) {
+            const vp = rewrittenHtml.match(/width:(\d+)px;height:(\d+)px/)
+            if (vp) {
+              fixedViewport = { width: parseInt(vp[1], 10), height: parseInt(vp[2], 10) }
+            }
+          }
+
           const pageHtml = renderPageHtml({
             content: rewrittenHtml,
             language,
@@ -351,6 +364,7 @@ export async function packageAdtWeb(
             hasMath: sectionHasMath,
             bundleVersion,
             applyBodyBackground,
+            fixedViewport,
           })
           fs.writeFileSync(path.join(adtDir, filename), pageHtml)
 
@@ -640,6 +654,9 @@ export async function packageAdtWeb(
   if (lockedSettings && lockedSettings.length > 0) {
     configJson.lockedSettings = lockedSettings
   }
+  if (fixedLayout) {
+    configJson.fixedLayout = true
+  }
 
   // ------------------------------------------------------------------
   // Copy web assets
@@ -773,7 +790,7 @@ export function packageWebpub(
 
   // Inject CSS into HTML pages to prevent readers (e.g. Thorium) from applying
   // column-based pagination which breaks the single-page ADT layout.
-  injectWebpubStyles(webpubDir)
+  injectWebpubStyles(webpubDir, { fixedLayout: options.fixedLayout })
 
   // Load metadata for manifest
   const metadataRow = storage.getLatestNodeData("metadata", "book")
@@ -837,8 +854,8 @@ export function packageWebpub(
   writeJson(path.join(webpubDir, "manifest.json"), manifest)
 }
 
-const WEBPUB_OVERRIDE_CSS = `<style>
-/* ── WebPub / EPUB reader overrides ──
+const REFLOWABLE_OVERRIDE_CSS = `<style>
+/* ── WebPub / EPUB reader overrides (reflowable) ──
    EPUB readers like Thorium inject their own column-based pagination.
    The ADT pages use Tailwind flex centering and responsive breakpoints
    that don't work well in reflowable EPUB viewports. Override everything
@@ -892,18 +909,65 @@ img {
 }
 </style>`
 
+const FIXED_LAYOUT_OVERRIDE_CSS = `<style>
+/* ── EPUB reader overrides (fixed-layout) ──
+   Preserve absolute positioning for fixed-layout pages while
+   ensuring content is visible and the viewport is respected. */
+
+/* Prevent reader column pagination */
+:root, html, body {
+  columns: auto !important;
+  column-width: auto !important;
+  column-count: auto !important;
+  column-gap: normal !important;
+}
+
+/* Body: fill viewport, no flex centering */
+body {
+  display: block !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  min-height: auto !important;
+  overflow: hidden !important;
+}
+
+/* Override Tailwind Preflight img reset that breaks positioned images */
+#content img {
+  max-width: none !important;
+}
+
+/* Content wrapper: preserve position:relative and explicit dimensions */
+#content {
+  opacity: 1 !important;
+  margin: 0 !important;
+}
+
+/* Positioned text must stay absolute */
+.text-overlay {
+  position: absolute !important;
+}
+.text-overlay p {
+  position: absolute !important;
+}
+</style>`
+
+export interface InjectWebpubStylesOptions {
+  fixedLayout?: boolean
+}
+
 /**
  * Walk all .html files in `dir` and inject a `<style>` block right before
  * `</head>` that overrides reader-injected column pagination CSS.
  */
-function injectWebpubStyles(dir: string): void {
+export function injectWebpubStyles(dir: string, options?: InjectWebpubStylesOptions): void {
+  const css = options?.fixedLayout ? FIXED_LAYOUT_OVERRIDE_CSS : REFLOWABLE_OVERRIDE_CSS
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
     const fullPath = path.join(dir, entry.name)
     if (entry.isDirectory()) {
-      injectWebpubStyles(fullPath)
+      injectWebpubStyles(fullPath, options)
     } else if (entry.isFile() && entry.name.endsWith(".html")) {
       let html = fs.readFileSync(fullPath, "utf-8")
-      html = html.replace("</head>", `${WEBPUB_OVERRIDE_CSS}\n</head>`)
+      html = html.replace("</head>", `${css}\n</head>`)
       fs.writeFileSync(fullPath, html)
     }
   }
@@ -952,6 +1016,9 @@ export interface RenderPageOptions {
   /** When true, renders a minimal page without navigation/sidebar chrome.
    *  Content is visible immediately (no opacity-0). Used for storyboard preview. */
   embed?: boolean
+  /** Fixed viewport dimensions for fixed-layout pages (e.g., pre-paginated EPUB).
+   *  When set, overrides the responsive viewport meta with a fixed size. */
+  fixedViewport?: { width: number; height: number }
 }
 
 /**
@@ -1000,11 +1067,13 @@ export function renderPageHtml(opts: RenderPageOptions): string {
   // a duplicate #content element.
   // Inject opacity-0 into the existing wrapper for the fade-in animation (skip in embed mode).
   const contentAlreadyWrapped = /^\s*<div\b[^>]*\bid="content"/.test(normalizedContent)
+  const skipOpacity = opts.embed || opts.fixedViewport
+
   const contentBlock = opts.skipContentWrapper
     ? `      ${normalizedContent}`
     : contentAlreadyWrapped
-      ? `      ${!opts.embed ? injectOpacityClass(normalizedContent) : normalizedContent}`
-      : `      <div id="content"${opts.embed ? "" : ` class="opacity-0"`}>
+      ? `      ${!skipOpacity ? injectOpacityClass(normalizedContent) : normalizedContent}`
+      : `      <div id="content"${skipOpacity ? "" : ` class="opacity-0"`}>
         ${normalizedContent}
       </div>`
 
@@ -1014,7 +1083,11 @@ export function renderPageHtml(opts: RenderPageOptions): string {
     : `      <h1 class="sr-only" id="page-heading">${escapeHtml(fallbackPageHeading)}</h1>
 `
 
-  const mainBlock = `    <main class="w-full">
+  const mainBlock = opts.fixedViewport
+    ? `    <main>
+${contentBlock}
+    </main>`
+    : `    <main class="w-full">
 ${fallbackHeadingHtml}${contentBlock}
     </main>`
 
@@ -1046,7 +1119,7 @@ ${fallbackHeadingHtml}${contentBlock}
 
 <head>
     <meta charset="utf-8" />
-    <meta content="width=device-width, initial-scale=1" name="viewport" />
+    <meta name="viewport" content="${opts.fixedViewport ? `width=${opts.fixedViewport.width}, height=${opts.fixedViewport.height}` : "width=device-width, initial-scale=1"}" />
     <title>${escapeHtml(opts.pageTitle)}</title>
     <meta name="title-id" content="${escapeAttr(opts.sectionId)}" />
     <meta name="page-section-id" content="${opts.pageIndex}" />
@@ -1055,7 +1128,7 @@ ${fallbackHeadingHtml}${contentBlock}
     <link href="./assets/fonts.css" rel="stylesheet">
 ${mathScript}${embedStyles}</head>
 
-<body class="min-h-screen flex items-center justify-center"${bodyStyle}>
+<body${opts.fixedViewport ? ` style="margin:0;overflow:hidden;width:${opts.fixedViewport.width}px;height:${opts.fixedViewport.height}px"` : ` class="min-h-screen flex items-center justify-center"${bodyStyle}`}>
 ${mainBlock}
 ${answersScript}
     <div class="relative z-50" id="interface-container"></div>
@@ -1366,11 +1439,14 @@ export function rewriteImageUrls(
         delete img.attribs.width
         delete img.attribs.height
         const existingStyle = img.attribs.style ?? ""
-        const sizeStyle = "max-width: 100%; height: auto;"
-        if (!existingStyle.includes("max-width")) {
-          img.attribs.style = existingStyle
-            ? `${existingStyle.trimEnd().replace(/;$/, "")}; ${sizeStyle}`
-            : sizeStyle
+        // Don't add responsive sizing to absolutely-positioned images (fixed-layout)
+        if (!existingStyle.includes("position:absolute")) {
+          const sizeStyle = "max-width: 100%; height: auto;"
+          if (!existingStyle.includes("max-width")) {
+            img.attribs.style = existingStyle
+              ? `${existingStyle.trimEnd().replace(/;$/, "")}; ${sizeStyle}`
+              : sizeStyle
+          }
         }
       }
     }
@@ -1386,11 +1462,14 @@ export function rewriteImageUrls(
       delete img.attribs.width
       delete img.attribs.height
       const existingStyle = img.attribs.style ?? ""
-      const sizeStyle = "max-width: 100%; height: auto;"
-      if (!existingStyle.includes("max-width")) {
-        img.attribs.style = existingStyle
-          ? `${existingStyle.trimEnd().replace(/;$/, "")}; ${sizeStyle}`
-          : sizeStyle
+      // Don't add responsive sizing to absolutely-positioned images (fixed-layout)
+      if (!existingStyle.includes("position:absolute")) {
+        const sizeStyle = "max-width: 100%; height: auto;"
+        if (!existingStyle.includes("max-width")) {
+          img.attribs.style = existingStyle
+            ? `${existingStyle.trimEnd().replace(/;$/, "")}; ${sizeStyle}`
+            : sizeStyle
+        }
       }
     }
 
@@ -2351,7 +2430,7 @@ function escapeInlineScriptJson(s: string): string {
     .replace(/&/g, "\\u0026")
 }
 
-function copyDirRecursive(
+export function copyDirRecursive(
   src: string,
   dest: string,
   skip?: Set<string>,

--- a/packages/pipeline/src/pdf-extraction.ts
+++ b/packages/pipeline/src/pdf-extraction.ts
@@ -10,6 +10,9 @@ export interface ExtractOptions {
   endPage?: number
   spreadMode?: boolean
   vectorTextGrouping?: boolean
+  /** Enables the metric-based positioned-text spacing cleanup; only
+   *  meaningful for fixed-layout books (reflowable text uses a separate path). */
+  fixedLayout?: boolean
 }
 
 export async function extractPDF(
@@ -17,7 +20,7 @@ export async function extractPDF(
   storage: Storage,
   progress: Progress
 ): Promise<void> {
-  const { pdfPath, startPage, endPage, spreadMode, vectorTextGrouping } = options
+  const { pdfPath, startPage, endPage, spreadMode, vectorTextGrouping, fixedLayout } = options
 
   progress.emit({ type: "step-start", step: "extract" })
 
@@ -25,7 +28,7 @@ export async function extractPDF(
     const pdfBuffer = fs.readFileSync(pdfPath)
 
     const { pdfMetadata, pages } = extractPdfStream(
-      { pdfBuffer, startPage, endPage, spreadMode, vectorTextGrouping },
+      { pdfBuffer, startPage, endPage, spreadMode, vectorTextGrouping, fixedLayout },
       (p) => {
         progress.emit({
           type: "step-progress",
@@ -42,6 +45,9 @@ export async function extractPDF(
 
     for await (const page of pages) {
       storage.putExtractedPage(page)
+      // Store positioned text (paragraphs + viewport dims). Always available so
+      // fixed-layout rendering doesn't need a separate pre-extraction step.
+      storage.putNodeData("positioned-text", page.pageId, page.positionedText)
       // Store extraction debug info (grouping decisions, render method choices)
       if (page.extractionDebug) {
         storage.putNodeData("extraction-debug", page.pageId, page.extractionDebug)

--- a/packages/pipeline/src/pipeline-dag.ts
+++ b/packages/pipeline/src/pipeline-dag.ts
@@ -56,6 +56,7 @@ import {
   type ProviderRouting,
 } from "./speech.js"
 import { packageAdtWeb } from "./package-web.js"
+import { processFixedLayoutPages, isFixedLayoutBook } from "./fixed-layout-rendering.js"
 import { runAccessibilityAssessment } from "./accessibility-assessment.js"
 import { loadBookConfig } from "./config.js"
 import { nullProgress, type Progress } from "./progress.js"
@@ -441,7 +442,18 @@ export async function runFullPipeline(
 
     // ── Sectioning stage ─────────────────────────────────────────
 
+    const isFixedLayout = isFixedLayoutBook(config)
+
     executors.set("page-sectioning", async (p) => {
+      if (isFixedLayout) {
+        // Fixed-layout: both sectioning and rendering happen here, driven
+        // off the positioned-text + image-filtering data the extract step
+        // already wrote. No LLM call.
+        const imageUrlPrefix = `/api/books/${label}/images`
+        processFixedLayoutPages(storage, imageUrlPrefix)
+        p.emit({ type: "step-progress", step: "page-sectioning", message: "fixed-layout pages" })
+        return
+      }
       const model = getModel(pageSectioningConfig.modelId)
       const pages = storage.getPages()
       const totalPages = pages.length
@@ -509,6 +521,9 @@ export async function runFullPipeline(
     })
 
     executors.set("web-rendering", async (p) => {
+      // Fixed-layout rendering is already done in page-sectioning step
+      if (isFixedLayout) return
+
       const renderModels = new Map<string, LLMModel>()
       const resolveRenderModel = (modelId: string): LLMModel => {
         let model = renderModels.get(modelId)

--- a/packages/pipeline/src/smil.ts
+++ b/packages/pipeline/src/smil.ts
@@ -3,13 +3,13 @@
  * word timestamps. Pure module — no filesystem access. Caller wires inputs
  * and writes the returned XML to disk.
  *
- * Per-paragraph behaviour mirrors the in-app viewer's count guard
- * (`tts_highlighter.js`): word-level `<par>` per word when source span
- * count exactly matches whisper word count, paragraph-level `<par>` for
- * the whole paragraph otherwise. No alignment / interpolation — if the
- * counts diverge, an EPUB reader gets a single highlight for the whole
- * paragraph instead of (potentially) wrong word timing.
+ * Per-paragraph emission: word-level `<par>` per word when the source word
+ * span count exactly matches the whisper word count; paragraph-level
+ * fallback otherwise. No alignment / interpolation — if the counts
+ * diverge, an EPUB reader gets a single highlight for the whole paragraph
+ * instead of (potentially) wrong word timing.
  */
+import { escapeHtml } from "./package-web.js"
 
 export interface SmilWordTimestamp {
   word: string
@@ -75,8 +75,8 @@ export function buildSmil(options: BuildSmilOptions): SmilOutput | null {
         const word = p.whisperWords[i]
         parLines.push(
           `      <par id="par${pad(parIdCounter)}">`,
-          `        <text src="${escapeXmlAttr(pageHref)}#${escapeXmlAttr(p.wordIds[i])}"/>`,
-          `        <audio src="${escapeXmlAttr(p.audioPath)}" clipBegin="${formatClock(word.start)}" clipEnd="${formatClock(word.end)}"/>`,
+          `        <text src="${escapeHtml(pageHref)}#${escapeHtml(p.wordIds[i])}"/>`,
+          `        <audio src="${escapeHtml(p.audioPath)}" clipBegin="${formatClock(word.start)}" clipEnd="${formatClock(word.end)}"/>`,
           `      </par>`,
         )
       }
@@ -84,14 +84,14 @@ export function buildSmil(options: BuildSmilOptions): SmilOutput | null {
       parIdCounter += 1
       parLines.push(
         `      <par id="par${pad(parIdCounter)}">`,
-        `        <text src="${escapeXmlAttr(pageHref)}#${escapeXmlAttr(p.paragraphId)}"/>`,
-        `        <audio src="${escapeXmlAttr(p.audioPath)}" clipBegin="${formatClock(0)}" clipEnd="${formatClock(p.audioDuration)}"/>`,
+        `        <text src="${escapeHtml(pageHref)}#${escapeHtml(p.paragraphId)}"/>`,
+        `        <audio src="${escapeHtml(p.audioPath)}" clipBegin="${formatClock(0)}" clipEnd="${formatClock(p.audioDuration)}"/>`,
         `      </par>`,
       )
     }
 
     seqs.push(
-      `    <seq id="seq-${escapeXmlAttr(p.paragraphId)}" epub:textref="${escapeXmlAttr(pageHref)}#${escapeXmlAttr(p.paragraphId)}">`,
+      `    <seq id="seq-${escapeHtml(p.paragraphId)}" epub:textref="${escapeHtml(pageHref)}#${escapeHtml(p.paragraphId)}">`,
       ...parLines,
       `    </seq>`,
     )
@@ -125,10 +125,3 @@ function pad(n: number): string {
   return String(n).padStart(4, "0")
 }
 
-function escapeXmlAttr(s: string): string {
-  return String(s)
-    .replace(/&/g, "&amp;")
-    .replace(/"/g, "&quot;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-}

--- a/packages/pipeline/src/smil.ts
+++ b/packages/pipeline/src/smil.ts
@@ -1,0 +1,134 @@
+/**
+ * Build EPUB 3 Media Overlay (SMIL) documents from paragraph audio + whisper
+ * word timestamps. Pure module — no filesystem access. Caller wires inputs
+ * and writes the returned XML to disk.
+ *
+ * Per-paragraph behaviour mirrors the in-app viewer's count guard
+ * (`tts_highlighter.js`): word-level `<par>` per word when source span
+ * count exactly matches whisper word count, paragraph-level `<par>` for
+ * the whole paragraph otherwise. No alignment / interpolation — if the
+ * counts diverge, an EPUB reader gets a single highlight for the whole
+ * paragraph instead of (potentially) wrong word timing.
+ */
+
+export interface SmilWordTimestamp {
+  word: string
+  start: number
+  end: number
+}
+
+export interface SmilParagraph {
+  /** data-id of the source `<p>` — used as the fragment for paragraph-level
+   *  fallback and as the seq id stem. */
+  paragraphId: string
+  /** Path to the audio file relative to the SMIL document's location
+   *  (e.g. `../en/audio/pg001_p001.mp3`). */
+  audioPath: string
+  /** Total length of the audio file in seconds. Used in media:duration
+   *  metadata aggregation. */
+  audioDuration: number
+  /** Renderer-emitted word span ids in document order. Empty → no
+   *  word-level data for this paragraph (always paragraph-level). */
+  wordIds: string[]
+  /** Whisper word timestamps in audio order. Empty → paragraph has no
+   *  audio at all and is skipped from the SMIL entirely. */
+  whisperWords: SmilWordTimestamp[]
+}
+
+export interface BuildSmilOptions {
+  /** Path to the page HTML (XHTML) relative to the SMIL document
+   *  (e.g. `../pg001_sec001.xhtml`). All `<text src="…#…"/>` references
+   *  are built from this. */
+  pageHref: string
+  paragraphs: SmilParagraph[]
+}
+
+export interface SmilOutput {
+  xml: string
+  /** Sum of `audioDuration` across paragraphs that contributed to the SMIL
+   *  (i.e. excluding paragraphs skipped for missing audio). Caller emits
+   *  this as `<meta property="media:duration" refines="#…">PT…S</meta>`. */
+  durationSeconds: number
+}
+
+/**
+ * @returns SMIL document + total duration, or `null` when no paragraphs
+ *   produce audio (caller skips writing the file and the OPF entry).
+ */
+export function buildSmil(options: BuildSmilOptions): SmilOutput | null {
+  const { pageHref, paragraphs } = options
+  const seqs: string[] = []
+  let totalDuration = 0
+  let parIdCounter = 0
+
+  for (const p of paragraphs) {
+    if (p.whisperWords.length === 0) continue
+    totalDuration += p.audioDuration
+
+    const wordLevel =
+      p.wordIds.length > 0 && p.wordIds.length === p.whisperWords.length
+
+    const parLines: string[] = []
+    if (wordLevel) {
+      for (let i = 0; i < p.wordIds.length; i++) {
+        parIdCounter += 1
+        const word = p.whisperWords[i]
+        parLines.push(
+          `      <par id="par${pad(parIdCounter)}">`,
+          `        <text src="${escapeXmlAttr(pageHref)}#${escapeXmlAttr(p.wordIds[i])}"/>`,
+          `        <audio src="${escapeXmlAttr(p.audioPath)}" clipBegin="${formatClock(word.start)}" clipEnd="${formatClock(word.end)}"/>`,
+          `      </par>`,
+        )
+      }
+    } else {
+      parIdCounter += 1
+      parLines.push(
+        `      <par id="par${pad(parIdCounter)}">`,
+        `        <text src="${escapeXmlAttr(pageHref)}#${escapeXmlAttr(p.paragraphId)}"/>`,
+        `        <audio src="${escapeXmlAttr(p.audioPath)}" clipBegin="${formatClock(0)}" clipEnd="${formatClock(p.audioDuration)}"/>`,
+        `      </par>`,
+      )
+    }
+
+    seqs.push(
+      `    <seq id="seq-${escapeXmlAttr(p.paragraphId)}" epub:textref="${escapeXmlAttr(pageHref)}#${escapeXmlAttr(p.paragraphId)}">`,
+      ...parLines,
+      `    </seq>`,
+    )
+  }
+
+  if (seqs.length === 0) return null
+
+  const xml = `<?xml version="1.0" encoding="utf-8"?>
+<smil xmlns="http://www.w3.org/ns/SMIL" xmlns:epub="http://www.idpf.org/2007/ops" version="3.0">
+  <body>
+${seqs.join("\n")}
+  </body>
+</smil>`
+
+  return { xml, durationSeconds: totalDuration }
+}
+
+/**
+ * Format a duration as an EPUB media:duration `PTnnnS` clock value.
+ * Three decimal places match SMIL convention and EPUBCheck expectations.
+ */
+export function formatMediaDuration(seconds: number): string {
+  return `PT${seconds.toFixed(3)}S`
+}
+
+function formatClock(seconds: number): string {
+  return `${seconds.toFixed(3)}s`
+}
+
+function pad(n: number): string {
+  return String(n).padStart(4, "0")
+}
+
+function escapeXmlAttr(s: string): string {
+  return String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+}

--- a/packages/pipeline/src/web-rendering.ts
+++ b/packages/pipeline/src/web-rendering.ts
@@ -20,7 +20,7 @@ export interface VisualRefinementConfig {
 }
 
 export interface RenderConfig {
-  renderType: "llm" | "template" | "activity"
+  renderType: "llm" | "template" | "activity" | "fixed_layout"
   // llm / activity fields
   promptName: string
   modelId: string

--- a/packages/pipeline/src/word-tokenize.ts
+++ b/packages/pipeline/src/word-tokenize.ts
@@ -1,0 +1,101 @@
+/**
+ * Word-boundary tokenizer. Single source of truth for how text is split into
+ * words anywhere a `<span id="…_wNNN">` is emitted — the fixed-layout
+ * renderer, its translation runtime mirror, and packaging-time reflowable
+ * word-wrapping all consume this. Whisper word counts and SMIL
+ * `<text src="…#…"/>` fragment ids only line up if all of those use the
+ * same boundary rule.
+ *
+ * The pattern matches one or more Unicode letters/numbers/marks, optionally
+ * extended via apostrophe (straight or curly) or hyphen, so contractions
+ * (`don't`, `it's`) and hyphenated compounds (`well-known`) stay as single
+ * words. Punctuation, whitespace, and `<br/>` substitutions become
+ * separators — they sit outside word spans so word measurement / contrast
+ * checks aren't affected by surrounding glyphs.
+ *
+ * Mirrors `WORD_PATTERN` in `assets/adt/modules/tts_highlighter_utils.js`;
+ * the viewer runtime can't import from TS yet, so the regex is duplicated.
+ * The parity assertion in `__tests__/word-tokenize.test.ts` guards drift.
+ *
+ * Scripts that don't separate words by whitespace (Chinese, Japanese, Thai)
+ * are out of scope here — they need a dedicated segmenter and Whisper
+ * alignment is unreliable for those anyway.
+ */
+export const WORD_PATTERN = /[\p{L}\p{N}\p{M}]+(?:[’'-][\p{L}\p{N}\p{M}]+)*/gu
+
+export interface WordToken {
+  type: "word"
+  /** The matched word text. */
+  text: string
+  /** 0-based character offset into the tokenized string. */
+  start: number
+  /** Exclusive end offset. */
+  end: number
+  /** 0-based index across the word tokens of this string. */
+  wordIndex: number
+}
+
+export interface SeparatorToken {
+  type: "separator"
+  text: string
+  start: number
+  end: number
+}
+
+export type TokenSegment = WordToken | SeparatorToken
+
+/**
+ * Tokenise `text` into alternating word / separator segments with character
+ * offsets. Concatenating segment `.text` reproduces the input exactly, so
+ * callers can re-emit the text losslessly while wrapping only words.
+ *
+ * Use the offsets to map back to a parent data model (e.g. style-run
+ * segments in a fixed-layout paragraph) — see
+ * `fixed-layout-rendering.ts:renderSegmentsToHtml` for the overlap-mapping
+ * pattern.
+ */
+export function tokenizeWords(text: string): TokenSegment[] {
+  const segments: TokenSegment[] = []
+  // Local regex instance so concurrent callers don't share `.lastIndex`.
+  const re = new RegExp(WORD_PATTERN.source, WORD_PATTERN.flags)
+  let lastIndex = 0
+  let wordIndex = 0
+
+  for (let match = re.exec(text); match !== null; match = re.exec(text)) {
+    const start = match.index
+    const end = start + match[0].length
+    if (start > lastIndex) {
+      segments.push({
+        type: "separator",
+        text: text.slice(lastIndex, start),
+        start: lastIndex,
+        end: start,
+      })
+    }
+    segments.push({
+      type: "word",
+      text: match[0],
+      start,
+      end,
+      wordIndex,
+    })
+    wordIndex += 1
+    lastIndex = end
+  }
+
+  if (lastIndex < text.length) {
+    segments.push({
+      type: "separator",
+      text: text.slice(lastIndex),
+      start: lastIndex,
+      end: text.length,
+    })
+  }
+
+  return segments
+}
+
+/** Convenience: just the word strings, in order. */
+export function extractWords(text: string): string[] {
+  return tokenizeWords(text).flatMap((s) => (s.type === "word" ? [s.text] : []))
+}

--- a/packages/storage/src/book-storage.ts
+++ b/packages/storage/src/book-storage.ts
@@ -135,15 +135,30 @@ export function createBookStorage(label: string, booksRoot: string): Storage {
 
     getPageImages(pageId: string): ImageData[] {
       const rows = db.all(
-        "SELECT image_id, width, height, render_method FROM images WHERE page_id = ? ORDER BY image_id",
+        "SELECT image_id, width, height, render_method, bounds_x, bounds_y, bounds_w, bounds_h FROM images WHERE page_id = ? ORDER BY image_id",
         [pageId]
-      ) as Array<{ image_id: string; width: number; height: number; render_method: string | null }>
-      return rows.map((r) => ({
-        imageId: r.image_id,
-        width: r.width,
-        height: r.height,
-        renderMethod: r.render_method as ImageData["renderMethod"],
-      }))
+      ) as Array<{
+        image_id: string
+        width: number
+        height: number
+        render_method: string | null
+        bounds_x: number | null
+        bounds_y: number | null
+        bounds_w: number | null
+        bounds_h: number | null
+      }>
+      return rows.map((r) => {
+        const image: ImageData = {
+          imageId: r.image_id,
+          width: r.width,
+          height: r.height,
+          renderMethod: r.render_method as ImageData["renderMethod"],
+        }
+        if (r.bounds_x !== null && r.bounds_y !== null && r.bounds_w !== null && r.bounds_h !== null) {
+          image.bounds = { x: r.bounds_x, y: r.bounds_y, width: r.bounds_w, height: r.bounds_h }
+        }
+        return image
+      })
     },
 
     putCroppedImage(input: CroppedImageInput): void {
@@ -502,8 +517,8 @@ function writeImage(
 
   db.run(
     `INSERT INTO images
-       (image_id, page_id, path, hash, width, height, source, render_method)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+       (image_id, page_id, path, hash, width, height, source, render_method, bounds_x, bounds_y, bounds_w, bounds_h)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
      ON CONFLICT (image_id) DO UPDATE SET
        page_id = excluded.page_id,
        path = excluded.path,
@@ -511,7 +526,11 @@ function writeImage(
        width = excluded.width,
        height = excluded.height,
        source = excluded.source,
-       render_method = excluded.render_method`,
+       render_method = excluded.render_method,
+       bounds_x = excluded.bounds_x,
+       bounds_y = excluded.bounds_y,
+       bounds_w = excluded.bounds_w,
+       bounds_h = excluded.bounds_h`,
     [
       image.imageId,
       pageId,
@@ -521,6 +540,10 @@ function writeImage(
       image.height,
       source,
       image.renderMethod ?? null,
+      image.bounds?.x ?? null,
+      image.bounds?.y ?? null,
+      image.bounds?.width ?? null,
+      image.bounds?.height ?? null,
     ]
   )
 }

--- a/packages/storage/src/db.ts
+++ b/packages/storage/src/db.ts
@@ -35,7 +35,11 @@ CREATE TABLE IF NOT EXISTS images (
   width INTEGER NOT NULL,
   height INTEGER NOT NULL,
   source TEXT NOT NULL CHECK (source IN ('page', 'extract', 'crop', 'segment', 'upload', 'translate')),
-  render_method TEXT CHECK (render_method IN ('vector', 'page-crop', 'raster') OR render_method IS NULL)
+  render_method TEXT CHECK (render_method IN ('vector', 'page-crop', 'raster') OR render_method IS NULL),
+  bounds_x REAL,
+  bounds_y REAL,
+  bounds_w REAL,
+  bounds_h REAL
 );
 
 CREATE TABLE IF NOT EXISTS llm_log (
@@ -147,6 +151,12 @@ function initSchema(db: sqlite.Database): void {
   if (version === 11) {
     migrateV11toV12(db)
     version = 12
+  }
+
+  // Migrate v12 → v13: add bounds_* columns to images for per-image page placement
+  if (version === 12) {
+    migrateV12toV13(db)
+    version = 13
   }
 
   if (version === SCHEMA_VERSION) {
@@ -378,6 +388,28 @@ function migrateV11toV12(db: sqlite.Database): void {
       INSERT INTO images_new SELECT * FROM images;
       DROP TABLE images;
       ALTER TABLE images_new RENAME TO images;
+    `)
+    db.exec("COMMIT")
+  } catch (err) {
+    db.exec("ROLLBACK")
+    throw err
+  }
+}
+
+/**
+ * Migrate v12 → v13: add per-image page-placement columns. Used by
+ * fixed-layout rendering to position each image at its PDF coordinates;
+ * NULL for images without a recorded placement (legacy rows, vector
+ * figures that don't map to a single quad).
+ */
+function migrateV12toV13(db: sqlite.Database): void {
+  db.exec("BEGIN IMMEDIATE")
+  try {
+    db.exec(`
+      ALTER TABLE images ADD COLUMN bounds_x REAL;
+      ALTER TABLE images ADD COLUMN bounds_y REAL;
+      ALTER TABLE images ADD COLUMN bounds_w REAL;
+      ALTER TABLE images ADD COLUMN bounds_h REAL;
     `)
     db.exec("COMMIT")
   } catch (err) {

--- a/packages/storage/src/storage.ts
+++ b/packages/storage/src/storage.ts
@@ -14,6 +14,8 @@ export interface ImageData {
   height: number
   /** How this image was produced: vector SVG render, page crop, or direct raster extraction */
   renderMethod?: RenderMethodValue
+  /** Placement on the page in PDF points (top-left origin), when known. */
+  bounds?: { x: number; y: number; width: number; height: number }
 }
 
 export interface NodeDataRow {

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -40,7 +40,7 @@ export const ImageTranslationConfig = StepConfig.extend({
 })
 export type ImageTranslationConfig = z.infer<typeof ImageTranslationConfig>
 
-export const BookFormat = z.enum(["web", "webpub"])
+export const BookFormat = z.enum(["web", "webpub", "epub"])
 export type BookFormat = z.infer<typeof BookFormat>
 
 export const LayoutType = z.enum(["textbook", "storybook", "reference", "custom"])
@@ -49,7 +49,7 @@ export type LayoutType = z.infer<typeof LayoutType>
 export const StyleguideName = z.string().regex(/^[a-zA-Z0-9_-]+$/)
 export type StyleguideName = z.infer<typeof StyleguideName>
 
-export const RenderType = z.enum(["llm", "template", "activity"])
+export const RenderType = z.enum(["llm", "template", "activity", "fixed_layout"])
 export type RenderType = z.infer<typeof RenderType>
 
 export const VisualRefinementStrategyConfig = z.object({

--- a/packages/types/src/db.ts
+++ b/packages/types/src/db.ts
@@ -1,6 +1,6 @@
 import { z } from "zod"
 
-export const SCHEMA_VERSION = 12
+export const SCHEMA_VERSION = 13
 
 export const ImageSource = z.enum(["page", "extract", "crop", "segment", "upload", "translate"])
 export type ImageSource = z.infer<typeof ImageSource>
@@ -27,6 +27,11 @@ export const ImageRow = z.object({
   height: z.number().int(),
   source: ImageSource,
   render_method: RenderMethod,
+  /** Placement on the page in PDF points (top-left origin). */
+  bounds_x: z.number().nullable(),
+  bounds_y: z.number().nullable(),
+  bounds_w: z.number().nullable(),
+  bounds_h: z.number().nullable(),
 })
 export type ImageRow = z.infer<typeof ImageRow>
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -67,6 +67,14 @@ export {
   PageSectioningOutput,
   buildPageSectioningLLMSchema,
   buildPageSectioningRefinementLLMSchema,
+  // Out-of-band placement sidecar — PDF coordinates, image clip/blend/opacity,
+  // viewport dimensions. Carried alongside the semantic tree on
+  // `PageSectioningSection.placement` so any renderer can use it.
+  TextPosition,
+  SectionTextSegment,
+  ImagePartBounds,
+  SectionViewport,
+  NodePlacement,
 } from "./page-sectioning.js"
 
 export {
@@ -189,6 +197,17 @@ export {
   ReviewerValidationConfig,
   type ReviewerValidationCatalog,
 } from "./reviewer-validation-config.js"
+
+export {
+  PositionedParagraph,
+  PositionedTextOutput,
+  ImageBounds,
+  DrawItem,
+  DrawItemImage,
+  DrawItemParagraph,
+  TextSegment,
+  TextBlockBounds,
+} from "./positioned-text.js"
 
 export {
   ReviewerValidationStatus,

--- a/packages/types/src/page-sectioning.ts
+++ b/packages/types/src/page-sectioning.ts
@@ -1,15 +1,15 @@
 import { z } from "zod"
+import { TextBlockBounds } from "./positioned-text.js"
 
 // ── Tree node ───────────────────────────────────────────────────
 // A content node is either a container (has `structure`, usually `children`)
 // or a leaf (has `role` and `text`). The two arms are mutually exclusive;
 // the runtime validator enforces this because Zod cannot express it cleanly
 // alongside recursion without blowing up OpenAI's structured-output support.
-
-// A content node is either a container (has `structure`, usually `children`)
-// or a leaf (has `role` and `text`). Images are represented as leaves with
-// role="image" whose `nodeId` IS the image file's id — an image_group
-// container wraps them alongside caption/label leaves.
+//
+// Images are represented as leaves with role="image" whose `nodeId` IS the
+// image file's id — an image_group container wraps them alongside
+// caption/label leaves.
 export type ContentNodeData = {
   nodeId: string
   isPruned: boolean
@@ -34,6 +34,120 @@ export const ContentNodeData: z.ZodType<ContentNodeData> = z.lazy(() =>
   })
 )
 
+// ── Placement sidecar (fixed-layout & friends) ───────────────────
+// Reflowable content's sectioning is a pure semantic tree. Some renderers
+// (fixed-layout EPUB, two-column print, accessibility overlays) need
+// PDF-coordinate placement metadata for the same nodes. Rather than
+// polluting the tree's leaf shape with optional positioning fields,
+// section carries an out-of-band `placement` map keyed by `nodeId`.
+//
+// Renderers that don't care about placement ignore the map; renderers that
+// do consume it without having to special-case section "modes". The same
+// data is available to LLM rendering, two-column print, activity detection,
+// translation reflow, accessibility — anything that benefits from knowing
+// the original PDF coordinates.
+
+/**
+ * Fixed-layout positioning metadata carried on a text leaf. Coordinates are
+ * in viewport units (PDF points at 1x, matching the page image's natural
+ * dimensions). When present, the renderer re-injects these as inline styles
+ * so absolute positioning survives any downstream HTML regeneration.
+ */
+export const TextPosition = z.object({
+  top: z.number(),
+  left: z.number(),
+  lineHeight: z.number(),
+})
+export type TextPosition = z.infer<typeof TextPosition>
+
+/**
+ * A styled run inside a placed text leaf. Parallel to `TextSegment` in
+ * positioned-text.ts — kept here so section JSON is self-contained.
+ */
+export const SectionTextSegment = z.object({
+  text: z.string(),
+  style: z.record(z.string(), z.string()).optional(),
+})
+export type SectionTextSegment = z.infer<typeof SectionTextSegment>
+
+/**
+ * Fixed-layout placement bounds for an image leaf. Coordinates are in
+ * viewport units (PDF points at 1x). When present, the renderer positions
+ * the image at these coordinates; when absent, the image fills the viewport.
+ */
+export const ImagePartBounds = z.object({
+  x: z.number(),
+  y: z.number(),
+  width: z.number(),
+  height: z.number(),
+})
+export type ImagePartBounds = z.infer<typeof ImagePartBounds>
+
+/** Fixed-layout viewport dimensions for the page (PDF points at 1x). */
+export const SectionViewport = z.object({
+  width: z.number(),
+  height: z.number(),
+})
+export type SectionViewport = z.infer<typeof SectionViewport>
+
+/**
+ * Out-of-band placement data for a single tree node. All fields are
+ * optional — text-leaf nodes typically carry the text-shape fields,
+ * image-leaf nodes typically carry the image-shape fields, and container
+ * nodes generally have no entry at all.
+ */
+export const NodePlacement = z.object({
+  // Text-leaf placement
+  position: TextPosition.optional(),
+  segments: z.array(SectionTextSegment).optional(),
+  /**
+   * Identifier of the visual block this text leaf belongs to. Wrapped
+   * lines inside the same bubble share a `blockId`; standalone leaves get
+   * their own. Stable per page.
+   */
+  blockId: z.string().optional(),
+  /**
+   * Bounds of the block this text leaf belongs to. Identical for all
+   * leaves with the same `blockId`. Use for translation reflow / fitting.
+   */
+  blockBounds: TextBlockBounds.optional(),
+  /**
+   * Inferred horizontal alignment ("center" or "right"). Absent for the
+   * CSS default (left). The renderer uses this to set `text-align` on
+   * the merged `<p>` so re-flowed translations preserve the original
+   * bubble's alignment.
+   */
+  textAlign: z.enum(["center", "right"]).optional(),
+  /**
+   * Per-leaf render-box height in PDF points (top-left origin space).
+   * When multiple text leaves share a `blockId`, each one's `<p>` should
+   * only occupy its slice of the block (top of this leaf → top of the
+   * next leaf, or block bottom for the last) — otherwise the absolute
+   * boxes stack with the full block height and overlap. Absent when the
+   * leaf is the only one in its block; renderer falls back to
+   * `blockBounds.height`.
+   */
+  renderHeight: z.number().optional(),
+
+  // Image-leaf placement
+  bounds: ImagePartBounds.optional(),
+  /**
+   * SVG path `d` for the PDF clip applied to this image at draw time, in
+   * absolute viewport coordinates. Renderer translates to image-local
+   * coords when emitting `<clipPath>`. Absent when the source PDF didn't
+   * meaningfully clip the image.
+   */
+  clipPath: z.string().optional(),
+  /**
+   * CSS `mix-blend-mode` keyword for images drawn under a non-Normal PDF
+   * blend mode (commonly "multiply" in illustrated storybooks).
+   */
+  blendMode: z.string().optional(),
+  /** Composed opacity (0..1) from PDF group / per-op alpha. */
+  opacity: z.number().optional(),
+})
+export type NodePlacement = z.infer<typeof NodePlacement>
+
 // ── Section ─────────────────────────────────────────────────────
 
 export const PageSectioningSection = z.object({
@@ -44,6 +158,18 @@ export const PageSectioningSection = z.object({
   pageNumber: z.number().int().nullable(),
   isPruned: z.boolean(),
   nodes: z.array(ContentNodeData),
+  /**
+   * Fixed-layout viewport dimensions, in PDF points at 1x. Present on
+   * fixed-layout sections so renderers can produce HTML without consulting
+   * the positioned-text node separately.
+   */
+  viewport: SectionViewport.optional(),
+  /**
+   * Per-node placement sidecar keyed by `nodeId`. Present whenever the
+   * sectioning step had PDF-coordinate data to attach (currently:
+   * fixed-layout pages). Renderers that don't need placement ignore it.
+   */
+  placement: z.record(z.string(), NodePlacement).optional(),
 })
 export type PageSectioningSection = z.infer<typeof PageSectioningSection>
 

--- a/packages/types/src/pipeline-effects.ts
+++ b/packages/types/src/pipeline-effects.ts
@@ -4,6 +4,9 @@ import type { StageName, StepName } from "./pipeline.js"
 export type PipelineNodeName =
   | StepName
   | "text-catalog-translation"
+  // Sub-product of the `extract` step — written alongside the main
+  // page data, not its own pipeline step.
+  | "positioned-text"
 
 /**
  * Shared, UI-agnostic cache/resource tags used by apps to derive
@@ -23,6 +26,7 @@ export type PipelineCacheResource =
 
 const EXTRA_STAGE_OUTPUT_NODES: Partial<Record<StageName, readonly PipelineNodeName[]>> = {
   "translate": ["text-catalog-translation"],
+  "extract": ["positioned-text"],
 }
 
 /** All node_data node names written by each stage. */
@@ -87,6 +91,7 @@ const NODE_CACHE_RESOURCES: Record<PipelineNodeName, readonly PipelineCacheResou
   "package-web": [],
   "accessibility-assessment": ["debug"],
   "text-catalog-translation": ["text-catalog"],
+  "positioned-text": ["pages"],
 }
 
 const CACHE_RESOURCE_ORDER: readonly PipelineCacheResource[] = [

--- a/packages/types/src/positioned-text.ts
+++ b/packages/types/src/positioned-text.ts
@@ -1,0 +1,146 @@
+import { z } from "zod"
+
+export const PositionedParagraph = z.object({
+  /** Top position in CSS pixels at render scale */
+  top: z.number(),
+  /** Left position in CSS pixels at render scale */
+  left: z.number(),
+  /** Line height in CSS pixels at render scale */
+  lineHeight: z.number(),
+  /** HTML content of the paragraph (spans with font styling) */
+  html: z.string(),
+})
+export type PositionedParagraph = z.infer<typeof PositionedParagraph>
+
+export const ImageBounds = z.object({
+  /** Left edge in PDF points */
+  x: z.number(),
+  /** Top edge in PDF points */
+  y: z.number(),
+  /** Width in PDF points */
+  width: z.number(),
+  /** Height in PDF points */
+  height: z.number(),
+})
+export type ImageBounds = z.infer<typeof ImageBounds>
+
+/**
+ * A single draw operation from the PDF, in the walker's natural sequence.
+ * Array order = PDF draw order = HTML DOM order, so later items appear on
+ * top in the fixed-layout render. Coordinates are in viewport units (PDF
+ * points at 1x, matching the page image's natural dimensions).
+ */
+export const DrawItemImage = z.object({
+  kind: z.literal("image"),
+  imageId: z.string(),
+  bounds: ImageBounds,
+  /**
+   * SVG path `d` attribute for the active PDF clip applied to this image,
+   * in absolute viewport coordinates (PDF points, top-left origin — same
+   * space as `bounds`). Present only when the PDF clip meaningfully
+   * reduces the image's visible area. The renderer translates these
+   * coordinates to the image's local origin when emitting `<clipPath>`.
+   */
+  clipPath: z.string().optional(),
+  /**
+   * CSS `mix-blend-mode` keyword (e.g. "multiply") for images drawn under a
+   * non-Normal PDF blend mode. Watercolor storybooks frequently rely on
+   * `/Multiply` to make white image backgrounds composite as transparent.
+   */
+  blendMode: z.string().optional(),
+  /**
+   * Composed opacity (0..1) when the source PDF set group / per-op alpha
+   * < 1. Renderer maps to CSS `opacity`. Absent for fully opaque draws.
+   */
+  opacity: z.number().optional(),
+})
+export type DrawItemImage = z.infer<typeof DrawItemImage>
+
+/**
+ * A run of characters inside a paragraph that share the same styling. A
+ * paragraph is a sequence of segments. Styling lives as CSS-compatible
+ * property/value pairs (e.g. `{ "font-family": "Palatino", "color": "#ff0000" }`)
+ * so the viewer can re-inject them after any text-swap without parsing
+ * inline strings. Font sizes are already converted to viewport `px` units.
+ */
+export const TextSegment = z.object({
+  text: z.string(),
+  style: z.record(z.string(), z.string()).optional(),
+})
+export type TextSegment = z.infer<typeof TextSegment>
+
+/**
+ * Bounding box of a logical text block — a cluster of paragraphs that
+ * visually belong together (e.g. one speech bubble's wrapped lines). Same
+ * coordinate space as a paragraph's `top` / `left` (PDF points, top-left
+ * origin). Used by translation flows: the original block's width/height
+ * tells the renderer how much room a translated string has to fit.
+ */
+export const TextBlockBounds = z.object({
+  x: z.number(),
+  y: z.number(),
+  width: z.number(),
+  height: z.number(),
+})
+export type TextBlockBounds = z.infer<typeof TextBlockBounds>
+
+export const DrawItemParagraph = z.object({
+  kind: z.literal("paragraph"),
+  /** Stable per-page id used for `data-id` attributes (TTS, translation). */
+  textId: z.string(),
+  top: z.number(),
+  left: z.number(),
+  lineHeight: z.number(),
+  /** Structured per-run styling. Concatenating `segments[].text` yields `text`. */
+  segments: z.array(TextSegment),
+  /** Plain-text concatenation of segment texts (convenience for catalogs). */
+  text: z.string(),
+  /**
+   * Identifier of the visual text block this paragraph belongs to. Wrapped
+   * lines inside the same speech bubble share a `blockId`; standalone
+   * paragraphs get their own. Stable per page.
+   */
+  blockId: z.string().optional(),
+  /**
+   * Bounds of the whole block (union of every paragraph in it). Identical
+   * across paragraphs that share `blockId`. Use for translation reflow /
+   * fitting — the original container's max width and height.
+   */
+  blockBounds: TextBlockBounds.optional(),
+  /**
+   * Identifier of the merged paragraph this line belongs to. Wrapped
+   * lines that the continuation heuristic treats as one logical
+   * paragraph share `mergedParagraphId`; sentence breaks inside the
+   * same block produce different ids. Sectioning collapses lines with
+   * matching ids into a single text entry.
+   */
+  mergedParagraphId: z.string().optional(),
+  /**
+   * Inferred horizontal alignment of the block ("center" or "right").
+   * Absent for left-aligned (CSS default). Carried so the renderer can
+   * apply `text-align` on the merged-paragraph `<p>` and translations
+   * stay visually centred / right-aligned when re-flowed.
+   */
+  textAlign: z.enum(["center", "right"]).optional(),
+})
+export type DrawItemParagraph = z.infer<typeof DrawItemParagraph>
+
+export const DrawItem = z.discriminatedUnion("kind", [DrawItemImage, DrawItemParagraph])
+export type DrawItem = z.infer<typeof DrawItem>
+
+export const PositionedTextOutput = z.object({
+  /**
+   * Draw items (images and paragraphs) in the PDF's draw order. Array order
+   * IS z-order: later items render on top.
+   */
+  drawItems: z.array(DrawItem),
+  /** Page width in PDF points */
+  pageWidth: z.number(),
+  /** Page height in PDF points */
+  pageHeight: z.number(),
+  /** Rendered width in pixels (at render scale, typically 2x) */
+  renderWidth: z.number(),
+  /** Rendered height in pixels (at render scale, typically 2x) */
+  renderHeight: z.number(),
+})
+export type PositionedTextOutput = z.infer<typeof PositionedTextOutput>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -550,6 +550,9 @@ importers:
       playwright:
         specifier: ^1.50.0
         version: 1.58.2
+      pngjs:
+        specifier: ^7.0.0
+        version: 7.0.0
       postcss:
         specifier: ^8.5.0
         version: 8.5.6
@@ -578,9 +581,6 @@ importers:
       esbuild:
         specifier: ^0.25.12
         version: 0.25.12
-      pngjs:
-        specifier: ^7.0.0
-        version: 7.0.0
 
   packages/storage:
     dependencies:


### PR DESCRIPTION
## Summary

Adds a fixed-layout rendering mode for illustrated PDFs (children's storybooks, picture books) where the original page composition matters: images placed by PDF coordinates, text overlaid as positioned spans for accessibility / search / TTS, blocks clustered at the speech-bubble level for translation. Ships alongside an EPUB 3 export format with **EPUB 3 Media Overlays (SMIL)** for word-level read-aloud sync.

## What's included

### Fixed-layout pipeline mode
- New `fixed_layout` render strategy (first-class, alongside `llm`, `single_column`, `two_column_story`, etc.); selectable under the Storybook and Custom presets.
- Single-pass StructuredText walk extracts paragraphs with per-glyph font / size / colour data. Spread-aware (left + right pages stitched to a unified viewport).
- Block clustering groups speech-bubble lines into one logical paragraph; sentence boundaries split for TTS / translation chunking.
- Renderer pins each block to PDF coordinates with line-height derived from max font-size; per-segment contrast strokes against sampled background; `data-segments` JSON carries styling for runtime rebuild on language swap and inline edits.
- Shared `assets/adt/auto-fit.js` shrinks letter-spacing then font-size to fit text into bubble bounds; reschedules on font-swap events (`document.fonts.ready` + `FontFaceSet.loadingdone`).

### Word-level spans + viewer highlighting
- Renderer wraps each whitespace-separated token in `<span id="{paragraphId}_w{NNN}">` inside the existing per-segment style span. Whitespace stays outside the span so layout is preserved.
- `data-id` (paragraph) vs `id` (word) split: paragraph `data-id` continues to drive text-catalog / TTS / language swap; word `id` is consumed only by SMIL fragment refs and the viewer's word highlighter.
- Runtime translation rebuild (`translations.js`) preserves word spans through both source-language and translation paths, so DevTools shows them after preview render.
- Viewer (`tts_highlighter.js`) detects fixed-layout word spans via id pattern and switches between word-level and block-level highlight; binary count-guard falls back to block highlight when source span count diverges from Whisper word count.

### EPUB 3 export + Media Overlays (SMIL)
- New `packageEpub` built from the same ADT web output as WebPub.
- OPF emits `rendition:layout pre-paginated` for fixed-layout books.
- New `packages/pipeline/src/smil.ts` builder: per-page SMIL document with one `<seq>` per paragraph, one `<par>` per word when source span count exactly matches Whisper word count, paragraph-level `<par>` fallback otherwise. Explicit `clipBegin` / `clipEnd` on every `<par>` so EPUBCheck and readers don't have to infer audio duration.
- Manifest `<item media-overlay="..."/>` (per EPUB 3 spec — not on spine `<itemref>`); `media:duration` per overlay + total; `media:active-class` set to `-epub-media-overlay-active` with a CSS rule in the page stylesheet.
- Gated on the **Read-aloud / Speech** export toggle (`features.readAloud`), independent of fixed-layout — reflowable EPUBs also get SMIL when audio is present.
- Paragraph parsing uses jsdom to walk any `[data-id]` element except `<img>`, so reflowable, fixed-layout, and mixed pages all flow through the same generator.
- Studio UI: EPUB card in the Export view; works in EPUB readers that support JavaScript (interactive features carry over).

### Wizard
- `fixed_layout` is selectable as a render strategy under the Storybook and Custom presets — no separate preset.
- Step 3 (content processing) shows a "no content processing needed" message when `fixed_layout` is selected, since activities detection, figure extraction, and image cropping/segmentation don't apply to that pipeline.
- New `FixedLayoutPreview` mockup tile in `LayoutPreview`.

### Studio preview
- `PreviewView` detects fixed-layout pages via the iframe `<body>`'s inline width/height and CSS-scales the iframe to fit the preview pane — mirrors the storyboard behaviour.

### Spread image stitching
- Horizontal stitching of left/right page images (PNG + JPEG); image filtering prunes original halves when a stitched spread exists.

## Storage

Schema v12 → v13: adds `bounds_x/y/w/h` columns to `images` for per-image PDF placement. Migration is additive (existing rows get NULL bounds).

## Demo: fixed layout EPUB read aloud in BookFusion reader
https://github.com/user-attachments/assets/e8dc4d55-8cf1-45ae-b124-22bf24e01c1b

