### PR TITLE
Add prune (soft-delete) support to glossary

### DIFF
--- a/apps/api/src/services/stage-runner.ts
+++ b/apps/api/src/services/stage-runner.ts
@@ -28,6 +28,7 @@ import {
   generateGlossary,
   buildGlossaryConfig,
   mergeGeneratedGlossaryWithManualItems,
+  getPrunedGlossaryWords,
   generateToc,
   buildTocGenerationConfig,
   generateAllQuizzes,
@@ -1282,12 +1283,15 @@ async function runGlossaryStep(
     const existingGlossaryRow = storage.getLatestNodeData("glossary", "book")
     const existingGlossary = existingGlossaryRow?.data as GlossaryOutput | undefined
 
+    const excludedWords = getPrunedGlossaryWords(existingGlossary?.items ?? [])
+
     const generatedGlossary = await generateGlossary({
       storage,
       pages,
       config: glossaryConfig,
       llmModel: glossaryModel,
       concurrency: effectiveConcurrency,
+      excludedWords,
       onBatchComplete: (completed, total) => {
         progress.emit({
           type: "step-progress",

--- a/apps/studio/src/api/client.ts
+++ b/apps/studio/src/api/client.ts
@@ -243,6 +243,7 @@ export interface GlossaryItem {
   definition: string
   variations: string[]
   emojis: string[]
+  pruned?: boolean
 }
 
 export interface GlossaryOutput {

--- a/apps/studio/src/components/pipeline/stages/glossary/GlossaryView.tsx
+++ b/apps/studio/src/components/pipeline/stages/glossary/GlossaryView.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useRef, useCallback } from "react"
-import { Check, ChevronDown, Loader2, Plus, Trash2 } from "lucide-react"
+import { useState, useEffect, useRef, useCallback, useMemo } from "react"
+import { Check, ChevronDown, EyeOff, Loader2, Plus, RotateCcw, Search, Trash2 } from "lucide-react"
 import { useQueryClient } from "@tanstack/react-query"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -164,6 +164,8 @@ export function GlossaryView({ bookLabel }: { bookLabel: string }) {
   const [pending, setPending] = useState<GlossaryData | null>(null)
   const [saving, setSaving] = useState(false)
   const [showAddDialog, setShowAddDialog] = useState(false)
+  const [searchQuery, setSearchQuery] = useState("")
+  const [showPruned, setShowPruned] = useState(false)
 
   // Reset pending when data changes
   useEffect(() => {
@@ -174,6 +176,20 @@ export function GlossaryView({ bookLabel }: { bookLabel: string }) {
   const items = effective?.items ?? []
   const dirty = pending != null
   const currentVersion = data?.version ?? null
+  const prunedCount = useMemo(() => items.filter((item) => item.pruned).length, [items])
+  const visibleCount = items.length - prunedCount
+
+  const filteredItems = useMemo(() => {
+    const q = searchQuery.trim().toLocaleLowerCase()
+    return items.filter((item) => {
+      if (!showPruned && item.pruned) return false
+      if (!q) return true
+      const haystack = [item.word, item.definition, ...item.variations]
+        .join(" ")
+        .toLocaleLowerCase()
+      return haystack.includes(q)
+    })
+  }, [items, searchQuery, showPruned])
 
   const openAddDialog = useCallback(() => {
     setShowAddDialog(true)
@@ -200,7 +216,7 @@ export function GlossaryView({ bookLabel }: { bookLabel: string }) {
   useEffect(() => {
     setExtra(
       <div className="flex items-center gap-1.5 ml-auto">
-        <span className="text-[10px] bg-white/20 rounded-full px-2 py-0.5">{t`${String(items.length)} terms`}</span>
+        <span className="text-[10px] bg-white/20 rounded-full px-2 py-0.5">{t`${String(visibleCount)} terms`}</span>
         <Button
           size="sm"
           className="h-6 px-2 text-[10px] bg-white/10 text-white hover:bg-white/20"
@@ -224,7 +240,7 @@ export function GlossaryView({ bookLabel }: { bookLabel: string }) {
       </div>
     )
     return () => setExtra(null)
-  }, [items.length, saving, dirty, bookLabel, currentVersion, openAddDialog, glossaryRunning, t, setExtra])
+  }, [visibleCount, saving, dirty, bookLabel, currentVersion, openAddDialog, glossaryRunning, t, setExtra])
 
   const updateDefinition = (itemId: string, newDefinition: string) => {
     const base = pending ?? data ?? createEmptyGlossary()
@@ -256,6 +272,17 @@ export function GlossaryView({ bookLabel }: { bookLabel: string }) {
       ...base,
       generatedAt: base.generatedAt || new Date().toISOString(),
       items: base.items.filter((item) => (item.id ?? item.word) !== itemId),
+    })
+  }
+
+  const togglePruned = (itemId: string, pruned: boolean) => {
+    const base = pending ?? data ?? createEmptyGlossary()
+    setPending({
+      ...base,
+      generatedAt: base.generatedAt || new Date().toISOString(),
+      items: base.items.map((item) =>
+        (item.id ?? item.word) === itemId ? { ...item, pruned } : item
+      ),
     })
   }
 
@@ -299,52 +326,119 @@ export function GlossaryView({ bookLabel }: { bookLabel: string }) {
   }
 
   return (
-    <div className="space-y-1">
-      {items.map((item) => (
-        <div
-          key={item.id ?? item.word}
-          className="flex items-start gap-3 px-3 py-2.5 rounded-md border bg-card"
-        >
-          <div className="shrink-0 w-32">
-            <span className="text-sm font-medium">{item.word}</span>
-            {item.source === "manual" && (
-              <Badge variant="secondary" className="ml-2 text-[10px] h-4 px-1.5">
-                {t`manual`}
-              </Badge>
-            )}
-          </div>
-          <EmojiInput
-            value={item.emojis}
-            onChange={(next) => updateEmojis(item.id ?? item.word, next)}
-            placeholder={t`Add emojis`}
+    <div className="space-y-2">
+      <div className="flex items-center gap-2 px-1">
+        <div className="relative flex-1 min-w-0">
+          <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder={t`Filter terms…`}
+            className="w-full text-sm rounded border border-input bg-background pl-7 pr-2 py-1.5 focus:outline-none focus:ring-1 focus:ring-ring"
           />
-          <Textarea
-            value={item.definition}
-            onChange={(e) => updateDefinition(item.id ?? item.word, e.target.value)}
-            className="flex-1 min-w-0 text-sm text-foreground leading-relaxed resize-none rounded border border-transparent bg-transparent p-1.5 -ml-1.5 hover:border-border hover:bg-muted/30 focus:border-ring focus:bg-white focus:outline-none focus:ring-1 focus:ring-ring transition-colors"
-            rows={1}
-          />
-          {item.variations.length > 0 && (
-            <div className="flex gap-1 shrink-0 flex-wrap">
-              {item.variations.map((v) => (
-                <Badge key={v} variant="outline" className="text-[10px] h-4 px-1.5">
-                  {v}
-                </Badge>
-              ))}
-            </div>
-          )}
-          {item.source === "manual" && (
-            <button
-              type="button"
-              onClick={() => removeManualItem(item.id ?? item.word)}
-              className="shrink-0 text-muted-foreground hover:text-destructive transition-colors"
-              title={t`Remove manual glossary term`}
-            >
-              <Trash2 className="h-3.5 w-3.5" />
-            </button>
-          )}
         </div>
-      ))}
+        {prunedCount > 0 && (
+          <button
+            type="button"
+            onClick={() => setShowPruned((v) => !v)}
+            className={`shrink-0 flex items-center gap-1 text-xs rounded border px-2 py-1 transition-colors ${
+              showPruned
+                ? "bg-accent text-accent-foreground border-accent"
+                : "bg-background text-muted-foreground hover:bg-muted"
+            }`}
+            title={showPruned ? t`Hide pruned terms` : t`Show pruned terms`}
+          >
+            <EyeOff className="h-3.5 w-3.5" />
+            {t`Pruned (${String(prunedCount)})`}
+          </button>
+        )}
+      </div>
+      <div className="space-y-1">
+        {filteredItems.length === 0 ? (
+          <div className="px-3 py-6 text-center text-sm text-muted-foreground">
+            {searchQuery
+              ? t`No terms match your filter.`
+              : t`No terms to show.`}
+          </div>
+        ) : (
+          filteredItems.map((item) => {
+            const itemId = item.id ?? item.word
+            const isPruned = item.pruned === true
+            const isManual = item.source === "manual"
+            return (
+              <div
+                key={itemId}
+                className={`flex items-start gap-3 px-3 py-2.5 rounded-md border bg-card transition-opacity ${
+                  isPruned ? "opacity-50" : ""
+                }`}
+              >
+                <div className="shrink-0 w-32">
+                  <span className={`text-sm font-medium ${isPruned ? "line-through" : ""}`}>{item.word}</span>
+                  {isManual && (
+                    <Badge variant="secondary" className="ml-2 text-[10px] h-4 px-1.5">
+                      {t`manual`}
+                    </Badge>
+                  )}
+                  {isPruned && (
+                    <Badge variant="outline" className="ml-2 text-[10px] h-4 px-1.5">
+                      {t`pruned`}
+                    </Badge>
+                  )}
+                </div>
+                <EmojiInput
+                  value={item.emojis}
+                  onChange={(next) => updateEmojis(itemId, next)}
+                  placeholder={t`Add emojis`}
+                />
+                <Textarea
+                  value={item.definition}
+                  onChange={(e) => updateDefinition(itemId, e.target.value)}
+                  className="flex-1 min-w-0 text-sm text-foreground leading-relaxed resize-none rounded border border-transparent bg-transparent p-1.5 -ml-1.5 hover:border-border hover:bg-muted/30 focus:border-ring focus:bg-white focus:outline-none focus:ring-1 focus:ring-ring transition-colors"
+                  rows={1}
+                />
+                {item.variations.length > 0 && (
+                  <div className="flex gap-1 shrink-0 flex-wrap">
+                    {item.variations.map((v) => (
+                      <Badge key={v} variant="outline" className="text-[10px] h-4 px-1.5">
+                        {v}
+                      </Badge>
+                    ))}
+                  </div>
+                )}
+                {isManual ? (
+                  <button
+                    type="button"
+                    onClick={() => removeManualItem(itemId)}
+                    className="shrink-0 text-muted-foreground hover:text-destructive transition-colors"
+                    title={t`Remove manual glossary term`}
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </button>
+                ) : isPruned ? (
+                  <button
+                    type="button"
+                    onClick={() => togglePruned(itemId, false)}
+                    className="shrink-0 text-muted-foreground hover:text-foreground transition-colors"
+                    title={t`Restore this term — it will be eligible again on the next regeneration.`}
+                  >
+                    <RotateCcw className="h-3.5 w-3.5" />
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => togglePruned(itemId, true)}
+                    className="shrink-0 text-muted-foreground hover:text-destructive transition-colors"
+                    title={t`Prune this term — it will be hidden from output and excluded from future regenerations.`}
+                  >
+                    <EyeOff className="h-3.5 w-3.5" />
+                  </button>
+                )}
+              </div>
+            )
+          })
+        )}
+      </div>
       <AddGlossaryDialog
         open={showAddDialog}
         onOpenChange={setShowAddDialog}

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -148,7 +148,7 @@ msgstr "{0} questions"
 msgid "{0} selected images are no longer in the storyboard."
 msgstr "{0} selected images are no longer in the storyboard."
 
-#. placeholder {0}: String(items.length)
+#. placeholder {0}: String(visibleCount)
 msgid "{0} terms"
 msgstr "{0} terms"
 
@@ -1888,6 +1888,9 @@ msgstr "Filter by image ID..."
 msgid "Filter by item ID..."
 msgstr "Filter by item ID..."
 
+msgid "Filter terms…"
+msgstr "Filter terms…"
+
 msgid "Filtered by:"
 msgstr "Filtered by:"
 
@@ -2093,6 +2096,9 @@ msgstr "Hide AI edit history"
 
 #~ msgid "Hide pruned images"
 #~ msgstr "Hide pruned images"
+
+msgid "Hide pruned terms"
+msgstr "Hide pruned terms"
 
 msgid "Higher values filter out simple or blank images."
 msgstr "Higher values filter out simple or blank images."
@@ -2918,6 +2924,12 @@ msgstr "No segmentation needed for this image"
 msgid "No sign language videos uploaded yet."
 msgstr "No sign language videos uploaded yet."
 
+msgid "No terms match your filter."
+msgstr "No terms match your filter."
+
+msgid "No terms to show."
+msgstr "No terms to show."
+
 msgid "No text extracted"
 msgstr "No text extracted"
 
@@ -3376,11 +3388,18 @@ msgstr "Prune section from flow"
 #~ msgid "Prune text"
 #~ msgstr "Prune text"
 
+msgid "Prune this term — it will be hidden from output and excluded from future regenerations."
+msgstr "Prune this term — it will be hidden from output and excluded from future regenerations."
+
 msgid "pruned"
 msgstr "pruned"
 
 msgid "Pruned"
 msgstr "Pruned"
+
+#. placeholder {0}: String(prunedCount)
+msgid "Pruned ({0})"
+msgstr "Pruned ({0})"
 
 msgid "Pruned Images"
 msgstr "Pruned Images"
@@ -3619,6 +3638,9 @@ msgstr "Restore element"
 
 msgid "Restore section to flow"
 msgstr "Restore section to flow"
+
+msgid "Restore this term — it will be eligible again on the next regeneration."
+msgstr "Restore this term — it will be eligible again on the next regeneration."
 
 msgid "Resume target"
 msgstr "Resume target"
@@ -4036,6 +4058,9 @@ msgstr "Show fewer"
 
 #~ msgid "Show pruned images"
 #~ msgstr "Show pruned images"
+
+msgid "Show pruned terms"
+msgstr "Show pruned terms"
 
 msgid "Show reviewer validation"
 msgstr "Show reviewer validation"

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -148,7 +148,7 @@ msgstr "{0} preguntas"
 msgid "{0} selected images are no longer in the storyboard."
 msgstr "{0} imágenes seleccionadas ya no están en el guion gráfico."
 
-#. placeholder {0}: String(items.length)
+#. placeholder {0}: String(visibleCount)
 msgid "{0} terms"
 msgstr "{0} términos"
 
@@ -1888,6 +1888,9 @@ msgstr "Filtrar por ID de imagen..."
 msgid "Filter by item ID..."
 msgstr "Filtrar por ID de ítem..."
 
+msgid "Filter terms…"
+msgstr "Filtrar términos…"
+
 msgid "Filtered by:"
 msgstr "Filtered by:"
 
@@ -2093,6 +2096,9 @@ msgstr "Ocultar historial de edición con IA"
 
 #~ msgid "Hide pruned images"
 #~ msgstr "Ocultar imágenes eliminadas"
+
+msgid "Hide pruned terms"
+msgstr "Ocultar términos podados"
 
 msgid "Higher values filter out simple or blank images."
 msgstr "Valores más altos filtran imágenes simples o en blanco."
@@ -2918,6 +2924,12 @@ msgstr "No segmentation needed for this image"
 msgid "No sign language videos uploaded yet."
 msgstr "Aún no se han cargado videos de lengua de señas."
 
+msgid "No terms match your filter."
+msgstr "Ningún término coincide con tu filtro."
+
+msgid "No terms to show."
+msgstr "Ningún término para mostrar."
+
 msgid "No text extracted"
 msgstr "No se extrajo texto"
 
@@ -3376,11 +3388,18 @@ msgstr "Eliminar sección del flujo"
 #~ msgid "Prune text"
 #~ msgstr "Eliminar texto"
 
+msgid "Prune this term — it will be hidden from output and excluded from future regenerations."
+msgstr "Podar este término — se ocultará de la salida y se excluirá de futuras regeneraciones."
+
 msgid "pruned"
 msgstr "eliminado"
 
 msgid "Pruned"
 msgstr "Eliminado"
+
+#. placeholder {0}: String(prunedCount)
+msgid "Pruned ({0})"
+msgstr "Podados ({0})"
 
 msgid "Pruned Images"
 msgstr "Imágenes eliminadas"
@@ -3619,6 +3638,9 @@ msgstr "Restaurar elemento"
 
 msgid "Restore section to flow"
 msgstr "Restaurar sección al flujo"
+
+msgid "Restore this term — it will be eligible again on the next regeneration."
+msgstr "Restaurar este término — volverá a ser elegible en la próxima regeneración."
 
 msgid "Resume target"
 msgstr "Resume target"
@@ -4036,6 +4058,9 @@ msgstr "Show fewer"
 
 #~ msgid "Show pruned images"
 #~ msgstr "Mostrar imágenes eliminadas"
+
+msgid "Show pruned terms"
+msgstr "Mostrar términos podados"
 
 msgid "Show reviewer validation"
 msgstr "Show reviewer validation"

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -149,7 +149,7 @@ msgstr "{0} questions"
 msgid "{0} selected images are no longer in the storyboard."
 msgstr "{0} images sélectionnées ne figurent plus dans le storyboard."
 
-#. placeholder {0}: String(items.length)
+#. placeholder {0}: String(visibleCount)
 msgid "{0} terms"
 msgstr "{0} termes"
 
@@ -1889,6 +1889,9 @@ msgstr "Filtrer by image ID..."
 msgid "Filter by item ID..."
 msgstr "Filtrer by élément ID..."
 
+msgid "Filter terms…"
+msgstr "Filtrer les termes…"
+
 msgid "Filtered by:"
 msgstr "Filtré par :"
 
@@ -2094,6 +2097,9 @@ msgstr "Masquer l'historique des modifications IA"
 
 #~ msgid "Hide pruned images"
 #~ msgstr "Masquer les images élaguées"
+
+msgid "Hide pruned terms"
+msgstr "Masquer les termes élagués"
 
 msgid "Higher values filter out simple or blank images."
 msgstr "Les valeurs plus élevées filtrent les images simples ou vides."
@@ -2919,6 +2925,12 @@ msgstr "Aucune segmentation nécessaire pour cette image"
 msgid "No sign language videos uploaded yet."
 msgstr "Aucune vidéo en langue des signes téléversée."
 
+msgid "No terms match your filter."
+msgstr "Aucun terme ne correspond à votre filtre."
+
+msgid "No terms to show."
+msgstr "Aucun terme à afficher."
+
 msgid "No text extracted"
 msgstr "Aucun texte extrait"
 
@@ -3377,11 +3389,18 @@ msgstr "Élaguer la section du flux"
 #~ msgid "Prune text"
 #~ msgstr "Élaguer le texte"
 
+msgid "Prune this term — it will be hidden from output and excluded from future regenerations."
+msgstr "Élaguer ce terme — il sera masqué de la sortie et exclu des régénérations futures."
+
 msgid "pruned"
 msgstr "élagué"
 
 msgid "Pruned"
 msgstr "Élagué"
+
+#. placeholder {0}: String(prunedCount)
+msgid "Pruned ({0})"
+msgstr "Élagués ({0})"
 
 msgid "Pruned Images"
 msgstr "Images élaguées"
@@ -3620,6 +3639,9 @@ msgstr "Restaurer l'élément"
 
 msgid "Restore section to flow"
 msgstr "Restaurer la section dans le flux"
+
+msgid "Restore this term — it will be eligible again on the next regeneration."
+msgstr "Restaurer ce terme — il sera de nouveau éligible à la prochaine régénération."
 
 msgid "Resume target"
 msgstr "Cible de reprise"
@@ -4037,6 +4059,9 @@ msgstr "Afficher moins"
 
 #~ msgid "Show pruned images"
 #~ msgstr "Afficher les images élaguées"
+
+msgid "Show pruned terms"
+msgstr "Afficher les termes élagués"
 
 msgid "Show reviewer validation"
 msgstr "Afficher la validation du réviseur"

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -148,7 +148,7 @@ msgstr "{0} questões"
 msgid "{0} selected images are no longer in the storyboard."
 msgstr "{0} imagens selecionadas não estão mais no storyboard."
 
-#. placeholder {0}: String(items.length)
+#. placeholder {0}: String(visibleCount)
 msgid "{0} terms"
 msgstr "{0} termos"
 
@@ -1888,6 +1888,9 @@ msgstr "Filtrar por ID da imagem..."
 msgid "Filter by item ID..."
 msgstr "Filtrar por ID do item..."
 
+msgid "Filter terms…"
+msgstr "Filtrar termos…"
+
 msgid "Filtered by:"
 msgstr "Filtered by:"
 
@@ -2093,6 +2096,9 @@ msgstr "Ocultar histórico de edições com IA"
 
 #~ msgid "Hide pruned images"
 #~ msgstr "Ocultar imagens removidas"
+
+msgid "Hide pruned terms"
+msgstr "Ocultar termos podados"
 
 msgid "Higher values filter out simple or blank images."
 msgstr "Valores mais altos filtram imagens simples ou em branco."
@@ -2918,6 +2924,12 @@ msgstr "No segmentation needed for this image"
 msgid "No sign language videos uploaded yet."
 msgstr "Nenhum vídeo de língua de sinais enviado ainda."
 
+msgid "No terms match your filter."
+msgstr "Nenhum termo corresponde ao seu filtro."
+
+msgid "No terms to show."
+msgstr "Nenhum termo para exibir."
+
 msgid "No text extracted"
 msgstr "Nenhum texto extraído"
 
@@ -3376,11 +3388,18 @@ msgstr "Remover seção do fluxo"
 #~ msgid "Prune text"
 #~ msgstr "Remover texto"
 
+msgid "Prune this term — it will be hidden from output and excluded from future regenerations."
+msgstr "Podar este termo — ele será ocultado da saída e excluído de regenerações futuras."
+
 msgid "pruned"
 msgstr "removido"
 
 msgid "Pruned"
 msgstr "Removido"
+
+#. placeholder {0}: String(prunedCount)
+msgid "Pruned ({0})"
+msgstr "Podados ({0})"
 
 msgid "Pruned Images"
 msgstr "Imagens removidas"
@@ -3619,6 +3638,9 @@ msgstr "Restaurar elemento"
 
 msgid "Restore section to flow"
 msgstr "Restaurar seção ao fluxo"
+
+msgid "Restore this term — it will be eligible again on the next regeneration."
+msgstr "Restaurar este termo — ele voltará a ser elegível na próxima regeneração."
 
 msgid "Resume target"
 msgstr "Resume target"
@@ -4036,6 +4058,9 @@ msgstr "Show fewer"
 
 #~ msgid "Show pruned images"
 #~ msgstr "Mostrar imagens removidas"
+
+msgid "Show pruned terms"
+msgstr "Mostrar termos podados"
 
 msgid "Show reviewer validation"
 msgstr "Show reviewer validation"

--- a/packages/pipeline/src/__tests__/glossary.test.ts
+++ b/packages/pipeline/src/__tests__/glossary.test.ts
@@ -403,6 +403,47 @@ describe("mergeGeneratedGlossaryWithManualItems", () => {
     })
   })
 
+  it("preserves pruned AI items and drops re-generated ones that match", () => {
+    const merged = mergeGeneratedGlossaryWithManualItems(
+      {
+        items: [
+          {
+            word: "Forest",
+            definition: "Trees",
+            variations: [],
+            emojis: ["🌲"],
+            source: "ai",
+          },
+          {
+            word: "River",
+            definition: "Water flow",
+            variations: [],
+            emojis: ["🏞️"],
+            source: "ai",
+          },
+        ],
+        pageCount: 1,
+        generatedAt: "2026-01-01T00:00:00.000Z",
+      },
+      [
+        {
+          word: "River",
+          definition: "Old definition",
+          variations: [],
+          emojis: ["🏞️"],
+          source: "ai",
+          pruned: true,
+        },
+      ],
+    )
+
+    const words = merged.items.map((item) => ({ word: item.word, pruned: item.pruned }))
+    expect(words).toEqual([
+      { word: "Forest", pruned: undefined },
+      { word: "River", pruned: true },
+    ])
+  })
+
   it("lets manual glossary entries override generated ones while preserving generated ids", () => {
     const merged = mergeGeneratedGlossaryWithManualItems(
       {

--- a/packages/pipeline/src/glossary.ts
+++ b/packages/pipeline/src/glossary.ts
@@ -53,16 +53,31 @@ export function isManualGlossaryItem(item: Pick<GlossaryItem, "source">): boolea
   return item.source === "manual"
 }
 
+export function isPrunedGlossaryItem(item: Pick<GlossaryItem, "pruned">): boolean {
+  return item.pruned === true
+}
+
+export function getPrunedGlossaryWords(items: GlossaryItem[]): string[] {
+  return items.filter(isPrunedGlossaryItem).map((item) => item.word)
+}
+
 export function mergeGeneratedGlossaryWithManualItems(
   generated: GlossaryOutput,
   existingItems: GlossaryItem[],
 ): GlossaryOutput {
   const manualItems = existingItems.filter(isManualGlossaryItem)
-  if (manualItems.length === 0) {
-    return generated
-  }
+  const prunedItems = existingItems.filter(
+    (item) => isPrunedGlossaryItem(item) && !isManualGlossaryItem(item),
+  )
+  const prunedWords = new Set(prunedItems.map((item) => normalizeGlossaryWord(item.word)))
 
-  const mergedItems = [...generated.items]
+  // Drop any generated item that matches a pruned word (server-side backstop
+  // in case the LLM ignores the excluded-words instruction).
+  const filteredGenerated = prunedWords.size > 0
+    ? generated.items.filter((item) => !prunedWords.has(normalizeGlossaryWord(item.word)))
+    : generated.items
+
+  const mergedItems = [...filteredGenerated]
   const existingIndexByWord = new Map(
     mergedItems.map((item, index) => [normalizeGlossaryWord(item.word), index]),
   )
@@ -85,6 +100,16 @@ export function mergeGeneratedGlossaryWithManualItems(
       ...manualItem,
       source: "manual",
     })
+  }
+
+  // Re-add pruned AI items so the user can still see / unprune them.
+  const wordsInMerged = new Set(mergedItems.map((item) => normalizeGlossaryWord(item.word)))
+  for (const prunedItem of prunedItems) {
+    const normalizedWord = normalizeGlossaryWord(prunedItem.word)
+    if (!wordsInMerged.has(normalizedWord)) {
+      mergedItems.push({ ...prunedItem, source: prunedItem.source ?? "ai", pruned: true })
+      wordsInMerged.add(normalizedWord)
+    }
   }
 
   return {
@@ -138,13 +163,17 @@ export interface GenerateGlossaryOptions {
   llmModel: LLMModel
   concurrency?: number
   onBatchComplete?: (completed: number, total: number) => void
+  /** Words the LLM should not re-suggest. Items returned matching one of these
+   * are also dropped server-side as a backstop. */
+  excludedWords?: string[]
 }
 
 export async function generateGlossary(
   options: GenerateGlossaryOptions
 ): Promise<GlossaryOutput> {
-  const { storage, pages, config, llmModel, concurrency = 1, onBatchComplete } = options
+  const { storage, pages, config, llmModel, concurrency = 1, onBatchComplete, excludedWords = [] } = options
   const languageContext = buildLanguageContext(config.language)
+  const excludedWordsNormalized = new Set(excludedWords.map(normalizeGlossaryWord))
 
   const pageTexts = collectPageTexts(storage, pages)
   if (pageTexts.length === 0) {
@@ -175,6 +204,7 @@ export async function generateGlossary(
       context: {
         ...languageContext,
         pages: batch,
+        excluded_words: excludedWords,
       },
       maxRetries: config.maxRetries,
       maxTokens: 16384,
@@ -189,10 +219,13 @@ export async function generateGlossary(
     onBatchComplete?.(completed, batches.length)
   })
 
-  // Deduplicate: first definition wins, case-insensitive
+  // Deduplicate: first definition wins, case-insensitive. Drop any item whose
+  // word matches the caller-supplied exclusion list (backstop in case the LLM
+  // ignores the prompt instruction).
   const seen = new Map<string, GlossaryItem>()
   for (const item of allItems) {
     const key = item.word.toLowerCase()
+    if (excludedWordsNormalized.has(normalizeGlossaryWord(item.word))) continue
     if (!seen.has(key)) {
       seen.set(key, item)
     }

--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -123,6 +123,8 @@ export {
   collectPageTexts,
   getGlossaryItemTextId,
   isManualGlossaryItem,
+  isPrunedGlossaryItem,
+  getPrunedGlossaryWords,
   mergeGeneratedGlossaryWithManualItems,
   type GlossaryConfig,
   type GenerateGlossaryOptions,

--- a/packages/pipeline/src/package-web.ts
+++ b/packages/pipeline/src/package-web.ts
@@ -575,7 +575,7 @@ export async function packageAdtWeb(
   // ------------------------------------------------------------------
   // config.json
   // ------------------------------------------------------------------
-  const hasGlossary = (features?.glossary !== false) && (glossary !== undefined && glossary.items.length > 0)
+  const hasGlossary = (features?.glossary !== false) && (glossary !== undefined && glossary.items.some((item) => !item.pruned))
   const hasQuiz = (features?.quizzes !== false) && (quizData !== undefined && quizData.quizzes.length > 0)
 
   const hasSignLanguageVideos = (features?.signLanguage !== false) && storage.getSignLanguageVideos().some((v) => v.sectionId !== null)
@@ -1410,6 +1410,7 @@ export function buildGlossaryJson(
 
   for (let i = 0; i < glossary.items.length; i++) {
     const item = glossary.items[i]
+    if (item.pruned) continue
     const glId = getGlossaryItemTextId(item, i)
     const defId = `${glId}_def`
 

--- a/packages/pipeline/src/text-catalog.ts
+++ b/packages/pipeline/src/text-catalog.ts
@@ -137,6 +137,7 @@ function buildGlossaryEntries(storage: Storage): TextCatalogEntry[] {
   const entries: TextCatalogEntry[] = []
   for (let i = 0; i < data.items.length; i++) {
     const item = data.items[i]
+    if (item.pruned) continue
     const id = getGlossaryItemTextId(item, i)
     entries.push({ id, text: item.word })
     entries.push({ id: `${id}_def`, text: item.definition })

--- a/packages/types/src/glossary.ts
+++ b/packages/types/src/glossary.ts
@@ -7,6 +7,7 @@ export const GlossaryItem = z.object({
   definition: z.string(),
   variations: z.array(z.string()),
   emojis: z.array(z.string()),
+  pruned: z.boolean().optional(),
 })
 export type GlossaryItem = z.infer<typeof GlossaryItem>
 

--- a/prompts/glossary.liquid
+++ b/prompts/glossary.liquid
@@ -8,6 +8,10 @@ I will provide you with text in {{ language }} (language code: {{ language_code 
 - Include 1-3 emojis per word in the separate "emojis" field.
 - Include variants of the word in the separate "variations" field. These are things like forest/forests, apple/apples, etc.
 - Do not include duplicate words. If a word appears multiple times, include it only once.
+{% if excluded_words and excluded_words.size > 0 %}
+- The following words have been explicitly rejected by the user and MUST NOT appear in your output, in any casing or variant form:
+{% for word in excluded_words %}  - {{ word }}
+{% endfor %}{% endif %}
 
 Provide me the answer in the given structure. Please take your time and think carefully before giving me the answers.
 {% endchat %}


### PR DESCRIPTION
## Summary

- Adds a `pruned` flag on glossary items so users can soft-delete AI-suggested terms without losing them across regenerations. Pruned words are passed to the LLM via a new `excluded_words` block in `glossary.liquid`, and any matching items the LLM still returns are dropped server-side as a backstop. Pruned items are also filtered out of the text catalog and packaged web bundle.
- The Glossary UI gains a search filter, a "Pruned (n)" toggle (hidden by default), and prune/restore actions per row; manual items keep hard-delete.
- All four locale catalogs updated, pipeline test added, full pipeline suite + typecheck + studio lint pass.

## Test plan

- [ ] Run glossary, prune a term, regenerate, confirm the term stays pruned and the LLM does not re-suggest it
- [ ] Toggle "Pruned (n)" and verify hidden/visible behaviour
- [ ] Search filter narrows the list as expected
- [ ] Manual term still hard-deletes via the trash icon
- [ ] Packaged web bundle and text catalog do not include pruned terms