### PR TITLE
fix: PR review fixes for word highlighting, glossary, and translations

### DIFF
--- a/apps/api/src/routes/adt-preview.test.ts
+++ b/apps/api/src/routes/adt-preview.test.ts
@@ -234,6 +234,10 @@ describe("ADT preview routes", () => {
   })
 
   it("serves runtime timecodes and enables highlight when word timestamps exist", async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, label, "config.yaml"),
+      "speech:\n  word_highlighting: true\n",
+    )
     const storage = createBookStorage(label, tmpDir)
     try {
       storage.putNodeData("tts", "en", {
@@ -295,6 +299,10 @@ describe("ADT preview routes", () => {
   })
 
   it("enables highlight fallback when TTS exists without stored word timestamps", async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, label, "config.yaml"),
+      "speech:\n  word_highlighting: true\n",
+    )
     const storage = createBookStorage(label, tmpDir)
     try {
       storage.putNodeData("tts", "en", {

--- a/apps/api/src/routes/adt-preview.ts
+++ b/apps/api/src/routes/adt-preview.ts
@@ -408,7 +408,7 @@ function buildPreviewConfig(
     storage.getLatestNodeData("tts", language) ??
     storage.getLatestNodeData("tts", legacyLanguage)
   const hasTTS = ttsRow !== null
-  const highlightEnabled = hasTTS && speechConfig?.word_highlighting !== false
+  const highlightEnabled = hasTTS && speechConfig?.word_highlighting === true
 
   const quizRow = storage.getLatestNodeData("quiz-generation", "book")
   const quizData = quizRow?.data as { quizzes?: unknown[] } | undefined
@@ -709,7 +709,7 @@ export function createAdtPreviewRoutes(
     const lang = normalizeLocale(c.req.param("lang"))
     const safeLabel = parseBookLabel(c.req.param("label"))
     const bookConfig = loadBookConfig(safeLabel, booksDir, configPath)
-    const timecodes = bookConfig.speech?.word_highlighting !== false
+    const timecodes = bookConfig.speech?.word_highlighting === true
       ? withStorage(c.req.param("label"), (storage) =>
           buildRuntimeTimecodeMap(getWordTimestamps(storage, lang))
         )

--- a/apps/api/src/routes/tts.ts
+++ b/apps/api/src/routes/tts.ts
@@ -19,7 +19,6 @@ import {
   createAzureTTSSynthesizer,
   createGeminiTTSSynthesizer,
   createTTSSynthesizer,
-  transcribeWithWhisper,
   type LlmLogEntry,
 } from "@adt/llm"
 import {
@@ -32,6 +31,7 @@ import {
   resolveSpeechModel,
   resolveVoice,
   generateSpeechFile,
+  generateWordTimestamps,
   type ProviderRouting,
 } from "@adt/pipeline"
 
@@ -1084,13 +1084,14 @@ export function createTTSRoutes(booksDir: string, configPath?: string, taskServi
         // Non-critical — proceed without prompt
       }
 
-      const result = await transcribeWithWhisper(
+      const result = await generateWordTimestamps({
         audioBuffer,
-        ttsEntry.fileName,
-        openaiApiKey,
-        baseLanguage,
-        textPrompt,
-      )
+        fileName: ttsEntry.fileName,
+        apiKey: openaiApiKey,
+        language: baseLanguage,
+        prompt: textPrompt,
+        cacheDir: path.join(bookDir, ".cache"),
+      })
 
       const timestampEntry: WordTimestampEntry = {
         textId: parsed.data.textId,
@@ -1216,13 +1217,14 @@ export function createTTSRoutes(booksDir: string, configPath?: string, taskServi
 
             const audioBuffer = Buffer.from(fs.readFileSync(audioPath))
             const textPrompt = textMap.get(ttsEntry.textId)
-            const result = await transcribeWithWhisper(
+            const result = await generateWordTimestamps({
               audioBuffer,
-              ttsEntry.fileName,
-              openaiApiKey,
-              baseLanguage,
-              textPrompt,
-            )
+              fileName: ttsEntry.fileName,
+              apiKey: openaiApiKey,
+              language: baseLanguage,
+              prompt: textPrompt,
+              cacheDir: path.join(bookDir, ".cache"),
+            })
 
             const entry: WordTimestampEntry = {
               textId: ttsEntry.textId,

--- a/apps/api/src/services/stage-runner.test.ts
+++ b/apps/api/src/services/stage-runner.test.ts
@@ -543,6 +543,10 @@ speech:
     fs.mkdirSync(promptsDir, { recursive: true })
     writeBaseConfig(configPath)
     seedTextAndSpeechBook(booksDir, "speech-word-timestamps")
+    fs.writeFileSync(
+      path.join(booksDir, "speech-word-timestamps", "config.yaml"),
+      "speech:\n  word_highlighting: true\n",
+    )
 
     generateSpeechFileMock.mockImplementation(async (options: {
       bookDir: string
@@ -687,11 +691,12 @@ speech:
     try {
       const row = storage.getLatestNodeData("tts-timestamps", "en")
       expect(row).not.toBeNull()
-      expect(
-        (row?.data as {
-          entries: Record<string, { words: Array<{ word: string; start: number; end: number }> }>
-        }).entries
-      ).toEqual({})
+      // With highlighting disabled, the seeded timestamps are preserved so that
+      // manually-calculated entries (via the speech view) survive a speech re-run.
+      const entries = (row?.data as {
+        entries: Record<string, { words: Array<{ word: string; start: number; end: number }> }>
+      }).entries
+      expect(entries.pg001_t001?.words).toEqual([{ word: "stale", start: 0, end: 0.9 }])
     } finally {
       storage.close()
     }

--- a/apps/api/src/services/stage-runner.ts
+++ b/apps/api/src/services/stage-runner.ts
@@ -3,7 +3,7 @@ import fs from "node:fs"
 import path from "node:path"
 import { createBookStorage } from "@adt/storage"
 import type { Storage } from "@adt/storage"
-import { createLLMModel, createPromptEngine, createRateLimiter, transcribeWithWhisper } from "@adt/llm"
+import { createLLMModel, createPromptEngine, createRateLimiter } from "@adt/llm"
 import type { LlmLogEntry } from "@adt/llm"
 import {
   extractPDF,
@@ -45,6 +45,7 @@ import {
   resolveSpeechModel,
   resolveSpeechFormat,
   generateSpeechFile,
+  generateWordTimestamps,
   generateBookSummary,
   buildBookSummaryConfig,
   filterPageImageMeaningfulness,
@@ -162,49 +163,33 @@ async function processWithConcurrency<T>(
   await Promise.all(executing)
 }
 
-function buildSpeechProgressMessage(
-  audioCompleted: number,
-  audioTotal: number,
-  audioFailures: number,
-  timingCompleted = 0,
-  timingTotal = 0,
-  timingFailures = 0,
-): string {
-  const parts = [
-    `${audioCompleted}/${audioTotal} audio entries${audioFailures > 0 ? ` (${audioFailures} failed)` : ""}`,
-  ]
-
-  if (timingTotal > 0) {
-    parts.push(
-      `word timings ${timingCompleted}/${timingTotal}${timingFailures > 0 ? ` (${timingFailures} failed)` : ""}`,
-    )
-  }
-
-  return parts.join(" · ")
-}
-
 function emitSpeechStepProgress(
   progress: StageRunProgress,
   audioCompleted: number,
   audioTotal: number,
   audioFailures: number,
-  timingCompleted = 0,
-  timingTotal = 0,
-  timingFailures = 0,
 ): void {
   progress.emit({
     type: "step-progress",
     step: "tts",
-    message: buildSpeechProgressMessage(
-      audioCompleted,
-      audioTotal,
-      audioFailures,
-      timingCompleted,
-      timingTotal,
-      timingFailures,
-    ),
+    message: `${audioCompleted}/${audioTotal} audio entries${audioFailures > 0 ? ` (${audioFailures} failed)` : ""}`,
     page: audioCompleted,
     totalPages: audioTotal,
+  })
+}
+
+function emitWordTimestampStepProgress(
+  progress: StageRunProgress,
+  completed: number,
+  total: number,
+  failures: number,
+): void {
+  progress.emit({
+    type: "step-progress",
+    step: "word-timestamps",
+    message: `${completed}/${total} entries${failures > 0 ? ` (${failures} failed)` : ""}`,
+    page: completed,
+    totalPages: total,
   })
 }
 
@@ -232,15 +217,13 @@ function resolveSpeechAudioPath(
 interface GenerateSpeechWordTimestampsOptions {
   label: string
   bookDir: string
+  cacheDir: string
   apiKey?: string
   outputLanguages: string[]
   ttsResultsByLang: Map<string, SpeechFileEntry[]>
   textByLanguage: Map<string, Map<string, string>>
   concurrency: number
   progress: StageRunProgress
-  audioCompleted: number
-  audioTotal: number
-  audioFailures: number
 }
 
 async function generateSpeechWordTimestamps(
@@ -252,15 +235,13 @@ async function generateSpeechWordTimestamps(
   const {
     label,
     bookDir,
+    cacheDir,
     apiKey,
     outputLanguages,
     ttsResultsByLang,
     textByLanguage,
     concurrency,
     progress,
-    audioCompleted,
-    audioTotal,
-    audioFailures,
   } = options
 
   const entriesByLanguage = new Map<string, Record<string, WordTimestampEntry>>()
@@ -288,15 +269,7 @@ async function generateSpeechWordTimestamps(
   const failedItems: string[] = []
   let completed = 0
 
-  emitSpeechStepProgress(
-    progress,
-    audioCompleted,
-    audioTotal,
-    audioFailures,
-    0,
-    workItems.length,
-    0,
-  )
+  emitWordTimestampStepProgress(progress, 0, workItems.length, 0)
 
   await processWithConcurrency(
     workItems,
@@ -309,13 +282,17 @@ async function generateSpeechWordTimestamps(
         }
 
         const audioBuffer = Buffer.from(fs.readFileSync(audioPath))
-        const result = await transcribeWithWhisper(
+        const result = await generateWordTimestamps({
           audioBuffer,
-          entry.fileName,
+          fileName: entry.fileName,
           apiKey,
-          getBaseLanguage(language),
+          language: getBaseLanguage(language),
           prompt,
-        )
+          cacheDir,
+        })
+        if (result.cached) {
+          console.log(`[stage-run] ${label}: word timestamps cache hit for ${entry.textId} (${language})`)
+        }
 
         entriesByLanguage.get(language)![entry.textId] = {
           textId: entry.textId,
@@ -331,15 +308,7 @@ async function generateSpeechWordTimestamps(
         )
       } finally {
         completed++
-        emitSpeechStepProgress(
-          progress,
-          audioCompleted,
-          audioTotal,
-          audioFailures,
-          completed,
-          workItems.length,
-          failedItems.length,
-        )
+        emitWordTimestampStepProgress(progress, completed, workItems.length, failedItems.length)
       }
     },
   )
@@ -1636,6 +1605,7 @@ async function runSpeechStep(
 
     if (!catalog || catalog.entries.length === 0) {
       progress.emit({ type: "step-skip", step: "tts" })
+      progress.emit({ type: "step-skip", step: "word-timestamps" })
       console.log(`[stage-run] ${label}: TTS skipped (empty catalog)`)
       return
     }
@@ -1914,44 +1884,6 @@ async function runSpeechStep(
       storage.putNodeData("tts", lang, output)
     }
 
-    const wordHighlightingEnabled = config.speech?.word_highlighting !== false
-    let wordTimestampsByLang = new Map<string, Record<string, WordTimestampEntry>>()
-    let timestampFailedItems: string[] = []
-    if (wordHighlightingEnabled) {
-      const generatedWordTimestamps = await generateSpeechWordTimestamps({
-        label,
-        bookDir,
-        apiKey: options.apiKey,
-        outputLanguages,
-        ttsResultsByLang,
-        textByLanguage,
-        concurrency: effectiveConcurrency,
-        progress,
-        audioCompleted: completedItems,
-        audioTotal: totalItems,
-        audioFailures: failedItems.length,
-      })
-      wordTimestampsByLang = generatedWordTimestamps.entriesByLanguage
-      timestampFailedItems = generatedWordTimestamps.failedItems
-    }
-
-    const timestampsGeneratedAt = new Date().toISOString()
-    for (const lang of outputLanguages) {
-      const entries = wordTimestampsByLang.get(lang) ?? {}
-      storage.putNodeData("tts-timestamps", lang, {
-        entries,
-        generatedAt: timestampsGeneratedAt,
-      } satisfies WordTimestampOutput)
-    }
-
-    if (timestampFailedItems.length > 0) {
-      console.warn(
-        `[stage-run] ${label}: ${timestampFailedItems.length} word timestamp item(s) failed:\n${timestampFailedItems.join("\n")}`,
-      )
-    } else if (!wordHighlightingEnabled) {
-      console.log(`[stage-run] ${label}: word-level highlighting disabled; skipping timestamp generation`)
-    }
-
     if (geminiFailedItems.length > 0) {
       const summary = `${geminiFailedItems.length} Gemini TTS item(s) failed. Missing Gemini audio can be generated one by one from the Speech view.`
       progress.emit({
@@ -1959,11 +1891,62 @@ async function runSpeechStep(
         step: "tts",
         error: summary,
       })
+      progress.emit({ type: "step-skip", step: "word-timestamps" })
       console.log(`[stage-run] ${label}: speech completed with Gemini TTS gaps`)
       return
     }
 
     progress.emit({ type: "step-complete", step: "tts" })
+
+    const wordHighlightingEnabled = config.speech?.word_highlighting === true
+    let wordTimestampsByLang = new Map<string, Record<string, WordTimestampEntry>>()
+    let timestampFailedItems: string[] = []
+    if (wordHighlightingEnabled) {
+      progress.emit({ type: "step-start", step: "word-timestamps" })
+      const generatedWordTimestamps = await generateSpeechWordTimestamps({
+        label,
+        bookDir,
+        cacheDir,
+        apiKey: options.apiKey,
+        outputLanguages,
+        ttsResultsByLang,
+        textByLanguage,
+        concurrency: effectiveConcurrency,
+        progress,
+      })
+      wordTimestampsByLang = generatedWordTimestamps.entriesByLanguage
+      timestampFailedItems = generatedWordTimestamps.failedItems
+
+      // Only persist tts-timestamps when we actually generated them. When
+      // highlighting is disabled, leave existing rows untouched so that
+      // manually-calculated timestamps (via the speech view) are preserved
+      // across speech re-runs.
+      const timestampsGeneratedAt = new Date().toISOString()
+      for (const lang of outputLanguages) {
+        const entries = wordTimestampsByLang.get(lang) ?? {}
+        storage.putNodeData("tts-timestamps", lang, {
+          entries,
+          generatedAt: timestampsGeneratedAt,
+        } satisfies WordTimestampOutput)
+      }
+    }
+
+    if (!wordHighlightingEnabled) {
+      progress.emit({ type: "step-skip", step: "word-timestamps" })
+      console.log(`[stage-run] ${label}: word-level highlighting disabled; skipping timestamp generation`)
+    } else if (timestampFailedItems.length > 0) {
+      console.warn(
+        `[stage-run] ${label}: ${timestampFailedItems.length} word timestamp item(s) failed:\n${timestampFailedItems.join("\n")}`,
+      )
+      progress.emit({
+        type: "step-error",
+        step: "word-timestamps",
+        error: `${timestampFailedItems.length} word timestamp item(s) failed`,
+      })
+    } else {
+      progress.emit({ type: "step-complete", step: "word-timestamps" })
+    }
+
     console.log(`[stage-run] ${label}: speech complete`)
   } finally {
     storage.close()

--- a/apps/studio/src/components/pipeline/StageSidebar.test.tsx
+++ b/apps/studio/src/components/pipeline/StageSidebar.test.tsx
@@ -86,6 +86,10 @@ vi.mock("@/hooks/use-book-tasks", () => ({
   useBookTasks: () => ({ runningTasks: [], runningCount: 0 }),
 }))
 
+vi.mock("@/hooks/use-stage-missing-counts", () => ({
+  useStageMissingCounts: () => ({ translate: 0, speech: 0 }),
+}))
+
 vi.mock("@/hooks/use-pages", () => ({
   usePages: () => ({ data: [] }),
   usePageImage: () => ({ data: null }),

--- a/apps/studio/src/components/pipeline/components/StageSidebar.tsx
+++ b/apps/studio/src/components/pipeline/components/StageSidebar.tsx
@@ -16,6 +16,7 @@ import { Button } from "@/components/ui/button"
 import { useBookRun } from "@/hooks/use-book-run"
 import { useAccessibilityAssessment } from "@/hooks/use-debug"
 import { useBookTasks } from "@/hooks/use-book-tasks"
+import { useStageMissingCounts } from "@/hooks/use-stage-missing-counts"
 import { StepProgressRing } from "./StepProgressRing"
 import { usePages, usePageImage } from "@/hooks/use-pages"
 import {
@@ -141,6 +142,9 @@ export function StageSidebar({
   const { stageState } = useBookRun()
   const { data: accessibilityAssessment } = useAccessibilityAssessment(bookLabel)
   const { openSettings } = useSettingsDialog()
+  const stageMissing = useStageMissingCounts(bookLabel)
+  const translateNeedsRerun = stageMissing.translate > 0
+  const speechNeedsRerun = stageMissing.speech > 0
 
   const currentState = stageState(activeStep)
   const effectivePagesOpen =
@@ -176,7 +180,14 @@ export function StageSidebar({
     const showSubTabs = isActive && isSettings && !!settingsTabs
     const state = step.slug === "validation" && validationCompleted ? "done" : stageState(step.slug)
     const stageCompleted = state === "done"
-    const ringState = state
+
+    // Translate/Speech revert to needs-rerun look when their downstream output
+    // has gaps (e.g. after a glossary addition). The in-view banner gives the
+    // user the actionable details and Re-run button.
+    const stageNeedsRerun =
+      (step.slug === "translate" && translateNeedsRerun) ||
+      (step.slug === "speech" && speechNeedsRerun)
+    const ringState = stageNeedsRerun ? "idle" : state
 
     // "book" is always filled; "validation", "preview" and "export" fill once storyboard is done;
     // pipeline stages fill when their own stage is completed.
@@ -185,7 +196,7 @@ export function StageSidebar({
         ? true
         : step.slug === "sign-language" || step.slug === "validation" || step.slug === "preview" || step.slug === "export"
           ? storyboardDone
-          : stageCompleted
+          : stageCompleted && !stageNeedsRerun
 
     const stepLabel = step.slug === "book" ? toCamelLabel(bookLabel) : getStageLabelI18n(step.slug)
 

--- a/apps/studio/src/components/pipeline/pipeline-i18n.ts
+++ b/apps/studio/src/components/pipeline/pipeline-i18n.ts
@@ -73,6 +73,7 @@ export const STEP_LABEL_MESSAGES: Record<string, MessageDescriptor> = {
   "text-catalog": msg`Text Catalog`,
   "catalog-translation": msg`Catalog Translation`,
   tts: msg`Speech Generation`,
+  "word-timestamps": msg`Word Highlighting`,
   "package-web": msg`Web Package`,
 }
 

--- a/apps/studio/src/components/pipeline/stages/glossary/GlossaryView.tsx
+++ b/apps/studio/src/components/pipeline/stages/glossary/GlossaryView.tsx
@@ -231,6 +231,18 @@ export function GlossaryView({ bookLabel }: { bookLabel: string }) {
     })
   }
 
+  const updateEmojis = (itemId: string, newEmojis: string[]) => {
+    const base = pending ?? data ?? createEmptyGlossary()
+    if (!base) return
+    setPending({
+      ...base,
+      generatedAt: base.generatedAt || new Date().toISOString(),
+      items: base.items.map((item) =>
+        (item.id ?? item.word) === itemId ? { ...item, emojis: newEmojis } : item
+      ),
+    })
+  }
+
   const removeManualItem = (itemId: string) => {
     const base = pending ?? data ?? createEmptyGlossary()
     setPending({
@@ -293,10 +305,12 @@ export function GlossaryView({ bookLabel }: { bookLabel: string }) {
                 {t`manual`}
               </Badge>
             )}
-            {item.emojis.length > 0 && (
-              <span className="ml-1.5">{item.emojis.join(" ")}</span>
-            )}
           </div>
+          <EmojiInput
+            value={item.emojis}
+            onChange={(next) => updateEmojis(item.id ?? item.word, next)}
+            placeholder={t`Add emojis`}
+          />
           <Textarea
             value={item.definition}
             onChange={(e) => updateDefinition(item.id ?? item.word, e.target.value)}
@@ -332,5 +346,51 @@ export function GlossaryView({ bookLabel }: { bookLabel: string }) {
         onAdd={addManualItem}
       />
     </div>
+  )
+}
+
+/** Inline editor for an emoji list. Stores a draft string while the field is
+ * focused so spaces can be typed naturally; commits to a deduped, whitespace-
+ * split array on blur or Enter. */
+function EmojiInput({
+  value,
+  onChange,
+  placeholder,
+}: {
+  value: string[]
+  onChange: (v: string[]) => void
+  placeholder?: string
+}) {
+  const [draft, setDraft] = useState<string | null>(null)
+  const display = draft ?? value.join(" ")
+
+  const commit = () => {
+    if (draft === null) return
+    const parsed = Array.from(new Set(draft.split(/\s+/).filter(Boolean)))
+    if (parsed.length !== value.length || parsed.some((e, i) => e !== value[i])) {
+      onChange(parsed)
+    }
+    setDraft(null)
+  }
+
+  return (
+    <input
+      type="text"
+      value={display}
+      placeholder={placeholder}
+      onChange={(e) => setDraft(e.target.value)}
+      onBlur={commit}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") {
+          e.preventDefault()
+          e.currentTarget.blur()
+        } else if (e.key === "Escape") {
+          e.preventDefault()
+          setDraft(null)
+          e.currentTarget.blur()
+        }
+      }}
+      className="shrink-0 w-24 text-sm rounded border border-transparent bg-transparent p-1.5 hover:border-border hover:bg-muted/30 focus:border-ring focus:bg-white focus:outline-none focus:ring-1 focus:ring-ring transition-colors"
+    />
   )
 }

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/SectionEditToolbar.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/SectionEditToolbar.tsx
@@ -1149,8 +1149,8 @@ export function SectionEditToolbar({
             )}
             {onReplace && (
               <div className="relative inline-flex" ref={replaceMenuRef}>
-                <button type="button" onClick={() => onReplace(dataId)} className={`flex items-center gap-1 text-[10px] font-medium px-2 py-1 bg-muted hover:bg-accent transition-colors cursor-pointer ${onReplaceFromBook ? "rounded-l" : "rounded"}`}>
-                  <Upload className="h-3 w-3" /><Trans>Replace</Trans>
+                <button type="button" onClick={() => onReplace(dataId)} title={t`Replace`} className={`flex items-center gap-1 text-[10px] font-medium px-2 py-1 bg-muted hover:bg-accent transition-colors cursor-pointer ${onReplaceFromBook ? "rounded-l" : "rounded"}`}>
+                  <Upload className="h-3 w-3" />
                 </button>
                 {onReplaceFromBook && (
                   <>

--- a/apps/studio/src/components/pipeline/stages/translations/TranslationsSettings.tsx
+++ b/apps/studio/src/components/pipeline/stages/translations/TranslationsSettings.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { Switch } from "@/components/ui/switch"
 import { ModelSelect, OPENAI_TTS_MODELS, AZURE_TTS_MODELS, GEMINI_TTS_MODELS } from "@/components/pipeline/components/ModelSelect"
 import { useBookConfig, useUpdateBookConfig } from "@/hooks/use-book-config"
 import { useActiveConfig } from "@/hooks/use-debug"
@@ -29,6 +30,7 @@ import { normalizeLocale } from "@/lib/languages"
 import { resolveSpeechProviderForLanguage } from "@/lib/speech-routing"
 import { SpeechPromptsEditor } from "./components/SpeechPromptsEditor"
 import { VoiceMappingsEditor } from "./components/VoiceMappingsEditor"
+import { WordHighlightPreview } from "./components/WordHighlightPreview"
 import { useLingui } from "@lingui/react/macro"
 
 const langNames = new Intl.DisplayNames(["en"], { type: "language" })
@@ -63,6 +65,7 @@ export function TranslationsSettings({ bookLabel, headerTarget, tab = "general",
   const [geminiLanguages, setGeminiLanguages] = useState("")
   const [bitRate, setBitRate] = useState("")
   const [sampleRate, setSampleRate] = useState("")
+  const [wordHighlighting, setWordHighlighting] = useState(false)
 
   const [dirty, setDirty] = useState<Record<string, boolean>>({})
   const markDirty = (field: string) => setDirty((prev) => ({ ...prev, [field]: true }))
@@ -88,6 +91,7 @@ export function TranslationsSettings({ bookLabel, headerTarget, tab = "general",
       if (s.default_provider) setDefaultProvider(String(s.default_provider))
       if (s.bit_rate) setBitRate(String(s.bit_rate))
       if (s.sample_rate) setSampleRate(String(s.sample_rate))
+      setWordHighlighting(s.word_highlighting === true)
       if (s.providers && typeof s.providers === "object") {
         const providers = s.providers as Record<string, Record<string, unknown>>
         if (providers.openai) {
@@ -153,6 +157,7 @@ export function TranslationsSettings({ bookLabel, headerTarget, tab = "general",
         providers: Object.keys(providers).length > 0 ? providers : undefined,
         bit_rate: bitRate.trim() || undefined,
         sample_rate: sampleRate.trim() ? Number(sampleRate.trim()) : undefined,
+        word_highlighting: wordHighlighting,
       }
     }
     return overrides
@@ -253,6 +258,7 @@ export function TranslationsSettings({ bookLabel, headerTarget, tab = "general",
           geminiLanguages={geminiLanguages} setGeminiLanguages={setGeminiLanguages}
           bitRate={bitRate} setBitRate={setBitRate}
           sampleRate={sampleRate} setSampleRate={setSampleRate}
+          wordHighlighting={wordHighlighting} setWordHighlighting={setWordHighlighting}
           markDirty={markDirty}
         />
       )}
@@ -328,6 +334,7 @@ function SpeechLanguageCards({
   geminiLanguages, setGeminiLanguages,
   bitRate, setBitRate,
   sampleRate, setSampleRate,
+  wordHighlighting, setWordHighlighting,
   markDirty,
 }: {
   bookLabel: string
@@ -344,6 +351,7 @@ function SpeechLanguageCards({
   geminiLanguages: string; setGeminiLanguages: (v: string) => void
   bitRate: string; setBitRate: (v: string) => void
   sampleRate: string; setSampleRate: (v: string) => void
+  wordHighlighting: boolean; setWordHighlighting: (v: boolean) => void
   markDirty: (field: string) => void
 }) {
   const { t } = useLingui()
@@ -494,6 +502,20 @@ function SpeechLanguageCards({
             />
           </div>
         </div>
+        <div className="flex items-start gap-3 pt-2">
+          <Switch
+            id="word-highlighting"
+            checked={wordHighlighting}
+            onCheckedChange={(v) => { setWordHighlighting(v); markDirty("speech") }}
+          />
+          <div className="space-y-2 flex-1">
+            <Label htmlFor="word-highlighting" className="text-xs">{t`Word-level highlighting`}</Label>
+            <p className="text-[11px] text-muted-foreground">
+              {t`When enabled, word-level timestamps are calculated automatically during speech generation so the reader can highlight words as they're spoken. When disabled, you can still calculate timestamps manually from the speech view.`}
+            </p>
+            <WordHighlightPreview enabled={wordHighlighting} />
+          </div>
+        </div>
       </div>
 
       {/* Per-language cards */}
@@ -579,3 +601,4 @@ function SpeechLanguageCards({
     </div>
   )
 }
+

--- a/apps/studio/src/components/pipeline/stages/translations/TranslationsView.tsx
+++ b/apps/studio/src/components/pipeline/stages/translations/TranslationsView.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback, useMemo, type ChangeEvent } from "react"
+import { createPortal } from "react-dom"
 import { Link } from "@tanstack/react-router"
 import { Check, ChevronDown, ChevronRight, ChevronUp, Languages, Loader2, Play, Pause, Plus, RotateCcw, Save, Settings, Trash2, Type, Upload, WandSparkles, X } from "lucide-react"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
@@ -10,6 +11,7 @@ import { useBook } from "@/hooks/use-books"
 import { useStepHeader } from "../../components/StepViewRouter"
 import { useBookRun } from "@/hooks/use-book-run"
 import { useBookTasks } from "@/hooks/use-book-tasks"
+import { useStageMissingCounts } from "@/hooks/use-stage-missing-counts"
 import { useApiKey } from "@/hooks/use-api-key"
 import { StageRunCard } from "../../components/StageRunCard"
 import { useVirtualizer } from "@tanstack/react-virtual"
@@ -18,7 +20,10 @@ import { normalizeLocale } from "@/lib/languages"
 import { languageUsesSpeechProvider, resolveSpeechProviderForLanguage } from "@/lib/speech-routing"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
+import { Switch } from "@/components/ui/switch"
 import { resolveTranslationLanguageState } from "./lib/translations-view-state"
+import { WordHighlightPreview } from "./components/WordHighlightPreview"
 import { msg } from "@lingui/core/macro"
 import { useLingui } from "@lingui/react/macro"
 
@@ -172,7 +177,7 @@ function VersionPicker({
 export function TranslationsView({ bookLabel, stageSlug = "translate", selectedPageId, onSelectPage }: { bookLabel: string; stageSlug?: string; selectedPageId?: string; onSelectPage?: (pageId: string | null) => void }) {
   const isSpeechStage = stageSlug === "speech"
   const { t, i18n } = useLingui()
-  const { setExtra } = useStepHeader()
+  const { headerSlotEl } = useStepHeader()
   const { data: bookConfigData } = useBookConfig(bookLabel)
   const updateConfig = useUpdateBookConfig()
   const { data: activeConfigData } = useActiveConfig(bookLabel)
@@ -190,12 +195,21 @@ export function TranslationsView({ bookLabel, stageSlug = "translate", selectedP
 
   const handleRun = useCallback(() => {
     if (!hasApiKey || isRunning) return
+    // Speech depends on translate, so always start from translate when running
+    // speech — new catalog entries (e.g. from a glossary addition) need their
+    // translations populated before TTS can synthesize them. The per-item cache
+    // makes already-translated entries near-instant.
     queueRun({
-      fromStage: stageSlug as "translate" | "speech",
+      fromStage: "translate",
       toStage: stageSlug as "translate" | "speech",
       apiKey,
     })
   }, [hasApiKey, isRunning, apiKey, queueRun, stageSlug])
+
+  const stageMissing = useStageMissingCounts(bookLabel)
+  const missingForCurrentStage =
+    isSpeechStage ? stageMissing.speech : stageMissing.translate
+  const showMissingBanner = stageDone && !isRunning && missingForCurrentStage > 0
 
   const handleDeleteTTS = useCallback(async () => {
     await api.deleteTTS(bookLabel)
@@ -220,7 +234,7 @@ export function TranslationsView({ bookLabel, stageSlug = "translate", selectedP
   const speechConfigRecord = speechConfig && typeof speechConfig === "object"
     ? speechConfig as Record<string, unknown>
     : null
-  const wordHighlightingEnabled = speechConfigRecord?.word_highlighting !== false
+  const wordHighlightingEnabled = speechConfigRecord?.word_highlighting === true
   const outputLanguages = Array.from(
     new Set(((merged?.output_languages as string[] | undefined) ?? []).map((code) => normalizeLocale(code)))
   )
@@ -525,113 +539,84 @@ export function TranslationsView({ bookLabel, stageSlug = "translate", selectedP
     [audioLang, apiKey, transcribeMutation]
   )
 
-  useEffect(() => {
-    if (!catalog) return
-    setExtra(
-      <div className="flex items-center gap-1.5 ml-auto">
-        <span className="text-[10px] bg-white/20 rounded-full px-2 py-0.5">{t`${String(displayEntries.length)} texts`}</span>
-        {outputLanguages.length > 1 && (
-          <span className="text-[10px] bg-white/20 rounded-full px-2 py-0.5">{t`${String(outputLanguages.length)} languages`}</span>
-        )}
-        {currentLanguageUsesGemini ? (
-          <span className="text-[10px] bg-white/20 rounded-full px-2 py-0.5">
-            {t`${String(generatedAudioCount)}/${String(displayEntries.length)} audio`}
-          </span>
-        ) : totalAudioFiles > 0 && (
-          <span className="text-[10px] bg-white/20 rounded-full px-2 py-0.5">{t`${String(totalAudioFiles)} audio`}</span>
-        )}
-        {isSpeechStage && (
+  const headerControls = catalog ? (
+    <div className="flex items-center gap-1.5 ml-auto">
+      <span className="text-[10px] bg-white/20 rounded-full px-2 py-0.5">{t`${String(displayEntries.length)} texts`}</span>
+      {outputLanguages.length > 1 && (
+        <span className="text-[10px] bg-white/20 rounded-full px-2 py-0.5">{t`${String(outputLanguages.length)} languages`}</span>
+      )}
+      {currentLanguageUsesGemini ? (
+        <span className="text-[10px] bg-white/20 rounded-full px-2 py-0.5">
+          {t`${String(generatedAudioCount)}/${String(displayEntries.length)} audio`}
+        </span>
+      ) : totalAudioFiles > 0 && (
+        <span className="text-[10px] bg-white/20 rounded-full px-2 py-0.5">{t`${String(totalAudioFiles)} audio`}</span>
+      )}
+      {currentLanguageUsesGemini && missingAudioCount > 0 && (
+        <span className="text-[10px] bg-amber-100 text-amber-900 rounded-full px-2 py-0.5">
+          {t`${missingAudioCount} missing`}
+        </span>
+      )}
+      {selectedLang && translationVersion != null && !isSourceLang && !isSpeechStage && (
+        <VersionPicker
+          currentVersion={translationVersion}
+          saving={saving}
+          dirty={dirty}
+          bookLabel={bookLabel}
+          language={selectedLang}
+          onPreview={(d) => {
+            const data = d as { entries?: TextCatalogEntry[] }
+            setPendingEntries(data?.entries ?? [])
+          }}
+          onSave={() => saveRef.current()}
+          onDiscard={() => setPendingEntries(null)}
+        />
+      )}
+      <div className="w-px h-4 bg-white/20" />
+      <button
+        type="button"
+        onClick={() => {
+          if (!hasApiKey || isRunning) return
+          queueRun({ fromStage: "translate", toStage: stageSlug as "translate" | "speech", apiKey })
+        }}
+        disabled={!hasApiKey || isRunning}
+        title={isSpeechStage ? t`Re-run speech` : t`Re-run translation`}
+        className="text-white/60 hover:text-white transition-colors disabled:opacity-30 cursor-pointer disabled:cursor-default"
+      >
+        <RotateCcw className="w-3.5 h-3.5" />
+      </button>
+      {isSpeechStage && (
+        <>
           <button
             type="button"
-            onClick={toggleWordHighlighting}
-            disabled={updateConfig.isPending}
-            aria-pressed={wordHighlightingEnabled}
-            title={wordHighlightingEnabled
-              ? t`Disable word-level highlighting and use sentence blocks`
-              : t`Enable word-level highlighting with timestamps`}
-            className={cn(
-              "inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[10px] font-medium transition-colors",
-              wordHighlightingEnabled
-                ? "bg-white text-pink-700 hover:bg-white/90"
-                : "bg-white/10 text-white/80 hover:bg-white/20 hover:text-white",
-              updateConfig.isPending && "cursor-default opacity-70",
-            )}
-          >
-            {updateConfig.isPending ? (
-              <Loader2 className="h-3 w-3 animate-spin" />
-            ) : (
-              <Type className="h-3 w-3" />
-            )}
-            {t`Word Highlight`}
-          </button>
-        )}
-        {currentLanguageUsesGemini && missingAudioCount > 0 && (
-          <span className="text-[10px] bg-amber-100 text-amber-900 rounded-full px-2 py-0.5">
-            {t`${missingAudioCount} missing`}
-          </span>
-        )}
-        {selectedLang && translationVersion != null && !isSourceLang && !isSpeechStage && (
-          <VersionPicker
-            currentVersion={translationVersion}
-            saving={saving}
-            dirty={dirty}
-            bookLabel={bookLabel}
-            language={selectedLang}
-            onPreview={(d) => {
-              const data = d as { entries?: TextCatalogEntry[] }
-              setPendingEntries(data?.entries ?? [])
+            onClick={() => {
+              if (!audioLang) return
+              const langDisplay = langNames.of(audioLang) ?? audioLang
+              if (!window.confirm(t`Are you sure you want to generate word-level timestamps for ${langDisplay}?`)) return
+              transcribeAllMutation.mutate(audioLang)
             }}
-            onSave={() => saveRef.current()}
-            onDiscard={() => setPendingEntries(null)}
-          />
-        )}
-        <div className="w-px h-4 bg-white/20" />
-        <button
-          type="button"
-          onClick={() => {
-            if (!hasApiKey || isRunning) return
-            queueRun({ fromStage: stageSlug as "translate" | "speech", toStage: stageSlug as "translate" | "speech", apiKey })
-          }}
-          disabled={!hasApiKey || isRunning}
-          title={isSpeechStage ? t`Re-run speech` : t`Re-run translation`}
-          className="text-white/60 hover:text-white transition-colors disabled:opacity-30 cursor-pointer disabled:cursor-default"
-        >
-          <RotateCcw className="w-3.5 h-3.5" />
-        </button>
-        {isSpeechStage && (
-          <>
-            <button
-              type="button"
-              onClick={() => {
-                if (!audioLang) return
-                const langDisplay = langNames.of(audioLang) ?? audioLang
-                if (!window.confirm(t`Are you sure you want to generate word-level timestamps for ${langDisplay}?`)) return
-                transcribeAllMutation.mutate(audioLang)
-              }}
-              disabled={!apiKey || totalAudioFiles === 0 || transcribeAllMutation.isPending || isTaskRunning("transcribe-timestamps")}
-              title={apiKey ? t`Calculate word timestamps for all entries` : t`OpenAI key required`}
-              className="text-white/60 hover:text-white transition-colors disabled:opacity-30 cursor-pointer disabled:cursor-default"
-            >
-              <Type className="w-3.5 h-3.5" />
-            </button>
-            <button
-              type="button"
-              onClick={() => {
-                if (!window.confirm(t`Are you sure you want to delete generated speech?`)) return
-                handleDeleteTTS()
-              }}
-              disabled={totalAudioFiles === 0}
-              title={t`Delete all speech`}
-              className="text-white/60 hover:text-white transition-colors disabled:opacity-30 cursor-pointer disabled:cursor-default"
-            >
-              <Trash2 className="w-3.5 h-3.5" />
-            </button>
-          </>
-        )}
-      </div>
-    )
-    return () => setExtra(null)
-  }, [catalog, t, displayEntries.length, outputLanguages.length, selectedLang, translationVersion, saving, dirty, bookLabel, isSourceLang, totalAudioFiles, selectedPageId, currentLanguageUsesGemini, generatedAudioCount, missingAudioCount, hasApiKey, isRunning, apiKey, queueRun, stageSlug, isSpeechStage, handleDeleteTTS, audioLang, transcribeAllMutation, isTaskRunning, toggleWordHighlighting, updateConfig.isPending, wordHighlightingEnabled])
+            disabled={!apiKey || totalAudioFiles === 0 || transcribeAllMutation.isPending || isTaskRunning("transcribe-timestamps")}
+            title={apiKey ? t`Calculate word timestamps for all entries` : t`OpenAI key required`}
+            className="text-white/60 hover:text-white transition-colors disabled:opacity-30 cursor-pointer disabled:cursor-default"
+          >
+            <Type className="w-3.5 h-3.5" />
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              if (!window.confirm(t`Are you sure you want to delete generated speech?`)) return
+              handleDeleteTTS()
+            }}
+            disabled={totalAudioFiles === 0}
+            title={t`Delete all speech`}
+            className="text-white/60 hover:text-white transition-colors disabled:opacity-30 cursor-pointer disabled:cursor-default"
+          >
+            <Trash2 className="w-3.5 h-3.5" />
+          </button>
+        </>
+      )}
+    </div>
+  ) : null
 
   if (!showRunCard && isLoading) {
     return (
@@ -658,6 +643,8 @@ export function TranslationsView({ bookLabel, stageSlug = "translate", selectedP
 
   if (showRunCard || !catalog || entries.length === 0) {
     return (
+      <>
+      {headerSlotEl && headerControls && createPortal(headerControls, headerSlotEl)}
       <div className="p-4">
         <StageRunCard
           stageSlug={stageSlug}
@@ -712,6 +699,25 @@ export function TranslationsView({ bookLabel, stageSlug = "translate", selectedP
                   <span className="text-muted-foreground">{speechSummary.model}</span>
                 </p>
               </div>
+              <div className="space-y-2">
+                <div className="flex flex-row items-center justify-between rounded-lg border bg-background p-3">
+                  <div className="space-y-0.5 pr-3">
+                    <Label htmlFor="word-highlight-landing" className="text-sm font-medium cursor-pointer">
+                      {t`Word-level highlighting`}
+                    </Label>
+                    <p className="text-xs text-muted-foreground">
+                      {t`Highlights words in sync with the audio. Adds noticeable time to speech generation.`}
+                    </p>
+                  </div>
+                  <Switch
+                    id="word-highlight-landing"
+                    checked={wordHighlightingEnabled}
+                    onCheckedChange={toggleWordHighlighting}
+                    disabled={updateConfig.isPending || isRunning}
+                  />
+                </div>
+                <WordHighlightPreview enabled={wordHighlightingEnabled} />
+              </div>
               <Link
                 to="/books/$label/$step/settings"
                 params={{ label: bookLabel, step: "speech" }}
@@ -725,6 +731,7 @@ export function TranslationsView({ bookLabel, stageSlug = "translate", selectedP
           )}
         </StageRunCard>
       </div>
+      </>
     )
   }
 
@@ -742,6 +749,8 @@ export function TranslationsView({ bookLabel, stageSlug = "translate", selectedP
 
   // Language tabs + entries
   return (
+    <>
+    {headerSlotEl && headerControls && createPortal(headerControls, headerSlotEl)}
     <div className="flex flex-col h-full">
       {/* Fixed header: alerts, language tabs, column headers */}
       <div className="shrink-0 px-4 pt-4 space-y-3">
@@ -751,6 +760,26 @@ export function TranslationsView({ bookLabel, stageSlug = "translate", selectedP
               {runError}
             </AlertDescription>
           </Alert>
+        )}
+
+        {showMissingBanner && (
+          <div className="flex items-center justify-between gap-3 rounded-md border border-amber-200 bg-amber-50 px-3 py-2">
+            <div className="text-xs text-amber-900">
+              {isSpeechStage
+                ? t`${missingForCurrentStage} entry/entries are missing audio. Re-run to generate the missing items.`
+                : t`${missingForCurrentStage} entry/entries are missing translations. Re-run to fill the missing items.`}
+            </div>
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-7 px-3 text-xs border-amber-300 bg-white text-amber-900 hover:bg-amber-100"
+              onClick={handleRun}
+              disabled={!hasApiKey || isRunning}
+            >
+              <RotateCcw className="mr-1 h-3 w-3" />
+              {isSpeechStage ? t`Re-run speech` : t`Re-run translation`}
+            </Button>
+          </div>
         )}
 
         {/* Language filter pills — always shown, base language first */}
@@ -1056,6 +1085,7 @@ export function TranslationsView({ bookLabel, stageSlug = "translate", selectedP
       </div>
       )}
     </div>
+    </>
   )
 }
 
@@ -1295,19 +1325,41 @@ function HighlightedText({ text, timestamps, currentTime, isPlaying }: {
   )
 }
 
-/** Editable timecode field with visible up/down clicker arrows, increments by 0.1. */
-function TimecodeInput({ value, onChange, title, className }: {
+/** Editable timecode field with visible up/down clicker arrows, increments by 0.1.
+ * Clamps to [min, max]. Flashes red briefly when the user attempts to push past
+ * a bound. */
+function TimecodeInput({ value, onChange, min = 0, max = Number.POSITIVE_INFINITY, title, className }: {
   value: number
   onChange: (v: number) => void
+  min?: number
+  max?: number
   title?: string
   className?: string
 }) {
   const [draft, setDraft] = useState<string | null>(null)
+  const [flash, setFlash] = useState(false)
+  const flashTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const display = draft ?? value.toFixed(3)
 
+  useEffect(() => () => {
+    if (flashTimerRef.current) clearTimeout(flashTimerRef.current)
+  }, [])
+
+  const triggerFlash = () => {
+    setFlash(true)
+    if (flashTimerRef.current) clearTimeout(flashTimerRef.current)
+    flashTimerRef.current = setTimeout(() => setFlash(false), 400)
+  }
+
+  const tryChange = (requested: number) => {
+    const clamped = Math.max(min, Math.min(max, requested))
+    if (clamped !== value) onChange(clamped)
+    if (Math.abs(clamped - requested) > 1e-6) triggerFlash()
+  }
+
   const nudge = (direction: 1 | -1) => {
-    const next = Math.max(0, Math.round((value + direction * 0.1) * 1000) / 1000)
-    onChange(next)
+    const next = Math.round((value + direction * 0.1) * 1000) / 1000
+    tryChange(next)
     setDraft(null)
   }
 
@@ -1321,7 +1373,7 @@ function TimecodeInput({ value, onChange, title, className }: {
         onBlur={() => {
           if (draft != null) {
             const v = parseFloat(draft)
-            if (!isNaN(v) && v !== value) onChange(v)
+            if (!isNaN(v)) tryChange(v)
             setDraft(null)
           }
         }}
@@ -1337,7 +1389,7 @@ function TimecodeInput({ value, onChange, title, className }: {
           }
         }}
         title={title}
-        className={className}
+        className={cn(className, flash && "!text-red-500 !border-red-500/60")}
       />
       <span className="inline-flex flex-col -ml-0.5 shrink-0">
         <button
@@ -1382,7 +1434,19 @@ function WordTimestampViewer({ timestamps, onSave, isSaving, columns = 2 }: {
 
   const updateWord = (index: number, field: "start" | "end", value: number) => {
     const base = editWords ?? [...timestamps.words]
-    const updated = base.map((w, i) => i === index ? { ...w, [field]: value } : w)
+    const current = base[index]
+    // Clamp to keep boundaries non-overlapping: start ≥ prev.end and ≤ own end;
+    // end ≥ own start and ≤ next.start. First word's lower bound is 0; last
+    // word's upper bound is unbounded.
+    let clamped = Math.max(0, value)
+    if (field === "start") {
+      const lower = index > 0 ? base[index - 1].end : 0
+      clamped = Math.max(lower, Math.min(clamped, current.end))
+    } else {
+      const upper = index < base.length - 1 ? base[index + 1].start : Number.POSITIVE_INFINITY
+      clamped = Math.min(upper, Math.max(clamped, current.start))
+    }
+    const updated = base.map((w, i) => i === index ? { ...w, [field]: clamped } : w)
     setEditWords(updated)
   }
 
@@ -1424,11 +1488,13 @@ function WordTimestampViewer({ timestamps, onSave, isSaving, columns = 2 }: {
                 <div key={colIdx} className={cn(colIdx > 0 && "border-l")}>
                   {chunk.map((w, rowIdx) => {
                     const globalIdx = colIdx * rowCount + rowIdx
+                    const prevEnd = globalIdx > 0 ? words[globalIdx - 1].end : 0
+                    const nextStart = globalIdx < words.length - 1 ? words[globalIdx + 1].start : Number.POSITIVE_INFINITY
                     return (
                       <div key={globalIdx} className={cn("flex items-center gap-1 px-1.5 py-0.5 text-xs", rowIdx > 0 && "border-t")}>
                         <span className="flex-1 min-w-0 truncate">{w.word}</span>
-                        <TimecodeInput value={w.start} onChange={(v) => updateWord(globalIdx, "start", v)} title={t`Start`} className={inputClass} />
-                        <TimecodeInput value={w.end} onChange={(v) => updateWord(globalIdx, "end", v)} title={t`End`} className={inputClass} />
+                        <TimecodeInput value={w.start} onChange={(v) => updateWord(globalIdx, "start", v)} min={prevEnd} max={w.end} title={t`Start`} className={inputClass} />
+                        <TimecodeInput value={w.end} onChange={(v) => updateWord(globalIdx, "end", v)} min={w.start} max={nextStart} title={t`End`} className={inputClass} />
                       </div>
                     )
                   })}
@@ -1536,11 +1602,11 @@ function AudioAction({
         title={audio ? t`Replace this audio file` : t`Upload your own audio file`}
       >
         {isUploading ? (
-          <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+          <Loader2 className={cn("h-3 w-3 animate-spin", !audio && "mr-1")} />
         ) : (
-          <Upload className="mr-1 h-3 w-3" />
+          <Upload className={cn("h-3 w-3", !audio && "mr-1")} />
         )}
-        {audio ? t`Replace` : t`Upload`}
+        {!audio && t`Upload`}
       </Button>
     </>
   ) : null

--- a/apps/studio/src/components/pipeline/stages/translations/components/WordHighlightPreview.tsx
+++ b/apps/studio/src/components/pipeline/stages/translations/components/WordHighlightPreview.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useMemo, useState } from "react"
+import { Play } from "lucide-react"
+import { useLingui } from "@lingui/react/macro"
+import { cn } from "@/lib/utils"
+
+export function WordHighlightPreview({ enabled }: { enabled: boolean }) {
+  const { t } = useLingui()
+  const sentence = t`The quick brown fox jumps over the lazy dog.`
+  const { words, wordIndices } = useMemo(() => {
+    const parts = sentence.split(/(\s+)/)
+    const indices = parts.map((part, i) => (/\s/.test(part) ? -1 : i)).filter((i) => i >= 0)
+    return { words: parts, wordIndices: indices }
+  }, [sentence])
+  const [activeWord, setActiveWord] = useState(0)
+
+  useEffect(() => {
+    if (!enabled || wordIndices.length === 0) return
+    setActiveWord(0)
+    const id = window.setInterval(() => {
+      setActiveWord((prev) => (prev + 1) % wordIndices.length)
+    }, 450)
+    return () => window.clearInterval(id)
+  }, [enabled, wordIndices.length])
+
+  return (
+    <div className="rounded-md border bg-background px-3 py-2">
+      <div className="flex items-center gap-1.5 mb-1.5">
+        <Play className="h-3 w-3 text-muted-foreground" />
+        <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
+          {enabled ? t`Preview: word-by-word` : t`Preview: per-sentence`}
+        </span>
+      </div>
+      {enabled ? (
+        <p className="text-sm leading-relaxed">
+          {words.map((part, i) => {
+            if (/\s/.test(part)) return <span key={i}>{part}</span>
+            const isActive = wordIndices[activeWord] === i
+            return (
+              <span
+                key={i}
+                className={cn(
+                  "rounded px-0.5 transition-colors duration-150",
+                  isActive && "bg-yellow-200 text-yellow-950",
+                )}
+              >
+                {part}
+              </span>
+            )
+          })}
+        </p>
+      ) : (
+        <p className="text-sm leading-relaxed">
+          <span className="rounded-lg outline outline-2 outline-blue-300 bg-blue-100/30 text-black px-1 -mx-1">
+            {sentence}
+          </span>
+        </p>
+      )}
+    </div>
+  )
+}

--- a/apps/studio/src/hooks/use-book-tasks.ts
+++ b/apps/studio/src/hooks/use-book-tasks.ts
@@ -1,6 +1,8 @@
-import { useCallback } from "react"
+import { useCallback, useMemo } from "react"
 import { useQuery } from "@tanstack/react-query"
 import { api, type TaskInfoResponse } from "@/api/client"
+
+const EMPTY_TASKS: TaskInfoResponse[] = []
 
 // ---------------------------------------------------------------------------
 // Query key
@@ -21,10 +23,11 @@ export function useBookTasks(label: string) {
     refetchInterval: 5_000,
   })
 
-  const tasks = data?.tasks ?? []
+  const tasks = data?.tasks ?? EMPTY_TASKS
 
-  const runningTasks = tasks.filter(
-    (t) => t.status === "running" || t.status === "queued"
+  const runningTasks = useMemo(
+    () => tasks.filter((t) => t.status === "running" || t.status === "queued"),
+    [tasks],
   )
 
   const isTaskRunning = useCallback(

--- a/apps/studio/src/hooks/use-stage-missing-counts.ts
+++ b/apps/studio/src/hooks/use-stage-missing-counts.ts
@@ -1,0 +1,68 @@
+import { useMemo } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { api } from "@/api/client"
+import { useActiveConfig } from "@/hooks/use-debug"
+import { normalizeLocale } from "@/lib/languages"
+
+/**
+ * Returns the number of catalog entries that lack downstream output for the
+ * `translate` and `speech` stages, summed across all configured output
+ * languages. Used to surface a "missing" pill on the sidebar so users notice
+ * when a glossary addition (or other catalog change) leaves gaps to backfill.
+ *
+ * Languages that have never been run contribute their full catalog size to
+ * the count, so configuring a new target language surfaces as missing too.
+ */
+export function useStageMissingCounts(label: string): { translate: number; speech: number } {
+  const { data: catalog } = useQuery({
+    queryKey: ["books", label, "text-catalog"],
+    queryFn: () => api.getTextCatalog(label),
+    enabled: !!label,
+  })
+
+  const { data: tts } = useQuery({
+    queryKey: ["books", label, "tts"],
+    queryFn: () => api.getTTS(label),
+    enabled: !!label,
+  })
+
+  const { data: activeConfig } = useActiveConfig(label)
+
+  return useMemo(() => {
+    if (!catalog) return { translate: 0, speech: 0 }
+    const total = catalog.entries.length
+    if (total === 0) return { translate: 0, speech: 0 }
+
+    const merged = (activeConfig as { merged?: Record<string, unknown> } | undefined)?.merged
+    const outputLanguages = Array.from(
+      new Set(((merged?.output_languages as string[] | undefined) ?? []).map((code) => normalizeLocale(code))),
+    )
+    if (outputLanguages.length === 0) return { translate: 0, speech: 0 }
+
+    let translate = 0
+    for (const lang of outputLanguages) {
+      const langData = catalog.translations?.[lang]
+      if (!langData) {
+        translate += total
+        continue
+      }
+      const present = new Set(
+        langData.entries.filter((e) => e.text && e.text.trim().length > 0).map((e) => e.id),
+      )
+      translate += Math.max(total - present.size, 0)
+    }
+
+    let speech = 0
+    for (const lang of outputLanguages) {
+      const langData = tts?.languages?.[lang]
+      if (!langData) {
+        speech += total
+        continue
+      }
+      const present = new Set(langData.entries.map((e) => e.textId))
+      speech += Math.max(total - present.size, 0)
+    }
+
+    return { translate, speech }
+  }, [catalog, tts, activeConfig])
+}

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -203,6 +203,15 @@ msgstr "{issuesLabel}, {reviewLabel}"
 msgid "{missingAudioCount} missing"
 msgstr "{missingAudioCount} missing"
 
+msgid "{missingForCurrentStage} entry/entries are missing audio. Re-run to generate the missing items."
+msgstr "{missingForCurrentStage} entry/entries are missing audio. Re-run to generate the missing items."
+
+msgid "{missingForCurrentStage} entry/entries are missing translations. Re-run to fill the missing items."
+msgstr "{missingForCurrentStage} entry/entries are missing translations. Re-run to fill the missing items."
+
+#~ msgid "{missingForStage} item(s) missing — re-run to fill"
+#~ msgstr "{missingForStage} item(s) missing — re-run to fill"
+
 msgid "{regionCount} {regionCount, plural, one {region} other {regions}} detected"
 msgstr "{regionCount} {regionCount, plural, one {region} other {regions}} detected"
 
@@ -454,6 +463,9 @@ msgstr "Add checklist item to this section"
 
 msgid "Add class"
 msgstr "Add class"
+
+msgid "Add emojis"
+msgstr "Add emojis"
 
 msgid "Add entry below"
 msgstr "Add entry below"
@@ -861,6 +873,9 @@ msgstr "Cached response"
 
 msgid "Calculate word timestamps for all entries"
 msgstr "Calculate word timestamps for all entries"
+
+#~ msgid "Calculates word-level timestamps so the reader can highlight words as they're spoken. Adds noticeable time to speech generation."
+#~ msgstr "Calculates word-level timestamps so the reader can highlight words as they're spoken. Adds noticeable time to speech generation."
 
 msgid "Calls"
 msgstr "Calls"
@@ -1320,8 +1335,8 @@ msgstr "Disable reviewer validation"
 msgid "Disable type"
 msgstr "Disable type"
 
-msgid "Disable word-level highlighting and use sentence blocks"
-msgstr "Disable word-level highlighting and use sentence blocks"
+#~ msgid "Disable word-level highlighting and use sentence blocks"
+#~ msgstr "Disable word-level highlighting and use sentence blocks"
 
 msgid "Disabled"
 msgstr "Disabled"
@@ -1472,8 +1487,8 @@ msgstr "Enable or disable reviewer-authored checklist reviews for this book. Aut
 msgid "Enable reviewer validation"
 msgstr "Enable reviewer validation"
 
-msgid "Enable word-level highlighting with timestamps"
-msgstr "Enable word-level highlighting with timestamps"
+#~ msgid "Enable word-level highlighting with timestamps"
+#~ msgstr "Enable word-level highlighting with timestamps"
 
 msgid "Enabled"
 msgstr "Enabled"
@@ -1851,6 +1866,9 @@ msgstr "Hide AI edit history"
 
 msgid "Higher values filter out simple or blank images."
 msgstr "Higher values filter out simple or blank images."
+
+msgid "Highlights words in sync with the audio. Adds noticeable time to speech generation."
+msgstr "Highlights words in sync with the audio. Adds noticeable time to speech generation."
 
 msgid "Hill"
 msgstr "Hill"
@@ -2891,6 +2909,15 @@ msgstr "Preview linked page"
 msgid "Preview of the HTML/CSS patterns used for LLM-generated pages."
 msgstr "Preview of the HTML/CSS patterns used for LLM-generated pages."
 
+#~ msgid "Preview: no highlighting"
+#~ msgstr "Preview: no highlighting"
+
+msgid "Preview: per-sentence"
+msgstr "Preview: per-sentence"
+
+msgid "Preview: word-by-word"
+msgstr "Preview: word-by-word"
+
 msgid "Previous slide"
 msgstr "Previous slide"
 
@@ -3870,6 +3897,9 @@ msgstr "The prompt template used to translate text catalog entries."
 msgid "The prompt used by the reviewer pass to inspect and correct a candidate sectioning tree. Shares the model and retry settings of the sectioning prompt."
 msgstr "The prompt used by the reviewer pass to inspect and correct a candidate sectioning tree. Shares the model and retry settings of the sectioning prompt."
 
+msgid "The quick brown fox jumps over the lazy dog."
+msgstr "The quick brown fox jumps over the lazy dog."
+
 msgid "The rendering strategy used for sections without an explicit mapping."
 msgstr "The rendering strategy used for sections without an explicit mapping."
 
@@ -4247,6 +4277,9 @@ msgstr "When enabled, background colors from the styleguide are applied to the f
 msgid "When enabled, text labels near vector images (e.g. chart dimensions, speech bubbles) are grouped together and extracted as raster crops. Disable to extract only the core vector shapes without text."
 msgstr "When enabled, text labels near vector images (e.g. chart dimensions, speech bubbles) are grouped together and extracted as raster crops. Disable to extract only the core vector shapes without text."
 
+msgid "When enabled, word-level timestamps are calculated automatically during speech generation so the reader can highlight words as they're spoken. When disabled, you can still calculate timestamps manually from the speech view."
+msgstr "When enabled, word-level timestamps are calculated automatically during speech generation so the reader can highlight words as they're spoken. When disabled, you can still calculate timestamps manually from the speech view."
+
 msgid "When your PDF isn't built around facing pages, single mode keeps every page separate: nothing is merged across a spread. That matches how most textbooks, novels, and reference books are read - one page at a time."
 msgstr "When your PDF isn't built around facing pages, single mode keeps every page separate: nothing is merged across a spread. That matches how most textbooks, novels, and reference books are read - one page at a time."
 
@@ -4265,8 +4298,14 @@ msgstr "Word"
 msgid "Word and definition are required."
 msgstr "Word and definition are required."
 
-msgid "Word Highlight"
-msgstr "Word Highlight"
+#~ msgid "Word Highlight"
+#~ msgstr "Word Highlight"
+
+msgid "Word Highlighting"
+msgstr "Word Highlighting"
+
+msgid "Word-level highlighting"
+msgstr "Word-level highlighting"
 
 msgid "words"
 msgstr "words"

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -203,6 +203,15 @@ msgstr "{issuesLabel}, {reviewLabel}"
 msgid "{missingAudioCount} missing"
 msgstr "{missingAudioCount} faltantes"
 
+msgid "{missingForCurrentStage} entry/entries are missing audio. Re-run to generate the missing items."
+msgstr "{missingForCurrentStage} entrada(s) sin audio. Vuelve a ejecutar para generar los elementos faltantes."
+
+msgid "{missingForCurrentStage} entry/entries are missing translations. Re-run to fill the missing items."
+msgstr "{missingForCurrentStage} entrada(s) sin traducción. Vuelve a ejecutar para completar los elementos faltantes."
+
+#~ msgid "{missingForStage} item(s) missing — re-run to fill"
+#~ msgstr "{missingForStage} elemento(s) faltante(s) — vuelve a ejecutar para completar"
+
 msgid "{regionCount} {regionCount, plural, one {region} other {regions}} detected"
 msgstr "{regionCount} {regionCount, plural, one {region} other {regions}} detected"
 
@@ -454,6 +463,9 @@ msgstr "Add checklist item to this section"
 
 msgid "Add class"
 msgstr "Agregar clase"
+
+msgid "Add emojis"
+msgstr "Añadir emojis"
 
 msgid "Add entry below"
 msgstr "Agregar entrada debajo"
@@ -861,6 +873,9 @@ msgstr "Respuesta en caché"
 
 msgid "Calculate word timestamps for all entries"
 msgstr "Calcular marcas de tiempo por palabra para todas las entradas"
+
+#~ msgid "Calculates word-level timestamps so the reader can highlight words as they're spoken. Adds noticeable time to speech generation."
+#~ msgstr "Calcula marcas de tiempo por palabra para que el lector pueda resaltar las palabras a medida que se pronuncian. Añade un tiempo considerable a la generación de voz."
 
 msgid "Calls"
 msgstr "Llamadas"
@@ -1320,8 +1335,8 @@ msgstr "Disable reviewer validation"
 msgid "Disable type"
 msgstr "Desactivar tipo"
 
-msgid "Disable word-level highlighting and use sentence blocks"
-msgstr "Desactivar el resaltado por palabra y usar bloques de oración"
+#~ msgid "Disable word-level highlighting and use sentence blocks"
+#~ msgstr "Desactivar el resaltado por palabra y usar bloques de oración"
 
 msgid "Disabled"
 msgstr "Disabled"
@@ -1472,8 +1487,8 @@ msgstr "Enable or disable reviewer-authored checklist reviews for this book. Aut
 msgid "Enable reviewer validation"
 msgstr "Enable reviewer validation"
 
-msgid "Enable word-level highlighting with timestamps"
-msgstr "Activar el resaltado por palabra con marcas de tiempo"
+#~ msgid "Enable word-level highlighting with timestamps"
+#~ msgstr "Activar el resaltado por palabra con marcas de tiempo"
 
 msgid "Enabled"
 msgstr "Enabled"
@@ -1851,6 +1866,9 @@ msgstr "Ocultar historial de edición con IA"
 
 msgid "Higher values filter out simple or blank images."
 msgstr "Valores más altos filtran imágenes simples o en blanco."
+
+msgid "Highlights words in sync with the audio. Adds noticeable time to speech generation."
+msgstr "Resalta palabras en sincronía con el audio. Añade un tiempo considerable a la generación de voz."
 
 msgid "Hill"
 msgstr "Colina"
@@ -2891,6 +2909,15 @@ msgstr "Vista previa de la página vinculada"
 msgid "Preview of the HTML/CSS patterns used for LLM-generated pages."
 msgstr "Vista previa de los patrones HTML/CSS usados para páginas generadas por LLM."
 
+#~ msgid "Preview: no highlighting"
+#~ msgstr "Vista previa: sin resaltado"
+
+msgid "Preview: per-sentence"
+msgstr "Vista previa: por oración"
+
+msgid "Preview: word-by-word"
+msgstr "Vista previa: palabra por palabra"
+
 msgid "Previous slide"
 msgstr "Diapositiva anterior"
 
@@ -3870,6 +3897,9 @@ msgstr "La plantilla de prompt usada para traducir entradas del catálogo de tex
 msgid "The prompt used by the reviewer pass to inspect and correct a candidate sectioning tree. Shares the model and retry settings of the sectioning prompt."
 msgstr "El prompt utilizado por la pasada de revisión para inspeccionar y corregir un árbol de sección candidato. Comparte el modelo y la configuración de reintentos del prompt de sección."
 
+msgid "The quick brown fox jumps over the lazy dog."
+msgstr "El veloz zorro marrón salta sobre el perro perezoso."
+
 msgid "The rendering strategy used for sections without an explicit mapping."
 msgstr "La estrategia de renderización usada para secciones sin un mapeo explícito."
 
@@ -4247,6 +4277,9 @@ msgstr "Cuando está activado, los colores de fondo de la guía de estilo se apl
 msgid "When enabled, text labels near vector images (e.g. chart dimensions, speech bubbles) are grouped together and extracted as raster crops. Disable to extract only the core vector shapes without text."
 msgstr "Cuando está activado, las etiquetas de texto cercanas a imágenes vectoriales (p. ej. dimensiones de gráficos, globos de diálogo) se agrupan y extraen como recortes rasterizados. Desactive para extraer solo las formas vectoriales sin texto."
 
+msgid "When enabled, word-level timestamps are calculated automatically during speech generation so the reader can highlight words as they're spoken. When disabled, you can still calculate timestamps manually from the speech view."
+msgstr "Cuando está activado, las marcas de tiempo por palabra se calculan automáticamente durante la generación de voz para que el lector pueda resaltar las palabras a medida que se pronuncian. Cuando está desactivado, todavía puedes calcular las marcas de tiempo manualmente desde la vista de voz."
+
 msgid "When your PDF isn't built around facing pages, single mode keeps every page separate: nothing is merged across a spread. That matches how most textbooks, novels, and reference books are read - one page at a time."
 msgstr "Cuando tu PDF no está construido alrededor de páginas enfrentadas, el modo único mantiene cada página separada: nada se fusiona a través de una extensión. Eso coincide con cómo se leen la mayoría de los libros de texto, novelas y libros de referencia - una página a la vez."
 
@@ -4265,7 +4298,13 @@ msgstr "Palabra"
 msgid "Word and definition are required."
 msgstr "La palabra y la definición son obligatorias."
 
-msgid "Word Highlight"
+#~ msgid "Word Highlight"
+#~ msgstr "Resaltado por palabra"
+
+msgid "Word Highlighting"
+msgstr "Resaltado de palabras"
+
+msgid "Word-level highlighting"
 msgstr "Resaltado por palabra"
 
 msgid "words"

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -204,6 +204,15 @@ msgstr "{issuesLabel}, {reviewLabel}"
 msgid "{missingAudioCount} missing"
 msgstr "{missingAudioCount} manquant"
 
+msgid "{missingForCurrentStage} entry/entries are missing audio. Re-run to generate the missing items."
+msgstr "{missingForCurrentStage} entrée(s) sans audio. Relancez pour générer les éléments manquants."
+
+msgid "{missingForCurrentStage} entry/entries are missing translations. Re-run to fill the missing items."
+msgstr "{missingForCurrentStage} entrée(s) sans traduction. Relancez pour compléter les éléments manquants."
+
+#~ msgid "{missingForStage} item(s) missing — re-run to fill"
+#~ msgstr "{missingForStage} élément(s) manquant(s) — relancez pour compléter"
+
 msgid "{regionCount} {regionCount, plural, one {region} other {regions}} detected"
 msgstr "{regionCount} {regionCount, plural, one {region} other {regions}} détectée(s)"
 
@@ -455,6 +464,9 @@ msgstr "Ajouter un élément de liste de contrôle à cette section"
 
 msgid "Add class"
 msgstr "Ajouter une classe"
+
+msgid "Add emojis"
+msgstr "Ajouter des emojis"
 
 msgid "Add entry below"
 msgstr "Ajouter une entrée ci-dessous"
@@ -862,6 +874,9 @@ msgstr "Réponse en cache"
 
 msgid "Calculate word timestamps for all entries"
 msgstr "Calculer les horodatages de mots pour toutes les entrées"
+
+#~ msgid "Calculates word-level timestamps so the reader can highlight words as they're spoken. Adds noticeable time to speech generation."
+#~ msgstr "Calcule les horodatages au niveau du mot afin que le lecteur puisse surligner les mots à mesure qu'ils sont prononcés. Ajoute un temps notable à la génération de la voix."
 
 msgid "Calls"
 msgstr "Appels"
@@ -1321,8 +1336,8 @@ msgstr "Désactiver la validation du réviseur"
 msgid "Disable type"
 msgstr "Désactiver le type"
 
-msgid "Disable word-level highlighting and use sentence blocks"
-msgstr "Désactiver le surlignage mot à mot et utiliser des blocs de phrases"
+#~ msgid "Disable word-level highlighting and use sentence blocks"
+#~ msgstr "Désactiver le surlignage mot à mot et utiliser des blocs de phrases"
 
 msgid "Disabled"
 msgstr "Désactivé"
@@ -1473,8 +1488,8 @@ msgstr "Activez ou désactivez les révisions par liste de contrôle pour ce liv
 msgid "Enable reviewer validation"
 msgstr "Activer la validation du réviseur"
 
-msgid "Enable word-level highlighting with timestamps"
-msgstr "Activer le surlignage mot à mot avec horodatage"
+#~ msgid "Enable word-level highlighting with timestamps"
+#~ msgstr "Activer le surlignage mot à mot avec horodatage"
 
 msgid "Enabled"
 msgstr "Activé"
@@ -1855,6 +1870,9 @@ msgstr "Masquer l'historique des modifications IA"
 
 msgid "Higher values filter out simple or blank images."
 msgstr "Les valeurs plus élevées filtrent les images simples ou vides."
+
+msgid "Highlights words in sync with the audio. Adds noticeable time to speech generation."
+msgstr "Surligne les mots en synchronisation avec l'audio. Ajoute un temps notable à la génération de la voix."
 
 msgid "Hill"
 msgstr "Colline"
@@ -2895,6 +2913,15 @@ msgstr "Aperçu de la page liée"
 msgid "Preview of the HTML/CSS patterns used for LLM-generated pages."
 msgstr "Aperçu des modèles HTML/CSS utilisés pour les pages générées par le LLM."
 
+#~ msgid "Preview: no highlighting"
+#~ msgstr "Aperçu : sans surlignage"
+
+msgid "Preview: per-sentence"
+msgstr "Aperçu : par phrase"
+
+msgid "Preview: word-by-word"
+msgstr "Aperçu : mot à mot"
+
 msgid "Previous slide"
 msgstr "Diapositive précédente"
 
@@ -3874,6 +3901,9 @@ msgstr "Le modèle d'invite utilisé pour traduire les entrées du catalogue de 
 msgid "The prompt used by the reviewer pass to inspect and correct a candidate sectioning tree. Shares the model and retry settings of the sectioning prompt."
 msgstr "Le prompt utilisé par la passe de revue pour inspecter et corriger un arbre de sectionnement candidat. Partage le modèle et les paramètres de réessai du prompt de sectionnement."
 
+msgid "The quick brown fox jumps over the lazy dog."
+msgstr "Le vif renard brun saute par-dessus le chien paresseux."
+
 msgid "The rendering strategy used for sections without an explicit mapping."
 msgstr "La stratégie de rendu utilisée pour les sections sans correspondance explicite."
 
@@ -4251,6 +4281,9 @@ msgstr "Lorsque cette option est activée, les couleurs d'arrière-plan du guide
 msgid "When enabled, text labels near vector images (e.g. chart dimensions, speech bubbles) are grouped together and extracted as raster crops. Disable to extract only the core vector shapes without text."
 msgstr "Lorsque cette option est activée, les libellés de texte proches des images vectorielles (par ex. dimensions de graphique, bulles de dialogue) sont regroupés et extraits en recadrages raster. Désactivez pour extraire uniquement les formes vectorielles sans texte."
 
+msgid "When enabled, word-level timestamps are calculated automatically during speech generation so the reader can highlight words as they're spoken. When disabled, you can still calculate timestamps manually from the speech view."
+msgstr "Lorsque cette option est activée, les horodatages au niveau du mot sont calculés automatiquement pendant la génération de la voix afin que le lecteur puisse surligner les mots à mesure qu'ils sont prononcés. Lorsqu'elle est désactivée, vous pouvez toujours calculer les horodatages manuellement depuis la vue voix."
+
 msgid "When your PDF isn't built around facing pages, single mode keeps every page separate: nothing is merged across a spread. That matches how most textbooks, novels, and reference books are read - one page at a time."
 msgstr "Lorsque votre PDF n'est pas conçu pour des pages en regard, le mode simple garde chaque page séparée : rien n'est fusionné sur une double page. Cela correspond à la lecture de la plupart des manuels, romans et ouvrages de référence — une page à la fois."
 
@@ -4269,7 +4302,13 @@ msgstr "Mot"
 msgid "Word and definition are required."
 msgstr "Le mot et la définition sont obligatoires."
 
-msgid "Word Highlight"
+#~ msgid "Word Highlight"
+#~ msgstr "Surlignage mot à mot"
+
+msgid "Word Highlighting"
+msgstr "Surlignage des mots"
+
+msgid "Word-level highlighting"
 msgstr "Surlignage mot à mot"
 
 msgid "words"

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -203,6 +203,15 @@ msgstr "{issuesLabel}, {reviewLabel}"
 msgid "{missingAudioCount} missing"
 msgstr "{missingAudioCount} faltando"
 
+msgid "{missingForCurrentStage} entry/entries are missing audio. Re-run to generate the missing items."
+msgstr "{missingForCurrentStage} entrada(s) sem áudio. Execute novamente para gerar os itens faltantes."
+
+msgid "{missingForCurrentStage} entry/entries are missing translations. Re-run to fill the missing items."
+msgstr "{missingForCurrentStage} entrada(s) sem tradução. Execute novamente para preencher os itens faltantes."
+
+#~ msgid "{missingForStage} item(s) missing — re-run to fill"
+#~ msgstr "{missingForStage} item(ns) faltando — execute novamente para preencher"
+
 msgid "{regionCount} {regionCount, plural, one {region} other {regions}} detected"
 msgstr "{regionCount} {regionCount, plural, one {region} other {regions}} detected"
 
@@ -454,6 +463,9 @@ msgstr "Add checklist item to this section"
 
 msgid "Add class"
 msgstr "Adicionar classe"
+
+msgid "Add emojis"
+msgstr "Adicionar emojis"
 
 msgid "Add entry below"
 msgstr "Adicionar entrada abaixo"
@@ -861,6 +873,9 @@ msgstr "Resposta em cache"
 
 msgid "Calculate word timestamps for all entries"
 msgstr "Calcular marcações de tempo por palavra para todas as entradas"
+
+#~ msgid "Calculates word-level timestamps so the reader can highlight words as they're spoken. Adds noticeable time to speech generation."
+#~ msgstr "Calcula marcações de tempo por palavra para que o leitor destaque as palavras conforme são faladas. Adiciona tempo considerável à geração de fala."
 
 msgid "Calls"
 msgstr "Chamadas"
@@ -1320,8 +1335,8 @@ msgstr "Disable reviewer validation"
 msgid "Disable type"
 msgstr "Desativar tipo"
 
-msgid "Disable word-level highlighting and use sentence blocks"
-msgstr "Desativar o destaque por palavra e usar blocos de frases"
+#~ msgid "Disable word-level highlighting and use sentence blocks"
+#~ msgstr "Desativar o destaque por palavra e usar blocos de frases"
 
 msgid "Disabled"
 msgstr "Disabled"
@@ -1472,8 +1487,8 @@ msgstr "Enable or disable reviewer-authored checklist reviews for this book. Aut
 msgid "Enable reviewer validation"
 msgstr "Enable reviewer validation"
 
-msgid "Enable word-level highlighting with timestamps"
-msgstr "Ativar o destaque por palavra com marcações de tempo"
+#~ msgid "Enable word-level highlighting with timestamps"
+#~ msgstr "Ativar o destaque por palavra com marcações de tempo"
 
 msgid "Enabled"
 msgstr "Enabled"
@@ -1851,6 +1866,9 @@ msgstr "Ocultar histórico de edições com IA"
 
 msgid "Higher values filter out simple or blank images."
 msgstr "Valores mais altos filtram imagens simples ou em branco."
+
+msgid "Highlights words in sync with the audio. Adds noticeable time to speech generation."
+msgstr "Destaca palavras em sincronia com o áudio. Adiciona tempo considerável à geração de fala."
 
 msgid "Hill"
 msgstr "Colina"
@@ -2891,6 +2909,15 @@ msgstr "Visualizar página vinculada"
 msgid "Preview of the HTML/CSS patterns used for LLM-generated pages."
 msgstr "Pré-visualização dos padrões HTML/CSS usados para páginas geradas por LLM."
 
+#~ msgid "Preview: no highlighting"
+#~ msgstr "Pré-visualização: sem destaque"
+
+msgid "Preview: per-sentence"
+msgstr "Pré-visualização: por frase"
+
+msgid "Preview: word-by-word"
+msgstr "Pré-visualização: palavra por palavra"
+
 msgid "Previous slide"
 msgstr "Slide anterior"
 
@@ -3870,6 +3897,9 @@ msgstr "O template de prompt usado para traduzir entradas do catálogo de textos
 msgid "The prompt used by the reviewer pass to inspect and correct a candidate sectioning tree. Shares the model and retry settings of the sectioning prompt."
 msgstr "O prompt usado pela passagem de revisão para inspecionar e corrigir uma árvore de seção candidata. Compartilha o modelo e as configurações de retentativa do prompt de seção."
 
+msgid "The quick brown fox jumps over the lazy dog."
+msgstr "A rápida raposa marrom salta sobre o cão preguiçoso."
+
 msgid "The rendering strategy used for sections without an explicit mapping."
 msgstr "A estratégia de renderização usada para seções sem um mapeamento explícito."
 
@@ -4247,6 +4277,9 @@ msgstr "Quando ativado, as cores de fundo do guia de estilo são aplicadas ao co
 msgid "When enabled, text labels near vector images (e.g. chart dimensions, speech bubbles) are grouped together and extracted as raster crops. Disable to extract only the core vector shapes without text."
 msgstr "Quando ativado, rótulos de texto próximos a imagens vetoriais (ex.: dimensões de gráficos, balões de fala) são agrupados e extraídos como recortes rasterizados. Desative para extrair apenas as formas vetoriais sem texto."
 
+msgid "When enabled, word-level timestamps are calculated automatically during speech generation so the reader can highlight words as they're spoken. When disabled, you can still calculate timestamps manually from the speech view."
+msgstr "Quando ativado, as marcações de tempo por palavra são calculadas automaticamente durante a geração de fala, para que o leitor destaque as palavras conforme são faladas. Quando desativado, ainda é possível calcular as marcações manualmente na visualização de fala."
+
 msgid "When your PDF isn't built around facing pages, single mode keeps every page separate: nothing is merged across a spread. That matches how most textbooks, novels, and reference books are read - one page at a time."
 msgstr "Quando o PDF não foi feito em torno de páginas opostas, o modo individual mantém cada página separada: nada é unido como numa dupla. É o jeito usual de ler livros didáticos, romances e obras de referência — uma página por vez."
 
@@ -4265,7 +4298,13 @@ msgstr "Palavra"
 msgid "Word and definition are required."
 msgstr "Palavra e definição são obrigatórias."
 
-msgid "Word Highlight"
+#~ msgid "Word Highlight"
+#~ msgstr "Destaque por palavra"
+
+msgid "Word Highlighting"
+msgstr "Destaque de palavras"
+
+msgid "Word-level highlighting"
 msgstr "Destaque por palavra"
 
 msgid "words"

--- a/assets/adt/modules/audio.js
+++ b/assets/adt/modules/audio.js
@@ -571,8 +571,11 @@ export const initializeTtsQuickToggle = () => {
         ttsQuickToggleButton.addEventListener("click", (e) => {
             e.preventDefault();
 
-            // Toggle read aloud mode
+            // Toggle read aloud mode and start playback immediately when enabling
             toggleReadAloud();
+            if (state.readAloudMode) {
+                playAudioSequentially();
+            }
         });
     }
 };

--- a/packages/pipeline/src/__tests__/package-web.test.ts
+++ b/packages/pipeline/src/__tests__/package-web.test.ts
@@ -552,6 +552,7 @@ describe("packageAdtWeb", () => {
       outputLanguages: ["en"],
       title: "Book Title",
       webAssetsDir,
+      speechConfig: { word_highlighting: true },
     })
 
     const timecodes = JSON.parse(
@@ -652,6 +653,7 @@ describe("packageAdtWeb", () => {
       outputLanguages: ["en"],
       title: "Book Title",
       webAssetsDir,
+      speechConfig: { word_highlighting: true },
     })
 
     const timecodes = JSON.parse(

--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -158,9 +158,12 @@ export {
   loadVoicesConfig,
   loadSpeechInstructions,
   generateSpeechFile,
+  generateWordTimestamps,
   type VoiceMaps,
   type InstructionsMap,
   type GenerateSpeechFileOptions,
+  type GenerateWordTimestampsOptions,
+  type GenerateWordTimestampsResult,
   type ProviderRouting,
 } from "./speech.js"
 export {

--- a/packages/pipeline/src/package-web.ts
+++ b/packages/pipeline/src/package-web.ts
@@ -441,7 +441,7 @@ export async function packageAdtWeb(
       )
     },
   )
-  const highlightEnabled = hasTTS && speechConfig?.word_highlighting !== false
+  const highlightEnabled = hasTTS && speechConfig?.word_highlighting === true
 
   for (const lang of outputLanguages) {
     const localeDir = path.join(contentDir, "i18n", lang)

--- a/packages/pipeline/src/speech.ts
+++ b/packages/pipeline/src/speech.ts
@@ -3,7 +3,8 @@ import path from "node:path"
 import crypto from "node:crypto"
 import yaml from "js-yaml"
 import type { SpeechFileEntry, TTSProviderConfig } from "@adt/types"
-import type { RateLimiter, TTSSynthesizer } from "@adt/llm"
+import type { RateLimiter, TTSSynthesizer, WhisperTranscriptionResult } from "@adt/llm"
+import { transcribeWithWhisper } from "@adt/llm"
 import { getBaseLanguage, normalizeLocale } from "./language-context.js"
 
 // ---------------------------------------------------------------------------
@@ -325,4 +326,57 @@ export async function generateSpeechFile(
     cached: false,
     provider,
   }
+}
+
+// ---------------------------------------------------------------------------
+// Word timestamp generation (Whisper) with cache
+// ---------------------------------------------------------------------------
+
+export interface GenerateWordTimestampsOptions {
+  audioBuffer: Buffer
+  fileName: string
+  apiKey: string
+  language?: string
+  prompt?: string
+  cacheDir: string
+}
+
+export interface GenerateWordTimestampsResult extends WhisperTranscriptionResult {
+  cached: boolean
+}
+
+/**
+ * Transcribe an audio file with Whisper word-level timestamps, cached on
+ * audio content + language + prompt so re-runs after a TTS cache hit are instant.
+ */
+export async function generateWordTimestamps(
+  options: GenerateWordTimestampsOptions,
+): Promise<GenerateWordTimestampsResult> {
+  const { audioBuffer, fileName, apiKey, language, prompt, cacheDir } = options
+
+  const audioHash = crypto.createHash("sha256").update(audioBuffer).digest("hex")
+  const hash = crypto
+    .createHash("sha256")
+    .update(JSON.stringify({ audioHash, language: language ?? "", prompt: prompt ?? "", model: "whisper-1" }))
+    .digest("hex")
+
+  const cacheRoot = path.resolve(cacheDir, "word-timestamps")
+  const cachePath = path.resolve(cacheRoot, `${hash}.json`)
+  assertWithinBase(cacheRoot, cachePath, "cache file")
+
+  if (fs.existsSync(cachePath)) {
+    try {
+      const parsed = JSON.parse(fs.readFileSync(cachePath, "utf-8")) as WhisperTranscriptionResult
+      return { ...parsed, cached: true }
+    } catch {
+      // Fall through to regenerate on parse failure
+    }
+  }
+
+  const result = await transcribeWithWhisper(audioBuffer, fileName, apiKey, language, prompt)
+
+  fs.mkdirSync(cacheRoot, { recursive: true })
+  fs.writeFileSync(cachePath, JSON.stringify(result, null, 2) + "\n")
+
+  return { ...result, cached: false }
 }

--- a/packages/types/src/__tests__/pipeline-effects.test.ts
+++ b/packages/types/src/__tests__/pipeline-effects.test.ts
@@ -14,6 +14,7 @@ describe("pipeline effects", () => {
       "catalog-translation",
       "text-catalog-translation",
       "tts",
+      "word-timestamps",
       "package-web",
       "accessibility-assessment",
     ])
@@ -38,6 +39,7 @@ describe("pipeline effects", () => {
       "tts",
       "step-status",
     ])
+    expect(getCacheResourcesForNode("word-timestamps")).toEqual(["tts"])
   })
 
   it("maps metadata node to book/list resources", () => {

--- a/packages/types/src/pipeline-effects.ts
+++ b/packages/types/src/pipeline-effects.ts
@@ -82,6 +82,7 @@ const NODE_CACHE_RESOURCES: Record<PipelineNodeName, readonly PipelineCacheResou
   "text-catalog": ["text-catalog"],
   "catalog-translation": ["text-catalog"],
   "tts": ["tts"],
+  "word-timestamps": ["tts"],
   "package-web": [],
   "accessibility-assessment": ["debug"],
   "text-catalog-translation": ["text-catalog"],

--- a/packages/types/src/pipeline.ts
+++ b/packages/types/src/pipeline.ts
@@ -20,6 +20,7 @@ export const StepName = z.enum([
   "text-catalog",
   "catalog-translation",
   "tts",
+  "word-timestamps",
   "package-web",
   "accessibility-assessment",
 ])
@@ -139,6 +140,7 @@ export const PIPELINE: StageDef[] = [
     dependsOn: ["translate"],
     steps: [
       { name: "tts", label: "Speech Generation" },
+      { name: "word-timestamps", label: "Word Highlighting", dependsOn: ["tts"] },
     ],
   },
   {

--- a/packages/types/src/speech.ts
+++ b/packages/types/src/speech.ts
@@ -23,7 +23,7 @@ export type SpeechConfig = z.infer<typeof SpeechConfig>
 export function isSpeechWordHighlightingEnabled(
   config?: Pick<SpeechConfig, "word_highlighting"> | null,
 ): boolean {
-  return config?.word_highlighting !== false
+  return config?.word_highlighting === true
 }
 
 export const SpeechFileEntry = z.object({


### PR DESCRIPTION
## Summary
- Word highlighting is now opt-in (`word_highlighting === true`) across runtime, packaging, and preview routes; split into its own `word-timestamps` pipeline step with cached Whisper transcription so re-runs after a TTS cache hit are instant.
- TranslationsView gains a re-run banner backed by a new `useStageMissingCounts` hook (counts gaps against configured `output_languages`, so never-run languages surface), a Switch-based highlight toggle with localized live preview, and clamped timecode editing.
- Glossary adds an inline emoji editor and stops reordering the list on manual add; the read-aloud quick toggle now starts playback immediately when enabled; storyboard Replace button collapses to icon-only.

## Test plan
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] Manually verify word-highlighting toggle, missing-count banner, and glossary emoji editing in the studio UI