### PR TITLE
Place caret at click point when editing storyboard text

### DIFF
--- a/apps/studio/src/components/pipeline/stages/storyboard/components/BookPreviewFrame.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/BookPreviewFrame.tsx
@@ -300,15 +300,17 @@ export const BookPreviewFrame = forwardRef<BookPreviewFrameHandle, BookPreviewFr
     savedOriginalText = null;
     el.contentEditable = 'false';
     el.removeAttribute('data-adt-editing');
-    // Capture the edited text before restoring MathML display
     var newText = el.textContent || '';
     var dataId = el.getAttribute('data-id');
-    // Restore MathML display immediately so the preview looks correct
-    if (restoreHtml != null) {
-      el.innerHTML = restoreHtml;
+    // If nothing changed, restore the saved MathML display so math content
+    // re-renders (startEditing had swapped it to LaTeX source).
+    if (newText === origText) {
+      if (restoreHtml != null) el.innerHTML = restoreHtml;
+      return;
     }
-    // Only notify parent if text actually changed
-    if (newText === origText) return;
+    // Text was edited: leave the new content in place and let the parent's
+    // re-render replace it. Restoring the pre-edit HTML here would cause a
+    // visible flash of the old text before the parent's update propagates.
     var wrapper = document.getElementById('content');
     var fullHtml;
     if (wrapper) {

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/BookPreviewFrame.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/BookPreviewFrame.tsx
@@ -271,7 +271,27 @@ export const BookPreviewFrame = forwardRef<BookPreviewFrameHandle, BookPreviewFr
     }, '*');
   }
 
-  function startEditing(el) {
+  function placeCaretAtPoint(x, y) {
+    var range = null;
+    if (document.caretPositionFromPoint) {
+      var pos = document.caretPositionFromPoint(x, y);
+      if (pos) {
+        range = document.createRange();
+        range.setStart(pos.offsetNode, pos.offset);
+        range.collapse(true);
+      }
+    } else if (document.caretRangeFromPoint) {
+      range = document.caretRangeFromPoint(x, y);
+    }
+    if (!range) return false;
+    var sel = window.getSelection();
+    if (!sel) return false;
+    sel.removeAllRanges();
+    sel.addRange(range);
+    return true;
+  }
+
+  function startEditing(el, clickX, clickY) {
     if (el.tagName === 'IMG') return;
     editing = el;
     // Save the current MathML display before swapping to LaTeX
@@ -286,6 +306,10 @@ export const BookPreviewFrame = forwardRef<BookPreviewFrameHandle, BookPreviewFr
     el.contentEditable = 'true';
     el.setAttribute('data-adt-editing', 'true');
     el.focus();
+    // Place the caret at the click point instead of position 0
+    if (typeof clickX === 'number' && typeof clickY === 'number') {
+      placeCaretAtPoint(clickX, clickY);
+    }
     parent.postMessage({ type: 'editing', dataId: dataId }, '*');
   }
 
@@ -356,7 +380,7 @@ export const BookPreviewFrame = forwardRef<BookPreviewFrameHandle, BookPreviewFr
     }
     if (editing && editing !== el) finishEditing();
     selectElement(el);
-    if (el.tagName !== 'IMG') startEditing(el);
+    if (el.tagName !== 'IMG') startEditing(el, e.clientX, e.clientY);
   });
 
   document.addEventListener('keydown', function(e) {

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/BookPreviewFrame.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/BookPreviewFrame.tsx
@@ -271,27 +271,8 @@ export const BookPreviewFrame = forwardRef<BookPreviewFrameHandle, BookPreviewFr
     }, '*');
   }
 
-  function placeCaretAtPoint(x, y) {
-    var range = null;
-    if (document.caretPositionFromPoint) {
-      var pos = document.caretPositionFromPoint(x, y);
-      if (pos) {
-        range = document.createRange();
-        range.setStart(pos.offsetNode, pos.offset);
-        range.collapse(true);
-      }
-    } else if (document.caretRangeFromPoint) {
-      range = document.caretRangeFromPoint(x, y);
-    }
-    if (!range) return false;
-    var sel = window.getSelection();
-    if (!sel) return false;
-    sel.removeAllRanges();
-    sel.addRange(range);
-    return true;
-  }
-
-  function startEditing(el, clickX, clickY) {
+  function startEditing(el) {
+    if (editing === el) return;
     if (el.tagName === 'IMG') return;
     editing = el;
     // Save the current MathML display before swapping to LaTeX
@@ -306,10 +287,6 @@ export const BookPreviewFrame = forwardRef<BookPreviewFrameHandle, BookPreviewFr
     el.contentEditable = 'true';
     el.setAttribute('data-adt-editing', 'true');
     el.focus();
-    // Place the caret at the click point instead of position 0
-    if (typeof clickX === 'number' && typeof clickY === 'number') {
-      placeCaretAtPoint(clickX, clickY);
-    }
     parent.postMessage({ type: 'editing', dataId: dataId }, '*');
   }
 
@@ -348,6 +325,21 @@ export const BookPreviewFrame = forwardRef<BookPreviewFrameHandle, BookPreviewFr
     }, '*');
   }
 
+  // Enter edit mode on mousedown (before the browser's default selection
+  // behavior) so native drag-to-select works within the contentEditable
+  // element. Handling this on 'click' was too late: the selection created
+  // during mousedown/drag was wiped when startEditing swapped innerHTML.
+  document.addEventListener('mousedown', function(e) {
+    if (!isEditable()) return;
+    var el = e.target.closest('[data-id]');
+    if (!el) return;
+    if (el.tagName === 'IMG') return;
+    if (editing === el) return;
+    if (editing && editing !== el) finishEditing();
+    selectElement(el);
+    startEditing(el);
+  });
+
   document.addEventListener('click', function(e) {
     if (!isEditable()) return;
     var el = e.target.closest('[data-id]');
@@ -378,9 +370,10 @@ export const BookPreviewFrame = forwardRef<BookPreviewFrameHandle, BookPreviewFr
       parent.postMessage({ type: 'deselect' }, '*');
       return;
     }
+    if (editing === el) return;
     if (editing && editing !== el) finishEditing();
     selectElement(el);
-    if (el.tagName !== 'IMG') startEditing(el, e.clientX, e.clientY);
+    if (el.tagName !== 'IMG') startEditing(el);
   });
 
   document.addEventListener('keydown', function(e) {


### PR DESCRIPTION
## Summary
- Clicking into an editable text element in the storyboard preview now places the caret at the click coordinates instead of position 0.
- Uses `caretPositionFromPoint` with a `caretRangeFromPoint` fallback for WebKit, applied after `focus()` so the selection isn't clobbered.

## Test plan
- [ ] Click in the middle/end of an editable text element in the storyboard preview and confirm the caret lands where clicked.
- [ ] Verify editing flow (type, Enter to commit, Escape to cancel) still works.
- [ ] Sanity check in Safari to confirm the `caretRangeFromPoint` fallback path.