### PR TITLE
Add persistent Save & Rerun action bar with stage-aware styling

### DIFF
--- a/apps/studio/src/components/pipeline/components/SettingsActionBar.tsx
+++ b/apps/studio/src/components/pipeline/components/SettingsActionBar.tsx
@@ -1,0 +1,96 @@
+import { ReactNode, createContext, useContext, ComponentProps } from "react"
+import { useParams } from "@tanstack/react-router"
+import { Trans } from "@lingui/react/macro"
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { STAGES } from "@/components/pipeline/stage-config"
+import { resolveSettingsStageSlug } from "@/components/pipeline/settings-routing"
+
+type Stage = (typeof STAGES)[number]
+
+const SettingsStageContext = createContext<Stage | null>(null)
+
+function useSettingsStage(): Stage | null {
+  const params = useParams({ strict: false }) as { step?: string }
+  if (!params.step) return null
+  const slug = resolveSettingsStageSlug(params.step)
+  if (!slug) return null
+  return STAGES.find((s) => s.slug === slug) ?? null
+}
+
+export function SettingsActionBar({
+  dirty,
+  children,
+  cleanMessage,
+  dirtyMessage,
+}: {
+  dirty: boolean
+  children: ReactNode
+  cleanMessage?: ReactNode
+  dirtyMessage?: ReactNode
+}) {
+  const stage = useSettingsStage()
+  const bgClass = stage?.bgLight ?? "bg-muted/30"
+  const borderColorClass = dirty
+    ? (stage?.borderDark ?? "border-foreground/30")
+    : (stage?.borderColor ?? "border-border")
+  const textColorClass = dirty
+    ? cn("font-medium", stage?.textColor ?? "text-foreground")
+    : "text-muted-foreground"
+  return (
+    <SettingsStageContext.Provider value={stage}>
+      <div
+        className={cn(
+          "flex items-center justify-between gap-3 px-4 py-2 transition-colors",
+          bgClass,
+          borderColorClass,
+          dirty ? "border-b-2" : "border-b",
+        )}
+      >
+        <span className={cn("text-xs", textColorClass)}>
+          {dirty
+            ? (dirtyMessage ?? <Trans>Unsaved changes — rerun to apply</Trans>)
+            : (cleanMessage ?? <Trans>No unsaved changes</Trans>)}
+        </span>
+        <div className="shrink-0">{children}</div>
+      </div>
+    </SettingsStageContext.Provider>
+  )
+}
+
+type SettingsActionButtonProps = ComponentProps<typeof Button> & { dirty: boolean }
+
+export function SettingsActionButton({
+  dirty,
+  className,
+  children,
+  ...buttonProps
+}: SettingsActionButtonProps) {
+  const stage = useContext(SettingsStageContext)
+  if (dirty && stage) {
+    return (
+      <Button
+        size="sm"
+        className={cn(
+          "h-8 px-3 text-xs font-medium text-white shadow-md border-transparent transition-colors",
+          stage.color,
+          stage.colorHover,
+          className,
+        )}
+        {...buttonProps}
+      >
+        {children}
+      </Button>
+    )
+  }
+  return (
+    <Button
+      size="sm"
+      variant={dirty ? "default" : "outline"}
+      className={cn("h-8 px-3 text-xs font-medium", className)}
+      {...buttonProps}
+    >
+      {children}
+    </Button>
+  )
+}

