### PR TITLE
Relax FITB validation, lower visual-review iterations, parallel screenshots

### DIFF
--- a/apps/studio/src/components/wizard/constants.ts
+++ b/apps/studio/src/components/wizard/constants.ts
@@ -194,7 +194,7 @@ export const PRESETS: PresetConfig[] = [
             max_retries: 5,
             timeout: 180,
             temperature: 0.3,
-            visual_refinement: { enabled: true, max_iterations: 20 },
+            visual_refinement: { enabled: true, max_iterations: 3 },
           },
         },
         "llm-overlay": {
@@ -205,7 +205,7 @@ export const PRESETS: PresetConfig[] = [
             max_retries: 25,
             timeout: 180,
             temperature: 0.3,
-            visual_refinement: { enabled: true, max_iterations: 5 },
+            visual_refinement: { enabled: true, max_iterations: 3 },
           },
         },
         two_column: {
@@ -221,7 +221,7 @@ export const PRESETS: PresetConfig[] = [
             max_retries: 5,
             timeout: 180,
             temperature: 0.3,
-            visual_refinement: { enabled: true, max_iterations: 5 },
+            visual_refinement: { enabled: true, max_iterations: 3 },
           },
         },
         activity_true_false: {
@@ -233,7 +233,7 @@ export const PRESETS: PresetConfig[] = [
             max_retries: 5,
             timeout: 180,
             temperature: 0.3,
-            visual_refinement: { enabled: true, max_iterations: 5 },
+            visual_refinement: { enabled: true, max_iterations: 3 },
           },
         },
         activity_fill_in_the_blank: {
@@ -245,7 +245,7 @@ export const PRESETS: PresetConfig[] = [
             max_retries: 5,
             timeout: 180,
             temperature: 0.3,
-            visual_refinement: { enabled: true, max_iterations: 5 },
+            visual_refinement: { enabled: true, max_iterations: 3 },
           },
         },
         activity_fill_in_a_table: {
@@ -257,7 +257,7 @@ export const PRESETS: PresetConfig[] = [
             max_retries: 5,
             timeout: 180,
             temperature: 0.3,
-            visual_refinement: { enabled: true, max_iterations: 5 },
+            visual_refinement: { enabled: true, max_iterations: 3 },
           },
         },
         activity_matching: {
@@ -269,7 +269,7 @@ export const PRESETS: PresetConfig[] = [
             max_retries: 5,
             timeout: 180,
             temperature: 0.3,
-            visual_refinement: { enabled: true, max_iterations: 5 },
+            visual_refinement: { enabled: true, max_iterations: 3 },
           },
         },
         activity_sorting: {
@@ -281,7 +281,7 @@ export const PRESETS: PresetConfig[] = [
             max_retries: 5,
             timeout: 180,
             temperature: 0.3,
-            visual_refinement: { enabled: true, max_iterations: 5 },
+            visual_refinement: { enabled: true, max_iterations: 3 },
           },
         },
         activity_open_ended_answer: {
@@ -292,7 +292,7 @@ export const PRESETS: PresetConfig[] = [
             max_retries: 5,
             timeout: 180,
             temperature: 0.3,
-            visual_refinement: { enabled: true, max_iterations: 5 },
+            visual_refinement: { enabled: true, max_iterations: 3 },
           },
         },
       },
@@ -447,7 +447,7 @@ export const PRESETS: PresetConfig[] = [
             model: "openai:gpt-5.4",
             max_retries: 5,
             timeout: 180,
-            visual_refinement: { enabled: true, max_iterations: 20 },
+            visual_refinement: { enabled: true, max_iterations: 3 },
           },
         },
         "llm-overlay": {
@@ -457,7 +457,7 @@ export const PRESETS: PresetConfig[] = [
             model: "openai:gpt-5.4",
             max_retries: 25,
             timeout: 180,
-            visual_refinement: { enabled: true, max_iterations: 5 },
+            visual_refinement: { enabled: true, max_iterations: 3 },
           },
         },
       },

--- a/config.yaml
+++ b/config.yaml
@@ -163,7 +163,6 @@ render_strategies:
       timeout: 180
       visual_refinement:
         enabled: true
-        max_iterations: 5
   llm-overlay:
     render_type: llm
     config:
@@ -173,7 +172,6 @@ render_strategies:
       timeout: 180
       visual_refinement:
         enabled: true
