### PR TITLE
Require editable inputs in writable activity sections

### DIFF
--- a/apps/api/src/routes/adt-preview.ts
+++ b/apps/api/src/routes/adt-preview.ts
@@ -64,6 +64,28 @@ function getMimeType(filePath: string): string {
   return MIME_TYPES[path.extname(filePath).toLowerCase()] ?? "application/octet-stream"
 }
 
+/** Highest mtime across base.js + everything under modules/ — used to detect
+ *  when the pre-built bundle is out of date relative to its sources. */
+function maxSourceMtime(webAssetsDir: string): number {
+  let max = 0
+  const baseJs = path.join(webAssetsDir, "base.js")
+  if (fs.existsSync(baseJs)) max = Math.max(max, fs.statSync(baseJs).mtimeMs)
+  const modulesDir = path.join(webAssetsDir, "modules")
+  if (!fs.existsSync(modulesDir)) return max
+  const walk = (dir: string) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name)
+      if (entry.isDirectory()) walk(full)
+      else if (entry.isFile()) {
+        const m = fs.statSync(full).mtimeMs
+        if (m > max) max = m
+      }
+    }
+  }
+  walk(modulesDir)
+  return max
+}
+
 // ---------------------------------------------------------------------------
 // Caches (built lazily per book)
 // ---------------------------------------------------------------------------
@@ -443,21 +465,28 @@ export function createAdtPreviewRoutes(
       throw new HTTPException(403, { message: "Forbidden" })
     }
 
