### PR TITLE
Fix crossword sectioning, image_group auto-repair, blank-cell validation

### DIFF
--- a/packages/pipeline/src/__tests__/page-sectioning.test.ts
+++ b/packages/pipeline/src/__tests__/page-sectioning.test.ts
@@ -6,6 +6,7 @@ import type {
   LLMModel,
 } from "@adt/llm"
 import {
+  applyAutoRepairs,
   buildPageSectioningConfig,
   finalizePageSectioning,
   flattenTreeToText,
@@ -860,6 +861,292 @@ describe("sectionPage", () => {
     expect(refinementCallCount).toBe(2)
     expect(output.reasoning).toBe("Reviewer rewrote it")
     expect(output.sections[0].nodes[0].text).toBe("Refined")
+  })
+})
+
+// ── applyAutoRepairs ────────────────────────────────────────────
+
+describe("applyAutoRepairs", () => {
+  it("unwraps an image_group containing only an image leaf into a bare image leaf", () => {
+    const raw = {
+      reasoning: "",
+      sections: [
+        {
+          section_type: "text_only",
+          background_color: "#fff",
+          text_color: "#000",
+          page_number: 1,
+          nodes: [
+            {
+              structure: "image_group",
+              children: [{ role: "image", image_id: "pg001_im001" }],
+            },
+          ],
+        },
+      ],
+    }
+    applyAutoRepairs(raw)
+    expect(raw.sections[0].nodes).toEqual([
+      { role: "image", image_id: "pg001_im001" },
+    ])
+  })
+
+  it("reorders an image_group so the image leaf is the first child", () => {
+    const raw = {
+      reasoning: "",
+      sections: [
+        {
+          section_type: "text_only",
+          background_color: "#fff",
+          text_color: "#000",
+          page_number: 1,
+          nodes: [
+            {
+              structure: "image_group",
+              children: [
+                { role: "caption", text: "Figure 1." },
+                { role: "image", image_id: "pg001_im001" },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+    applyAutoRepairs(raw)
+    const ig = raw.sections[0].nodes[0] as {
+      children: Array<{ role: string; text?: string; image_id?: string }>
+    }
+    expect(ig.children[0].role).toBe("image")
+    expect(ig.children[1].role).toBe("caption")
+  })
+
+  it("moves a container's text into a leading text leaf when both text and children are present", () => {
+    const raw = {
+      reasoning: "",
+      sections: [
+        {
+          section_type: "text_only",
+          background_color: "#fff",
+          text_color: "#000",
+          page_number: 1,
+          nodes: [
+            {
+              structure: "paragraph",
+              text: "Title text",
+              children: [{ role: "text", text: "Body" }],
+            },
+          ],
+        },
+      ],
+    }
+    applyAutoRepairs(raw)
+    const para = raw.sections[0].nodes[0] as {
+      structure: string
+      text: string | null
+      children: Array<{ role: string; text: string }>
+    }
+    expect(para.text).toBeNull()
+    expect(para.children[0]).toEqual({ role: "text", text: "Title text" })
+    expect(para.children[1]).toEqual({ role: "text", text: "Body" })
+  })
+
+  it("splits a single-letter-row leaf into one leaf per letter (crossword cells)", () => {
+    const raw = {
+      reasoning: "",
+      sections: [
+        {
+          section_type: "text_only",
+          background_color: "#fff",
+          text_color: "#000",
+          page_number: 1,
+          nodes: [
+            {
+              structure: "activity",
+              children: [
+                { role: "activity_fill_in_the_blank", text: "R E C E T A S" },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+    applyAutoRepairs(raw)
+    const activity = raw.sections[0].nodes[0] as {
+      children: Array<{ role: string; text: string }>
+    }
+    expect(activity.children).toHaveLength(7)
+    expect(activity.children.map((c) => c.text)).toEqual([
+      "R",
+      "E",
+      "C",
+      "E",
+      "T",
+      "A",
+      "S",
+    ])
+    expect(activity.children.every((c) => c.role === "activity_fill_in_the_blank")).toBe(true)
+  })
+
+  it("does not split a single-leaf single-blank line like 'Nombre: ___'", () => {
+    const raw = {
+      reasoning: "",
+      sections: [
+        {
+          section_type: "text_only",
+          background_color: "#fff",
+          text_color: "#000",
+          page_number: 1,
+          nodes: [
+            { role: "activity_fill_in_the_blank", text: "Nombre: ___" },
+          ],
+        },
+      ],
+    }
+    applyAutoRepairs(raw)
+    expect(raw.sections[0].nodes).toHaveLength(1)
+    expect(
+      (raw.sections[0].nodes[0] as { text: string }).text
+    ).toBe("Nombre: ___")
+  })
+
+  it("does not split a normal multi-word sentence", () => {
+    const raw = {
+      reasoning: "",
+      sections: [
+        {
+          section_type: "text_only",
+          background_color: "#fff",
+          text_color: "#000",
+          page_number: 1,
+          nodes: [{ role: "text", text: "Hola mundo" }],
+        },
+      ],
+    }
+    applyAutoRepairs(raw)
+    expect(raw.sections[0].nodes).toHaveLength(1)
+  })
+
+  it("repaired tree passes the validator (image_group unwrap)", () => {
+    const raw = {
+      reasoning: "",
+      sections: [
+        {
+          section_type: "text_only",
+          background_color: "#fff",
+          text_color: "#000",
+          page_number: 1,
+          nodes: [
+            {
+              structure: "image_group",
+              children: [{ role: "image", image_id: "pg001_im001" }],
+            },
+          ],
+        },
+      ],
+    }
+    applyAutoRepairs(raw)
+    const result = runValidator(
+      raw,
+      makeCtx({ availableImageIds: ["pg001_im001"] })
+    )
+    expect(result.valid).toBe(true)
+  })
+
+  it("repaired tree passes the validator (image_group reorder)", () => {
+    const raw = {
+      reasoning: "",
+      sections: [
+        {
+          section_type: "text_only",
+          background_color: "#fff",
+          text_color: "#000",
+          page_number: 1,
+          nodes: [
+            {
+              structure: "image_group",
+              children: [
+                { role: "caption", text: "Figure 1." },
+                { role: "image", image_id: "pg001_im001" },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+    applyAutoRepairs(raw)
+    const result = runValidator(
+      raw,
+      makeCtx({ availableImageIds: ["pg001_im001"] })
+    )
+    expect(result.valid).toBe(true)
+  })
+
+  it("keeps image first when image_group has both text and children (repair ordering)", () => {
+    const raw = {
+      reasoning: "",
+      sections: [
+        {
+          section_type: "text_only",
+          background_color: "#fff",
+          text_color: "#000",
+          page_number: 1,
+          nodes: [
+            {
+              structure: "image_group",
+              text: "Title overlay",
+              children: [
+                { role: "image", image_id: "pg001_im001" },
+                { role: "caption", text: "A caption." },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+    applyAutoRepairs(raw)
+    const ig = raw.sections[0].nodes[0] as {
+      structure: string
+      text: string | null
+      children: Array<{ role: string; text?: string; image_id?: string }>
+    }
+    expect(ig.text).toBeNull()
+    expect(ig.children[0].role).toBe("image")
+    const result = runValidator(
+      raw,
+      makeCtx({ availableImageIds: ["pg001_im001"] })
+    )
+    expect(result.valid).toBe(true)
+  })
+
+  it("recurses into nested children (image_group inside a paragraph)", () => {
+    const raw = {
+      reasoning: "",
+      sections: [
+        {
+          section_type: "text_only",
+          background_color: "#fff",
+          text_color: "#000",
+          page_number: 1,
+          nodes: [
+            {
+              structure: "paragraph",
+              children: [
+                {
+                  structure: "image_group",
+                  children: [{ role: "image", image_id: "pg001_im001" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+    applyAutoRepairs(raw)
+    const para = raw.sections[0].nodes[0] as {
+      children: Array<{ role?: string; image_id?: string; structure?: string }>
+    }
+    expect(para.children).toHaveLength(1)
+    expect(para.children[0]).toEqual({ role: "image", image_id: "pg001_im001" })
   })
 })
 

--- a/packages/pipeline/src/__tests__/render-llm.test.ts
+++ b/packages/pipeline/src/__tests__/render-llm.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest"
+import { collectOptionalTextIds } from "../render-llm.js"
+
+describe("collectOptionalTextIds", () => {
+  it("marks single-underscore blank-cell leaves as optional (crossword cells)", () => {
+    const optional = collectOptionalTextIds([
+      { text_id: "n1", text_type: "activity_fill_in_the_blank", text: "_" },
+      { text_id: "n2", text_type: "activity_fill_in_the_blank", text: "__" },
+      { text_id: "n3", text_type: "activity_fill_in_the_blank", text: "___" },
+    ])
+    expect(optional.has("n1")).toBe(true)
+    expect(optional.has("n2")).toBe(true)
+    expect(optional.has("n3")).toBe(true)
+  })
+
+  it("marks visible letters as required (not optional)", () => {
+    const optional = collectOptionalTextIds([
+      { text_id: "n1", text_type: "activity_fill_in_the_blank", text: "R" },
+      { text_id: "n2", text_type: "activity_fill_in_the_blank", text: "E" },
+    ])
+    expect(optional.has("n1")).toBe(false)
+    expect(optional.has("n2")).toBe(false)
+  })
+
+  it("marks footer/header/page_number roles as optional", () => {
+    const optional = collectOptionalTextIds([
+      { text_id: "f1", text_type: "footer", text: "Some footer text" },
+      { text_id: "h1", text_type: "header", text: "Header" },
+      { text_id: "p1", text_type: "page_number", text: "42" },
+    ])
+    expect(optional.has("f1")).toBe(true)
+    expect(optional.has("h1")).toBe(true)
+    expect(optional.has("p1")).toBe(true)
+  })
+
+  it("marks placeholder-only text with underscores and separators as optional", () => {
+    const optional = collectOptionalTextIds([
+      { text_id: "n1", text_type: "activity_fill_in_the_blank", text: "_ _ _" },
+      { text_id: "n2", text_type: "activity_fill_in_the_blank", text: "___/___/___" },
+      { text_id: "n3", text_type: "activity_fill_in_the_blank", text: "..." },
+    ])
+    expect(optional.has("n1")).toBe(true)
+    expect(optional.has("n2")).toBe(true)
+    expect(optional.has("n3")).toBe(true)
+  })
+
+  it("does not mark mixed text-with-blank leaves as optional", () => {
+    const optional = collectOptionalTextIds([
+      { text_id: "n1", text_type: "activity_fill_in_the_blank", text: "Nombre: ___" },
+      { text_id: "n2", text_type: "activity_fill_in_the_blank", text: "El Sol es una ___" },
+    ])
+    expect(optional.has("n1")).toBe(false)
+    expect(optional.has("n2")).toBe(false)
+  })
+
+  it("does not match a single dot (normal punctuation)", () => {
+    const optional = collectOptionalTextIds([
+      { text_id: "n1", text_type: "text", text: "." },
+    ])
+    expect(optional.has("n1")).toBe(false)
+  })
+
+  it("matches a stateful regex consistently across repeated calls", () => {
+    const leaves = [
+      { text_id: "n1", text_type: "activity_fill_in_the_blank", text: "_" },
+    ]
+    expect(collectOptionalTextIds(leaves).has("n1")).toBe(true)
+    expect(collectOptionalTextIds(leaves).has("n1")).toBe(true)
+    expect(collectOptionalTextIds(leaves).has("n1")).toBe(true)
+  })
+})

--- a/packages/pipeline/src/page-sectioning.ts
+++ b/packages/pipeline/src/page-sectioning.ts
@@ -97,6 +97,7 @@ export async function sectionPage(
   // Initial generation (with built-in validation retry).
   const initial = await generateInitial(input, config, validatorContext, llmModel)
   let candidate = initial
+  applyAutoRepairs(candidate)
 
   // Refinement loop — up to maxRefinements reviewer passes.
   const priorNotes: string[] = []
@@ -113,6 +114,7 @@ export async function sectionPage(
 
     // The reviewer proposed a replacement. Validate it before adopting.
     if (review.nodes_and_sections) {
+      applyAutoRepairs(review.nodes_and_sections)
       const err = runValidator(review.nodes_and_sections, validatorContext)
       if (err.valid) {
         candidate = review.nodes_and_sections
@@ -149,7 +151,10 @@ async function generateInitial(
       section_types: config.sectionTypes,
       mode: config.mode,
     },
-    validate: (raw) => runValidator(raw, validatorContext),
+    validate: (raw) => {
+      applyAutoRepairs(raw as LLMStructuringResult | null)
+      return runValidator(raw, validatorContext)
+    },
     maxRetries: config.maxRetries,
     maxTokens: 16384,
     log: {
@@ -204,6 +209,108 @@ async function generateReview(
     },
   })
   return result.object
+}
+
+// ── Auto-repair ─────────────────────────────────────────────────
+
+/**
+ * Mutate an LLM structuring result in place to fix mechanically-fixable shape
+ * issues that the validator would otherwise reject. Runs before validation so
+ * the LLM doesn't burn retries on cheap repairs. Conservative — only the
+ * unambiguous transformations listed; never invents missing content.
+ *
+ * Repairs:
+ *  1. `image_group` with only the image as a child → unwrap to a bare
+ *     `role: "image"` leaf.
+ *  2. `image_group` with the image not first (and exactly one image child) →
+ *     reorder so the image is the first child.
+ *  3. Container that carries both `text` and `children` → move `text` into a
+ *     synthetic leading `role: "text"` leaf.
+ *  4. A leaf whose text is a row of single-letter tokens separated by spaces
+ *     (crossword/letter-grid pattern) → split into one leaf per letter.
+ */
+export function applyAutoRepairs(raw: LLMStructuringResult | null | undefined): void {
+  if (!raw || !Array.isArray(raw.sections)) return
+  for (const section of raw.sections) {
+    if (Array.isArray(section.nodes)) {
+      section.nodes = repairChildren(section.nodes)
+    }
+  }
+}
+
+const SINGLE_LETTER_ROW = /^[A-Za-zÀ-ÿ](\s+[A-Za-zÀ-ÿ])+$/
+
+function repairChildren(children: LLMNode[]): LLMNode[] {
+  const out: LLMNode[] = []
+  for (const original of children) {
+    if (!original || typeof original !== "object") {
+      out.push(original)
+      continue
+    }
+    let child = original
+
+    // Recurse first so deeper repairs propagate up.
+    if (Array.isArray(child.children)) {
+      child.children = repairChildren(child.children)
+    }
+
+    // Repair (3) — run before image_group repairs so reordering can still
+    // place the image first if a text leaf gets prepended here.
+    const isContainer =
+      typeof child.structure === "string" && child.structure.length > 0
+    if (
+      isContainer &&
+      typeof child.text === "string" &&
+      child.text.length > 0 &&
+      Array.isArray(child.children) &&
+      child.children.length > 0
+    ) {
+      const textLeaf: LLMNode = { role: "text", text: child.text }
+      child.children = [textLeaf, ...child.children]
+      child.text = null
+    }
+
+    // Repair (1) + (2): image_group child arrangement.
+    if (
+      child.structure === "image_group" &&
+      Array.isArray(child.children) &&
+      child.children.length > 0
+    ) {
+      const imageChildren = child.children.filter(
+        (c): c is LLMNode => !!c && c.role === "image"
+      )
+      if (child.children.length === 1 && imageChildren.length === 1) {
+        // Unwrap: lone image inside image_group → bare image leaf.
+        out.push(imageChildren[0])
+        continue
+      }
+      if (
+        imageChildren.length === 1 &&
+        child.children[0]?.role !== "image"
+      ) {
+        const image = imageChildren[0]
+        const rest = child.children.filter((c) => c !== image)
+        child.children = [image, ...rest]
+      }
+    }
+
+    // Repair (4): split single-letter-row leaves into one leaf per letter.
+    const isLeaf = typeof child.role === "string" && child.role.length > 0
+    if (
+      isLeaf &&
+      typeof child.text === "string" &&
+      SINGLE_LETTER_ROW.test(child.text.trim())
+    ) {
+      const letters = child.text.trim().split(/\s+/)
+      for (const letter of letters) {
+        out.push({ ...child, text: letter })
+      }
+      continue
+    }
+
+    out.push(child)
+  }
+  return out
 }
 
 // ── Validator ───────────────────────────────────────────────────

--- a/packages/pipeline/src/render-llm.ts
+++ b/packages/pipeline/src/render-llm.ts
@@ -204,7 +204,10 @@ function validateWebRendering(
   return { valid: check.valid, errors: check.errors }
 }
 
-const TEXTBOOK_BLANK_RE = /_{3,}|\.{3,}/g
+// Recognize underscore runs of any length (single-cell crossword blanks emit
+// just `"_"`, inline-sentence blanks emit `___`) and dot runs of 3+
+// (single dots are normal punctuation).
+const TEXTBOOK_BLANK_RE = /_+|\.{3,}/g
 const PLACEHOLDER_MARKER_RE = /\[placeholder:[^\]]+\]/g
 const OPTIONAL_TEXT_ROLES = new Set(["footer", "header", "page_number"])
 
@@ -227,7 +230,7 @@ function isPlaceholderOnlyText(text: string): boolean {
   return stripped.length === 0
 }
 
-function collectOptionalTextIds(
+export function collectOptionalTextIds(
   leafTexts: Array<{ text_id: string; text_type: string; text: string }>
 ): Set<string> {
   const optional = new Set<string>()

--- a/prompts/page_sectioning.liquid
+++ b/prompts/page_sectioning.liquid
@@ -97,6 +97,7 @@ Use these to disambiguate activity types:
 6. Tables: use `table` → `table_row` → `table_cell`. Cells in left-to-right order within each row; rows in top-to-bottom order.
 7. Lists: use `list` → `list_item`. A list_item's children are the leaves or containers inside the item.
 8. Poetry / preformatted: use `preformatted` where line breaks matter; each line is a text leaf child.
+9. Letter-by-letter cells / crossword grids: when a row or column shows visually distinct boxes (or crossword-style cells) where each box contains a single character (or is meant to hold one), emit ONE leaf PER CELL — never a single merged leaf containing the whole word. The natural reading order across cells determines node ordering. Example: a 7-cell row visibly showing "R E C E T A S" must produce 7 sibling leaves, one per letter, NOT one leaf with text `"R E C E T A S"`. Empty cells (visually blank boxes) emit a leaf with text `"_"`. Exception: a single full-width writable line beside a prompt (e.g. `"Nombre: ___"`) is ONE leaf — the multi-cell rule only applies when there are visually distinct per-character boxes.
 
 ## Text extraction rules
 
@@ -182,6 +183,56 @@ Do NOT split in any of these cases:
     { "role": "caption", "text": "Figure 3. The water cycle." }
   ]
 }
+```
+
+### image_group — WRONG vs RIGHT
+
+WRONG (image alone in image_group — should be a bare image leaf):
+```json
+{ "structure": "image_group", "children": [
+  { "role": "image", "image_id": "p3_img002" }
+]}
+```
+
+RIGHT (no caption/label/overlay → bare image):
+```json
+{ "role": "image", "image_id": "p3_img002" }
+```
+
+WRONG (caption first, image second):
+```json
+{ "structure": "image_group", "children": [
+  { "role": "caption", "text": "Figure 3." },
+  { "role": "image", "image_id": "p3_img002" }
+]}
+```
+
+RIGHT (image first, then caption):
+```json
+{ "structure": "image_group", "children": [
+  { "role": "image", "image_id": "p3_img002" },
+  { "role": "caption", "text": "Figure 3." }
+]}
+```
+
+### Letter-by-letter cells (crossword / per-character grid)
+
+WRONG (one merged leaf for the whole row):
+```json
+{ "role": "activity_fill_in_the_blank", "text": "R E C E T A S" }
+```
+
+RIGHT (one leaf per cell, in reading order):
+```json
+{ "structure": "activity", "children": [
+  { "role": "activity_fill_in_the_blank", "text": "R" },
+  { "role": "activity_fill_in_the_blank", "text": "E" },
+  { "role": "activity_fill_in_the_blank", "text": "C" },
+  { "role": "activity_fill_in_the_blank", "text": "E" },
+  { "role": "activity_fill_in_the_blank", "text": "T" },
+  { "role": "activity_fill_in_the_blank", "text": "A" },
+  { "role": "activity_fill_in_the_blank", "text": "S" }
+]}
 ```
 
 ### Image as background with text overlaid on top


### PR DESCRIPTION
## Summary
- **Page-sectioning auto-repair** (`page-sectioning.ts`): runs before validation to unwrap lone-image `image_group`s, reorder image_groups so the image is first, hoist container `text` into a leading text leaf, and split single-letter-row leaves (crossword cells like `"R E C E T A S"`) into one leaf per cell. Saves the LLM from burning retries on mechanically-fixable shape errors.
- **Prompt** (`prompts/page_sectioning.liquid`): explicit wrong-vs-right examples for `image_group` shapes and crossword/per-cell letter grids.
- **Blank-cell validation** (`render-llm.ts`): relax `TEXTBOOK_BLANK_RE` from `_{3,}` to `_+` so single-/double-underscore blank-cell leaves emitted by sectioning are recognized as placeholder-only and added to `optionalTextIds`. Eliminates the "Missing required text data-id" failures crossword pages were exhausting their retry budget on.
- **Tests**: 10 new `applyAutoRepairs` cases (incl. the repair-ordering edge case where `image_group` had both `text` and `children`) and a new `render-llm.test.ts` covering `collectOptionalTextIds`.

## Test plan
- [x] `pnpm vitest run packages/pipeline/src/__tests__/{page-sectioning,render-llm,validate-html}.test.ts` — 142 passing
- [x] `pnpm typecheck` clean
- [x] End-to-end re-run on the previously failing crossword pages (pg015, pg016): 30 + 26 validation errors → 0 across the full activity-rendering / visual-review / activity-answers chain