### PR TITLE
Tune visual review: section scope, flexible/strict, FITB hydration, loop optimizations

### DIFF
--- a/apps/studio/src/components/pipeline/components/PromptViewer.tsx
+++ b/apps/studio/src/components/pipeline/components/PromptViewer.tsx
@@ -28,6 +28,8 @@ interface PromptViewerBaseProps {
   modelGroups?: ModelGroup[]
   /** Whether to fetch the prompt (set false to defer loading) */
   enabled?: boolean
+  /** When true, the prompt is shown as a read-only preview (no editing). */
+  readOnly?: boolean
 }
 
 type PromptViewerProps =
@@ -64,6 +66,7 @@ export function PromptViewer({
   modelGroups = LLM_MODEL_GROUPS,
   enabled = true,
   hideModel = false,
+  readOnly = false,
 }: PromptViewerProps) {
   const { t } = useLingui()
 
@@ -163,6 +166,7 @@ export function PromptViewer({
             onChange={(e) => onChange(e.target.value)}
             onScroll={syncScroll}
             spellCheck={false}
+            readOnly={readOnly}
             className="relative w-full h-full text-xs font-mono p-4 whitespace-pre-wrap break-words bg-transparent text-transparent caret-foreground resize-none outline-none"
             style={{ WebkitTextFillColor: "transparent" }}
           />

--- a/apps/studio/src/components/pipeline/components/StageSidebar.tsx
+++ b/apps/studio/src/components/pipeline/components/StageSidebar.tsx
@@ -47,6 +47,7 @@ const SETTINGS_TAB_MESSAGE: Record<string, MessageDescriptor> = {
   "rendering-template": msg`Template Rendering`,
   "activity-prompts": msg`Activity Rendering`,
   "image-generation": msg`Image Generation`,
+  "visual-review-prompt": msg`Visual Review`,
   "quiz-prompt": msg`Quiz Prompt`,
   "glossary-prompt": msg`Glossary Prompt`,
   "caption-prompt": msg`Caption Prompt`,
@@ -93,6 +94,7 @@ function getSettingsTabs(
       { key: "rendering-template", label: i18n._(SETTINGS_TAB_MESSAGE["rendering-template"]) },
       { key: "activity-prompts", label: i18n._(SETTINGS_TAB_MESSAGE["activity-prompts"]) },
       { key: "image-generation", label: i18n._(SETTINGS_TAB_MESSAGE["image-generation"]) },
+      { key: "visual-review-prompt", label: i18n._(SETTINGS_TAB_MESSAGE["visual-review-prompt"]) },
     ],
     quizzes: [
       { key: "general", label: i18n._(SETTINGS_TAB_MESSAGE.general) },

--- a/apps/studio/src/components/pipeline/stages/storyboard/StoryboardSettings.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/StoryboardSettings.tsx
@@ -164,7 +164,7 @@ export function StoryboardSettings({ bookLabel, headerTarget, tab = "general" }:
   const [imageGenPromptDraft, setImageGenPromptDraft] = useState<string | null>(null)
   const [imageEditPromptDraft, setImageEditPromptDraft] = useState<string | null>(null)
   const [imagePromptSubTab, setImagePromptSubTab] = useState<"generate" | "edit">("generate")
-  const [visualReviewPrompt, setVisualReviewPrompt] = useState<"visual_review" | "visual_review_flexible">("visual_review_flexible")
+  const [visualReviewPrompt, setVisualReviewPrompt] = useState<"visual_review" | "visual_review_flexible">("visual_review")
   const [visualReviewMaxIterations, setVisualReviewMaxIterations] = useState("")
 
   // Derive activity strategies directly from merged config (synchronous)
@@ -302,9 +302,9 @@ export function StoryboardSettings({ bookLabel, headerTarget, tab = "general" }:
     setRenderingTemperature(defaultStrategy?.config?.temperature != null ? String(defaultStrategy.config.temperature) : "")
     setRenderingRetries(defaultStrategy?.config?.max_retries != null ? String(defaultStrategy.config.max_retries) : "")
 
-    // Visual review prompt — top-level override; defaults to flexible when unset
+    // Visual review prompt — top-level override; defaults to strict when unset
     const vrPrompt = typeof merged.visual_review_prompt === "string" ? merged.visual_review_prompt : ""
-    setVisualReviewPrompt(vrPrompt === "visual_review" ? "visual_review" : "visual_review_flexible")
+    setVisualReviewPrompt(vrPrompt === "visual_review_flexible" ? "visual_review_flexible" : "visual_review")
     setVisualReviewMaxIterations(
       typeof merged.visual_review_max_iterations === "number" ? String(merged.visual_review_max_iterations) : ""
     )

--- a/apps/studio/src/components/pipeline/stages/storyboard/StoryboardSettings.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/StoryboardSettings.tsx
@@ -21,6 +21,7 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { Label } from "@/components/ui/label"
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
 import { useBookConfig, useUpdateBookConfig } from "@/hooks/use-book-config"
 import { useActiveConfig } from "@/hooks/use-debug"
 import { useApiKey } from "@/hooks/use-api-key"
@@ -163,6 +164,8 @@ export function StoryboardSettings({ bookLabel, headerTarget, tab = "general" }:
   const [imageGenPromptDraft, setImageGenPromptDraft] = useState<string | null>(null)
   const [imageEditPromptDraft, setImageEditPromptDraft] = useState<string | null>(null)
   const [imagePromptSubTab, setImagePromptSubTab] = useState<"generate" | "edit">("generate")
+  const [visualReviewPrompt, setVisualReviewPrompt] = useState<"visual_review" | "visual_review_flexible">("visual_review_flexible")
+  const [visualReviewMaxIterations, setVisualReviewMaxIterations] = useState("")
 
   // Derive activity strategies directly from merged config (synchronous)
   const activityStrategies = useMemo(() => {
@@ -298,6 +301,13 @@ export function StoryboardSettings({ bookLabel, headerTarget, tab = "general" }:
     }
     setRenderingTemperature(defaultStrategy?.config?.temperature != null ? String(defaultStrategy.config.temperature) : "")
     setRenderingRetries(defaultStrategy?.config?.max_retries != null ? String(defaultStrategy.config.max_retries) : "")
+
+    // Visual review prompt — top-level override; defaults to flexible when unset
+    const vrPrompt = typeof merged.visual_review_prompt === "string" ? merged.visual_review_prompt : ""
+    setVisualReviewPrompt(vrPrompt === "visual_review" ? "visual_review" : "visual_review_flexible")
+    setVisualReviewMaxIterations(
+      typeof merged.visual_review_max_iterations === "number" ? String(merged.visual_review_max_iterations) : ""
+    )
   }, [activeConfigData])
 
   // Helper: only write a field if the user changed it or the book config already had it
@@ -329,6 +339,14 @@ export function StoryboardSettings({ bookLabel, headerTarget, tab = "general" }:
     }
     if (shouldWrite("apply_body_background")) {
       overrides.apply_body_background = applyBodyBackground
+    }
+    if (shouldWrite("visual_review_prompt")) {
+      overrides.visual_review_prompt = visualReviewPrompt
+    }
+    if (shouldWrite("visual_review_max_iterations")) {
+      overrides.visual_review_max_iterations = visualReviewMaxIterations.trim()
+        ? Number(visualReviewMaxIterations)
+        : undefined
     }
     // Write rendering temperature / retries into the default render strategy config
     if ((shouldWrite("rendering_temperature") || shouldWrite("rendering_retries")) && defaultRenderStrategy) {
@@ -410,7 +428,7 @@ export function StoryboardSettings({ bookLabel, headerTarget, tab = "general" }:
   }
 
   return (
-    <div className={tab === "rendering-prompt" || tab === "rendering-template" || tab === "activity-prompts" || tab === "image-generation" ? "h-full" : "p-4 space-y-6"}>
+    <div className={tab === "rendering-prompt" || tab === "rendering-template" || tab === "activity-prompts" || tab === "image-generation" || tab === "visual-review-prompt" ? "h-full" : "p-4 space-y-6"}>
       {tab === "general" && (
         <div>
           <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-3">
@@ -786,6 +804,85 @@ export function StoryboardSettings({ bookLabel, headerTarget, tab = "general" }:
                 onContentChange={setImageEditPromptDraft}
               />
             )}
+          </div>
+        </div>
+      )}
+
+      {tab === "visual-review-prompt" && (
+        <div className="flex flex-col h-full">
+          <div className="shrink-0 p-4 pb-0 space-y-4">
+            <div>
+              <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
+                {<Trans>Match Design</Trans>}
+              </h3>
+              <p className="text-xs text-muted-foreground mb-3">
+                {<Trans>How closely should the visual review match the original page? The reviewer rejects renderings that don't pass — stricter settings cause more rejections and rerenders.</Trans>}
+              </p>
+              <RadioGroup
+                value={visualReviewPrompt}
+                onValueChange={(v) => {
+                  setVisualReviewPrompt(v as "visual_review" | "visual_review_flexible")
+                  markDirty("visual_review_prompt")
+                }}
+                className="gap-3"
+              >
+                <div className="flex items-start gap-2">
+                  <RadioGroupItem value="visual_review_flexible" id="vr-flexible" className="mt-0.5" />
+                  <Label htmlFor="vr-flexible" className="cursor-pointer font-normal">
+                    <span className="text-sm font-medium">{<Trans>Flexible</Trans>}</span>
+                    <span className="block text-xs text-muted-foreground mt-0.5">
+                      {<Trans>Accept reasonable web redesigns. Reject only for functional defects (visible placeholder tokens, missing content, overlap, overflow). Fewest rejections.</Trans>}
+                    </span>
+                  </Label>
+                </div>
+                <div className="flex items-start gap-2">
+                  <RadioGroupItem value="visual_review" id="vr-strict" className="mt-0.5" />
+                  <Label htmlFor="vr-strict" className="cursor-pointer font-normal">
+                    <span className="text-sm font-medium">{<Trans>Strict</Trans>}</span>
+                    <span className="block text-xs text-muted-foreground mt-0.5">
+                      {<Trans>Reject renderings that diverge stylistically from the original. More rejections and rerenders, closer match to the source.</Trans>}
+                    </span>
+                  </Label>
+                </div>
+              </RadioGroup>
+            </div>
+            <div>
+              <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
+                {<Trans>Max Iterations</Trans>}
+              </h3>
+              <div className="flex items-center gap-2">
+                <Input
+                  type="number"
+                  min={1}
+                  max={50}
+                  step={1}
+                  value={visualReviewMaxIterations}
+                  onChange={(e) => {
+                    setVisualReviewMaxIterations(e.target.value)
+                    markDirty("visual_review_max_iterations")
+                  }}
+                  placeholder="5"
+                  className="h-9 w-24 text-sm"
+                />
+                <Label className="text-xs text-muted-foreground">
+                  {<Trans>Max review/revise rounds per section before accepting the current rendering</Trans>}
+                </Label>
+              </div>
+              <p className="text-xs text-muted-foreground mt-1.5">
+                {<Trans>Each iteration is one LLM call. Lower values are faster and cheaper; higher values give the reviewer more chances to fix problems.</Trans>}
+              </p>
+            </div>
+          </div>
+          <div className="flex-1 min-h-0 mt-2">
+            <PromptViewer
+              key={visualReviewPrompt}
+              promptName={visualReviewPrompt}
+              bookLabel={bookLabel}
+              title={t`Visual Review Prompt (read-only)`}
+              description={t`This prompt instructs the LLM how to evaluate the rendered HTML against the original page. Selection above controls which template is used.`}
+              hideModel
+              readOnly
+            />
           </div>
         </div>
       )}

--- a/apps/studio/src/components/pipeline/stages/storyboard/StoryboardSettings.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/StoryboardSettings.tsx
@@ -861,7 +861,7 @@ export function StoryboardSettings({ bookLabel, headerTarget, tab = "general" }:
                     setVisualReviewMaxIterations(e.target.value)
                     markDirty("visual_review_max_iterations")
                   }}
-                  placeholder="5"
+                  placeholder="3"
                   className="h-9 w-24 text-sm"
                 />
                 <Label className="text-xs text-muted-foreground">

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -396,6 +396,9 @@ msgstr "About section mode"
 msgid "Accent Prompt"
 msgstr "Accent Prompt"
 
+msgid "Accept reasonable web redesigns. Reject only for functional defects (visible placeholder tokens, missing content, overlap, overflow). Fewest rejections."
+msgstr "Accept reasonable web redesigns. Reject only for functional defects (visible placeholder tokens, missing content, overlap, overflow). Fewest rejections."
+
 msgid "Accessibility"
 msgstr "Accessibility"
 
@@ -1595,6 +1598,9 @@ msgstr "e.g., A cheerful leopard family in a green forest..."
 msgid "e.g., Make the background brighter, add more trees..."
 msgstr "e.g., Make the background brighter, add more trees..."
 
+msgid "Each iteration is one LLM call. Lower values are faster and cheaper; higher values give the reviewer more chances to fix problems."
+msgstr "Each iteration is one LLM call. Lower values are faster and cheaper; higher values give the reviewer more chances to fix problems."
+
 msgid "Each polyp secretes a hard calcium carbonate skeleton. Over hundreds of years, millions of these skeletons build up into the massive reef structures we see today."
 msgstr "Each polyp secretes a hard calcium carbonate skeleton. Over hundreds of years, millions of these skeletons build up into the massive reef structures we see today."
 
@@ -1909,6 +1915,9 @@ msgstr "Flagged findings"
 msgid "Flat Vector"
 msgstr "Flat Vector"
 
+msgid "Flexible"
+msgstr "Flexible"
+
 #~ msgid "Footer Text"
 #~ msgstr "Footer Text"
 
@@ -2102,6 +2111,9 @@ msgstr "Hit"
 
 msgid "Hover a setting to see how LLM cropping, segmentation, or the size threshold changes extracted images."
 msgstr "Hover a setting to see how LLM cropping, segmentation, or the size threshold changes extracted images."
+
+msgid "How closely should the visual review match the original page? The reviewer rejects renderings that don't pass — stricter settings cause more rejections and rerenders."
+msgstr "How closely should the visual review match the original page? The reviewer rejects renderings that don't pass — stricter settings cause more rejections and rerenders."
 
 msgid "How it works"
 msgstr "How it works"
@@ -2555,14 +2567,23 @@ msgstr "Map language codes to voice names for each TTS provider."
 msgid "margin"
 msgstr "margin"
 
+msgid "Match Design"
+msgstr "Match Design"
+
 msgid "Match each stage of the water cycle to its definition:"
 msgstr "Match each stage of the water cycle to its definition:"
 
 #~ msgid "Math"
 #~ msgstr "Math"
 
+msgid "Max Iterations"
+msgstr "Max Iterations"
+
 msgid "Max Refinements"
 msgstr "Max Refinements"
+
+msgid "Max review/revise rounds per section before accepting the current rendering"
+msgstr "Max review/revise rounds per section before accepting the current rendering"
 
 #~ msgid "Max Side"
 #~ msgstr "Max Side"
@@ -3497,6 +3518,9 @@ msgstr "Regenerate selected images for each output language so that any text bur
 msgid "Region"
 msgstr "Region"
 
+msgid "Reject renderings that diverge stylistically from the original. More rejections and rerenders, closer match to the source."
+msgstr "Reject renderings that diverge stylistically from the original. More rejections and rerenders, closer match to the source."
+
 msgid "Release to upload"
 msgstr "Release to upload"
 
@@ -4165,6 +4189,9 @@ msgstr "Storyboard has already been run. Changes made here will not take effect 
 msgid "Storybook"
 msgstr "Storybook"
 
+msgid "Strict"
+msgstr "Strict"
+
 msgid "Structure"
 msgstr "Structure"
 
@@ -4447,6 +4474,9 @@ msgstr "This page has no translatable text entries"
 
 msgid "This page has not been reviewed yet"
 msgstr "This page has not been reviewed yet"
+
+msgid "This prompt instructs the LLM how to evaluate the rendered HTML against the original page. Selection above controls which template is used."
+msgstr "This prompt instructs the LLM how to evaluate the rendered HTML against the original page. Selection above controls which template is used."
 
 msgid "This section has no storyboard rendering yet"
 msgstr "This section has no storyboard rendering yet"
@@ -4764,6 +4794,12 @@ msgstr "Visual & sensory cues"
 
 msgid "Visual Layout"
 msgstr "Visual Layout"
+
+msgid "Visual Review"
+msgstr "Visual Review"
+
+msgid "Visual Review Prompt (read-only)"
+msgstr "Visual Review Prompt (read-only)"
 
 msgid "Voice"
 msgstr "Voice"

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -396,6 +396,9 @@ msgstr "Acerca del modo de sección"
 msgid "Accent Prompt"
 msgstr "Prompt de acento"
 
+msgid "Accept reasonable web redesigns. Reject only for functional defects (visible placeholder tokens, missing content, overlap, overflow). Fewest rejections."
+msgstr "Acepta rediseños web razonables. Rechaza solo por defectos funcionales (tokens de marcador visibles, contenido faltante, superposición, desbordamiento). Menos rechazos."
+
 msgid "Accessibility"
 msgstr "Accessibility"
 
@@ -1595,6 +1598,9 @@ msgstr "ej., Una familia de leopardos alegres en un bosque verde..."
 msgid "e.g., Make the background brighter, add more trees..."
 msgstr "ej., Haz el fondo más brillante, añade más árboles..."
 
+msgid "Each iteration is one LLM call. Lower values are faster and cheaper; higher values give the reviewer more chances to fix problems."
+msgstr "Cada iteración es una llamada al LLM. Valores más bajos son más rápidos y económicos; valores más altos dan al revisor más oportunidades de corregir problemas."
+
 msgid "Each polyp secretes a hard calcium carbonate skeleton. Over hundreds of years, millions of these skeletons build up into the massive reef structures we see today."
 msgstr "Cada pólipo secreta un esqueleto duro de carbonato de calcio. Durante cientos de años, millones de estos esqueletos se acumulan en las estructuras masivas de arrecifes que vemos hoy."
 
@@ -1909,6 +1915,9 @@ msgstr "Flagged findings"
 msgid "Flat Vector"
 msgstr "Vector plano"
 
+msgid "Flexible"
+msgstr "Flexible"
+
 #~ msgid "Footer Text"
 #~ msgstr "Texto de pie de página"
 
@@ -2102,6 +2111,9 @@ msgstr "Hit"
 
 msgid "Hover a setting to see how LLM cropping, segmentation, or the size threshold changes extracted images."
 msgstr "Pasa el cursor sobre una configuración para ver cómo el recorte, segmentación o el umbral de tamaño del LLM cambian las imágenes extraídas."
+
+msgid "How closely should the visual review match the original page? The reviewer rejects renderings that don't pass — stricter settings cause more rejections and rerenders."
+msgstr "¿Qué tan fielmente debe coincidir la revisión visual con la página original? El revisor rechaza los renderizados que no pasan — los ajustes más estrictos causan más rechazos y nuevas renderizaciones."
 
 msgid "How it works"
 msgstr "Cómo funciona"
@@ -2555,14 +2567,23 @@ msgstr "Asigna códigos de idioma a nombres de voz para cada proveedor de TTS."
 msgid "margin"
 msgstr "margen"
 
+msgid "Match Design"
+msgstr "Coincidir con el diseño"
+
 msgid "Match each stage of the water cycle to its definition:"
 msgstr "Asocia cada etapa del ciclo del agua con su definición:"
 
 #~ msgid "Math"
 #~ msgstr "Matemáticas"
 
+msgid "Max Iterations"
+msgstr "Iteraciones máximas"
+
 msgid "Max Refinements"
 msgstr "Refinamientos máximos"
+
+msgid "Max review/revise rounds per section before accepting the current rendering"
+msgstr "Máximo de rondas de revisión/corrección por sección antes de aceptar el renderizado actual"
 
 #~ msgid "Max Side"
 #~ msgstr "Lado Máximo"
@@ -3497,6 +3518,9 @@ msgstr "Regenera las imágenes seleccionadas para cada idioma de salida de modo 
 msgid "Region"
 msgstr "Región"
 
+msgid "Reject renderings that diverge stylistically from the original. More rejections and rerenders, closer match to the source."
+msgstr "Rechaza los renderizados que difieran estilísticamente del original. Más rechazos y re-renderizados, mayor coincidencia con la fuente."
+
 msgid "Release to upload"
 msgstr "Suelta para subir"
 
@@ -4165,6 +4189,9 @@ msgstr "El storyboard ya se ejecutó. Los cambios realizados aquí no tendrán e
 msgid "Storybook"
 msgstr "Libro de cuentos"
 
+msgid "Strict"
+msgstr "Estricto"
+
 msgid "Structure"
 msgstr "Estructura"
 
@@ -4447,6 +4474,9 @@ msgstr "Esta página no tiene entradas de texto traducibles"
 
 msgid "This page has not been reviewed yet"
 msgstr "This page has not been reviewed yet"
+
+msgid "This prompt instructs the LLM how to evaluate the rendered HTML against the original page. Selection above controls which template is used."
+msgstr "Este prompt indica al LLM cómo evaluar el HTML renderizado frente a la página original. La selección de arriba controla qué plantilla se utiliza."
 
 msgid "This section has no storyboard rendering yet"
 msgstr "Esta sección aún no tiene renderización de storyboard"
@@ -4764,6 +4794,12 @@ msgstr "Visual & sensory cues"
 
 msgid "Visual Layout"
 msgstr "Diseño Visual"
+
+msgid "Visual Review"
+msgstr "Revisión visual"
+
+msgid "Visual Review Prompt (read-only)"
+msgstr "Prompt de revisión visual (solo lectura)"
 
 msgid "Voice"
 msgstr "Voz"

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -397,6 +397,9 @@ msgstr "À propos du mode de section"
 msgid "Accent Prompt"
 msgstr "Accent Invite"
 
+msgid "Accept reasonable web redesigns. Reject only for functional defects (visible placeholder tokens, missing content, overlap, overflow). Fewest rejections."
+msgstr "Accepter les refontes web raisonnables. Rejeter uniquement pour des défauts fonctionnels (jetons d'espace réservé visibles, contenu manquant, chevauchement, débordement). Moins de rejets."
+
 msgid "Accessibility"
 msgstr "Accessibilité"
 
@@ -1596,6 +1599,9 @@ msgstr "ex., Une joyeuse famille de léopards dans une forêt verte..."
 msgid "e.g., Make the background brighter, add more trees..."
 msgstr "ex., Rendre l'arrière-plan plus lumineux, ajouter plus d'arbres..."
 
+msgid "Each iteration is one LLM call. Lower values are faster and cheaper; higher values give the reviewer more chances to fix problems."
+msgstr "Chaque itération est un appel au LLM. Des valeurs plus basses sont plus rapides et moins coûteuses ; des valeurs plus élevées donnent au relecteur plus de chances de corriger les problèmes."
+
 msgid "Each polyp secretes a hard calcium carbonate skeleton. Over hundreds of years, millions of these skeletons build up into the massive reef structures we see today."
 msgstr "Chaque polype sécrète un squelette rigide de carbonate de calcium. Au fil de centaines d'années, des millions de ces squelettes s'accumulent pour former les immenses structures récifales que nous voyons aujourd'hui."
 
@@ -1910,6 +1916,9 @@ msgstr "Résultats signalés"
 msgid "Flat Vector"
 msgstr "Vecteur plat"
 
+msgid "Flexible"
+msgstr "Flexible"
+
 #~ msgid "Footer Text"
 #~ msgstr "Pied de page Texte"
 
@@ -2103,6 +2112,9 @@ msgstr "Hit"
 
 msgid "Hover a setting to see how LLM cropping, segmentation, or the size threshold changes extracted images."
 msgstr "Survolez un paramètre pour voir comment le recadrage LLM, la segmentation ou le seuil de taille modifient les images extraites."
+
+msgid "How closely should the visual review match the original page? The reviewer rejects renderings that don't pass — stricter settings cause more rejections and rerenders."
+msgstr "À quel point la revue visuelle doit-elle correspondre à la page originale ? Le relecteur rejette les rendus qui ne passent pas — les paramètres plus stricts entraînent plus de rejets et de nouveaux rendus."
 
 msgid "How it works"
 msgstr "Comment ça marche"
@@ -2556,14 +2568,23 @@ msgstr "Associez les codes de langue aux noms de voix pour chaque fournisseur TT
 msgid "margin"
 msgstr "marge"
 
+msgid "Match Design"
+msgstr "Correspondance avec le design"
+
 msgid "Match each stage of the water cycle to its definition:"
 msgstr "Associez chaque étape du cycle de l'eau à sa définition :"
 
 #~ msgid "Math"
 #~ msgstr "Math"
 
+msgid "Max Iterations"
+msgstr "Itérations max"
+
 msgid "Max Refinements"
 msgstr "Raffinements max"
+
+msgid "Max review/revise rounds per section before accepting the current rendering"
+msgstr "Nombre maximum de tours de revue/correction par section avant d'accepter le rendu actuel"
 
 #~ msgid "Max Side"
 #~ msgstr "Côté max."
@@ -3498,6 +3519,9 @@ msgstr "Régénère les images sélectionnées pour chaque langue de sortie afin
 msgid "Region"
 msgstr "Région"
 
+msgid "Reject renderings that diverge stylistically from the original. More rejections and rerenders, closer match to the source."
+msgstr "Rejeter les rendus qui divergent stylistiquement de l'original. Plus de rejets et de nouveaux rendus, correspondance plus proche de la source."
+
 msgid "Release to upload"
 msgstr "Relâchez pour importer"
 
@@ -4166,6 +4190,9 @@ msgstr "Le scénarimage a déjà été exécuté. Les modifications effectuées 
 msgid "Storybook"
 msgstr "Livre d'histoires"
 
+msgid "Strict"
+msgstr "Strict"
+
 msgid "Structure"
 msgstr "Structure"
 
@@ -4448,6 +4475,9 @@ msgstr "Cette page n'a pas d'entrées de texte traduisibles"
 
 msgid "This page has not been reviewed yet"
 msgstr "Cette page n'a pas encore été révisée"
+
+msgid "This prompt instructs the LLM how to evaluate the rendered HTML against the original page. Selection above controls which template is used."
+msgstr "Ce prompt indique au LLM comment évaluer le HTML rendu par rapport à la page originale. La sélection ci-dessus contrôle quel modèle est utilisé."
 
 msgid "This section has no storyboard rendering yet"
 msgstr "Cette section n'a pas encore de rendu de scénarimage"
@@ -4765,6 +4795,12 @@ msgstr "Indices visuels et sensoriels"
 
 msgid "Visual Layout"
 msgstr "Mise en page visuelle"
+
+msgid "Visual Review"
+msgstr "Revue visuelle"
+
+msgid "Visual Review Prompt (read-only)"
+msgstr "Prompt de revue visuelle (lecture seule)"
 
 msgid "Voice"
 msgstr "Voix"

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -396,6 +396,9 @@ msgstr "Sobre modo de seção"
 msgid "Accent Prompt"
 msgstr "Prompt de sotaque"
 
+msgid "Accept reasonable web redesigns. Reject only for functional defects (visible placeholder tokens, missing content, overlap, overflow). Fewest rejections."
+msgstr "Aceita redesenhos web razoáveis. Rejeita apenas por defeitos funcionais (tokens de espaço reservado visíveis, conteúdo ausente, sobreposição, transbordamento). Menos rejeições."
+
 msgid "Accessibility"
 msgstr "Accessibility"
 
@@ -1595,6 +1598,9 @@ msgstr "ex.: Uma família de leopardos alegres em uma floresta verde..."
 msgid "e.g., Make the background brighter, add more trees..."
 msgstr "ex.: Deixe o fundo mais claro, adicione mais árvores..."
 
+msgid "Each iteration is one LLM call. Lower values are faster and cheaper; higher values give the reviewer more chances to fix problems."
+msgstr "Cada iteração é uma chamada ao LLM. Valores mais baixos são mais rápidos e mais baratos; valores mais altos dão ao revisor mais chances de corrigir problemas."
+
 msgid "Each polyp secretes a hard calcium carbonate skeleton. Over hundreds of years, millions of these skeletons build up into the massive reef structures we see today."
 msgstr "Cada pólipo secreta um esqueleto duro de carbonato de cálcio. Ao longo de centenas de anos, milhões desses esqueletos formam as enormes estruturas de recifes que vemos hoje."
 
@@ -1909,6 +1915,9 @@ msgstr "Flagged findings"
 msgid "Flat Vector"
 msgstr "Vetor plano"
 
+msgid "Flexible"
+msgstr "Flexível"
+
 #~ msgid "Footer Text"
 #~ msgstr "Texto de rodapé"
 
@@ -2102,6 +2111,9 @@ msgstr "Hit"
 
 msgid "Hover a setting to see how LLM cropping, segmentation, or the size threshold changes extracted images."
 msgstr "Passe o mouse sobre uma configuração para ver como o corte, segmentação ou o limite de tamanho do LLM altera as imagens extraídas."
+
+msgid "How closely should the visual review match the original page? The reviewer rejects renderings that don't pass — stricter settings cause more rejections and rerenders."
+msgstr "Quão próximo a revisão visual deve corresponder à página original? O revisor rejeita renderizações que não passam — configurações mais rigorosas causam mais rejeições e novas renderizações."
 
 msgid "How it works"
 msgstr "Como funciona"
@@ -2555,14 +2567,23 @@ msgstr "Mapeie códigos de idioma para nomes de voz de cada provedor de TTS."
 msgid "margin"
 msgstr "margem"
 
+msgid "Match Design"
+msgstr "Combinar com o design"
+
 msgid "Match each stage of the water cycle to its definition:"
 msgstr "Associe cada estágio do ciclo da água à sua definição:"
 
 #~ msgid "Math"
 #~ msgstr "Matemática"
 
+msgid "Max Iterations"
+msgstr "Iterações máximas"
+
 msgid "Max Refinements"
 msgstr "Refinamentos máximos"
+
+msgid "Max review/revise rounds per section before accepting the current rendering"
+msgstr "Máximo de rodadas de revisão/correção por seção antes de aceitar a renderização atual"
 
 #~ msgid "Max Side"
 #~ msgstr "Lado Máximo"
@@ -3497,6 +3518,9 @@ msgstr "Regenera as imagens selecionadas para cada idioma de saída para que qua
 msgid "Region"
 msgstr "Região"
 
+msgid "Reject renderings that diverge stylistically from the original. More rejections and rerenders, closer match to the source."
+msgstr "Rejeita renderizações que divergem estilisticamente do original. Mais rejeições e novas renderizações, correspondência mais próxima à fonte."
+
 msgid "Release to upload"
 msgstr "Solte para enviar"
 
@@ -4165,6 +4189,9 @@ msgstr "O storyboard já foi executado. As alterações feitas aqui não terão 
 msgid "Storybook"
 msgstr "Livro de Histórias"
 
+msgid "Strict"
+msgstr "Estrito"
+
 msgid "Structure"
 msgstr "Estrutura"
 
@@ -4447,6 +4474,9 @@ msgstr "Esta página não tem entradas de texto traduzíveis"
 
 msgid "This page has not been reviewed yet"
 msgstr "This page has not been reviewed yet"
+
+msgid "This prompt instructs the LLM how to evaluate the rendered HTML against the original page. Selection above controls which template is used."
+msgstr "Este prompt instrui o LLM sobre como avaliar o HTML renderizado em relação à página original. A seleção acima controla qual modelo é usado."
 
 msgid "This section has no storyboard rendering yet"
 msgstr "Esta seção ainda não tem renderização de storyboard"
@@ -4764,6 +4794,12 @@ msgstr "Visual & sensory cues"
 
 msgid "Visual Layout"
 msgstr "Layout Visual"
+
+msgid "Visual Review"
+msgstr "Revisão visual"
+
+msgid "Visual Review Prompt (read-only)"
+msgstr "Prompt de revisão visual (somente leitura)"
 
 msgid "Voice"
 msgstr "Voz"

--- a/packages/pipeline/src/__tests__/visual-review.test.ts
+++ b/packages/pipeline/src/__tests__/visual-review.test.ts
@@ -183,13 +183,13 @@ describe("runVisualReviewLoop", () => {
     expect(result.approved).toBe(true)
     expect(result.html).toContain(">v3<")
 
-    // On the 4th call, history keeps initial turn and latest two turns:
-    // Initial, v2, v3 (v1 is dropped).
+    // The conversation window keeps only the most recent turn; the system prompt
+    // is sent separately so prior screenshots/HTML aren't carried forward.
     const fourthCall = userHtmlSnippetsByCall[3]
-    expect(fourthCall).toHaveLength(3)
-    expect(fourthCall[0]).toContain("Initial")
-    expect(fourthCall[1]).toContain("v2")
-    expect(fourthCall[2]).toContain("v3")
-    expect(fourthCall.join(" ")).not.toContain("v1")
+    expect(fourthCall).toHaveLength(1)
+    expect(fourthCall[0]).toContain("v3")
+    expect(fourthCall[0]).not.toContain("Initial")
+    expect(fourthCall[0]).not.toContain("v1")
+    expect(fourthCall[0]).not.toContain("v2")
   })
 })

--- a/packages/pipeline/src/screenshot-html.ts
+++ b/packages/pipeline/src/screenshot-html.ts
@@ -152,27 +152,48 @@ function buildInlineFontCss(webAssetsDir: string): string {
  */
 const FITB_HYDRATION_SCRIPT = `<script>
 (function() {
-  var sentences = document.querySelectorAll('.fitb-sentence');
-  sentences.forEach(function(sentence) {
-    var targets = sentence.querySelectorAll('[data-id]');
-    var elements = targets.length > 0 ? targets : [sentence];
-    elements.forEach(function(el) {
-      var html = el.innerHTML;
-      if (html.indexOf('[[blank:') === -1) return;
-      el.innerHTML = html.replace(
-        /\\[\\[blank:item-(\\d+)(?::([^\\]]+))?\\]\\]/g,
-        function(_, itemNum, hint) {
-          var charWidth = hint ? Math.max(hint.length + 2, 6) : 8;
-          var valueAttr = hint ? ' placeholder="' + hint.replace(/"/g, '&quot;') + '"' : '';
-          return '<input type="text"'
-            + ' class="fitb-inline-input inline-block mx-1 px-1 py-0.5 border-b-2 border-gray-400 bg-transparent text-center"'
-            + ' style="width: ' + charWidth + 'ch; min-width: 4ch; max-width: 100%;"'
-            + ' data-activity-item="item-' + itemNum + '"'
-            + valueAttr + ' />';
-        }
-      );
-    });
+  function replaceBlanks(html) {
+    return html.replace(
+      /\\[\\[blank:item-(\\d+)(?::([^\\]]+))?\\]\\]/g,
+      function(_, itemNum, hint) {
+        var charWidth = hint ? Math.max(hint.length + 2, 6) : 8;
+        var valueAttr = hint ? ' placeholder="' + hint.replace(/"/g, '&quot;') + '"' : '';
+        return '<input type="text"'
+          + ' class="fitb-inline-input inline-block mx-1 px-1 py-0.5 border-b-2 border-gray-400 bg-transparent text-center"'
+          + ' style="width: ' + charWidth + 'ch; min-width: 4ch; max-width: 100%;"'
+          + ' data-activity-item="item-' + itemNum + '"'
+          + valueAttr + ' />';
+      }
+    );
+  }
+
+  // Pass 1: replace inside [data-id] elements (the canonical text containers).
+  var dataIdEls = document.querySelectorAll('[data-id]');
+  dataIdEls.forEach(function(el) {
+    if (el.innerHTML.indexOf('[[blank:') === -1) return;
+    el.innerHTML = replaceBlanks(el.innerHTML);
   });
+
+  // Pass 2: catch any remaining markers that appeared in plain wrapper elements
+  // without their own data-id (text nodes directly inside <p>/<div>/<li>/<span>).
+  // Walk all leaf-ish elements and only touch those still containing markers.
+  var all = document.querySelectorAll('*');
+  for (var i = 0; i < all.length; i++) {
+    var el = all[i];
+    if (el.tagName === 'SCRIPT' || el.tagName === 'STYLE') continue;
+    if (el.innerHTML.indexOf('[[blank:') === -1) continue;
+    // Only rewrite if no descendant still contains the marker — process leaves only.
+    var hasDescendantMarker = false;
+    var children = el.children;
+    for (var j = 0; j < children.length; j++) {
+      if (children[j].innerHTML && children[j].innerHTML.indexOf('[[blank:') !== -1) {
+        hasDescendantMarker = true;
+        break;
+      }
+    }
+    if (hasDescendantMarker) continue;
+    el.innerHTML = replaceBlanks(el.innerHTML);
+  }
 })();
 </script>`
 

--- a/packages/pipeline/src/visual-review.ts
+++ b/packages/pipeline/src/visual-review.ts
@@ -55,10 +55,11 @@ function stripMarkdownFence(content: string): string {
 }
 
 function buildConversationWindow(turns: ConversationTurn[]): Message[] {
-  // Keep the first (original) turn and the most recent two turns.
-  const selectedTurns = turns.length <= 3
-    ? turns
-    : [turns[0], ...turns.slice(-2)]
+  // Keep only the most recent turn (carries the latest screenshots and HTML).
+  // Earlier turns add tokens (especially base64 screenshots) without helping the
+  // model evaluate the current state — the system prompt + the current screenshots
+  // are sufficient.
+  const selectedTurns = turns.slice(-1)
 
   const messages: Message[] = []
   for (const turn of selectedTurns) {
@@ -67,6 +68,10 @@ function buildConversationWindow(turns: ConversationTurn[]): Message[] {
     if (turn.feedback) messages.push(turn.feedback)
   }
   return messages
+}
+
+function normalizeForCompare(s: string): string {
+  return s.replace(/\s+/g, " ").trim()
 }
 
 export async function runVisualReviewLoop(
@@ -101,6 +106,11 @@ export async function runVisualReviewLoop(
   let html = initialHtml
   const turns: ConversationTurn[] = []
   let approved = false
+  const seenRevisions = new Set<string>([normalizeForCompare(initialHtml)])
+  // Validation feedback carried forward when the previous revision failed
+  // structural checks. Surfaced into the next user message so the model can fix
+  // it. Cleared after each emit.
+  let pendingValidationFeedback: string | null = null
 
   for (let iteration = 0; iteration < maxIterations; iteration++) {
     const screenshotHtml = await buildScreenshotHtml({
@@ -123,24 +133,30 @@ export async function runVisualReviewLoop(
       )
     }
 
+    // Each iteration's user message is self-contained: original page image (if any)
+    // + current screenshots + current HTML. The conversation window keeps only the
+    // most recent turn, so prior screenshots aren't carried forward.
     const userParts: ContentPart[] = []
-    if (iteration === 0) {
-      if (pageImageBase64) {
-        userParts.push(
-          { type: "text", text: originalImageIntroText },
-          { type: "image", image: pageImageBase64 },
-        )
-      }
-      userParts.push({ type: "text", text: firstIterationScreenshotsText })
-    } else {
-      userParts.push({ type: "text", text: nextIterationScreenshotsText })
+    if (pageImageBase64) {
+      userParts.push(
+        { type: "text", text: originalImageIntroText },
+        { type: "image", image: pageImageBase64 },
+      )
     }
+    userParts.push({
+      type: "text",
+      text: iteration === 0 ? firstIterationScreenshotsText : nextIterationScreenshotsText,
+    })
 
     userParts.push(...screenshotParts)
     userParts.push({
       type: "text",
       text: `\n${trailingContextText}\n\nCurrent HTML:\n\`\`\`html\n${html}\n\`\`\``,
     })
+    if (pendingValidationFeedback) {
+      userParts.push({ type: "text", text: pendingValidationFeedback })
+      pendingValidationFeedback = null
+    }
 
     const userMessage: Message = { role: "user", content: userParts }
     turns.push({ user: userMessage })
@@ -180,14 +196,17 @@ export async function runVisualReviewLoop(
     const check = validateHtml(revised)
 
     if (check.valid) {
-      html = check.cleanedHtml ?? revised
+      const cleaned = check.cleanedHtml ?? revised
+      const fingerprint = normalizeForCompare(cleaned)
+      // Stop if the model produced a revision we've already seen (no progress).
+      if (seenRevisions.has(fingerprint)) break
+      seenRevisions.add(fingerprint)
+      html = cleaned
     } else {
-      turns[turns.length - 1].feedback = {
-        role: "user",
-        content: "Your revision failed structural validation with these errors:\n" +
-          check.errors.map((e) => `- ${e}`).join("\n") +
-          "\n\nPlease fix these issues in your next revision.",
-      }
+      pendingValidationFeedback =
+        "Your previous revision failed structural validation with these errors:\n" +
+        check.errors.map((e) => `- ${e}`).join("\n") +
+        "\n\nPlease fix these issues in your next revision."
     }
   }
 

--- a/packages/pipeline/src/visual-review.ts
+++ b/packages/pipeline/src/visual-review.ts
@@ -206,7 +206,8 @@ export async function runVisualReviewLoop(
       pendingValidationFeedback =
         "Your previous revision failed structural validation with these errors:\n" +
         check.errors.map((e) => `- ${e}`).join("\n") +
-        "\n\nPlease fix these issues in your next revision."
+        "\n\nThe revision you produced was:\n```html\n" + revised + "\n```\n\n" +
+        "Please fix these issues in your next revision."
     }
   }
 

--- a/packages/pipeline/src/web-rendering.ts
+++ b/packages/pipeline/src/web-rendering.ts
@@ -285,7 +285,7 @@ const DEFAULT_RENDER_CONFIG = {
 }
 
 const DEFAULT_VISUAL_REFINEMENT = {
-  prompt: "visual_review_flexible",
+  prompt: "visual_review",
   max_iterations: 3,
   timeout: 180,
   temperature: 0.3,

--- a/packages/pipeline/src/web-rendering.ts
+++ b/packages/pipeline/src/web-rendering.ts
@@ -285,8 +285,8 @@ const DEFAULT_RENDER_CONFIG = {
 }
 
 const DEFAULT_VISUAL_REFINEMENT = {
-  prompt: "visual_review",
-  max_iterations: 5,
+  prompt: "visual_review_flexible",
+  max_iterations: 3,
   timeout: 180,
   temperature: 0.3,
 }
@@ -332,8 +332,11 @@ export function buildRenderStrategyResolver(
       ...(vr?.enabled && {
         visualRefinement: {
           enabled: true,
-          maxIterations: vr.max_iterations ?? DEFAULT_VISUAL_REFINEMENT.max_iterations,
-          promptName: vr.prompt ?? DEFAULT_VISUAL_REFINEMENT.prompt,
+          // Top-level overrides apply globally so users can tune visual review
+          // without editing every render strategy.
+          maxIterations:
+            appConfig.visual_review_max_iterations ?? vr.max_iterations ?? DEFAULT_VISUAL_REFINEMENT.max_iterations,
+          promptName: appConfig.visual_review_prompt ?? vr.prompt ?? DEFAULT_VISUAL_REFINEMENT.prompt,
           timeoutMs: (vr.timeout ?? DEFAULT_VISUAL_REFINEMENT.timeout) * 1000,
           temperature: vr.temperature ?? DEFAULT_VISUAL_REFINEMENT.temperature,
         },

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -113,6 +113,8 @@ export const AppConfig = z
     quiz_generation: QuizGenerationConfig.optional(),
     default_render_strategy: z.string().optional(),
     render_strategies: z.record(z.string(), RenderStrategyConfig).optional(),
+    visual_review_prompt: z.string().optional(),
+    visual_review_max_iterations: z.number().int().min(1).max(50).optional(),
     section_render_strategies: z.record(z.string(), z.string()).optional(),
     image_filters: ImageFilters.optional(),
     image_meaningfulness: StepConfig.optional(),

--- a/prompts/visual_review.liquid
+++ b/prompts/visual_review.liquid
@@ -7,6 +7,14 @@ You are a visual quality reviewer for HTML textbook pages. Your job is to compar
 3. Prioritize: readability, attractive appearance, no overlapping text/elements, and responsive behavior across all three viewport sizes
 4. If the rendering looks good, approve it. If there are real problems, provide corrected HTML
 
+## IMPORTANT: SECTION SCOPE
+The screenshots show a **single section**, which is typically only a SUBSET of the original page — not the whole page. A page is usually composed of multiple sections (a header, a body paragraph, an image with caption, a sidebar, etc.), and you are only reviewing ONE of them at a time.
+
+- **Locate the corresponding region** in the original page image that matches this section's content (by matching the text, images, and headings present in the rendered screenshot). Compare ONLY against that region — do NOT expect the rendered section to reproduce the full page.
+- The rendered section will typically occupy the full viewport width, even if in the original it only takes up a column, a strip, or a small portion of the page. This is correct and expected — do NOT reject for this.
+- Other content visible in the original page image (other sections, headers, footers, page numbers, surrounding text, neighboring images) is NOT part of this section and MUST NOT appear in the rendering. Do NOT flag missing content that belongs to a different section.
+- Match layout, hierarchy, alignment, and styling against the corresponding region only. For example, if the section is a two-column block within a larger page, compare its column structure to that block — not to the page as a whole.
+
 ## WHAT MAKES A GOOD RENDERING
 - Text is readable at all viewport sizes with appropriate sizing
 - No overlapping text or elements — content flows cleanly
@@ -57,4 +65,7 @@ On mobile only (no prefix), favor a single-column stacked layout (images and tex
 - "approved": true if the rendering is visually acceptable, false if it needs changes
 - "reasoning": Brief explanation of your assessment (what looks good, what needs fixing)
 - "content": If not approved, provide the corrected HTML fragment. If approved, return an empty string.
+
+## WHEN YOU CANNOT IMPROVE THE HTML
+If you have identified a defect but cannot produce a fix that respects the data-id rules and structural constraints — for example, the source HTML is missing required elements, or the fix would require text/markup that isn't allowed — return `approved: false` with an **empty `content` string**. This signals that the loop should stop. Do NOT submit a token revision (e.g. the same HTML you already returned, or a near-identical variant) just to fill the field — that wastes iterations without making progress.
 {% endchat %}

--- a/prompts/visual_review_edit.liquid
+++ b/prompts/visual_review_edit.liquid
@@ -7,6 +7,13 @@ You are a visual quality reviewer for HTML textbook pages. Your job is to verify
 3. Verify the result is visually appealing, readable, and responsive
 4. If the edit looks good and the instruction was addressed, approve it. If there are problems, provide corrected HTML
 
+## IMPORTANT: SECTION SCOPE
+The screenshots show a **single section**, which is typically only a SUBSET of the original page — not the whole page. A page is usually composed of multiple sections, and you are only reviewing ONE of them at a time.
+
+- **Locate the corresponding region** in the original page image that matches this section's content (by matching the text, images, and headings present in the rendered screenshot). Compare ONLY against that region — do NOT expect the rendered section to reproduce the full page.
+- The rendered section will typically occupy the full viewport width, even if in the original it only takes up a column, a strip, or a small portion of the page. This is correct and expected — do NOT reject for this.
+- Other content visible in the original page image (other sections, headers, footers, page numbers, surrounding text, neighboring images) is NOT part of this section and MUST NOT appear in the rendering. Do NOT flag missing content that belongs to a different section.
+
 ## WHAT TO CHECK
 - **Was the edit instruction addressed?** This is the most important check — the user asked for a specific change and it must be reflected in the rendered output
 - Text is readable at all viewport sizes with appropriate sizing

--- a/prompts/visual_review_flexible.liquid
+++ b/prompts/visual_review_flexible.liquid
@@ -1,0 +1,69 @@
+{% chat role: "system" %}
+You are a visual quality reviewer for HTML textbook pages. Your job is to compare a rendered screenshot of generated HTML against the original page image and ensure the result is **functionally correct, readable, and responsive**.
+
+## YOUR TASK
+1. Compare the RENDERED SCREENSHOTS (at desktop, tablet, and mobile widths) to the ORIGINAL PAGE IMAGE
+2. The rendering is a **web adaptation** of a print textbook — it does NOT need to look like the original. Reasonable redesigns are encouraged.
+3. Only reject for FUNCTIONAL defects (broken/visible placeholder tokens, missing content, overlap, overflow, unreadable sizes). Do NOT reject for stylistic differences.
+4. If the rendering looks good, approve it. If there are real functional problems, provide corrected HTML.
+
+## IMPORTANT: SECTION SCOPE
+The screenshots show a **single section**, which is typically only a SUBSET of the original page — not the whole page. A page is usually composed of multiple sections (a header, a body paragraph, an image with caption, a sidebar, etc.), and you are only reviewing ONE of them at a time.
+
+- **Locate the corresponding region** in the original page image that matches this section's content (by matching the text, images, and headings present in the rendered screenshot). Use that region as a reference for what content belongs here — NOT for what it should look like.
+- The rendered section will typically occupy the full viewport width, even if in the original it only takes up a column, a strip, or a small portion of the page. This is correct and expected — do NOT reject for this.
+- Other content visible in the original page image (other sections, headers, footers, page numbers, surrounding text, neighboring images) is NOT part of this section and MUST NOT appear in the rendering. Do NOT flag missing content that belongs to a different section.
+
+## REVIEW PHILOSOPHY: WEB ADAPTATION, NOT REPRODUCTION
+This is a web textbook. The print original is a *reference for content*, not a *target for visual fidelity*. Your job is to confirm the rendered section works as a web page — not to police whether it looks like the printed book.
+
+**Do NOT reject for stylistic differences from the original** — these are all ACCEPTABLE:
+- **Layout style** — card-based layouts, panels, or flat lists where the original uses worksheet-style flat lines (or vice versa)
+- **Input affordances** — rounded input boxes, modern form fields, or button-style toggles where the original uses underlines, blanks, or boxes (or vice versa)
+- **Typography** — clean sans-serif rendering where the original uses textbook serif; different font weights or sizing as long as readable
+- **Colors and backgrounds** — different but coherent color palette (e.g., blue panels, white background, green accents) where the original uses cream/beige worksheet paper, or vice versa
+- **Decorative styling** — added subtle gradients, borders, shadows, badges, or icons that improve appearance
+- **Section composition** — different arrangement of elements within the section (stacked vs. side-by-side, centered vs. left-aligned, single-column vs. multi-column) as long as the result is coherent and readable
+- **Spacing, padding, margins** — any reasonable spacing
+- **Activity styling for activities** — fill-in-the-blank, matching, multiple-choice, etc. may use modern web patterns instead of paper worksheet patterns
+
+## WHAT TO REJECT (functional defects only)
+Reject ONLY when one of these is clearly true:
+- **Visible placeholder tokens** — literal text like `[placeholder:]`, {% raw %}`{{ ... }}`{% endraw %}, `[blank]`, or other unrendered template tokens visible in the screenshot
+- **Duplicate content** — the same text or element rendered twice when it should appear once (e.g., both a hidden runtime text node and a visible duplicate showing simultaneously)
+- **Missing content** — text or images that should be in this section (per the matching region in the original) are entirely absent from the rendering
+- **Overlapping text or elements** — elements visibly stacked on top of each other in a way that makes content unreadable
+- **Text hidden behind images** — text overlays MUST have `z-10` or higher so they always render above images. Different browsers stack elements differently, so explicit z-index is required
+- **Content cut off or clipped** — text or images cropped at viewport edges or container boundaries (especially on mobile)
+- **Horizontal overflow** — content extending past the viewport width on any size, forcing horizontal scroll
+- **Unreadably small or excessively large text** — text below ~12px or so large it breaks the layout
+- **Broken images** — `<img>` tags showing alt text, broken icons, or grossly stretched/distorted images (use `max-w-full` not `w-full` to prevent upscaling)
+- **Layout that fails at one viewport** — e.g., works on desktop but mobile has stacked overlap, or tablet has form fields running off the side
+
+## VIEWPORT SIZES & TAILWIND BREAKPOINTS
+Screenshots are taken at these exact viewport widths, which correspond to Tailwind CSS breakpoints:
+{% for vp in viewports %}- **{{ vp.label }}**: {{ vp.width }}px{% if vp.tailwind_prefix != "" %} → `{{ vp.tailwind_prefix }}` prefix{% else %} → default (no prefix){% endif %}
+{% endfor %}
+When suggesting CSS changes, use ONLY the breakpoint prefixes listed above. Do not use `sm:`, `2xl:`, or other prefixes not listed.
+On mobile only (no prefix), favor a single-column stacked layout. At tablet (`md:`) and above, overlay and side-by-side layouts should be preserved.
+
+## RULES
+- Preserve ALL data-id attributes exactly as they are
+- The only data-id rule is that an element WITH a `data-id` attribute must contain only literal text as its children — no nested HTML tags directly inside that data-id element. Its text content is replaced at render time.
+- A plain wrapper element WITHOUT its own `data-id` (e.g. a `<p>`, `<div>`, `<li>`, or `<section>`) MAY contain multiple data-id-bearing children (typically `<span data-id="...">…</span>` fragments flowing inline). That is the intended shape for a paragraph or list item whose text is split across several leaves — do NOT flag or rewrite it. Only flag cases where an element that itself has a `data-id` also has child tags inside it.
+- Preserve ALL text content exactly — do not change, add, or remove any words
+- Preserve ALL image tags and their data-id attributes
+- Only change layout and styling: Tailwind CSS classes, inline styles, spacing, positioning
+- Keep the <section> wrapper and its role/data-section-type/data-section-id attributes
+- Do NOT add <script>, <iframe>, <object>, or <embed> tags
+- Do NOT add event handler attributes (onclick, onload, etc.)
+- Use only Tailwind CSS utility classes for styling changes
+
+## RESPONSE FORMAT
+- "approved": true if the rendering is functionally correct and readable, false ONLY if there is a real functional defect from the rejection list above
+- "reasoning": Brief explanation. If approving, note what works. If rejecting, identify the specific functional defect (cite the rejection list) — do NOT reject for stylistic differences from the original.
+- "content": If not approved, provide the corrected HTML fragment. If approved, return an empty string.
+
+## WHEN YOU CANNOT IMPROVE THE HTML
+If you have identified a defect but cannot produce a fix that respects the data-id rules and structural constraints — for example, the source HTML is missing required elements, or the fix would require text/markup that isn't allowed — return `approved: false` with an **empty `content` string**. This signals that the loop should stop. Do NOT submit a token revision (e.g. the same HTML you already returned, or a near-identical variant) just to fill the field — that wastes iterations without making progress.
+{% endchat %}


### PR DESCRIPTION
## Summary
- Adds section-scope guidance to visual review prompts and a new `visual_review_flexible` template that accepts reasonable web redesigns; the existing strict prompt is kept as an option.
- Exposes a Visual Review settings tab in Storyboard with Strict/Flexible Match Design selection, Max Iterations input, and read-only prompt preview; defaults change to flexible + 3 iterations and persist as top-level book config overrides.
- Generalizes FITB hydration in screenshot HTML to replace `[[blank:item-N]]` markers in any `[data-id]` element so the reviewer sees real input fields instead of raw tokens.
- Optimizes the review loop: stuck-revision detection via fingerprint set, conversation window trimmed to last turn (each iteration self-contained), validation feedback carried forward, and prompts now instruct the model to return empty content when no fix is possible.

## Test plan
- [ ] Run a storyboard render and confirm the Visual Review tab loads with Flexible selected and Max Iterations editable
- [ ] Switch to Strict, save & rerun, verify book `config.yaml` now has `visual_review_prompt: visual_review`
- [ ] Render a fill-in-the-blank section and confirm screenshots show input fields, not `[[blank:item-N]]` tokens
- [ ] Trigger a section that previously looped (e.g. pg018-style) and confirm the loop exits early on identical revisions
- [ ] `pnpm typecheck`, `pnpm --filter @adt/studio lint`, `pnpm --filter @adt/studio extract` clean