### PR TITLE
Always include base language as a first-class output

### DIFF
--- a/apps/api/src/routes/package.ts
+++ b/apps/api/src/routes/package.ts
@@ -55,9 +55,9 @@ function resolvePackagingParams(
   )
   const outputLanguages = Array.from(
     new Set(
-      (config.output_languages && config.output_languages.length > 0
-        ? config.output_languages
-        : [language]).map((code) => normalizeLocale(code)),
+      [language, ...(config.output_languages ?? [])].map((code) =>
+        normalizeLocale(code),
+      ),
     ),
   )
   const title = metadata?.title ?? safeLabel

--- a/apps/api/src/routes/tts.ts
+++ b/apps/api/src/routes/tts.ts
@@ -94,9 +94,9 @@ function getOutputLanguages(
 ): string[] {
   return Array.from(
     new Set(
-      (config.output_languages && config.output_languages.length > 0
-        ? config.output_languages
-        : [sourceLanguage]).map((code) => normalizeLocale(code))
+      [sourceLanguage, ...(config.output_languages ?? [])].map((code) =>
+        normalizeLocale(code)
+      )
     )
   )
 }

--- a/apps/api/src/services/export-service.ts
+++ b/apps/api/src/services/export-service.ts
@@ -91,9 +91,7 @@ export async function prepareExport(
     const language = normalizeLocale(config.editing_language ?? metadata?.language_code ?? "en")
     const outputLanguages = Array.from(
       new Set(
-        (config.output_languages && config.output_languages.length > 0
-          ? config.output_languages
-          : [language]).map((code) => normalizeLocale(code))
+        [language, ...(config.output_languages ?? [])].map((code) => normalizeLocale(code))
       )
     )
     const title = metadata?.title ?? safeLabel

--- a/apps/api/src/services/stage-runner.ts
+++ b/apps/api/src/services/stage-runner.ts
@@ -1392,12 +1392,10 @@ async function runTranslateStep(
     const pages = storage.getPages()
     const effectiveConcurrency = config.concurrency ?? 32
 
-    // Output languages default to editing language if not set
+    // Output languages — always include the base language so it's treated as a first-class output
     const outputLanguages = Array.from(
       new Set(
-        (config.output_languages && config.output_languages.length > 0
-          ? config.output_languages
-          : [language]).map((code) => normalizeLocale(code))
+        [language, ...(config.output_languages ?? [])].map((code) => normalizeLocale(code))
       )
     )
 

--- a/apps/studio/src/components/pipeline/stages/export/ExportDialog.tsx
+++ b/apps/studio/src/components/pipeline/stages/export/ExportDialog.tsx
@@ -569,12 +569,22 @@ export function ExportDialog({
   const formatConfigByType = buildExportFormatConfig(t);
 
   const { data: configData } = useBookConfig(bookLabel);
+  const { data: book } = useBook(bookLabel);
   const config = configData?.config as Record<string, unknown> | undefined;
+  const baseLanguage = normalizeLocale(
+    (config?.editing_language as string | undefined) ??
+      book?.languageCode ??
+      book?.metadata?.language_code ??
+      "en",
+  );
   const configLanguages = Array.from(
     new Set(
-      ((config?.output_languages as string[] | undefined) ?? []).map((code) =>
-        normalizeLocale(code),
-      ),
+      [
+        baseLanguage,
+        ...((config?.output_languages as string[] | undefined) ?? []).map(
+          (code) => normalizeLocale(code),
+        ),
+      ],
     ),
   );
 

--- a/packages/pipeline/src/pipeline-dag.ts
+++ b/packages/pipeline/src/pipeline-dag.ts
@@ -918,9 +918,7 @@ function getOutputLanguages(
 ): string[] {
   return Array.from(
     new Set(
-      (config.output_languages && config.output_languages.length > 0
-        ? config.output_languages
-        : [language]).map((code) => normalizeLocale(code))
+      [language, ...(config.output_languages ?? [])].map((code) => normalizeLocale(code))
     )
   )
 }

--- a/scripts/run-browser-a11y-recheck.ts
+++ b/scripts/run-browser-a11y-recheck.ts
@@ -164,7 +164,7 @@ async function assessBook(label: string): Promise<BookSummary> {
       const language = normalizeLocale(config.editing_language ?? metadata?.language_code ?? 'en')
       const outputLanguages = Array.from(
         new Set(
-          (config.output_languages?.length ? config.output_languages : [language]).map((code) => normalizeLocale(code))
+          [language, ...(config.output_languages ?? [])].map((code) => normalizeLocale(code))
         )
       )
       const title = metadata?.title ?? label

--- a/scripts/run-curated-a11y-regression.ts
+++ b/scripts/run-curated-a11y-regression.ts
@@ -112,7 +112,7 @@ async function assessBook(label: string): Promise<BookSummary> {
       const language = normalizeLocale(config.editing_language ?? metadata?.language_code ?? 'en')
       const outputLanguages = Array.from(
         new Set(
-          (config.output_languages?.length ? config.output_languages : [language]).map((code) => normalizeLocale(code))
+          [language, ...(config.output_languages ?? [])].map((code) => normalizeLocale(code))
         )
       )
       const title = metadata?.title ?? label


### PR DESCRIPTION
## Summary
- Prepend the base/editing language to `outputLanguages` everywhere it's computed (api routes, export-service, stage-runner, pipeline-dag, a11y scripts) instead of only using it as a fallback when `config.output_languages` is empty. `Set` dedupes.
- Update `ExportDialog` to derive `baseLanguage` from `editing_language → book.languageCode → metadata.language_code → "en"` and include it in the displayed `configLanguages`.

## Test plan
- [ ] Export a book with `output_languages` set to a list that excludes the base language; verify the base language is still exported.
- [ ] Export a book with no `output_languages` configured; verify behavior is unchanged (base language only).
- [ ] Confirm the ExportDialog shows the base language in the language list.