-        max_iterations: 5
   two_column:
     render_type: template
     config:
@@ -196,7 +194,6 @@ render_strategies:
       timeout: 180
       visual_refinement:
         enabled: true
-        max_iterations: 5
   activity_true_false:
     render_type: activity
     config:
@@ -207,7 +204,6 @@ render_strategies:
       timeout: 180
       visual_refinement:
         enabled: true
-        max_iterations: 5
   activity_fill_in_the_blank:
     render_type: activity
     config:
@@ -218,7 +214,6 @@ render_strategies:
       timeout: 180
       visual_refinement:
         enabled: true
-        max_iterations: 5
   activity_fill_in_a_table:
     render_type: activity
     config:
@@ -229,7 +224,6 @@ render_strategies:
       timeout: 180
       visual_refinement:
         enabled: true
-        max_iterations: 5
   activity_matching:
     render_type: activity
     config:
@@ -240,7 +234,6 @@ render_strategies:
       timeout: 180
       visual_refinement:
         enabled: true
-        max_iterations: 5
   activity_sorting:
     render_type: activity
     config:
@@ -251,7 +244,6 @@ render_strategies:
       timeout: 180
       visual_refinement:
         enabled: true
-        max_iterations: 5
   activity_open_ended_answer:
     render_type: activity
     config:
@@ -261,7 +253,6 @@ render_strategies:
       timeout: 180
       visual_refinement:
         enabled: true
-        max_iterations: 5
 
 section_render_strategies:
   activity_multiple_choice: activity_multiple_choice

--- a/docs/specs/SECTIONING_CROSSWORD_BUG.md
+++ b/docs/specs/SECTIONING_CROSSWORD_BUG.md
@@ -1,0 +1,63 @@
+# Spec: Crossword cells collapsed into a single leaf during page-sectioning
+
+## Problem
+
+Page-sectioning sometimes collapses a crossword's individual letter cells into a single `activity_fill_in_the_blank` leaf containing the whole word, instead of emitting one leaf per cell.
+
+When this happens, the downstream activity-rendering LLM cannot satisfy validation: the visual layout has N cells, but the source content tree has only one `data-id` to attach. Splitting that `data-id` across multiple cells produces "Text mismatch" errors (each cell's text doesn't match the full word) and "Text node outside any data-id element" errors (bare letters in styled cells).
+
+## Observed example
+
+Two near-identical crossword pages from the same book, processed in the same run, produced different extractions:
+
+**pg015 (correct extraction — one leaf per cell):**
+```
+activity_fill_in_the_blank id=pg015_n0007 "R"
+activity_fill_in_the_blank id=pg015_n0008 "E"
+activity_fill_in_the_blank id=pg015_n0009 "C"
+activity_fill_in_the_blank id=pg015_n0010 "E"
+activity_fill_in_the_blank id=pg015_n0011 "T"
+activity_fill_in_the_blank id=pg015_n0012 "A"
+```
+
+**pg016 (collapsed extraction — bug):**
+```
+activity_fill_in_the_blank id=pg016_n0004 "R E C E T A S"
+```
+
+Both pages visually show the same shape: a row of seven boxes, one letter per box, prefilled (or to be filled) with the letters of "RECETAS".
+
+## Where it happens
+
+The page-sectioning step (`packages/pipeline/src/page-sectioning.ts` and the `page_sectioning` LLM prompt) decides how to break page content into nodes. The bug is in the prompt or the post-processing logic that lets it merge consecutive single-character cells into one node when their visual layout reads left-to-right as a word.
+
+## What "fixed" looks like
+
+For any visually grid-arranged set of single-character or `__`-style cells (crossword grids, letter-by-letter answer rows, "complete the word" boxes, fill-the-syllable strips, etc.), each cell must be emitted as its own leaf node:
+
+- One letter per leaf when a letter is shown.
+- One blank-placeholder leaf per cell when the cell is empty (text `"_"` or `"__"`).
+- The natural reading order across cells determines node ordering.
+
+Fix should NOT regress the case where a single answer line truly is one input — e.g., `"Nombre: ___"` stays a single `activity_fill_in_the_blank` leaf because there's just one writable area, not a grid.
+
+## Acceptance criteria
+
+1. Re-running page-sectioning on a book containing a crossword produces one leaf per cell (matches the pg015 shape, not the pg016 shape).
+2. The activity-rendering step then passes validation for that page (no "Text mismatch" or "Text node outside any data-id element" errors on cells).
+3. Existing single-input cases (e.g., `"Nombre: ___"`) remain a single leaf.
+4. Add a regression test: a fixture page-sectioning input that visually shows a 7-cell crossword row should round-trip to 7 leaves, not 1.
+
+## Suggested approach
+
+Two paths, ranked by intrusiveness:
+
+1. **Prompt-only fix.** Add explicit guidance to the `page_sectioning` prompt: "When a row or column of visually distinct boxes/cells each contains (or is meant to contain) a single character or short fragment, emit one leaf per cell, not one merged leaf for the row." Include a small example. Cheapest if it works.
+
+2. **Post-processing detector.** If prompt guidance is unreliable, add a deterministic check in `page-sectioning.ts` that splits a leaf whose text matches the pattern `^[A-Za-zÀ-ÿ](\s+[A-Za-zÀ-ÿ])+$` (single letters separated by spaces) into one leaf per letter, preserving role and parent. Belt-and-suspenders if the LLM keeps merging them.
+
+Start with #1, fall back to #2 if a follow-up run still shows collapsed cells.
+
+## Related context
+
+The downstream FITB renderer already has guidance for both shapes (per-letter leaves AND single-leaf row strings) in `prompts/activity_fill_in_the_blank.liquid` section 1c. That guidance is a partial workaround for the collapsed case but cannot produce a correct visual rendering when the source has a single leaf — fix must happen upstream in sectioning.

