### PR TITLE
Grey out stage icons until those stages have been completed

### DIFF
--- a/apps/studio/src/components/pipeline/StageSidebar.test.tsx
+++ b/apps/studio/src/components/pipeline/StageSidebar.test.tsx
@@ -83,7 +83,15 @@ vi.mock("@/hooks/use-debug", () => ({
 }))
 
 vi.mock("@/hooks/use-book-tasks", () => ({
-  useBookTasks: () => ({ runningTasks: [], runningCount: 0 }),
+  useBookTasks: () => ({ runningTasks: [], runningCount: 0, tasks: [] }),
+}))
+
+vi.mock("@/hooks/use-books", () => ({
+  usePackageAdtStatus: () => ({ data: { hasAdt: false } }),
+}))
+
+vi.mock("@/hooks/use-sign-language-videos", () => ({
+  useSignLanguageVideos: () => ({ data: { videos: [] } }),
 }))
 
 vi.mock("@/hooks/use-pages", () => ({

--- a/apps/studio/src/components/pipeline/components/StageSidebar.tsx
+++ b/apps/studio/src/components/pipeline/components/StageSidebar.tsx
@@ -16,6 +16,8 @@ import { Button } from "@/components/ui/button"
 import { useBookRun } from "@/hooks/use-book-run"
 import { useAccessibilityAssessment } from "@/hooks/use-debug"
 import { useBookTasks } from "@/hooks/use-book-tasks"
+import { usePackageAdtStatus } from "@/hooks/use-books"
+import { useSignLanguageVideos } from "@/hooks/use-sign-language-videos"
 import { StepProgressRing } from "./StepProgressRing"
 import { usePages, usePageImage } from "@/hooks/use-pages"
 import {
@@ -140,6 +142,9 @@ export function StageSidebar({
   const search = useSearch({ strict: false }) as { tab?: string }
   const { stageState } = useBookRun()
   const { data: accessibilityAssessment } = useAccessibilityAssessment(bookLabel)
+  const { data: signLanguageData } = useSignLanguageVideos(bookLabel)
+  const { data: packageStatus } = usePackageAdtStatus(bookLabel)
+  const { tasks } = useBookTasks(bookLabel)
   const { openSettings } = useSettingsDialog()
 
   const currentState = stageState(activeStep)
@@ -166,26 +171,29 @@ export function StageSidebar({
     flex1:     "flex-1",
   }
 
-  const storyboardDone = stageState("storyboard") === "done"
   const validationCompleted = Boolean(accessibilityAssessment?.assessment)
+  const signLanguageCompleted = signLanguageData?.videos?.some((v) => v.sectionId !== null) ?? false
+  const previewCompleted = packageStatus?.hasAdt ?? false
+  const exportCompleted = tasks.some((t) => t.kind === "prepare-export" && t.status === "completed")
+
+  const completionOverrides: Record<string, boolean> = {
+    "sign-language": signLanguageCompleted,
+    validation: validationCompleted,
+    preview: previewCompleted,
+    export: exportCompleted,
+  }
 
   const stageItems = STAGES.map((step, index) => {
     const isActive = step.slug === activeStep
     const Icon = step.icon
     const settingsTabs = getSettingsTabs(step.slug, i18n)
     const showSubTabs = isActive && isSettings && !!settingsTabs
-    const state = step.slug === "validation" && validationCompleted ? "done" : stageState(step.slug)
+    const state = completionOverrides[step.slug] ? "done" : stageState(step.slug)
     const stageCompleted = state === "done"
     const ringState = state
 
-    // "book" is always filled; "validation", "preview" and "export" fill once storyboard is done;
-    // pipeline stages fill when their own stage is completed.
-    const iconFilled =
-      step.slug === "book"
-        ? true
-        : step.slug === "sign-language" || step.slug === "validation" || step.slug === "preview" || step.slug === "export"
-          ? storyboardDone
-          : stageCompleted
+    // "book" is always filled; all other stages fill when their own completion signal is met.
+    const iconFilled = step.slug === "book" ? true : stageCompleted
 
     const stepLabel = step.slug === "book" ? toCamelLabel(bookLabel) : getStageLabelI18n(step.slug)
 


### PR DESCRIPTION
## Summary
The Sign Language, Validation, Preview, and Export sidebar icons previously appeared fully colored as soon as Storyboard finished, regardless of whether the user had used those stages. They now stay greyed out until each stage has actual output: a sign language video assigned to a section, an accessibility assessment, a packaged ADT, or a completed export task.

## Test plan
- [ ] Open a book where Storyboard is done but Sign Language / Validation / Preview / Export have not been used — icons render greyed out
- [ ] Upload and assign a sign language video → Sign Language icon turns cyan
- [ ] Run validation → Validation icon turns green
- [ ] Package ADT (Preview) → Preview icon turns dark grey
- [ ] Export a bundle → Export icon turns indigo