### PR TITLE
fix(glossary): prevent duplicate LLM call from regenerate button

### DIFF
--- a/apps/studio/src/components/pipeline/stages/glossary/AddGlossaryDialog.tsx
+++ b/apps/studio/src/components/pipeline/stages/glossary/AddGlossaryDialog.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react"
 import { useQuery } from "@tanstack/react-query"
 import { useLingui } from "@lingui/react/macro"
-import { Loader2, Sparkles } from "lucide-react"
+import { Loader2, RotateCw } from "lucide-react"
 import { api } from "@/api/client"
 import type { GlossaryItem } from "@/api/client"
 import { Button } from "@/components/ui/button"
@@ -139,6 +139,7 @@ export function AddGlossaryDialog({
   const [generating, setGenerating] = useState(false)
   const generateReqId = useRef(0)
   const suggestionsRef = useRef<HTMLDivElement>(null)
+  const regenerateButtonRef = useRef<HTMLButtonElement>(null)
 
   useEffect(() => {
     if (open) {
@@ -270,9 +271,21 @@ export function AddGlossaryDialog({
                   setHighlight(0)
                 }}
                 onFocus={() => setShowSuggestions(true)}
-                onBlur={() => {
+                onBlur={(e) => {
                   // Delay so an onMouseDown on a suggestion item can register before we hide the list.
                   setTimeout(() => setShowSuggestions(false), 120)
+                  // Skip auto-generate when focus moves to the regenerate button — it will fire its own onClick.
+                  if (e.relatedTarget === regenerateButtonRef.current) return
+                  const trimmed = word.trim()
+                  if (
+                    hasApiKey &&
+                    trimmed &&
+                    !definition.trim() &&
+                    !generating
+                  ) {
+                    const sample = wordIndex.get(normalize(trimmed))?.sample ?? ""
+                    void autoGenerate(trimmed, sample)
+                  }
                 }}
                 onKeyDown={handleKeyDown}
                 placeholder={t`Start typing to see words from the book…`}
@@ -280,23 +293,23 @@ export function AddGlossaryDialog({
                 disabled={generating}
               />
               <Button
+                ref={regenerateButtonRef}
                 type="button"
-                variant="outline"
-                size="sm"
+                variant="ghost"
+                size="icon"
                 disabled={!hasApiKey || !word.trim() || generating}
                 onClick={() => {
                   const sample = wordIndex.get(normalize(word))?.sample ?? ""
                   void autoGenerate(word.trim(), sample)
                 }}
-                title={hasApiKey ? t`Generate definition, variations, and emoji` : t`Set your API key to auto-generate`}
-                className="shrink-0"
+                title={hasApiKey ? t`Regenerate definition, variations, and emoji` : t`Set your API key to auto-generate`}
+                className="shrink-0 text-muted-foreground"
               >
                 {generating ? (
-                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  <Loader2 className="h-4 w-4 animate-spin" />
                 ) : (
-                  <Sparkles className="h-3.5 w-3.5" />
+                  <RotateCw className="h-4 w-4" />
                 )}
-                <span className="ml-1 text-xs">{t`Generate`}</span>
               </Button>
             </div>
             {showSuggestions && suggestions.length > 0 && (

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -1762,8 +1762,8 @@ msgstr "Generate audio narration for the book content."
 msgid "Generate comprehension quizzes and activities based on the book content."
 msgstr "Generate comprehension quizzes and activities based on the book content."
 
-msgid "Generate definition, variations, and emoji"
-msgstr "Generate definition, variations, and emoji"
+#~ msgid "Generate definition, variations, and emoji"
+#~ msgstr "Generate definition, variations, and emoji"
 
 msgid "Generate from pages"
 msgstr "Generate from pages"
@@ -3077,6 +3077,9 @@ msgstr "Refresh validation"
 
 msgid "Refreshing results for this packaged preview."
 msgstr "Refreshing results for this packaged preview."
+
+msgid "Regenerate definition, variations, and emoji"
+msgstr "Regenerate definition, variations, and emoji"
 
 msgid "Region"
 msgstr "Region"

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -1762,8 +1762,8 @@ msgstr "Generar narración de audio para el contenido del libro."
 msgid "Generate comprehension quizzes and activities based on the book content."
 msgstr "Genera cuestionarios y actividades de comprensión basados en el contenido del libro."
 
-msgid "Generate definition, variations, and emoji"
-msgstr "Generar definición, variaciones y emoji"
+#~ msgid "Generate definition, variations, and emoji"
+#~ msgstr "Generar definición, variaciones y emoji"
 
 msgid "Generate from pages"
 msgstr "Generar desde páginas"
@@ -3077,6 +3077,9 @@ msgstr "Refresh validation"
 
 msgid "Refreshing results for this packaged preview."
 msgstr "Refreshing results for this packaged preview."
+
+msgid "Regenerate definition, variations, and emoji"
+msgstr "Regenerar definición, variaciones y emoji"
 
 msgid "Region"
 msgstr "Región"

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -1766,8 +1766,8 @@ msgstr "Générez la narration audio pour le contenu du livre."
 msgid "Generate comprehension quizzes and activities based on the book content."
 msgstr "Générez des quiz de compréhension et des activités basés sur le contenu du livre."
 
-msgid "Generate definition, variations, and emoji"
-msgstr "Générer la définition, les variantes et l'emoji"
+#~ msgid "Generate definition, variations, and emoji"
+#~ msgstr "Générer la définition, les variantes et l'emoji"
 
 msgid "Generate from pages"
 msgstr "Générer à partir des pages"
@@ -3081,6 +3081,9 @@ msgstr "Actualiser validation"
 
 msgid "Refreshing results for this packaged preview."
 msgstr "Actualisation des résultats pour cet aperçu empaqueté."
+
+msgid "Regenerate definition, variations, and emoji"
+msgstr "Regénérer la définition, les variations et l'emoji"
 
 msgid "Region"
 msgstr "Région"

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -1762,8 +1762,8 @@ msgstr "Gerar narração de áudio para o conteúdo do livro."
 msgid "Generate comprehension quizzes and activities based on the book content."
 msgstr "Gera questionários e atividades de compreensão com base no conteúdo do livro."
 
-msgid "Generate definition, variations, and emoji"
-msgstr "Gerar definição, variações e emoji"
+#~ msgid "Generate definition, variations, and emoji"
+#~ msgstr "Gerar definição, variações e emoji"
 
 msgid "Generate from pages"
 msgstr "Gerar a partir das páginas"
@@ -3077,6 +3077,9 @@ msgstr "Refresh validation"
 
 msgid "Refreshing results for this packaged preview."
 msgstr "Refreshing results for this packaged preview."
+
+msgid "Regenerate definition, variations, and emoji"
+msgstr "Regenerar definição, variações e emoji"
 
 msgid "Region"
 msgstr "Região"


### PR DESCRIPTION
## Summary
- Clicking the new regenerate icon button in the Add Glossary dialog blurred the word input, which triggered `autoGenerate` from `onBlur`, and then the button's `onClick` triggered it again — firing two LLM generations per click. The `generateReqId` ref only deduplicates state updates, not the network requests.
- Fix: attach a ref to the regenerate button and skip the blur-path `autoGenerate` when `e.relatedTarget` is that button, leaving the button's `onClick` as the sole trigger. Other blur paths (tabbing to definition, closing the dialog) keep the auto-generate-on-blur behavior introduced on this branch.

## Test plan
- [ ] Open Add Glossary dialog with API key set, type a word, click the regenerate button — only one generation request fires.
- [ ] Type a word and tab/click into the definition field — auto-generate still runs once.
- [ ] Pick a suggestion from the dropdown — auto-generate still runs once.