### PR TITLE
chore(i18n): re-run extract after main merge

### DIFF
--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -249,11 +249,11 @@ msgstr "/ Section {0}"
 msgid "="
 msgstr "="
 
-msgid "🌿"
-msgstr "🌿"
-
 msgid "● LIVE"
 msgstr "● LIVE"
+
+msgid "🌿"
+msgstr "🌿"
 
 msgid "0 = deterministic, 2 = max creativity"
 msgstr "0 = deterministic, 2 = max creativity"
@@ -2185,9 +2185,6 @@ msgstr "Images smaller than your minimum dimension skip segmentation - saving co
 msgid "Images with shortest side below min or longest side above max are pruned."
 msgstr "Images with shortest side below min or longest side above max are pruned."
 
-msgid "In book:"
-msgstr "In book:"
-
 msgid "Import"
 msgstr "Import"
 
@@ -2202,6 +2199,9 @@ msgstr "Import Project"
 
 msgid "Importing..."
 msgstr "Importing..."
+
+msgid "In book:"
+msgstr "In book:"
 
 msgid "In case you don't want to convert the whole book, adjust the sliders to define which pages will be digitized."
 msgstr "In case you don't want to convert the whole book, adjust the sliders to define which pages will be digitized."
@@ -2333,6 +2333,7 @@ msgstr "Laying out spreads"
 
 #~ msgid "Leaf text roles the LLM can assign to each text element. Pruned roles are classified but excluded from rendering."
 #~ msgstr "Leaf text roles the LLM can assign to each text element. Pruned roles are classified but excluded from rendering."
+
 msgid "Leave at None to run segmentation on all qualifying images (subject to pipeline rules)."
 msgstr "Leave at None to run segmentation on all qualifying images (subject to pipeline rules)."
 
@@ -2492,11 +2493,11 @@ msgstr "Lookup definitions for key terms"
 msgid "Lower values produce more consistent styling across pages."
 msgstr "Lower values produce more consistent styling across pages."
 
-msgid "manual"
-msgstr "manual"
-
 msgid "Make sure you're uploading a .zip file exported from ADT Studio."
 msgstr "Make sure you're uploading a .zip file exported from ADT Studio."
+
+msgid "manual"
+msgstr "manual"
 
 msgid "Manual review"
 msgstr "Manual review"
@@ -2533,6 +2534,7 @@ msgstr "Max Size (px)"
 
 #~ msgid "Maximum number of reviewer passes after the initial sectioning. Set to 0 to disable refinement."
 #~ msgstr "Maximum number of reviewer passes after the initial sectioning. Set to 0 to disable refinement."
+
 msgid "Meaningfulness Prompt"
 msgstr "Meaningfulness Prompt"
 
@@ -3165,14 +3167,14 @@ msgstr "Perfect for children's books, pairing large images with minimal text."
 msgid "Photograph"
 msgstr "Photograph"
 
+msgid "photosynthesis"
+msgstr "photosynthesis"
+
 #~ msgid "Photosynthesis"
 #~ msgstr "Photosynthesis"
 
 msgid "photosynthetic, photosynthesizing"
 msgstr "photosynthetic, photosynthesizing"
-
-msgid "photosynthesis"
-msgstr "photosynthesis"
 
 msgid "Pick a preset"
 msgstr "Pick a preset"
@@ -3460,9 +3462,6 @@ msgstr "Remove from group"
 msgid "Remove manual glossary term"
 msgstr "Remove manual glossary term"
 
-msgid "Remove PDF"
-msgstr "Remove PDF"
-
 #~ msgid "Remove PDF"
 #~ msgstr "Remove PDF"
 
@@ -3496,11 +3495,11 @@ msgstr "Replace"
 msgid "Replace from Book"
 msgstr "Replace from Book"
 
-msgid "Replace this audio file"
-msgstr "Replace this audio file"
-
 msgid "Replace PDF"
 msgstr "Replace PDF"
+
+msgid "Replace this audio file"
+msgstr "Replace this audio file"
 
 msgid "Replace Video?"
 msgstr "Replace Video?"
