### PR TITLE
Hide Two Columns render strategy from wizard picker

### DIFF
--- a/apps/studio/src/components/wizard/constants.ts
+++ b/apps/studio/src/components/wizard/constants.ts
@@ -48,6 +48,7 @@ export const STRATEGY_CATEGORIES: Record<
 
 export interface RenderStrategyOption extends WizardOption {
   category: StrategyCategory;
+  hidden?: boolean;
 }
 
 // ─── Render Strategies (Step 2) ──────────────────────────────────────────────
@@ -80,6 +81,7 @@ export const RENDER_STRATEGIES = [
     title: msg`Two Columns`,
     description: msg`The ideal choice for novels, focused on a clean and continuous reading experience.`,
     category: "template",
+    hidden: true,
   },
   {
     id: "two_column_story",

--- a/apps/studio/src/components/wizard/step2LayoutOptions/RenderStrategyPicker.tsx
+++ b/apps/studio/src/components/wizard/step2LayoutOptions/RenderStrategyPicker.tsx
@@ -110,9 +110,12 @@ export function RenderStrategyPicker() {
   const presetLabel = preset?.title
   const accent = getPresetAccent(selectedPresetId)
 
+  const visibleStrategies = RENDER_STRATEGIES.filter(
+    (s) => !("hidden" in s && s.hidden),
+  )
   const strategies = allowedIds
-    ? RENDER_STRATEGIES.filter((s) => allowedIds.includes(s.id))
-    : RENDER_STRATEGIES
+    ? visibleStrategies.filter((s) => allowedIds.includes(s.id))
+    : visibleStrategies
 
   const recommendedStrategies = recommended?.length
     ? strategies.filter((s) => recommended.includes(s.id))


### PR DESCRIPTION
## Summary
- Adds optional `hidden` flag to `RenderStrategyOption` and marks `two_column` as hidden so it no longer appears in Step 2's render strategy picker.
- `RenderStrategyPicker` filters out hidden strategies before applying preset `allowedIds`. The strategy remains valid in preset `baseConfig` and the legacy `render-strategy.ts` fallback, so no runtime behavior changes outside the UI.

## Test plan
- [ ] Open the Book Creation Wizard → Step 2 and confirm "Two Columns" no longer appears under any preset (textbook, storybook, reference, custom).
- [ ] Confirm "Two Columns Story" and other strategies still render and are selectable.