### PR TITLE
fix(glossary): unblock manual glossary autofill before translate stage

### DIFF
--- a/apps/api/src/routes/text-catalog.ts
+++ b/apps/api/src/routes/text-catalog.ts
@@ -5,6 +5,7 @@ import { HTTPException } from "hono/http-exception"
 import { z } from "zod"
 import { parseBookLabel } from "@adt/types"
 import { openBookDb, createBookStorage } from "@adt/storage"
+import { buildTextCatalog } from "@adt/pipeline"
 
 const TranslationBody = z
   .object({
@@ -18,13 +19,30 @@ export function createTextCatalogRoutes(booksDir: string): Hono {
   const app = new Hono()
 
   // GET /books/:label/text-catalog — Get text catalog with optional translations
-  app.get("/books/:label/text-catalog", (c) => {
+  app.get("/books/:label/text-catalog", async (c) => {
     const { label } = c.req.param()
     const safeLabel = parseBookLabel(label)
     const dbPath = path.join(path.resolve(booksDir), safeLabel, `${safeLabel}.db`)
 
     if (!fs.existsSync(dbPath)) {
       throw new HTTPException(404, { message: `Book not found: ${safeLabel}` })
+    }
+
+    // If no catalog exists yet (translate stage hasn't run), build one on demand
+    // from existing pipeline outputs so consumers like the glossary autofill have
+    // source-language text available before translation.
+    {
+      const storage = createBookStorage(safeLabel, booksDir)
+      try {
+        const existing = storage.getLatestNodeData("text-catalog", "book")
+        if (!existing) {
+          const pages = storage.getPages()
+          const catalog = await buildTextCatalog(storage, pages)
+          storage.putNodeData("text-catalog", "book", catalog)
+        }
+      } finally {
+        storage.close()
+      }
     }
 
     const db = openBookDb(dbPath)

--- a/apps/studio/src/components/pipeline/stages/glossary/GlossaryView.tsx
+++ b/apps/studio/src/components/pipeline/stages/glossary/GlossaryView.tsx
@@ -30,6 +30,7 @@ function VersionPicker({
   saving,
   dirty,
   bookLabel,
+  disableSave = false,
   onPreview,
   onSave,
   onDiscard,
@@ -38,6 +39,7 @@ function VersionPicker({
   saving: boolean
   dirty: boolean
   bookLabel: string
+  disableSave?: boolean
   onPreview: (data: unknown) => void
   onSave: () => void
   onDiscard: () => void
@@ -92,7 +94,9 @@ function VersionPicker({
         <button
           type="button"
           onClick={onSave}
-          className="flex items-center gap-1 text-[10px] font-medium rounded px-2 py-0.5 bg-white text-green-800 hover:bg-white/80 cursor-pointer transition-colors"
+          disabled={disableSave}
+          title={disableSave ? t`Wait for glossary generation to finish` : undefined}
+          className="flex items-center gap-1 text-[10px] font-medium rounded px-2 py-0.5 bg-white text-green-800 hover:bg-white/80 cursor-pointer transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
         >
           <Check className="h-3 w-3" />
           {t`Save`}
@@ -201,6 +205,8 @@ export function GlossaryView({ bookLabel }: { bookLabel: string }) {
           size="sm"
           className="h-6 px-2 text-[10px] bg-white/10 text-white hover:bg-white/20"
           onClick={openAddDialog}
+          disabled={glossaryRunning}
+          title={glossaryRunning ? t`Wait for glossary generation to finish` : undefined}
         >
           <Plus className="mr-1 h-3 w-3" />
           {t`Add Term`}
@@ -210,6 +216,7 @@ export function GlossaryView({ bookLabel }: { bookLabel: string }) {
           saving={saving}
           dirty={dirty}
           bookLabel={bookLabel}
+          disableSave={glossaryRunning}
           onPreview={(d) => setPending(d as GlossaryData)}
           onSave={() => saveRef.current()}
           onDiscard={() => setPending(null)}
@@ -217,7 +224,7 @@ export function GlossaryView({ bookLabel }: { bookLabel: string }) {
       </div>
     )
     return () => setExtra(null)
-  }, [items.length, saving, dirty, bookLabel, currentVersion, openAddDialog, t, setExtra])
+  }, [items.length, saving, dirty, bookLabel, currentVersion, openAddDialog, glossaryRunning, t, setExtra])
 
   const updateDefinition = (itemId: string, newDefinition: string) => {
     const base = pending ?? data ?? createEmptyGlossary()

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -4202,6 +4202,9 @@ msgstr "Voice Mappings"
 msgid "Voices"
 msgstr "Voices"
 
+msgid "Wait for glossary generation to finish"
+msgstr "Wait for glossary generation to finish"
+
 msgid "Wait for storyboard to complete"
 msgstr "Wait for storyboard to complete"
 

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -4202,6 +4202,9 @@ msgstr "Asignaciones de voz"
 msgid "Voices"
 msgstr "Voces"
 
+msgid "Wait for glossary generation to finish"
+msgstr "Espera a que termine la generación del glosario"
+
 msgid "Wait for storyboard to complete"
 msgstr "Espere a que el storyboard se complete"
 

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -4206,6 +4206,9 @@ msgstr "Correspondances de voix"
 msgid "Voices"
 msgstr "Voix"
 
+msgid "Wait for glossary generation to finish"
+msgstr "Attendre la fin de la génération du glossaire"
+
 msgid "Wait for storyboard to complete"
 msgstr "Attendre la fin du scénarimage"
 

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -4202,6 +4202,9 @@ msgstr "Mapeamentos de voz"
 msgid "Voices"
 msgstr "Vozes"
 
+msgid "Wait for glossary generation to finish"
+msgstr "Aguarde o término da geração do glossário"
+
 msgid "Wait for storyboard to complete"
 msgstr "Aguarde a conclusão do storyboard"
 


### PR DESCRIPTION
## Summary
- Glossary autofill (`AddGlossaryDialog`) reads from the `text-catalog` node, which is only built during the `translate` stage. Books stopped at glossary/quizzes had no catalog → suggestions silently empty. The `GET /books/:label/text-catalog` endpoint now lazily builds the catalog from existing pipeline outputs when missing (no LLM calls, just reads `web-rendering`/`image-captioning`/`glossary`/`quiz-generation`).
- Disables **Add Term** and the version-picker **Save** button while the glossary stage is running, preventing a stale `pending` edit from clobbering a freshly generated glossary on save (the PUT route doesn't merge — only the stage runner does).
- Adds the new tooltip string to `en/es/fr/pt-BR` catalogs.

## Test plan
- [ ] Open the manual glossary dialog on a book that has run extract → storyboard → glossary → quizzes (no translate). Suggestions populate.
- [ ] Start a glossary run; confirm Add Term + Save are disabled with tooltip.