--- a/apps/studio/src/components/pipeline/stage-config.ts
+++ b/apps/studio/src/components/pipeline/stage-config.ts
@@ -17,26 +17,27 @@ import {
 } from "lucide-react"
 
 export const STAGES = [
-  { slug: "book", label: "Book", runningLabel: "Loading Book", icon: BookMarked, color: "bg-gray-600", hex: "#4b5563", textColor: "text-gray-600", bgLight: "bg-gray-50", borderColor: "border-gray-200", borderDark: "border-gray-600" },
-  { slug: "extract", label: "Extract", runningLabel: "Extracting", icon: FileText, color: "bg-blue-600", hex: "#2563eb", textColor: "text-blue-600", bgLight: "bg-blue-50", borderColor: "border-blue-200", borderDark: "border-blue-600" },
-  { slug: "sectioning", label: "Sectioning", runningLabel: "Sectioning Pages", icon: Network, color: "bg-sky-600", hex: "#0284c7", textColor: "text-sky-600", bgLight: "bg-sky-50", borderColor: "border-sky-200", borderDark: "border-sky-600" },
-  { slug: "storyboard", label: "Storyboard", runningLabel: "Building Storyboard", icon: LayoutGrid, color: "bg-violet-600", hex: "#7c3aed", textColor: "text-violet-600", bgLight: "bg-violet-50", borderColor: "border-violet-200", borderDark: "border-violet-600" },
-  { slug: "quizzes", label: "Quizzes", runningLabel: "Generating Quizzes", icon: HelpCircle, color: "bg-orange-600", hex: "#ea580c", textColor: "text-orange-600", bgLight: "bg-orange-50", borderColor: "border-orange-200", borderDark: "border-orange-600" },
-  { slug: "captions", label: "Image Captions", runningLabel: "Captioning Images", icon: Image, color: "bg-teal-600", hex: "#0d9488", textColor: "text-teal-600", bgLight: "bg-teal-50", borderColor: "border-teal-200", borderDark: "border-teal-600" },
-  { slug: "glossary", label: "Glossary", runningLabel: "Generating Glossary", icon: BookOpen, color: "bg-lime-600", hex: "#65a30d", textColor: "text-lime-600", bgLight: "bg-lime-50", borderColor: "border-lime-200", borderDark: "border-lime-600" },
-  { slug: "toc", label: "Table of Contents", runningLabel: "Generating TOC", icon: List, color: "bg-amber-600", hex: "#d97706", textColor: "text-amber-600", bgLight: "bg-amber-50", borderColor: "border-amber-200", borderDark: "border-amber-600" },
-  { slug: "translate", label: "Language", runningLabel: "Translating", icon: Languages, color: "bg-pink-600", hex: "#db2777", textColor: "text-pink-600", bgLight: "bg-pink-50", borderColor: "border-pink-200", borderDark: "border-pink-600" },
-  { slug: "speech", label: "Speech", runningLabel: "Generating Speech", icon: AudioLines, color: "bg-rose-600", hex: "#e11d48", textColor: "text-rose-600", bgLight: "bg-rose-50", borderColor: "border-rose-200", borderDark: "border-rose-600" },
-  { slug: "sign-language", label: "Sign Language", runningLabel: "Sign Language", icon: Hand, color: "bg-cyan-600", hex: "#0891b2", textColor: "text-cyan-600", bgLight: "bg-cyan-50", borderColor: "border-cyan-200", borderDark: "border-cyan-600" },
-  { slug: "validation", label: "Validation", runningLabel: "Running Validation", icon: ShieldCheck, color: "bg-emerald-600", hex: "#059669", textColor: "text-emerald-600", bgLight: "bg-emerald-50", borderColor: "border-emerald-200", borderDark: "border-emerald-600" },
-  { slug: "preview", label: "Preview", runningLabel: "Building Preview", icon: Eye, color: "bg-gray-600", hex: "#4b5563", textColor: "text-gray-600", bgLight: "bg-gray-50", borderColor: "border-gray-200", borderDark: "border-gray-600" },
-  { slug: "export", label: "Export", runningLabel: "Exporting", icon: FileDown, color: "bg-indigo-700", hex: "#4338ca", textColor: "text-indigo-700", bgLight: "bg-indigo-50", borderColor: "border-indigo-200", borderDark: "border-indigo-700" },
+  { slug: "book", label: "Book", runningLabel: "Loading Book", icon: BookMarked, color: "bg-gray-600", colorHover: "hover:bg-gray-700", hex: "#4b5563", textColor: "text-gray-600", bgLight: "bg-gray-50", borderColor: "border-gray-200", borderDark: "border-gray-600" },
+  { slug: "extract", label: "Extract", runningLabel: "Extracting", icon: FileText, color: "bg-blue-600", colorHover: "hover:bg-blue-700", hex: "#2563eb", textColor: "text-blue-600", bgLight: "bg-blue-50", borderColor: "border-blue-200", borderDark: "border-blue-600" },
+  { slug: "sectioning", label: "Sectioning", runningLabel: "Sectioning Pages", icon: Network, color: "bg-sky-600", colorHover: "hover:bg-sky-700", hex: "#0284c7", textColor: "text-sky-600", bgLight: "bg-sky-50", borderColor: "border-sky-200", borderDark: "border-sky-600" },
+  { slug: "storyboard", label: "Storyboard", runningLabel: "Building Storyboard", icon: LayoutGrid, color: "bg-violet-600", colorHover: "hover:bg-violet-700", hex: "#7c3aed", textColor: "text-violet-600", bgLight: "bg-violet-50", borderColor: "border-violet-200", borderDark: "border-violet-600" },
+  { slug: "quizzes", label: "Quizzes", runningLabel: "Generating Quizzes", icon: HelpCircle, color: "bg-orange-600", colorHover: "hover:bg-orange-700", hex: "#ea580c", textColor: "text-orange-600", bgLight: "bg-orange-50", borderColor: "border-orange-200", borderDark: "border-orange-600" },
+  { slug: "captions", label: "Image Captions", runningLabel: "Captioning Images", icon: Image, color: "bg-teal-600", colorHover: "hover:bg-teal-700", hex: "#0d9488", textColor: "text-teal-600", bgLight: "bg-teal-50", borderColor: "border-teal-200", borderDark: "border-teal-600" },
+  { slug: "glossary", label: "Glossary", runningLabel: "Generating Glossary", icon: BookOpen, color: "bg-lime-600", colorHover: "hover:bg-lime-700", hex: "#65a30d", textColor: "text-lime-600", bgLight: "bg-lime-50", borderColor: "border-lime-200", borderDark: "border-lime-600" },
+  { slug: "toc", label: "Table of Contents", runningLabel: "Generating TOC", icon: List, color: "bg-amber-600", colorHover: "hover:bg-amber-700", hex: "#d97706", textColor: "text-amber-600", bgLight: "bg-amber-50", borderColor: "border-amber-200", borderDark: "border-amber-600" },
+  { slug: "translate", label: "Language", runningLabel: "Translating", icon: Languages, color: "bg-pink-600", colorHover: "hover:bg-pink-700", hex: "#db2777", textColor: "text-pink-600", bgLight: "bg-pink-50", borderColor: "border-pink-200", borderDark: "border-pink-600" },
+  { slug: "speech", label: "Speech", runningLabel: "Generating Speech", icon: AudioLines, color: "bg-rose-600", colorHover: "hover:bg-rose-700", hex: "#e11d48", textColor: "text-rose-600", bgLight: "bg-rose-50", borderColor: "border-rose-200", borderDark: "border-rose-600" },
+  { slug: "sign-language", label: "Sign Language", runningLabel: "Sign Language", icon: Hand, color: "bg-cyan-600", colorHover: "hover:bg-cyan-700", hex: "#0891b2", textColor: "text-cyan-600", bgLight: "bg-cyan-50", borderColor: "border-cyan-200", borderDark: "border-cyan-600" },
+  { slug: "validation", label: "Validation", runningLabel: "Running Validation", icon: ShieldCheck, color: "bg-emerald-600", colorHover: "hover:bg-emerald-700", hex: "#059669", textColor: "text-emerald-600", bgLight: "bg-emerald-50", borderColor: "border-emerald-200", borderDark: "border-emerald-600" },
+  { slug: "preview", label: "Preview", runningLabel: "Building Preview", icon: Eye, color: "bg-gray-600", colorHover: "hover:bg-gray-700", hex: "#4b5563", textColor: "text-gray-600", bgLight: "bg-gray-50", borderColor: "border-gray-200", borderDark: "border-gray-600" },
+  { slug: "export", label: "Export", runningLabel: "Exporting", icon: FileDown, color: "bg-indigo-700", colorHover: "hover:bg-indigo-800", hex: "#4338ca", textColor: "text-indigo-700", bgLight: "bg-indigo-50", borderColor: "border-indigo-200", borderDark: "border-indigo-700" },
 ] as const satisfies ReadonlyArray<{
   slug: string
   label: string
   runningLabel: string
   icon: LucideIcon
   color: string
+  colorHover: string
   hex: string
   textColor: string
   bgLight: string

--- a/apps/studio/src/components/pipeline/stages/captions/CaptionsSettings.tsx
+++ b/apps/studio/src/components/pipeline/stages/captions/CaptionsSettings.tsx
@@ -16,6 +16,7 @@ import { useActiveConfig } from "@/hooks/use-debug"
 import { useApiKey } from "@/hooks/use-api-key"
 import { api } from "@/api/client"
 import { PromptViewer } from "@/components/pipeline/components/PromptViewer"
+import { SettingsActionBar, SettingsActionButton } from "@/components/pipeline/components/SettingsActionBar"
 import { useBookRun } from "@/hooks/use-book-run"
 import { useStepConfig } from "@/hooks/use-step-config"
 import { useLingui } from "@lingui/react/macro"
@@ -86,15 +87,21 @@ export function CaptionsSettings({ bookLabel, headerTarget }: { bookLabel: strin
       />
 
       {headerTarget && createPortal(
-        <Button
-          size="sm"
-          className="h-7 px-2.5 text-xs bg-black/15 text-white hover:bg-black/25"
-          onClick={() => setShowRerunDialog(true)}
-          disabled={updateConfig.isPending || !hasApiKey}
-        >
-          <Play className="mr-1.5 h-3.5 w-3.5" />
-          {t`Save & Rerun`}
-        </Button>,
+        (() => {
+          const isDirty = Object.values(dirty).some(Boolean) || promptDraft != null
+          return (
+            <SettingsActionBar dirty={isDirty}>
+              <SettingsActionButton
+                dirty={isDirty}
+                onClick={() => setShowRerunDialog(true)}
+                disabled={updateConfig.isPending || !hasApiKey}
+              >
+                <Play className="mr-1.5 h-3.5 w-3.5" />
+                {t`Save & Rerun`}
+              </SettingsActionButton>
+            </SettingsActionBar>
+          )
+        })(),
         headerTarget
       )}
 

--- a/apps/studio/src/components/pipeline/stages/extract/ExtractSettings.tsx
+++ b/apps/studio/src/components/pipeline/stages/extract/ExtractSettings.tsx
@@ -20,6 +20,7 @@ import { useActiveConfig } from "@/hooks/use-debug"
 import { useApiKey } from "@/hooks/use-api-key"
 import { api } from "@/api/client"
 import { PromptViewer } from "@/components/pipeline/components/PromptViewer"
+import { SettingsActionBar, SettingsActionButton } from "@/components/pipeline/components/SettingsActionBar"
 import { useBookRun } from "@/hooks/use-book-run"
 import { useStepConfig } from "@/hooks/use-step-config"
 import { normalizeLocale } from "@/lib/languages"
@@ -444,15 +445,26 @@ export function ExtractSettings({ bookLabel, headerTarget, tab = "general" }: { 
       )}
 
       {headerTarget && createPortal(
-        <Button
-          size="sm"
-          className="h-7 px-2.5 text-xs bg-black/15 text-white hover:bg-black/25"
-          onClick={() => setShowRerunDialog(true)}
-          disabled={updateConfig.isPending || !hasApiKey}
-        >
-          <Play className="mr-1.5 h-3.5 w-3.5" />
-          {t`Save & Rerun`}
-        </Button>,
+        (() => {
+          const isDirty =
+            Object.values(dirty).some(Boolean) ||
+            metadataPromptDraft != null ||
+            meaningfulnessPromptDraft != null ||
+            croppingPromptDraft != null ||
+            segmentationPromptDraft != null
+          return (
+            <SettingsActionBar dirty={isDirty}>
+              <SettingsActionButton
+                dirty={isDirty}
+                onClick={() => setShowRerunDialog(true)}
+                disabled={updateConfig.isPending || !hasApiKey}
+              >
+                <Play className="mr-1.5 h-3.5 w-3.5" />
+                {t`Save & Rerun`}
+              </SettingsActionButton>
+            </SettingsActionBar>
+          )
+        })(),
         headerTarget
       )}
 

--- a/apps/studio/src/components/pipeline/stages/glossary/GlossarySettings.tsx
+++ b/apps/studio/src/components/pipeline/stages/glossary/GlossarySettings.tsx
@@ -16,6 +16,7 @@ import { useActiveConfig } from "@/hooks/use-debug"
 import { useApiKey } from "@/hooks/use-api-key"
 import { api } from "@/api/client"
 import { PromptViewer } from "@/components/pipeline/components/PromptViewer"
+import { SettingsActionBar, SettingsActionButton } from "@/components/pipeline/components/SettingsActionBar"
 import { useBookRun } from "@/hooks/use-book-run"
 import { useStepConfig } from "@/hooks/use-step-config"
 import { useLingui } from "@lingui/react/macro"
@@ -86,15 +87,21 @@ export function GlossarySettings({ bookLabel, headerTarget }: { bookLabel: strin
       />
 
       {headerTarget && createPortal(
-        <Button
-          size="sm"
-          className="h-7 px-2.5 text-xs bg-black/15 text-white hover:bg-black/25"
-          onClick={() => setShowRerunDialog(true)}
-          disabled={updateConfig.isPending || !hasApiKey}
-        >
-          <Play className="mr-1.5 h-3.5 w-3.5" />
-          {t`Save & Rerun`}
-        </Button>,
+        (() => {
+          const isDirty = Object.values(dirty).some(Boolean) || promptDraft != null
+          return (
+            <SettingsActionBar dirty={isDirty}>
+              <SettingsActionButton
+                dirty={isDirty}
+                onClick={() => setShowRerunDialog(true)}
+                disabled={updateConfig.isPending || !hasApiKey}
+              >
+                <Play className="mr-1.5 h-3.5 w-3.5" />
+                {t`Save & Rerun`}
+              </SettingsActionButton>
+            </SettingsActionBar>
+          )
+        })(),
         headerTarget
       )}
 

--- a/apps/studio/src/components/pipeline/stages/quizzes/QuizzesSettings.tsx
+++ b/apps/studio/src/components/pipeline/stages/quizzes/QuizzesSettings.tsx
@@ -18,6 +18,7 @@ import { useActiveConfig } from "@/hooks/use-debug"
 import { useApiKey } from "@/hooks/use-api-key"
 import { api } from "@/api/client"
 import { PromptViewer } from "@/components/pipeline/components/PromptViewer"
+import { SettingsActionBar, SettingsActionButton } from "@/components/pipeline/components/SettingsActionBar"
 import { useBookRun } from "@/hooks/use-book-run"
 import { useStepConfig } from "@/hooks/use-step-config"
 import { useLingui } from "@lingui/react/macro"
@@ -194,15 +195,21 @@ export function QuizzesSettings({ bookLabel, headerTarget, tab = "general" }: { 
       )}
 
       {headerTarget && createPortal(
-        <Button
-          size="sm"
-          className="h-7 px-2.5 text-xs bg-black/15 text-white hover:bg-black/25"
-          onClick={() => setShowRerunDialog(true)}
-          disabled={updateConfig.isPending || !hasApiKey}
-        >
-          <Play className="mr-1.5 h-3.5 w-3.5" />
-          {t`Save & Rerun`}
-        </Button>,
+        (() => {
+          const isDirty = Object.values(dirty).some(Boolean) || promptDraft != null
+          return (
+            <SettingsActionBar dirty={isDirty}>
+              <SettingsActionButton
+                dirty={isDirty}
+                onClick={() => setShowRerunDialog(true)}
+                disabled={updateConfig.isPending || !hasApiKey}
+              >
+                <Play className="mr-1.5 h-3.5 w-3.5" />
+                {t`Save & Rerun`}
+              </SettingsActionButton>
+            </SettingsActionBar>
+          )
+        })(),
         headerTarget
       )}
 

--- a/apps/studio/src/components/pipeline/stages/sectioning/SectioningSettings.tsx
+++ b/apps/studio/src/components/pipeline/stages/sectioning/SectioningSettings.tsx
@@ -27,6 +27,7 @@ import { useActiveConfig } from "@/hooks/use-debug"
 import { useApiKey } from "@/hooks/use-api-key"
 import { api } from "@/api/client"
 import { PromptViewer } from "@/components/pipeline/components/PromptViewer"
+import { SettingsActionBar, SettingsActionButton } from "@/components/pipeline/components/SettingsActionBar"
 import { useBookRun } from "@/hooks/use-book-run"
 import { useStepConfig } from "@/hooks/use-step-config"
 import { Trans } from "@lingui/react/macro"
@@ -766,15 +767,24 @@ export function SectioningSettings({ bookLabel, headerTarget, tab = "general" }:
       )}
 
       {headerTarget && createPortal(
-        <Button
-          size="sm"
-          className="h-7 px-2.5 text-xs bg-black/15 text-white hover:bg-black/25"
-          onClick={() => setShowRerunDialog(true)}
-          disabled={updateConfig.isPending || !hasApiKey}
-        >
-          <Play className="mr-1.5 h-3.5 w-3.5" />
-          {<Trans>Save & Rerun</Trans>}
-        </Button>,
+        (() => {
+          const isDirty =
+            Object.values(dirty).some(Boolean) ||
+            sectioningPromptDraft != null ||
+            refinementPromptDraft != null
+          return (
+            <SettingsActionBar dirty={isDirty}>
+              <SettingsActionButton
+                dirty={isDirty}
+                onClick={() => setShowRerunDialog(true)}
+                disabled={updateConfig.isPending || !hasApiKey}
+              >
+                <Play className="mr-1.5 h-3.5 w-3.5" />
+                {<Trans>Save & Rerun</Trans>}
+              </SettingsActionButton>
+            </SettingsActionBar>
+          )
+        })(),
         headerTarget
       )}
 

--- a/apps/studio/src/components/pipeline/stages/storyboard/StoryboardSettings.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/StoryboardSettings.tsx
@@ -30,6 +30,7 @@ import { usePages, usePageImage } from "@/hooks/use-pages"
 import { api } from "@/api/client"
 import { PromptViewer } from "@/components/pipeline/components/PromptViewer"
 import { TemplateViewer } from "@/components/pipeline/components/TemplateViewer"
+import { SettingsActionBar, SettingsActionButton } from "@/components/pipeline/components/SettingsActionBar"
 import { useBookRun } from "@/hooks/use-book-run"
 import { Trans } from "@lingui/react/macro"
 import { msg } from "@lingui/core/macro"
@@ -889,24 +890,42 @@ export function StoryboardSettings({ bookLabel, headerTarget, tab = "general" }:
 
       {headerTarget && createPortal(
         tab === "image-generation" ? (
-          <Button
-            size="sm"
-            className="h-7 px-2.5 text-xs bg-black/15 text-white hover:bg-black/25"
-            onClick={saveImagePrompts}
-            disabled={savingImageGenPrompt || (imageGenPromptDraft == null && imageEditPromptDraft == null)}
-          >
-            {savingImageGenPrompt ? t`Saving...` : t`Save`}
-          </Button>
+          (() => {
+            const imageDirty = imageGenPromptDraft != null || imageEditPromptDraft != null
+            return (
+              <SettingsActionBar dirty={imageDirty}>
+                <SettingsActionButton
+                  dirty={imageDirty}
+                  onClick={saveImagePrompts}
+                  disabled={savingImageGenPrompt || !imageDirty}
+                >
+                  {savingImageGenPrompt ? t`Saving...` : t`Save`}
+                </SettingsActionButton>
+              </SettingsActionBar>
+            )
+          })()
         ) : (
-          <Button
-            size="sm"
-            className="h-7 px-2.5 text-xs bg-black/15 text-white hover:bg-black/25"
-            onClick={() => setShowRerunDialog(true)}
-            disabled={updateConfig.isPending || !hasApiKey}
-          >
-            <Play className="mr-1.5 h-3.5 w-3.5" />
-            {<Trans>Save & Rerun</Trans>}
-          </Button>
+          (() => {
+            const isDirty =
+              Object.values(dirty).some(Boolean) ||
+              renderingPromptDraft != null ||
+              renderingTemplateDraft != null ||
+              templateTabDraft != null ||
+              activityPromptDraft != null ||
+              activityAnswerDraft != null
+            return (
+              <SettingsActionBar dirty={isDirty}>
+                <SettingsActionButton
+                  dirty={isDirty}
+                  onClick={() => setShowRerunDialog(true)}
+                  disabled={updateConfig.isPending || !hasApiKey}
+                >
+                  <Play className="mr-1.5 h-3.5 w-3.5" />
+                  {<Trans>Save & Rerun</Trans>}
+                </SettingsActionButton>
+              </SettingsActionBar>
+            )
+          })()
         ),
         headerTarget
       )}

--- a/apps/studio/src/components/pipeline/stages/toc/TocSettings.tsx
+++ b/apps/studio/src/components/pipeline/stages/toc/TocSettings.tsx
@@ -16,6 +16,7 @@ import { useActiveConfig } from "@/hooks/use-debug"
 import { useApiKey } from "@/hooks/use-api-key"
 import { api } from "@/api/client"
 import { PromptViewer } from "@/components/pipeline/components/PromptViewer"
+import { SettingsActionBar, SettingsActionButton } from "@/components/pipeline/components/SettingsActionBar"
 import { useBookRun } from "@/hooks/use-book-run"
 import { useStepConfig } from "@/hooks/use-step-config"
 import { useLingui } from "@lingui/react/macro"
@@ -86,15 +87,21 @@ export function TocSettings({ bookLabel, headerTarget }: { bookLabel: string; he
       />
 
       {headerTarget && createPortal(
-        <Button
-          size="sm"
-          className="h-7 px-2.5 text-xs bg-black/15 text-white hover:bg-black/25"
-          onClick={() => setShowRerunDialog(true)}
-          disabled={updateConfig.isPending || !hasApiKey}
-        >
-          <Play className="mr-1.5 h-3.5 w-3.5" />
-          {t`Save & Rerun`}
-        </Button>,
+        (() => {
+          const isDirty = Object.values(dirty).some(Boolean) || generationPromptDraft != null
+          return (
+            <SettingsActionBar dirty={isDirty}>
+              <SettingsActionButton
+                dirty={isDirty}
+                onClick={() => setShowRerunDialog(true)}
+                disabled={updateConfig.isPending || !hasApiKey}
+              >
+                <Play className="mr-1.5 h-3.5 w-3.5" />
+                {t`Save & Rerun`}
+              </SettingsActionButton>
+            </SettingsActionBar>
+          )
+        })(),
         headerTarget,
       )}
 

--- a/apps/studio/src/components/pipeline/stages/translations/TranslationsSettings.tsx
+++ b/apps/studio/src/components/pipeline/stages/translations/TranslationsSettings.tsx
@@ -22,6 +22,7 @@ import { useActiveConfig } from "@/hooks/use-debug"
 import { useApiKey } from "@/hooks/use-api-key"
 import { api } from "@/api/client"
 import { PromptViewer } from "@/components/pipeline/components/PromptViewer"
+import { SettingsActionBar, SettingsActionButton } from "@/components/pipeline/components/SettingsActionBar"
 import { LanguagePicker } from "@/components/LanguagePicker"
 import { useBook } from "@/hooks/use-books"
 import { useBookRun } from "@/hooks/use-book-run"
@@ -447,15 +448,24 @@ export function TranslationsSettings({ bookLabel, headerTarget, tab = "general",
       )}
 
       {headerTarget && (tab === "general" || tab === "prompt" || tab === "speech" || tab === "image-translation") && createPortal(
-        <Button
-          size="sm"
-          className="h-7 px-2.5 text-xs bg-black/15 text-white hover:bg-black/25"
-          onClick={() => setShowRerunDialog(true)}
-          disabled={updateConfig.isPending || !hasApiKey}
-        >
-          <Play className="mr-1.5 h-3.5 w-3.5" />
-          {t`Save & Rerun`}
-        </Button>,
+        (() => {
+          const isDirty =
+            Object.values(dirty).some(Boolean) ||
+            promptDraft != null ||
+            imagePromptDraft != null
+          return (
+            <SettingsActionBar dirty={isDirty}>
+              <SettingsActionButton
+                dirty={isDirty}
+                onClick={() => setShowRerunDialog(true)}
+                disabled={updateConfig.isPending || !hasApiKey}
+              >
+                <Play className="mr-1.5 h-3.5 w-3.5" />
+                {t`Save & Rerun`}
+              </SettingsActionButton>
+            </SettingsActionBar>
+          )
+        })(),
         headerTarget
       )}
 

--- a/apps/studio/src/components/pipeline/stages/translations/components/SpeechPromptsEditor.tsx
+++ b/apps/studio/src/components/pipeline/stages/translations/components/SpeechPromptsEditor.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { api } from "@/api/client"
+import { SettingsActionBar, SettingsActionButton } from "@/components/pipeline/components/SettingsActionBar"
 import { useLingui } from "@lingui/react/macro"
 
 interface SpeechPromptsEditorProps {
@@ -75,15 +76,16 @@ export function SpeechPromptsEditor({ bookLabel, headerTarget }: SpeechPromptsEd
   return (
     <div className="p-4 max-w-2xl space-y-6">
       {headerTarget && createPortal(
-        <Button
-          size="sm"
-          className="h-7 px-2.5 text-xs bg-black/15 text-white hover:bg-black/25"
-          onClick={handleSave}
-          disabled={saving || !dirty}
-        >
-          <Save className="mr-1.5 h-3.5 w-3.5" />
-          {saving ? t`Saving...` : t`Save`}
-        </Button>,
+        <SettingsActionBar dirty={dirty}>
+          <SettingsActionButton
+            dirty={dirty}
+            onClick={handleSave}
+            disabled={saving || !dirty}
+          >
+            <Save className="mr-1.5 h-3.5 w-3.5" />
+            {saving ? t`Saving...` : t`Save`}
+          </SettingsActionButton>
+        </SettingsActionBar>,
         headerTarget
       )}
 

--- a/apps/studio/src/components/pipeline/stages/translations/components/VoiceMappingsEditor.tsx
+++ b/apps/studio/src/components/pipeline/stages/translations/components/VoiceMappingsEditor.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { api } from "@/api/client"
+import { SettingsActionBar, SettingsActionButton } from "@/components/pipeline/components/SettingsActionBar"
 import { useBookConfig, useUpdateBookConfig } from "@/hooks/use-book-config"
 import { useActiveConfig } from "@/hooks/use-debug"
 import { useLingui } from "@lingui/react/macro"
@@ -162,15 +163,21 @@ export function VoiceMappingsEditor({ bookLabel, headerTarget }: VoiceMappingsEd
   return (
     <div className="p-4 space-y-4">
       {headerTarget && createPortal(
-        <Button
-          size="sm"
-          className="h-7 px-2.5 text-xs bg-black/15 text-white hover:bg-black/25"
-          onClick={handleSave}
-          disabled={saving || updateConfig.isPending || (!dirtyMappings && !dirtyDefaultVoice) || (dirtyDefaultVoice && isBookConfigLoading)}
-        >
-          <Save className="mr-1.5 h-3.5 w-3.5" />
-          {saving ? t`Saving...` : t`Save`}
-        </Button>,
+        (() => {
+          const isDirty = dirtyMappings || dirtyDefaultVoice
+          return (
+            <SettingsActionBar dirty={isDirty}>
+              <SettingsActionButton
+                dirty={isDirty}
+                onClick={handleSave}
+                disabled={saving || updateConfig.isPending || !isDirty || (dirtyDefaultVoice && isBookConfigLoading)}
+              >
+                <Save className="mr-1.5 h-3.5 w-3.5" />
+                {saving ? t`Saving...` : t`Save`}
+              </SettingsActionButton>
+            </SettingsActionBar>
+          )
+        })(),
         headerTarget
       )}
 

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -2936,6 +2936,9 @@ msgstr "No text extracted"
 msgid "No translations for this page"
 msgstr "No translations for this page"
 
+msgid "No unsaved changes"
+msgstr "No unsaved changes"
+
 msgid "No versions"
 msgstr "No versions"
 
@@ -4697,6 +4700,9 @@ msgstr "Unprune image"
 
 msgid "Unsaved changes"
 msgstr "Unsaved changes"
+
+msgid "Unsaved changes — rerun to apply"
+msgstr "Unsaved changes — rerun to apply"
 
 msgid "Unsaved:"
 msgstr "Unsaved:"

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -2936,6 +2936,9 @@ msgstr "No se extrajo texto"
 msgid "No translations for this page"
 msgstr "Sin traducciones para esta página"
 
+msgid "No unsaved changes"
+msgstr "Sin cambios sin guardar"
+
 msgid "No versions"
 msgstr "Sin versiones"
 
@@ -4697,6 +4700,9 @@ msgstr "Restaurar imagen"
 
 msgid "Unsaved changes"
 msgstr "Cambios sin guardar"
+
+msgid "Unsaved changes — rerun to apply"
+msgstr "Cambios sin guardar — vuelve a ejecutar para aplicar"
 
 msgid "Unsaved:"
 msgstr "Sin guardar:"

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -2937,6 +2937,9 @@ msgstr "Aucun texte extrait"
 msgid "No translations for this page"
 msgstr "Aucune traduction pour cette page"
 
+msgid "No unsaved changes"
+msgstr "Aucune modification non enregistrée"
+
 msgid "No versions"
 msgstr "Aucune version"
 
@@ -4698,6 +4701,9 @@ msgstr "Restaurer l'image"
 
 msgid "Unsaved changes"
 msgstr "Modifications non enregistrées"
+
+msgid "Unsaved changes — rerun to apply"
+msgstr "Modifications non enregistrées — relancez pour appliquer"
 
 msgid "Unsaved:"
 msgstr "Non enregistré :"

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -2936,6 +2936,9 @@ msgstr "Nenhum texto extraído"
 msgid "No translations for this page"
 msgstr "Sem traduções para esta página"
 
+msgid "No unsaved changes"
+msgstr "Sem alterações não salvas"
+
 msgid "No versions"
 msgstr "Sem versões"
 
@@ -4697,6 +4700,9 @@ msgstr "Restaurar imagem"
 
 msgid "Unsaved changes"
 msgstr "Alterações não salvas"
+
+msgid "Unsaved changes — rerun to apply"
+msgstr "Alterações não salvas — reexecute para aplicar"
 
 msgid "Unsaved:"
 msgstr "Não salvo:"

--- a/apps/studio/src/routes/books.$label.$step.settings.tsx
+++ b/apps/studio/src/routes/books.$label.$step.settings.tsx
@@ -70,15 +70,17 @@ export function StepSettingsPage() {
         </Link>
         <span className="text-white/40 text-sm">/</span>
         <span className="text-sm font-medium"><Trans>Settings</Trans></span>
-        <div ref={setHeaderTarget} className="ml-auto" />
         <Link
           to="/books/$label/$step"
           params={{ label, step }}
-          className="inline-flex items-center justify-center h-7 w-7 rounded-full bg-black/15 text-white/80 hover:bg-black/25 hover:text-white transition-colors"
+          className="ml-auto inline-flex items-center justify-center h-7 w-7 rounded-full bg-black/15 text-white/80 hover:bg-black/25 hover:text-white transition-colors"
         >
           <X className="w-4 h-4" />
         </Link>
       </div>
+
+      {/* Persistent action bar (Save & Rerun) — settings components portal into this */}
+      <div ref={setHeaderTarget} className="shrink-0" />
 
       {/* Settings content */}
       <div className="flex-1 min-h-0 overflow-auto">


### PR DESCRIPTION
## Summary
- Introduce `SettingsActionBar` + `SettingsActionButton` to replace the small portaled Save/Save & Rerun buttons in each pipeline stage settings panel. The bar shows dirty state inline ("Unsaved changes — rerun to apply" / "No unsaved changes") and emphasizes the action button using the current stage's color when there are pending changes.
- Wire all stage settings (extract, sectioning, storyboard, quizzes, captions, glossary, toc, translations, speech prompts, voice mappings) through the new component, computing dirty state from existing `dirty` records plus prompt/template drafts.
- Move the portal target out from beside the close button so the action bar can occupy a dedicated row under the stage header.
- Add a `colorHover` per stage in `stage-config.ts` and use it for the active-state button so hover darkens to the same hue instead of falling back to shadcn's default primary blue.

## Test plan
- [ ] Visit settings for each pipeline stage (extract, sectioning, storyboard, quizzes, captions, glossary, toc, translate, speech) — clean state shows muted bar; editing fields toggles to the stage-colored bar with the matching button hover.
- [ ] Confirm Storyboard `image-generation`, Translations `voices`, and Translations `speech-prompts` Save buttons work and stay disabled until edits exist.