### PR TITLE
Tree-based sectioning, structured content editor, and section thumbnails

### DIFF
--- a/apps/api/src/routes/books.ts
+++ b/apps/api/src/routes/books.ts
@@ -3,7 +3,7 @@ import path from "node:path"
 import { Hono } from "hono"
 import { HTTPException } from "hono/http-exception"
 import { parseBookLabel, PIPELINE } from "@adt/types"
-import { openBookDb } from "@adt/storage"
+import { openBookDb, resolveBookPaths } from "@adt/storage"
 import {
   listBooks,
   getBook,
@@ -358,6 +358,38 @@ export function createBookRoutes(
     } finally {
       db.close()
     }
+  })
+
+  // GET /books/:label/thumbnails/:filename — Serve section preview thumbnail PNG
+  app.get("/books/:label/thumbnails/:filename", (c) => {
+    const { label, filename } = c.req.param()
+    let paths: ReturnType<typeof resolveBookPaths>
+    try {
+      paths = resolveBookPaths(label, booksDir)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      throw new HTTPException(400, { message })
+    }
+    if (!/^[a-zA-Z0-9_-]+\.png$/.test(filename)) {
+      throw new HTTPException(400, { message: "Invalid thumbnail filename" })
+    }
+    const thumbPath = path.resolve(paths.thumbnailsDir, filename)
+    if (!thumbPath.startsWith(path.resolve(paths.thumbnailsDir) + path.sep)) {
+      throw new HTTPException(400, { message: "Invalid thumbnail path" })
+    }
+    let stat: fs.Stats
+    try {
+      stat = fs.statSync(thumbPath)
+    } catch {
+      throw new HTTPException(404, { message: `Thumbnail not found: ${filename}` })
+    }
+    if (!stat.isFile()) {
+      throw new HTTPException(404, { message: `Thumbnail not found: ${filename}` })
+    }
+    const buffer = fs.readFileSync(thumbPath)
+    c.header("Content-Type", "image/png")
+    c.header("Cache-Control", "public, max-age=3600")
+    return c.body(buffer)
   })
 
   // GET /books/:label/adt/* — Serve packaged ADT static files

--- a/apps/api/src/services/page-edit-service.ts
+++ b/apps/api/src/services/page-edit-service.ts
@@ -3,9 +3,9 @@ import path from "node:path"
 import { createBookStorage } from "@adt/storage"
 import { createLLMModel, createPromptEngine } from "@adt/llm"
 import type { LLMModel } from "@adt/llm"