@@ -4615,11 +4614,11 @@ msgstr "Upload sign language videos and assign them to sections."
 msgid "Upload Style Guide"
 msgstr "Upload Style Guide"
 
-msgid "Upload your own audio file"
-msgstr "Upload your own audio file"
-
 msgid "Upload to an LMS as a SCORM 1.2 package with completion tracking and offline support."
 msgstr "Upload to an LMS as a SCORM 1.2 package with completion tracking and offline support."
+
+msgid "Upload your own audio file"
+msgstr "Upload your own audio file"
 
 msgid "Upload ZIP or drag and drop"
 msgstr "Upload ZIP or drag and drop"

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -249,11 +249,11 @@ msgstr "/ Sección {0}"
 msgid "="
 msgstr "="
 
-msgid "🌿"
-msgstr "🌿"
-
 msgid "● LIVE"
 msgstr "● EN VIVO"
+
+msgid "🌿"
+msgstr "🌿"
 
 msgid "0 = deterministic, 2 = max creativity"
 msgstr "0 = determinístico, 2 = creatividad máxima"
@@ -2185,9 +2185,6 @@ msgstr "Las imágenes más pequeñas que tu dimensión mínima omiten la segment
 msgid "Images with shortest side below min or longest side above max are pruned."
 msgstr "Las imágenes con el lado más corto por debajo del mínimo o el lado más largo por encima del máximo se eliminan."
 
-msgid "In book:"
-msgstr "En el libro:"
-
 msgid "Import"
 msgstr "Importar"
 
@@ -2202,6 +2199,9 @@ msgstr "Importar proyecto"
 
 msgid "Importing..."
 msgstr "Importando..."
+
+msgid "In book:"
+msgstr "En el libro:"
 
 msgid "In case you don't want to convert the whole book, adjust the sliders to define which pages will be digitized."
 msgstr "En caso de que no quieras convertir todo el libro, ajusta los controles deslizantes para definir qué páginas se digitalizarán."
@@ -2333,6 +2333,7 @@ msgstr "Organizando páginas dobles"
 
 #~ msgid "Leaf text roles the LLM can assign to each text element. Pruned roles are classified but excluded from rendering."
 #~ msgstr "Roles de texto hoja que el LLM puede asignar a cada elemento de texto. Los roles podados se clasifican pero se excluyen del renderizado."
+
 msgid "Leave at None to run segmentation on all qualifying images (subject to pipeline rules)."
 msgstr "Dejar en Ninguno para ejecutar segmentación en todas las imágenes calificadas (sujeto a reglas de la canalización)."
 
@@ -2492,11 +2493,11 @@ msgstr "Buscar definiciones de términos clave"
 msgid "Lower values produce more consistent styling across pages."
 msgstr "Valores más bajos producen estilos más consistentes entre páginas."
 
-msgid "manual"
-msgstr "manual"
-
 msgid "Make sure you're uploading a .zip file exported from ADT Studio."
 msgstr "Asegúrese de subir un archivo .zip exportado desde ADT Studio."
+
+msgid "manual"
+msgstr "manual"
 
 msgid "Manual review"
 msgstr "Revisión manual"
@@ -2533,6 +2534,7 @@ msgstr "Tamaño Máx (px)"
 
 #~ msgid "Maximum number of reviewer passes after the initial sectioning. Set to 0 to disable refinement."
 #~ msgstr "Número máximo de pasadas del revisor después de la sección inicial. Establece en 0 para desactivar el refinamiento."
+
 msgid "Meaningfulness Prompt"
 msgstr "Indicación de significado"
 
@@ -3165,14 +3167,14 @@ msgstr "Perfecto para libros infantiles, combinando imágenes grandes con texto 
 msgid "Photograph"
 msgstr "Fotografía"
 
+msgid "photosynthesis"
+msgstr "fotosíntesis"
+
 #~ msgid "Photosynthesis"
 #~ msgstr "Fotosíntesis"
 
 msgid "photosynthetic, photosynthesizing"
 msgstr "fotosintético, realizando la fotosíntesis"
