### PR TITLE
Rename "Activities Generator" to "Activity Converter"

### DIFF
--- a/apps/studio/src/components/wizard/step3ContentProcessing/ImageProcessingPreviewPane.tsx
+++ b/apps/studio/src/components/wizard/step3ContentProcessing/ImageProcessingPreviewPane.tsx
@@ -435,7 +435,7 @@ function FilterSizeIllustration() {
 
 const PREVIEW_LABEL_MSGS: Record<ImageProcessingPreviewFocus, MessageDescriptor> = {
   idle: msg`Image processing`,
-  activities: msg`Activities generator`,
+  activities: msg`Activity Converter`,
   figureExtraction: msg`Figure Extraction`,
   cropping: msg`LLM cropping`,
   segmentation: msg`LLM segmentation`,

--- a/apps/studio/src/components/wizard/step3ContentProcessing/index.tsx
+++ b/apps/studio/src/components/wizard/step3ContentProcessing/index.tsx
@@ -21,7 +21,7 @@ const MIN_DIM_NONE = msg`None`
 const MIN_DIM_HELP = msg`Leave at None to run segmentation on all qualifying images (subject to pipeline rules).`
 const VALUE_UNIT_PX = msg`px`
 
-const TITLE_ACTIVITIES = msg`Activities Generator`
+const TITLE_ACTIVITIES = msg`Activity Converter`
 const SUBTITLE_ACTIVITIES = msg`Detects activities already present in the book and transforms them into interactive HTML elements like radio buttons and text inputs.`
 
 const TITLE_FIGURE_EXTRACTION = msg`Figure Extraction`

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -427,11 +427,11 @@ msgstr "Activities disabled"
 msgid "Activities enabled"
 msgstr "Activities enabled"
 
-msgid "Activity Converter"
-msgstr "Activity Converter"
-
 msgid "Activity 5.1"
 msgstr "Activity 5.1"
+
+msgid "Activity Converter"
+msgstr "Activity Converter"
 
 #~ msgid "Activity Input Placeholder"
 #~ msgstr "Activity Input Placeholder"

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -427,11 +427,8 @@ msgstr "Activities disabled"
 msgid "Activities enabled"
 msgstr "Activities enabled"
 
-msgid "Activities generator"
-msgstr "Activities generator"
-
-msgid "Activities Generator"
-msgstr "Activities Generator"
+msgid "Activity Converter"
+msgstr "Activity Converter"
 
 msgid "Activity 5.1"
 msgstr "Activity 5.1"

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -427,11 +427,11 @@ msgstr "Actividades desactivadas"
 msgid "Activities enabled"
 msgstr "Actividades activadas"
 
-msgid "Activity Converter"
-msgstr "Convertidor de actividades"
-
 msgid "Activity 5.1"
 msgstr "Actividad 5.1"
+
+msgid "Activity Converter"
+msgstr "Convertidor de actividades"
 
 #~ msgid "Activity Input Placeholder"
 #~ msgstr "Placeholder de entrada de actividad"

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -427,11 +427,8 @@ msgstr "Actividades desactivadas"
 msgid "Activities enabled"
 msgstr "Actividades activadas"
 
-msgid "Activities generator"
-msgstr "Generador de actividades"
-
-msgid "Activities Generator"
-msgstr "Generador de Actividades"
+msgid "Activity Converter"
+msgstr "Convertidor de actividades"
 
 msgid "Activity 5.1"
 msgstr "Actividad 5.1"

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -428,11 +428,8 @@ msgstr "Activités désactivées"
 msgid "Activities enabled"
 msgstr "Activités activées"
 
-msgid "Activities generator"
-msgstr "Générateur d'activités"
-
-msgid "Activities Generator"
-msgstr "Générateur d'activités"
+msgid "Activity Converter"
+msgstr "Convertisseur d'activités"
 
 msgid "Activity 5.1"
 msgstr "Activité 5.1"

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -428,11 +428,11 @@ msgstr "Activités désactivées"
 msgid "Activities enabled"
 msgstr "Activités activées"
 
-msgid "Activity Converter"
-msgstr "Convertisseur d'activités"
-
 msgid "Activity 5.1"
 msgstr "Activité 5.1"
+
+msgid "Activity Converter"
+msgstr "Convertisseur d'activités"
 
 #~ msgid "Activity Input Placeholder"
 #~ msgstr "Espace réservé de saisie d'activité"
@@ -1823,9 +1823,6 @@ msgstr "Filtrer by image ID..."
 
 msgid "Filter by item ID..."
 msgstr "Filtrer by élément ID..."
-
-#~ msgid "Filter stages"
-#~ msgstr "Filtrer les étapes"
 
 msgid "Filtered by:"
 msgstr "Filtré par :"

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -427,11 +427,11 @@ msgstr "Atividades desativadas"
 msgid "Activities enabled"
 msgstr "Atividades ativadas"
 
-msgid "Activity Converter"
-msgstr "Conversão de atividades"
-
 msgid "Activity 5.1"
 msgstr "Atividade 5.1"
+
+msgid "Activity Converter"
+msgstr "Conversão de atividades"
 
 #~ msgid "Activity Input Placeholder"
 #~ msgstr "Texto de sugestão (Placeholder)"

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -427,11 +427,8 @@ msgstr "Atividades desativadas"
 msgid "Activities enabled"
 msgstr "Atividades ativadas"
 
-msgid "Activities generator"
-msgstr "Gerador de atividades"
-
-msgid "Activities Generator"
-msgstr "Gerador de Atividades"
+msgid "Activity Converter"
+msgstr "Conversão de atividades"
 
 msgid "Activity 5.1"
 msgstr "Atividade 5.1"


### PR DESCRIPTION
## Summary
- Renames the wizard's content-processing toggle label from "Activities Generator" to "Activity Converter" to better reflect that it converts existing activities rather than generating new ones.
- Updates the preview-pane label and re-extracts en/es/fr/pt-BR catalogs.

Closes #342