-import { renderPage, buildRenderStrategyResolver, createTemplateEngine, loadBookConfig, createScreenshotRenderer, runVisualReviewLoop, DEFAULT_VISUAL_REVIEW_MODEL_ID, structurePage, buildStructureConfig } from "@adt/pipeline"
-import type { VisualRefinementDeps } from "@adt/pipeline"
-import { PageSectioningOutput, WebRenderingOutput, webRenderingLLMSchema, ImageClassificationOutput } from "@adt/types"
+import { renderPage, buildRenderStrategyResolver, createTemplateEngine, loadBookConfig, createScreenshotRenderer, runVisualReviewLoop, DEFAULT_VISUAL_REVIEW_MODEL_ID, structurePage, buildStructureConfig, renderSectionThumbnail } from "@adt/pipeline"
+import type { VisualRefinementDeps, ScreenshotRenderer } from "@adt/pipeline"
+import { PageSectioningOutput, WebRenderingOutput, webRenderingLLMSchema, ImageClassificationOutput, type ContentNodeData } from "@adt/types"
 import { loadStyleguideContent } from "./styleguide.js"
 
 export interface ReRenderOptions {
@@ -70,6 +70,7 @@ export async function reRenderPage(
 
   const storage = createBookStorage(label, booksDir)
   let visualRefinement: VisualRefinementDeps | undefined
+  let screenshotRenderer: ScreenshotRenderer | undefined
 
   try {
     // Read latest pipeline data
@@ -100,6 +101,8 @@ export async function reRenderPage(
         if (part.type === "image" && !part.isPruned && !renderImages.has(part.imageId)) {
           const dims = storage.getImageDimensions(part.imageId)
           renderImages.set(part.imageId, { base64: storage.getImageBase64(part.imageId), width: dims?.width, height: dims?.height })
+        } else if (part.type === "content_node" && !part.isPruned) {
+          collectImageIdsFromNode(part.node, renderImages, storage)
         }
       }
     }
@@ -137,13 +140,13 @@ export async function reRenderPage(
       throw new Error(`Section index ${sectionIndex} out of range`)
     }
 
-    // Set up visual refinement if any render strategy enables it
+    // Set up shared screenshot renderer for visual refinement + thumbnails
     if (webAssetsDir) {
       const hasVisualRefinement = Object.values(config.render_strategies ?? {}).some(
         (s) => s.config?.visual_refinement?.enabled
       )
+      screenshotRenderer = await createScreenshotRenderer()
       if (hasVisualRefinement) {
-        const screenshotRenderer = await createScreenshotRenderer()
         visualRefinement = {
           screenshotRenderer,
           webAssetsDir,
@@ -152,6 +155,28 @@ export async function reRenderPage(
             const hash = crypto.createHash("sha256").update(base64).digest("hex").slice(0, 16)
             storage.putDebugImage(hash, Buffer.from(base64, "base64"))
           },
+        }
+      }
+    }
+
+    const captureThumbnails = async (rendering: WebRenderingOutput): Promise<void> => {
+      if (!screenshotRenderer || !webAssetsDir) return
+      const thumbImages = new Map<string, { base64: string }>()
+      for (const [id, img] of renderImages) thumbImages.set(id, { base64: img.base64 })
+      for (const section of rendering.sections) {
+        try {
+          const buffer = await renderSectionThumbnail({
+            section,
+            label,
+            images: thumbImages,
+            webAssetsDir,
+            screenshotRenderer,
+          })
+          storage.putSectionThumbnail(pageId, section.sectionIndex, buffer)
+        } catch (err) {
+          console.error(
+            `[page-edit] ${label}: thumbnail failed for ${pageId} sec${section.sectionIndex}: ${err instanceof Error ? err.message : String(err)}`
+          )
         }
       }
     }
@@ -186,6 +211,7 @@ export async function reRenderPage(
 
     if (sectionIndex === undefined) {
       const version = storage.putNodeData("web-rendering", pageId, renderResult)
+      await captureThumbnails(renderResult)
       return { version, rendering: renderResult }
     }
 
@@ -209,10 +235,11 @@ export async function reRenderPage(
     const mergedRendering = { sections: mergedSections }
 
     const version = storage.putNodeData("web-rendering", pageId, mergedRendering)
+    await captureThumbnails(mergedRendering)
     return { version, rendering: mergedRendering }
   } finally {
-    if (visualRefinement) {
-      await visualRefinement.screenshotRenderer.close()
+    if (screenshotRenderer) {
+      await screenshotRenderer.close()
     }
     storage.clearNodesByType(["image-captioning", "text-catalog", "text-catalog-translation", "tts", "tts-timestamps"])
     storage.clearStepRuns(["image-captioning", "text-catalog", "catalog-translation", "tts"])
@@ -504,6 +531,30 @@ export async function reStructurePage(
       process.env.OPENAI_API_KEY = previousKey
     } else {
       delete process.env.OPENAI_API_KEY
+    }
+  }
+}
+
+/**
+ * Recursively collect image IDs from a content node tree and add them to the render images map.
+ */
+function collectImageIdsFromNode(
+  node: ContentNodeData,
+  renderImages: Map<string, { base64: string; width?: number; height?: number }>,
+  storage: { getImageBase64: (id: string) => string; getImageDimensions: (id: string) => { width: number; height: number } | null }
+): void {
+  if (node.isPruned) return
+  if (node.imageId && !renderImages.has(node.imageId)) {
+    try {
+      const dims = storage.getImageDimensions(node.imageId)
+      renderImages.set(node.imageId, { base64: storage.getImageBase64(node.imageId), width: dims?.width, height: dims?.height })
+    } catch {
+      // Image not found in storage — skip
+    }
+  }
+  if (node.children) {
+    for (const child of node.children) {
+      collectImageIdsFromNode(child, renderImages, storage)
     }
   }
 }

--- a/apps/api/src/services/stage-runner.ts
+++ b/apps/api/src/services/stage-runner.ts
@@ -59,8 +59,9 @@ import {
   getSegmentedImageId,
   createScreenshotRenderer,
   DEFAULT_VISUAL_REVIEW_MODEL_ID,
+  renderSectionThumbnail,
 } from "@adt/pipeline"
-import type { TranslationConfig, QuizPageInput, ProviderRouting, MeaningfulnessConfig, CroppingConfig, SegmentationConfig, VisualRefinementDeps } from "@adt/pipeline"
+import type { TranslationConfig, QuizPageInput, ProviderRouting, MeaningfulnessConfig, CroppingConfig, SegmentationConfig, VisualRefinementDeps, ScreenshotRenderer } from "@adt/pipeline"
 import { loadStyleguideContent } from "./styleguide.js"
 import { createTTSSynthesizer, createAzureTTSSynthesizer, createGeminiTTSSynthesizer } from "@adt/llm"
 import type { TTSSynthesizer } from "@adt/llm"
@@ -563,6 +564,7 @@ async function runStoryboardStep(
 
   const storage = createBookStorage(label, booksDir)
   let visualRefinement: VisualRefinementDeps | undefined
+  let screenshotRenderer: ScreenshotRenderer | undefined
 
   try {
     const config = loadBookConfig(label, booksDir, configPath)
@@ -617,13 +619,13 @@ async function runStoryboardStep(
       return model
     }
 
-    // Set up visual refinement if any render strategy enables it
+    // Set up shared screenshot renderer for visual refinement + thumbnails
     if (webAssetsDir) {
       const hasVisualRefinement = Object.values(config.render_strategies ?? {}).some(
         (s) => s.config?.visual_refinement?.enabled
       )
+      screenshotRenderer = await createScreenshotRenderer()
       if (hasVisualRefinement) {
-        const screenshotRenderer = await createScreenshotRenderer()
         visualRefinement = {
           screenshotRenderer,
           webAssetsDir,
@@ -632,6 +634,32 @@ async function runStoryboardStep(
             const hash = crypto.createHash("sha256").update(base64).digest("hex").slice(0, 16)
             storage.putDebugImage(hash, Buffer.from(base64, "base64"))
           },
+        }
+      }
+    }
+
+    const captureThumbnails = async (
+      pageId: string,
+      renderResult: WebRenderingOutput,
+      renderImages: Map<string, { base64: string; width?: number; height?: number }>
+    ): Promise<void> => {
+      if (!screenshotRenderer || !webAssetsDir) return
+      const thumbImages = new Map<string, { base64: string }>()
+      for (const [id, img] of renderImages) thumbImages.set(id, { base64: img.base64 })
+      for (const section of renderResult.sections) {
+        try {
+          const buffer = await renderSectionThumbnail({
+            section,
+            label,
+            images: thumbImages,
+            webAssetsDir,
+            screenshotRenderer,
+          })
+          storage.putSectionThumbnail(pageId, section.sectionIndex, buffer)
+        } catch (err) {
+          console.error(
+            `[stage-run] ${label}: thumbnail failed for ${pageId} sec${section.sectionIndex}: ${toErrorMessage(err)}`
+          )
         }
       }
     }
@@ -704,6 +732,7 @@ async function runStoryboardStep(
               visualRefinement,
             )
             storage.putNodeData("web-rendering", page.pageId, renderResult)
+            await captureThumbnails(page.pageId, renderResult, renderImages)
             completedRendering++
             progress.emit({
               type: "step-progress",
@@ -771,7 +800,11 @@ async function runStoryboardStep(
               )
               return
             }
-            const textClassification = textClassificationRow.data as TextClassificationOutput
+            // Detect tree-based data (has `nodes` array) vs legacy flat data (has `groups` array)
+            const rawData = textClassificationRow.data as Record<string, unknown>
+            const isTree = rawData && Array.isArray(rawData.nodes)
+            const contentTree = isTree ? (rawData as unknown as PageStructuringOutput) : undefined
+            const textClassification = !isTree ? (rawData as unknown as TextClassificationOutput) : undefined
 
             // Get image-filtering data
             const imageClassificationRow = storage.getLatestNodeData(
@@ -807,6 +840,7 @@ async function runStoryboardStep(
                 pageNumber: page.pageNumber,
                 pageImageBase64,
                 textClassification,
+                contentTree,
                 imageClassification,
                 images: sectionImages,
               },
@@ -851,6 +885,7 @@ async function runStoryboardStep(
               visualRefinement,
             )
             storage.putNodeData("web-rendering", page.pageId, renderResult)
+            await captureThumbnails(page.pageId, renderResult, renderImages)
             completedRendering++
             progress.emit({
               type: "step-progress",
@@ -888,8 +923,8 @@ async function runStoryboardStep(
       console.log(`[stage-run] ${label}: storyboard complete`)
     }
   } finally {
-    if (visualRefinement) {
-      await visualRefinement.screenshotRenderer.close()
+    if (screenshotRenderer) {
+      await screenshotRenderer.close()
     }
     storage.close()
     restoreEnvKeys()

--- a/apps/studio/src/api/client.ts
+++ b/apps/studio/src/api/client.ts
@@ -207,6 +207,12 @@ export interface PageDetail {
             isPruned: boolean
             reason?: string
           }
+        | {
+            type: "content_node"
+            nodeId: string
+            node: ContentNodeData
+            isPruned: boolean
+          }
       >
       backgroundColor: string
       textColor: string

--- a/apps/studio/src/components/pipeline/stages/extract/components/ExtractPageDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/extract/components/ExtractPageDetail.tsx
@@ -11,8 +11,13 @@ import { useBookTasks } from "@/hooks/use-book-tasks"
 import { useApiKey } from "@/hooks/use-api-key"
 import { Trans } from "@lingui/react/macro"
 import { useLingui } from "@lingui/react/macro"
-import { getTextGroupLabel, getTextTypeLabel } from "@/lib/text-type-labels"
 import { ImageCropDialog } from "@/components/pipeline/stages/storyboard/components/ImageCropDialog"
+import {
+  ContentNodeBlock,
+  updateNodeInTree as updateNodeInTreeSingle,
+  removeNodeFromTree,
+  insertNodeIntoTree,
+} from "@/components/pipeline/stages/storyboard/components/ContentNodeBlock"
 
 function VersionPicker({
   currentVersion,
@@ -202,211 +207,13 @@ function ImageCard({ imageId, bookLabel, isPruned, reason, onTogglePrune, onRecr
 }
 
 type PageStructuringData = NonNullable<import("@/api/client").PageDetail["pageStructuring"]>
-
-function ContentNodeView({
-  node,
-  depth,
-  configuredTextTypes,
-  configuredContainerTypes,
-  bookLabel,
-  collapsed,
-  onUpdate,
-  onTogglePrune,
-  onToggleCollapse,
-}: {
-  node: ContentNodeData
-  depth: number
-  configuredTextTypes: string[]
-  configuredContainerTypes: string[]
-  bookLabel: string
-  collapsed: Set<string>
-  onUpdate: (nodeId: string, field: string, value: string) => void
-  onTogglePrune: (nodeId: string) => void
-  onToggleCollapse: (nodeId: string) => void
-}) {
-  const { t } = useLingui()
-  const hasChildren = node.children != null && node.children.length > 0
-  const isContainer = hasChildren || (node.structure != null && node.imageId != null)
-  const isText = node.text != null
-  const isCollapsed = collapsed.has(node.nodeId)
-
-  // Container node (includes image containers and containers with background images)
-  if (isContainer) {
-    // eslint-disable-next-line lingui/no-unlocalized-strings
-    const imgSrc = node.imageId ? `${BASE_URL}/books/${bookLabel}/images/${node.imageId}` : null
-    const hasBody = hasChildren || imgSrc != null
-    return (
-      <div className={`relative ${node.isPruned ? "opacity-40" : ""}`} style={{ paddingLeft: depth * 20 }}>
-        {/* Vertical connector from parent */}
-        {depth > 0 && (
-          <div
-            className="absolute top-0 bottom-0 border-l border-muted-foreground/15"
-            style={{ left: (depth - 1) * 20 + 9 }}
-          />
-        )}
-        <div className="group/container relative flex items-center gap-2 rounded-md px-1.5 py-1 hover:bg-muted/40 transition-colors">
-          <select
-            value={node.structure ?? ""}
-            onChange={(e) => onUpdate(node.nodeId, "structure", e.target.value)}
-            onClick={(e) => {
-              if (hasBody && (e.target as HTMLSelectElement).value === node.structure) {
-                e.preventDefault()
-                onToggleCollapse(node.nodeId)
-              }
-            }}
-            className="shrink-0 text-[11px] font-semibold uppercase tracking-wide rounded-full px-2 py-0.5 border-0 outline-none focus:ring-1 focus:ring-ring cursor-pointer appearance-none bg-primary/10 text-primary"
-            style={{ width: `${Math.max((getTextGroupLabel(node.structure ?? "")).length * 0.85 + 1.5, 4.5)}em` }}
-          >
-            {!configuredContainerTypes.includes(node.structure ?? "") && (
-              <option value={node.structure ?? ""}>{getTextGroupLabel(node.structure ?? "")}</option>
-            )}
-            {configuredContainerTypes.map((ct) => (
-              <option key={ct} value={ct}>
-                {getTextGroupLabel(ct)}
-              </option>
-            ))}
-          </select>
-          {node.imageId && (
-            <span className="text-[10px] text-muted-foreground/60 font-mono truncate">{node.imageId}</span>
-          )}
-          <button
-            type="button"
-            onClick={() => onTogglePrune(node.nodeId)}
-            className={`shrink-0 ml-auto flex items-center justify-center w-5 h-5 rounded cursor-pointer transition-colors ${
-              node.isPruned
-                ? "text-destructive hover:bg-destructive/10"
-                : "text-muted-foreground/40 opacity-0 group-hover/container:opacity-100 hover:bg-muted hover:text-muted-foreground"
-            }`}
-            title={node.isPruned ? t`Unprune` : t`Prune`}
-          >
-            {node.isPruned
-              ? <EyeOff className="h-3.5 w-3.5" />
-              : <Eye className="h-3.5 w-3.5" />
-            }
-          </button>
-        </div>
-        {hasBody && !isCollapsed && (
-          <div className="relative">
-            {imgSrc && (
-              <div className="relative py-1" style={{ paddingLeft: (depth + 1) * 20 }}>
-                {/* Connector line through image area */}
-                <div
-                  className="absolute top-0 bottom-0 border-l border-muted-foreground/15"
-                  style={{ left: depth * 20 + 9 }}
-                />
-                <img
-                  src={imgSrc}
-                  alt={node.imageId!}
-                  className="relative max-h-[140px] max-w-full object-contain rounded-lg border border-border/50 shadow-sm"
-                  onError={(e) => { (e.target as HTMLImageElement).style.display = "none" }}
-                />
-              </div>
-            )}
-            {hasChildren && node.children!.map((child) => (
-              <ContentNodeView
-                key={child.nodeId}
-                node={child}
-                depth={depth + 1}
-                configuredTextTypes={configuredTextTypes}
-                configuredContainerTypes={configuredContainerTypes}
-                bookLabel={bookLabel}
-                collapsed={collapsed}
-                onUpdate={onUpdate}
-                onTogglePrune={onTogglePrune}
-                onToggleCollapse={onToggleCollapse}
-              />
-            ))}
-          </div>
-        )}
-      </div>
-    )
-  }
-
-  // Text leaf node
-  if (isText) {
-    return (
-      <div
-        className={`relative ${node.isPruned ? "opacity-40" : ""}`}
-        style={{ paddingLeft: depth * 20 }}
-      >
-        {/* Vertical connector from parent */}
-        {depth > 0 && (
-          <div
-            className="absolute top-0 bottom-0 border-l border-muted-foreground/15"
-            style={{ left: (depth - 1) * 20 + 9 }}
-          />
-        )}
-        <div className="group/node relative flex items-start gap-2 rounded-md px-1.5 py-1 hover:bg-muted/40 transition-colors">
-          <select
-            value={node.role ?? ""}
-            onChange={(e) => onUpdate(node.nodeId, "role", e.target.value)}
-            className="shrink-0 text-[11px] font-semibold uppercase tracking-wide rounded-full px-2 py-0.5 bg-muted text-muted-foreground border-0 outline-none focus:ring-1 focus:ring-ring cursor-pointer appearance-none mt-px"
-            style={{ width: `${Math.max((getTextTypeLabel(node.role ?? "")).length * 0.85 + 1.5, 4.5)}em` }}
-          >
-            {!configuredTextTypes.includes(node.role ?? "") && (
-              <option value={node.role ?? ""}>{getTextTypeLabel(node.role ?? "")}</option>
-            )}
-            {configuredTextTypes.map((tt) => (
-              <option key={tt} value={tt}>
-                {getTextTypeLabel(tt)}
-              </option>
-            ))}
-          </select>
-          <textarea
-            value={node.text ?? ""}
-            onChange={(e) => onUpdate(node.nodeId, "text", e.target.value)}
-            rows={1}
-            className="leading-relaxed flex-1 min-w-0 text-[13px] bg-transparent border-0 outline-none resize-none overflow-hidden p-0 focus:ring-1 focus:ring-ring focus:rounded mt-px"
-            onInput={(e) => {
-              const el = e.target as HTMLTextAreaElement
-              el.style.height = "auto"
-              el.style.height = el.scrollHeight + "px"
-            }}
-            ref={(el) => {
-              if (el) {
-                el.style.height = "auto"
-                el.style.height = el.scrollHeight + "px"
-              }
-            }}
-          />
-          <button
-            type="button"
-            onClick={() => onTogglePrune(node.nodeId)}
-            className={`shrink-0 self-center flex items-center justify-center w-5 h-5 rounded cursor-pointer transition-colors ${
-              node.isPruned
-                ? "text-destructive hover:bg-destructive/10"
-                : "text-muted-foreground/40 opacity-0 group-hover/node:opacity-100 hover:bg-muted hover:text-muted-foreground"
-            }`}
-            title={node.isPruned ? t`Unprune` : t`Prune`}
-          >
-            {node.isPruned
-              ? <EyeOff className="h-3.5 w-3.5" />
-              : <Eye className="h-3.5 w-3.5" />
-            }
-          </button>
-        </div>
-      </div>
-    )
-  }
-
-  // Empty node (shouldn't happen but handle gracefully)
-  return null
-}
 type ImageClassData = NonNullable<import("@/api/client").PageDetail["imageClassification"]>
 
-/** Recursively find and update a node by ID in a tree */
-function updateNodeInTree(
-  nodes: ContentNodeData[],
-  nodeId: string,
-  updater: (node: ContentNodeData) => ContentNodeData
-): ContentNodeData[] {
-  return nodes.map((node) => {
-    if (node.nodeId === nodeId) return updater(node)
-    if (node.children) {
-      return { ...node, children: updateNodeInTree(node.children, nodeId, updater) }
-    }
-    return node
-  })
+// eslint-disable-next-line lingui/no-unlocalized-strings
+const VIRTUAL_ROOT_ID = "__extract_virtual_root__"
+
+function wrapRoot(nodes: ContentNodeData[]): ContentNodeData {
+  return { nodeId: VIRTUAL_ROOT_ID, isPruned: false, children: nodes }
 }
 
 export function ExtractPageDetail({
@@ -421,12 +228,8 @@ export function ExtractPageDetail({
   const { data: imageData } = usePageImage(bookLabel, pageId)
   const { data: activeConfigData } = useActiveConfig(bookLabel)
   const mergedConfig = activeConfigData?.merged as Record<string, unknown> | undefined
-  const configuredTextTypes = mergedConfig
-    ? Object.keys((mergedConfig.text_types ?? {}) as Record<string, string>)
-    : []
-  const configuredContainerTypes = mergedConfig
-    ? Object.keys((mergedConfig.container_types ?? {}) as Record<string, string>)
-    : []
+  const leafTypes = mergedConfig?.text_types as Record<string, string> | undefined
+  const containerTypes = mergedConfig?.container_types as Record<string, string> | undefined
   const [pageImageDims, setPageImageDims] = useState<{ w: number; h: number } | null>(null)
   const { apiKey } = useApiKey()
   const { stageState, stepState } = useBookRun()
@@ -440,7 +243,6 @@ export function ExtractPageDetail({
   const [savingText, setSavingText] = useState(false)
   const [savingImages, setSavingImages] = useState(false)
   const [pendingTextData, setPendingTextData] = useState<PageStructuringData | null>(null)
-  const [collapsed, setCollapsed] = useState<Set<string>>(new Set())
   const [pendingImageData, setPendingImageData] = useState<ImageClassData | null>(null)
   const [cropTarget, setCropTarget] = useState<string | null>(null)
   const [cropPageSrc, setCropPageSrc] = useState<string | null>(null)
@@ -495,29 +297,31 @@ export function ExtractPageDetail({
   const textDirty = pendingTextData != null
   const imageDirty = pendingImageData != null
 
-  const updateNodeField = (nodeId: string, field: string, value: string) => {
+  const updateTree = (updater: (root: ContentNodeData) => ContentNodeData | null) => {
     const base = pendingTextData ?? page?.pageStructuring
     if (!base) return
-    setPendingTextData({
-      ...base,
-      nodes: updateNodeInTree(base.nodes, nodeId, (node) => ({ ...node, [field]: value })),
-    })
+    const next = updater(wrapRoot(base.nodes))
+    if (!next) return
+    setPendingTextData({ ...base, nodes: next.children ?? [] })
   }
 
-  const toggleNodePrune = (nodeId: string) => {
-    const base = pendingTextData ?? page?.pageStructuring
-    if (!base) return
-    setPendingTextData({
-      ...base,
-      nodes: updateNodeInTree(base.nodes, nodeId, (node) => ({ ...node, isPruned: !node.isPruned })),
-    })
+  const handleTogglePruned = (nodeId: string) => {
+    updateTree((root) => updateNodeInTreeSingle(root, nodeId, (n) => ({ ...n, isPruned: !n.isPruned })))
   }
 
-  const toggleCollapse = (nodeId: string) => {
-    setCollapsed((prev) => {
-      const next = new Set(prev)
-      next.has(nodeId) ? next.delete(nodeId) : next.add(nodeId)
-      return next
+  const handleEditText = (nodeId: string, newText: string) => {
+    updateTree((root) => updateNodeInTreeSingle(root, nodeId, (n) => ({ ...n, text: newText })))
+  }
+
+  const handleChangeType = (nodeId: string, field: "structure" | "role", newType: string) => {
+    updateTree((root) => updateNodeInTreeSingle(root, nodeId, (n) => ({ ...n, [field]: newType })))
+  }
+
+  const handleMoveNode = (dragNodeId: string, targetParentId: string | null, insertIndex: number) => {
+    updateTree((root) => {
+      const [treeWithout, draggedNode] = removeNodeFromTree(root, dragNodeId)
+      if (!treeWithout || !draggedNode) return null
+      return insertNodeIntoTree(treeWithout, draggedNode, targetParentId ?? VIRTUAL_ROOT_ID, insertIndex)
     })
   }
 
@@ -745,19 +549,22 @@ export function ExtractPageDetail({
               )}
               </div>
             </h3>
-            <div>
-              {structuringData.nodes.map((node) => (
-                <ContentNodeView
+            <div className="space-y-0.5">
+              {structuringData.nodes.map((node, i) => (
+                <ContentNodeBlock
                   key={node.nodeId}
                   node={node}
-                  depth={0}
-                  configuredTextTypes={configuredTextTypes}
-                  configuredContainerTypes={configuredContainerTypes}
+                  parentId={null}
+                  indexInParent={i}
                   bookLabel={bookLabel}
-                  collapsed={collapsed}
-                  onUpdate={updateNodeField}
-                  onTogglePrune={toggleNodePrune}
-                  onToggleCollapse={toggleCollapse}
+                  depth={0}
+                  disabled={storyboardRunning}
+                  containerTypes={containerTypes}
+                  leafTypes={leafTypes}
+                  onTogglePruned={handleTogglePruned}
+                  onEditText={handleEditText}
+                  onChangeType={handleChangeType}
+                  onMoveNode={handleMoveNode}
                 />
               ))}
             </div>

--- a/apps/studio/src/components/pipeline/stages/storyboard/StoryboardView.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/StoryboardView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useCallback, useState } from "react"
-import { ArrowLeft, ArrowRight, LayoutGrid, Loader2, Table2 } from "lucide-react"
+import { ArrowLeft, ArrowRight, LayoutGrid, Loader2, FileText, Eye } from "lucide-react"
 import { usePages, usePage } from "@/hooks/use-pages"
 import { useStepHeader } from "../../components/StepViewRouter"
 import { useBookRun } from "@/hooks/use-book-run"
@@ -16,7 +16,8 @@ export function StoryboardView({ bookLabel, selectedPageId: selectedPageIdProp, 
   const { t } = useLingui()
   const { data: pages, isLoading: pagesLoading } = usePages(bookLabel)
   const setSelectedPageId = onSelectPage ?? (() => {})
-  const [overviewMode, setOverviewMode] = useState(false)
+  const [activeTab, setActiveTab] = useState<"content" | "preview">("content")
+  const [editPanelOpen, setEditPanelOpen] = useState(false)
   const { setExtra, setOnLabelClick } = useStepHeader()
   const { stageState, queueRun } = useBookRun()
   const { apiKey, hasApiKey } = useApiKey()
@@ -138,23 +139,39 @@ export function StoryboardView({ bookLabel, selectedPageId: selectedPageIdProp, 
     </>
   ) : null
 
-  // Overview toggle button (reused in multiple header states)
-  const overviewToggle = (
-    <button
-      type="button"
-      className={`flex items-center justify-center w-7 h-7 rounded transition-colors ${
-        overviewMode ? "bg-white/30 text-white" : "bg-white/15 hover:bg-white/25 text-white/70"
-      }`}
-      onClick={() => setOverviewMode((v) => !v)}
-      title={t`Overview`}
-    >
-      <Table2 className="h-3.5 w-3.5" />
-    </button>
+  // Tab buttons for Content / Preview
+  const tabButtons = (
+    <div className="flex items-center gap-0.5 bg-white/10 rounded p-0.5">
+      <button
+        type="button"
+        className={`flex items-center gap-1 px-2 py-1 rounded text-[11px] font-medium transition-colors ${
+          activeTab === "content"
+            ? "bg-white/25 text-white"
+            : "text-white/60 hover:text-white hover:bg-white/10"
+        }`}
+        onClick={() => setActiveTab("content")}
+      >
+        <FileText className="h-3 w-3" />
+        {t`Content`}
+      </button>
+      <button
+        type="button"
+        className={`flex items-center gap-1 px-2 py-1 rounded text-[11px] font-medium transition-colors ${
+          activeTab === "preview"
+            ? "bg-white/25 text-white"
+            : "text-white/60 hover:text-white hover:bg-white/10"
+        }`}
+        onClick={() => setActiveTab("preview")}
+      >
+        <Eye className="h-3 w-3" />
+        {t`Preview`}
+      </button>
+    </div>
   )
 
   const navigationArrows = (
-    <div className="flex gap-1">
-      {overviewToggle}
+    <div className="flex items-center gap-1.5">
+      {tabButtons}
       <button
         type="button"
         className="flex items-center justify-center w-7 h-7 rounded bg-white/15 hover:bg-white/25 transition-colors disabled:opacity-30 disabled:cursor-default"
@@ -185,17 +202,13 @@ export function StoryboardView({ bookLabel, selectedPageId: selectedPageIdProp, 
       }
     }
 
-    // Overview mode: show overview header
-    if (overviewMode) {
+    // Content tab: simple header with tab buttons only (SectioningOverview shows all pages)
+    if (activeTab === "content") {
       setOnLabelClick(null)
       setExtra(
-        <>
-          <span className="text-white/40 text-sm">/</span>
-          <span className="text-sm font-medium">{t`Overview`}</span>
-          <div className="ml-auto flex gap-1">
-            {overviewToggle}
-          </div>
-        </>
+        <div className="ml-auto flex items-center gap-1.5">
+          {tabButtons}
+        </div>
       )
       return () => {
         setExtra(null)
@@ -203,8 +216,8 @@ export function StoryboardView({ bookLabel, selectedPageId: selectedPageIdProp, 
       }
     }
 
-    // When StoryboardSectionDetail is rendered, it manages the header itself
-    if (page?.sectioning && sectionCount > 0) return
+    // When StoryboardSectionDetail is rendered (preview tab), it manages the header itself
+    if (activeTab === "preview" && page?.sectioning && sectionCount > 0) return
 
     if (selectedPageSummary) {
       setOnLabelClick(null)
@@ -213,7 +226,6 @@ export function StoryboardView({ bookLabel, selectedPageId: selectedPageIdProp, 
           <span className="text-white/40 text-sm">/</span>
           <span className="text-sm font-medium">{t`Page ${String(selectedPageSummary.pageNumber)}`}</span>
           <div className="ml-auto flex gap-1">
-            {overviewToggle}
             <button
               type="button"
               className="flex items-center justify-center w-7 h-7 rounded bg-white/15 hover:bg-white/25 transition-colors disabled:opacity-30 disabled:cursor-default"
@@ -241,7 +253,7 @@ export function StoryboardView({ bookLabel, selectedPageId: selectedPageIdProp, 
       setExtra(null)
       setOnLabelClick(null)
     }
-  }, [selectedPageId, selectedPageSummary?.pageNumber, sectionIndex, sectionCount, canGoPrev, canGoNext, prevPageId, nextPageId, setExtra, setOnLabelClick, page?.sectioning, showRunCard, overviewMode])
+  }, [selectedPageId, selectedPageSummary?.pageNumber, sectionIndex, sectionCount, canGoPrev, canGoNext, prevPageId, nextPageId, setExtra, setOnLabelClick, page?.sectioning, showRunCard, activeTab])
 
   // Keyboard arrow navigation
   useEffect(() => {
@@ -293,14 +305,14 @@ export function StoryboardView({ bookLabel, selectedPageId: selectedPageIdProp, 
     )
   }
 
-  // Overview mode: show sectioning table for all pages
-  if (overviewMode) {
+  // Content tab: sectioning overview for all pages
+  if (activeTab === "content") {
     return (
       <SectioningOverview
         bookLabel={bookLabel}
         pages={pageList}
         onNavigateToSection={(pageId, sectionIdx) => {
-          setOverviewMode(false)
+          setActiveTab("preview")
           setSelectedPageId(pageId)
           setSectionIndex(sectionIdx)
         }}
@@ -363,6 +375,8 @@ export function StoryboardView({ bookLabel, selectedPageId: selectedPageIdProp, 
       onNavigateSection={setSectionIndex}
       hasPrevPage={!!prevPageId}
       hasNextPage={!!nextPageId}
+      panelOpen={editPanelOpen}
+      onPanelOpenChange={setEditPanelOpen}
     />
   )
 }

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/ContentEditor.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/ContentEditor.tsx
@@ -1,0 +1,753 @@
+import { useState, useCallback } from "react"
+import { useQueries, useQueryClient, useMutation } from "@tanstack/react-query"
+import { Eye, EyeOff, ChevronDown, ChevronRight, Loader2, SlidersHorizontal, Sparkles, LayoutTemplate } from "lucide-react"
+import type { ContentNodeData } from "@adt/types"
+import { api, BASE_URL, type PageSummaryItem, type PageDetail, type SectionRendering } from "@/api/client"
+import { invalidateStoryboardDependents } from "@/hooks/use-page-mutations"
+import { SectionActionsDropdown } from "./SectionActionsDropdown"
+import { ContentNodeBlock, updateNodeInTree, moveNodeInTree } from "./ContentNodeBlock"
+import { useBookRun } from "@/hooks/use-book-run"
+import { useActiveConfig } from "@/hooks/use-debug"
+import { getTextGroupLabel, getTextTypeLabel } from "@/lib/text-type-labels"
+import { Trans } from "@lingui/react/macro"
+import { useLingui } from "@lingui/react/macro"
+import { cn } from "@/lib/utils"
+
+type SectionData = NonNullable<PageDetail["sectioning"]>["sections"][number]
+type PartData = SectionData["parts"][number]
+
+type DetailFilter = "structure" | "images" | "pruned"
+const ALL_FILTERS: DetailFilter[] = ["structure", "images", "pruned"]
+
+interface ContentEditorProps {
+  bookLabel: string
+  pages: PageSummaryItem[]
+  onNavigateToSection?: (pageId: string, sectionIndex: number) => void
+}
+
+export function ContentEditor({ bookLabel, pages, onNavigateToSection }: ContentEditorProps) {
+  const { t } = useLingui()
+  const queryClient = useQueryClient()
+  const { stageState } = useBookRun()
+  const storyboardRunning = stageState("storyboard") === "running" || stageState("storyboard") === "queued"
+  const [expandedPages, setExpandedPages] = useState<Set<string>>(() => new Set(pages.map((p) => p.pageId)))
+  const [confirmDialog, setConfirmDialog] = useState<{ message: string; onConfirm: () => void } | null>(null)
+  const [visibleFilters, setVisibleFilters] = useState<Set<DetailFilter>>(() => new Set(ALL_FILTERS))
+
+  const { data: activeConfigData } = useActiveConfig(bookLabel)
+  const mergedConfig = activeConfigData?.merged as Record<string, unknown> | undefined
+  const renderStrategies = (mergedConfig?.render_strategies ?? {}) as Record<string, { render_type: string }>
+  const strategyNames = Object.keys(renderStrategies)
+  const containerTypes = mergedConfig?.container_types as Record<string, string> | undefined
+  const leafTypes = mergedConfig?.text_types as Record<string, string> | undefined
+
+  const toggleFilter = (f: DetailFilter) => {
+    setVisibleFilters((prev) => {
+      const next = new Set(prev)
+      if (next.has(f)) next.delete(f)
+      else next.add(f)
+      return next
+    })
+  }
+
+  const filterLabels: Record<DetailFilter, string> = {
+    structure: t`Structure`,
+    images: t`Images`,
+    pruned: t`Pruned`,
+  }
+
+  // Fetch full page details for pages that have sections
+  const pagesWithSections = pages.filter((p) => p.sectionCount > 0)
+  const pageQueries = useQueries({
+    queries: pagesWithSections.map((p) => ({
+      queryKey: ["books", bookLabel, "pages", p.pageId],
+      queryFn: () => api.getPage(bookLabel, p.pageId),
+      staleTime: 30_000,
+    })),
+  })
+
+  const isLoading = pageQueries.some((q) => q.isLoading)
+  const pageDetailMap = new Map<string, PageDetail>()
+  for (const q of pageQueries) {
+    if (q.data) pageDetailMap.set(q.data.pageId, q.data)
+  }
+
+  const allPageIds = pages.map((p) => p.pageId)
+
+  const invalidatePages = (...pageIds: string[]) => {
+    for (const pid of pageIds) {
+      queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "pages", pid] })
+    }
+    queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "pages"] })
+    invalidateStoryboardDependents(queryClient, bookLabel)
+  }
+
+  // Mutations (from SectioningOverview)
+  const mergeMutation = useMutation({
+    mutationFn: ({ pageId, sectionIndex, direction }: { pageId: string; sectionIndex: number; direction: "prev" | "next" }) =>
+      api.mergeSection(bookLabel, pageId, sectionIndex, direction),
+    onSuccess: (_data, vars) => invalidatePages(vars.pageId),
+  })
+  const mergeCrossPageMutation = useMutation({
+    mutationFn: ({ pageId, sectionIndex, direction }: { pageId: string; sectionIndex: number; direction: "prev" | "next" }) =>
+      api.mergeSectionCrossPage(bookLabel, pageId, sectionIndex, direction),
+    onSuccess: (data) => invalidatePages(data.sourcePageId, data.targetPageId),
+  })
+  const cloneMutation = useMutation({
+    mutationFn: ({ pageId, sectionIndex }: { pageId: string; sectionIndex: number }) =>
+      api.cloneSection(bookLabel, pageId, sectionIndex),
+    onSuccess: (_data, vars) => invalidatePages(vars.pageId),
+  })
+  const deleteMutation = useMutation({
+    mutationFn: ({ pageId, sectionIndex }: { pageId: string; sectionIndex: number }) =>
+      api.deleteSection(bookLabel, pageId, sectionIndex),
+    onSuccess: (_data, vars) => invalidatePages(vars.pageId),
+  })
+  const togglePruneMutation = useMutation({
+    mutationFn: ({ pageId, sectionIndex }: { pageId: string; sectionIndex: number }) => {
+      const page = pageDetailMap.get(pageId)
+      if (!page?.sectioning) throw new Error("No sectioning data")
+      const updated = {
+        ...page.sectioning,
+        sections: page.sectioning.sections.map((s, i) =>
+          i === sectionIndex ? { ...s, isPruned: !s.isPruned } : s
+        ),
+      }
+      return api.updateSectioning(bookLabel, pageId, updated)
+    },
+    onSuccess: (_data, vars) => invalidatePages(vars.pageId),
+  })
+  // General sectioning update — used for node-level edits (prune, text, type, move)
+  const updateSectioningMutation = useMutation({
+    mutationFn: ({ pageId, sectioning }: { pageId: string; sectioning: NonNullable<PageDetail["sectioning"]> }) =>
+      api.updateSectioning(bookLabel, pageId, sectioning),
+    onSuccess: (_data, vars) => invalidatePages(vars.pageId),
+  })
+
+  const isMutating = storyboardRunning || mergeMutation.isPending || mergeCrossPageMutation.isPending || cloneMutation.isPending || deleteMutation.isPending || togglePruneMutation.isPending || updateSectioningMutation.isPending
+
+  const togglePage = useCallback((pageId: string) => {
+    setExpandedPages((prev) => {
+      const next = new Set(prev)
+      if (next.has(pageId)) next.delete(pageId)
+      else next.add(pageId)
+      return next
+    })
+  }, [])
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center gap-2 p-6 text-sm text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        <Trans>Loading pages...</Trans>
+      </div>
+    )
+  }
+
+  return (
+    <div className="h-full overflow-auto">
+      {/* Confirm dialog */}
+      {confirmDialog && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+          <div className="bg-popover rounded-lg border shadow-lg p-4 max-w-sm mx-4">
+            <p className="text-sm mb-4">{confirmDialog.message}</p>
+            <div className="flex justify-end gap-2">
+              <button type="button" onClick={() => setConfirmDialog(null)} className="px-3 py-1.5 text-xs rounded bg-muted hover:bg-muted/80">
+                <Trans>Cancel</Trans>
+              </button>
+              <button type="button" onClick={() => { confirmDialog.onConfirm(); setConfirmDialog(null) }} className="px-3 py-1.5 text-xs rounded bg-destructive text-destructive-foreground hover:bg-destructive/90">
+                <Trans>Confirm</Trans>
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <div className="p-4 space-y-2">
+        {/* Filter bar */}
+        <div className="flex items-center gap-2 pb-2">
+          <SlidersHorizontal className="h-3.5 w-3.5 text-muted-foreground" />
+          <span className="text-xs text-muted-foreground"><Trans>Show:</Trans></span>
+          {ALL_FILTERS.map((f) => (
+            <button
+              key={f}
+              type="button"
+              onClick={() => toggleFilter(f)}
+              className={cn(
+                "px-2 py-1 text-xs rounded border transition-colors",
+                visibleFilters.has(f)
+                  ? "bg-primary text-primary-foreground border-primary"
+                  : "bg-background text-muted-foreground border-border hover:bg-accent"
+              )}
+            >
+              {filterLabels[f]}
+            </button>
+          ))}
+        </div>
+
+        {/* Page list */}
+        {pages.map((pageSummary) => {
+          const pageDetail = pageDetailMap.get(pageSummary.pageId)
+          const isExpanded = expandedPages.has(pageSummary.pageId)
+          const sectionCount = pageSummary.sectionCount
+          const pageIdx = allPageIds.indexOf(pageSummary.pageId)
+          const hasPrevPage = pageIdx > 0
+          const hasNextPage = pageIdx < allPageIds.length - 1
+
+          return (
+            <div key={pageSummary.pageId} className="border rounded-lg overflow-hidden">
+              {/* Page header — always visible */}
+              <button
+                type="button"
+                onClick={() => togglePage(pageSummary.pageId)}
+                className="flex items-center gap-3 w-full px-3 py-2 hover:bg-muted/40 transition-colors text-left"
+              >
+                {isExpanded ? <ChevronDown className="h-3.5 w-3.5 text-muted-foreground/60 shrink-0" /> : <ChevronRight className="h-3.5 w-3.5 text-muted-foreground/60 shrink-0" />}
+                <span className="text-xs font-medium">
+                  {t`Page ${String(pageSummary.pageNumber)}`}
+                </span>
+                <span className="text-[10px] text-muted-foreground/50">
+                  {sectionCount} {sectionCount === 1 ? t`section` : t`sections`}
+                </span>
+                {pageSummary.wordCount > 0 && (
+                  <span className="text-[10px] text-muted-foreground/40">
+                    {pageSummary.wordCount} {t`words`}
+                  </span>
+                )}
+              </button>
+
+              {/* Expanded: sections */}
+              {isExpanded && pageDetail?.sectioning && (
+                <div className="border-t px-3 py-2 space-y-2">
+                  {pageDetail.sectioning.sections.map((section, sectionIdx) => {
+                    if (section.isPruned && !visibleFilters.has("pruned")) return null
+                    return (
+                      <SectionCard
+                        key={section.sectionId}
+                        section={section}
+                        sectionIdx={sectionIdx}
+                        sectionCount={pageDetail.sectioning!.sections.length}
+                        pageId={pageSummary.pageId}
+                        bookLabel={bookLabel}
+                        rendering={pageDetail.rendering?.sections[sectionIdx] ?? null}
+                        renderingVersion={pageDetail.versions.rendering}
+                        visibleFilters={visibleFilters}
+                        strategyNames={strategyNames}
+                        renderStrategies={renderStrategies}
+                        hasPrevPage={hasPrevPage}
+                        hasNextPage={hasNextPage}
+                        disabled={isMutating}
+                        onTogglePrune={() => togglePruneMutation.mutate({ pageId: pageSummary.pageId, sectionIndex: sectionIdx })}
+                        onMerge={(dir) => mergeMutation.mutate({ pageId: pageSummary.pageId, sectionIndex: sectionIdx, direction: dir })}
+                        onMergeCrossPage={(dir) => mergeCrossPageMutation.mutate({ pageId: pageSummary.pageId, sectionIndex: sectionIdx, direction: dir })}
+                        onClone={() => cloneMutation.mutate({ pageId: pageSummary.pageId, sectionIndex: sectionIdx })}
+                        onDelete={() => setConfirmDialog({
+                          message: t`Delete section ${String(sectionIdx + 1)}? This cannot be undone.`,
+                          onConfirm: () => deleteMutation.mutate({ pageId: pageSummary.pageId, sectionIndex: sectionIdx }),
+                        })}
+                        onConfirmMerge={(label, action) => setConfirmDialog({ message: t`Are you sure you want to ${label}?`, onConfirm: action })}
+                        onNavigate={() => onNavigateToSection?.(pageSummary.pageId, sectionIdx)}
+                        containerTypes={containerTypes}
+                        leafTypes={leafTypes}
+                        onUpdateSectioning={(sectioning) => updateSectioningMutation.mutate({ pageId: pageSummary.pageId, sectioning })}
+                        sectioning={pageDetail.sectioning!}
+                        sectionIndex={sectionIdx}
+                      />
+                    )
+                  })}
+                </div>
+              )}
+
+              {isExpanded && !pageDetail?.sectioning && sectionCount > 0 && (
+                <div className="border-t px-3 py-3 flex items-center gap-2 text-xs text-muted-foreground">
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                  <Trans>Loading...</Trans>
+                </div>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// SectionCard — a single section within a page
+// ---------------------------------------------------------------------------
+
+type SectioningData = NonNullable<PageDetail["sectioning"]>
+
+function SectionCard({
+  section,
+  sectionIdx,
+  sectionCount,
+  pageId,
+  bookLabel,
+  rendering,
+  renderingVersion,
+  visibleFilters,
+  strategyNames,
+  renderStrategies,
+  hasPrevPage,
+  hasNextPage,
+  disabled,
+  onTogglePrune,
+  onMerge,
+  onMergeCrossPage,
+  onClone,
+  onDelete,
+  onConfirmMerge,
+  onNavigate,
+  containerTypes,
+  leafTypes,
+  onUpdateSectioning,
+  sectioning,
+  sectionIndex,
+}: {
+  section: SectionData
+  sectionIdx: number
+  sectionCount: number
+  pageId: string
+  bookLabel: string
+  rendering: SectionRendering | null
+  renderingVersion: number | null
+  visibleFilters: Set<DetailFilter>
+  strategyNames: string[]
+  renderStrategies: Record<string, { render_type: string }>
+  hasPrevPage: boolean
+  hasNextPage: boolean
+  disabled: boolean
+  onTogglePrune: () => void
+  onMerge: (direction: "prev" | "next") => void
+  onMergeCrossPage: (direction: "prev" | "next") => void
+  onClone: () => void
+  onDelete: () => void
+  onConfirmMerge: (label: string, action: () => void) => void
+  onNavigate: () => void
+  containerTypes?: Record<string, string>
+  leafTypes?: Record<string, string>
+  onUpdateSectioning: (sectioning: SectioningData) => void
+  sectioning: SectioningData
+  sectionIndex: number
+}) {
+  const { t } = useLingui()
+  const [isExpanded, setIsExpanded] = useState(false)
+  const isActivity = section.sectionType.startsWith("activity")
+  const hasPreview = rendering?.html != null
+  const activityAnswers = rendering?.activityAnswers
+  const hasAnswers = activityAnswers != null && Object.keys(activityAnswers).length > 0
+
+  // Helper: update a specific part's content_node tree and save
+  const updatePartNode = (partIndex: number, updater: (node: ContentNodeData) => ContentNodeData) => {
+    const updated: SectioningData = {
+      ...sectioning,
+      sections: sectioning.sections.map((s, si) => {
+        if (si !== sectionIndex) return s
+        return {
+          ...s,
+          parts: s.parts.map((p, pi) => {
+            if (pi !== partIndex || p.type !== "content_node") return p
+            return { ...p, node: updater(p.node) }
+          }),
+        }
+      }),
+    }
+    onUpdateSectioning(updated)
+  }
+
+  const handleToggleNodePruned = (partIndex: number, nodeId: string) => {
+    updatePartNode(partIndex, (root) =>
+      updateNodeInTree(root, nodeId, (n) => ({ ...n, isPruned: !n.isPruned })),
+    )
+  }
+
+  const handleEditNodeText = (partIndex: number, nodeId: string, newText: string) => {
+    updatePartNode(partIndex, (root) =>
+      updateNodeInTree(root, nodeId, (n) => ({ ...n, text: newText })),
+    )
+  }
+
+  const handleChangeNodeType = (partIndex: number, nodeId: string, field: "structure" | "role", newType: string) => {
+    updatePartNode(partIndex, (root) =>
+      updateNodeInTree(root, nodeId, (n) => ({ ...n, [field]: newType })),
+    )
+  }
+
+  const handleMoveNode = (partIndex: number, dragNodeId: string, targetParentId: string | null, insertIndex: number) => {
+    updatePartNode(partIndex, (root) => {
+      const result = moveNodeInTree(root, dragNodeId, targetParentId, insertIndex)
+      return result ?? root
+    })
+  }
+
+  const thumbnailSrc = hasPreview
+    ? `${BASE_URL}/books/${bookLabel}/thumbnails/${pageId}_sec${String(sectionIdx + 1).padStart(3, "0")}.png?v=${renderingVersion ?? 0}`
+    : null
+
+  return (
+    <div
+      className={`rounded-lg border transition-colors ${
+        section.isPruned
+          ? "border-dashed border-muted-foreground/20 bg-muted/20 opacity-60"
+          : "border-border bg-card"
+      }`}
+    >
+      {/* Section header */}
+      <div className="flex items-center gap-2 px-3 py-1.5">
+        <button
+          type="button"
+          onClick={() => setIsExpanded(!isExpanded)}
+          className="shrink-0 text-muted-foreground/60 hover:text-muted-foreground transition-colors"
+        >
+          {isExpanded ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
+        </button>
+
+        <button
+          type="button"
+          onClick={onNavigate}
+          className="text-[11px] font-semibold uppercase tracking-wide text-primary hover:underline"
+          title={t`Go to preview`}
+        >
+          {sectionIdx + 1}
+        </button>
+
+        <span
+          className="text-[11px] font-medium px-2 py-0.5 rounded-full"
+          style={{ backgroundColor: section.backgroundColor, color: section.textColor }}
+        >
+          {section.sectionType.replace(/_/g, " ")}
+        </span>
+
+        <span className="text-[10px] text-muted-foreground/50">
+          {section.parts.length} {section.parts.length === 1 ? t`part` : t`parts`}
+        </span>
+
+        {/* Activity render type selector */}
+        {isActivity && strategyNames.length > 0 && (
+          <div className="flex items-center gap-1 ml-1">
+            <RenderTypeIndicator renderStrategies={renderStrategies} strategyNames={strategyNames} sectionType={section.sectionType} />
+          </div>
+        )}
+
+        <div className="ml-auto flex items-center gap-0.5">
+          <button
+            type="button"
+            onClick={onTogglePrune}
+            className={`flex items-center justify-center w-5 h-5 rounded cursor-pointer transition-colors ${
+              section.isPruned
+                ? "text-destructive hover:bg-destructive/10"
+                : "text-muted-foreground/40 hover:bg-muted hover:text-muted-foreground"
+            }`}
+            title={section.isPruned ? t`Unprune section` : t`Prune section`}
+          >
+            {section.isPruned ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
+          </button>
+          <SectionActionsDropdown
+            sectionIndex={sectionIdx}
+            sectionCount={sectionCount}
+            isPruned={section.isPruned}
+            hasPrevPage={hasPrevPage}
+            hasNextPage={hasNextPage}
+            onTogglePrune={onTogglePrune}
+            onMerge={onMerge}
+            onMergeCrossPage={onMergeCrossPage}
+            onClone={onClone}
+            onDelete={onDelete}
+            onConfirmMerge={onConfirmMerge}
+            disabled={disabled}
+          />
+        </div>
+      </div>
+
+      {/* Section body: structure + preview side by side */}
+      {isExpanded && (
+        <div className="border-t">
+          <div className="flex">
+            {/* Left: content structure */}
+            {visibleFilters.has("structure") && (
+              <SectionContentTree
+                section={section}
+                bookLabel={bookLabel}
+                visibleFilters={visibleFilters}
+                disabled={disabled}
+                containerTypes={containerTypes}
+                leafTypes={leafTypes}
+                onToggleNodePruned={handleToggleNodePruned}
+                onEditNodeText={handleEditNodeText}
+                onChangeNodeType={handleChangeNodeType}
+                onMoveNode={handleMoveNode}
+                className={hasPreview ? "w-1/2 border-r" : "w-full"}
+              />
+            )}
+
+            {/* Right: rendered preview thumbnail */}
+            {hasPreview && thumbnailSrc && (
+              <div className={cn("py-2 px-2 flex flex-col gap-2", visibleFilters.has("structure") ? "w-1/2" : "w-full")}>
+                <button
+                  type="button"
+                  className="w-[200px] h-[260px] border rounded overflow-hidden bg-white relative cursor-pointer hover:ring-2 hover:ring-violet-400 transition-shadow shrink-0"
+                  onClick={onNavigate}
+                  title={t`Go to preview`}
+                >
+                  <img
+                    src={thumbnailSrc}
+                    alt={t`Section ${String(sectionIdx + 1)} preview`}
+                    className="w-full h-full object-contain"
+                    loading="lazy"
+                  />
+                </button>
+              </div>
+            )}
+          </div>
+
+          {/* Activity answers — after content tree, with context */}
+          {hasAnswers && (
+            <ActivityAnswerKey answers={activityAnswers!} renderedHtml={rendering?.html} />
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// SectionContentTree — renders parts with images grouped horizontally
+// ---------------------------------------------------------------------------
+
+function SectionContentTree({
+  section,
+  bookLabel,
+  visibleFilters,
+  disabled,
+  containerTypes,
+  leafTypes,
+  onToggleNodePruned,
+  onEditNodeText,
+  onChangeNodeType,
+  onMoveNode,
+  className,
+}: {
+  section: SectionData
+  bookLabel: string
+  visibleFilters: Set<DetailFilter>
+  disabled: boolean
+  containerTypes?: Record<string, string>
+  leafTypes?: Record<string, string>
+  onToggleNodePruned: (partIndex: number, nodeId: string) => void
+  onEditNodeText: (partIndex: number, nodeId: string, newText: string) => void
+  onChangeNodeType: (partIndex: number, nodeId: string, field: "structure" | "role", newType: string) => void
+  onMoveNode: (partIndex: number, dragNodeId: string, targetParentId: string | null, insertIndex: number) => void
+  className?: string
+}) {
+  const showPruned = visibleFilters.has("pruned")
+  const showImages = visibleFilters.has("images")
+
+  return (
+    <div className={cn("px-3 py-2 space-y-1 overflow-auto", className)}>
+      {section.parts.map((part, partIndex) => {
+        if (part.isPruned && !showPruned) return null
+        if (part.type === "content_node") {
+          return (
+            <ContentNodeBlock
+              key={part.nodeId}
+              node={part.node}
+              parentId={null}
+              indexInParent={0}
+              bookLabel={bookLabel}
+              depth={0}
+              disabled={disabled}
+              containerTypes={containerTypes}
+              leafTypes={leafTypes}
+              onTogglePruned={(nodeId) => onToggleNodePruned(partIndex, nodeId)}
+              onEditText={(nodeId, newText) => onEditNodeText(partIndex, nodeId, newText)}
+              onChangeType={(nodeId, field, newType) => onChangeNodeType(partIndex, nodeId, field, newType)}
+              onMoveNode={(dragId, targetParentId, insertIdx) => onMoveNode(partIndex, dragId, targetParentId, insertIdx)}
+            />
+          )
+        }
+        if (part.type === "text_group") {
+          return <TextGroupPartView key={part.groupId} part={part} />
+        }
+        if (part.type === "image" && showImages) {
+          return <ImagePartView key={part.imageId} part={part} bookLabel={bookLabel} />
+        }
+        return null
+      })}
+      {section.parts.length === 0 && (
+        <div className="py-2 text-center text-[10px] text-muted-foreground/40">
+          <Trans>No content</Trans>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// RenderTypeIndicator — shows AI / Template badge for activity sections
+// ---------------------------------------------------------------------------
+
+function RenderTypeIndicator({
+  renderStrategies,
+  strategyNames,
+  sectionType,
+}: {
+  renderStrategies: Record<string, { render_type: string }>
+  strategyNames: string[]
+  sectionType: string
+}) {
+  // Find which strategy this section type maps to
+  const matchedStrategy = strategyNames.find((name) => name === sectionType)
+  const strategy = matchedStrategy ? renderStrategies[matchedStrategy] : null
+  const renderType = strategy?.render_type ?? "llm"
+
+  const isTemplate = renderType === "template"
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-0.5 px-1.5 py-px rounded text-[9px] font-medium",
+        isTemplate
+          ? "bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-300"
+          : "bg-violet-100 text-violet-700 dark:bg-violet-950 dark:text-violet-300"
+      )}
+    >
+      {isTemplate ? <LayoutTemplate className="h-2.5 w-2.5" /> : <Sparkles className="h-2.5 w-2.5" />}
+      {isTemplate ? "Template" : "AI"}
+    </span>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Legacy part renderers
+// ---------------------------------------------------------------------------
+
+function TextGroupPartView({ part }: { part: Extract<PartData, { type: "text_group" }> }) {
+  return (
+    <div className="border-l-2 border-primary/25 ml-0.5 mt-1">
+      <div className="pl-1.5 py-px">
+        <span className="text-[9px] font-medium uppercase tracking-wider text-primary/70">{getTextGroupLabel(part.groupType)}</span>
+      </div>
+      {part.texts.map((text) => (
+        <div key={text.textId} className={cn("flex items-baseline gap-1 pl-1.5 py-px ml-0.5", text.isPruned && "opacity-35")}>
+          <span className="shrink-0 text-[9px] font-medium uppercase tracking-wider text-muted-foreground/50">{getTextTypeLabel(text.textType)}</span>
+          <span className="text-[11px] leading-snug line-clamp-2">{text.text}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function ImagePartView({ part, bookLabel }: { part: Extract<PartData, { type: "image" }>; bookLabel: string }) {
+  // eslint-disable-next-line lingui/no-unlocalized-strings
+  const imgSrc = `${BASE_URL}/books/${bookLabel}/images/${part.imageId}`
+  return (
+    <div className="flex items-center gap-2">
+      <img
+        src={imgSrc}
+        alt={part.imageId}
+        className="max-h-[50px] max-w-[100px] object-contain rounded border border-border/50"
+        onError={(e) => { (e.target as HTMLImageElement).style.display = "none" }}
+      />
+      <span className="text-[9px] text-muted-foreground/50 font-mono truncate">{part.imageId}</span>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Activity Answer Key — shows answers with context from rendered HTML
+// ---------------------------------------------------------------------------
+
+function extractAnswerContexts(html: string): Map<string, string> {
+  const ctx = new Map<string, string>()
+  const parser = new DOMParser()
+  const doc = parser.parseFromString(html, "text/html")
+
+  const inputs = doc.querySelectorAll("[data-activity-item]")
+  for (const input of inputs) {
+    const itemId = input.getAttribute("data-activity-item")
+    if (!itemId) continue
+    const label = input.closest("label")
+    if (label) { ctx.set(itemId, label.textContent?.trim() ?? ""); continue }
+    const id = input.getAttribute("id")
+    if (id) {
+      const assocLabel = doc.querySelector(`label[for="${id}"]`)
+      if (assocLabel) { ctx.set(itemId, assocLabel.textContent?.trim() ?? ""); continue }
+    }
+    const container = input.closest("li") ?? input.closest("div")
+    if (container) ctx.set(itemId, container.textContent?.trim() ?? "")
+  }
+
+  const blankRe = /\[\[blank:(item-\d+)(?::([^\]]+))?\]\]/g
+  let match
+  while ((match = blankRe.exec(html)) !== null) {
+    const itemId = match[1]
+    if (ctx.has(itemId)) continue
+    const start = Math.max(0, match.index - 80)
+    const end = Math.min(html.length, match.index + match[0].length + 80)
+    let snippet = html.slice(start, end)
+    snippet = snippet.replace(/<[^>]+>/g, "").trim()
+    snippet = snippet.replace(/\[\[blank:item-\d+(?::[^\]]+)?\]\]/g, "___")
+    ctx.set(itemId, snippet)
+  }
+
+  return ctx
+}
+
+function ActivityAnswerKey({
+  answers,
+  renderedHtml,
+}: {
+  answers: Record<string, string | boolean | number>
+  renderedHtml?: string
+}) {
+  const contexts = renderedHtml ? extractAnswerContexts(renderedHtml) : new Map<string, string>()
+
+  const sorted = Object.entries(answers).sort(([a], [b]) => {
+    const na = parseInt(a.replace(/\D/g, ""), 10)
+    const nb = parseInt(b.replace(/\D/g, ""), 10)
+    if (!isNaN(na) && !isNaN(nb)) return na - nb
+    return a.localeCompare(b)
+  })
+
+  return (
+    <div className="mx-3 mb-2">
+      <h4 className="text-[10px] font-medium text-amber-700 dark:text-amber-400 uppercase tracking-wider mb-1.5">
+        <Trans>Answers</Trans>
+      </h4>
+      <div className="space-y-1.5">
+        {sorted.map(([id, value]) => {
+          const context = contexts.get(id)
+          const strValue = String(value)
+          const isBoolTrue = value === true || strValue === "true"
+          const isBoolFalse = value === false || strValue === "false"
+
+          return (
+            <div
+              key={id}
+              className="flex items-center gap-2.5 rounded-lg border border-amber-200 dark:border-amber-800/40 bg-amber-50/80 dark:bg-amber-950/20 px-3 py-2"
+            >
+              <span className="text-[11px] font-medium px-2 py-0.5 rounded-full bg-amber-200/80 dark:bg-amber-800/40 text-amber-800 dark:text-amber-300 shrink-0">
+                {id}
+              </span>
+              <span className={cn(
+                "text-[12px] font-medium shrink-0",
+                isBoolTrue && "text-green-700 dark:text-green-400",
+                isBoolFalse && "text-red-600 dark:text-red-400",
+                !isBoolTrue && !isBoolFalse && "text-foreground/80",
+              )}>
+                {strValue}
+              </span>
+              {context && (
+                <span className="text-[11px] text-muted-foreground/60 truncate" title={context}>
+                  — {context}
+                </span>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/ContentNodeBlock.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/ContentNodeBlock.tsx
@@ -1,0 +1,675 @@
+import { useState, useRef, useCallback, useEffect, type ReactNode } from "react"
+import {
+  AlignLeft,
+  ChevronDown,
+  ChevronRight,
+  Eye,
+  EyeOff,
+  GripVertical,
+  Hash,
+  Image,
+  Layers,
+  List,
+  MessageSquare,
+  PanelTop,
+  Puzzle,
+  SquarePen,
+  TextCursorInput,
+  Type,
+} from "lucide-react"
+import { BASE_URL } from "@/api/client"
+import type { ContentNodeData } from "@adt/types"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { useLingui } from "@lingui/react/macro"
+import { cn } from "@/lib/utils"
+
+// ---------------------------------------------------------------------------
+// Type styling — maps type names to colors and icons
+// ---------------------------------------------------------------------------
+
+type TypeStyle = { bg: string; text: string; borderL: string; icon: ReactNode }
+
+const IC = "h-3 w-3"
+
+// Color categories:
+//   purple = activity-related
+//   blue   = groups (group, list, panel, sidebar, list_item)
+//   grey   = text / general
+//   amber  = headings
+//   green  = images
+const PURPLE: Pick<TypeStyle, "bg" | "text" | "borderL"> = { bg: "bg-violet-100 dark:bg-violet-900/30", text: "text-violet-700 dark:text-violet-400", borderL: "border-l-violet-400/60 dark:border-l-violet-500/40" }
+const BLUE: Pick<TypeStyle, "bg" | "text" | "borderL"> = { bg: "bg-blue-100 dark:bg-blue-900/30", text: "text-blue-700 dark:text-blue-400", borderL: "border-l-blue-400/60 dark:border-l-blue-500/40" }
+const GREY: Pick<TypeStyle, "bg" | "text" | "borderL"> = { bg: "bg-gray-100 dark:bg-gray-800/40", text: "text-gray-600 dark:text-gray-400", borderL: "border-l-gray-300/60 dark:border-l-gray-600/40" }
+const AMBER: Pick<TypeStyle, "bg" | "text" | "borderL"> = { bg: "bg-amber-100 dark:bg-amber-900/30", text: "text-amber-700 dark:text-amber-400", borderL: "border-l-amber-400/60 dark:border-l-amber-500/40" }
+const GREEN: Pick<TypeStyle, "bg" | "text" | "borderL"> = { bg: "bg-emerald-100 dark:bg-emerald-900/30", text: "text-emerald-700 dark:text-emerald-400", borderL: "border-l-emerald-400/60 dark:border-l-emerald-500/40" }
+
+const CONTAINER_STYLES: Record<string, TypeStyle> = {
+  activity: { ...PURPLE, icon: <Puzzle className={IC} /> },
+  group: { ...BLUE, icon: <Layers className={IC} /> },
+  image_group: { ...GREEN, icon: <Image className={IC} /> },
+  list: { ...BLUE, icon: <List className={IC} /> },
+  list_item: { ...BLUE, icon: <List className={IC} /> },
+  panel: { ...BLUE, icon: <PanelTop className={IC} /> },
+  sidebar: { ...BLUE, icon: <PanelTop className={IC} /> },
+}
+
+const LEAF_STYLES: Record<string, TypeStyle> = {
+  text: { ...GREY, icon: <Type className={IC} /> },
+  heading: { ...AMBER, icon: <Hash className={IC} /> },
+  section_heading: { ...AMBER, icon: <Hash className={IC} /> },
+  activity_instruction: { ...PURPLE, icon: <SquarePen className={IC} /> },
+  activity_question: { ...PURPLE, icon: <MessageSquare className={IC} /> },
+  activity_option: { ...PURPLE, icon: <Puzzle className={IC} /> },
+  activity_number: { ...PURPLE, icon: <Puzzle className={IC} /> },
+  activity_fill_in_the_blank: { ...PURPLE, icon: <TextCursorInput className={IC} /> },
+  instruction_text: { ...PURPLE, icon: <SquarePen className={IC} /> },
+  caption: { ...GREY, icon: <AlignLeft className={IC} /> },
+  label: { ...GREY, icon: <AlignLeft className={IC} /> },
+  quote: { ...GREY, icon: <MessageSquare className={IC} /> },
+  math: { ...GREY, icon: <Type className={IC} /> },
+  page_number: { ...GREY, icon: <Type className={IC} /> },
+  book_metadata: { ...GREY, icon: <Type className={IC} /> },
+  header: { ...GREY, icon: <Type className={IC} /> },
+  footer: { ...GREY, icon: <Type className={IC} /> },
+  image: { ...GREEN, icon: <Image className={IC} /> },
+}
+
+const DEFAULT_CONTAINER_STYLE: TypeStyle = { ...BLUE, icon: <Layers className={IC} /> }
+const DEFAULT_LEAF_STYLE: TypeStyle = { ...GREY, icon: <Type className={IC} /> }
+
+function getTypeStyle(typeName: string, isContainer: boolean): TypeStyle {
+  // Check both maps — activity types can appear as containers or leaves
+  if (isContainer) {
+    if (CONTAINER_STYLES[typeName]) return CONTAINER_STYLES[typeName]
+    // Activity sub-types used as containers (e.g. activity_option as a container)
+    if (typeName.startsWith("activity")) return { ...PURPLE, icon: <Puzzle className={IC} /> }
+    return DEFAULT_CONTAINER_STYLE
+  }
+  if (LEAF_STYLES[typeName]) return LEAF_STYLES[typeName]
+  if (typeName.startsWith("activity")) return { ...PURPLE, icon: <Puzzle className={IC} /> }
+  return DEFAULT_LEAF_STYLE
+}
+
+
+// ---------------------------------------------------------------------------
+// EditableText — click-to-edit inline text
+// ---------------------------------------------------------------------------
+
+export function EditableText({
+  value,
+  onCommit,
+  disabled,
+}: {
+  value: string
+  onCommit: (newText: string) => void
+  disabled?: boolean
+}) {
+  const { t } = useLingui()
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState(value)
+  const cancelRef = useRef(false)
+
+  useEffect(() => {
+    if (!editing) setDraft(value)
+  }, [value, editing])
+
+  const commit = useCallback(() => {
+    if (cancelRef.current) {
+      cancelRef.current = false
+      return
+    }
+    setEditing(false)
+    const trimmed = draft.trim()
+    if (trimmed && trimmed !== value) {
+      onCommit(trimmed)
+    } else {
+      setDraft(value)
+    }
+  }, [draft, value, onCommit])
+
+  if (!editing) {
+    return (
+      <span
+        className={cn("leading-relaxed flex-1 min-w-0 text-xs rounded px-0.5 -mx-0.5 transition-colors", disabled ? "cursor-default opacity-60" : "cursor-text hover:bg-accent/50")}
+        onClick={() => {
+          if (!disabled) setEditing(true)
+        }}
+        title={disabled ? undefined : t`Click to edit`}
+      >
+        {value}
+      </span>
+    )
+  }
+
+  return (
+    <textarea
+      value={draft}
+      onChange={(e) => setDraft(e.target.value)}
+      onBlur={commit}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" && !e.shiftKey) {
+          e.preventDefault()
+          cancelRef.current = false
+          e.currentTarget.blur()
+        }
+        if (e.key === "Escape") {
+          cancelRef.current = true
+          setDraft(value)
+          setEditing(false)
+        }
+      }}
+      className="leading-relaxed flex-1 min-w-0 text-xs rounded border border-ring bg-background px-1 py-0.5 -mx-0.5 resize-none focus:outline-none focus:ring-1 focus:ring-ring"
+      rows={Math.max(2, Math.ceil(draft.length / 50))}
+      autoFocus
+    />
+  )
+}
+
+// ---------------------------------------------------------------------------
+// TypePill — colored badge with icon for type labels
+// ---------------------------------------------------------------------------
+
+function TypePill({
+  typeValue,
+  isContainer,
+  typeOptions,
+  disabled,
+  onChangeType,
+  nodeId,
+  expanded,
+}: {
+  typeValue: string
+  isContainer: boolean
+  typeOptions?: Record<string, string>
+  disabled: boolean
+  onChangeType: (nodeId: string, field: "structure" | "role", newType: string) => void
+  nodeId: string
+  /** When true, always show the label text (no hover needed). Use for container/group rows with no inline text. */
+  expanded?: boolean
+}) {
+  const style = getTypeStyle(typeValue, isContainer)
+  const label = typeValue.replace(/_/g, " ")
+
+  const labelClass = expanded
+    ? "ml-1 text-[9px] font-semibold uppercase tracking-wide"
+    : "max-w-0 overflow-hidden opacity-0 group-hover/pill:max-w-[120px] group-hover/pill:opacity-100 group-hover/pill:ml-1 transition-all duration-150 text-[9px] font-semibold uppercase tracking-wide"
+
+  const pillContent = (
+    <span className={cn("group/pill inline-flex items-center gap-0 rounded px-1 py-0.5 whitespace-nowrap shrink-0", style.bg, style.text)}>
+      {style.icon}
+      <span className={labelClass}>
+        {label}
+      </span>
+    </span>
+  )
+
+  if (!typeOptions) return pillContent
+
+  return (
+    <Select
+      value={typeValue}
+      onValueChange={(v) => onChangeType(nodeId, isContainer ? "structure" : "role", v)}
+      disabled={disabled}
+    >
+      <SelectTrigger className={cn(
+        "group/pill h-auto py-0.5 px-1 border-0 shadow-none rounded gap-0 min-w-0 w-auto shrink-0 focus:ring-1 focus:ring-ring/30 whitespace-nowrap",
+        style.bg, style.text,
+        !disabled && "hover:brightness-95 dark:hover:brightness-110",
+      )}>
+        {style.icon}
+        <span className={labelClass}>
+          <SelectValue>{label}</SelectValue>
+        </span>
+      </SelectTrigger>
+      <SelectContent>
+        {Object.entries(typeOptions).map(([key, desc]) => {
+          const s = getTypeStyle(key, isContainer)
+          return (
+            <SelectItem key={key} value={key} className="text-xs">
+              <span className="inline-flex items-center gap-1.5 whitespace-nowrap">
+                <span className={cn("inline-flex items-center gap-1 px-1 py-px rounded text-[10px] font-medium", s.bg, s.text)}>
+                  {s.icon}
+                  <span className="uppercase tracking-wide">{key.replace(/_/g, " ")}</span>
+                </span>
+                {desc && <span className="text-muted-foreground text-[10px] whitespace-normal">{desc}</span>}
+              </span>
+            </SelectItem>
+          )
+        })}
+      </SelectContent>
+    </Select>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// ContainerDropZone — minimal drop target at the bottom of containers
+// ---------------------------------------------------------------------------
+
+const DRAG_TYPE_NODE = "application/x-content-node"
+
+function ContainerDropZone({ nodeId, childCount, disabled, onMoveNode }: {
+  nodeId: string
+  childCount: number
+  disabled: boolean
+  onMoveNode: (dragNodeId: string, targetParentId: string | null, insertIndex: number) => void
+}) {
+  const { t } = useLingui()
+  const [active, setActive] = useState(false)
+  return (
+    <div
+      className={cn(
+        "rounded transition-colors text-center text-[10px]",
+        active
+          ? "border border-dashed border-primary bg-primary/5 text-primary py-1.5"
+          : childCount === 0
+            ? "border border-dashed border-border/40 py-1 text-muted-foreground/30 italic"
+            : "py-0.5",
+      )}
+      onDragOver={(e) => {
+        if (!e.dataTransfer.types.includes(DRAG_TYPE_NODE)) return
+        e.preventDefault()
+        e.stopPropagation()
+        e.dataTransfer.dropEffect = "move"
+        setActive(true)
+      }}
+      onDragLeave={() => setActive(false)}
+      onDrop={(e) => {
+        e.preventDefault()
+        e.stopPropagation()
+        const dragId = e.dataTransfer.getData(DRAG_TYPE_NODE)
+        if (dragId && !disabled) onMoveNode(dragId, nodeId, childCount)
+        setActive(false)
+      }}
+    >
+      {childCount === 0 ? t`Empty` : (active ? t`Drop here` : "")}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// ContentNodeBlock — draggable block editor for content_node parts
+// ---------------------------------------------------------------------------
+
+export interface ContentNodeBlockProps {
+  node: ContentNodeData
+  parentId: string | null
+  indexInParent: number
+  bookLabel: string
+  depth: number
+  disabled: boolean
+  containerTypes?: Record<string, string>
+  leafTypes?: Record<string, string>
+  onTogglePruned: (nodeId: string) => void
+  onEditText: (nodeId: string, newText: string) => void
+  onChangeType: (nodeId: string, field: "structure" | "role", newType: string) => void
+  onMoveNode: (dragNodeId: string, targetParentId: string | null, insertIndex: number) => void
+}
+
+export function ContentNodeBlock({
+  node,
+  parentId,
+  indexInParent,
+  bookLabel,
+  depth,
+  disabled,
+  containerTypes,
+  leafTypes,
+  onTogglePruned,
+  onEditText,
+  onChangeType,
+  onMoveNode,
+}: ContentNodeBlockProps) {
+  const { t } = useLingui()
+  const [collapsed, setCollapsed] = useState(false)
+  const [dropPosition, setDropPosition] = useState<"before" | "inside" | "after" | null>(null)
+  const hasChildren = node.children != null && node.children.length > 0
+  const isContainer = hasChildren || (node.structure != null)
+  const isText = node.text != null
+  const imgSrc = node.imageId ? `${BASE_URL}/books/${bookLabel}/images/${node.imageId}` : null
+  const isImageLeaf = !isContainer && !isText && !!node.imageId
+
+  const handleDragStart = (e: React.DragEvent) => {
+    if (disabled) { e.preventDefault(); return }
+    e.dataTransfer.setData(DRAG_TYPE_NODE, node.nodeId)
+    e.dataTransfer.effectAllowed = "move"
+  }
+
+  const handleDragOver = (e: React.DragEvent) => {
+    if (!e.dataTransfer.types.includes(DRAG_TYPE_NODE)) return
+    e.preventDefault()
+    e.stopPropagation()
+    e.dataTransfer.dropEffect = "move"
+    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect()
+    const y = e.clientY - rect.top
+    if (isContainer) {
+      if (y < rect.height * 0.25) setDropPosition("before")
+      else if (y > rect.height * 0.75) setDropPosition("after")
+      else setDropPosition("inside")
+    } else {
+      setDropPosition(y < rect.height / 2 ? "before" : "after")
+    }
+  }
+
+  const handleDragLeave = (e: React.DragEvent) => {
+    if (!e.currentTarget.contains(e.relatedTarget as Node)) setDropPosition(null)
+  }
+
+  const isDescendant = (root: ContentNodeData, targetId: string): boolean => {
+    if (root.nodeId === targetId) return true
+    return root.children?.some((c) => isDescendant(c, targetId)) ?? false
+  }
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    const dragId = e.dataTransfer.getData(DRAG_TYPE_NODE)
+    if (!dragId || dragId === node.nodeId) { setDropPosition(null); return }
+    if (isContainer && dropPosition === "inside" && isDescendant(node, dragId)) { setDropPosition(null); return }
+    if (dropPosition === "before") onMoveNode(dragId, parentId, indexInParent)
+    else if (dropPosition === "after") onMoveNode(dragId, parentId, indexInParent + 1)
+    else if (dropPosition === "inside" && isContainer) onMoveNode(dragId, node.nodeId, node.children?.length ?? 0)
+    setDropPosition(null)
+  }
+
+  const typeValue = isContainer ? (node.structure ?? "") : (node.role ?? "")
+  const typeOptions = isContainer ? containerTypes : leafTypes
+  const style = getTypeStyle(typeValue, isContainer)
+
+  const dragHandle = (
+    <div
+      draggable={!disabled}
+      onDragStart={handleDragStart}
+      className={cn(
+        "p-0.5 rounded shrink-0 opacity-0 group-hover/block:opacity-40 hover:!opacity-80 transition-opacity",
+        disabled ? "cursor-default" : "cursor-grab active:cursor-grabbing",
+      )}
+    >
+      <GripVertical className="h-3 w-3 text-muted-foreground" />
+    </div>
+  )
+
+  const pruneBtn = (
+    <button
+      type="button"
+      onClick={() => onTogglePruned(node.nodeId)}
+      disabled={disabled}
+      className="p-0.5 rounded hover:bg-muted transition-colors disabled:opacity-30 opacity-0 group-hover/block:opacity-60 hover:!opacity-100 shrink-0"
+      title={node.isPruned ? t`Include in render` : t`Exclude from render`}
+    >
+      {node.isPruned ? <EyeOff className="h-3 w-3 text-destructive/60" /> : <Eye className="h-3 w-3 text-muted-foreground/40" />}
+    </button>
+  )
+
+  const dropIndicator = (pos: "before" | "after") =>
+    dropPosition === pos && <div className={cn("absolute left-0 right-0 h-0.5 bg-primary rounded-full z-10", pos === "before" ? "-top-px" : "-bottom-px")} />
+
+  // Container block
+  if (isContainer) {
+    return (
+      <div className="relative">
+        {dropIndicator("before")}
+        <div
+          className={cn(
+            "group/container rounded-md border border-border/25 border-l-2 transition-all",
+            style.borderL,
+            "hover:border-border/60",
+            node.isPruned ? "opacity-40" : "",
+            dropPosition === "inside" && "ring-1 ring-primary/50 bg-primary/5",
+          )}
+          onDragOver={handleDragOver}
+          onDragLeave={handleDragLeave}
+          onDrop={handleDrop}
+        >
+          {/* Container header — pill flush against left border */}
+          <div className="group/block flex items-center gap-1 px-1.5 py-0.5">
+            <TypePill
+              typeValue={typeValue}
+              isContainer
+              typeOptions={typeOptions}
+              disabled={disabled}
+              onChangeType={onChangeType}
+              nodeId={node.nodeId}
+              expanded
+            />
+            <button
+              type="button"
+              onClick={() => setCollapsed(!collapsed)}
+              className="shrink-0 p-0.5 text-muted-foreground/50 hover:text-muted-foreground rounded hover:bg-muted/60"
+            >
+              {collapsed ? <ChevronRight className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
+            </button>
+            {collapsed && hasChildren && (
+              <span className="text-[9px] text-muted-foreground/40">{node.children!.length}</span>
+            )}
+            <div className="ml-auto flex items-center gap-0.5">
+              {dragHandle}
+              {pruneBtn}
+            </div>
+          </div>
+          {/* Children */}
+          {!collapsed && (
+            <div className="pl-5 pr-1 pb-1 space-y-0.5">
+              {hasChildren && node.children!.map((child, ci) => (
+                <ContentNodeBlock
+                  key={child.nodeId}
+                  node={child}
+                  parentId={node.nodeId}
+                  indexInParent={ci}
+                  bookLabel={bookLabel}
+                  depth={depth + 1}
+                  disabled={disabled}
+                  containerTypes={containerTypes}
+                  leafTypes={leafTypes}
+                  onTogglePruned={onTogglePruned}
+                  onEditText={onEditText}
+                  onChangeType={onChangeType}
+                  onMoveNode={onMoveNode}
+                />
+              ))}
+              <ContainerDropZone nodeId={node.nodeId} childCount={node.children?.length ?? 0} disabled={disabled} onMoveNode={onMoveNode} />
+            </div>
+          )}
+        </div>
+        {dropIndicator("after")}
+      </div>
+    )
+  }
+
+  // Text leaf block
+  if (isText) {
+    return (
+      <div className="relative">
+        {dropIndicator("before")}
+        <div
+          className={cn(
+            "group/block flex items-start gap-1 rounded-md py-0.5 px-1.5 transition-colors",
+            node.isPruned ? "opacity-40" : "hover:bg-accent/40 hover:outline hover:outline-1 hover:outline-border/50",
+          )}
+          onDragOver={handleDragOver}
+          onDragLeave={handleDragLeave}
+          onDrop={handleDrop}
+        >
+          <TypePill
+            typeValue={typeValue}
+            isContainer={false}
+            typeOptions={typeOptions}
+            disabled={disabled}
+            onChangeType={onChangeType}
+            nodeId={node.nodeId}
+          />
+          <div className="flex-1 min-w-0 text-[11px] leading-snug pt-px">
+            <EditableText
+              value={node.text!}
+              onCommit={(newText) => onEditText(node.nodeId, newText)}
+              disabled={disabled}
+            />
+          </div>
+          {dragHandle}
+          {pruneBtn}
+        </div>
+        {dropIndicator("after")}
+      </div>
+    )
+  }
+
+  // Image leaf block
+  if (isImageLeaf && imgSrc) {
+    return (
+      <div className="relative">
+        {dropIndicator("before")}
+        <div
+          className={cn(
+            "group/block flex items-center gap-1 rounded-md py-0.5 px-1.5 transition-colors",
+            node.isPruned ? "opacity-40" : "hover:bg-accent/40 hover:outline hover:outline-1 hover:outline-border/50",
+          )}
+          onDragOver={handleDragOver}
+          onDragLeave={handleDragLeave}
+          onDrop={handleDrop}
+        >
+          <span className={cn("inline-flex items-center rounded px-1 py-0.5 shrink-0", GREEN.bg, GREEN.text)}>
+            <Image className={IC} />
+          </span>
+          <img src={imgSrc} alt={node.imageId ?? "image"} className="h-16 w-auto object-contain rounded border border-border/40" onError={(e) => { (e.target as HTMLImageElement).style.display = "none" }} />
+          <span className="text-[9px] text-muted-foreground/40 font-mono truncate">{node.imageId}</span>
+          <div className="ml-auto flex items-center gap-0.5">
+            {dragHandle}
+            {pruneBtn}
+          </div>
+        </div>
+        {dropIndicator("after")}
+      </div>
+    )
+  }
+
+  return null
+}
+
+// ---------------------------------------------------------------------------
+// Tree manipulation helpers
+// ---------------------------------------------------------------------------
+
+/** Deep-update a node in a ContentNodeData tree by nodeId. Returns a new tree (immutable). */
+export function updateNodeInTree(
+  node: ContentNodeData,
+  nodeId: string,
+  updater: (n: ContentNodeData) => ContentNodeData,
+): ContentNodeData {
+  if (node.nodeId === nodeId) return updater(node)
+  if (!node.children) return node
+  let changed = false
+  const updatedChildren = node.children.map((c) => {
+    const updated = updateNodeInTree(c, nodeId, updater)
+    if (updated !== c) changed = true
+    return updated
+  })
+  return changed ? { ...node, children: updatedChildren } : node
+}
+
+/** Check if a node or any of its descendants has the given nodeId. */
+export function treeContainsNode(root: ContentNodeData, nodeId: string): boolean {
+  if (root.nodeId === nodeId) return true
+  return root.children?.some((c) => treeContainsNode(c, nodeId)) ?? false
+}
+
+/** Remove a node from the tree. Returns [updatedTree, removedNode]. If the root itself matches, returns [null, root]. */
+export function removeNodeFromTree(
+  root: ContentNodeData,
+  nodeId: string,
+): [ContentNodeData | null, ContentNodeData | null] {
+  if (root.nodeId === nodeId) return [null, root]
+  if (!root.children) return [root, null]
+
+  let found: ContentNodeData | null = null
+  const filtered: ContentNodeData[] = []
+  for (const child of root.children) {
+    if (child.nodeId === nodeId) {
+      found = child
+      continue
+    }
+    if (!found) {
+      const [updated, removed] = removeNodeFromTree(child, nodeId)
+      if (removed) {
+        found = removed
+        if (updated) filtered.push(updated)
+        continue
+      }
+    }
+    filtered.push(child)
+  }
+  if (!found) return [root, null]
+  return [{ ...root, children: filtered }, found]
+}
+
+/** Insert a node into a tree at the given parent and index. Returns null if targetParentId not found. */
+export function insertNodeIntoTree(
+  root: ContentNodeData,
+  node: ContentNodeData,
+  targetParentId: string | null,
+  insertIndex: number,
+): ContentNodeData | null {
+  if (targetParentId === null || targetParentId === root.nodeId) {
+    const children = [...(root.children ?? [])]
+    children.splice(insertIndex, 0, node)
+    return { ...root, children }
+  }
+
+  let inserted = false
+  const walk = (n: ContentNodeData): ContentNodeData => {
+    if (n.nodeId === targetParentId) {
+      inserted = true
+      const children = [...(n.children ?? [])]
+      children.splice(insertIndex, 0, node)
+      return { ...n, children }
+    }
+    if (!n.children) return n
+    return { ...n, children: n.children.map(walk) }
+  }
+  const result = walk(root)
+  return inserted ? result : null
+}
+
+/** Remove a node from the tree and insert it at a new position. Returns null if the drag node was not found. */
+export function moveNodeInTree(
+  root: ContentNodeData,
+  dragNodeId: string,
+  targetParentId: string | null,
+  insertIndex: number,
+): ContentNodeData | null {
+  let draggedNode: ContentNodeData | null = null
+  const removeNode = (n: ContentNodeData): ContentNodeData => {
+    if (!n.children) return n
+    const filtered = n.children.filter((c) => {
+      if (c.nodeId === dragNodeId) { draggedNode = c; return false }
+      return true
+    }).map(removeNode)
+    return { ...n, children: filtered }
+  }
+  const treeWithout = removeNode(root)
+  if (!draggedNode) return null
+
+  if (targetParentId === null || targetParentId === root.nodeId) {
+    const children = [...(treeWithout.children ?? [])]
+    children.splice(insertIndex, 0, draggedNode)
+    return { ...treeWithout, children }
+  }
+
+  let inserted = false
+  const insertInto = (n: ContentNodeData): ContentNodeData => {
+    if (n.nodeId === targetParentId) {
+      inserted = true
+      const children = [...(n.children ?? [])]
+      children.splice(insertIndex, 0, draggedNode!)
+      return { ...n, children }
+    }
+    if (!n.children) return n
+    return { ...n, children: n.children.map(insertInto) }
+  }
+  const result = insertInto(treeWithout)
+  return inserted ? result : null
+}

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/SectionDataPanel.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/SectionDataPanel.tsx
@@ -10,9 +10,11 @@ import {
   Plus,
   RefreshCw,
   Trash2,
+  TreePine,
   X,
 } from "lucide-react"
 import { SectionActionsDropdown } from "./SectionActionsDropdown"
+import { ContentNodeBlock, EditableText } from "./ContentNodeBlock"
 import { BASE_URL } from "@/api/client"
 import {
   Select,
@@ -60,6 +62,10 @@ interface SectionDataPanelProps {
   onDeleteGroup: (partIndex: number) => void
   onReorderParts: (fromIndex: number, toIndex: number) => void
   onEditText: (partIndex: number, textIndex: number, newText: string) => void
+  onToggleNodePruned: (partIndex: number, nodeId: string) => void
+  onEditNodeText: (partIndex: number, nodeId: string, newText: string) => void
+  onChangeNodeType: (partIndex: number, nodeId: string, field: "structure" | "role", newType: string) => void
+  onMoveNode: (partIndex: number, dragNodeId: string, targetParentId: string | null, insertIndex: number) => void
   onMoveText: (
     fromPartIndex: number,
     textIndex: number,
@@ -141,83 +147,6 @@ function ImageCard({
   )
 }
 
-// -- Inline editable text --
-
-function EditableText({
-  value,
-  onCommit,
-  disabled,
-}: {
-  value: string
-  onCommit: (newText: string) => void
-  disabled?: boolean
-}) {
-  const { t } = useLingui()
-  const [editing, setEditing] = useState(false)
-  const [draft, setDraft] = useState(value)
-  // Guard against double-commit (Enter triggers blur when textarea is removed)
-  // and against committing on Escape (blur fires when editing is cancelled).
-  const cancelRef = useRef(false)
-
-  // Sync draft when value changes externally while not editing
-  useEffect(() => {
-    if (!editing) setDraft(value)
-  }, [value, editing])
-
-  const commit = useCallback(() => {
-    if (cancelRef.current) {
-      cancelRef.current = false
-      return
-    }
-    setEditing(false)
-    const trimmed = draft.trim()
-    if (trimmed && trimmed !== value) {
-      onCommit(trimmed)
-    } else {
-      setDraft(value)
-    }
-  }, [draft, value, onCommit])
-
-  if (!editing) {
-    return (
-      <span
-        className={cn("leading-relaxed flex-1 min-w-0 text-xs rounded px-0.5 -mx-0.5 transition-colors", disabled ? "cursor-default opacity-60" : "cursor-text hover:bg-accent/50")}
-        onClick={() => {
-          if (!disabled) setEditing(true)
-        }}
-        title={disabled ? undefined : t`Click to edit`}
-      >
-        {value}
-      </span>
-    )
-  }
-
-  return (
-    <textarea
-      value={draft}
-      onChange={(e) => setDraft(e.target.value)}
-      onBlur={commit}
-      onKeyDown={(e) => {
-        if (e.key === "Enter" && !e.shiftKey) {
-          e.preventDefault()
-          // Let blur handler do the commit — prevents double-fire
-          cancelRef.current = false
-          e.currentTarget.blur()
-        }
-        if (e.key === "Escape") {
-          // Discard edit — suppress the blur commit
-          cancelRef.current = true
-          setDraft(value)
-          setEditing(false)
-        }
-      }}
-      className="leading-relaxed flex-1 min-w-0 text-xs rounded border border-ring bg-background px-1 py-0.5 -mx-0.5 resize-none focus:outline-none focus:ring-1 focus:ring-ring"
-      rows={Math.max(2, Math.ceil(draft.length / 50))}
-      autoFocus
-    />
-  )
-}
-
 // -- Drag types --
 
 const DRAG_TYPE_GROUP = "application/x-group-index"
@@ -245,6 +174,10 @@ export function SectionDataPanel({
   onDeleteTextEntry,
   onDuplicateTextEntry,
   onEditText,
+  onToggleNodePruned,
+  onEditNodeText,
+  onChangeNodeType,
+  onMoveNode,
   onAddGroup,
   onDuplicateGroup,
   onDeleteGroup,
@@ -278,6 +211,7 @@ export function SectionDataPanel({
   const parts = section.parts
 
   const hasTextParts = parts.some((p) => p.type === "text_group")
+  const hasContentNodeParts = parts.some((p) => p.type === "content_node")
   const hasImageParts = parts.some((p) => p.type === "image")
 
   // -- Group drag state --
@@ -435,9 +369,10 @@ export function SectionDataPanel({
 
   return (
     <div
-      className={`absolute top-0 right-0 h-full w-[480px] flex flex-col bg-background border-l shadow-lg transition-transform duration-200 ease-in-out z-30 ${
+      className={cn(
+        "absolute top-0 right-0 h-full w-[480px] flex flex-col bg-background border-l shadow-lg transition-transform duration-200 ease-in-out z-30",
         open ? "translate-x-0" : "translate-x-full"
-      }`}
+      )}
     >
       {/* Panel header */}
       <div className="border-b">
@@ -861,6 +796,36 @@ export function SectionDataPanel({
           </button>
         </div>
 
+        {/* Content Tree — for content_node parts */}
+        {hasContentNodeParts && (
+          <div>
+            <h3 className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
+              <TreePine className="h-3 w-3" />
+              {t`Content Tree`}
+            </h3>
+            {parts.map((p, partIndex) => {
+              if (p.type !== "content_node") return null
+              return (
+                <ContentNodeBlock
+                  key={p.nodeId}
+                  node={p.node}
+                  parentId={null}
+                  indexInParent={0}
+                  bookLabel={bookLabel}
+                  depth={0}
+                  disabled={!!pipelineRunning}
+                  containerTypes={groupTypes}
+                  leafTypes={textTypes}
+                  onTogglePruned={(nodeId) => onToggleNodePruned(partIndex, nodeId)}
+                  onEditText={(nodeId, newText) => onEditNodeText(partIndex, nodeId, newText)}
+                  onChangeType={(nodeId, field, newType) => onChangeNodeType(partIndex, nodeId, field, newType)}
+                  onMoveNode={(dragId, targetParentId, insertIdx) => onMoveNode(partIndex, dragId, targetParentId, insertIdx)}
+                />
+              )
+            })}
+          </div>
+        )}
+
         {/* Activity Answers */}
         {activityAnswers && Object.keys(activityAnswers).length > 0 && (
           <div>
@@ -971,3 +936,6 @@ export function SectionDataPanel({
     </div>
   )
 }
+
+// NOTE: ContentNodeBlock and EditableText are imported from ./ContentNodeBlock
+

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/SectioningOverview.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/SectioningOverview.tsx
@@ -1,29 +1,128 @@
-import { useState, useEffect, useRef, useCallback } from "react"
+import { useState, useRef, useCallback } from "react"
 import { useQueries, useQueryClient, useMutation } from "@tanstack/react-query"
 import { api, BASE_URL, type PageSummaryItem, type PageDetail } from "@/api/client"
-import type { SectionPart, PageSection } from "@adt/types"
+import type { SectionPart, PageSection, ContentNodeData } from "@adt/types"
 import { invalidateStoryboardDependents } from "@/hooks/use-page-mutations"
 import {
   ChevronDown,
   ChevronRight,
+  GripVertical,
   Layers,
   Image,
   FileText,
   Loader2,
+  Puzzle,
+  Save,
   SlidersHorizontal,
+  X,
 } from "lucide-react"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import { SectionActionsDropdown } from "./SectionActionsDropdown"
 import { SectionEditToolbar } from "./SectionEditToolbar"
 import { ImageCropDialog } from "./ImageCropDialog"
 import { AiImageDialog } from "./AiImageDialog"
+import { ContentNodeBlock, updateNodeInTree, treeContainsNode, removeNodeFromTree, insertNodeIntoTree } from "./ContentNodeBlock"
 import { useApiKey } from "@/hooks/use-api-key"
 import { useBookRun } from "@/hooks/use-book-run"
+import { useActiveConfig } from "@/hooks/use-debug"
 import { Trans } from "@lingui/react/macro"
 import { useLingui } from "@lingui/react/macro"
 import { cn } from "@/lib/utils"
+import { getSectionTypeLabel } from "@/lib/section-constants"
 
-type DetailPanel = "preview" | "metadata" | "textGroups" | "images" | "prunedImages"
-const ALL_PANELS: DetailPanel[] = ["preview", "metadata", "textGroups", "images", "prunedImages"]
+function getSectionTypeDisplayLabel(value: string): string {
+  return getSectionTypeLabel(value) || value.replace(/_/g, " ")
+}
+
+function SectionTypeIcon({ sectionType, className }: { sectionType: string; className?: string }) {
+  if (sectionType.startsWith("activity") || sectionType.startsWith("exercise")) {
+    return <Puzzle className={className} />
+  }
+  if (sectionType === "images_only" || sectionType === "image") {
+    return <Image className={className} />
+  }
+  return <Layers className={className} />
+}
+
+/** Recursively extract text from a ContentNodeData tree for preview */
+function extractNodeText(node: ContentNodeData): string {
+  if (node.text) return node.text
+  if (node.children) return node.children.map(extractNodeText).join(" ")
+  return ""
+}
+
+/**
+ * Extract context for each activity answer item from rendered HTML.
+ * Returns a map of item ID → context string (question text, option label, or surrounding text for blanks).
+ */
+function extractAnswerContexts(html: string): Map<string, string> {
+  const ctx = new Map<string, string>()
+  const parser = new DOMParser()
+  const doc = parser.parseFromString(html, "text/html")
+
+  // Multiple choice / checkboxes: find inputs with data-activity-item
+  const inputs = doc.querySelectorAll("[data-activity-item]")
+  for (const input of inputs) {
+    const itemId = input.getAttribute("data-activity-item")
+    if (!itemId) continue
+    // Find the label or parent text that describes this option
+    const label = input.closest("label")
+    if (label) {
+      ctx.set(itemId, label.textContent?.trim() ?? "")
+      continue
+    }
+    // Check for an associated label via "for" attribute
+    const id = input.getAttribute("id")
+    if (id) {
+      const assocLabel = doc.querySelector(`label[for="${id}"]`)
+      if (assocLabel) {
+        ctx.set(itemId, assocLabel.textContent?.trim() ?? "")
+        continue
+      }
+    }
+    // Fallback: use parent li/div text
+    const container = input.closest("li") ?? input.closest("div")
+    if (container) {
+      ctx.set(itemId, container.textContent?.trim() ?? "")
+    }
+  }
+
+  // Fill-in-the-blank: find [[blank:item-N]] or [[blank:item-N:hint]] markers in raw HTML
+  const blankRe = /\[\[blank:(item-\d+)(?::([^\]]+))?\]\]/g
+  let match
+  while ((match = blankRe.exec(html)) !== null) {
+    const itemId = match[1]
+    if (ctx.has(itemId)) continue
+    // Extract surrounding sentence context (up to 80 chars each side)
+    const start = Math.max(0, match.index - 80)
+    const end = Math.min(html.length, match.index + match[0].length + 80)
+    let snippet = html.slice(start, end)
+    // Strip HTML tags from snippet
+    snippet = snippet.replace(/<[^>]+>/g, "").trim()
+    // Replace the blank marker with ___
+    snippet = snippet.replace(/\[\[blank:item-\d+(?::[^\]]+)?\]\]/g, "___")
+    ctx.set(itemId, snippet)
+  }
+
+  return ctx
+}
+
+/** A flattened section entry with its parent page context */
+interface FlatSection {
+  page: PageDetail
+  section: PageSection
+  sectionIndex: number // index within the page
+  pageNumber: number | null
+}
+
+type DetailPanel = "preview" | "metadata" | "textGroups" | "images" | "prunedImages" | "answers"
+const ALL_PANELS: DetailPanel[] = ["preview", "metadata", "textGroups", "images", "prunedImages", "answers"]
 
 interface SectioningOverviewProps {
   bookLabel: string
@@ -38,8 +137,26 @@ export function SectioningOverview({ bookLabel, pages, onNavigateToSection }: Se
   const storyboardRunning = stageState("storyboard") === "running" || stageState("storyboard") === "queued"
   const [confirmDialog, setConfirmDialog] = useState<{ message: string; onConfirm: () => void } | null>(null)
   const [visiblePanels, setVisiblePanels] = useState<Set<DetailPanel>>(() => new Set(ALL_PANELS))
+  const [expanded, setExpanded] = useState<Set<number>>(new Set())
   const [allExpanded, setAllExpanded] = useState(false)
-  const [expandSignal, setExpandSignal] = useState<{ action: "expand" | "collapse"; tick: number }>({ action: "collapse", tick: 0 })
+  // Pending (unsaved) sectioning changes per page
+  const [pendingByPage, setPendingByPage] = useState<Map<string, NonNullable<PageDetail["sectioning"]>>>(new Map())
+  const [saving, setSaving] = useState(false)
+  const { apiKey, hasApiKey } = useApiKey()
+  const hasPendingChanges = pendingByPage.size > 0
+
+  const { data: activeConfigData } = useActiveConfig(bookLabel)
+  const mergedConfig = activeConfigData?.merged as Record<string, unknown> | undefined
+  const containerTypes = mergedConfig?.container_types as Record<string, string> | undefined
+  const leafTypes = mergedConfig?.text_types as Record<string, string> | undefined
+  const allSectionTypes = mergedConfig?.section_types as Record<string, string> | undefined
+  const disabledSectionTypes = new Set(mergedConfig?.disabled_section_types as string[] ?? [])
+  const sectionTypes = allSectionTypes
+    ? Object.fromEntries(Object.entries(allSectionTypes).filter(([k]) => !disabledSectionTypes.has(k)))
+    : undefined
+  // Drag state for section reordering
+  const [dragIdx, setDragIdx] = useState<number | null>(null)
+  const [dropIdx, setDropIdx] = useState<number | null>(null)
 
   const togglePanel = (panel: DetailPanel) => {
     setVisiblePanels((prev) => {
@@ -56,6 +173,7 @@ export function SectioningOverview({ bookLabel, pages, onNavigateToSection }: Se
     textGroups: t`Text Groups`,
     images: t`Images`,
     prunedImages: t`Pruned Images`,
+    answers: t`Answers`,
   }
 
   // Fetch full page details for all pages that have sections
@@ -73,8 +191,29 @@ export function SectioningOverview({ bookLabel, pages, onNavigateToSection }: Se
     .map((q) => q.data)
     .filter((d): d is PageDetail => d != null)
 
-  // Build ordered list of all page IDs (including those without sections) for adjacency
+  // Build ordered list of all page IDs for adjacency checks
   const allPageIds = pages.map((p) => p.pageId)
+
+  // Build effective page details — overlaying pending sectioning changes
+  const effectivePages: PageDetail[] = pageDetails.map((p) => {
+    const pending = pendingByPage.get(p.pageId)
+    return pending ? { ...p, sectioning: pending } : p
+  })
+
+  // Build flat section list across all pages
+  const flatSections: FlatSection[] = []
+  for (const page of effectivePages) {
+    if (!page.sectioning) continue
+    for (let si = 0; si < page.sectioning.sections.length; si++) {
+      const section = page.sectioning.sections[si]
+      flatSections.push({
+        page,
+        section,
+        sectionIndex: si,
+        pageNumber: section.pageNumber ?? null,
+      })
+    }
+  }
 
   const invalidatePages = (...pageIds: string[]) => {
     for (const pid of pageIds) {
@@ -123,7 +262,77 @@ export function SectioningOverview({ bookLabel, pages, onNavigateToSection }: Se
     onSuccess: (_data, vars) => invalidatePages(vars.pageId),
   })
 
-  const isMutating = storyboardRunning || mergeMutation.isPending || mergeCrossPageMutation.isPending || cloneMutation.isPending || deleteMutation.isPending || togglePruneMutation.isPending
+  const updateSectioningMutation = useMutation({
+    mutationFn: ({ pageId, sectioning }: { pageId: string; sectioning: NonNullable<PageDetail["sectioning"]> }) =>
+      api.updateSectioning(bookLabel, pageId, sectioning),
+    onSuccess: (_data, vars) => invalidatePages(vars.pageId),
+  })
+
+  // Defer a sectioning edit to the pending state (shown immediately, persisted on Save)
+  const stagePendingSectioning = useCallback((pageId: string, sectioning: NonNullable<PageDetail["sectioning"]>) => {
+    setPendingByPage((prev) => {
+      const next = new Map(prev)
+      next.set(pageId, sectioning)
+      return next
+    })
+  }, [])
+
+  const discardPending = useCallback(() => {
+    setPendingByPage(new Map())
+  }, [])
+
+  const saveAllPending = useCallback(async () => {
+    if (pendingByPage.size === 0 || saving) return
+    setSaving(true)
+    const entries = Array.from(pendingByPage.entries())
+    try {
+      for (const [pageId, sectioning] of entries) {
+        await api.updateSectioning(bookLabel, pageId, sectioning)
+      }
+      // Trigger re-render for each affected page
+      if (hasApiKey) {
+        for (const [pageId] of entries) {
+          api.reRenderPage(bookLabel, pageId, apiKey).catch(() => {})
+        }
+      }
+      setPendingByPage(new Map())
+      for (const [pageId] of entries) {
+        invalidatePages(pageId)
+      }
+    } finally {
+      setSaving(false)
+    }
+  }, [pendingByPage, saving, bookLabel, hasApiKey, apiKey])
+
+  const isMutating = saving || storyboardRunning || mergeMutation.isPending || mergeCrossPageMutation.isPending || cloneMutation.isPending || deleteMutation.isPending || togglePruneMutation.isPending || updateSectioningMutation.isPending
+
+  const toggleSection = (idx: number) => {
+    setExpanded((prev) => {
+      const next = new Set(prev)
+      if (next.has(idx)) next.delete(idx)
+      else next.add(idx)
+      return next
+    })
+  }
+
+  // Drag-and-drop reorder handler (same-page only)
+  const handleDrop = useCallback((fromGlobalIdx: number, toGlobalIdx: number) => {
+    if (fromGlobalIdx === toGlobalIdx) return
+    const from = flatSections[fromGlobalIdx]
+    const to = flatSections[toGlobalIdx]
+    if (!from || !to) return
+    // Only allow same-page reorder
+    if (from.page.pageId !== to.page.pageId) return
+    const page = from.page
+    if (!page.sectioning) return
+
+    const sections = [...page.sectioning.sections]
+    const [moved] = sections.splice(from.sectionIndex, 1)
+    sections.splice(to.sectionIndex, 0, moved)
+
+    const updated = { ...page.sectioning, sections }
+    stagePendingSectioning(page.pageId, updated)
+  }, [flatSections, stagePendingSectioning])
 
   if (isLoading) {
     return (
@@ -134,7 +343,7 @@ export function SectioningOverview({ bookLabel, pages, onNavigateToSection }: Se
     )
   }
 
-  if (pageDetails.length === 0) {
+  if (flatSections.length === 0) {
     return (
       <div className="p-6 text-sm text-muted-foreground">
         <Trans>No sectioning data available.</Trans>
@@ -170,13 +379,18 @@ export function SectioningOverview({ bookLabel, pages, onNavigateToSection }: Se
           <table className="w-full text-xs">
             <thead>
               <tr className="bg-muted/50 border-b">
-                <th className="text-left px-3 py-2 font-medium text-muted-foreground w-8">
+                <th className="text-left px-2 py-2 font-medium text-muted-foreground w-6" />
+                <th className="text-left px-1 py-2 font-medium text-muted-foreground w-8">
                   <button
                     type="button"
                     onClick={() => {
                       const next = !allExpanded
                       setAllExpanded(next)
-                      setExpandSignal({ action: next ? "expand" : "collapse", tick: Date.now() })
+                      if (next) {
+                        setExpanded(new Set(flatSections.map((_, i) => i)))
+                      } else {
+                        setExpanded(new Set())
+                      }
                     }}
                     className="hover:bg-accent rounded p-0.5 transition-colors"
                     title={allExpanded ? t`Collapse all sections` : t`Expand all sections`}
@@ -188,13 +402,13 @@ export function SectioningOverview({ bookLabel, pages, onNavigateToSection }: Se
                     )}
                   </button>
                 </th>
-                <th className="text-left px-3 py-2 font-medium text-muted-foreground w-24">
-                  <Trans>Page</Trans>
+                <th className="text-left px-3 py-2 font-medium text-muted-foreground w-10">
+                  #
                 </th>
                 <th className="text-left px-3 py-2 font-medium text-muted-foreground w-40">
                   <Trans>Section</Trans>
                 </th>
-                <th className="text-left px-3 py-2 font-medium text-muted-foreground w-36">
+                <th className="text-left px-3 py-2 font-medium text-muted-foreground whitespace-nowrap">
                   <Trans>Type</Trans>
                 </th>
                 <th className="text-left px-3 py-2 font-medium text-muted-foreground">
@@ -207,39 +421,89 @@ export function SectioningOverview({ bookLabel, pages, onNavigateToSection }: Se
               </tr>
             </thead>
             <tbody>
-              {pageDetails.map((page) => {
+              {flatSections.map((entry, globalIdx) => {
+                const { page, section, sectionIndex } = entry
                 const pageIdx = allPageIds.indexOf(page.pageId)
                 const hasPrevPage = pageIdx > 0
                 const hasNextPage = pageIdx < allPageIds.length - 1
+                const sectionCount = page.sectioning!.sections.length
+                const isExpanded = expanded.has(globalIdx)
+
+                const textParts = section.parts.filter((p) => p.type === "text_group")
+                const imageParts = section.parts.filter((p) => p.type === "image")
+                const contentNodeParts = section.parts.filter((p) => p.type === "content_node")
+                const textCount = textParts.length + contentNodeParts.length
+                const imageCount = imageParts.length
+
+                // Content preview
+                const firstText = textParts[0]
+                let preview: string | null = null
+                if (firstText?.type === "text_group") {
+                  preview = firstText.texts.map((tx) => tx.text).join(" ").slice(0, 120)
+                } else if (contentNodeParts.length > 0) {
+                  const firstNode = contentNodeParts[0]
+                  if (firstNode.type === "content_node") {
+                    preview = extractNodeText(firstNode.node).slice(0, 120)
+                  }
+                }
+
+                // Rendering data
+                const renderSection = page.rendering?.sections.find((r) => r.sectionIndex === sectionIndex)
+
+                // Determine if this row is a drop target
+                const isDragOver = dropIdx === globalIdx && dragIdx !== null && dragIdx !== globalIdx
+                // Only highlight if same page
+                const dragEntry = dragIdx != null ? flatSections[dragIdx] : null
+                const samePageDrag = dragEntry != null && dragEntry.page.pageId === page.pageId
 
                 return (
-                  <PageSectionRows
-                    key={page.pageId}
+                  <SectionRow
+                    key={`${page.pageId}-${section.sectionId}`}
                     page={page}
-                    bookLabel={bookLabel}
+                    section={section}
+                    sectionIndex={sectionIndex}
+                    sectionCount={sectionCount}
+                    globalIndex={globalIdx + 1}
                     hasPrevPage={hasPrevPage}
                     hasNextPage={hasNextPage}
-                    onNavigateToSection={onNavigateToSection}
-                    onMerge={(sectionIndex, direction) =>
-                      mergeMutation.mutate({ pageId: page.pageId, sectionIndex, direction })
-                    }
-                    onMergeCrossPage={(sectionIndex, direction) =>
-                      mergeCrossPageMutation.mutate({ pageId: page.pageId, sectionIndex, direction })
-                    }
-                    onClone={(sectionIndex) =>
-                      cloneMutation.mutate({ pageId: page.pageId, sectionIndex })
-                    }
-                    onDelete={(sectionIndex) =>
-                      deleteMutation.mutate({ pageId: page.pageId, sectionIndex })
-                    }
-                    onTogglePrune={(sectionIndex) =>
-                      togglePruneMutation.mutate({ pageId: page.pageId, sectionIndex })
-                    }
+                    textParts={textParts}
+                    imageParts={imageParts}
+                    textCount={textCount}
+                    imageCount={imageCount}
+                    preview={preview}
+                    isExpanded={isExpanded}
+                    onToggle={() => toggleSection(globalIdx)}
+                    renderReasoning={renderSection?.reasoning}
+                    activityAnswers={renderSection?.activityAnswers}
+                    renderedHtml={renderSection?.html}
+                    bookLabel={bookLabel}
+                    onMerge={(direction) => mergeMutation.mutate({ pageId: page.pageId, sectionIndex, direction })}
+                    onMergeCrossPage={(direction) => mergeCrossPageMutation.mutate({ pageId: page.pageId, sectionIndex, direction })}
+                    onClone={() => cloneMutation.mutate({ pageId: page.pageId, sectionIndex })}
+                    onDelete={() => deleteMutation.mutate({ pageId: page.pageId, sectionIndex })}
+                    onTogglePrune={() => togglePruneMutation.mutate({ pageId: page.pageId, sectionIndex })}
                     onConfirmAction={setConfirmDialog}
                     isMutating={isMutating}
                     visiblePanels={visiblePanels}
-                    expandSignal={expandSignal}
+                    renderingVersion={page.versions.rendering}
                     onInvalidatePages={invalidatePages}
+                    containerTypes={containerTypes}
+                    leafTypes={leafTypes}
+                    sectionTypes={sectionTypes}
+                    onUpdateSectioning={(sectioning) => stagePendingSectioning(page.pageId, sectioning)}
+                    sectioning={page.sectioning!}
+                    disabled={isMutating}
+                    pageNumber={entry.pageNumber}
+                    isDragOver={isDragOver && samePageDrag}
+                    onDragStart={() => setDragIdx(globalIdx)}
+                    onDragOver={() => setDropIdx(globalIdx)}
+                    onDragEnd={() => {
+                      if (dragIdx != null && dropIdx != null && dragIdx !== dropIdx) {
+                        handleDrop(dragIdx, dropIdx)
+                      }
+                      setDragIdx(null)
+                      setDropIdx(null)
+                    }}
                   />
                 )
               })}
@@ -258,6 +522,40 @@ export function SectioningOverview({ bookLabel, pages, onNavigateToSection }: Se
           }}
           onCancel={() => setConfirmDialog(null)}
         />
+      )}
+
+      {/* Floating save/discard bar — shown when there are pending changes */}
+      {hasPendingChanges && !saving && (
+        <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-40 flex items-center gap-2 bg-popover border shadow-lg rounded-full px-3 py-1.5 animate-in slide-in-from-bottom-4">
+          <span className="text-xs text-muted-foreground pl-1">
+            <Trans>Unsaved changes on {pendingByPage.size} {pendingByPage.size === 1 ? "page" : "pages"}</Trans>
+          </span>
+          <button
+            type="button"
+            onClick={discardPending}
+            className="flex items-center gap-1 px-2.5 py-1 text-xs rounded-full border hover:bg-accent transition-colors"
+          >
+            <X className="h-3 w-3" />
+            <Trans>Discard</Trans>
+          </button>
+          <button
+            type="button"
+            onClick={saveAllPending}
+            disabled={!hasApiKey}
+            className="flex items-center gap-1 px-2.5 py-1 text-xs rounded-full bg-primary text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-50"
+            title={!hasApiKey ? t`API key required to save and re-render` : undefined}
+          >
+            <Save className="h-3 w-3" />
+            <Trans>Save</Trans>
+          </button>
+        </div>
+      )}
+
+      {saving && (
+        <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-40 flex items-center gap-2 bg-popover border shadow-lg rounded-full px-3 py-1.5">
+          <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />
+          <span className="text-xs text-muted-foreground"><Trans>Saving...</Trans></span>
+        </div>
       )}
     </div>
   )
@@ -304,165 +602,7 @@ function ConfirmDialog({
 }
 
 // ---------------------------------------------------------------------------
-// Per-page section rows (with reasoning header)
-// ---------------------------------------------------------------------------
-
-function PageSectionRows({
-  page,
-  bookLabel,
-  hasPrevPage,
-  hasNextPage,
-  onNavigateToSection,
-  onMerge,
-  onMergeCrossPage,
-  onClone,
-  onDelete,
-  onTogglePrune,
-  onConfirmAction,
-  isMutating,
-  visiblePanels,
-  expandSignal,
-  onInvalidatePages,
-}: {
-  page: PageDetail
-  bookLabel: string
-  hasPrevPage: boolean
-  hasNextPage: boolean
-  onNavigateToSection?: (pageId: string, sectionIndex: number) => void
-  onMerge: (sectionIndex: number, direction: "prev" | "next") => void
-  onMergeCrossPage: (sectionIndex: number, direction: "prev" | "next") => void
-  onClone: (sectionIndex: number) => void
-  onDelete: (sectionIndex: number) => void
-  onTogglePrune: (sectionIndex: number) => void
-  onConfirmAction: (dialog: { message: string; onConfirm: () => void }) => void
-  isMutating: boolean
-  visiblePanels: Set<DetailPanel>
-  expandSignal: { action: "expand" | "collapse"; tick: number }
-  onInvalidatePages: (...pageIds: string[]) => void
-}) {
-  const { t } = useLingui()
-  const [expanded, setExpanded] = useState<Set<number>>(new Set())
-  const [reasoningOpen, setReasoningOpen] = useState(false)
-
-  const lastTick = useRef(expandSignal.tick)
-  useEffect(() => {
-    if (expandSignal.tick === lastTick.current) return
-    lastTick.current = expandSignal.tick
-    if (!page.sectioning) return
-    if (expandSignal.action === "expand") {
-      setExpanded(new Set(page.sectioning.sections.map((_, i) => i)))
-    } else {
-      setExpanded(new Set())
-    }
-  }, [expandSignal, page.sectioning])
-
-  if (!page.sectioning) return null
-
-  const sections = page.sectioning.sections
-  const reasoning = page.sectioning.reasoning
-
-  const toggleSection = (idx: number) => {
-    setExpanded((prev) => {
-      const next = new Set(prev)
-      if (next.has(idx)) next.delete(idx)
-      else next.add(idx)
-      return next
-    })
-  }
-
-  return (
-    <>
-      {/* Page reasoning header row */}
-      <tr className="bg-muted/30 border-b border-t">
-        <td colSpan={7} className="px-0 py-0">
-          <button
-            type="button"
-            onClick={() => setReasoningOpen(!reasoningOpen)}
-            className="flex items-center gap-2 w-full px-3 py-2 text-left hover:bg-muted/50 transition-colors"
-          >
-            <span className="font-medium text-xs">
-              {page.pageId}
-              {sections[0]?.pageNumber != null && (
-                <span className="text-muted-foreground font-normal ml-1.5">
-                  <Trans>(p.{sections[0].pageNumber})</Trans>
-                </span>
-              )}
-            </span>
-            <span className="text-muted-foreground text-[10px] ml-1">
-              — {sections.length} {sections.length === 1 ? t`section` : t`sections`}
-            </span>
-            {reasoning && reasoning !== "No content to section" && (
-              <>
-                {reasoningOpen ? (
-                  <ChevronDown className="h-3 w-3 text-muted-foreground ml-auto shrink-0" />
-                ) : (
-                  <ChevronRight className="h-3 w-3 text-muted-foreground ml-auto shrink-0" />
-                )}
-              </>
-            )}
-          </button>
-          {/* Expanded reasoning */}
-          {reasoningOpen && reasoning && reasoning !== "No content to section" && (
-            <div className="px-3 pb-3 pt-0">
-              <div className="rounded border bg-violet-50/50 dark:bg-violet-950/20 p-3">
-                <span className="text-[10px] font-medium text-violet-600 dark:text-violet-400 uppercase tracking-wider">
-                  {t`Sectioning Reasoning`}
-                </span>
-                <pre className="text-xs text-muted-foreground whitespace-pre-wrap font-mono leading-relaxed mt-1.5">
-                  {reasoning}
-                </pre>
-              </div>
-            </div>
-          )}
-        </td>
-      </tr>
-
-      {/* Section rows */}
-      {sections.map((section, idx) => {
-        const textParts = section.parts.filter((p) => p.type === "text_group")
-        const imageParts = section.parts.filter((p) => p.type === "image")
-        const isExpanded = expanded.has(idx)
-
-        // Get rendering reasoning if available
-        const renderSection = page.rendering?.sections.find(
-          (r) => r.sectionIndex === idx
-        )
-
-        return (
-          <SectionRow
-            key={section.sectionId}
-            page={page}
-            section={section}
-            sectionIndex={idx}
-            sectionCount={sections.length}
-            hasPrevPage={hasPrevPage}
-            hasNextPage={hasNextPage}
-            textParts={textParts}
-            imageParts={imageParts}
-            isExpanded={isExpanded}
-            onToggle={() => toggleSection(idx)}
-            renderReasoning={renderSection?.reasoning}
-            bookLabel={bookLabel}
-            onNavigate={onNavigateToSection ? () => onNavigateToSection(page.pageId, idx) : undefined}
-            onMerge={(direction) => onMerge(idx, direction)}
-            onMergeCrossPage={(direction) => onMergeCrossPage(idx, direction)}
-            onClone={() => onClone(idx)}
-            onDelete={() => onDelete(idx)}
-            onTogglePrune={() => onTogglePrune(idx)}
-            onConfirmAction={onConfirmAction}
-            isMutating={isMutating}
-            visiblePanels={visiblePanels}
-            renderingVersion={page.versions.rendering}
-            onInvalidatePages={onInvalidatePages}
-          />
-        )
-      })}
-    </>
-  )
-}
-
-// ---------------------------------------------------------------------------
-// Individual section row with expandable detail
+// Individual section row
 // ---------------------------------------------------------------------------
 
 function SectionRow({
@@ -470,15 +610,20 @@ function SectionRow({
   section,
   sectionIndex,
   sectionCount,
+  globalIndex,
   hasPrevPage,
   hasNextPage,
   textParts,
   imageParts,
+  textCount,
+  imageCount,
+  preview,
   isExpanded,
   onToggle,
   renderReasoning,
+  activityAnswers,
+  renderedHtml,
   bookLabel,
-  onNavigate,
   onMerge,
   onMergeCrossPage,
   onClone,
@@ -489,20 +634,36 @@ function SectionRow({
   visiblePanels,
   renderingVersion,
   onInvalidatePages,
+  containerTypes,
+  leafTypes,
+  sectionTypes,
+  onUpdateSectioning,
+  sectioning,
+  disabled,
+  pageNumber,
+  isDragOver,
+  onDragStart,
+  onDragOver,
+  onDragEnd,
 }: {
   page: PageDetail
   section: PageSection
   sectionIndex: number
   sectionCount: number
+  globalIndex: number
   hasPrevPage: boolean
   hasNextPage: boolean
   textParts: SectionPart[]
   imageParts: SectionPart[]
+  textCount: number
+  imageCount: number
+  preview: string | null
   isExpanded: boolean
   onToggle: () => void
   renderReasoning?: string
+  activityAnswers?: Record<string, string | boolean | number>
+  renderedHtml?: string
   bookLabel: string
-  onNavigate?: () => void
   onMerge: (direction: "prev" | "next") => void
   onMergeCrossPage: (direction: "prev" | "next") => void
   onClone: () => void
@@ -513,65 +674,121 @@ function SectionRow({
   visiblePanels: Set<DetailPanel>
   renderingVersion: number | null
   onInvalidatePages: (...pageIds: string[]) => void
+  containerTypes?: Record<string, string>
+  leafTypes?: Record<string, string>
+  sectionTypes?: Record<string, string>
+  onUpdateSectioning: (sectioning: NonNullable<PageDetail["sectioning"]>) => void
+  sectioning: NonNullable<PageDetail["sectioning"]>
+  disabled: boolean
+  pageNumber: number | null
+  isDragOver: boolean
+  onDragStart: () => void
+  onDragOver: () => void
+  onDragEnd: () => void
 }) {
   const { t } = useLingui()
-  const textCount = textParts.length
-  const imageCount = imageParts.length
 
-  // Build a content preview from the first text group
-  const firstText = textParts[0]
-  const preview = firstText?.type === "text_group"
-    ? firstText.texts.map((tx) => tx.text).join(" ").slice(0, 120)
-    : null
+  const handleSectionTypeChange = (newType: string) => {
+    const updated: NonNullable<PageDetail["sectioning"]> = {
+      ...sectioning,
+      sections: sectioning.sections.map((s, i) =>
+        i === sectionIndex ? { ...s, sectionType: newType } : s
+      ),
+    }
+    onUpdateSectioning(updated)
+  }
 
   return (
     <>
       <tr
         className={cn(
           "border-b hover:bg-muted/30 cursor-pointer transition-colors",
-          section.isPruned && "opacity-50"
+          section.isPruned && "opacity-50",
+          isDragOver && "bg-violet-100/50 dark:bg-violet-900/20"
         )}
         onClick={onToggle}
+        draggable
+        onDragStart={(e) => {
+          e.dataTransfer.effectAllowed = "move"
+          onDragStart()
+        }}
+        onDragOver={(e) => {
+          e.preventDefault()
+          e.dataTransfer.dropEffect = "move"
+          onDragOver()
+        }}
+        onDrop={(e) => {
+          e.preventDefault()
+          onDragEnd()
+        }}
+        onDragEnd={onDragEnd}
       >
-        <td className="px-3 py-2">
+        {/* Drag handle */}
+        <td className="px-2 py-2">
+          <GripVertical className="h-3 w-3 text-muted-foreground/40 cursor-grab" />
+        </td>
+        {/* Expand toggle */}
+        <td className="px-1 py-2">
           {isExpanded ? (
             <ChevronDown className="h-3 w-3 text-muted-foreground" />
           ) : (
             <ChevronRight className="h-3 w-3 text-muted-foreground" />
           )}
         </td>
+        {/* Global index */}
         <td className="px-3 py-2">
           <span className="font-mono text-muted-foreground">
-            {page.pageId}
+            {globalIndex}
           </span>
         </td>
+        {/* Section ID */}
         <td className="px-3 py-2">
-          <button
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation()
-              onNavigate?.()
-            }}
-            className={cn(
-              "font-mono hover:underline",
-              onNavigate ? "text-violet-600 dark:text-violet-400" : "text-foreground"
-            )}
+          <span
+            className="font-mono text-foreground"
             title={section.sectionId}
           >
             {section.sectionId}
-          </button>
+          </span>
           {section.isPruned && (
             <span className="ml-1.5 text-[10px] bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400 px-1 rounded">
               <Trans>pruned</Trans>
             </span>
           )}
         </td>
-        <td className="px-3 py-2">
-          <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-muted text-muted-foreground">
-            <Layers className="h-3 w-3" />
-            {section.sectionType}
-          </span>
+        {/* Section type */}
+        <td className="px-3 py-2 whitespace-nowrap" onClick={(e) => e.stopPropagation()}>
+          {sectionTypes ? (
+            <Select
+              value={section.sectionType}
+              onValueChange={handleSectionTypeChange}
+              disabled={isMutating}
+            >
+              <SelectTrigger className="h-6 text-xs font-medium px-1.5 py-0 w-auto border-0 bg-muted/50 whitespace-nowrap gap-1 [&>span]:line-clamp-none [&>span]:flex [&>span]:items-center [&>span]:gap-1.5">
+                <SectionTypeIcon sectionType={section.sectionType} className="h-3.5 w-3.5 shrink-0" />
+                <span>{getSectionTypeDisplayLabel(section.sectionType)}</span>
+              </SelectTrigger>
+              <SelectContent>
+                {Object.entries(sectionTypes).map(([key, desc]) => (
+                  <SelectItem key={key} value={key} className="text-xs">
+                    <span className="inline-flex items-center gap-1.5">
+                      <SectionTypeIcon sectionType={key} className="h-3.5 w-3.5 shrink-0" />
+                      {getSectionTypeDisplayLabel(key)}
+                    </span>
+                    {desc && (
+                      <span className="ml-1 text-muted-foreground text-[10px]">{desc}</span>
+                    )}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          ) : (
+            <span className="inline-flex items-center gap-1.5 px-1.5 py-0.5 rounded bg-muted text-muted-foreground whitespace-nowrap">
+              <SectionTypeIcon sectionType={section.sectionType} className="h-3.5 w-3.5 shrink-0" />
+              {getSectionTypeDisplayLabel(section.sectionType)}
+            </span>
+          )}
         </td>
+        {/* Content preview */}
         <td className="px-3 py-2 text-muted-foreground truncate max-w-xs">
           {preview ? (
             <span title={preview}>{preview}…</span>
@@ -581,6 +798,7 @@ function SectionRow({
             <span className="italic"><Trans>Empty section</Trans></span>
           )}
         </td>
+        {/* Part counts */}
         <td className="px-3 py-2 text-center">
           <div className="flex items-center justify-center gap-2">
             {textCount > 0 && (
@@ -597,6 +815,7 @@ function SectionRow({
             )}
           </div>
         </td>
+        {/* Actions dropdown */}
         <td className="px-3 py-2">
           <SectionActionsDropdown
             sectionIndex={sectionIndex}
@@ -628,20 +847,27 @@ function SectionRow({
       {/* Expanded detail */}
       {isExpanded && (
         <tr className="border-b bg-muted/10">
-          <td colSpan={7} className="px-6 py-3">
+          <td colSpan={8} className="px-6 py-3">
             <SectionDetail
               section={section}
               sectionIndex={sectionIndex}
               textParts={textParts as Extract<SectionPart, { type: "text_group" }>[]}
               imageParts={imageParts as Extract<SectionPart, { type: "image" }>[]}
               renderReasoning={renderReasoning}
+              activityAnswers={activityAnswers}
+              renderedHtml={renderedHtml}
               bookLabel={bookLabel}
               pageId={page.pageId}
               onConfirmAction={onConfirmAction}
               visiblePanels={visiblePanels}
               renderingVersion={renderingVersion}
-              onNavigate={onNavigate}
               onInvalidatePages={onInvalidatePages}
+              containerTypes={containerTypes}
+              leafTypes={leafTypes}
+              onUpdateSectioning={onUpdateSectioning}
+              sectioning={sectioning}
+              disabled={disabled}
+              pageNumber={pageNumber}
             />
           </td>
         </tr>
@@ -660,26 +886,40 @@ function SectionDetail({
   textParts,
   imageParts,
   renderReasoning,
+  activityAnswers,
+  renderedHtml,
   bookLabel,
   pageId,
   onConfirmAction,
   visiblePanels,
   renderingVersion,
-  onNavigate,
   onInvalidatePages,
+  containerTypes,
+  leafTypes,
+  onUpdateSectioning,
+  sectioning,
+  disabled,
+  pageNumber,
 }: {
-  section: { sectionId: string; sectionType: string; backgroundColor: string; textColor: string }
+  section: { sectionId: string; sectionType: string; backgroundColor: string; textColor: string; parts: SectionPart[] }
   sectionIndex: number
   textParts: Array<{ type: "text_group"; groupId: string; groupType: string; texts: Array<{ textId: string; textType: string; text: string; isPruned: boolean }>; isPruned: boolean }>
   imageParts: Array<{ type: "image"; imageId: string; isPruned: boolean; reason?: string }>
   renderReasoning?: string
+  activityAnswers?: Record<string, string | boolean | number>
+  renderedHtml?: string
   bookLabel: string
   pageId: string
   onConfirmAction: (dialog: { message: string; onConfirm: () => void }) => void
   visiblePanels: Set<DetailPanel>
   renderingVersion: number | null
-  onNavigate?: () => void
   onInvalidatePages: (...pageIds: string[]) => void
+  containerTypes?: Record<string, string>
+  leafTypes?: Record<string, string>
+  onUpdateSectioning: (sectioning: NonNullable<PageDetail["sectioning"]>) => void
+  sectioning: NonNullable<PageDetail["sectioning"]>
+  disabled: boolean
+  pageNumber: number | null
 }) {
   const { t } = useLingui()
   const { apiKey, hasApiKey } = useApiKey()
@@ -698,6 +938,102 @@ function SectionDetail({
   const [recropPageSrc, setRecropPageSrc] = useState<string | null>(null)
   const [aiImageTarget, setAiImageTarget] = useState<string | null>(null)
 
+  // Content node handlers
+  const contentNodeParts = section.parts
+    .map((p, i) => ({ part: p, index: i }))
+    .filter((x) => x.part.type === "content_node")
+
+  const showAnswers = visiblePanels.has("answers")
+
+  const updatePartNode = (partIndex: number, updater: (node: ContentNodeData) => ContentNodeData) => {
+    const updated: NonNullable<PageDetail["sectioning"]> = {
+      ...sectioning,
+      sections: sectioning.sections.map((s, si) => {
+        if (si !== sectionIndex) return s
+        return {
+          ...s,
+          parts: s.parts.map((p, pi) => {
+            if (pi !== partIndex || p.type !== "content_node") return p
+            return { ...p, node: updater(p.node) }
+          }),
+        }
+      }),
+    }
+    onUpdateSectioning(updated)
+  }
+
+  const handleToggleNodePruned = (partIndex: number, nodeId: string) => {
+    updatePartNode(partIndex, (root) =>
+      updateNodeInTree(root, nodeId, (n) => ({ ...n, isPruned: !n.isPruned })),
+    )
+  }
+
+  const handleEditNodeText = (partIndex: number, nodeId: string, newText: string) => {
+    updatePartNode(partIndex, (root) =>
+      updateNodeInTree(root, nodeId, (n) => ({ ...n, text: newText })),
+    )
+  }
+
+  const handleChangeNodeType = (partIndex: number, nodeId: string, field: "structure" | "role", newType: string) => {
+    updatePartNode(partIndex, (root) =>
+      updateNodeInTree(root, nodeId, (n) => ({ ...n, [field]: newType })),
+    )
+  }
+
+  const handleMoveNode = (targetPartIndex: number, dragNodeId: string, targetParentId: string | null, insertIndex: number) => {
+    // Find which part contains the dragged node
+    const sourceEntry = contentNodeParts.find(({ part }) =>
+      part.type === "content_node" && treeContainsNode(part.node, dragNodeId)
+    )
+    if (!sourceEntry) return
+
+    const sourcePartIndex = sourceEntry.index
+
+    if (sourcePartIndex === targetPartIndex) {
+      // Same-part move: use existing single-tree logic
+      updatePartNode(targetPartIndex, (root) => {
+        const [treeWithout, draggedNode] = removeNodeFromTree(root, dragNodeId)
+        if (!treeWithout || !draggedNode) return root
+        const result = insertNodeIntoTree(treeWithout, draggedNode, targetParentId, insertIndex)
+        return result ?? root
+      })
+    } else {
+      // Cross-part move: remove from source, insert into target
+      const sourcePart = sourceEntry.part
+      if (sourcePart.type !== "content_node") return
+
+      const [sourceTreeAfter, draggedNode] = removeNodeFromTree(sourcePart.node, dragNodeId)
+      if (!draggedNode) return
+
+      const targetEntry = contentNodeParts.find(({ index: i }) => i === targetPartIndex)
+      if (!targetEntry || targetEntry.part.type !== "content_node") return
+
+      const targetResult = insertNodeIntoTree(targetEntry.part.node, draggedNode, targetParentId, insertIndex)
+      if (!targetResult) return
+
+      // Build updated parts array
+      const updated: NonNullable<PageDetail["sectioning"]> = {
+        ...sectioning,
+        sections: sectioning.sections.map((s, si) => {
+          if (si !== sectionIndex) return s
+          const newParts = s.parts.map((p, pi) => {
+            if (pi === sourcePartIndex && p.type === "content_node") {
+              // Source part: removed the node — if root was removed, mark for deletion
+              if (!sourceTreeAfter) return null
+              return { ...p, node: sourceTreeAfter }
+            }
+            if (pi === targetPartIndex && p.type === "content_node") {
+              return { ...p, node: targetResult }
+            }
+            return p
+          }).filter((p): p is NonNullable<typeof p> => p !== null)
+          return { ...s, parts: newParts }
+        }),
+      }
+      onUpdateSectioning(updated)
+    }
+  }
+
   const handleImageClick = useCallback((e: React.MouseEvent, img: { imageId: string; isPruned: boolean }) => {
     if (storyboardRunning) return
     e.stopPropagation()
@@ -713,7 +1049,6 @@ function SectionDetail({
   const handleCropApply = useCallback(async (blob: Blob) => {
     if (!cropTarget) return
     const result = await api.uploadCroppedImage(bookLabel, pageId, cropTarget, blob)
-    // Swap the imageId in sectioning data
     const pageData = queryClient.getQueryData<PageDetail>(["books", bookLabel, "pages", pageId])
     if (pageData?.sectioning) {
       const updated = {
@@ -795,7 +1130,6 @@ function SectionDetail({
       sectionIndex,
       mode: "swap",
     })
-    // Task-based: server saves on completion. Invalidate after a short delay to pick up the task.
     setTimeout(() => onInvalidatePages(pageId), 2000)
   }, [aiImageTarget, bookLabel, pageId, apiKey, sectionIndex, onInvalidatePages])
 
@@ -836,8 +1170,8 @@ function SectionDetail({
     onInvalidatePages(pageId)
   }, [bookLabel, pageId, sectionIndex, queryClient, onInvalidatePages])
 
-  const sectionFilename = `${pageId}_sec${String(sectionIndex + 1).padStart(3, "0")}.html`
-  const previewSrc = `${BASE_URL}/books/${bookLabel}/adt-preview/${sectionFilename}?embed=1&v=${renderingVersion ?? 0}`
+  const thumbnailFilename = `${pageId}_sec${String(sectionIndex + 1).padStart(3, "0")}.png`
+  const thumbnailSrc = `${BASE_URL}/books/${bookLabel}/thumbnails/${thumbnailFilename}?v=${renderingVersion ?? 0}`
 
   return (
     <div className="space-y-3">
@@ -848,25 +1182,16 @@ function SectionDetail({
             <h4 className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider mb-1.5">
               <Trans>Preview</Trans>
             </h4>
-            <button
-              type="button"
-              className="w-[200px] h-[260px] border rounded overflow-hidden bg-white relative cursor-pointer hover:ring-2 hover:ring-violet-400 transition-shadow"
-              onClick={() => onNavigate?.()}
-              title={t`Edit this section`}
+            <div
+              className="w-[200px] h-[260px] border rounded overflow-hidden bg-white relative"
             >
-              <iframe
-                src={previewSrc}
-                title={t`Section preview`}
-                className="pointer-events-none origin-top-left"
-                style={{
-                  width: "800px",
-                  height: "1040px",
-                  transform: "scale(0.25)",
-                  transformOrigin: "top left",
-                }}
-                sandbox="allow-same-origin"
+              <img
+                src={thumbnailSrc}
+                alt={t`Section preview`}
+                className="w-full h-full object-contain"
+                loading="lazy"
               />
-            </button>
+            </div>
           </div>
         )}
 
@@ -876,6 +1201,12 @@ function SectionDetail({
           {visiblePanels.has("metadata") && (
             <>
               <div className="flex items-center gap-4 text-xs">
+                {pageNumber != null && (
+                  <>
+                    <span className="text-muted-foreground"><Trans>From page</Trans>:</span>
+                    <span className="font-mono">{pageNumber}</span>
+                  </>
+                )}
                 <span className="text-muted-foreground"><Trans>Background</Trans>:</span>
                 <span className="flex items-center gap-1">
                   <span
@@ -903,11 +1234,43 @@ function SectionDetail({
                   <p className="text-xs text-muted-foreground mt-1 whitespace-pre-wrap">{renderReasoning}</p>
                 </div>
               )}
+
             </>
           )}
 
-          {/* Text groups */}
-          {visiblePanels.has("textGroups") && textParts.length > 0 && (
+          {/* Content tree (interactive) — for content_node parts */}
+          {visiblePanels.has("textGroups") && contentNodeParts.length > 0 && (
+            <div>
+              <h4 className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider mb-1.5">
+                <Trans>Content</Trans>
+              </h4>
+              <div className="space-y-1">
+                {contentNodeParts.map(({ part, index: partIndex }) => {
+                  if (part.type !== "content_node") return null
+                  return (
+                    <ContentNodeBlock
+                      key={part.nodeId}
+                      node={part.node}
+                      parentId={null}
+                      indexInParent={0}
+                      bookLabel={bookLabel}
+                      depth={0}
+                      disabled={disabled}
+                      containerTypes={containerTypes}
+                      leafTypes={leafTypes}
+                      onTogglePruned={(nodeId) => handleToggleNodePruned(partIndex, nodeId)}
+                      onEditText={(nodeId, newText) => handleEditNodeText(partIndex, nodeId, newText)}
+                      onChangeType={(nodeId, field, newType) => handleChangeNodeType(partIndex, nodeId, field, newType)}
+                      onMoveNode={(dragId, targetParentId, insertIdx) => handleMoveNode(partIndex, dragId, targetParentId, insertIdx)}
+                    />
+                  )
+                })}
+              </div>
+            </div>
+          )}
+
+          {/* Text groups (legacy flat format) */}
+          {visiblePanels.has("textGroups") && contentNodeParts.length === 0 && textParts.length > 0 && (
             <div>
               <h4 className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider mb-1.5">
                 <Trans>Text Groups</Trans>
@@ -950,6 +1313,11 @@ function SectionDetail({
                 ))}
               </div>
             </div>
+          )}
+
+          {/* Activity answers — after tree, with context from rendered HTML */}
+          {showAnswers && activityAnswers != null && Object.keys(activityAnswers).length > 0 && (
+            <ActivityAnswerKey answers={activityAnswers} renderedHtml={renderedHtml} />
           )}
 
           {/* Images */}
@@ -1045,6 +1413,69 @@ function SectionDetail({
           onClose={() => setAiImageTarget(null)}
         />
       )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Activity Answer Key — shows answers with context from rendered HTML
+// ---------------------------------------------------------------------------
+
+function ActivityAnswerKey({
+  answers,
+  renderedHtml,
+}: {
+  answers: Record<string, string | boolean | number>
+  renderedHtml?: string
+}) {
+  // Extract context for each answer item from the rendered HTML
+  const contexts = renderedHtml ? extractAnswerContexts(renderedHtml) : new Map<string, string>()
+
+  // Sort entries by item number (item-1, item-2, ...)
+  const sorted = Object.entries(answers).sort(([a], [b]) => {
+    const na = parseInt(a.replace(/\D/g, ""), 10)
+    const nb = parseInt(b.replace(/\D/g, ""), 10)
+    if (!isNaN(na) && !isNaN(nb)) return na - nb
+    return a.localeCompare(b)
+  })
+
+  return (
+    <div>
+      <h4 className="text-[10px] font-medium text-amber-700 dark:text-amber-400 uppercase tracking-wider mb-1.5">
+        <Trans>Answers</Trans>
+      </h4>
+      <div className="space-y-1.5">
+        {sorted.map(([id, value]) => {
+          const context = contexts.get(id)
+          const strValue = String(value)
+          const isBoolTrue = value === true || strValue === "true"
+          const isBoolFalse = value === false || strValue === "false"
+
+          return (
+            <div
+              key={id}
+              className="flex items-center gap-2.5 rounded-lg border border-amber-200 dark:border-amber-800/40 bg-amber-50/80 dark:bg-amber-950/20 px-3 py-2"
+            >
+              <span className="text-[11px] font-medium px-2 py-0.5 rounded-full bg-amber-200/80 dark:bg-amber-800/40 text-amber-800 dark:text-amber-300 shrink-0">
+                {id}
+              </span>
+              <span className={cn(
+                "text-[12px] font-medium shrink-0",
+                isBoolTrue && "text-green-700 dark:text-green-400",
+                isBoolFalse && "text-red-600 dark:text-red-400",
+                !isBoolTrue && !isBoolFalse && "text-foreground/80",
+              )}>
+                {strValue}
+              </span>
+              {context && (
+                <span className="text-[11px] text-muted-foreground/60 truncate" title={context}>
+                  — {context}
+                </span>
+              )}
+            </div>
+          )
+        })}
+      </div>
     </div>
   )
 }

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
@@ -5,6 +5,7 @@ import { SectionDataPanel } from "./SectionDataPanel"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { api, BASE_URL } from "@/api/client"
 import type { PageDetail, VersionEntry } from "@/api/client"
+import type { ContentNodeData } from "@adt/types"
 import { useApiKey } from "@/hooks/use-api-key"
 import { useActiveConfig } from "@/hooks/use-debug"
 import { useBookTasks } from "@/hooks/use-book-tasks"
@@ -189,6 +190,23 @@ function VersionPicker({
 
 type SectioningData = NonNullable<PageDetail["sectioning"]>
 type RenderingData = NonNullable<PageDetail["rendering"]>
+
+/** Deep-update a node in a ContentNodeData tree by nodeId. Returns a new tree (immutable). */
+function updateNodeInTree<T extends { nodeId: string; children?: T[] }>(
+  node: T,
+  nodeId: string,
+  updater: (n: T) => T,
+): T {
+  if (node.nodeId === nodeId) return updater(node)
+  if (!node.children) return node
+  let changed = false
+  const updatedChildren = node.children.map((c) => {
+    const updated = updateNodeInTree(c, nodeId, updater)
+    if (updated !== c) changed = true
+    return updated
+  })
+  return changed ? { ...node, children: updatedChildren } : node
+}
 
 function getRenderedSectionByIndex(
   rendering: RenderingData | null | undefined,
@@ -384,6 +402,8 @@ export function StoryboardSectionDetail({
   onNavigateSection,
   hasPrevPage,
   hasNextPage,
+  panelOpen: panelOpen_prop,
+  onPanelOpenChange,
 }: {
   bookLabel: string
   pageId: string
@@ -400,6 +420,9 @@ export function StoryboardSectionDetail({
   /** Whether there is a page before/after this one (for cross-page merge) */
   hasPrevPage?: boolean
   hasNextPage?: boolean
+  /** Controlled edit panel open state — lifted to parent to persist across page changes */
+  panelOpen?: boolean
+  onPanelOpenChange?: (open: boolean) => void
 }) {
   const { t } = useLingui()
   const queryClient = useQueryClient()
@@ -442,8 +465,10 @@ export function StoryboardSectionDetail({
 
   // Track current pageId so async callbacks can detect stale closures
 
-  // Section data panel state
-  const [panelOpen, setPanelOpen] = useState(false)
+  // Section data panel state — controlled from parent to persist across page changes
+  const [localPanelOpen, setLocalPanelOpen] = useState(false)
+  const panelOpen = panelOpen_prop ?? localPanelOpen
+  const setPanelOpen = onPanelOpenChange ?? setLocalPanelOpen
   const [htmlPreview, setHtmlPreview] = useState(false)
   const [htmlPanelHeight, setHtmlPanelHeight] = useState(() => Math.floor(window.innerHeight * 0.35))
   const htmlPanelRef = useRef<HTMLDivElement>(null)
@@ -569,7 +594,7 @@ export function StoryboardSectionDetail({
   })
 
   const textTypes = configQuery.data?.merged?.text_types as Record<string, string> | undefined
-  const groupTypes = configQuery.data?.merged?.text_group_types as Record<string, string> | undefined
+  const groupTypes = configQuery.data?.merged?.container_types as Record<string, string> | undefined
   const allSectionTypes = configQuery.data?.merged?.section_types as Record<string, string> | undefined
   const disabledSectionTypes = new Set(configQuery.data?.merged?.disabled_section_types as string[] ?? [])
   const sectionTypes = allSectionTypes
@@ -1202,6 +1227,126 @@ export function StoryboardSectionDetail({
       // No rendering data — need re-render to sync
       needsRerenderRef.current = true
     }
+  }
+
+  // Toggle pruned state of a node within a content_node part
+  const toggleNodePruned = (partIndex: number, nodeId: string) => {
+    needsRerenderRef.current = true
+    const base = pendingSectioning ?? page.sectioning
+    if (!base) return
+    const updated: SectioningData = {
+      ...base,
+      sections: base.sections.map((s, si) => {
+        if (si !== sectionIndex) return s
+        return {
+          ...s,
+          parts: s.parts.map((p, pi) => {
+            if (pi !== partIndex || p.type !== "content_node") return p
+            return { ...p, node: updateNodeInTree(p.node, nodeId, (n) => ({ ...n, isPruned: !n.isPruned })) }
+          }),
+        }
+      }),
+    }
+    setPendingSectioning(updated)
+  }
+
+  // Edit text of a node within a content_node part
+  const editNodeText = (partIndex: number, nodeId: string, newText: string) => {
+    needsRerenderRef.current = true
+    const base = pendingSectioning ?? page.sectioning
+    if (!base) return
+    const updated: SectioningData = {
+      ...base,
+      sections: base.sections.map((s, si) => {
+        if (si !== sectionIndex) return s
+        return {
+          ...s,
+          parts: s.parts.map((p, pi) => {
+            if (pi !== partIndex || p.type !== "content_node") return p
+            return { ...p, node: updateNodeInTree(p.node, nodeId, (n) => ({ ...n, text: newText })) }
+          }),
+        }
+      }),
+    }
+    setPendingSectioning(updated)
+  }
+
+  // Change structure/role type of a node within a content_node part
+  const changeNodeType = (partIndex: number, nodeId: string, field: "structure" | "role", newType: string) => {
+    needsRerenderRef.current = true
+    const base = pendingSectioning ?? page.sectioning
+    if (!base) return
+    const updated: SectioningData = {
+      ...base,
+      sections: base.sections.map((s, si) => {
+        if (si !== sectionIndex) return s
+        return {
+          ...s,
+          parts: s.parts.map((p, pi) => {
+            if (pi !== partIndex || p.type !== "content_node") return p
+            return { ...p, node: updateNodeInTree(p.node, nodeId, (n) => ({ ...n, [field]: newType })) }
+          }),
+        }
+      }),
+    }
+    setPendingSectioning(updated)
+  }
+
+  // Move a node within the content tree: remove from current parent, insert at new position
+  const moveNodeInTree = (partIndex: number, dragNodeId: string, targetParentId: string | null, insertIndex: number) => {
+    needsRerenderRef.current = true
+    const base = pendingSectioning ?? page.sectioning
+    if (!base) return
+
+    const updated: SectioningData = {
+      ...base,
+      sections: base.sections.map((s, si) => {
+        if (si !== sectionIndex) return s
+        return {
+          ...s,
+          parts: s.parts.map((p, pi) => {
+            if (pi !== partIndex || p.type !== "content_node") return p
+            // 1. Extract the dragged node and remove it from the tree
+            let draggedNode: ContentNodeData | null = null
+            const removeNode = (n: ContentNodeData): ContentNodeData => {
+              if (!n.children) return n
+              const filtered = n.children.filter((c) => {
+                if (c.nodeId === dragNodeId) { draggedNode = c; return false }
+                return true
+              }).map(removeNode)
+              return { ...n, children: filtered }
+            }
+            const treeWithout = removeNode(p.node)
+            if (!draggedNode) return p
+
+            // 2. Insert at target position
+            if (targetParentId === null || targetParentId === p.node.nodeId) {
+              // Insert at root level of this content_node part's children
+              const children = [...(treeWithout.children ?? [])]
+              children.splice(insertIndex, 0, draggedNode)
+              return { ...p, node: { ...treeWithout, children } }
+            }
+            // Insert into a specific parent container
+            let inserted = false
+            const insertInto = (n: ContentNodeData): ContentNodeData => {
+              if (n.nodeId === targetParentId) {
+                inserted = true
+                const children = [...(n.children ?? [])]
+                children.splice(insertIndex, 0, draggedNode!)
+                return { ...n, children }
+              }
+              if (!n.children) return n
+              return { ...n, children: n.children.map(insertInto) }
+            }
+            const result = insertInto(treeWithout)
+            // If target not found, abort — don't lose the dragged node
+            if (!inserted) return p
+            return { ...p, node: result }
+          }),
+        }
+      }),
+    }
+    setPendingSectioning(updated)
   }
 
   // Change group type for a specific text group
@@ -2288,7 +2433,7 @@ export function StoryboardSectionDetail({
       )}
       <button
         type="button"
-        onClick={() => setPanelOpen((v) => !v)}
+        onClick={() => setPanelOpen(!panelOpen)}
         className="flex items-center gap-1 px-2 py-1 rounded bg-white/10 hover:bg-white/20 transition-colors cursor-pointer shrink-0"
         title={panelOpen ? t`Close edit panel` : t`Open edit panel`}
       >
@@ -2323,8 +2468,8 @@ export function StoryboardSectionDetail({
         </div>
       )}
 
-      {/* Preview — fills remaining space, scrolls independently */}
-      <div className="flex-1 overflow-auto px-4 py-4 relative" ref={scrollContainerRef}>
+      {/* Preview — fills remaining space, scrolls independently; shrinks when edit panel is open */}
+      <div className={`flex-1 overflow-auto px-4 py-4 relative transition-[margin] duration-200 ${panelOpen ? "mr-[480px]" : ""}`} ref={scrollContainerRef}>
         {!section ? (
           <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
             <div className="w-12 h-12 rounded-full bg-muted/50 flex items-center justify-center mb-3">
@@ -2623,7 +2768,7 @@ export function StoryboardSectionDetail({
         />
       )}
 
-      {/* Slide-out section data panel */}
+      {/* Slide-out section data panel — inside the flex row so it sits beside the preview */}
       {section && (
       <SectionDataPanel
         open={panelOpen}
@@ -2645,6 +2790,10 @@ export function StoryboardSectionDetail({
         onDeleteTextEntry={deleteTextEntry}
         onDuplicateTextEntry={duplicateTextEntry}
         onEditText={editText}
+        onToggleNodePruned={toggleNodePruned}
+        onEditNodeText={editNodeText}
+        onChangeNodeType={changeNodeType}
+        onMoveNode={moveNodeInTree}
         onAddGroup={addGroup}
         onDuplicateGroup={duplicateGroup}
         onDeleteGroup={deleteGroup}

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -42,9 +42,8 @@ msgstr "(base)"
 msgid "(no target)"
 msgstr "(no target)"
 
-#. placeholder {0}: sections[0].pageNumber
-msgid "(p.{0})"
-msgstr "(p.{0})"
+#~ msgid "(p.{0})"
+#~ msgstr "(p.{0})"
 
 msgid "(template)"
 msgstr "(template)"
@@ -571,6 +570,9 @@ msgstr "An open-ended answer activity."
 msgid "Answer"
 msgstr "Answer"
 
+#~ msgid "Answer Key"
+#~ msgstr "Answer Key"
+
 msgid "Answer Prompt"
 msgstr "Answer Prompt"
 
@@ -604,6 +606,9 @@ msgstr "API Key (optional)"
 msgid "API key required to re-render"
 msgstr "API key required to re-render"
 
+msgid "API key required to save and re-render"
+msgstr "API key required to save and re-render"
+
 msgid "API Key Settings"
 msgstr "API Key Settings"
 
@@ -625,6 +630,9 @@ msgstr "Apply Segmentation"
 #. placeholder {0}: confirmMerge?.label ?? ""
 msgid "Are you sure you want to {0}? This action cannot be undone."
 msgstr "Are you sure you want to {0}? This action cannot be undone."
+
+msgid "Are you sure you want to {label}?"
+msgstr "Are you sure you want to {label}?"
 
 msgid "Are you sure you want to {label}? This action cannot be undone."
 msgstr "Are you sure you want to {label}? This action cannot be undone."
@@ -1009,6 +1017,9 @@ msgstr "Configure API keys for AI pipeline features."
 msgid "Configure basic document information and file paths"
 msgstr "Configure basic document information and file paths"
 
+msgid "Confirm"
+msgstr "Confirm"
+
 msgid "Confirm merge"
 msgstr "Confirm merge"
 
@@ -1029,6 +1040,9 @@ msgstr "Content"
 
 msgid "Content Processing"
 msgstr "Content Processing"
+
+msgid "Content Tree"
+msgstr "Content Tree"
 
 msgid "Continue"
 msgstr "Continue"
@@ -1242,6 +1256,10 @@ msgstr "Delete group"
 msgid "Delete section"
 msgstr "Delete section"
 
+#. placeholder {0}: String(sectionIdx + 1)
+msgid "Delete section {0}? This cannot be undone."
+msgstr "Delete section {0}? This cannot be undone."
+
 msgid "Delete text entry"
 msgstr "Delete text entry"
 
@@ -1317,6 +1335,12 @@ msgstr "Drag to reorder or move to another group"
 msgid "Drag vertices to reshape. Click midpoints (+) to add points. Right-click a vertex to remove it."
 msgstr "Drag vertices to reshape. Click midpoints (+) to add points. Right-click a vertex to remove it."
 
+#~ msgid "Drop content here"
+#~ msgstr "Drop content here"
+
+msgid "Drop here"
+msgstr "Drop here"
+
 msgid "Drop PDF here"
 msgstr "Drop PDF here"
 
@@ -1386,8 +1410,8 @@ msgstr "Edit the Liquid/HTML template below. Changes are saved when you click Sa
 msgid "Edit this image"
 msgstr "Edit this image"
 
-msgid "Edit this section"
-msgstr "Edit this section"
+#~ msgid "Edit this section"
+#~ msgstr "Edit this section"
 
 msgid "Edited in"
 msgstr "Edited in"
@@ -1400,6 +1424,9 @@ msgstr "Editing is disabled while the storyboard is running"
 
 msgid "Editing Language"
 msgstr "Editing Language"
+
+msgid "Empty"
+msgstr "Empty"
 
 msgid "Empty group — drag text entries here"
 msgstr "Empty group — drag text entries here"
@@ -1645,6 +1672,9 @@ msgstr "Format"
 msgid "Forms & controls"
 msgstr "Forms & controls"
 
+msgid "From page"
+msgstr "From page"
+
 msgid "From reference image..."
 msgstr "From reference image..."
 
@@ -1752,6 +1782,9 @@ msgstr "Glossary Prompt"
 
 msgid "Go to book"
 msgstr "Go to book"
+
+msgid "Go to preview"
+msgstr "Go to preview"
 
 msgid "Google"
 msgstr "Google"
@@ -2355,6 +2388,9 @@ msgstr "No captions for this page"
 msgid "No changes flagged on this page"
 msgstr "No changes flagged on this page"
 
+msgid "No content"
+msgstr "No content"
+
 msgid "No data"
 msgstr "No data"
 
@@ -2620,8 +2656,8 @@ msgstr "Output Tokens"
 msgid "Overall page note"
 msgstr "Overall page note"
 
-msgid "Overview"
-msgstr "Overview"
+#~ msgid "Overview"
+#~ msgstr "Overview"
 
 msgid "Package and preview the final ADT web application."
 msgstr "Package and preview the final ADT web application."
@@ -2646,7 +2682,7 @@ msgstr "Page"
 
 #. placeholder {0}: String(page.pageNumber)
 #. placeholder {0}: String(pageNumber)
-#. placeholder {0}: String(selectedPage.pageNumber)
+#. placeholder {0}: String(pageSummary.pageNumber)
 msgid "Page {0}"
 msgstr "Page {0}"
 
@@ -2716,6 +2752,12 @@ msgstr "Paper Collage"
 
 #~ msgid "Paragraph"
 #~ msgstr "Paragraph"
+
+msgid "part"
+msgstr "part"
+
+msgid "parts"
+msgstr "parts"
 
 msgid "Parts"
 msgstr "Parts"
@@ -2851,6 +2893,9 @@ msgstr "Prune element"
 
 msgid "Prune image"
 msgstr "Prune image"
+
+msgid "Prune section"
+msgstr "Prune section"
 
 msgid "Prune section from flow"
 msgstr "Prune section from flow"
@@ -3013,6 +3058,9 @@ msgstr "Remove this block"
 msgid "Remove type"
 msgstr "Remove type"
 
+#~ msgid "Render"
+#~ msgstr "Render"
+
 msgid "Render Reasoning"
 msgstr "Render Reasoning"
 
@@ -3167,6 +3215,9 @@ msgstr "Sample Reference Manual"
 msgid "Save"
 msgstr "Save"
 
+#~ msgid "Save & Re-render"
+#~ msgstr "Save & Re-render"
+
 msgid "Save & Rerun"
 msgstr "Save & Rerun"
 
@@ -3261,6 +3312,10 @@ msgstr "Section {0} — {1}"
 msgid "Section {0} (pruned)"
 msgstr "Section {0} (pruned)"
 
+#. placeholder {0}: String(sectionIdx + 1)
+msgid "Section {0} preview"
+msgstr "Section {0} preview"
+
 msgid "Section 3.2"
 msgstr "Section 3.2"
 
@@ -3297,8 +3352,8 @@ msgstr "Sectioning"
 msgid "Sectioning Mode"
 msgstr "Sectioning Mode"
 
-msgid "Sectioning Reasoning"
-msgstr "Sectioning Reasoning"
+#~ msgid "Sectioning Reasoning"
+#~ msgstr "Sectioning Reasoning"
 
 msgid "sections"
 msgstr "sections"
@@ -3970,8 +4025,8 @@ msgstr "Unknown step slug: {step}"
 msgid "Unknown step: {step}"
 msgstr "Unknown step: {step}"
 
-msgid "Unprune"
-msgstr "Unprune"
+#~ msgid "Unprune"
+#~ msgstr "Unprune"
 
 #~ msgid "Unprune group"
 #~ msgstr "Unprune group"
@@ -3979,11 +4034,19 @@ msgstr "Unprune"
 msgid "Unprune image"
 msgstr "Unprune image"
 
+msgid "Unprune section"
+msgstr "Unprune section"
+
 #~ msgid "Unprune text"
 #~ msgstr "Unprune text"
 
 msgid "Unsaved changes"
 msgstr "Unsaved changes"
+
+#. placeholder {0}: pendingByPage.size
+#. placeholder {1}: pendingByPage.size === 1 ? "page" : "pages"
+msgid "Unsaved changes on {0} {1}"
+msgstr "Unsaved changes on {0} {1}"
 
 msgid "Unsaved:"
 msgstr "Unsaved:"

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -42,9 +42,8 @@ msgstr "(base)"
 msgid "(no target)"
 msgstr "(no target)"
 
-#. placeholder {0}: sections[0].pageNumber
-msgid "(p.{0})"
-msgstr "(p.{0})"
+#~ msgid "(p.{0})"
+#~ msgstr "(p.{0})"
 
 msgid "(template)"
 msgstr "(plantilla)"
@@ -571,6 +570,9 @@ msgstr "Una actividad de respuesta abierta."
 msgid "Answer"
 msgstr "Respuesta"
 
+#~ msgid "Answer Key"
+#~ msgstr "Clave de respuestas"
+
 msgid "Answer Prompt"
 msgstr "Prompt de respuesta"
 
@@ -604,6 +606,9 @@ msgstr "Clave de API (opcional)"
 msgid "API key required to re-render"
 msgstr "Se requiere clave de API para re-renderizar"
 
+msgid "API key required to save and re-render"
+msgstr "Se requiere clave de API para guardar y volver a renderizar"
+
 msgid "API Key Settings"
 msgstr "Configuración de clave API"
 
@@ -625,6 +630,9 @@ msgstr "Apply Segmentation"
 #. placeholder {0}: confirmMerge?.label ?? ""
 msgid "Are you sure you want to {0}? This action cannot be undone."
 msgstr "¿Seguro que quieres {0}? Esta acción no se puede deshacer."
+
+msgid "Are you sure you want to {label}?"
+msgstr "¿Estás seguro de que quieres {label}?"
 
 msgid "Are you sure you want to {label}? This action cannot be undone."
 msgstr "¿Seguro que quieres {label}? Esta acción no se puede deshacer."
@@ -1009,6 +1017,9 @@ msgstr "Configura las claves de API para las funciones de IA."
 msgid "Configure basic document information and file paths"
 msgstr "Configura la información básica del documento y las rutas de archivo"
 
+msgid "Confirm"
+msgstr "Confirmar"
+
 msgid "Confirm merge"
 msgstr "Confirmar fusión"
 
@@ -1029,6 +1040,9 @@ msgstr "Contenido"
 
 msgid "Content Processing"
 msgstr "Procesamiento de Contenido"
+
+msgid "Content Tree"
+msgstr "Árbol de contenido"
 
 msgid "Continue"
 msgstr "Continuar"
@@ -1242,6 +1256,10 @@ msgstr "Eliminar grupo"
 msgid "Delete section"
 msgstr "Eliminar sección"
 
+#. placeholder {0}: String(sectionIdx + 1)
+msgid "Delete section {0}? This cannot be undone."
+msgstr "¿Eliminar sección {0}? Esta acción no se puede deshacer."
+
 msgid "Delete text entry"
 msgstr "Eliminar entrada de texto"
 
@@ -1317,6 +1335,12 @@ msgstr "Arrastra para reordenar o mover a otro grupo"
 msgid "Drag vertices to reshape. Click midpoints (+) to add points. Right-click a vertex to remove it."
 msgstr "Arrastra los vértices para cambiar la forma. Haz clic en los puntos medios (+) para agregar puntos. Haz clic derecho en un vértice para eliminarlo."
 
+#~ msgid "Drop content here"
+#~ msgstr "Soltar contenido aquí"
+
+msgid "Drop here"
+msgstr "Soltar aquí"
+
 msgid "Drop PDF here"
 msgstr "Suelta el PDF aquí"
 
@@ -1386,8 +1410,8 @@ msgstr "Edita la plantilla Liquid/HTML a continuación. Los cambios se guardan c
 msgid "Edit this image"
 msgstr "Editar esta imagen"
 
-msgid "Edit this section"
-msgstr "Editar esta sección"
+#~ msgid "Edit this section"
+#~ msgstr "Editar esta sección"
 
 msgid "Edited in"
 msgstr "Editado en"
@@ -1400,6 +1424,9 @@ msgstr "La edición está deshabilitada mientras el storyboard se está ejecutan
 
 msgid "Editing Language"
 msgstr "Idioma de edición"
+
+msgid "Empty"
+msgstr "Vacío"
 
 msgid "Empty group — drag text entries here"
 msgstr "Grupo vacío — arrastra entradas de texto aquí"
@@ -1645,6 +1672,9 @@ msgstr "Formato"
 msgid "Forms & controls"
 msgstr "Forms & controls"
 
+msgid "From page"
+msgstr "De la página"
+
 msgid "From reference image..."
 msgstr "Desde imagen de referencia..."
 
@@ -1752,6 +1782,9 @@ msgstr "Prompt de glosario"
 
 msgid "Go to book"
 msgstr "Ir al libro"
+
+msgid "Go to preview"
+msgstr "Ir a vista previa"
 
 msgid "Google"
 msgstr "Google"
@@ -2355,6 +2388,9 @@ msgstr "Sin leyendas para esta página"
 msgid "No changes flagged on this page"
 msgstr "No changes flagged on this page"
 
+msgid "No content"
+msgstr "Sin contenido"
+
 msgid "No data"
 msgstr "Sin datos"
 
@@ -2620,8 +2656,8 @@ msgstr "Tokens de salida"
 msgid "Overall page note"
 msgstr "Overall page note"
 
-msgid "Overview"
-msgstr "Vista general"
+#~ msgid "Overview"
+#~ msgstr "Vista general"
 
 msgid "Package and preview the final ADT web application."
 msgstr "Empaqueta y previsualiza la aplicación web ADT final."
@@ -2646,7 +2682,7 @@ msgstr "Página"
 
 #. placeholder {0}: String(page.pageNumber)
 #. placeholder {0}: String(pageNumber)
-#. placeholder {0}: String(selectedPage.pageNumber)
+#. placeholder {0}: String(pageSummary.pageNumber)
 msgid "Page {0}"
 msgstr "Página {0}"
 
@@ -2716,6 +2752,12 @@ msgstr "Collage en papel"
 
 #~ msgid "Paragraph"
 #~ msgstr "Párrafo"
+
+msgid "part"
+msgstr "parte"
+
+msgid "parts"
+msgstr "partes"
 
 msgid "Parts"
 msgstr "Partes"
@@ -2851,6 +2893,9 @@ msgstr "Eliminar elemento"
 
 msgid "Prune image"
 msgstr "Eliminar imagen"
+
+msgid "Prune section"
+msgstr "Podar sección"
 
 msgid "Prune section from flow"
 msgstr "Eliminar sección del flujo"
@@ -3013,6 +3058,9 @@ msgstr "Quitar este bloque"
 msgid "Remove type"
 msgstr "Eliminar tipo"
 
+#~ msgid "Render"
+#~ msgstr "Renderizado"
+
 msgid "Render Reasoning"
 msgstr "Razonamiento de renderizado"
 
@@ -3167,6 +3215,9 @@ msgstr "Ejemplo de Manual de Referencia"
 msgid "Save"
 msgstr "Guardar"
 
+#~ msgid "Save & Re-render"
+#~ msgstr "Guardar y re-renderizar"
+
 msgid "Save & Rerun"
 msgstr "Guardar y reejecutar"
 
@@ -3261,6 +3312,10 @@ msgstr "Sección {0} — {1}"
 msgid "Section {0} (pruned)"
 msgstr "Sección {0} (eliminada)"
 
+#. placeholder {0}: String(sectionIdx + 1)
+msgid "Section {0} preview"
+msgstr "Vista previa de sección {0}"
+
 msgid "Section 3.2"
 msgstr "Sección 3.2"
 
@@ -3297,8 +3352,8 @@ msgstr "Seccionamiento"
 msgid "Sectioning Mode"
 msgstr "Modo de sección"
 
-msgid "Sectioning Reasoning"
-msgstr "Razonamiento de sección"
+#~ msgid "Sectioning Reasoning"
+#~ msgstr "Razonamiento de sección"
 
 msgid "sections"
 msgstr "secciones"
@@ -3970,8 +4025,8 @@ msgstr "Slug de etapa desconocido: {0}"
 msgid "Unknown step: {step}"
 msgstr "Paso desconocido: {0}"
 
-msgid "Unprune"
-msgstr "Restaurar"
+#~ msgid "Unprune"
+#~ msgstr "Restaurar"
 
 #~ msgid "Unprune group"
 #~ msgstr "Restaurar grupo"
@@ -3979,11 +4034,19 @@ msgstr "Restaurar"
 msgid "Unprune image"
 msgstr "Restaurar imagen"
 
+msgid "Unprune section"
+msgstr "Restaurar sección"
+
 #~ msgid "Unprune text"
 #~ msgstr "Restaurar texto"
 
 msgid "Unsaved changes"
 msgstr "Cambios sin guardar"
+
+#. placeholder {0}: pendingByPage.size
+#. placeholder {1}: pendingByPage.size === 1 ? "page" : "pages"
+msgid "Unsaved changes on {0} {1}"
+msgstr "Cambios sin guardar en {0} {1}"
 
 msgid "Unsaved:"
 msgstr "Sin guardar:"

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -42,9 +42,8 @@ msgstr "(base)"
 msgid "(no target)"
 msgstr "(no target)"
 
-#. placeholder {0}: sections[0].pageNumber
-msgid "(p.{0})"
-msgstr "(p.{0})"
+#~ msgid "(p.{0})"
+#~ msgstr "(p.{0})"
 
 msgid "(template)"
 msgstr "(template)"
@@ -571,6 +570,9 @@ msgstr "Uma atividade de resposta aberta."
 msgid "Answer"
 msgstr "Resposta"
 
+#~ msgid "Answer Key"
+#~ msgstr "Gabarito"
+
 msgid "Answer Prompt"
 msgstr "Prompt de resposta"
 
@@ -604,6 +606,9 @@ msgstr "Chave de API (opcional)"
 msgid "API key required to re-render"
 msgstr "Chave de API necessária para rerenderizar"
 
+msgid "API key required to save and re-render"
+msgstr "Chave de API necessária para salvar e renderizar novamente"
+
 msgid "API Key Settings"
 msgstr "Configurações da chave de API"
 
@@ -625,6 +630,9 @@ msgstr "Apply Segmentation"
 #. placeholder {0}: confirmMerge?.label ?? ""
 msgid "Are you sure you want to {0}? This action cannot be undone."
 msgstr "Tem certeza que deseja {0}? Esta ação não pode ser desfeita."
+
+msgid "Are you sure you want to {label}?"
+msgstr "Tem certeza que deseja {label}?"
 
 msgid "Are you sure you want to {label}? This action cannot be undone."
 msgstr "Tem certeza que deseja {label}? Esta ação não pode ser desfeita."
@@ -1009,6 +1017,9 @@ msgstr "Configure as chaves de API para os recursos de IA."
 msgid "Configure basic document information and file paths"
 msgstr "Configurar informações básicas do documento e caminhos de arquivos"
 
+msgid "Confirm"
+msgstr "Confirmar"
+
 msgid "Confirm merge"
 msgstr "Confirmar mesclagem"
 
@@ -1029,6 +1040,9 @@ msgstr "Conteúdo"
 
 msgid "Content Processing"
 msgstr "Processamento de Conteúdo"
+
+msgid "Content Tree"
+msgstr "Árvore de conteúdo"
 
 msgid "Continue"
 msgstr "Continuar"
@@ -1242,6 +1256,10 @@ msgstr "Excluir grupo"
 msgid "Delete section"
 msgstr "Excluir seção"
 
+#. placeholder {0}: String(sectionIdx + 1)
+msgid "Delete section {0}? This cannot be undone."
+msgstr "Excluir seção {0}? Esta ação não pode ser desfeita."
+
 msgid "Delete text entry"
 msgstr "Excluir entrada de texto"
 
@@ -1317,6 +1335,12 @@ msgstr "Arraste para reordenar ou mover para outro grupo"
 msgid "Drag vertices to reshape. Click midpoints (+) to add points. Right-click a vertex to remove it."
 msgstr "Arraste os vértices para remodelar. Clique nos pontos médios (+) para adicionar pontos. Clique com o botão direito em um vértice para removê-lo."
 
+#~ msgid "Drop content here"
+#~ msgstr "Soltar conteúdo aqui"
+
+msgid "Drop here"
+msgstr "Soltar aqui"
+
 msgid "Drop PDF here"
 msgstr "Solte o PDF aqui"
 
@@ -1386,8 +1410,8 @@ msgstr "Edite o template Liquid/HTML abaixo. As alterações são salvas quando 
 msgid "Edit this image"
 msgstr "Editar esta imagem"
 
-msgid "Edit this section"
-msgstr "Editar esta seção"
+#~ msgid "Edit this section"
+#~ msgstr "Editar esta seção"
 
 msgid "Edited in"
 msgstr "Editado em"
@@ -1400,6 +1424,9 @@ msgstr "A edição está desabilitada enquanto o storyboard está em execução"
 
 msgid "Editing Language"
 msgstr "Idioma de edição"
+
+msgid "Empty"
+msgstr "Vazio"
 
 msgid "Empty group — drag text entries here"
 msgstr "Grupo vazio — arraste entradas de texto aqui"
@@ -1645,6 +1672,9 @@ msgstr "Formato"
 msgid "Forms & controls"
 msgstr "Forms & controls"
 
+msgid "From page"
+msgstr "Da página"
+
 msgid "From reference image..."
 msgstr "A partir de imagem de referência..."
 
@@ -1752,6 +1782,9 @@ msgstr "Prompt de glossário"
 
 msgid "Go to book"
 msgstr "Ir para o livro"
+
+msgid "Go to preview"
+msgstr "Ir para visualização"
 
 msgid "Google"
 msgstr "Google"
@@ -2355,6 +2388,9 @@ msgstr "Sem legendas para esta página"
 msgid "No changes flagged on this page"
 msgstr "No changes flagged on this page"
 
+msgid "No content"
+msgstr "Sem conteúdo"
+
 msgid "No data"
 msgstr "Sem dados"
 
@@ -2620,8 +2656,8 @@ msgstr "Tokens de saída"
 msgid "Overall page note"
 msgstr "Overall page note"
 
-msgid "Overview"
-msgstr "Visão geral"
+#~ msgid "Overview"
+#~ msgstr "Visão geral"
 
 msgid "Package and preview the final ADT web application."
 msgstr "Empacota e pré-visualiza a aplicação web ADT final."
@@ -2646,7 +2682,7 @@ msgstr "Página"
 
 #. placeholder {0}: String(page.pageNumber)
 #. placeholder {0}: String(pageNumber)
-#. placeholder {0}: String(selectedPage.pageNumber)
+#. placeholder {0}: String(pageSummary.pageNumber)
 msgid "Page {0}"
 msgstr "Página {0}"
 
@@ -2716,6 +2752,12 @@ msgstr "Colagem em papel"
 
 #~ msgid "Paragraph"
 #~ msgstr "Parágrafo"
+
+msgid "part"
+msgstr "parte"
+
+msgid "parts"
+msgstr "partes"
 
 msgid "Parts"
 msgstr "Partes"
@@ -2851,6 +2893,9 @@ msgstr "Remover elemento"
 
 msgid "Prune image"
 msgstr "Remover imagem"
+
+msgid "Prune section"
+msgstr "Podar seção"
 
 msgid "Prune section from flow"
 msgstr "Remover seção do fluxo"
@@ -3013,6 +3058,9 @@ msgstr "Remover este bloco"
 msgid "Remove type"
 msgstr "Remover tipo"
 
+#~ msgid "Render"
+#~ msgstr "Renderização"
+
 msgid "Render Reasoning"
 msgstr "Raciocínio de renderização"
 
@@ -3167,6 +3215,9 @@ msgstr "Manual de Referência de Exemplo"
 msgid "Save"
 msgstr "Salvar"
 
+#~ msgid "Save & Re-render"
+#~ msgstr "Salvar e re-renderizar"
+
 msgid "Save & Rerun"
 msgstr "Salvar e reexecutar"
 
@@ -3261,6 +3312,10 @@ msgstr "Seção {0} — {1}"
 msgid "Section {0} (pruned)"
 msgstr "Seção {0} (removida)"
 
+#. placeholder {0}: String(sectionIdx + 1)
+msgid "Section {0} preview"
+msgstr "Visualização da seção {0}"
+
 msgid "Section 3.2"
 msgstr "Seção 3.2"
 
@@ -3297,8 +3352,8 @@ msgstr "Seccionamento"
 msgid "Sectioning Mode"
 msgstr "Modo de seção"
 
-msgid "Sectioning Reasoning"
-msgstr "Raciocínio de seção"
+#~ msgid "Sectioning Reasoning"
+#~ msgstr "Raciocínio de seção"
 
 msgid "sections"
 msgstr "seções"
@@ -3970,8 +4025,8 @@ msgstr "Slug de etapa desconhecido: {0}"
 msgid "Unknown step: {step}"
 msgstr "Etapa desconhecida: {0}"
 
-msgid "Unprune"
-msgstr "Restaurar"
+#~ msgid "Unprune"
+#~ msgstr "Restaurar"
 
 #~ msgid "Unprune group"
 #~ msgstr "Restaurar grupo"
@@ -3979,11 +4034,19 @@ msgstr "Restaurar"
 msgid "Unprune image"
 msgstr "Restaurar imagem"
 
+msgid "Unprune section"
+msgstr "Restaurar seção"
+
 #~ msgid "Unprune text"
 #~ msgstr "Restaurar texto"
 
 msgid "Unsaved changes"
 msgstr "Alterações não salvas"
+
+#. placeholder {0}: pendingByPage.size
+#. placeholder {1}: pendingByPage.size === 1 ? "page" : "pages"
+msgid "Unsaved changes on {0} {1}"
+msgstr "Alterações não salvas em {0} {1}"
 
 msgid "Unsaved:"
 msgstr "Não salvo:"

--- a/config.yaml
+++ b/config.yaml
@@ -15,7 +15,7 @@ text_types:
   quote: Quoted or cited text
 
 container_types:
-  image: An image — set image_id on this container. May have children for captions, labels, or text within the image.
+  image_group: An image group — contains an image leaf child and optional captions, labels, or text associated with the image.
   activity: A single question, exercise, or activity
   activity_option: A selectable choice in a multiple-choice or matching activity
   group: A generic content grouping when no more specific container fits

--- a/packages/pipeline/src/__tests__/page-structuring.test.ts
+++ b/packages/pipeline/src/__tests__/page-structuring.test.ts
@@ -37,7 +37,7 @@ const baseConfig: StructureConfig = {
     { key: "body", description: "Body text" },
   ],
   containerTypes: [
-    { key: "image", description: "An image" },
+    { key: "image_group", description: "An image group" },
     { key: "group", description: "Content group" },
   ],
   prunedTextTypes: ["header"],

--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -64,6 +64,8 @@ export {
   sectionPage,
   buildSectioningConfig,
   buildGroupSummaries,
+  buildNodeSummaries,
+  findNodeById,
   type SectioningConfig,
   type SectionPageInput,
 } from "./page-sectioning.js"
@@ -94,6 +96,12 @@ export {
   type ScreenshotRenderer,
 } from "./screenshot.js"
 export { buildScreenshotHtml } from "./screenshot-html.js"
+export {
+  renderSectionThumbnail,
+  DEFAULT_THUMBNAIL_VIEWPORT,
+  type ThumbnailViewport,
+  type RenderSectionThumbnailInput,
+} from "./section-thumbnail.js"
 export {
   createTemplateEngine,
   renderSectionTemplate,

--- a/packages/pipeline/src/page-sectioning.ts
+++ b/packages/pipeline/src/page-sectioning.ts
@@ -2,6 +2,8 @@ import type {
   TextClassificationOutput,
   ImageClassificationOutput,
   PageSectioningOutput,
+  PageStructuringOutput,
+  ContentNodeData,
   SectionPart,
   AppConfig,
   TypeDef,
@@ -26,7 +28,8 @@ export interface SectionPageInput {
   pageId: string
   pageNumber: number
   pageImageBase64: string
-  textClassification: TextClassificationOutput
+  textClassification?: TextClassificationOutput
+  contentTree?: PageStructuringOutput
   imageClassification: ImageClassificationOutput
   images: Array<{ imageId: string; imageBase64: string }>
 }
@@ -54,6 +57,57 @@ export function buildGroupSummaries(
 }
 
 /**
+ * Recursively find a node by ID in a content tree.
+ */
+export function findNodeById(
+  nodes: ContentNodeData[],
+  id: string
+): ContentNodeData | undefined {
+  for (const node of nodes) {
+    if (node.nodeId === id) return node
+    if (node.children) {
+      const found = findNodeById(node.children, id)
+      if (found) return found
+    }
+  }
+  return undefined
+}
+
+/**
+ * Collect text from a content tree node for LLM summarisation.
+ */
+function collectNodeText(node: ContentNodeData): string {
+  if (node.isPruned) return ""
+  if (node.text != null) return node.text
+  if (node.children) {
+    return node.children
+      .filter((c) => !c.isPruned)
+      .map(collectNodeText)
+      .filter(Boolean)
+      .join(" ")
+  }
+  return ""
+}
+
+/**
+ * Build concise node summaries from a content tree for the LLM.
+ * Only top-level nodes are emitted as assignable parts.
+ * Pruned nodes are omitted.
+ */
+export function buildNodeSummaries(
+  contentTree: PageStructuringOutput
+): Array<{ nodeId: string; nodeType: string; text: string }> {
+  return contentTree.nodes
+    .filter((n) => !n.isPruned)
+    .map((node) => ({
+      nodeId: node.nodeId,
+      nodeType: node.structure ?? node.role ?? "unknown",
+      text: collectNodeText(node),
+    }))
+    .filter((s) => s.text.length > 0 || s.nodeType !== "unknown")
+}
+
+/**
  * Section a page into semantic groups. Pure function — no side effects.
  * The caller handles concurrency, storage writes, and progress.
  */
@@ -62,8 +116,12 @@ export async function sectionPage(
   config: SectioningConfig,
   llmModel: LLMModel
 ): Promise<PageSectioningOutput> {
-  // Build group summaries (excludes pruned text entries)
-  const groupSummaries = buildGroupSummaries(input.textClassification)
+  const useTree = !!input.contentTree
+  const textClassification = input.textClassification
+
+  // Build summaries based on input format
+  const groupSummaries = textClassification ? buildGroupSummaries(textClassification) : []
+  const nodeSummaries = input.contentTree ? buildNodeSummaries(input.contentTree) : []
 
   // Filter to un-pruned images
   const prunedImageIds = new Set(
@@ -76,10 +134,15 @@ export async function sectionPage(
   )
 
   // Build valid part IDs for the schema
-  const validPartIds = [
-    ...groupSummaries.map((g) => g.groupId),
-    ...unprunedImages.map((img) => img.imageId),
-  ]
+  const validPartIds = useTree
+    ? [
+        ...nodeSummaries.map((n) => n.nodeId),
+        ...unprunedImages.map((img) => img.imageId),
+      ]
+    : [
+        ...groupSummaries.map((g) => g.groupId),
+        ...unprunedImages.map((img) => img.imageId),
+      ]
 
   // If no parts to section, return empty result
   if (validPartIds.length === 0) {
@@ -93,6 +156,31 @@ export async function sectionPage(
 
   const schema = buildPageSectioningLLMSchema()
 
+  // Build LLM context — use nodes when tree is available, otherwise groups
+  const llmContext: Record<string, unknown> = {
+    sectioning_mode: config.mode,
+    page: { imageBase64: input.pageImageBase64 },
+    images: unprunedImages.map((img) => ({
+      image_id: img.imageId,
+      imageBase64: img.imageBase64,
+    })),
+    section_types: config.sectionTypes,
+  }
+
+  if (useTree) {
+    llmContext.nodes = nodeSummaries.map((n) => ({
+      node_id: n.nodeId,
+      node_type: n.nodeType,
+      text: n.text,
+    }))
+  } else {
+    llmContext.groups = groupSummaries.map((g) => ({
+      group_id: g.groupId,
+      group_type: g.groupType,
+      text: g.text,
+    }))
+  }
+
   const result = await llmModel.generateObject<{
     reasoning: string
     sections: Array<{
@@ -105,20 +193,7 @@ export async function sectionPage(
   }>({
     schema,
     prompt: config.promptName,
-    context: {
-      sectioning_mode: config.mode,
-      page: { imageBase64: input.pageImageBase64 },
-      images: unprunedImages.map((img) => ({
-        image_id: img.imageId,
-        imageBase64: img.imageBase64,
-      })),
-      groups: groupSummaries.map((g) => ({
-        group_id: g.groupId,
-        group_type: g.groupType,
-        text: g.text,
-      })),
-      section_types: config.sectionTypes,
-    },
+    context: llmContext,
     validate: validatePageSectioning,
     maxRetries: config.maxRetries,
     maxTokens: 16384,
@@ -130,9 +205,6 @@ export async function sectionPage(
   })
 
   // Build lookup maps for expanding part_ids into inline parts
-  const groupMap = new Map(
-    input.textClassification.groups.map((g) => [g.groupId, g])
-  )
   const imageClassMap = new Map(
     input.imageClassification.images.map((img) => [img.imageId, img])
   )
@@ -143,9 +215,89 @@ export async function sectionPage(
   // Post-process: mark pruned sections, expand part_ids to inline parts
   const prunedSet = new Set(config.prunedSectionTypes)
 
+  if (useTree) {
+    // Tree-based flow: expand part_ids to SectionContentNodePart
+    const treeNodes = input.contentTree!.nodes
+
+    const sections = result.object.sections.map((s, idx) => {
+      const sectionId = `${input.pageId}_sec${String(idx + 1).padStart(3, "0")}`
+      const parts: SectionPart[] = s.part_ids.map((partId) => {
+        assignedPartIds.add(partId)
+
+        // Check if this is a node ID
+        const node = findNodeById(treeNodes, partId)
+        if (node) {
+          return {
+            type: "content_node" as const,
+            nodeId: node.nodeId,
+            node,
+            isPruned: node.isPruned,
+          }
+        }
+
+        // Otherwise it's an image ID
+        const imgClass = imageClassMap.get(partId)
+        return {
+          type: "image" as const,
+          imageId: partId,
+          isPruned: false,
+          ...(imgClass?.reason ? { reason: imgClass.reason } : {}),
+        }
+      })
+
+      return {
+        sectionId,
+        sectionType: s.section_type,
+        parts,
+        backgroundColor: s.background_color,
+        textColor: s.text_color,
+        pageNumber: s.page_number,
+        isPruned: prunedSet.has(s.section_type),
+      }
+    })
+
+    // Handle image segmentation for tree path
+    handleImageSegmentation(sections, input.imageClassification.images, imageClassMap, assignedPartIds)
+
+    // Collect unassigned nodes
+    const unassignedParts: SectionPart[] = []
+    for (const node of treeNodes) {
+      if (!assignedPartIds.has(node.nodeId)) {
+        unassignedParts.push({
+          type: "content_node" as const,
+          nodeId: node.nodeId,
+          node,
+          isPruned: true,
+        })
+      }
+    }
+    for (const img of input.imageClassification.images) {
+      if (!assignedPartIds.has(img.imageId)) {
+        unassignedParts.push({
+          type: "image",
+          imageId: img.imageId,
+          isPruned: img.isPruned,
+          ...(img.reason ? { reason: img.reason } : {}),
+        })
+      }
+    }
+
+    if (unassignedParts.length > 0 && sections.length > 0) {
+      const targetSection =
+        [...sections].reverse().find((s) => !s.isPruned) ?? sections[0]
+      targetSection.parts.push(...unassignedParts)
+    }
+
+    return { reasoning: result.object.reasoning, sections }
+  }
+
+  // Legacy flat flow: expand part_ids to SectionTextPart/SectionImagePart
+  const groupMap = new Map(
+    textClassification!.groups.map((g) => [g.groupId, g])
+  )
+
   const sections = result.object.sections.map((s, idx) => {
     const sectionId = `${input.pageId}_sec${String(idx + 1).padStart(3, "0")}`
-    // Expand part_ids to full SectionPart objects
     const parts: SectionPart[] = s.part_ids.map((partId) => {
       assignedPartIds.add(partId)
 
@@ -185,50 +337,13 @@ export async function sectionPage(
     }
   })
 
-  // Build a map from segmented source image → ordered segment image IDs.
-  // Segmented images have IDs like "{sourceId}_seg{NNN}_v{N}".
-  const segmentsBySource = new Map<string, string[]>()
-  for (const img of input.imageClassification.images) {
-    const segMatch = img.imageId.match(/^(.+)_seg\d{3}_v\d+$/)
-    if (segMatch) {
-      const sourceId = segMatch[1]
-      if (!segmentsBySource.has(sourceId)) segmentsBySource.set(sourceId, [])
-      segmentsBySource.get(sourceId)!.push(img.imageId)
-    }
-  }
-
-  // Replace segmented originals in-place with their segments.
-  // This keeps segments in the same position as the original image
-  // instead of appending them to the end of the section.
-  for (const section of sections) {
-    const expandedParts: SectionPart[] = []
-    for (const part of section.parts) {
-      if (part.type === "image" && segmentsBySource.has(part.imageId)) {
-        // Replace the original (now pruned) with its segments in-place
-        const segIds = segmentsBySource.get(part.imageId)!
-        for (const segId of segIds) {
-          const segClass = imageClassMap.get(segId)
-          expandedParts.push({
-            type: "image",
-            imageId: segId,
-            isPruned: segClass?.isPruned ?? false,
-            ...(segClass?.reason ? { reason: segClass.reason } : {}),
-          })
-          assignedPartIds.add(segId)
-        }
-        // Keep the original as pruned
-        expandedParts.push({ ...part, isPruned: true, reason: "segmented" })
-      } else {
-        expandedParts.push(part)
-      }
-    }
-    section.parts = expandedParts
-  }
+  // Handle image segmentation for legacy path
+  handleImageSegmentation(sections, input.imageClassification.images, imageClassMap, assignedPartIds)
 
   // Collect unassigned parts and add them to the last non-pruned section
   const unassignedParts: SectionPart[] = []
 
-  for (const group of input.textClassification.groups) {
+  for (const group of textClassification!.groups) {
     if (!assignedPartIds.has(group.groupId)) {
       unassignedParts.push({
         type: "text_group",
@@ -268,6 +383,49 @@ export async function sectionPage(
   }
 }
 
+/**
+ * Extract segmented images and replace originals in-place within sections.
+ */
+function handleImageSegmentation(
+  sections: Array<{ parts: SectionPart[] }>,
+  allImages: Array<{ imageId: string; isPruned: boolean; reason?: string }>,
+  imageClassMap: Map<string, { imageId: string; isPruned: boolean; reason?: string }>,
+  assignedPartIds: Set<string>
+): void {
+  const segmentsBySource = new Map<string, string[]>()
+  for (const img of allImages) {
+    const segMatch = img.imageId.match(/^(.+)_seg\d{3}_v\d+$/)
+    if (segMatch) {
+      const sourceId = segMatch[1]
+      if (!segmentsBySource.has(sourceId)) segmentsBySource.set(sourceId, [])
+      segmentsBySource.get(sourceId)!.push(img.imageId)
+    }
+  }
+
+  for (const section of sections) {
+    const expandedParts: SectionPart[] = []
+    for (const part of section.parts) {
+      if (part.type === "image" && segmentsBySource.has(part.imageId)) {
+        const segIds = segmentsBySource.get(part.imageId)!
+        for (const segId of segIds) {
+          const segClass = imageClassMap.get(segId)
+          expandedParts.push({
+            type: "image",
+            imageId: segId,
+            isPruned: segClass?.isPruned ?? false,
+            ...(segClass?.reason ? { reason: segClass.reason } : {}),
+          })
+          assignedPartIds.add(segId)
+        }
+        expandedParts.push({ ...part, isPruned: true, reason: "segmented" })
+      } else {
+        expandedParts.push(part)
+      }
+    }
+    section.parts = expandedParts
+  }
+}
+
 function validatePageSectioning(
   result: unknown,
   context: Record<string, unknown>
@@ -276,12 +434,14 @@ function validatePageSectioning(
     sections: Array<{ section_type: string; part_ids: string[] }>
   }
   const sectionTypes = context.section_types as TypeDef[]
-  const groups = context.groups as Array<{ group_id: string }>
+  const groups = (context.groups as Array<{ group_id: string }>) ?? []
+  const nodes = (context.nodes as Array<{ node_id: string }>) ?? []
   const images = context.images as Array<{ image_id: string }>
 
   const sectionTypeKeys = new Set(sectionTypes.map((s) => s.key))
   const validPartIds = new Set([
     ...groups.map((g) => g.group_id),
+    ...nodes.map((n) => n.node_id),
     ...images.map((img) => img.image_id),
   ])
 

--- a/packages/pipeline/src/page-structuring.ts
+++ b/packages/pipeline/src/page-structuring.ts
@@ -138,16 +138,14 @@ function finalizePageStructuringNodes(
       const nodeId = `${pageId}_nd${String(nodeCounter).padStart(3, "0")}`
 
       const hasChildren = node.children != null && node.children.length > 0
-      const isImageContainer = node.structure === "image" && node.image_id != null
 
-      if (hasChildren || isImageContainer) {
+      if (hasChildren) {
         const container: ContentNodeData = {
           nodeId,
           structure: node.structure!,
-          children: hasChildren ? assignIds(node.children!) : [],
+          children: assignIds(node.children!),
           isPruned: false,
         }
-        if (node.image_id != null) container.imageId = node.image_id
         return container
       }
 
@@ -157,6 +155,7 @@ function finalizePageStructuringNodes(
         isPruned: prunedSet.has(node.role!),
       }
       if (node.text != null) finalized.text = node.text
+      if (node.image_id != null) finalized.imageId = node.image_id
       return finalized
     })
   }
@@ -251,11 +250,8 @@ function validatePageStructuringNodes(
       const hasStructure = node.structure != null
       const hasRole = node.role != null
 
-      // Image container: structure "image" with image_id, optionally with children
-      const isImageContainer = hasStructure && node.structure === "image" && hasImage
-
       // Detect nodes that look like failed containers — the LLM wanted to nest
-      // deeper but couldn't. Allow image containers without children.
+      // deeper but couldn't.
       if (!hasChildren && hasStructure && !hasText && !hasImage) {
         tooDeep = true
         errors.push(
@@ -264,8 +260,8 @@ function validatePageStructuringNodes(
         continue
       }
 
-      if (hasChildren || isImageContainer) {
-        // Container node: must have structure, no role. May have image_id.
+      if (hasChildren) {
+        // Container node: must have structure, no role, no image_id.
         if (!hasStructure) {
           errors.push(
             `${nodePath}: Container node (has children) is missing "structure". Set structure to one of: ${[...containerTypeKeys].join(", ")}`
@@ -280,9 +276,9 @@ function validatePageStructuringNodes(
             `${nodePath}: Container node should not have "role" — use "structure" for containers and "role" for leaves.`
           )
         }
-        if (hasImage && !imageIdSet.has(node.image_id!)) {
+        if (hasImage) {
           errors.push(
-            `${nodePath}: Invalid image_id "${node.image_id}". Must be one of: ${validImageIds.join(", ")}`
+            `${nodePath}: Container node should not have "image_id". Use an image leaf child (role: "image") inside the container instead.`
           )
         }
       } else if (hasText) {
@@ -323,7 +319,7 @@ function validatePageStructuringNodes(
       // Leaf nodes should not have both text and image
       if (hasText && hasImage) {
         errors.push(
-          `${nodePath}: Node has both text and image_id. Use an "image" container with text children instead.`
+          `${nodePath}: Node has both text and image_id. Use an "image_group" container with an image leaf child and text children instead.`
         )
       }
 

--- a/packages/pipeline/src/screenshot.ts
+++ b/packages/pipeline/src/screenshot.ts
@@ -24,11 +24,17 @@ export function getViewportBreakpoints() {
   }))
 }
 
+export interface ScreenshotOptions {
+  /** Capture the full page height (default true). When false, captures only viewport-sized region. */
+  fullPage?: boolean
+}
+
 export interface ScreenshotRenderer {
   /** Render HTML to a PNG screenshot and return it as base64. */
   screenshot(
     html: string,
-    viewport?: { width: number; height: number }
+    viewport?: { width: number; height: number },
+    options?: ScreenshotOptions
   ): Promise<string>
   /** Release browser resources. */
   close(): Promise<void>
@@ -52,15 +58,17 @@ export async function createScreenshotRenderer(): Promise<ScreenshotRenderer> {
   return {
     async screenshot(
       html: string,
-      viewport = { width: 1024, height: 768 }
+      viewport = { width: 1024, height: 768 },
+      options: ScreenshotOptions = {}
     ): Promise<string> {
+      const { fullPage = true } = options
       const context = await browser.newContext({ viewport })
       try {
         const page = await context.newPage()
         await page.setContent(html, { waitUntil: "load" })
         // Wait for web fonts to finish loading before screenshotting
         await page.waitForFunction("document.fonts.ready")
-        const buffer = await page.screenshot({ fullPage: true, type: "png" })
+        const buffer = await page.screenshot({ fullPage, type: "png" })
         return buffer.toString("base64")
       } finally {
         await context.close()
@@ -87,5 +95,5 @@ interface PlaywrightContext {
 interface PlaywrightPage {
   setContent(html: string, opts?: { waitUntil?: string }): Promise<void>
   waitForFunction(expression: string): Promise<unknown>
-  screenshot(opts?: { fullPage?: boolean; type?: string }): Promise<Buffer>
+  screenshot(opts?: { fullPage?: boolean; type?: string; clip?: { x: number; y: number; width: number; height: number } }): Promise<Buffer>
 }

--- a/packages/pipeline/src/section-thumbnail.ts
+++ b/packages/pipeline/src/section-thumbnail.ts
@@ -1,0 +1,50 @@
+import type { SectionRendering } from "@adt/types"
+import { buildScreenshotHtml } from "./screenshot-html.js"
+import type { ScreenshotRenderer } from "./screenshot.js"
+
+export interface ThumbnailViewport {
+  width: number
+  height: number
+}
+
+export const DEFAULT_THUMBNAIL_VIEWPORT: ThumbnailViewport = { width: 800, height: 1040 }
+
+export interface RenderSectionThumbnailInput {
+  section: SectionRendering
+  label: string
+  images: Map<string, { base64: string }>
+  webAssetsDir: string
+  screenshotRenderer: ScreenshotRenderer
+  language?: string
+  viewport?: ThumbnailViewport
+}
+
+/**
+ * Render a single section to a thumbnail PNG buffer.
+ * Produces a fixed-viewport screenshot (no scrolling past viewport height)
+ * so thumbnails stay small and consistent.
+ */
+export async function renderSectionThumbnail(
+  input: RenderSectionThumbnailInput
+): Promise<Buffer> {
+  const {
+    section,
+    label,
+    images,
+    webAssetsDir,
+    screenshotRenderer,
+    language,
+    viewport = DEFAULT_THUMBNAIL_VIEWPORT,
+  } = input
+
+  const html = await buildScreenshotHtml({
+    sectionHtml: section.html,
+    label,
+    images,
+    webAssetsDir,
+    language,
+  })
+
+  const base64 = await screenshotRenderer.screenshot(html, viewport, { fullPage: false })
+  return Buffer.from(base64, "base64")
+}

--- a/packages/pipeline/src/web-rendering.ts
+++ b/packages/pipeline/src/web-rendering.ts
@@ -1,5 +1,6 @@
 import {
   type PageSectioningOutput,
+  type ContentNodeData,
   type AppConfig,
   type SectionRendering,
   type WebRenderingOutput,
@@ -121,10 +122,58 @@ function expandParts(
       if (imgData) {
         parts.push({ type: "image", imageId: part.imageId, imageBase64: imgData.base64, width: imgData.width, height: imgData.height })
       }
+    } else if (part.type === "content_node") {
+      flattenContentNode(part.node, images, parts)
     }
   }
 
   return parts
+}
+
+/**
+ * Recursively flatten a ContentNodeData subtree into render-ready SectionParts.
+ * Text leaves become group parts, image leaves become image parts.
+ * Container nodes recurse into their children.
+ */
+function flattenContentNode(
+  node: ContentNodeData,
+  images: Map<string, { base64: string; width?: number; height?: number }>,
+  parts: SectionPart[]
+): void {
+  if (node.isPruned) return
+
+  // Text leaf
+  if (node.text != null && node.role) {
+    parts.push({
+      type: "group",
+      groupId: node.nodeId,
+      groupType: node.role,
+      texts: [{ textId: node.nodeId, textType: node.role, text: node.text }],
+    })
+    return
+  }
+
+  // Image leaf
+  if (node.imageId && !node.children?.length) {
+    const imgData = images.get(node.imageId)
+    if (imgData) {
+      parts.push({
+        type: "image",
+        imageId: node.imageId,
+        imageBase64: imgData.base64,
+        width: imgData.width,
+        height: imgData.height,
+      })
+    }
+    return
+  }
+
+  // Container — recurse into children
+  if (node.children) {
+    for (const child of node.children) {
+      flattenContentNode(child, images, parts)
+    }
+  }
 }
 
 /**

--- a/packages/storage/src/book-storage.ts
+++ b/packages/storage/src/book-storage.ts
@@ -12,6 +12,7 @@ export interface BookPaths {
   dbPath: string
   imagesDir: string
   debugImagesDir: string
+  thumbnailsDir: string
   videosDir: string
 }
 
@@ -27,6 +28,7 @@ export function resolveBookPaths(label: string, booksRoot: string): BookPaths {
     dbPath: path.join(bookDir, `${safeLabel}.db`),
     imagesDir: path.join(bookDir, "images"),
     debugImagesDir: path.join(bookDir, ".debug-images"),
+    thumbnailsDir: path.join(bookDir, "thumbnails"),
     videosDir: path.join(bookDir, "videos"),
   }
 }
@@ -37,6 +39,7 @@ export function createBookStorage(label: string, booksRoot: string): Storage {
   fs.mkdirSync(paths.bookDir, { recursive: true })
   fs.mkdirSync(paths.imagesDir, { recursive: true })
   fs.mkdirSync(paths.debugImagesDir, { recursive: true })
+  fs.mkdirSync(paths.thumbnailsDir, { recursive: true })
   fs.mkdirSync(paths.videosDir, { recursive: true })
 
   const db = openBookDb(paths.dbPath)
@@ -311,6 +314,24 @@ export function createBookStorage(label: string, booksRoot: string): Storage {
       clearImageFiles(paths.debugImagesDir)
     },
 
+    putSectionThumbnail(pageId: string, sectionIndex: number, data: Buffer): void {
+      const filename = buildThumbnailFilename(pageId, sectionIndex)
+      const filePath = path.join(paths.thumbnailsDir, filename)
+      fs.writeFileSync(filePath, data)
+    },
+
+    getSectionThumbnailPath(filename: string): string | null {
+      if (!/^[a-zA-Z0-9_-]+\.png$/.test(filename)) return null
+      const filePath = path.join(paths.thumbnailsDir, filename)
+      const resolved = path.resolve(filePath)
+      if (!resolved.startsWith(path.resolve(paths.thumbnailsDir) + path.sep)) return null
+      return fs.existsSync(resolved) ? resolved : null
+    },
+
+    clearSectionThumbnails(): void {
+      clearImageFiles(paths.thumbnailsDir)
+    },
+
     putSignLanguageVideo(videoId: string, buffer: Buffer, originalName: string, mimeType: string): void {
       const ext = mimeType === "video/webm" ? ".webm" : ".mp4"
       const filename = `${videoId}${ext}`
@@ -381,6 +402,11 @@ export function createBookStorage(label: string, booksRoot: string): Storage {
       db.close()
     },
   }
+}
+
+export function buildThumbnailFilename(pageId: string, sectionIndex: number): string {
+  const idx = String(sectionIndex + 1).padStart(3, "0")
+  return `${pageId}_sec${idx}.png`
 }
 
 function clearImageFiles(imagesDir: string): void {

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -2,6 +2,7 @@ export type { Storage, PageData, ImageData, NodeDataRow, CroppedImageInput, Segm
 export {
   createBookStorage,
   resolveBookPaths,
+  buildThumbnailFilename,
   type BookPaths,
 } from "./book-storage.js"
 export { openBookDb, cleanupInterruptedSteps } from "./db.js"

--- a/packages/storage/src/storage.ts
+++ b/packages/storage/src/storage.ts
@@ -94,6 +94,13 @@ export interface Storage {
   /** Clear all debug images (used when regenerating storyboard outputs). */
   clearDebugImages(): void
 
+  /** Write a section preview thumbnail PNG to disk as thumbnails/{pageId}_sec{NNN}.png. */
+  putSectionThumbnail(pageId: string, sectionIndex: number, data: Buffer): void
+  /** Resolve the filesystem path for a stored section thumbnail, or null if not present. */
+  getSectionThumbnailPath(filename: string): string | null
+  /** Delete all section preview thumbnails. */
+  clearSectionThumbnails(): void
+
   /** Add a sign language video to the book. */
   putSignLanguageVideo(videoId: string, buffer: Buffer, originalName: string, mimeType: string): void
   /** List all sign language videos. */

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -111,6 +111,7 @@ export {
   SectionTextEntry,
   SectionTextPart,
   SectionImagePart,
+  SectionContentNodePart,
   SectionPart,
   PageSection,
   PageSectioningOutput,

--- a/packages/types/src/page-sectioning.ts
+++ b/packages/types/src/page-sectioning.ts
@@ -1,4 +1,5 @@
 import { z } from "zod"
+import { ContentNode } from "./page-structuring.js"
 
 export const SectionTextEntry = z.object({
   textId: z.string(),
@@ -25,7 +26,15 @@ export const SectionImagePart = z.object({
 })
 export type SectionImagePart = z.infer<typeof SectionImagePart>
 
-export const SectionPart = z.discriminatedUnion("type", [SectionTextPart, SectionImagePart])
+export const SectionContentNodePart = z.object({
+  type: z.literal("content_node"),
+  nodeId: z.string(),
+  node: ContentNode,
+  isPruned: z.boolean(),
+})
+export type SectionContentNodePart = z.infer<typeof SectionContentNodePart>
+
+export const SectionPart = z.discriminatedUnion("type", [SectionTextPart, SectionImagePart, SectionContentNodePart])
 export type SectionPart = z.infer<typeof SectionPart>
 
 export const PageSection = z.object({

--- a/packages/types/src/page-structuring.ts
+++ b/packages/types/src/page-structuring.ts
@@ -12,7 +12,7 @@ export interface ContentNodeData {
   role?: string
   /** Text content — present on text leaf nodes only */
   text?: string
-  /** Image reference — image leaf nodes, or container background image */
+  /** Image reference — present on image leaf nodes only (role: "image") */
   imageId?: string
   /** Child nodes — present on container nodes only */
   children?: ContentNodeData[]
@@ -24,8 +24,8 @@ export interface ContentNodeData {
  *
  * Nodes are either:
  *   - Leaf (text): has `role` + `text`, no `children`
- *   - Leaf (image): has `role` + `imageId`, no `children`
- *   - Container: has `structure` + `children`, optionally `imageId` for background
+ *   - Leaf (image): has `role: "image"` + `imageId`, no `children`
+ *   - Container: has `structure` + `children`
  */
 export const ContentNode: z.ZodType<ContentNodeData> = z.lazy(() =>
   z.object({

--- a/prompts/page_sectioning.liquid
+++ b/prompts/page_sectioning.liquid
@@ -41,11 +41,13 @@ CLASSIFICATION RULES (use these to disambiguate activity types):
 - activity_other is a last resort — only use it when the learning mechanic itself is truly unique (e.g., free drawing, crafts, physical movement) and no other activity type applies.
 
 RULES:
-- ONLY use IDs that are explicitly listed below in "Text groups" and "Image" entries. Do NOT invent or generate new IDs.
+{% if nodes %}- ONLY use IDs that are explicitly listed below in "Content nodes" and "Image" entries. Do NOT invent or generate new IDs.
+{% else %}- ONLY use IDs that are explicitly listed below in "Text groups" and "Image" entries. Do NOT invent or generate new IDs.
+{% endif %}
 {% if sectioning_mode == "page" %}
-- Create EXACTLY ONE section containing ALL listed group IDs and ALL listed image IDs
+- Create EXACTLY ONE section containing ALL listed {% if nodes %}node{% else %}group{% endif %} IDs and ALL listed image IDs
 - Choose the single most appropriate section type for the page as a whole
-- ALL listed group IDs and ALL listed image IDs must be assigned to this one section
+- ALL listed {% if nodes %}node{% else %}group{% endif %} IDs and ALL listed image IDs must be assigned to this one section
 - If no image IDs are listed below, do NOT include any image IDs in part_ids
 {% elsif sectioning_mode == "dynamic" %}
 - DEFAULT: Keep all content in a SINGLE section. Prefer one section per page.
@@ -57,14 +59,14 @@ RULES:
 - NOTE: A single activity with many questions (e.g., one set of fill-in-the-blank sentences under shared instructions) stays as ONE section. But two separate activities with their own instructions are separate sections, even if both are the same type.
 - When splitting multiple-choice or true/false questions: put any shared header, instructions, or passage text into the FIRST section, then give each question its own section. Include the question prompt and its answer choices together in each section.
 - When splitting: group consecutive content that belongs to the same activity together.
-- IMPORTANT: When splitting, do NOT pre-label activity types in your reasoning. First decide WHICH groups belong together, then apply the CLASSIFICATION RULES (including the 3-step count) to each section individually. The reasoning must show the per-section analysis with item counts.
-- ALL listed group IDs must be assigned to at least one section
+- IMPORTANT: When splitting, do NOT pre-label activity types in your reasoning. First decide WHICH {% if nodes %}nodes{% else %}groups{% endif %} belong together, then apply the CLASSIFICATION RULES (including the 3-step count) to each section individually. The reasoning must show the per-section analysis with item counts.
+- ALL listed {% if nodes %}node{% else %}group{% endif %} IDs must be assigned to at least one section
 - ALL listed image IDs must be assigned to at least one section — assign each image to the section it visually belongs to
-- Group/image IDs may appear in multiple sections only when it makes strong pedagogical sense (e.g. shared instructions)
+- {% if nodes %}Node{% else %}Group{% endif %}/image IDs may appear in multiple sections only when it makes strong pedagogical sense (e.g. shared instructions)
 {% else %}
-- ALL listed group IDs must be assigned to at least one section
+- ALL listed {% if nodes %}node{% else %}group{% endif %} IDs must be assigned to at least one section
 - ALL listed image IDs must be assigned to at least one section — assign each image to the section it visually belongs to
-- Group/image IDs may appear in multiple sections only when it makes strong pedagogical sense (e.g. shared instructions)
+- {% if nodes %}Node{% else %}Group{% endif %}/image IDs may appear in multiple sections only when it makes strong pedagogical sense (e.g. shared instructions)
 - Keep related content together — prefer fewer, more comprehensive sections over many small ones
 {% endif %}
 - Extract page number if visible (headers, footers, margins). Use null if none found
@@ -81,10 +83,17 @@ Image {{ image.image_id }}:
 {% image image.imageBase64 %}
 {% endfor %}
 
+{% if nodes %}
+Content nodes:
+{% for node in nodes %}
+- {{ node.node_id }} ({{ node.node_type }}): {{ node.text }}
+{% endfor %}
+{% else %}
 Text groups:
 {% for group in groups %}
 - {{ group.group_id }} ({{ group.group_type }}): {{ group.text }}
 {% endfor %}
+{% endif %}
 
 {% if sectioning_mode == "page" %}
 Please place ALL content into a single section.

--- a/prompts/page_structuring.liquid
+++ b/prompts/page_structuring.liquid
@@ -7,20 +7,22 @@ Your task is to produce a **tree structure** that captures the semantic hierarch
 
 Every node has either `structure` (for containers) or `role` (for leaves), never both.
 
-**Container nodes** — have `structure` and `children`, never `text`. May include `image_id` to associate an image with the container:
+**Container nodes** — have `structure` and `children`, never `text` or `image_id`:
 {% for t in container_types %}- {{ t.key }}: {{ t.description }}
 {% endfor %}
 **Text leaf nodes** — have `role` and `text`, never `children` or `image_id`:
 {% for t in text_types %}- {{ t.key }}: {{ t.description }}
 {% endfor %}
+**Image leaf nodes** — have `role: "image"` and `image_id`, never `children` or `text`.
+
 ## Tree Structure Rules
 
-1. **Containers vs leaves**: Container nodes group related content using `structure` and MUST have `children` (except `image` containers, which may be childless for standalone images). Leaf nodes hold actual content using `role` and MUST NOT have `children`.
+1. **Containers vs leaves**: Container nodes group related content using `structure` and MUST have `children`. Leaf nodes hold actual content using `role` and MUST NOT have `children`.
 2. **Nesting depth**: Use as many levels as needed to capture the document's logical hierarchy. A simple page might be flat; a complex page with sidebars and nested activities could be deeply nested.
 3. **Reading order**: Children within a container must follow left-to-right, top-to-bottom reading order, respecting column layouts.
-4. **Images**: Use an "image" container with `image_id` set on it.{% if image_ids.size > 0 %} Available image IDs: {% for id in image_ids %}{{ id }}{% unless forloop.last %}, {% endunless %}{% endfor %}.{% endif %} A standalone image has no children. An image with a caption, label, or embedded text has those as children.
-5. **Background images**: When a page has a full-bleed or background image behind content, set `image_id` directly on a non-image container (e.g., "group", "sidebar"). This keeps the background separate from the reading flow.
-6. **Text within images**: When text is visually layered on, overlaid on, or contained within an image (speech bubbles, signs, posters, annotations, labels on diagrams, title text over illustrations, text banners over photos), that text MUST be placed as children of the "image" container — never as siblings outside it. If you see text sitting on top of an image in the page, it belongs inside that image's container.
+4. **Images**: Images are always leaf nodes with `role: "image"` and `image_id`.{% if image_ids.size > 0 %} Available image IDs: {% for id in image_ids %}{{ id }}{% unless forloop.last %}, {% endunless %}{% endfor %}.{% endif %} A standalone image is a leaf node on its own. An image with a caption, label, or associated text should be wrapped in an `image_group` container, with the image leaf and text leaves as siblings.
+5. **Background images**: When a page has a full-bleed or background image behind content, wrap all the content in an `image_group` container with the background image as the first child (a leaf with `role: "image"`) and the overlaid content as subsequent children.
+6. **Text within images**: When text is visually layered on, overlaid on, or contained within an image (speech bubbles, signs, posters, annotations, labels on diagrams, title text over illustrations, text banners over photos), that text MUST be placed as siblings of the image leaf inside an `image_group` container — never outside the container. If you see text sitting on top of an image in the page, it belongs inside the same `image_group`.
 7. **Every text must be captured**: ALL of the provided page text MUST appear in your output — every line, every fragment. If text is in the input, it must be in a leaf node. Do not summarize, skip, or omit any text. This includes text embedded inside illustrations, posters, and diagrams.
 8. **Visual separators**: Ignore lines of dashes, asterisks, underscores, or similar characters used purely as visual dividers or section breaks (e.g., `---`, `***`, `_ _ _`). These are decorative and should not appear as text nodes.
 
@@ -36,7 +38,7 @@ Every node has either `structure` (for containers) or `role` (for leaves), never
 8. When an activity number or letter is detected (e.g., 1, 2, A, B), it should be a child of an "activity" container along with the activity's other content.
 9. For data tables, use a "table" container with "table_row" children. Each row contains "table_cell" children, and each cell contains leaf nodes for its content.
 10. Preserve original spelling and punctuation exactly as shown.
-11. If the page is blank or contains only images with no text, use "image" containers (or return an empty nodes array).
+11. If the page is blank or contains only images with no text, use image leaf nodes with `role: "image"` (or return an empty nodes array).
 12. Use the extracted text as a reference but trust the image as the primary source — correct OCR errors when the image clearly shows different text.
 13. For fill-in-the-blank activities: when a word appears as a placeholder (dotted, underlined, inside blanks), wrap it as `[placeholder:word]`. Only do this when visually styled as a fill-in blank on the page image.
 
@@ -57,9 +59,9 @@ For a page with a heading, two paragraphs, an image with caption, and a sidebar:
       ]
     },
     {
-      "structure": "image",
-      "image_id": "pg003_im001",
+      "structure": "image_group",
       "children": [
+        { "role": "image", "image_id": "pg003_im001" },
         { "role": "caption", "text": "Figure 3.1: The stages of the water cycle" }
       ]
     },


### PR DESCRIPTION
## Summary

- Extend `page-sectioning` to consume the recursive content tree from `page-structuring` via a new `SectionContentNodePart` variant; stage-runner detects tree-vs-flat data and routes accordingly, and `web-rendering`'s `expandParts` flattens subtrees.
- Replace the extract stage's legacy detail view with the shared `ContentNodeBlock` tree UI (drag/drop restructure, inline text editing, role/structure pills) and unify storyboard overview + per-section editing into one all-pages view.
- Capture fixed-viewport PNG section thumbnails during every render/re-render using a shared Playwright `ScreenshotRenderer`; serve via new `GET /books/:label/thumbnails/:filename` and swap the scaled-iframe previews in `SectioningOverview` and `ContentEditor` for `<img>` tags.
- Misc: storage gains `thumbnails/` dir + helpers, new Lingui strings extracted and translated to es / pt-BR, prompt updates for tree node summaries.

## Test plan

- [ ] `pnpm typecheck` passes
- [ ] Run storyboard on a book with tree-based structuring and verify sections render with `content_node` parts
- [ ] Verify thumbnails appear in the overview and content editor after render, and refresh after re-render
- [ ] Drag/drop content across sections, save, and confirm re-render reflects the new structure
- [ ] Confirm older flat text-classification books still section + render (backward compat)