### PR TITLE
Ignore colocated .test.tsx files in TanStack Router route discovery

### DIFF
--- a/apps/studio/vite.config.ts
+++ b/apps/studio/vite.config.ts
@@ -8,7 +8,7 @@ import { fileURLToPath, URL } from "node:url"
 export default defineConfig({
   plugins: [
     lingui(),
-    TanStackRouterVite({ quoteStyle: "double" }),
+    TanStackRouterVite({ quoteStyle: "double", routeFileIgnorePattern: "\\.test\\.tsx?$" }),
     react({
       babel: {
         plugins: ["@lingui/babel-plugin-lingui-macro"],


### PR DESCRIPTION
## Summary
- Adds a `routeFileIgnorePattern` to the TanStack Router Vite plugin so colocated `*.test.tsx` files under `apps/studio/src/routes/` are skipped during route tree generation.
- Silences the dev-server warning about `books.$label.$step.settings.test.tsx` not exporting a `Route`, and handles any future colocated route tests automatically.

## Test plan
- [ ] `pnpm dev` no longer prints the "does not export a Route" warning
- [ ] Existing routes still resolve correctly in the app