--- a/docs/specs/SECTIONING_VALIDATION_FAILURES.md
+++ b/docs/specs/SECTIONING_VALIDATION_FAILURES.md
@@ -1,0 +1,124 @@
+# Spec: Reduce page-sectioning validation failures (image_group + others)
+
+## Problem
+
+Page-sectioning currently exhausts its retry budget on a class of validator
+errors that the LLM keeps re-emitting even after seeing the feedback. The
+failures aren't ambiguous — they're shape errors the validator rejects
+deterministically — but the prompt doesn't give the model enough guidance to
+avoid them on the next attempt, so the page fails outright after
+`maxRetries` (default 5).
+
+The most common offender is the `image_group` rule: the validator requires
+an `image_group` container to hold the image leaf **plus at least one
+associated content leaf** (`packages/pipeline/src/page-sectioning.ts:325-338`).
+The model frequently emits an `image_group` with only the image inside, or
+puts the image second instead of first, and burns retries on it.
+
+## Where it happens
+
+- Validator: `packages/pipeline/src/page-sectioning.ts`, `validateNode()`
+  (lines ~270-391).
+- Retry loop: handed to `generateWithValidation` in `@adt/llm`; on failure
+  the validator's error strings are appended to the next attempt's
+  messages. After `maxRetries` exhausted, the step throws and the page is
+  marked failed.
+- Prompt: `prompts/page_sectioning.liquid` (and the refinement variant).
+
+## Validator failures, ranked by observed frequency
+
+These all come from `validateNode()` — every one of them is a shape rule
+the LLM should be able to follow given clear guidance:
+
+1. **`image_group` missing associated content leaf** — line 333. The
+   container has only the image inside.
+2. **`image_group` first child is not the image** — line 328. Image is
+   placed second/last instead of first.
+3. **Container with `text`** — line 305. Model puts a title string on the
+   container instead of in a child leaf.
+4. **Leaf with `role` but no `text`** — line 376. Empty leaves emitted for
+   visually-empty boxes (this overlaps with the crossword bug).
+5. **Image leaf carries `text`** — line 357. Caption text glued onto the
+   image leaf instead of a sibling leaf.
+6. **Duplicate `image_id`** — line 368. Same image referenced from two
+   places when the model is unsure where it belongs.
+7. **Empty non-`table_cell` container** — line 318. Container emitted with
+   no children at all.
+8. **Both `structure` and `role` set, or neither** — lines 284, 289.
+
+## What "fixed" looks like
+
+For each failure mode above, the prompt should make the rule unmissable
+and provide a small example of the right shape vs. the wrong shape — the
+same approach used in the FITB prompt's section 1c
+(`prompts/activity_fill_in_the_blank.liquid`). The validator messages are
+already clear; the gap is that the model doesn't internalize the rule
+from a single feedback message.
+
+Concretely:
+
+- An `image_group` block in the prompt that shows: image + caption (good),
+  image alone (bad — should be a bare `role: "image"` leaf instead),
+  caption + image in that order (bad — image must be first).
+- A "container vs. leaf" block that shows: title leaf inside a
+  `section_block` container (good), title text on the container itself
+  (bad).
+- An "empty cells" block that says: visually-empty boxes should emit a
+  leaf with text `"_"` (or whatever the placeholder convention is), never
+  a leaf with no `text` and never an empty container.
+- A "one image, one place" reminder: every `image_id` appears exactly
+  once across the whole tree.
+
+## Acceptance criteria
+
+1. Re-running page-sectioning on a sample of pages that previously failed
+   with `image_group must contain the image leaf plus at least one
+   associated content leaf` succeeds on the first or second attempt.
+2. Across a 50-page test book, the rate of pages that exhaust
+   `maxRetries` drops materially. (Pick a baseline number from the most
+   recent run before merging.)
+3. No regression in pages that already section cleanly — the prompt
+   additions are guidance, not new constraints.
+4. Add at least one regression test per rule in
+   `packages/pipeline/src/__tests__/page-sectioning.test.ts` covering the
+   bad-shape input → validator error path. (The image_group case at
+   line 350-375 is the existing template.)
+
+## Suggested approach
+
+Two paths, ranked by intrusiveness:
+
+1. **Prompt-only fix.** Extend `prompts/page_sectioning.liquid` with the
+   blocks listed under "What 'fixed' looks like." Keep examples short and
+   show wrong-vs-right for each rule. Cheapest if it works.
+
+2. **Validator-side auto-repair for the cheap cases.** A few of these
+   failures are mechanically fixable without re-prompting:
+   - `image_group` with only an image child → unwrap to a bare
+     `role: "image"` leaf in the parent's children list.
+   - `image_group` with image not first → reorder children so image is
+     first (only safe if exactly one child has `role: "image"`).
+   - Container with both `text` and `children` → move the `text` into a
+     synthetic leading child leaf with an inferred role.
+
+   Auto-repair should run **before** the validator on each attempt's raw
+   output, so the LLM never sees the failure and the retry budget is
+   preserved for genuine ambiguity. Keep the repairs conservative — only
+   the unambiguous transformations above; don't try to invent missing
+   captions.
+
+Start with #1. If a follow-up run still shows >X% of pages failing on
+these specific rules, layer in #2 for the mechanical cases.
+
+## Related context
+
+- The crossword-collapse bug (`SECTIONING_CROSSWORD_BUG.md`) is a
+  separate sectioning failure mode — the validator passes but the
+  extraction is semantically wrong. That spec proposes a similar
+  prompt-first / post-process-fallback strategy and the two fixes can
+  share a single prompt-revision pass.
+- The downstream `validate-html.ts` recently grew an `optionalTextIds`
+  escape hatch for cases where the source tree's data-ids can't all be
+  rendered. That is a different layer; the goal here is to keep the
+  source tree itself well-formed so downstream layers don't need
+  workarounds.