-
-msgid "photosynthesis"
-msgstr "fotosíntesis"
 
 msgid "Pick a preset"
 msgstr "Elige un preajuste"
@@ -3460,9 +3462,6 @@ msgstr "Quitar del grupo"
 msgid "Remove manual glossary term"
 msgstr "Eliminar término manual del glosario"
 
-msgid "Remove PDF"
-msgstr "Eliminar PDF"
-
 #~ msgid "Remove PDF"
 #~ msgstr "Eliminar PDF"
 
@@ -3496,11 +3495,11 @@ msgstr "Reemplazar"
 msgid "Replace from Book"
 msgstr "Reemplazar del libro"
 
-msgid "Replace this audio file"
-msgstr "Reemplazar este archivo de audio"
-
 msgid "Replace PDF"
 msgstr "Reemplazar PDF"
+
+msgid "Replace this audio file"
+msgstr "Reemplazar este archivo de audio"
 
 msgid "Replace Video?"
 msgstr "¿Reemplazar Video?"
@@ -4615,11 +4614,11 @@ msgstr "Sube videos de lengua de señas y asígnalos a secciones."
 msgid "Upload Style Guide"
 msgstr "Subir Guía de Estilo"
 
-msgid "Upload your own audio file"
-msgstr "Sube tu propio archivo de audio"
-
 msgid "Upload to an LMS as a SCORM 1.2 package with completion tracking and offline support."
 msgstr "Sube a un LMS como paquete SCORM 1.2 con seguimiento de finalización y soporte sin conexión."
+
+msgid "Upload your own audio file"
+msgstr "Sube tu propio archivo de audio"
 
 msgid "Upload ZIP or drag and drop"
 msgstr "Sube un ZIP o arrastra y suelta"

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -250,11 +250,11 @@ msgstr "/ Section {0}"
 msgid "="
 msgstr "="
 
-msgid "🌿"
-msgstr "🌿"
-
 msgid "● LIVE"
 msgstr "● EN DIRECT"
+
+msgid "🌿"
+msgstr "🌿"
 
 msgid "0 = deterministic, 2 = max creativity"
 msgstr "0 = déterministe, 2 = créativité maximale"
@@ -2186,9 +2186,6 @@ msgstr "Les images plus petites que votre dimension minimale ne passent pas par 
 msgid "Images with shortest side below min or longest side above max are pruned."
 msgstr "Les images dont le côté le plus court est inférieur au minimum ou le côté le plus long supérieur au maximum sont élaguées."
 
-msgid "In book:"
-msgstr "Dans le livre :"
-
 msgid "Import"
 msgstr "Importer"
 
@@ -2203,6 +2200,9 @@ msgstr "Importer le projet"
 
 msgid "Importing..."
 msgstr "Importation..."
+
+msgid "In book:"
+msgstr "Dans le livre :"
 
 msgid "In case you don't want to convert the whole book, adjust the sliders to define which pages will be digitized."
 msgstr "Si vous ne souhaitez pas convertir le livre entier, ajustez les curseurs pour définir quelles pages seront numérisées."
@@ -2334,6 +2334,7 @@ msgstr "Mise en page des doubles pages"
 
 #~ msgid "Leaf text roles the LLM can assign to each text element. Pruned roles are classified but excluded from rendering."
 #~ msgstr "Rôles de texte feuilles que le LLM peut attribuer à chaque élément de texte. Les rôles élagués sont classés mais exclus du rendu."
+
 msgid "Leave at None to run segmentation on all qualifying images (subject to pipeline rules)."
 msgstr "Laissez sur Aucun pour exécuter la segmentation sur toutes les images éligibles (selon les règles du pipeline)."
 
@@ -2493,11 +2494,11 @@ msgstr "Rechercher les définitions des termes clés"
 msgid "Lower values produce more consistent styling across pages."
 msgstr "Les valeurs plus basses produisent un style plus cohérent entre les pages."
 
-msgid "manual"
-msgstr "manuel"
-
 msgid "Make sure you're uploading a .zip file exported from ADT Studio."
 msgstr "Assurez-vous de télécharger un fichier .zip exporté depuis ADT Studio."