-    // Auto-build base.bundle.min.js on-the-fly if it doesn't exist (dev mode).
-    // The file is gitignored and normally pre-built by `pnpm --filter @adt/api bundle`.
-    if (!fs.existsSync(resolved) && assetPath === "base.bundle.min.js") {
+    // Auto-build base.bundle.min.js on-the-fly if it's missing OR stale relative
+    // to its source modules (dev mode). The file is gitignored and normally
+    // pre-built by `pnpm --filter @adt/api bundle`. Skip in packaged mode
+    // (ADT_RESOURCES_ZIP) where esbuild isn't available inside the pkg'd binary.
+    if (assetPath === "base.bundle.min.js" && !process.env.ADT_RESOURCES_ZIP) {
       const entryPoint = path.join(webAssetsDir, "base.js")
       if (fs.existsSync(entryPoint)) {
-        const esbuild = await import("esbuild")
-        await esbuild.build({
-          entryPoints: [entryPoint],
-          bundle: true,
-          minify: true,
-          sourcemap: true,
-          format: "esm",
-          target: "es2020",
-          outfile: resolved,
-        })
+        const bundleMtime = fs.existsSync(resolved) ? fs.statSync(resolved).mtimeMs : 0
+        const isStale =
+          bundleMtime === 0 || maxSourceMtime(webAssetsDir) > bundleMtime
+        if (isStale) {
+          const esbuild = await import("esbuild")
+          await esbuild.build({
+            entryPoints: [entryPoint],
+            bundle: true,
+            minify: true,
+            sourcemap: true,
+            format: "esm",
+            target: "es2020",
+            outfile: resolved,
+          })
+        }
       }
     }
 

--- a/assets/adt/modules/activities/fill_in_the_blank.js
+++ b/assets/adt/modules/activities/fill_in_the_blank.js
@@ -37,7 +37,7 @@ export const hydrateFitbSentences = (container) => {
 
             const hydratedHtml = html.replace(
                 /\[\[blank:item-(\d+)(?::([^\]]+))?\]\]/g,
-                (_match, itemNum, hint) => {
+                (match, itemNum, hint, offset, source) => {
                     ariaCounter++;
                     const placeholderAttr = hint
                         ? ` placeholder="${hint.replace(/"/g, '&quot;')}"`
@@ -49,13 +49,49 @@ export const hydrateFitbSentences = (container) => {
                     const label = blankLabel.startsWith('fitb-')
                         ? (totalBlanks > 1 ? `Blank ${ariaCounter} of ${totalBlanks}` : 'Blank')
                         : blankLabel;
-                    // Size the input to roughly fit the expected answer.
-                    // Use the hint length when available, otherwise a sensible default.
-                    const charWidth = hint ? Math.max(hint.length + 2, 6) : 8;
+                    // Detect word-internal blanks — the marker sits INSIDE a word rather
+                    // than between words (e.g. "en[[blank:item-1]]ro" for a missing-letter
+                    // exercise). Used for tighter spacing, and as a fallback for sizing
+                    // when no answer is available yet (e.g. preview before answers gen).
+                    const WORD_CHAR = /\p{L}/u;
+                    const prevChar = source[offset - 1] || '';
+                    const nextChar = source[offset + match.length] || '';
+                    const isWordInternal =
+                        !hint && (WORD_CHAR.test(prevChar) || WORD_CHAR.test(nextChar));
+                    // Look up the correct answer for this blank (injected as a global by
+                    // package-web). Pipe-separated alternatives use the longest variant so
+                    // every acceptable answer fits. Size to answer length + 1 for safety.
+                    const answer = typeof window !== 'undefined'
+                        ? window.correctAnswers?.[`item-${itemNum}`]
+                        : undefined;
+                    const answerLength = typeof answer === 'string' && answer.length > 0
+                        ? answer.split('|').reduce((max, a) => Math.max(max, a.length), 0)
+                        : 0;
+                    // Size priority:
+                    //   1. Explicit hint in the marker (`[[blank:item-N:hint]]`) — hint IS the answer shape
+                    //   2. Known answer from window.correctAnswers — size to answer length + 1
+                    //   3. Word-internal heuristic — narrow single-letter slot
+                    //   4. Fallback — default word-sized slot
+                    let charWidth;
+                    let minWidth;
+                    if (hint) {
+                        charWidth = Math.max(hint.length + 2, 6);
+                        minWidth = '4ch';
+                    } else if (answerLength > 0) {
+                        charWidth = Math.max(answerLength + 1, 2);
+                        minWidth = answerLength <= 2 ? '1.5ch' : '4ch';
+                    } else if (isWordInternal) {
+                        charWidth = 2;
+                        minWidth = '1.5ch';
+                    } else {
+                        charWidth = 8;
+                        minWidth = '4ch';
+                    }
+                    const spacingClasses = isWordInternal ? 'mx-px' : 'mx-1';
                     return `<input type="text" `
                         + `id="fitb-input-${itemNum}" `
-                        + `class="fitb-inline-input inline-block mx-1 px-1 py-0.5 border-b-2 border-gray-400 bg-transparent text-center focus:border-blue-500 focus:outline-none" `
-                        + `style="width: ${charWidth}ch; min-width: 4ch; max-width: 100%;" `
+                        + `class="fitb-inline-input inline-block ${spacingClasses} px-1 py-0.5 border-b-2 border-gray-400 bg-transparent text-center focus:border-blue-500 focus:outline-none" `
+                        + `style="width: ${charWidth}ch; min-width: ${minWidth}; max-width: 100%;" `
                         + `aria-label="${label.replace(/"/g, '&quot;')}" `
                         + `aria-invalid="false" `
                         + `autocomplete="off" `

--- a/assets/adt/tailwind_css.css
+++ b/assets/adt/tailwind_css.css
@@ -1,3 +1,17 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/*
+ * Ruled-paper styling for open-ended-answer textareas.
+ * The fixed line-height is required so the dotted background lines up
+ * with each row of typed text; without it, text would drift off the lines.
+ */
+section[data-section-type="activity_open_ended_answer"] textarea {
+    line-height: 1.75rem;
+    background-image: radial-gradient(circle, #d1d5db 1px, transparent 1.5px);
+    background-size: 6px 1.75rem;
+    background-position: 0 0.875rem;
+    background-repeat: repeat;
+    background-attachment: local;
+}

--- a/packages/pipeline/src/__tests__/validate-html.test.ts
+++ b/packages/pipeline/src/__tests__/validate-html.test.ts
@@ -915,6 +915,85 @@ describe("validateSectionHtml", () => {
     expect(result.valid).toBe(true)
   })
 
+  it("accepts inline letter blanks: single-word source with single underscores replaced by markers", () => {
+    const html = `
+      <section>
+        <span class="fitb-sentence" data-id="tx001">en[[blank:item-1]]ro</span>
+      </section>
+    `
+    const expectedTexts = new Map([["tx001", "en_ro"]])
+    const result = validateSectionHtml(
+      html,
+      ["tx001"],
+      [],
+      undefined,
+      { expectedTexts }
+    )
+    expect(result.valid).toBe(true)
+    expect(result.errors).toHaveLength(0)
+    expect(result.sectionHtml).toContain("[[blank:item-1]]")
+  })
+
+  it("accepts inline letter blanks with multiple underscores in a single word", () => {
+    const html = `
+      <section>
+        <span class="fitb-sentence" data-id="tx001">[[blank:item-1]]eptiembr[[blank:item-2]]</span>
+      </section>
+    `
+    const expectedTexts = new Map([["tx001", "_eptiembr_"]])
+    const result = validateSectionHtml(
+      html,
+      ["tx001"],
+      [],
+      undefined,
+      { expectedTexts }
+    )
+    expect(result.valid).toBe(true)
+    expect(result.errors).toHaveLength(0)
+  })
+
+  it("strips orphan separator runs left behind after removing date-style blank runs", () => {
+    const html = `
+      <section>
+        <label data-id="tx001">Fecha de nacimiento:</label>
+      </section>
+    `
+    const expectedTexts = new Map([
+      ["tx001", "Fecha de nacimiento: ___/___/___"],
+    ])
+    const result = validateSectionHtml(
+      html,
+      ["tx001"],
+      [],
+      undefined,
+      { expectedTexts }
+    )
+    expect(result.valid).toBe(true)
+    expect(result.errors).toHaveLength(0)
+    expect(result.sectionHtml).toContain("Fecha de nacimiento:")
+    expect(result.sectionHtml).not.toContain("//")
+  })
+
+  it("strips orphan separator runs with whitespace between the blanks", () => {
+    const html = `
+      <section>
+        <label data-id="tx001">Tel&#xe9;fono:</label>
+      </section>
+    `
+    const expectedTexts = new Map([
+      ["tx001", "Teléfono: ___ - ___ - ___"],
+    ])
+    const result = validateSectionHtml(
+      html,
+      ["tx001"],
+      [],
+      undefined,
+      { expectedTexts }
+    )
+    expect(result.valid).toBe(true)
+    expect(result.sectionHtml).not.toMatch(/-\s*-/)
+  })
+
   it("does not substitute expected text on image data-ids", () => {
     const html = `
       <section>

--- a/packages/pipeline/src/__tests__/validate-html.test.ts
+++ b/packages/pipeline/src/__tests__/validate-html.test.ts
@@ -1066,3 +1066,291 @@ describe("textSimilarity", () => {
     expect(textSimilarity("abc", "xyz")).toBe(0.0)
   })
 })
+
+describe("writable section types require editable inputs", () => {
+  it("fails activity_open_ended_answer with no textarea/input/blank marker", () => {
+    const html = `
+      <section data-section-type="activity_open_ended_answer" data-section-id="pg001_section">
+        <p data-id="pg001_gp001">Write your answer below:</p>
+        <hr class="border-b border-gray-400" />
+        <hr class="border-b border-gray-400" />
+      </section>
+    `
+    const result = validateSectionHtml(html, ["pg001_gp001"], [])
+    expect(result.valid).toBe(false)
+    expect(result.errors).toContainEqual(
+      expect.stringContaining(
+        'Section type "activity_open_ended_answer" requires at least one editable element'
+      )
+    )
+  })
+
+  it("passes activity_open_ended_answer when a <textarea> is present", () => {
+    const html = `
+      <section data-section-type="activity_open_ended_answer" data-section-id="pg001_section">
+        <p data-id="pg001_gp001">Write your answer below:</p>
+        <textarea class="w-full" aria-label="answer"></textarea>
+      </section>
+    `
+    const result = validateSectionHtml(html, ["pg001_gp001"], [])
+    expect(result.valid).toBe(true)
+  })
+
+  it("passes activity_fill_in_the_blank when a [[blank:item-N]] marker is present", () => {
+    const html = `
+      <section data-section-type="activity_fill_in_the_blank" data-section-id="pg001_section">
+        <p class="fitb-sentence" data-id="pg001_gp001">The capital of France is [[blank:item-1]].</p>
+      </section>
+    `
+    const result = validateSectionHtml(
+      html,
+      ["pg001_gp001"],
+      [],
+      undefined,
+      {
+        expectedTexts: new Map([
+          ["pg001_gp001", "The capital of France is ___."],
+        ]),
+      }
+    )
+    expect(result.valid).toBe(true)
+  })
+
+  it("fails activity_fill_in_a_table when no <input> elements are present", () => {
+    const html = `
+      <section data-section-type="activity_fill_in_a_table" data-section-id="pg001_section">
+        <table>
+          <tr>
+            <td data-id="pg001_gp001">Name</td>
+            <td><div class="border-b"></div></td>
+          </tr>
+        </table>
+      </section>
+    `
+    const result = validateSectionHtml(html, ["pg001_gp001"], [])
+    expect(result.valid).toBe(false)
+    expect(result.errors).toContainEqual(
+      expect.stringContaining(
+        'Section type "activity_fill_in_a_table" requires at least one editable element'
+      )
+    )
+  })
+
+  it("does not require editable elements for non-writable section types", () => {
+    const html = `
+      <section data-section-type="text_only" data-section-id="pg001_section">
+        <p data-id="pg001_gp001">Just some prose.</p>
+      </section>
+    `
+    const result = validateSectionHtml(html, ["pg001_gp001"], [])
+    expect(result.valid).toBe(true)
+  })
+})
+
+describe("textbook blank placeholders may be omitted when editable element is provided", () => {
+  it("accepts label text with underscores stripped when a <textarea> is added next to it", () => {
+    const html = `
+      <section data-section-type="activity_open_ended_answer" data-section-id="pg010_section">
+        <div>
+          <p data-id="pg010_gp001_tx001">Nombre:</p>
+          <textarea aria-label="nombre"></textarea>
+        </div>
+      </section>
+    `
+    const result = validateSectionHtml(
+      html,
+      ["pg010_gp001_tx001"],
+      [],
+      undefined,
+      {
+        expectedTexts: new Map([["pg010_gp001_tx001", "Nombre: ___"]]),
+      }
+    )
+    expect(result.valid).toBe(true)
+    expect(result.errors).toEqual([])
+  })
+
+  it("accepts label with multiple stripped underscore runs (e.g. dates)", () => {
+    const html = `
+      <section data-section-type="activity_open_ended_answer" data-section-id="pg011_section">
+        <div>
+          <p data-id="pg011_gp002_tx003">Fecha de nacimiento:</p>
+          <textarea aria-label="fecha"></textarea>
+        </div>
+      </section>
+    `
+    const result = validateSectionHtml(
+      html,
+      ["pg011_gp002_tx003"],
+      [],
+      undefined,
+      {
+        expectedTexts: new Map([
+          ["pg011_gp002_tx003", "Fecha de nacimiento: ___ / ___ / ___"],
+        ]),
+      }
+    )
+    expect(result.valid).toBe(true)
+    expect(result.errors).toEqual([])
+  })
+
+  it("preserves the rendered (stripped) text when underscores were dropped", () => {
+    const html = `
+      <section data-section-type="activity_open_ended_answer" data-section-id="pg010_section">
+        <p data-id="pg010_gp009_tx003">¡Soy !</p>
+        <textarea aria-label="soy"></textarea>
+      </section>
+    `
+    const result = validateSectionHtml(
+      html,
+      ["pg010_gp009_tx003"],
+      [],
+      undefined,
+      {
+        expectedTexts: new Map([["pg010_gp009_tx003", "¡Soy ___ !"]]),
+      }
+    )
+    expect(result.valid).toBe(true)
+    // Rendered HTML should keep the stripped version, not put the underscores back.
+    expect(result.sectionHtml).not.toContain("___")
+  })
+
+  it("still rejects truly different text even with underscore stripping", () => {
+    const html = `
+      <section data-section-type="activity_open_ended_answer" data-section-id="pg010_section">
+        <p data-id="pg010_gp001_tx001">Completely unrelated text here</p>
+        <textarea aria-label="x"></textarea>
+      </section>
+    `
+    const result = validateSectionHtml(
+      html,
+      ["pg010_gp001_tx001"],
+      [],
+      undefined,
+      {
+        expectedTexts: new Map([["pg010_gp001_tx001", "Nombre: ___"]]),
+      }
+    )
+    expect(result.valid).toBe(false)
+    expect(result.errors).toContainEqual(
+      expect.stringContaining('Text mismatch for data-id "pg010_gp001_tx001"')
+    )
+  })
+})
+
+describe("hasEditableElement — input type filtering", () => {
+  it("does not count <input type=\"radio\"> as a writable input", () => {
+    const html = `
+      <section data-section-type="activity_open_ended_answer" data-section-id="pg001_section">
+        <p data-id="pg001_gp001">Question?</p>
+        <input type="radio" value="a" />
+        <input type="radio" value="b" />
+      </section>
+    `
+    const result = validateSectionHtml(html, ["pg001_gp001"], [])
+    expect(result.valid).toBe(false)
+    expect(result.errors).toContainEqual(
+      expect.stringContaining(
+        'Section type "activity_open_ended_answer" requires at least one editable element'
+      )
+    )
+  })
+
+  it("does not count <input type=\"checkbox\">, \"submit\", \"hidden\" as writable", () => {
+    const html = `
+      <section data-section-type="activity_fill_in_the_blank" data-section-id="pg001_section">
+        <p data-id="pg001_gp001">Label</p>
+        <input type="checkbox" />
+        <input type="submit" value="Go" />
+        <input type="hidden" name="x" value="1" />
+      </section>
+    `
+    const result = validateSectionHtml(html, ["pg001_gp001"], [])
+    expect(result.valid).toBe(false)
+    expect(result.errors).toContainEqual(
+      expect.stringContaining(
+        'Section type "activity_fill_in_the_blank" requires at least one editable element'
+      )
+    )
+  })
+
+  it("counts <input> with no type attribute as writable (defaults to text)", () => {
+    const html = `
+      <section data-section-type="activity_fill_in_the_blank" data-section-id="pg001_section">
+        <p data-id="pg001_gp001">Name:</p>
+        <input data-activity-item="item-1" aria-label="name" />
+      </section>
+    `
+    const result = validateSectionHtml(html, ["pg001_gp001"], [])
+    expect(result.valid).toBe(true)
+  })
+
+  it("counts <input type=\"text\"> as writable", () => {
+    const html = `
+      <section data-section-type="activity_fill_in_the_blank" data-section-id="pg001_section">
+        <p data-id="pg001_gp001">Name:</p>
+        <input type="text" data-activity-item="item-1" aria-label="name" />
+      </section>
+    `
+    const result = validateSectionHtml(html, ["pg001_gp001"], [])
+    expect(result.valid).toBe(true)
+  })
+
+  it("ignores [[blank:item-N]] markers inside <style> blocks", () => {
+    const html = `
+      <section data-section-type="activity_fill_in_the_blank" data-section-id="pg001_section">
+        <style>/* [[blank:item-1]] */</style>
+        <p data-id="pg001_gp001">Label</p>
+      </section>
+    `
+    const result = validateSectionHtml(html, ["pg001_gp001"], [])
+    expect(result.valid).toBe(false)
+    expect(result.errors).toContainEqual(
+      expect.stringContaining(
+        'Section type "activity_fill_in_the_blank" requires at least one editable element'
+      )
+    )
+  })
+})
+
+describe("text replacement preserves nested editables", () => {
+  it("does not destroy a <textarea> nested inside a data-id element", () => {
+    const html = `
+      <section data-section-type="activity_open_ended_answer" data-section-id="pg001_section">
+        <p data-id="pg001_gp001">La capital es <textarea aria-label="capital"></textarea></p>
+      </section>
+    `
+    const result = validateSectionHtml(
+      html,
+      ["pg001_gp001"],
+      [],
+      undefined,
+      {
+        expectedTexts: new Map([["pg001_gp001", "La capital es ___"]]),
+      }
+    )
+    expect(result.valid).toBe(true)
+    // The nested textarea must survive — otherwise the page renders as
+    // static text and the learner can no longer write an answer.
+    expect(result.sectionHtml).toContain("<textarea")
+  })
+
+  it("does not destroy a nested <input> writable element", () => {
+    const html = `
+      <section data-section-type="activity_fill_in_the_blank" data-section-id="pg001_section">
+        <p data-id="pg001_gp001">Nombre: <input type="text" data-activity-item="item-1" aria-label="nombre" /></p>
+      </section>
+    `
+    const result = validateSectionHtml(
+      html,
+      ["pg001_gp001"],
+      [],
+      undefined,
+      {
+        expectedTexts: new Map([["pg001_gp001", "Nombre: ___"]]),
+      }
+    )
+    expect(result.valid).toBe(true)
+    expect(result.sectionHtml).toContain("<input")
+  })
+})

--- a/packages/pipeline/src/validate-html.ts
+++ b/packages/pipeline/src/validate-html.ts
@@ -347,9 +347,16 @@ function walkNode(
             `Element with data-id "${dataId}" contains [[blank:item-N]] markers but is missing the "fitb-sentence" class (required on the element or an ancestor for runtime hydration)`
           )
         }
-        // Compare without the blank markers in actual and underscore/dot/placeholder markers in expected
+        // Compare without the blank markers in actual and underscore/dot/placeholder markers in expected.
+        // Also strip single `_` chars from the expected so inline letter blanks (e.g. source text `"en_ro"`
+        // rendered as `"en[[blank:item-1]]ro"`) match without the underscore throwing off similarity.
         const strippedActual = normalizeText(actualText.replace(BLANK_MARKER_RE, ""))
-        const strippedExpected = normalizeText(expectedText.replace(TEXTBOOK_BLANK_RE, "").replace(PLACEHOLDER_MARKER_RE, ""))
+        const strippedExpected = normalizeText(
+          expectedText
+            .replace(TEXTBOOK_BLANK_RE, "")
+            .replace(PLACEHOLDER_MARKER_RE, "")
+            .replace(/_/g, "")
+        )
         if (strippedActual !== strippedExpected) {
           const similarity = textSimilarity(strippedActual, strippedExpected)
           if (similarity < TEXT_SIMILARITY_THRESHOLD) {
@@ -509,14 +516,25 @@ function normalizeText(text: string): string {
  * left behind. Used when the LLM has correctly replaced a visual blank with
  * an editable element (textarea or input) and the surrounding label text
  * therefore omits the placeholder.
+ *
+ * Also collapses orphan separator runs left behind when a split field like
+ * `___/___/___` (date) or `___-___-___` (phone) is stripped — those slashes
+ * and dashes belong between inputs, not in the label text.
  */
 function stripBlankPlaceholders(text: string): string {
   return text
     .replace(TEXTBOOK_BLANK_RE, "")
     .replace(PLACEHOLDER_MARKER_RE, "")
+    .replace(ORPHAN_SEPARATOR_RUN_RE, "")
     .replace(/\s+/g, " ")
     .trim()
 }
+
+// Matches 2+ separator characters (/ or -) separated only by whitespace —
+// the kind of leftover you get after stripping placeholder runs from
+// "___/___/___". Real data like "2024/01/15" has alphanumerics between the
+// separators, so it won't match.
+const ORPHAN_SEPARATOR_RUN_RE = /([/\-])(\s*[/\-])+/g
 
 function repairMalformedHtmlEntities(html: string): string {
   let repaired = html

--- a/packages/pipeline/src/validate-html.ts
+++ b/packages/pipeline/src/validate-html.ts
@@ -16,6 +16,29 @@ const EXEMPT_TAGS = new Set(["style", "script"])
 const BLANK_MARKER_RE = /\[\[blank:item-\d+(?::[^\]]+)?\]\]/g
 /** Non-global version for .test() checks (avoids stateful lastIndex issues) */
 const BLANK_MARKER_TEST_RE = /\[\[blank:item-\d+(?::[^\]]+)?\]\]/
+/** Section types whose rendered HTML must contain at least one editable element. */
+const WRITABLE_SECTION_TYPES = new Set([
+  "activity_open_ended_answer",
+  "activity_fill_in_the_blank",
+  "activity_fill_in_a_table",
+])
+/**
+ * Input `type` values that are NOT writable (radio/checkbox/submit/etc.).
+ * An <input> is only counted as an editable element if its type is absent or
+ * is not in this set. A missing type defaults to "text" per the HTML spec.
+ */
+const NON_WRITABLE_INPUT_TYPES = new Set([
+  "radio",
+  "checkbox",
+  "hidden",
+  "submit",
+  "button",
+  "reset",
+  "image",
+  "file",
+  "range",
+  "color",
+])
 /** Matches placeholder sequences used in textbooks for blanks (3+ underscores or 3+ dots) */
 const TEXTBOOK_BLANK_RE = /_{3,}|\.{3,}/g
 /** Matches [placeholder:word] markers added during text classification */
@@ -98,6 +121,21 @@ export function validateSectionHtml(
 
   walkNode(section, allowedIds, imageIdSet, errors, options)
 
+  // Sections whose whole purpose is for the learner to write must contain
+  // at least one editable element. If the LLM emits only static underlines
+  // (decorative borders, <hr>s, runs of underscores), the page looks right
+  // but is unusable — fail loudly so the renderer retries.
+  const sectionType = section.attribs?.["data-section-type"]
+  if (
+    typeof sectionType === "string" &&
+    WRITABLE_SECTION_TYPES.has(sectionType) &&
+    !hasEditableElement(section)
+  ) {
+    errors.push(
+      `Section type "${sectionType}" requires at least one editable element (<textarea>, <input>, or [[blank:item-N]] marker), but none were found. The learner cannot type into this page.`
+    )
+  }
+
   // Verify all expected text IDs are present in the generated HTML.
   // This ensures the LLM doesn't silently drop entries (e.g. duplicated texts).
   if (allowedTextIds.length > 0) {
@@ -158,6 +196,48 @@ function validateRequiredSectionAttributes(
       )
     }
   }
+}
+
+/**
+ * True if the node is a writable input element: a <textarea>, or an <input>
+ * whose type is absent or is a text-accepting type (not radio/checkbox/etc.).
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function isWritableInput(node: any): boolean {
+  if (node.type !== "tag") return false
+  const tagName = (node.name ?? "").toLowerCase()
+  if (tagName === "textarea") return true
+  if (tagName !== "input") return false
+  const inputType = (node.attribs?.type ?? "text").toLowerCase()
+  return !NON_WRITABLE_INPUT_TYPES.has(inputType)
+}
+
+/**
+ * Walk the subtree and report whether any editable element is present: a
+ * writable <input>/<textarea>, or text containing a [[blank:item-N]] marker
+ * (which gets hydrated into an <input> at runtime). Skips <script>/<style>
+ * subtrees so markers appearing inside them don't falsely satisfy the check.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function hasEditableElement(node: any): boolean {
+  // htmlparser2 uses dedicated node types for <script>/<style>; these are
+  // never writable and their text content is not rendered as HTML, so any
+  // marker inside them must be ignored.
+  if (node.type === "script" || node.type === "style") return false
+  if (node.type === "tag") {
+    const tagName = (node.name ?? "").toLowerCase()
+    if (tagName === "script" || tagName === "style") return false
+    if (isWritableInput(node)) return true
+  }
+  if (node.type === "text" && typeof node.data === "string") {
+    if (BLANK_MARKER_TEST_RE.test(node.data)) return true
+  }
+  if (node.children) {
+    for (const child of node.children) {
+      if (hasEditableElement(child)) return true
+    }
+  }
+  return false
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -279,12 +359,25 @@ function walkNode(
         }
         // Do NOT set replacementText — preserve the blank markers in the HTML
       } else {
-        replacementText = options.expectedTexts.get(dataId)!
-        if (actualText !== expectedText) {
-          const similarity = textSimilarity(actualText, expectedText)
+        // The LLM is permitted to omit textbook-style blank placeholders
+        // (___ or ...) from the rendered text when it emits a separate
+        // editable element (e.g. a <textarea>) for that input. Compute both
+        // the full and the placeholder-stripped expected; pick whichever is
+        // closer to what the LLM rendered for both the similarity check and
+        // the text replacement.
+        const rawExpected = options.expectedTexts.get(dataId)!
+        const strippedRaw = stripBlankPlaceholders(rawExpected)
+        const strippedExpected = normalizeText(strippedRaw)
+        const fullSim = textSimilarity(actualText, expectedText)
+        const strippedSim = textSimilarity(actualText, strippedExpected)
+        const preferStripped = strippedSim > fullSim
+        const targetExpected = preferStripped ? strippedExpected : expectedText
+        replacementText = preferStripped ? strippedRaw : rawExpected
+        if (actualText !== targetExpected) {
+          const similarity = Math.max(fullSim, strippedSim)
           if (similarity < TEXT_SIMILARITY_THRESHOLD) {
             errors.push(
-              `Text mismatch for data-id "${dataId}": expected "${expectedText.slice(0, 80)}" but got "${actualText.slice(0, 80)}"`
+              `Text mismatch for data-id "${dataId}": expected "${targetExpected.slice(0, 80)}" but got "${actualText.slice(0, 80)}"`
             )
           }
         }
@@ -298,7 +391,7 @@ function walkNode(
     }
   }
 
-  if (replacementText !== undefined) {
+  if (replacementText !== undefined && !hasEditableElement(node)) {
     replaceChildrenWithText(node, replacementText)
   }
 }
@@ -381,6 +474,21 @@ function hasAncestorWithDataId(node: any): boolean {
 function normalizeText(text: string): string {
   return decodePossiblyMalformedHtmlEntities(text)
     .normalize("NFC")
+    .replace(/\s+/g, " ")
+    .trim()
+}
+
+/**
+ * Remove textbook-style blank placeholders (___ or ...) and inline
+ * [placeholder:word] markers from text, then collapse the whitespace gaps
+ * left behind. Used when the LLM has correctly replaced a visual blank with
+ * an editable element (textarea or input) and the surrounding label text
+ * therefore omits the placeholder.
+ */
+function stripBlankPlaceholders(text: string): string {
+  return text
+    .replace(TEXTBOOK_BLANK_RE, "")
+    .replace(PLACEHOLDER_MARKER_RE, "")
     .replace(/\s+/g, " ")
     .trim()
 }

--- a/packages/pipeline/src/validate-html.ts
+++ b/packages/pipeline/src/validate-html.ts
@@ -267,6 +267,7 @@ function walkNode(
     if (node.data.trim().length > 0) {
       if (isInsideExemptTag(node)) return
       if (hasGeneratedA11yLabelAncestor(node)) return
+      if (hasAriaHiddenAncestor(node)) return
       // Allow single-digit numbers as bare text (used as option markers in activities)
       if (/^\d$/.test(node.data.trim())) return
       if (!hasAncestorWithDataId(node)) {
@@ -359,18 +360,23 @@ function walkNode(
         }
         // Do NOT set replacementText — preserve the blank markers in the HTML
       } else {
-        // The LLM is permitted to omit textbook-style blank placeholders
-        // (___ or ...) from the rendered text when it emits a separate
-        // editable element (e.g. a <textarea>) for that input. Compute both
-        // the full and the placeholder-stripped expected; pick whichever is
-        // closer to what the LLM rendered for both the similarity check and
-        // the text replacement.
+        // The LLM is expected to replace textbook-style blank placeholders
+        // (___ or ...) with a separate editable element. If the raw expected
+        // text contains such a placeholder, we always strip it from the
+        // rendered text — never let the underscores/dots appear visibly
+        // next to the input, even if the LLM kept them in its output.
+        // Compute both full and placeholder-stripped variants; pick the
+        // stripped version whenever the expected text has a placeholder,
+        // otherwise fall back to whichever is closer to the LLM's output.
         const rawExpected = options.expectedTexts.get(dataId)!
         const strippedRaw = stripBlankPlaceholders(rawExpected)
         const strippedExpected = normalizeText(strippedRaw)
+        const hasTextbookPlaceholder =
+          /_{3,}|\.{3,}/.test(rawExpected) ||
+          /\[placeholder:[^\]]+\]/.test(rawExpected)
         const fullSim = textSimilarity(actualText, expectedText)
         const strippedSim = textSimilarity(actualText, strippedExpected)
-        const preferStripped = strippedSim > fullSim
+        const preferStripped = hasTextbookPlaceholder || strippedSim > fullSim
         const targetExpected = preferStripped ? strippedExpected : expectedText
         replacementText = preferStripped ? strippedRaw : rawExpected
         if (actualText !== targetExpected) {
@@ -402,6 +408,25 @@ function hasGeneratedA11yLabelAncestor(node: any): boolean {
   let current = node.parent
   while (current) {
     if (current.attribs?.["data-generated-a11y-label"] === "true") {
+      return true
+    }
+    current = current.parent
+  }
+  return false
+}
+
+/**
+ * True if the node sits inside an element marked aria-hidden="true". Such
+ * content is purely decorative (screen readers skip it), so short visual
+ * characters like "→", "/", "•" used as separators or icons don't need a
+ * data-id. Relaxing this keeps the validator consistent with prompt
+ * guidance that already uses aria-hidden spans for decorative glyphs.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function hasAriaHiddenAncestor(node: any): boolean {
+  let current = node.parent
+  while (current) {
+    if (current.attribs?.["aria-hidden"] === "true") {
       return true
     }
     current = current.parent

--- a/prompts/activity_fill_in_the_blank.liquid
+++ b/prompts/activity_fill_in_the_blank.liquid
@@ -27,9 +27,11 @@ Rules for `[[blank:item-N]]` markers:
 - `N` is the sequential item number (1, 2, 3, ...)
 - Place the marker **exactly where the missing word goes** in the sentence
 - The marker replaces the missing word — do NOT leave the original word in the text
-- Markers are placed inside elements that have a `data-id` attribute
+- Markers MUST be placed **inside the text content of an element that has a `data-id` attribute**. NEVER emit a marker as a bare/orphan text node outside a `data-id` element — the validator will reject any `[[blank:item-N]]` that is not inside a `data-id` span/paragraph.
+- The element whose `data-id` text contains the marker (or one of its ancestors) MUST carry the `fitb-sentence` class so the runtime hydration script can find and replace the marker with an `<input>`.
 - At runtime, JavaScript will replace these markers with interactive `<input>` elements
 - **Hint/placeholder text**: If the input text contains `[placeholder:word]` markers (e.g., `[placeholder:afloja]`), these indicate the textbook showed the answer as a visible hint in the blank. Convert each one to `[[blank:item-N:word]]` — for example, `[placeholder:afloja]` becomes `[[blank:item-3:afloja]]`. The hint appears as gray placeholder text inside the input field. You may also use `[[blank:item-N:hint]]` when the textbook visibly shows the answer or a hint even without a `[placeholder:]` marker (e.g., the word is dotted/underlined).
+- **When the source text is a form-style label without an inline blank position** (e.g. the provided text is just `"Nombre:"`, `"Apellido:"`, `"Fecha:"` and the writable area sits separately to the right of or below the label rather than inside the sentence), DO NOT invent a marker position by appending `[[blank:item-N]]` to the label text. Instead, render the label inside its own `data-id` element verbatim and emit a separate `<input type="text">` (with `data-aria-id` and a unique `data-activity-item="item-N"`) **outside** the `data-id` span, immediately after the label. The input has no `data-id` of its own. See pattern in section 2b below.
 
 ```html
 <div class="flex flex-col gap-4 mb-6 max-w-2xl mx-auto">
@@ -59,6 +61,76 @@ For numbered or labeled sentences, combine a label with the sentence:
   </div>
 </div>
 ```
+
+**2b. Label + Separate Writable Area(s)** — use when the source text is a standalone label (e.g. `"Nombre:"`, `"Fecha de nacimiento:"`, `"Pregunta 1:"`) and the writable area sits next to or below the label rather than inside a sentence.
+
+This pattern is deliberately flexible. Choose the element and sizing based on the expected answer for each specific field:
+
+| Expected answer | Element | Typical width/height |
+|-----------------|---------|----------------------|
+| Single number, letter, or date component (day, month) | `<input type="text">` | `w-12` / `w-16` / `w-20`, `text-center` |
+| Single word, name, short value | `<input type="text">` | `w-32` / `w-48` / `w-64` |
+| Short phrase or single-line answer | `<input type="text">` | `flex-1` or `w-full` |
+| Sentence or longer free-form answer | `<textarea>` + `resize-none` | `min-h-16` short, `min-h-32` standard, `min-h-48` paragraph |
+
+Pick the layout that matches the textbook page:
+
+**Horizontal — label beside input** (good for short labels, one field per line):
+```html
+<div class="mb-4 flex items-center gap-3">
+  <label class="font-semibold whitespace-nowrap" data-id="text-1">Nombre:</label>
+  <input class="flex-1 p-2 border border-gray-400 rounded"
+         data-aria-id="aria-1-0-0"
+         data-activity-item="item-1"
+         tabindex="0"
+         type="text" />
+</div>
+```
+
+**Vertical — label above input** (good for longer prompts or longer answers):
+```html
+<div class="mb-6">
+  <p class="text-lg mb-2"><span data-id="text-1">Describe what happened in the story.</span></p>
+  <textarea class="w-full p-2 border border-gray-400 rounded min-h-32 resize-none"
+            data-aria-id="aria-1-0-0"
+            data-activity-item="item-1"
+            aria-label="Answer: describe what happened"
+            tabindex="0"></textarea>
+</div>
+```
+
+**Multiple inputs per label** (use for dates, addresses, number sequences, or any source text that visibly splits one prompt across multiple blanks such as `"Fecha de nacimiento: ___ / ___ / ___"`):
+```html
+<div class="mb-4 flex items-center gap-3 flex-wrap">
+  <label class="font-semibold whitespace-nowrap" data-id="text-1">Fecha de nacimiento:</label>
+  <input class="w-16 p-2 border border-gray-400 rounded text-center"
+         data-aria-id="aria-1-0-0"
+         data-activity-item="item-1"
+         aria-label="Day"
+         tabindex="0" type="text" />
+  <span aria-hidden="true">/</span>
+  <input class="w-16 p-2 border border-gray-400 rounded text-center"
+         data-aria-id="aria-1-0-1"
+         data-activity-item="item-2"
+         aria-label="Month"
+         tabindex="0" type="text" />
+  <span aria-hidden="true">/</span>
+  <input class="w-20 p-2 border border-gray-400 rounded text-center"
+         data-aria-id="aria-1-0-2"
+         data-activity-item="item-3"
+         aria-label="Year"
+         tabindex="0" type="text" />
+</div>
+```
+
+Rules for this pattern:
+- The label text stays inside its `data-id` element verbatim — never append a marker or strip words from it
+- Every `<input>`/`<textarea>` sits OUTSIDE any `data-id` element, in the flow next to the label it belongs to
+- Every `<input>`/`<textarea>` has a unique `data-aria-id`, a unique `data-activity-item="item-N"` (increment sequentially across the whole page), and `tabindex="0"`. It has NO `data-id`.
+- For accessibility, each `<input>`/`<textarea>` should have an `aria-label` that identifies which field it is (especially when multiple inputs share a single label, like date parts)
+- Do NOT set a `placeholder` attribute with user-visible prompt text like "Escribe aquí" — that doesn't localise cleanly. Short language-neutral separators (`/`, `-`) go in adjacent `<span aria-hidden="true">` elements, not as placeholders.
+- This pattern does NOT use `[[blank:item-N]]` markers and does NOT need the `fitb-sentence` class
+- You may freely mix this pattern with inline-blank sentences (2) on the same page — e.g. a form section with separate inputs followed by a cloze section with markers. Just keep `data-activity-item` numbering sequential across all fields on the page.
 
 **3. Hierarchical Diagram** (secondary layout — use only when the textbook explicitly shows a diagram/concept map):
 ```html
@@ -97,9 +169,18 @@ For numbered or labeled sentences, combine a label with the sentence:
 
 ### Layout Decision Guide
 
-- **DEFAULT**: Use inline blanks (`fitb-sentence` + `[[blank:item-N]]`). This is the correct choice for sentences, paragraphs, fill-in-the-sentence exercises, cloze exercises, and any activity where students complete sentences.
-- **Hierarchical diagram**: Use ONLY when the textbook page explicitly shows a tree, concept map, organizational chart, or diagram with connecting lines between levels.
-- When in doubt, always choose inline blanks.
+Pick the pattern per sentence/field — you can mix them on the same page.
+
+- **Inline blanks (pattern 2)**: Use when the source text is a sentence with a missing word (underscores, dots, or an implied gap inside the sentence). Insert a `[[blank:item-N]]` marker inside the `data-id` span at the exact gap position and add the `fitb-sentence` class.
+- **Label + separate writable area (pattern 2b)**: Use when the source text is a standalone label or question prompt (e.g. `"Nombre:"`, `"Apellido:"`, `"Fecha de nacimiento:"`, `"1. Describe your favorite character"`) and the writable area is visually separate. Keep the label verbatim inside its `data-id` element and emit an `<input>` or `<textarea>` next to or below it. This pattern is flexible — pick `<input>` for short answers, `<textarea>` for sentence/paragraph answers, narrow widths for dates/numbers, multiple inputs per label for split fields like dates.
+- **Hierarchical diagram (pattern 3)**: Use ONLY when the textbook page explicitly shows a tree, concept map, organisational chart, or diagram with connecting lines between levels.
+
+Decision rule: "Does the source text contain an obvious word-shaped gap inside a sentence?"
+- Yes (underscores/dots inside a sentence, or an obvious missing word mid-sentence) → pattern 2
+- No (the source is a label or a standalone question prompt) → pattern 2b
+- The textbook literally shows a diagram with connecting lines → pattern 3
+
+When in doubt, pattern 2b is safer than pattern 2 — a misplaced marker outside a `data-id` fails validation, but a label + input is always valid.
 
 ### CRITICAL Requirements
 1. Include exactly ONE top-level `<section>` with `data-section-type` equal to the provided section type and `data-section-id` equal to the provided section ID. Do NOT add `role="activity"`
@@ -108,11 +189,13 @@ For numbered or labeled sentences, combine a label with the sentence:
 4. ALL images MUST have `data-id` matching provided image IDs
 5. Text for each text ID must match the provided text exactly, EXCEPT: you may replace a word with a `[[blank:item-N]]` marker to create the blank
 6. `[[blank:item-N]]` markers replace the missing word at its exact position in the sentence — the item numbers must be unique and sequential (item-1, item-2, etc.)
-7. For the hierarchical diagram layout only: inputs MUST have both `data-aria-id` AND `data-activity-item`
-8. NO stray visible text outside elements with valid provided `data-id`
-9. Use semantic colors: green for main level, blue for secondary, gray for tertiary
-10. If validator feedback says an exact expected value (for example section ID), use that exact value
-11. The `fitb-sentence` class MUST be present on any element (or its parent) that contains `[[blank:item-N]]` markers
+7. Every `[[blank:item-N]]` marker MUST sit inside the text content of an element that has a `data-id` attribute. NEVER emit a marker as a bare text node outside any `data-id` element. If the source text has no natural inline blank position, use pattern 2b (label + separate writable area) instead.
+8. For patterns 2b and 3: every standalone `<input>` or `<textarea>` MUST have both `data-aria-id` AND a unique `data-activity-item="item-N"`, and MUST have no `data-id`. Numbering of `data-activity-item` is sequential across all writable fields on the page (including markers — a marker `[[blank:item-3]]` and a separate `<input data-activity-item="item-4">` share the same counter).
+9. The page MUST contain at least one editable input — a `[[blank:item-N]]` marker (hydrated to an `<input>` at runtime), a literal `<input>`, or a literal `<textarea>`. A fill-in-the-blank activity with no editable element is invalid.
+10. NO stray visible text outside elements with valid provided `data-id`
+11. Use semantic colors: green for main level, blue for secondary, gray for tertiary
+12. If validator feedback says an exact expected value (for example section ID), use that exact value
+13. The `fitb-sentence` class MUST be present on any element (or its parent) that contains `[[blank:item-N]]` markers
 
 ### Response Format (STRICT)
 Return JSON object:

--- a/prompts/activity_fill_in_the_blank.liquid
+++ b/prompts/activity_fill_in_the_blank.liquid
@@ -66,13 +66,13 @@ For numbered or labeled sentences, combine a label with the sentence:
 
 ```html
 <!-- Source: "en_ro"  -->
-<span class="fitb-sentence text-2xl tracking-wide" data-id="text-1">en[[blank:item-1]]ro</span>
+<span class="fitb-sentence text-lg tracking-wide" data-id="text-1">en[[blank:item-1]]ro</span>
 
 <!-- Source: "m_y_" (two missing letters) -->
-<span class="fitb-sentence text-2xl tracking-wide" data-id="text-2">m[[blank:item-2]]y[[blank:item-3]]</span>
+<span class="fitb-sentence text-lg tracking-wide" data-id="text-2">m[[blank:item-2]]y[[blank:item-3]]</span>
 
 <!-- Source: "_eptiembr_" (missing letter at start AND end) -->
-<span class="fitb-sentence text-2xl tracking-wide" data-id="text-3">[[blank:item-4]]eptiembr[[blank:item-5]]</span>
+<span class="fitb-sentence text-lg tracking-wide" data-id="text-3">[[blank:item-4]]eptiembr[[blank:item-5]]</span>
 ```
 
 Rules for inline letter blanks:
@@ -80,6 +80,7 @@ Rules for inline letter blanks:
 - Do NOT leave the `_` character in the rendered text — the marker replaces it
 - Each marker increments `item-N` across the whole page
 - This is still pattern 2 — do NOT fall back to pattern 2b (label + separate input), which would park the input away from the letter gap and look wrong
+- Default font size is `text-lg` (~18px). Only step up to `text-xl` when the word is very short (≤4 rendered characters including blanks) AND the layout is a single centred row — never in multi-column grids, because longer words (e.g. `_eptiembr_`, `no_iembr_`) wrap and break the card layout at larger sizes
 
 **2b. Label + Separate Writable Area(s)** — use when the source text is a standalone label (e.g. `"Nombre:"`, `"Fecha de nacimiento:"`, `"Pregunta 1:"`) and the writable area sits next to or below the label rather than inside a sentence.
 
@@ -223,6 +224,7 @@ When in doubt, pattern 2b is safer than pattern 2 — a misplaced marker outside
 11. Use semantic colors: green for main level, blue for secondary, gray for tertiary
 12. If validator feedback says an exact expected value (for example section ID), use that exact value
 13. The `fitb-sentence` class MUST be present on any element (or its parent) that contains `[[blank:item-N]]` markers
+14. Font sizing: prefer `text-lg` (~18px) for fitb content. You may use `text-base` when cells are tight, and `text-xl` sparingly for single short words in wide single-column layouts. Avoid `text-2xl` or larger in multi-column grids — long words wrap and overflow the cells on desktop even when the page looks fine on mobile
 
 ### Response Format (STRICT)
 Return JSON object:

--- a/prompts/activity_fill_in_the_blank.liquid
+++ b/prompts/activity_fill_in_the_blank.liquid
@@ -62,6 +62,25 @@ For numbered or labeled sentences, combine a label with the sentence:
 </div>
 ```
 
+**Inline letter blanks inside a single word** — when the source text is a single word (no spaces) containing one or more `_` characters at missing-letter positions (e.g. `"en_ro"`, `"m_y_"`, `"_eptiembr_"` — meses/letras activities), still use pattern 2. Replace each `_` with a `[[blank:item-N]]` marker and keep the rest of the letters as plain text inside the same `data-id` span. Wrap the span (or its parent) with the `fitb-sentence` class so the markers hydrate into narrow inline inputs at exactly the letter gaps.
+
+```html
+<!-- Source: "en_ro"  -->
+<span class="fitb-sentence text-2xl tracking-wide" data-id="text-1">en[[blank:item-1]]ro</span>
+
+<!-- Source: "m_y_" (two missing letters) -->
+<span class="fitb-sentence text-2xl tracking-wide" data-id="text-2">m[[blank:item-2]]y[[blank:item-3]]</span>
+
+<!-- Source: "_eptiembr_" (missing letter at start AND end) -->
+<span class="fitb-sentence text-2xl tracking-wide" data-id="text-3">[[blank:item-4]]eptiembr[[blank:item-5]]</span>
+```
+
+Rules for inline letter blanks:
+- Emit ONE marker per `_` in the source word
+- Do NOT leave the `_` character in the rendered text — the marker replaces it
+- Each marker increments `item-N` across the whole page
+- This is still pattern 2 — do NOT fall back to pattern 2b (label + separate input), which would park the input away from the letter gap and look wrong
+
 **2b. Label + Separate Writable Area(s)** — use when the source text is a standalone label (e.g. `"Nombre:"`, `"Fecha de nacimiento:"`, `"Pregunta 1:"`) and the writable area sits next to or below the label rather than inside a sentence.
 
 This pattern is deliberately flexible. Choose the element and sizing based on the expected answer for each specific field:
@@ -99,7 +118,7 @@ Pick the layout that matches the textbook page:
 </div>
 ```
 
-**Multiple inputs per label** (use for dates, addresses, number sequences, or any source text that visibly splits one prompt across multiple blanks such as `"Fecha de nacimiento: ___ / ___ / ___"`):
+**Multiple inputs per label — date/phone/split-value fields** (use for dates like `"Fecha de nacimiento: ___/___/___"`, `"___ / ___ / ___"`, phone numbers like `"Teléfono: ___-___-___"`, or any source text that visibly splits one prompt across multiple blanks separated by `/`, `-`, or similar connectors):
 ```html
 <div class="mb-4 flex items-center gap-3 flex-wrap">
   <label class="font-semibold whitespace-nowrap" data-id="text-1">Fecha de nacimiento:</label>
@@ -122,6 +141,12 @@ Pick the layout that matches the textbook page:
          tabindex="0" type="text" />
 </div>
 ```
+
+Hard rules for split-value fields (critical — this is a common failure mode):
+- The label inside the `data-id` element contains ONLY the leading label text up to (and optionally including) the colon. It must NOT contain any `/`, `-`, or other separator characters that originally sat between the blanks — those live between the inputs as `<span aria-hidden="true">...</span>`, never inside the label. For `"Fecha de nacimiento: ___/___/___"` the label renders as `Fecha de nacimiento:` — if you render `Fecha de nacimiento: //` or `Fecha de nacimiento: / /` (slashes stranded in the label) the layout is wrong.
+- Every input sits in the SAME flex row as the label, interleaved with `<span aria-hidden="true">/</span>` (or `-`) between them. Do NOT put the inputs in a separate grid or row below the label — they must flow next to the label like `Fecha de nacimiento: [d] / [m] / [y]`.
+- Use fixed narrow widths (`w-12` / `w-16` / `w-20`) and `text-center` so the inputs look like date/phone cells, not full-width text boxes.
+- Emit exactly one input per `___` run in the source text. For `___/___/___` → 3 inputs. For `___-___` → 2 inputs.
 
 Rules for this pattern:
 - The label text stays inside its `data-id` element verbatim — never append a marker or strip words from it
@@ -171,13 +196,15 @@ Rules for this pattern:
 
 Pick the pattern per sentence/field — you can mix them on the same page.
 
-- **Inline blanks (pattern 2)**: Use when the source text is a sentence with a missing word (underscores, dots, or an implied gap inside the sentence). Insert a `[[blank:item-N]]` marker inside the `data-id` span at the exact gap position and add the `fitb-sentence` class.
+- **Inline blanks (pattern 2)**: Use when the source text contains the blank INSIDE it — a sentence with a missing word, OR a single word with missing letters marked by `_` (e.g. `"en_ro"`, `"m_y_"`). Insert `[[blank:item-N]]` markers at each gap and add the `fitb-sentence` class.
 - **Label + separate writable area (pattern 2b)**: Use when the source text is a standalone label or question prompt (e.g. `"Nombre:"`, `"Apellido:"`, `"Fecha de nacimiento:"`, `"1. Describe your favorite character"`) and the writable area is visually separate. Keep the label verbatim inside its `data-id` element and emit an `<input>` or `<textarea>` next to or below it. This pattern is flexible — pick `<input>` for short answers, `<textarea>` for sentence/paragraph answers, narrow widths for dates/numbers, multiple inputs per label for split fields like dates.
 - **Hierarchical diagram (pattern 3)**: Use ONLY when the textbook page explicitly shows a tree, concept map, organisational chart, or diagram with connecting lines between levels.
 
-Decision rule: "Does the source text contain an obvious word-shaped gap inside a sentence?"
-- Yes (underscores/dots inside a sentence, or an obvious missing word mid-sentence) → pattern 2
-- No (the source is a label or a standalone question prompt) → pattern 2b
+Decision rule: "Does the source text contain the blank INSIDE it?"
+- Yes, inside a sentence (underscores, dots, or an obvious missing word mid-sentence) → pattern 2
+- Yes, inside a single word (one or more `_` chars marking missing letters — e.g. `"en_ro"`) → pattern 2, one marker per `_`
+- The source text is a label followed by `___<sep>___<sep>___` (date/phone/split value) → pattern 2b "Multiple inputs per label"
+- The source is a plain standalone label or question prompt (e.g. `"Nombre:"`, `"Apellido:"`) → pattern 2b
 - The textbook literally shows a diagram with connecting lines → pattern 3
 
 When in doubt, pattern 2b is safer than pattern 2 — a misplaced marker outside a `data-id` fails validation, but a label + input is always valid.

--- a/prompts/activity_open_ended_answer.liquid
+++ b/prompts/activity_open_ended_answer.liquid
@@ -28,14 +28,18 @@ You are an expert frontend engineer creating beautiful, kid-friendly HTML pages 
 - Annotations use: `bg-amber-600 text-white py-1 px-2 rounded-full`
 - All spans must have data-id
 
-**4. Text Input Area**
-- Use `<textarea>` for multi-line input
-- Required attributes:
-  - `class="w-full p-2 border border-gray-400 rounded min-h-32 resize-none"`
-  - `data-aria-id="aria-X-Y-Z"` (sequential numbering)
-  - `aria-label="Descriptive label"`
-  - `placeholder="Escribe aquí tu texto"`
+**4. Text Input Areas (CRITICAL)**
+- Every place where the source page shows a response line, underline, dotted line, or empty box for the learner to WRITE on MUST become an editable `<textarea>` — never render the underlines as static `<hr>`, `<div class="border-b">`, decorative borders, runs of underscores, or any other non-editable element.
+- Emit ONE `<textarea>` per distinct response field on the page. If the source page has many lines or blanks (one per question, one per sub-question, multiple lines under a single prompt), produce that many separate `<textarea>` elements. Do NOT collapse multiple distinct response fields into a single `<textarea>`.
+- A "distinct response field" is a separate writing area — typically one per question, sub-question, bullet, or labelled prompt. Multiple ruled lines that visually belong to the SAME single question (e.g. three lines giving the learner room for one longer answer) collapse into ONE multi-line `<textarea>` (use `min-h-32` or larger). Lines that belong to DIFFERENT questions or prompts each get their own `<textarea>`.
+- Place each `<textarea>` immediately after the prompt/question it answers, in document order. Group prompt + textarea together visually (e.g. inside the same `<div>` with `mb-6`) so the learner sees them paired.
+- Required attributes on every `<textarea>`:
+  - `class="w-full p-2 border border-gray-400 rounded min-h-32 resize-none"` (use `min-h-16` for short single-line answers, `min-h-32` for longer answers, `min-h-48` for paragraph-length)
+  - `data-aria-id="aria-X-Y-Z"` (sequential numbering — must be unique per textarea on the page)
+  - `aria-label="Descriptive label"` (different per textarea — describe the question being answered)
   - `tabindex="0"`
+- Do NOT add a `placeholder` attribute. The bordered textarea is itself the visual cue that the learner can type — no language-specific prompt text is needed. (Keeping placeholders out also avoids translation drift across activity languages.)
+- A textarea is its own UI element — it has NO `data-id` attribute and is NOT counted against the provided text IDs.
 
 **5. Hints/Tips Box (optional)**
 - Use: `bg-amber-50 p-4 rounded-lg -mr-6 pr-8 rounded-lg font-semibold`
@@ -47,10 +51,11 @@ You are an expert frontend engineer creating beautiful, kid-friendly HTML pages 
 2. Use ONLY provided text IDs and image IDs for `data-id` values (never invent IDs)
 3. ALL text must have `data-id` matching provided text IDs
 4. ALL images must have `data-id` matching provided image IDs
-5. Text for each text ID must match the provided text exactly (no paraphrasing, no added text, no punctuation changes)
+5. Text for each text ID must match the provided text exactly (no paraphrasing, no added text, no punctuation changes). EXCEPTION: if a provided text contains runs of underscores (`___`) or dots (`...`) representing a blank line for writing, omit that placeholder from the rendered text and emit a `<textarea>` after the surrounding sentence instead — the textarea replaces the visual blank.
 6. NO stray visible text outside elements with valid provided `data-id`
-7. Textarea must have `data-aria-id` for accessibility
-8. If validator feedback says an exact expected value (for example section ID), use that exact value
+7. The page MUST contain at least one `<textarea>` — an open-ended-answer activity without an editable input is invalid. Each textarea must have a unique `data-aria-id` for accessibility.
+8. NEVER render response lines as static decoration (no `<hr>`, no `border-b`, no underscore runs, no empty `<div>` placeholders styled to look like lines). The learner must be able to type into every writable area.
+9. If validator feedback says an exact expected value (for example section ID), use that exact value
 
 ### Response Format (STRICT)
 Return JSON object:
@@ -62,7 +67,7 @@ Return JSON object:
 ```
 IMPORTANT: Your reasoning MUST be written in English, regardless of the activity language. The HTML content itself should match the activity language.
 
-### Example Structure
+### Example Structure (multiple questions, one textarea per question)
 ```html
 <div class="flex justify-center items-start min-h-[calc(100dvh-100px)]">
   <div class="container mx-auto max-w-5xl bg-white rounded-lg lg:px-24 md:px-12 sm:px-6 pt-12 pb-12" id="content">
@@ -70,37 +75,35 @@ IMPORTANT: Your reasoning MUST be written in English, regardless of the activity
       <h1 class="text-5xl font-bold mb-4 text-amber-700" data-id="text-1">Activity Title</h1>
 
       <p class="text-xl mb-8">
-        <i class="fas fa-book text-blue-700 mr-2"></i>
-        <span data-id="text-2">Read the text carefully.</span>
+        <i class="fas fa-pen-to-square text-blue-700 mr-2"></i>
+        <span data-id="text-2">Answer the following questions.</span>
       </p>
 
-      <div class="bg-amber-50 rounded-xl p-4 mb-8">
-        <p class="text-lg">
-          <span data-id="text-3">Reference text here.</span>
-          <span class="bg-amber-600 text-white py-1 px-2 rounded-full" data-id="text-4">Annotation</span>
-          <span data-id="text-5">More text.</span>
-        </p>
+      <div class="mb-6">
+        <p class="text-lg mb-2"><span data-id="text-3">1. What is the main idea of the story?</span></p>
+        <textarea
+          class="w-full p-2 border border-gray-400 rounded min-h-32 resize-none"
+          data-aria-id="aria-1-0-0"
+          aria-label="Answer to question 1: main idea of the story"
+          tabindex="0"></textarea>
       </div>
 
-      <p class="text-xl mb-8">
-        <i class="fas fa-pen-to-square text-blue-700 mr-2"></i>
-        <span data-id="text-6">Write your answer below.</span>
-      </p>
+      <div class="mb-6">
+        <p class="text-lg mb-2"><span data-id="text-4">2. Who is your favorite character and why?</span></p>
+        <textarea
+          class="w-full p-2 border border-gray-400 rounded min-h-32 resize-none"
+          data-aria-id="aria-1-0-1"
+          aria-label="Answer to question 2: favorite character"
+          tabindex="0"></textarea>
+      </div>
 
-      <textarea
-        class="w-full p-2 border border-gray-400 rounded min-h-32 resize-none"
-        data-aria-id="aria-1-0-0"
-        aria-label="Write your answer here"
-        placeholder="Escribe aquí tu texto"
-        tabindex="0"></textarea>
-
-      <div class="flex items-center justify-center mt-6">
-        <div class="bg-amber-50 p-4 rounded-lg -mr-6 pr-8 rounded-lg font-semibold">
-          <p class="text-amber-900 font-semibold">
-            <span data-id="text-7">Helpful tip here.</span>
-          </p>
-        </div>
-        <img src="images/character.svg" alt="Character" class="h-40" data-id="img-1" />
+      <div class="mb-6">
+        <p class="text-lg mb-2"><span data-id="text-5">3. Describe one lesson you learned.</span></p>
+        <textarea
+          class="w-full p-2 border border-gray-400 rounded min-h-48 resize-none"
+          data-aria-id="aria-1-0-2"
+          aria-label="Answer to question 3: lesson learned"
+          tabindex="0"></textarea>
       </div>
     </section>
   </div>
@@ -112,6 +115,7 @@ IMPORTANT: Your reasoning MUST be written in English, regardless of the activity
 - Focus on clear instructions and adequate space for student responses
 - Use warm colors (amber) to create inviting writing environment
 - Include helpful tips or scaffolding when available in text IDs
+- Count the writable areas on the source page image. The number of `<textarea>` elements you emit should match the number of distinct response fields the learner is expected to fill in.
 {% endchat %}
 
 {% chat role: "user" %}

--- a/prompts/activity_open_ended_answer.liquid
+++ b/prompts/activity_open_ended_answer.liquid
@@ -29,17 +29,29 @@ You are an expert frontend engineer creating beautiful, kid-friendly HTML pages 
 - All spans must have data-id
 
 **4. Text Input Areas (CRITICAL)**
-- Every place where the source page shows a response line, underline, dotted line, or empty box for the learner to WRITE on MUST become an editable `<textarea>` — never render the underlines as static `<hr>`, `<div class="border-b">`, decorative borders, runs of underscores, or any other non-editable element.
-- Emit ONE `<textarea>` per distinct response field on the page. If the source page has many lines or blanks (one per question, one per sub-question, multiple lines under a single prompt), produce that many separate `<textarea>` elements. Do NOT collapse multiple distinct response fields into a single `<textarea>`.
-- A "distinct response field" is a separate writing area — typically one per question, sub-question, bullet, or labelled prompt. Multiple ruled lines that visually belong to the SAME single question (e.g. three lines giving the learner room for one longer answer) collapse into ONE multi-line `<textarea>` (use `min-h-32` or larger). Lines that belong to DIFFERENT questions or prompts each get their own `<textarea>`.
-- Place each `<textarea>` immediately after the prompt/question it answers, in document order. Group prompt + textarea together visually (e.g. inside the same `<div>` with `mb-6`) so the learner sees them paired.
-- Required attributes on every `<textarea>`:
-  - `class="w-full p-2 border border-gray-400 rounded min-h-32 resize-none"` (use `min-h-16` for short single-line answers, `min-h-32` for longer answers, `min-h-48` for paragraph-length)
-  - `data-aria-id="aria-X-Y-Z"` (sequential numbering — must be unique per textarea on the page)
-  - `aria-label="Descriptive label"` (different per textarea — describe the question being answered)
+- Every place where the source page shows a response line, underline, dotted line, or empty box for the learner to WRITE on MUST become an editable element — either an `<input type="text">` (for single-line answers) or a `<textarea>` (for multi-line answers). Never render writable areas as static `<hr>`, `<div class="border-b">`, decorative borders, runs of underscores, or any other non-editable element.
+- **Pick the right element per field based on the expected answer length.** Do not default to `<textarea>` for short fields — a one-line textarea pushes the first keystroke off the visible text baseline and looks broken.
+
+| Expected answer | Element | Typical sizing |
+|-----------------|---------|----------------|
+| Single number, letter, or date component (day, month) | `<input type="text">` | `w-12` / `w-16` / `w-20`, `text-center` |
+| Single word, name, short value (e.g. `Nombre:`, `Edad:`) | `<input type="text">` | `w-32` / `w-48` / `w-64` |
+| Short phrase or single-line answer that spans the row | `<input type="text">` | `w-full` |
+| Sentence-length answer (one full sentence) | `<textarea>` + `resize-none` | `min-h-16` |
+| Paragraph / multi-line answer (multiple ruled lines under one prompt) | `<textarea>` + `resize-none` | `min-h-32` standard, `min-h-48` longer |
+
+- Decision rule: "Does the learner need more than one line of vertical space to answer?" Yes → `<textarea>`. No → `<input type="text">`. When in doubt for a short labelled field (`Nombre:`, `Fecha:`, `Título:`), choose `<input>`. For an open question asking the learner to describe/explain/write about something, choose `<textarea>`.
+- Emit ONE editable element per distinct response field on the page. If the source page has many lines or blanks (one per question, one per sub-question, multiple lines under a single prompt), produce that many separate elements. Do NOT collapse multiple distinct response fields into a single element.
+- A "distinct response field" is a separate writing area — typically one per question, sub-question, bullet, or labelled prompt. Multiple ruled lines that visually belong to the SAME single question (e.g. three lines giving the learner room for one longer answer) collapse into ONE multi-line `<textarea>`. Lines that belong to DIFFERENT questions or prompts each get their own element.
+- Place each editable element immediately after the prompt/question it answers, in document order. Group prompt + input together visually (e.g. inside the same `<div>` with `mb-6`) so the learner sees them paired.
+- Required attributes on every editable element:
+  - Base classes `p-2 border border-gray-400 rounded` plus the sizing classes from the table above (and `resize-none` on any `<textarea>`)
+  - `data-aria-id="aria-X-Y-Z"` (sequential numbering — must be unique per element on the page)
+  - `aria-label="Descriptive label"` (different per element — describe the question being answered)
   - `tabindex="0"`
-- Do NOT add a `placeholder` attribute. The bordered textarea is itself the visual cue that the learner can type — no language-specific prompt text is needed. (Keeping placeholders out also avoids translation drift across activity languages.)
-- A textarea is its own UI element — it has NO `data-id` attribute and is NOT counted against the provided text IDs.
+- Do NOT add a `placeholder` attribute. The bordered element is itself the visual cue that the learner can type — no language-specific prompt text is needed. (Keeping placeholders out also avoids translation drift across activity languages.)
+- An editable element has NO `data-id` attribute and is NOT counted against the provided text IDs.
+- For decorative separators that sit between inputs (e.g. `/` between day/month/year on a date field, `-` in a phone number), wrap them in a `<span aria-hidden="true">/</span>` so they pass validation without needing a `data-id` and are skipped by screen readers.
 
 **5. Hints/Tips Box (optional)**
 - Use: `bg-amber-50 p-4 rounded-lg -mr-6 pr-8 rounded-lg font-semibold`
@@ -51,9 +63,9 @@ You are an expert frontend engineer creating beautiful, kid-friendly HTML pages 
 2. Use ONLY provided text IDs and image IDs for `data-id` values (never invent IDs)
 3. ALL text must have `data-id` matching provided text IDs
 4. ALL images must have `data-id` matching provided image IDs
-5. Text for each text ID must match the provided text exactly (no paraphrasing, no added text, no punctuation changes). EXCEPTION: if a provided text contains runs of underscores (`___`) or dots (`...`) representing a blank line for writing, omit that placeholder from the rendered text and emit a `<textarea>` after the surrounding sentence instead — the textarea replaces the visual blank.
+5. Text for each text ID must match the provided text exactly (no paraphrasing, no added text, no punctuation changes). EXCEPTION: if a provided text contains runs of underscores (`___`) or dots (`...`) representing a blank line for writing, omit that placeholder from the rendered text and emit a `<textarea>` or `<input type="text">` after the surrounding sentence instead — the editable element replaces the visual blank.
 6. NO stray visible text outside elements with valid provided `data-id`
-7. The page MUST contain at least one `<textarea>` — an open-ended-answer activity without an editable input is invalid. Each textarea must have a unique `data-aria-id` for accessibility.
+7. The page MUST contain at least one editable element — either a `<textarea>` or an `<input type="text">`. An open-ended-answer activity without an editable input is invalid. Each editable element must have a unique `data-aria-id` for accessibility.
 8. NEVER render response lines as static decoration (no `<hr>`, no `border-b`, no underscore runs, no empty `<div>` placeholders styled to look like lines). The learner must be able to type into every writable area.
 9. If validator feedback says an exact expected value (for example section ID), use that exact value
 
@@ -67,7 +79,7 @@ Return JSON object:
 ```
 IMPORTANT: Your reasoning MUST be written in English, regardless of the activity language. The HTML content itself should match the activity language.
 
-### Example Structure (multiple questions, one textarea per question)
+### Example Structure (mix of short `<input>` fields and longer `<textarea>` fields)
 ```html
 <div class="flex justify-center items-start min-h-[calc(100dvh-100px)]">
   <div class="container mx-auto max-w-5xl bg-white rounded-lg lg:px-24 md:px-12 sm:px-6 pt-12 pb-12" id="content">
@@ -76,33 +88,37 @@ IMPORTANT: Your reasoning MUST be written in English, regardless of the activity
 
       <p class="text-xl mb-8">
         <i class="fas fa-pen-to-square text-blue-700 mr-2"></i>
-        <span data-id="text-2">Answer the following questions.</span>
+        <span data-id="text-2">Complete the following.</span>
       </p>
 
+      <!-- Short single-line answer → <input> -->
+      <div class="mb-4 flex items-center gap-3">
+        <label class="font-semibold whitespace-nowrap" data-id="text-3">Name:</label>
+        <input
+          class="flex-1 p-2 border border-gray-400 rounded"
+          data-aria-id="aria-1-0-0"
+          aria-label="Student name"
+          tabindex="0"
+          type="text" />
+      </div>
+
+      <!-- Longer answer → <textarea> -->
       <div class="mb-6">
-        <p class="text-lg mb-2"><span data-id="text-3">1. What is the main idea of the story?</span></p>
+        <p class="text-lg mb-2"><span data-id="text-4">1. What is the main idea of the story?</span></p>
         <textarea
           class="w-full p-2 border border-gray-400 rounded min-h-32 resize-none"
-          data-aria-id="aria-1-0-0"
+          data-aria-id="aria-1-0-1"
           aria-label="Answer to question 1: main idea of the story"
           tabindex="0"></textarea>
       </div>
 
+      <!-- Paragraph-length answer → taller <textarea> -->
       <div class="mb-6">
-        <p class="text-lg mb-2"><span data-id="text-4">2. Who is your favorite character and why?</span></p>
-        <textarea
-          class="w-full p-2 border border-gray-400 rounded min-h-32 resize-none"
-          data-aria-id="aria-1-0-1"
-          aria-label="Answer to question 2: favorite character"
-          tabindex="0"></textarea>
-      </div>
-
-      <div class="mb-6">
-        <p class="text-lg mb-2"><span data-id="text-5">3. Describe one lesson you learned.</span></p>
+        <p class="text-lg mb-2"><span data-id="text-5">2. Describe one lesson you learned and why it mattered.</span></p>
         <textarea
           class="w-full p-2 border border-gray-400 rounded min-h-48 resize-none"
           data-aria-id="aria-1-0-2"
-          aria-label="Answer to question 3: lesson learned"
+          aria-label="Answer to question 2: lesson learned"
           tabindex="0"></textarea>
       </div>
     </section>
@@ -115,7 +131,7 @@ IMPORTANT: Your reasoning MUST be written in English, regardless of the activity
 - Focus on clear instructions and adequate space for student responses
 - Use warm colors (amber) to create inviting writing environment
 - Include helpful tips or scaffolding when available in text IDs
-- Count the writable areas on the source page image. The number of `<textarea>` elements you emit should match the number of distinct response fields the learner is expected to fill in.
+- Count the writable areas on the source page image. The number of editable elements (`<textarea>` + `<input type="text">`) you emit should match the number of distinct response fields the learner is expected to fill in.
 {% endchat %}
 
 {% chat role: "user" %}

--- a/prompts/page_sectioning.liquid
+++ b/prompts/page_sectioning.liquid
@@ -19,10 +19,24 @@ SECTION TYPES:
 
 CLASSIFICATION RULES (use these to disambiguate activity types):
 - WRITABLE-PAGE PRECEDENCE: If the page contains ANY response lines, blank lines, underlines, dotted lines, or empty boxes/cells where the learner is expected to WRITE (a word, a phrase, a sentence, or a longer answer), the section MUST be classified as an activity type — never as text_only, boxed_text, text_and_single_image, text_and_images, or other. This holds regardless of how much surrounding prose, instructions, or imagery the page contains. Choose the activity sub-type using the rules below.
-  • Lines/underscores under or after a question prompt where the learner writes a free-form answer → activity_open_ended_answer
-  • Blanks embedded inside a sentence (the learner supplies a missing word or phrase) → activity_fill_in_the_blank
-  • Empty cells inside a table grid → activity_fill_in_a_table
-  Visual signals that indicate writable response areas include: horizontal lines (solid, dotted, or dashed), runs of underscores ("___"), runs of dots ("..."), empty ruled rows, and blank boxes labelled "Answer:", "Write:", "Respuesta:", "Escribe:", or similar.
+  Visual signals that indicate writable response areas include: horizontal lines (solid, dotted, or dashed), runs of underscores ("___"), runs of dots ("..."), empty ruled rows, empty small squares or rectangular boxes sitting next to a prompt (they are blanks even without a line — the learner writes a number, letter, or short answer inside the box), and blank boxes labelled "Answer:", "Write:", "Respuesta:", "Escribe:", or similar. A small empty square beside a prompt is every bit as much a writable blank as an underline is — do not skip the writable classification just because the textbook used a box instead of a line.
+- WRITABLE SUB-TYPE TEST: The sub-type depends on the STRUCTURE of the response, NOT on whether the correct answer is knowable from the page. A full-width line next to a prompt is NOT automatically open-ended — look at what shape of answer the prompt expects.
+  • STRUCTURED / DISCRETE FIELDS → activity_fill_in_the_blank. Pick this whenever the writing area expects a specific type of short answer: a word, number, letter, date, name, short phrase, or a value copied from the prompt. This covers:
+    - Inline blanks inside a sentence ("El Sol es una ___")
+    - Labeled form fields where the learner writes a specific datum (e.g. "Nombre: ___", "Apellido: ___", "Fecha de nacimiento: ___ / ___ / ___", "Lugar: ___", "Edad: ___") — including when the value is the LEARNER'S OWN information. The structure (one labelled field per datum) is what makes it fill-in-the-blank, not whether a teacher could mark it right.
+    - Determinable answers derivable from the page context: unscrambling scrambled letters, counting syllables/letters/words, filling in missing letters of a partially-written word, choosing the longer/shorter/correct of two given options, solving a shown equation, translating a shown word, copying a specific value from a reading passage.
+    This applies whether the writing area is an inline blank, a small box, an empty cell, or a full-width line beside the prompt.
+  • FREE-FORM COMPOSITION → activity_open_ended_answer. Pick this ONLY when the prompt expects the learner to write sentences or paragraphs in their own words — opinion, description, narrative, explanation, reflection. The writable area is typically large (several ruled lines under one prompt, or a tall box). Examples: "Describe tu personaje favorito", "Explica qué aprendiste", "Escribe un final diferente a la historia", "¿Qué harías tú en esta situación?". Also: dictation activities where the answer comes from the teacher speaking aloud and cannot be derived from the page alone.
+  • Empty cells inside a table grid where the learner fills each cell → activity_fill_in_a_table
+  Decision rule: "Is the learner filling in DISCRETE values (word/number/name/date/short phrase) into one or more labelled fields, OR writing SENTENCES/PARAGRAPHS in free-form composition?"
+    - Discrete values (one per field, however many fields) → activity_fill_in_the_blank
+    - Sentences/paragraphs in the learner's own words → activity_open_ended_answer
+  Worked examples:
+    - "Ordena las letras para formar los meses del año: orene ____" → activity_fill_in_the_blank (discrete word, one per line, derivable answer).
+    - "Nombre: ___, Apellido: ___, Fecha de nacimiento: ___/___/___, Lugar: ___" (an ID form the learner fills with their own info) → activity_fill_in_the_blank. Discrete labelled fields, one value per field — even though the values are the learner's personal data and a teacher could not mark them "wrong".
+    - "Tiene ___ sílabas" for the word "Nacimiento" → activity_fill_in_the_blank (discrete number, determinable).
+    - "Describe a tu familia: _________________" with 4 ruled lines → activity_open_ended_answer (free-form composition about personal life, spans multiple lines).
+    - "¿Qué aprendiste hoy? _________________" with a large box → activity_open_ended_answer.
 - Classify by the COGNITIVE TASK the learner must perform, not the physical action (circling, coloring, underlining, drawing lines). Look at what the learner must DECIDE or PRODUCE, not how they mark their answer.
 - For EVERY activity section, your "reasoning" field MUST include:
   1. What the instructions ask the learner to do
@@ -40,8 +54,8 @@ CLASSIFICATION RULES (use these to disambiguate activity types):
   • activity_sorting — learner assigns ALL items to categories, and items OUTNUMBER categories (many-to-one)
   Hard constraint: if total items > total categories, it is activity_sorting, never activity_matching — regardless of what the instruction wording suggests.
 - If there are exactly two options (true/false, yes/no, correct/incorrect) → activity_true_false
-- If no options are provided and the learner writes freely → activity_open_ended_answer
-- If sentences have blanks to fill in with missing words → activity_fill_in_the_blank
+- If the expected answer is FREE-FORM (legitimately varies between students — opinion, description, narrative, reflection, personal data, or teacher-dictated content) → activity_open_ended_answer
+- If the expected answer is DETERMINABLE (one correct value derivable from the prompt or page — unscrambling, counting, missing letters, labelling, copying from a passage, solving) → activity_fill_in_the_blank. This is the right pick whenever the writing area has a correct answer, regardless of whether the blank is inline in a sentence or a full-width line beside the prompt.
 - If a table grid has empty cells to complete → activity_fill_in_a_table
 - activity_other is a last resort — only use it when the learning mechanic itself is truly unique (e.g., free drawing, crafts, physical movement) and no other activity type applies.
 

--- a/prompts/page_sectioning.liquid
+++ b/prompts/page_sectioning.liquid
@@ -18,10 +18,15 @@ SECTION TYPES:
 {% endfor %}
 
 CLASSIFICATION RULES (use these to disambiguate activity types):
+- WRITABLE-PAGE PRECEDENCE: If the page contains ANY response lines, blank lines, underlines, dotted lines, or empty boxes/cells where the learner is expected to WRITE (a word, a phrase, a sentence, or a longer answer), the section MUST be classified as an activity type — never as text_only, boxed_text, text_and_single_image, text_and_images, or other. This holds regardless of how much surrounding prose, instructions, or imagery the page contains. Choose the activity sub-type using the rules below.
+  • Lines/underscores under or after a question prompt where the learner writes a free-form answer → activity_open_ended_answer
+  • Blanks embedded inside a sentence (the learner supplies a missing word or phrase) → activity_fill_in_the_blank
+  • Empty cells inside a table grid → activity_fill_in_a_table
+  Visual signals that indicate writable response areas include: horizontal lines (solid, dotted, or dashed), runs of underscores ("___"), runs of dots ("..."), empty ruled rows, and blank boxes labelled "Answer:", "Write:", "Respuesta:", "Escribe:", or similar.
 - Classify by the COGNITIVE TASK the learner must perform, not the physical action (circling, coloring, underlining, drawing lines). Look at what the learner must DECIDE or PRODUCE, not how they mark their answer.
 - For EVERY activity section, your "reasoning" field MUST include:
   1. What the instructions ask the learner to do
-  2. What the visual layout shows on the page image
+  2. What the visual layout shows on the page image (call out any response lines or empty fields explicitly)
   3. For sorting/matching activities: an explicit count (e.g., "X total items, Y categories")
   Then choose the activity type based on all of the above.
 - MULTIPLE CHOICE vs SORTING vs MATCHING — Gather all evidence before deciding:


### PR DESCRIPTION
## Summary
- Validator now fails activity_open_ended_answer, activity_fill_in_the_blank, and activity_fill_in_a_table sections that lack any editable element (textarea, writable input, or [[blank:item-N]] marker), so the LLM can't ship pages where the learner can't type.
- Permit the LLM to strip textbook blank placeholders (___ or ...) from label text when it emits a separate editable element, and skip text replacement on data-id elements containing nested editables so they aren't destroyed.
- Updated prompts add a label-plus-separate-input pattern (good for "Nombre:" / date-style fields), require one textarea per response field, drop the hardcoded Spanish placeholder, and add a writable-page precedence rule to page sectioning.

## Test plan
- [ ] pnpm --filter @adt/pipeline test (covers new writable-section, placeholder-stripping, input-type-filtering, and nested-editable-preservation cases)
- [ ] Re-run the renderer against a book with form-style pages (e.g. labelled "Nombre:" fields and open-ended response lines) and confirm textareas/inputs are emitted instead of decorative underlines