--- a/packages/pipeline/src/__tests__/validate-html.test.ts
+++ b/packages/pipeline/src/__tests__/validate-html.test.ts
@@ -19,6 +19,43 @@ describe("validateSectionHtml", () => {
     expect(result.errors).toEqual([])
   })
 
+  it("allows optional text-ids to be omitted", () => {
+    const html = `
+      <div id="content"><section data-section-type="activity_fill_in_the_blank">
+        <p data-id="pg001_n0001">Question?</p>
+        <input type="text" />
+      </section></div>
+    `
+    const result = validateSectionHtml(
+      html,
+      ["pg001_n0001", "pg001_n0002", "pg001_n0003"],
+      [],
+      undefined,
+      { optionalTextIds: new Set(["pg001_n0002", "pg001_n0003"]) }
+    )
+    expect(result.valid).toBe(true)
+    expect(result.errors).toEqual([])
+  })
+
+  it("still requires non-optional text-ids when optionalTextIds is set", () => {
+    const html = `
+      <section data-section-type="activity_fill_in_the_blank">
+        <p data-id="pg001_n0002">Foo</p>
+      </section>
+    `
+    const result = validateSectionHtml(
+      html,
+      ["pg001_n0001", "pg001_n0002"],
+      [],
+      undefined,
+      { optionalTextIds: new Set(["pg001_n0002"]) }
+    )
+    expect(result.valid).toBe(false)
+    expect(result.errors).toContainEqual(
+      expect.stringContaining('Missing required text data-id: "pg001_n0001"')
+    )
+  })
+
   it("detects unknown data-id", () => {
     const html = `
       <section>

--- a/packages/pipeline/src/render-llm.ts
+++ b/packages/pipeline/src/render-llm.ts
@@ -168,7 +168,7 @@ function validateWebRendering(
 ): ValidationResult {
   const r = result as { reasoning: string; content: string }
   const label = context.label as string
-  const leaf_texts = context.leaf_texts as Array<{ text_id: string; text: string }>
+  const leaf_texts = context.leaf_texts as Array<{ text_id: string; text_type: string; text: string }>
   const images = context.images as Array<{ image_id: string }>
   const group_ids = context.group_ids as string[]
   const isActivity = context._isActivity as boolean | undefined
@@ -178,6 +178,7 @@ function validateWebRendering(
   const allowedImageIds = images.map((img) => img.image_id)
   const imageUrlPrefix = `/api/books/${label}/images`
   const expectedTexts = new Map(leaf_texts.map((t) => [t.text_id, t.text]))
+  const optionalTextIds = collectOptionalTextIds(leaf_texts)
 
   const check = validateSectionHtml(
     r.content,
@@ -190,6 +191,7 @@ function validateWebRendering(
       expectedTexts,
       expectedSectionType: sectionType,
       expectedSectionId: sectionId,
+      optionalTextIds,
     }
   )
   if (check.valid && check.sectionHtml) {
@@ -200,4 +202,43 @@ function validateWebRendering(
     }
   }
   return { valid: check.valid, errors: check.errors }
+}
+
+const TEXTBOOK_BLANK_RE = /_{3,}|\.{3,}/g
+const PLACEHOLDER_MARKER_RE = /\[placeholder:[^\]]+\]/g
+const OPTIONAL_TEXT_ROLES = new Set(["footer", "header", "page_number"])
+
+/** True if the leaf's text is nothing but textbook blank placeholders
+ * (`___`, `...`, `[placeholder:...]`) and inert separators (whitespace,
+ * `/`, `-`). Such a leaf carries no content the learner needs to see, so
+ * the LLM may legitimately replace it with an editable field and drop
+ * the source span. */
+function isPlaceholderOnlyText(text: string): boolean {
+  if (!TEXTBOOK_BLANK_RE.test(text) && !PLACEHOLDER_MARKER_RE.test(text)) {
+    return false
+  }
+  // Reset regex lastIndex (the .test() call above advances stateful global regexes).
+  TEXTBOOK_BLANK_RE.lastIndex = 0
+  PLACEHOLDER_MARKER_RE.lastIndex = 0
+  const stripped = text
+    .replace(TEXTBOOK_BLANK_RE, "")
+    .replace(PLACEHOLDER_MARKER_RE, "")
+    .replace(/[\s/\-]/g, "")
+  return stripped.length === 0
+}
+
+function collectOptionalTextIds(
+  leafTexts: Array<{ text_id: string; text_type: string; text: string }>
+): Set<string> {
+  const optional = new Set<string>()
+  for (const leaf of leafTexts) {
+    if (OPTIONAL_TEXT_ROLES.has(leaf.text_type)) {
+      optional.add(leaf.text_id)
+      continue
+    }
+    if (isPlaceholderOnlyText(leaf.text ?? "")) {
+      optional.add(leaf.text_id)
+    }
+  }
+  return optional
 }

--- a/packages/pipeline/src/validate-html.ts
+++ b/packages/pipeline/src/validate-html.ts
@@ -101,6 +101,16 @@ export interface HtmlValidationOptions {
    * not required to be present.
    */
   allowedContainerIds?: string[]
+  /**
+   * Subset of text data-ids that may legitimately be omitted from the
+   * rendered HTML. Used for nodes whose source text carries no content
+   * the learner needs to see — e.g. an `activity_fill_in_the_blank`
+   * leaf whose entire text is a textbook blank placeholder ("___"),
+   * or a `footer` leaf that survived pruning. The LLM is still allowed
+   * to include them, but the "Missing required text data-id" check is
+   * suppressed if it doesn't.
+   */
+  optionalTextIds?: Set<string>
 }
 
 export function validateSectionHtml(
@@ -147,11 +157,14 @@ export function validateSectionHtml(
 
   // Verify all expected text IDs are present in the generated HTML.
   // This ensures the LLM doesn't silently drop entries (e.g. duplicated texts).
+  // IDs in `optionalTextIds` may be absent (placeholder-only blanks, leaked
+  // footers, etc.) — they're still allowed if the LLM chooses to include them.
   if (allowedTextIds.length > 0) {
+    const optional = options?.optionalTextIds
     const renderedDataIds = new Set<string>()
     collectDataIds(section, renderedDataIds)
     for (const textId of allowedTextIds) {
-      if (!renderedDataIds.has(textId)) {
+      if (!renderedDataIds.has(textId) && !optional?.has(textId)) {
         errors.push(`Missing required text data-id: "${textId}"`)
       }
     }

--- a/packages/pipeline/src/visual-review.ts
+++ b/packages/pipeline/src/visual-review.ts
@@ -120,12 +120,20 @@ export async function runVisualReviewLoop(
       webAssetsDir: deps.webAssetsDir,
     })
 
-    const screenshotParts: ContentPart[] = []
-    for (const vp of SCREENSHOT_VIEWPORTS) {
-      const base64 = await deps.screenshotRenderer.screenshot(
-        screenshotHtml,
-        { width: vp.width, height: vp.height }
+    // Render all viewport screenshots in parallel — they're independent and
+    // each takes ~1-2s, so serialising them was a 3-6s tax per iteration.
+    const screenshots = await Promise.all(
+      SCREENSHOT_VIEWPORTS.map((vp) =>
+        deps.screenshotRenderer.screenshot(
+          screenshotHtml,
+          { width: vp.width, height: vp.height }
+        )
       )
+    )
+    const screenshotParts: ContentPart[] = []
+    for (let i = 0; i < SCREENSHOT_VIEWPORTS.length; i++) {
+      const vp = SCREENSHOT_VIEWPORTS[i]
+      const base64 = screenshots[i]
       deps.storeScreenshot?.(base64)
       screenshotParts.push(
         { type: "text", text: `${vp.label} screenshot (${vp.width}px wide):` },

--- a/prompts/activity_fill_in_the_blank.liquid
+++ b/prompts/activity_fill_in_the_blank.liquid
@@ -19,6 +19,47 @@ You are an expert frontend engineer creating beautiful, kid-friendly HTML pages 
 - Class: `text-center mb-2` or `text-center mb-4`
 - Can include optional link buttons with purple styling
 
+**1b. Activity numbers**
+When the input provides an `activity_number` leaf (typically a single digit like `"1"`, `"2"`, `"3"`), its text MUST be wrapped in an element carrying the corresponding `data-id` — never hard-code the digit. The element can still sit inside a styled badge/circle/pill for visual emphasis.
+
+Correct:
+```html
+<div class="bg-green-600 text-white rounded-full h-10 w-10 flex items-center justify-center font-bold">
+  <span data-id="text-N">2</span>
+</div>
+```
+
+Wrong (digit not wrapped — fails validation, the activity number's data-id goes missing):
+```html
+<div class="bg-green-600 text-white rounded-full ...">2</div>
+```
+
+**1c. Single-letter cells (crosswords, letter-by-letter blanks)**
+Some inputs provide one leaf per cell whose text is a single letter (e.g. several consecutive `activity_fill_in_the_blank` leaves with text `"R"`, `"E"`, `"C"`, `"E"`, `"T"`, `"A"`, `"S"` — a crossword's prefilled letters or letter-by-letter answer row). Each letter MUST be wrapped in its own `<span data-id="...">` inside its grid cell. The same applies when a leaf's text is a string like `"__ __ R __ __ __ __"` representing one row of a letter grid: keep the entire string inside one `data-id` span — do not split it across multiple cells with bare letters.
+
+Correct (one letter per cell, each wrapped):
+```html
+<div class="grid grid-cols-7 gap-1">
+  <div class="border-2 border-gray-700 w-10 h-10 flex items-center justify-center text-xl font-bold">
+    <span data-id="text-7">R</span>
+  </div>
+  <div class="border-2 border-gray-700 w-10 h-10 flex items-center justify-center text-xl font-bold">
+    <span data-id="text-8">E</span>
+  </div>
+  <!-- ...one cell per single-letter leaf, each with its data-id... -->
+</div>
+```
+
+Wrong (bare letters in cells — fails "Text node outside any data-id element"):
+```html
+<div class="grid grid-cols-7 gap-1">
+  <div class="border-2 ...">R</div>
+  <div class="border-2 ...">E</div>
+</div>
+```
+
+If the source provides a SINGLE leaf containing the whole word (e.g. one `activity_fill_in_the_blank` with text `"R E C E T A S"`) and the page visually shows one cell per letter, you cannot split it across multiple `data-id` spans — the validator requires the full text to live in the one provided `data-id`. Render the whole string inside a single `<span data-id="...">` styled as a row of boxes (e.g. via `letter-spacing` or styled child spans without data-ids that are decorative only); editable inputs for the learner go OUTSIDE the data-id span as separate `<input>` elements per cell.
+
 **2. Fill-in-the-Blank Sentences (PREFERRED — Inline Blanks)**
 
 This is the **default and strongly preferred** layout. Each sentence containing a blank is wrapped in a container with the `fitb-sentence` class. Instead of placing `<input>` elements directly, insert `[[blank:item-N]]` placeholder markers at the exact position where the missing word belongs.

--- a/prompts/activity_fill_in_the_blank.liquid
+++ b/prompts/activity_fill_in_the_blank.liquid
@@ -35,7 +35,9 @@ Wrong (digit not wrapped — fails validation, the activity number's data-id goe
 ```
 
 **1c. Single-letter cells (crosswords, letter-by-letter blanks)**
-Some inputs provide one leaf per cell whose text is a single letter (e.g. several consecutive `activity_fill_in_the_blank` leaves with text `"R"`, `"E"`, `"C"`, `"E"`, `"T"`, `"A"`, `"S"` — a crossword's prefilled letters or letter-by-letter answer row). Each letter MUST be wrapped in its own `<span data-id="...">` inside its grid cell. The same applies when a leaf's text is a string like `"__ __ R __ __ __ __"` representing one row of a letter grid: keep the entire string inside one `data-id` span — do not split it across multiple cells with bare letters.
+Some inputs provide one leaf per cell whose text is a single letter (e.g. several consecutive `activity_fill_in_the_blank` leaves with text `"R"`, `"E"`, `"C"`, `"E"`, `"T"`, `"A"`, `"S"` — a crossword's prefilled letters or letter-by-letter answer row). Each letter MUST be wrapped in its own `<span data-id="...">` inside its grid cell — do not render the letters as bare text in styled boxes.
+
+A different shape: when a leaf's text is a single multi-cell row string like `"__ __ R __ __ __ __"`, keep that entire string inside ONE `<span data-id>` (it's one leaf, one data-id). Do not split the row's underscores and the visible letter across multiple data-id spans — the validator's text-similarity check will fail.
 
 Correct (one letter per cell, each wrapped):
 ```html


### PR DESCRIPTION
## Summary
- Relax `validateSectionHtml` to accept omitted text data-ids when the source leaf is a placeholder-only blank (`___`/`...`/`[placeholder:...]`) or a `footer`/`header`/`page_number` role; drives a sharp drop in spurious "Missing required text data-id" failures observed on FITB books.
- Strengthen `activity_fill_in_the_blank.liquid` with explicit guidance that `activity_number` digits and single-letter crossword/letter-cell contents must be wrapped in their `data-id` span.
- Render the three viewport screenshots in `visual-review` in parallel instead of sequentially.
- Drop per-strategy `max_iterations` from the global `config.yaml` and update the Studio wizard preset constants from 5 (and the runaway 20 on the `llm` strategy) to 3, so all newly created books get the same iteration cap as the hardcoded fallback.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm exec vitest run packages/pipeline/src/__tests__/` (502 tests pass)
- [ ] Run the FITB test book end-to-end and confirm activity-rendering errors stay near zero
- [ ] Create a new book via the wizard and verify its `config.yaml` shows `max_iterations: 3` (or no entry) on every strategy