+
+msgid "manual"
+msgstr "manuel"
 
 msgid "Manual review"
 msgstr "Révision manuelle"
@@ -2534,6 +2535,7 @@ msgstr "Taille max (px)"
 
 #~ msgid "Maximum number of reviewer passes after the initial sectioning. Set to 0 to disable refinement."
 #~ msgstr "Nombre maximum de passes du réviseur après le sectionnement initial. Mettre à 0 pour désactiver le raffinement."
+
 msgid "Meaningfulness Prompt"
 msgstr "Meaningfulness Invite"
 
@@ -3166,14 +3168,14 @@ msgstr "Parfait pour les livres pour enfants, associant de grandes images avec u
 msgid "Photograph"
 msgstr "Photographie"
 
+msgid "photosynthesis"
+msgstr "photosynthèse"
+
 #~ msgid "Photosynthesis"
 #~ msgstr "Photosynthèse"
 
 msgid "photosynthetic, photosynthesizing"
 msgstr "photosynthétique, en train de faire la photosynthèse"
-
-msgid "photosynthesis"
-msgstr "photosynthèse"
 
 msgid "Pick a preset"
 msgstr "Choisissez un préréglage"
@@ -3461,9 +3463,6 @@ msgstr "Retirer du groupe"
 msgid "Remove manual glossary term"
 msgstr "Supprimer le terme manuel du glossaire"
 
-msgid "Remove PDF"
-msgstr "Retirer PDF"
-
 #~ msgid "Remove PDF"
 #~ msgstr "Retirer PDF"
 
@@ -3497,11 +3496,11 @@ msgstr "Remplacer"
 msgid "Replace from Book"
 msgstr "Remplacer depuis le livre"
 
-msgid "Replace this audio file"
-msgstr "Remplacer ce fichier audio"
-
 msgid "Replace PDF"
 msgstr "Remplacer le PDF"
+
+msgid "Replace this audio file"
+msgstr "Remplacer ce fichier audio"
 
 msgid "Replace Video?"
 msgstr "Remplacer la vidéo ?"
@@ -4616,11 +4615,11 @@ msgstr "Téléversez des vidéos en langue des signes et assignez-les aux sectio
 msgid "Upload Style Guide"
 msgstr "Téléverser un guide de style"
 
-msgid "Upload your own audio file"
-msgstr "Téléversez votre propre fichier audio"
-
 msgid "Upload to an LMS as a SCORM 1.2 package with completion tracking and offline support."
 msgstr "Téléchargez vers un LMS en tant que package SCORM 1.2 avec suivi de l'achèvement et support hors ligne."
+
+msgid "Upload your own audio file"
+msgstr "Téléversez votre propre fichier audio"
 
 msgid "Upload ZIP or drag and drop"
 msgstr "Téléchargez le ZIP ou glissez-déposez"

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -249,11 +249,11 @@ msgstr "/ Seção {0}"
 msgid "="
 msgstr "="
 
-msgid "🌿"
-msgstr "🌿"
-
 msgid "● LIVE"
 msgstr "● AO VIVO"
+
+msgid "🌿"
+msgstr "🌿"
 
 msgid "0 = deterministic, 2 = max creativity"
 msgstr "0 = determinístico, 2 = criatividade máxima"
@@ -2185,9 +2185,6 @@ msgstr "Imagens menores que sua dimensão mínima pulam a segmentação - econom
 msgid "Images with shortest side below min or longest side above max are pruned."
 msgstr "Imagens com lado menor abaixo do mínimo ou lado maior acima do máximo são removidas."
 
-msgid "In book:"
-msgstr "No livro:"
-
 msgid "Import"
 msgstr "Importar"
 
@@ -2202,6 +2199,9 @@ msgstr "Importar projeto"
 
 msgid "Importing..."
 msgstr "Importando..."
+
+msgid "In book:"
+msgstr "No livro:"
 
 msgid "In case you don't want to convert the whole book, adjust the sliders to define which pages will be digitized."
 msgstr "Caso não queira converter o livro inteiro, ajuste os controles deslizantes para definir quais páginas serão digitalizadas."
