### PR TITLE
Default image translation model to openai:gpt-image-2

### DIFF
--- a/apps/studio/src/components/pipeline/stages/translations/TranslationsSettings.tsx
+++ b/apps/studio/src/components/pipeline/stages/translations/TranslationsSettings.tsx
@@ -333,7 +333,7 @@ export function TranslationsSettings({ bookLabel, headerTarget, tab = "general",
             <ModelSelect
               value={imageModel}
               onChange={(v) => { setImageModel(v); markDirty("image_translation") }}
-              placeholder="openai:gpt-image-1.5"
+              placeholder="openai:gpt-image-2"
               groups={IMAGE_MODEL_GROUPS}
               prefixProvider
               className="max-w-md"

--- a/packages/pipeline/src/image-translation.ts
+++ b/packages/pipeline/src/image-translation.ts
@@ -17,7 +17,7 @@ export function buildImageTranslationConfig(appConfig: AppConfig): {
   const cfg = appConfig.image_translation
   return {
     enabled: cfg?.enabled === true,
-    modelId: cfg?.image_model ?? "openai:gpt-image-1.5",
+    modelId: cfg?.image_model ?? "openai:gpt-image-2",
     selectedImageIds: cfg?.selected_image_ids ?? [],
   }
 }


### PR DESCRIPTION
## Summary
- Updates the default image translation model from `openai:gpt-image-1.5` to `openai:gpt-image-2` in both the runtime config builder (`packages/pipeline/src/image-translation.ts`) and the UI placeholder (`TranslationsSettings.tsx`).

## Test plan
- [ ] Open Translations settings; image model field shows `openai:gpt-image-2` placeholder when unset.
- [ ] Run image translation with no `image_model` configured; confirm it uses `openai:gpt-image-2`.