### PR TITLE
Flip wizard flow: PDF upload before preset selection

### DIFF
--- a/apps/studio/src/components/wizard/BookCreationWizard.tsx
+++ b/apps/studio/src/components/wizard/BookCreationWizard.tsx
@@ -14,6 +14,7 @@ import { STEPS } from "./steps"
 import { buildConfigOverrides } from "./bookCreationConfig"
 import { getPresetAccent, type PresetAccent } from "./constants"
 import { Step0Preset } from "./step0preset"
+import { StepUpload } from "./stepUpload"
 import { StudioTopBar } from "@/components/StudioTopBar"
 import { PdfCoverPreview } from "./shared/PdfCoverPreview"
 import { LayoutPreview, getPreviewWidth } from "./step2LayoutOptions/LayoutPreview"
@@ -193,7 +194,7 @@ function PreviewContainer({
 export function BookCreationWizard() {
   const { t, i18n } = useLingui()
   const navigate = useNavigate()
-  const { currentStep, setCurrentStep, stepDirection, previewFocus } = useWizard()
+  const { phase, currentStep, setCurrentStep, stepDirection, previewFocus } = useWizard()
   const form = useWizardForm()
   const createMutation = useCreateBook()
   const { data: books, isPending: booksLoading } = useBooks()
@@ -231,11 +232,15 @@ export function BookCreationWizard() {
     if (focusable) setTimeout(() => focusable.focus({ preventScroll: true }), 300)
   }
 
+  if (phase === "upload") {
+    return <StepUpload />
+  }
+
   if (currentStep === 0) {
     return (
       <div className="flex flex-1 min-h-0 flex-col h-full bg-white">
         <StudioTopBar brandLinksHome trailingTitle={<Trans>Add Book</Trans>} />
-        <div className="flex flex-1 min-h-0 flex-col overflow-auto">
+        <div className="flex flex-1 min-h-0 flex-col overflow-y-auto overflow-x-hidden">
           <Step0Preset />
         </div>
       </div>

--- a/apps/studio/src/components/wizard/index.tsx
+++ b/apps/studio/src/components/wizard/index.tsx
@@ -10,7 +10,11 @@ import {
 import type { ImageProcessingPreviewFocus } from "./step3ContentProcessing/imageProcessingPreviewTypes"
 import type { PresetId } from "./constants"
 
+export type WizardPhase = "upload" | "wizard"
+
 interface WizardContextValue {
+  phase: WizardPhase
+  setPhase: (phase: WizardPhase) => void
   currentStep: number
   setCurrentStep: (step: number) => void
   stepDirection: "forward" | "back"
@@ -23,17 +27,23 @@ interface WizardContextValue {
 const WizardContext = createContext<WizardContextValue | null>(null)
 
 export function WizardProvider({ children }: { children: ReactNode }) {
+  const [phase, setPhaseRaw] = useState<WizardPhase>("upload")
   const [currentStep, setCurrentStepRaw] = useState(0)
   const [stepDirection, setStepDirection] = useState<"forward" | "back">("forward")
 
+  const setPhase = useCallback((next: WizardPhase) => {
+    setStepDirection(next === "wizard" ? "forward" : "back")
+    setPhaseRaw(next)
+  }, [])
+
   useEffect(() => {
-    if (currentStep === 0) return
+    if (phase === "upload" && currentStep === 0) return
     const handler = (e: BeforeUnloadEvent) => {
       e.preventDefault()
     }
     window.addEventListener("beforeunload", handler)
     return () => window.removeEventListener("beforeunload", handler)
-  }, [currentStep])
+  }, [phase, currentStep])
 
   const [previewFocus, setPreviewFocusRaw] =
     useState<ImageProcessingPreviewFocus>("idle")
@@ -54,6 +64,8 @@ export function WizardProvider({ children }: { children: ReactNode }) {
   return (
     <WizardContext.Provider
       value={{
+        phase,
+        setPhase,
         currentStep,
         setCurrentStep,
         stepDirection,

--- a/apps/studio/src/components/wizard/shared/pdfMetadata.ts
+++ b/apps/studio/src/components/wizard/shared/pdfMetadata.ts
@@ -1,0 +1,22 @@
+import { getPdfJs } from "@/components/wizard/shared/pdfjsLoader"
+
+const pageCountCache = new WeakMap<File, number>()
+
+export function getCachedPdfPageCount(file: File): number | undefined {
+  return pageCountCache.get(file)
+}
+
+export async function getPdfPageCount(file: File): Promise<number> {
+  const cached = pageCountCache.get(file)
+  if (cached !== undefined) return cached
+  const pdfjs = await getPdfJs()
+  const buffer = await file.arrayBuffer()
+  const pdf = await pdfjs.getDocument({ data: buffer }).promise
+  try {
+    const count = pdf.numPages
+    pageCountCache.set(file, count)
+    return count
+  } finally {
+    await pdf.destroy()
+  }
+}

--- a/apps/studio/src/components/wizard/step0preset/index.tsx
+++ b/apps/studio/src/components/wizard/step0preset/index.tsx
@@ -1,6 +1,5 @@
 import { ArrowLeft, ArrowRight, RotateCcw } from "lucide-react"
 import { Trans } from "@lingui/react/macro"
-import { useNavigate } from "@tanstack/react-router"
 import { useStore } from "@tanstack/react-form"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
@@ -27,8 +26,13 @@ function applyPreset(form: ReturnType<typeof useWizardForm>, id: PresetId) {
 }
 
 export function Step0Preset() {
-  const navigate = useNavigate()
-  const { setCurrentStep, committedStep0Preset, setCommittedStep0Preset } = useWizard()
+  const {
+    setCurrentStep,
+    setPhase,
+    stepDirection,
+    committedStep0Preset,
+    setCommittedStep0Preset,
+  } = useWizard()
   const form = useWizardForm()
   const selected = useStore(form.store, (s) => s.values.selectedPreset) as PresetId | null
   const accent = getPresetAccent(selected)
@@ -52,8 +56,15 @@ export function Step0Preset() {
   }
 
   return (
-    <div className="flex flex-1 min-h-0 w-full bg-white flex-col items-center justify-center gap-6 sm:gap-8 px-4 py-10">
-      <div className="flex flex-col items-center gap-1">
+    <div
+      className={cn(
+        "flex flex-1 min-h-0 w-full bg-white flex-col items-center justify-center gap-6 sm:gap-8 px-4 py-10",
+        stepDirection === "forward"
+          ? "animate-step-enter-forward"
+          : "animate-step-enter-back",
+      )}
+    >
+      <div className="relative flex flex-col items-center gap-1">
         <h1
           id="preset-step-heading"
           className="text-2xl sm:text-[30px] font-semibold leading-tight sm:leading-9 tracking-[-0.75px] text-[#030303] text-center"
@@ -68,7 +79,7 @@ export function Step0Preset() {
           </Trans>
         </p>
         <div
-          className="flex min-h-[2.75rem] w-full max-w-lg items-center justify-center px-2"
+          className="pointer-events-none absolute left-1/2 top-full mt-2 flex w-full max-w-lg -translate-x-1/2 items-center justify-center px-2"
           aria-live="polite"
         >
           <p
@@ -76,7 +87,7 @@ export function Step0Preset() {
               "flex items-center justify-center gap-1.5 text-center text-sm text-red-600 transition-[opacity,transform] duration-300 ease-out motion-reduce:transition-none motion-reduce:transform-none",
               presetChanged
                 ? "opacity-100 translate-y-0"
-                : "pointer-events-none select-none opacity-0 translate-y-1",
+                : "select-none opacity-0 translate-y-1",
             )}
             aria-hidden={!presetChanged}
           >
@@ -97,7 +108,7 @@ export function Step0Preset() {
       <div className="flex items-center gap-3">
         <Button
           variant="secondary"
-          onClick={() => navigate({ to: "/" })}
+          onClick={() => setPhase("upload")}
           className="h-9 px-3 py-2 bg-[#f5f5f5] text-[#262626] hover:bg-[#e5e5e5] border-0"
         >
           <ArrowLeft className="h-4 w-4 mr-1.5" />

--- a/apps/studio/src/components/wizard/step1BasicInfo/PageRange.tsx
+++ b/apps/studio/src/components/wizard/step1BasicInfo/PageRange.tsx
@@ -2,7 +2,7 @@ import { useStore } from "@tanstack/react-form"
 import { useWizardForm } from "@/components/wizard/wizardForm"
 import { RangeSlider } from "@/components/wizard/shared/RangeSlider"
 import { getPresetAccent } from "@/components/wizard/constants"
-import { usePdfUpload } from "./PdfUpload"
+import { usePdfField } from "./PdfField"
 import { t } from "@lingui/core/macro"
 
 export function PageRange() {
@@ -11,7 +11,7 @@ export function PageRange() {
   const startPage = useStore(form.store, (s) => s.values.startPage)
   const endPage = useStore(form.store, (s) => s.values.endPage)
   const selectedPreset = useStore(form.store, (s) => s.values.selectedPreset)
-  const { totalPages } = usePdfUpload()
+  const { totalPages } = usePdfField()
   const accent = getPresetAccent(selectedPreset)
 
   const disabled = !file || totalPages === 0

--- a/apps/studio/src/components/wizard/step1BasicInfo/PdfField.tsx
+++ b/apps/studio/src/components/wizard/step1BasicInfo/PdfField.tsx
@@ -1,25 +1,15 @@
-import { useCallback, useEffect, useRef, useState } from "react"
+import { useCallback, useEffect, useRef, useState, type CSSProperties } from "react"
 import { Trans, useLingui } from "@lingui/react/macro"
 import { msg } from "@lingui/core/macro"
-import { Upload, Trash2 } from "lucide-react"
+import { Upload, RefreshCw } from "lucide-react"
 import { useStore } from "@tanstack/react-form"
 import { Button } from "@/components/ui/button"
 import { FileDropOverlay, useFileDropZone } from "@/components/ui/file-drop-overlay"
 import { useWizardForm } from "@/components/wizard/wizardForm"
 import { useBooks } from "@/hooks/use-books"
-import { getPdfJs } from "@/components/wizard/shared/pdfjsLoader"
+import { getPdfPageCount } from "@/components/wizard/shared/pdfMetadata"
+import { getPresetAccent } from "@/components/wizard/constants"
 import { cn, formatBytes } from "@/lib/utils"
-
-async function getPdfPageCount(file: File): Promise<number> {
-  const pdfjs = await getPdfJs()
-  const buffer = await file.arrayBuffer()
-  const pdf = await pdfjs.getDocument({ data: buffer }).promise
-  try {
-    return pdf.numPages
-  } finally {
-    await pdf.destroy()
-  }
-}
 
 function waitTwoAnimationFrames(): Promise<void> {
   return new Promise((resolve) => {
@@ -37,7 +27,7 @@ export function suggestLabel(file: File) {
     .slice(0, 64)
 }
 
-function suggestUniqueLabel(file: File, existingLabels: string[]): string {
+export function suggestUniqueLabel(file: File, existingLabels: string[]): string {
   const base = suggestLabel(file)
   if (!existingLabels.includes(base)) return base
   let i = 2
@@ -47,7 +37,7 @@ function suggestUniqueLabel(file: File, existingLabels: string[]): string {
 
 const pdfCache = { file: null as File | null, totalPages: 0 }
 
-export function usePdfUpload() {
+export function usePdfField() {
   const form = useWizardForm()
   const { i18n } = useLingui()
   const { data: books } = useBooks()
@@ -113,10 +103,19 @@ export function usePdfUpload() {
   return { file, totalPages, pdfError, setFile, clearFile }
 }
 
-export function PdfUpload() {
+export function PdfField() {
   const { t } = useLingui()
-  const { file, pdfError, setFile, clearFile } = usePdfUpload()
+  const form = useWizardForm()
+  const { file, pdfError, setFile } = usePdfField()
   const pdfRef = useRef<HTMLInputElement>(null)
+  const selectedPreset = useStore(form.store, (s) => s.values.selectedPreset)
+  const accent = getPresetAccent(selectedPreset)
+  const accentStyle = {
+    "--accent": accent.bg,
+    "--accent-60": `${accent.bg}99`,
+    "--accent-06": `${accent.bg}0f`,
+    "--accent-02": `${accent.bg}05`,
+  } as CSSProperties
 
   const { overlay } = useFileDropZone({
     accept: (f) => f.type === "application/pdf",
@@ -128,6 +127,8 @@ export function PdfUpload() {
     if (picked) setFile(picked)
     e.target.value = ""
   }, [setFile])
+
+  const openFilePicker = useCallback(() => pdfRef.current?.click(), [])
 
   return (
     <>
@@ -148,7 +149,16 @@ export function PdfUpload() {
           className={cn("overflow-hidden transition-[height] duration-300 ease-in-out", file ? "h-[60px]" : "h-[112px]")}
         >
           {file ? (
-            <div className="flex items-center gap-3 border border-[#e5e5e5] rounded-lg px-4 py-3 h-full">
+            <div
+              id="wizard-pdf-upload"
+              role="button"
+              tabIndex={0}
+              onClick={openFilePicker}
+              onKeyDown={(e) => e.key === "Enter" && openFilePicker()}
+              aria-label={t`Replace PDF`}
+              style={accentStyle}
+              className="flex items-center gap-3 border border-[#e5e5e5] rounded-lg px-4 py-3 h-full cursor-pointer hover:border-[var(--accent-60)] hover:bg-[var(--accent-02)] transition-colors duration-200"
+            >
               <div className="flex-1 min-w-0">
                 <p className="text-sm text-black truncate">{file.name}</p>
                 <p className="text-xs text-[#a3a3a3]">{formatBytes(file.size)}</p>
@@ -156,12 +166,19 @@ export function PdfUpload() {
               <Button
                 type="button"
                 variant="ghost"
-                size="icon"
-                onClick={clearFile}
-                aria-label={t`Remove PDF`}
-                className="h-8 w-8 text-[#737373] hover:text-[#ef4444] hover:bg-[#ef4444]/10 transition-colors shrink-0"
+                size="sm"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  openFilePicker()
+                }}
+                aria-label={t`Replace PDF`}
+                style={accentStyle}
+                className="h-8 px-2 text-[#737373] hover:text-[var(--accent)] hover:bg-[var(--accent-06)] transition-colors shrink-0 gap-1.5"
               >
-                <Trash2 className="h-4 w-4" />
+                <RefreshCw className="h-3.5 w-3.5" />
+                <span className="text-xs font-medium">
+                  <Trans>Replace</Trans>
+                </span>
               </Button>
             </div>
           ) : (
@@ -169,10 +186,11 @@ export function PdfUpload() {
               id="wizard-pdf-upload"
               role="button"
               tabIndex={0}
-              onClick={() => pdfRef.current?.click()}
-              onKeyDown={(e) => e.key === "Enter" && pdfRef.current?.click()}
+              onClick={openFilePicker}
+              onKeyDown={(e) => e.key === "Enter" && openFilePicker()}
               aria-label={t`Upload PDF or drag and drop`}
-              className="flex flex-col items-center justify-center gap-2 border border-dashed border-[#d4d4d4] rounded-lg h-full cursor-pointer hover:border-[#2b7fff]/60 hover:bg-[#2b7fff]/[0.02] transition-colors duration-200"
+              style={accentStyle}
+              className="flex flex-col items-center justify-center gap-2 border border-dashed border-[#d4d4d4] rounded-lg h-full cursor-pointer hover:border-[var(--accent-60)] hover:bg-[var(--accent-02)] transition-colors duration-200"
             >
               <Upload className="h-4 w-4 text-[#737373]" />
               <span className="text-sm text-[#737373]">

--- a/apps/studio/src/components/wizard/step1BasicInfo/index.tsx
+++ b/apps/studio/src/components/wizard/step1BasicInfo/index.tsx
@@ -1,7 +1,7 @@
 import { useBooks } from "@/hooks/use-books"
 import { useWizardForm } from "../wizardForm"
 import { PresetViewer } from "./PresetViewer"
-import { PdfUpload } from "./PdfUpload"
+import { PdfField } from "./PdfField"
 import { PageRange } from "./PageRange"
 import { ProjectNameField } from "./ProjectNameField"
 import { createProjectLabelSchema } from "./projectLabelSchema"
@@ -14,7 +14,7 @@ export function Step1() {
   return (
     <div className="flex flex-col gap-6 p-8">
       <PresetViewer />
-      <PdfUpload />
+      <PdfField />
 
       <form.Field
         name="label"

--- a/apps/studio/src/components/wizard/step3ContentProcessing/index.tsx
+++ b/apps/studio/src/components/wizard/step3ContentProcessing/index.tsx
@@ -34,8 +34,8 @@ const TITLE_SEGMENTATION = msg`Image Segmentation`
 const SUBTITLE_SEGMENTATION = msg`Detects and splits composited illustrations into separate regions so each asset can be placed and refined on its own.`
 
 const FILTER_LABEL = msg`Image Filter Size`
-const FILTER_MIN_LABEL = msg`Min Side`
-const FILTER_MAX_LABEL = msg`Max Side`
+const FILTER_MIN_LABEL = msg`Min Size (px)`
+const FILTER_MAX_LABEL = msg`Max Size (px)`
 
 function SegmentationThresholdPanel({
   segmentationMinSide,

--- a/apps/studio/src/components/wizard/stepUpload/index.tsx
+++ b/apps/studio/src/components/wizard/stepUpload/index.tsx
@@ -1,0 +1,462 @@
+/* eslint-disable lingui/no-unlocalized-strings -- wizard strings are finalized later */
+import { useCallback, useEffect, useRef, useState } from "react"
+import { useNavigate } from "@tanstack/react-router"
+import { useStore } from "@tanstack/react-form"
+import {
+  ArrowLeft,
+  ArrowRight,
+  Upload,
+  Loader2,
+  Trash2,
+  FileText,
+  BookOpen,
+  AlertCircle,
+} from "lucide-react"
+import { Button } from "@/components/ui/button"
+import {
+  FileDropOverlay,
+  useFileDropZone,
+} from "@/components/ui/file-drop-overlay"
+import { cn, formatBytes } from "@/lib/utils"
+import { useWizard } from "@/components/wizard"
+import { useWizardForm } from "@/components/wizard/wizardForm"
+import { useBooks } from "@/hooks/use-books"
+import { StudioTopBar } from "@/components/StudioTopBar"
+import {
+  suggestLabel,
+  suggestUniqueLabel,
+} from "@/components/wizard/step1BasicInfo/PdfField"
+import {
+  getCachedPdfPageCount,
+  getPdfPageCount,
+} from "@/components/wizard/shared/pdfMetadata"
+import { usePdfPreviewPages } from "@/components/wizard/shared/usePdfPreviewPages"
+
+const CARD_HEIGHT = "h-[340px]"
+
+function isPdfFile(f: File) {
+  return f.type === "application/pdf" || f.name.toLowerCase().endsWith(".pdf")
+}
+
+function PdfPreviewCard({
+  file,
+  pageCount,
+  onReplace,
+}: {
+  file: File
+  pageCount: number
+  onReplace: () => void
+}) {
+  const { pages, isLoading } = usePdfPreviewPages({
+    file,
+    mode: "first",
+    width: 160,
+    height: 220,
+  })
+  const cover = pages[0]
+  const displayTitle = suggestLabel(file) || file.name
+
+  return (
+    <div className={cn("w-full max-w-2xl border border-slate-200 rounded-lg overflow-hidden grid grid-cols-[2fr_1fr] bg-white", CARD_HEIGHT)}>
+      <div className="flex flex-col">
+        <div className="px-5 pt-5 pb-3 space-y-1">
+          <p className="font-semibold text-lg leading-snug line-clamp-2 text-slate-900">
+            {displayTitle}
+          </p>
+          <p className="text-[11px] text-slate-400 truncate">
+            {file.name} &middot; {formatBytes(file.size)}
+          </p>
+        </div>
+
+        <div className="px-5 pb-4">
+          <p className="text-[10px] font-semibold uppercase tracking-wider text-slate-400 mb-2">
+            PDF info
+          </p>
+          <div className="space-y-2 text-xs text-slate-500">
+            <div className="flex items-center gap-2">
+              <FileText className="w-3.5 h-3.5 text-slate-400 shrink-0" />
+              <span>
+                {pageCount} {pageCount === 1 ? "page" : "pages"}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div className="px-5 pb-4 mt-auto">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={onReplace}
+            className="h-8 px-3 text-xs"
+          >
+            <Upload className="h-3.5 w-3.5 mr-1.5" />
+            Replace PDF
+          </Button>
+        </div>
+      </div>
+
+      <div className="flex flex-col justify-center items-center border-l border-slate-200 bg-slate-50/50 p-5">
+        {cover ? (
+          <img
+            src={cover}
+            alt={displayTitle}
+            className="w-full max-w-[160px] rounded-sm border border-slate-200 shadow-md object-contain"
+          />
+        ) : (
+          <div className="w-full aspect-[3/4] max-w-[160px] rounded-sm border border-slate-200 bg-gradient-to-br from-slate-100 to-slate-200 flex flex-col items-center justify-center gap-3 shadow-md">
+            {isLoading ? (
+              <Loader2 className="w-6 h-6 text-slate-400 animate-spin" />
+            ) : (
+              <BookOpen className="w-10 h-10 text-slate-300" />
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export function StepUpload() {
+  const navigate = useNavigate()
+  const { setPhase, stepDirection } = useWizard()
+  const form = useWizardForm()
+  const { data: books } = useBooks()
+  const file = useStore(form.store, (s) => s.values.file)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const [pageCount, setPageCount] = useState<number>(() =>
+    file ? getCachedPdfPageCount(file) ?? 0 : 0,
+  )
+  const [previewLoading, setPreviewLoading] = useState(false)
+  const [previewError, setPreviewError] = useState<string | null>(null)
+
+  const setFile = useCallback(
+    (f: File) => {
+      const existingLabels = books?.map((b: { label: string }) => b.label) ?? []
+      form.setFieldValue("file", f)
+      form.setFieldValue("label", suggestUniqueLabel(f, existingLabels))
+    },
+    [form, books],
+  )
+
+  const clearFile = useCallback(() => {
+    form.setFieldValue("file", null)
+    form.setFieldValue("label", "")
+    form.setFieldValue("startPage", "")
+    form.setFieldValue("endPage", "")
+    setPageCount(0)
+    setPreviewError(null)
+  }, [form])
+
+  const handleAccept = useCallback(
+    (f: File) => {
+      setFile(f)
+    },
+    [setFile],
+  )
+
+  useEffect(() => {
+    if (!file) {
+      setPageCount(0)
+      setPreviewLoading(false)
+      setPreviewError(null)
+      return
+    }
+    const cached = getCachedPdfPageCount(file)
+    if (cached !== undefined) {
+      setPageCount(cached)
+      setPreviewLoading(false)
+      setPreviewError(null)
+      return
+    }
+    let cancelled = false
+    setPreviewLoading(true)
+    setPreviewError(null)
+    ;(async () => {
+      try {
+        const count = await getPdfPageCount(file)
+        if (cancelled) return
+        setPageCount(count)
+        form.setFieldValue("startPage", "1")
+        form.setFieldValue("endPage", String(count))
+      } catch {
+        if (cancelled) return
+        setPreviewError(
+          "Could not read this PDF. The file may be corrupted or password-protected.",
+        )
+      } finally {
+        if (!cancelled) setPreviewLoading(false)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [file])
+
+  const { overlay } = useFileDropZone({
+    accept: isPdfFile,
+    onAccept: handleAccept,
+  })
+
+  const handleFileChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const picked = e.target.files?.[0]
+      if (picked && isPdfFile(picked)) handleAccept(picked)
+      e.target.value = ""
+    },
+    [handleAccept],
+  )
+
+  const openFilePicker = useCallback(() => fileInputRef.current?.click(), [])
+
+  const hasPreview = !!(file && pageCount > 0 && !previewError)
+  const hasError = !!previewError
+
+  const initialHasPreview = !!(file && getCachedPdfPageCount(file))
+  const skipAcceptAnimationRef = useRef(initialHasPreview)
+  const [accepted, setAccepted] = useState(initialHasPreview)
+  const [showPreview, setShowPreview] = useState(initialHasPreview)
+
+  useEffect(() => {
+    if (!hasPreview) {
+      setAccepted(false)
+      setShowPreview(false)
+      skipAcceptAnimationRef.current = false
+      return
+    }
+    if (skipAcceptAnimationRef.current) {
+      skipAcceptAnimationRef.current = false
+      return
+    }
+    setAccepted(true)
+    const timer = setTimeout(() => setShowPreview(true), 1200)
+    return () => clearTimeout(timer)
+  }, [hasPreview])
+
+  function handleContinue() {
+    if (!hasPreview) return
+    setPhase("wizard")
+  }
+
+  return (
+    <div className="flex flex-1 min-h-0 flex-col h-full bg-white">
+      <StudioTopBar brandLinksHome trailingTitle="Add Book" />
+      <FileDropOverlay
+        overlay={overlay}
+        dropLabel="Drop PDF here"
+        errorLabel="Only PDF files are supported"
+        accent="blue"
+      />
+
+      <div
+        className={cn(
+          "flex flex-1 min-h-0 w-full flex-col items-center justify-center gap-6 sm:gap-8 px-4 py-10 overflow-y-auto overflow-x-hidden",
+          stepDirection === "forward"
+            ? "animate-step-enter-forward"
+            : "animate-step-enter-back",
+        )}
+      >
+        <div className="flex flex-col items-center gap-1">
+          <h1 className="text-2xl sm:text-[30px] font-semibold leading-tight sm:leading-9 tracking-[-0.75px] text-[#030303] text-center">
+            Convert a PDF
+          </h1>
+          <div className="max-w-xl grid [&>*]:col-start-1 [&>*]:row-start-1">
+            <p
+              className={cn(
+                "text-center text-sm text-[#525252] transition-opacity duration-300 ease-out",
+                showPreview ? "opacity-0 pointer-events-none" : "opacity-100",
+              )}
+            >
+              Upload the source PDF of your book and we&apos;ll turn it into an Accessible
+              Digital Textbook with interactive activities and adaptive layouts.
+            </p>
+            <p
+              className={cn(
+                "text-center text-sm text-[#525252] transition-opacity duration-300 ease-out",
+                showPreview ? "opacity-100" : "opacity-0 pointer-events-none",
+              )}
+            >
+              Review the source PDF details below and continue to configure how your book
+              will be converted into an Accessible Digital Textbook.
+            </p>
+          </div>
+        </div>
+
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="application/pdf"
+          className="hidden"
+          onChange={handleFileChange}
+        />
+
+        <div className="w-full flex flex-col items-center px-4">
+          <div
+            className={cn(
+              "w-full max-w-md transition-all duration-300 ease-out",
+              hasError
+                ? "opacity-100 max-h-40 mb-4 scale-100"
+                : "opacity-0 max-h-0 mb-0 scale-95 overflow-hidden pointer-events-none",
+            )}
+          >
+            {previewError && (
+              <div className="flex items-start gap-3 rounded-lg border border-red-200 bg-red-50/60 px-4 py-3">
+                <AlertCircle className="w-4 h-4 text-red-500 shrink-0 mt-0.5" />
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium text-red-700">
+                    Couldn&apos;t read this PDF
+                  </p>
+                  <p className="text-xs text-red-600/80 mt-0.5 leading-relaxed">
+                    {previewError}
+                  </p>
+                </div>
+              </div>
+            )}
+          </div>
+
+          <div className="w-full grid place-items-center [&>*]:col-start-1 [&>*]:row-start-1">
+            <div
+              className={cn(
+                "w-full flex justify-center transition-all ease-out",
+                showPreview
+                  ? "opacity-0 scale-95 pointer-events-none duration-300"
+                  : `opacity-100 scale-100 ${CARD_HEIGHT} duration-300`,
+              )}
+            >
+              <div
+                role="button"
+                tabIndex={showPreview ? -1 : 0}
+                onClick={openFilePicker}
+                onKeyDown={(e) => e.key === "Enter" && openFilePicker()}
+                aria-label="Upload PDF or drag and drop"
+                className={cn(
+                  "flex flex-col items-center justify-center gap-2 border-2 border-dashed rounded-lg w-full max-w-md h-full cursor-pointer transition-colors duration-300",
+                  accepted
+                    ? "border-emerald-400 bg-emerald-50/40"
+                    : previewLoading
+                      ? "border-blue-400/60 bg-blue-500/[0.02]"
+                      : hasError
+                        ? "border-red-300 hover:border-red-400 bg-red-50/30 hover:bg-red-50/50"
+                        : "border-[#d4d4d4] hover:border-[#2b7fff]/60 hover:bg-[#2b7fff]/[0.02]",
+                )}
+              >
+                <div className="grid place-items-center [&>*]:col-start-1 [&>*]:row-start-1">
+                  <div
+                    className={cn(
+                      "flex items-center gap-2 transition-all duration-300 ease-out",
+                      accepted
+                        ? "opacity-100 scale-100"
+                        : "opacity-0 scale-90 pointer-events-none",
+                    )}
+                  >
+                    <div className="w-5 h-5 rounded-full bg-emerald-100 flex items-center justify-center">
+                      <svg
+                        className="w-3 h-3 text-emerald-600"
+                        viewBox="0 0 12 12"
+                        fill="none"
+                      >
+                        <path
+                          d="M2.5 6L5 8.5L9.5 3.5"
+                          stroke="currentColor"
+                          strokeWidth="1.5"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        />
+                      </svg>
+                    </div>
+                    <span className="text-sm font-medium text-emerald-600">
+                      PDF accepted
+                    </span>
+                  </div>
+                  <div
+                    className={cn(
+                      "flex flex-col items-center gap-2 transition-all duration-300 ease-out",
+                      previewLoading && !accepted
+                        ? "opacity-100 scale-100"
+                        : "opacity-0 scale-90 pointer-events-none",
+                    )}
+                  >
+                    <Loader2 className="h-5 w-5 text-[#2b7fff] animate-spin" />
+                    <span className="text-sm text-[#737373]">
+                      Reading PDF...
+                    </span>
+                  </div>
+                  <div
+                    className={cn(
+                      "flex flex-col items-center gap-2 transition-all duration-300 ease-out",
+                      !previewLoading && !accepted
+                        ? "opacity-100 scale-100"
+                        : "opacity-0 scale-90 pointer-events-none",
+                    )}
+                  >
+                    <Upload
+                      className={cn(
+                        "h-5 w-5",
+                        hasError ? "text-red-400" : "text-[#737373]",
+                      )}
+                    />
+                    <span
+                      className={cn(
+                        "text-sm",
+                        hasError ? "text-red-500" : "text-[#737373]",
+                      )}
+                    >
+                      {hasError ? "Try another file" : "Upload PDF or drag and drop"}
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div
+              className={cn(
+                "w-full flex justify-center transition-all duration-500 ease-out",
+                showPreview
+                  ? "opacity-100 scale-100"
+                  : "opacity-0 scale-95 pointer-events-none",
+              )}
+            >
+              {hasPreview && (
+                <div className="relative">
+                  <PdfPreviewCard
+                    file={file}
+                    pageCount={pageCount}
+                    onReplace={openFilePicker}
+                  />
+                  <button
+                    type="button"
+                    onClick={clearFile}
+                    className="absolute -top-2 -right-2 flex h-6 w-6 items-center justify-center rounded-full bg-white border border-[#e5e5e5] text-[#737373] hover:text-[#ef4444] hover:border-[#ef4444]/50 transition-colors shadow-sm"
+                    aria-label="Remove PDF"
+                  >
+                    <Trash2 className="h-3 w-3" />
+                  </button>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <Button
+            variant="secondary"
+            onClick={() => navigate({ to: "/" })}
+            className="h-9 px-3 py-2 bg-[#f5f5f5] text-[#262626] hover:bg-[#e5e5e5] border-0"
+          >
+            <ArrowLeft className="h-4 w-4 mr-1.5" />
+            Back
+          </Button>
+          <Button
+            disabled={!hasPreview || previewLoading}
+            onClick={handleContinue}
+            className="h-9 px-3 py-2 text-white bg-[#2b7fff] hover:bg-[#2b7fff]/90 disabled:opacity-50 border-0"
+          >
+            Continue
+            <ArrowRight className="h-4 w-4 ml-1.5" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/studio/src/components/wizard/steps.ts
+++ b/apps/studio/src/components/wizard/steps.ts
@@ -65,7 +65,7 @@ export const STEPS: StepDef[] = [
   },
   {
     title: msg`Content Processing`,
-    description: msg`Configure activity detection and image processing options for extracted content.`,
+    description: msg`Configure activity detection and image processing options for extracted content. Hover any setting to see how it affects the preview.`,
     component: Step3,
     isValid: (v) => {
       if (!v.imageSegmentation) return true

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -1051,8 +1051,11 @@ msgstr "Completion across the assigned page range for this reviewer session."
 msgid "Condensation"
 msgstr "Condensation"
 
-msgid "Configure activity detection and image processing options for extracted content."
-msgstr "Configure activity detection and image processing options for extracted content."
+#~ msgid "Configure activity detection and image processing options for extracted content."
+#~ msgstr "Configure activity detection and image processing options for extracted content."
+
+msgid "Configure activity detection and image processing options for extracted content. Hover any setting to see how it affects the preview."
+msgstr "Configure activity detection and image processing options for extracted content. Hover any setting to see how it affects the preview."
 
 msgid "Configure API keys for AI pipeline features."
 msgstr "Configure API keys for AI pipeline features."
@@ -2301,11 +2304,14 @@ msgstr "Match each stage of the water cycle to its definition:"
 msgid "Max Refinements"
 msgstr "Max Refinements"
 
-msgid "Max Side"
-msgstr "Max Side"
+#~ msgid "Max Side"
+#~ msgstr "Max Side"
 
 msgid "Max side (px)"
 msgstr "Max side (px)"
+
+msgid "Max Size (px)"
+msgstr "Max Size (px)"
 
 #~ msgid "Maximum number of reviewer passes after the initial sectioning. Set to 0 to disable refinement."
 #~ msgstr "Maximum number of reviewer passes after the initial sectioning. Set to 0 to disable refinement."
@@ -2376,11 +2382,14 @@ msgstr "Min complexity"
 msgid "Min image dimension (px)"
 msgstr "Min image dimension (px)"
 
-msgid "Min Side"
-msgstr "Min Side"
+#~ msgid "Min Side"
+#~ msgstr "Min Side"
 
 msgid "Min side (px)"
 msgstr "Min side (px)"
+
+msgid "Min Size (px)"
+msgstr "Min Size (px)"
 
 msgid "Minimum image dimension"
 msgstr "Minimum image dimension"
@@ -3165,8 +3174,8 @@ msgstr "Remove file"
 msgid "Remove from group"
 msgstr "Remove from group"
 
-msgid "Remove PDF"
-msgstr "Remove PDF"
+#~ msgid "Remove PDF"
+#~ msgstr "Remove PDF"
 
 msgid "Remove section"
 msgstr "Remove section"
@@ -3197,6 +3206,9 @@ msgstr "Replace"
 
 msgid "Replace from Book"
 msgstr "Replace from Book"
+
+msgid "Replace PDF"
+msgstr "Replace PDF"
 
 msgid "Replace Video?"
 msgstr "Replace Video?"

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -1051,8 +1051,11 @@ msgstr "Completion across the assigned page range for this reviewer session."
 msgid "Condensation"
 msgstr "Condensación"
 
-msgid "Configure activity detection and image processing options for extracted content."
-msgstr "Configura las opciones de detección de actividades y procesamiento de imágenes para el contenido extraído."
+#~ msgid "Configure activity detection and image processing options for extracted content."
+#~ msgstr "Configura las opciones de detección de actividades y procesamiento de imágenes para el contenido extraído."
+
+msgid "Configure activity detection and image processing options for extracted content. Hover any setting to see how it affects the preview."
+msgstr "Configura las opciones de detección de actividad y procesamiento de imágenes para el contenido extraído. Pasa el cursor sobre cualquier configuración para ver cómo afecta la vista previa."
 
 msgid "Configure API keys for AI pipeline features."
 msgstr "Configura las claves de API para las funciones de IA."
@@ -2301,11 +2304,14 @@ msgstr "Asocia cada etapa del ciclo del agua con su definición:"
 msgid "Max Refinements"
 msgstr "Refinamientos máximos"
 
-msgid "Max Side"
-msgstr "Lado Máximo"
+#~ msgid "Max Side"
+#~ msgstr "Lado Máximo"
 
 msgid "Max side (px)"
 msgstr "Lado máximo (px)"
+
+msgid "Max Size (px)"
+msgstr "Tamaño Máx (px)"
 
 #~ msgid "Maximum number of reviewer passes after the initial sectioning. Set to 0 to disable refinement."
 #~ msgstr "Número máximo de pasadas del revisor después de la sección inicial. Establece en 0 para desactivar el refinamiento."
@@ -2376,11 +2382,14 @@ msgstr "Complejidad mínima"
 msgid "Min image dimension (px)"
 msgstr "Dimensión mínima de imagen (px)"
 
-msgid "Min Side"
-msgstr "Lado Mínimo"
+#~ msgid "Min Side"
+#~ msgstr "Lado Mínimo"
 
 msgid "Min side (px)"
 msgstr "Lado mínimo (px)"
+
+msgid "Min Size (px)"
+msgstr "Tamaño Mín (px)"
 
 msgid "Minimum image dimension"
 msgstr "Dimensión mínima de imagen"
@@ -3165,8 +3174,8 @@ msgstr "Eliminar archivo"
 msgid "Remove from group"
 msgstr "Quitar del grupo"
 
-msgid "Remove PDF"
-msgstr "Eliminar PDF"
+#~ msgid "Remove PDF"
+#~ msgstr "Eliminar PDF"
 
 msgid "Remove section"
 msgstr "Remove section"
@@ -3197,6 +3206,9 @@ msgstr "Reemplazar"
 
 msgid "Replace from Book"
 msgstr "Reemplazar del libro"
+
+msgid "Replace PDF"
+msgstr "Reemplazar PDF"
 
 msgid "Replace Video?"
 msgstr "¿Reemplazar Video?"

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -1052,8 +1052,11 @@ msgstr "Progression sur la plage de pages assignée pour cette session de révis
 msgid "Condensation"
 msgstr "Condensation"
 
-msgid "Configure activity detection and image processing options for extracted content."
-msgstr "Configurez les options de détection d'activité et de traitement d'image pour le contenu extrait."
+#~ msgid "Configure activity detection and image processing options for extracted content."
+#~ msgstr "Configurez les options de détection d'activité et de traitement d'image pour le contenu extrait."
+
+msgid "Configure activity detection and image processing options for extracted content. Hover any setting to see how it affects the preview."
+msgstr "Configurer les options de détection d'activité et de traitement d'image pour le contenu extrait. Survolez un paramètre pour voir comment il affecte l'aperçu."
 
 msgid "Configure API keys for AI pipeline features."
 msgstr "Configurez les clés API pour les fonctionnalités du pipeline IA."
@@ -2305,11 +2308,14 @@ msgstr "Associez chaque étape du cycle de l'eau à sa définition :"
 msgid "Max Refinements"
 msgstr "Raffinements max"
 
-msgid "Max Side"
-msgstr "Côté max."
+#~ msgid "Max Side"
+#~ msgstr "Côté max."
 
 msgid "Max side (px)"
 msgstr "Côté max. (px)"
+
+msgid "Max Size (px)"
+msgstr "Taille max (px)"
 
 #~ msgid "Maximum number of reviewer passes after the initial sectioning. Set to 0 to disable refinement."
 #~ msgstr "Nombre maximum de passes du réviseur après le sectionnement initial. Mettre à 0 pour désactiver le raffinement."
@@ -2380,11 +2386,14 @@ msgstr "Min complexité"
 msgid "Min image dimension (px)"
 msgstr "Dimension min. d'image (px)"
 
-msgid "Min Side"
-msgstr "Côté min."
+#~ msgid "Min Side"
+#~ msgstr "Côté min."
 
 msgid "Min side (px)"
 msgstr "Côté min. (px)"
+
+msgid "Min Size (px)"
+msgstr "Taille min (px)"
 
 msgid "Minimum image dimension"
 msgstr "Dimension minimale d'image"
@@ -3169,8 +3178,8 @@ msgstr "Supprimer le fichier"
 msgid "Remove from group"
 msgstr "Retirer du groupe"
 
-msgid "Remove PDF"
-msgstr "Retirer PDF"
+#~ msgid "Remove PDF"
+#~ msgstr "Retirer PDF"
 
 msgid "Remove section"
 msgstr "Retirer section"
@@ -3201,6 +3210,9 @@ msgstr "Remplacer"
 
 msgid "Replace from Book"
 msgstr "Remplacer depuis le livre"
+
+msgid "Replace PDF"
+msgstr "Remplacer le PDF"
 
 msgid "Replace Video?"
 msgstr "Remplacer la vidéo ?"

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -1051,8 +1051,11 @@ msgstr "Completion across the assigned page range for this reviewer session."
 msgid "Condensation"
 msgstr "Condensação"
 
-msgid "Configure activity detection and image processing options for extracted content."
-msgstr "Configurar opções de detecção de atividades e processamento de imagens para conteúdo extraído."
+#~ msgid "Configure activity detection and image processing options for extracted content."
+#~ msgstr "Configurar opções de detecção de atividades e processamento de imagens para conteúdo extraído."
+
+msgid "Configure activity detection and image processing options for extracted content. Hover any setting to see how it affects the preview."
+msgstr "Configure as opções de detecção de atividade e processamento de imagem para o conteúdo extraído. Passe o mouse sobre qualquer configuração para ver como ela afeta a visualização."
 
 msgid "Configure API keys for AI pipeline features."
 msgstr "Configure as chaves de API para os recursos de IA."
@@ -2301,11 +2304,14 @@ msgstr "Associe cada estágio do ciclo da água à sua definição:"
 msgid "Max Refinements"
 msgstr "Refinamentos máximos"
 
-msgid "Max Side"
-msgstr "Lado Máximo"
+#~ msgid "Max Side"
+#~ msgstr "Lado Máximo"
 
 msgid "Max side (px)"
 msgstr "Lado máximo (px)"
+
+msgid "Max Size (px)"
+msgstr "Tamanho Máx (px)"
 
 #~ msgid "Maximum number of reviewer passes after the initial sectioning. Set to 0 to disable refinement."
 #~ msgstr "Número máximo de passagens do revisor após o seccionamento inicial. Defina como 0 para desativar o refinamento."
@@ -2376,11 +2382,14 @@ msgstr "Complexidade mínima"
 msgid "Min image dimension (px)"
 msgstr "Dimensão mínima da imagem (px)"
 
-msgid "Min Side"
-msgstr "Lado Mínimo"
+#~ msgid "Min Side"
+#~ msgstr "Lado Mínimo"
 
 msgid "Min side (px)"
 msgstr "Lado mínimo (px)"
+
+msgid "Min Size (px)"
+msgstr "Tamanho Mín (px)"
 
 msgid "Minimum image dimension"
 msgstr "Dimensão mínima da imagem"
@@ -3165,8 +3174,8 @@ msgstr "Remover arquivo"
 msgid "Remove from group"
 msgstr "Remover do grupo"
 
-msgid "Remove PDF"
-msgstr "Remover PDF"
+#~ msgid "Remove PDF"
+#~ msgstr "Remover PDF"
 
 msgid "Remove section"
 msgstr "Remove section"
@@ -3197,6 +3206,9 @@ msgstr "Substituir"
 
 msgid "Replace from Book"
 msgstr "Substituir do livro"
+
+msgid "Replace PDF"
+msgstr "Substituir PDF"
 
 msgid "Replace Video?"
 msgstr "Substituir Vídeo?"


### PR DESCRIPTION
**Draft: based on #272 to reuse the shared file-input component. Will rebase onto main and move out of draft once that PR is merged.**


## Context
Users opening the old Create a New Book flow were confused about what the wizard actually does. The opening screen with "Choose a Preset" misled them into thinking they were creating a book from scratch instead of converting a PDF into one.

The fix is a flow inversion: the PDF comes first, then the preset, then the configuration. By leading with the file, the rest of the wizard has something concrete to operate on, and the language shifts from "creating" to "converting" so expectations match what the tool actually does.

## What changed
- The wizard now opens on a new **Convert a PDF** screen where the user uploads (or drags in) the source PDF before anything else. Once a PDF is accepted, a card shows the cover, filename, size, and page count so the user can confirm it's the right file before moving on.
- In the Basic Info step, the user can now only replace the current PDF, not remove it, so there's always a selected PDF after the first upload stage.
- Small changes to the **Content Processing** step: added a hint telling users to hover a setting to see the preview update, and renamed *Min Side* / *Max Side* to *Min Size (px)* / *Max Size (px)*.

## Test plan
- [ ] From the home screen, enter the wizard and verify the first screen is now *Convert a PDF*
- [ ] Drop or pick a PDF → continue to *Choose a Preset* → pick a preset → step through the rest of the wizard
- [ ] Go back from presets to the upload screen: the preview card should appear immediately (no green *PDF accepted* flash, no *Reading PDF...* spinner)
- [ ] Drag a non-PDF file onto the upload screen; the error banner should animate in and out without shifting the layout
- [ ] Confirm that the title and Back/Continue buttons stay in the same Y position when moving between *Convert a PDF* and *Choose a Preset*
- [ ] On Step 1 (Basic Info), confirm the PDF can be replaced but not removed, and that its hover tint matches the selected preset's accent
- [ ] On the Content Processing step, confirm the new hover hint appears under the title and the Image Filter Size slider labels read *Min Size (px)* / *Max Size (px)*