@@ -2333,6 +2333,7 @@ msgstr "Diagramando páginas duplas"
 
 #~ msgid "Leaf text roles the LLM can assign to each text element. Pruned roles are classified but excluded from rendering."
 #~ msgstr "Papéis de texto folha que o LLM pode atribuir a cada elemento de texto. Papéis podados são classificados, mas excluídos da renderização."
+
 msgid "Leave at None to run segmentation on all qualifying images (subject to pipeline rules)."
 msgstr "Deixe em Nenhum para executar segmentação em todas as imagens qualificadas (sujeito às regras do pipeline)."
 
@@ -2492,11 +2493,11 @@ msgstr "Procurar definições de termos-chave"
 msgid "Lower values produce more consistent styling across pages."
 msgstr "Valores mais baixos produzem estilização mais consistente entre as páginas."
 
-msgid "manual"
-msgstr "manual"
-
 msgid "Make sure you're uploading a .zip file exported from ADT Studio."
 msgstr "Certifique-se de enviar um arquivo .zip exportado do ADT Studio."
+
+msgid "manual"
+msgstr "manual"
 
 msgid "Manual review"
 msgstr "Revisão manual"
@@ -2533,6 +2534,7 @@ msgstr "Tamanho Máx (px)"
 
 #~ msgid "Maximum number of reviewer passes after the initial sectioning. Set to 0 to disable refinement."
 #~ msgstr "Número máximo de passagens do revisor após o seccionamento inicial. Defina como 0 para desativar o refinamento."
+
 msgid "Meaningfulness Prompt"
 msgstr "Prompt de relevância"
 
@@ -3165,14 +3167,14 @@ msgstr "Perfeito para livros infantis, combinando imagens grandes com texto mín
 msgid "Photograph"
 msgstr "Fotografia"
 
+msgid "photosynthesis"
+msgstr "fotossíntese"
+
 #~ msgid "Photosynthesis"
 #~ msgstr "Fotossíntese"
 
 msgid "photosynthetic, photosynthesizing"
 msgstr "fotossintético, realizando fotossíntese"
-
-msgid "photosynthesis"
-msgstr "fotossíntese"
 
 msgid "Pick a preset"
 msgstr "Escolha um preset"
@@ -3460,9 +3462,6 @@ msgstr "Remover do grupo"
 msgid "Remove manual glossary term"
 msgstr "Remover termo manual do glossário"
 
-msgid "Remove PDF"
-msgstr "Remover PDF"
-
 #~ msgid "Remove PDF"
 #~ msgstr "Remover PDF"
 
@@ -3496,11 +3495,11 @@ msgstr "Substituir"
 msgid "Replace from Book"
 msgstr "Substituir do livro"
 
-msgid "Replace this audio file"
-msgstr "Substituir este arquivo de áudio"
-
 msgid "Replace PDF"
 msgstr "Substituir PDF"
+
+msgid "Replace this audio file"
+msgstr "Substituir este arquivo de áudio"
 
 msgid "Replace Video?"
 msgstr "Substituir Vídeo?"
@@ -4615,11 +4614,11 @@ msgstr "Envie vídeos de língua de sinais e atribua-os às seções."
 msgid "Upload Style Guide"
 msgstr "Enviar Guia de Estilo"
 
-msgid "Upload your own audio file"
-msgstr "Envie seu próprio arquivo de áudio"
-
 msgid "Upload to an LMS as a SCORM 1.2 package with completion tracking and offline support."
 msgstr "Faça upload para um LMS como pacote SCORM 1.2 com rastreamento de conclusão e suporte offline."
+
+msgid "Upload your own audio file"
+msgstr "Envie seu próprio arquivo de áudio"
 
 msgid "Upload ZIP or drag and drop"
 msgstr "Envie um ZIP ou arraste e solte"


### PR DESCRIPTION
## Summary
- Re-ran `pnpm --filter @adt/studio extract` after merging main, which reordered entries in the `.po` catalogs.
- Fixes the failing `i18n` CI step that flagged the catalogs as out of date.

## Test plan
- [ ] CI `i18n` job passes