### PR TITLE
Add book cover thumbnails to the book list

### DIFF
--- a/apps/api/src/routes/books.ts
+++ b/apps/api/src/routes/books.ts
@@ -430,9 +430,33 @@ export function createBookRoutes(
 
     const db = openBookDb(dbPath)
     try {
-      const pageRows = db.all(
-        "SELECT page_id FROM pages ORDER BY page_number ASC LIMIT 1"
-      ) as Array<{ page_id: string }>
+      const metadataRow = db.all(
+        `SELECT data FROM node_data
+         WHERE node = 'metadata' AND item_id = 'book'
+         ORDER BY version DESC LIMIT 1`
+      ) as Array<{ data: string }>
+
+      let coverPageNumber: number | null = null
+      if (metadataRow.length > 0) {
+        try {
+          const parsed = JSON.parse(metadataRow[0].data) as {
+            cover_page_number?: number | null
+          }
+          if (typeof parsed.cover_page_number === "number") {
+            coverPageNumber = parsed.cover_page_number
+          }
+        } catch { /* ignore malformed metadata */ }
+      }
+
+      const pageRows =
+        coverPageNumber !== null
+          ? (db.all(
+              "SELECT page_id FROM pages WHERE page_number = ? LIMIT 1",
+              [coverPageNumber]
+            ) as Array<{ page_id: string }>)
+          : (db.all(
+              "SELECT page_id FROM pages ORDER BY page_number ASC LIMIT 1"
+            ) as Array<{ page_id: string }>)
 
       if (pageRows.length === 0) {
         throw new HTTPException(404, { message: "No pages extracted yet" })

--- a/apps/api/src/routes/books.ts
+++ b/apps/api/src/routes/books.ts
@@ -408,6 +408,73 @@ export function createBookRoutes(
     }
   })
 
+  // GET /books/:label/cover — Serve the first extracted page image (book cover)
+  app.get("/books/:label/cover", (c) => {
+    const { label } = c.req.param()
+    let safeLabel: string
+    try {
+      safeLabel = parseBookLabel(label)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      throw new HTTPException(400, { message })
+    }
+    const resolvedDir = path.resolve(booksDir)
+    const bookDir = path.join(resolvedDir, safeLabel)
+    const dbPath = path.join(bookDir, `${safeLabel}.db`)
+
+    if (!fs.existsSync(dbPath)) {
+      throw new HTTPException(404, {
+        message: `Book not found: ${safeLabel}`,
+      })
+    }
+
+    const db = openBookDb(dbPath)
+    try {
+      const pageRows = db.all(
+        "SELECT page_id FROM pages ORDER BY page_number ASC LIMIT 1"
+      ) as Array<{ page_id: string }>
+
+      if (pageRows.length === 0) {
+        throw new HTTPException(404, { message: "No pages extracted yet" })
+      }
+
+      const imageId = `${pageRows[0].page_id}_page`
+      const imageRows = db.all(
+        "SELECT path FROM images WHERE image_id = ?",
+        [imageId]
+      ) as Array<{ path: string }>
+
+      if (imageRows.length === 0) {
+        throw new HTTPException(404, { message: "Cover image not found" })
+      }
+
+      const imagePath = path.resolve(bookDir, imageRows[0].path)
+      if (!imagePath.startsWith(bookDir + path.sep)) {
+        throw new HTTPException(400, { message: "Invalid image path" })
+      }
+
+      let stat: fs.Stats
+      try {
+        stat = fs.statSync(imagePath)
+      } catch {
+        throw new HTTPException(404, { message: "Cover image file not found" })
+      }
+      if (!stat.isFile()) {
+        throw new HTTPException(404, { message: "Cover image file not found" })
+      }
+
+      const imageBuffer = fs.readFileSync(imagePath)
+      const ext = path.extname(imagePath).toLowerCase()
+      const contentType =
+        ext === ".jpg" || ext === ".jpeg" ? "image/jpeg" : "image/png"
+      c.header("Content-Type", contentType)
+      c.header("Cache-Control", "public, max-age=86400")
+      return c.body(imageBuffer)
+    } finally {
+      db.close()
+    }
+  })
+
   // GET /books/:label/images/:imageId — Serve extracted image binary
   app.get("/books/:label/images/:imageId", (c) => {
     const { label, imageId } = c.req.param()

--- a/apps/studio/src/api/client.ts
+++ b/apps/studio/src/api/client.ts
@@ -47,6 +47,13 @@ export function getSignLanguageVideoUrl(label: string, videoId: string): string 
   return `${BASE_URL}/books/${label}/sign-language-videos/${videoId}`
 }
 
+export function getBookCoverUrl(label: string, cacheKey?: string): string {
+  const base = `${BASE_URL}/books/${label}/cover`
+  if (!cacheKey) return base
+  const params = new URLSearchParams({ v: cacheKey })
+  return `${base}?${params.toString()}`
+}
+
 async function request<T>(path: string, options?: RequestInit): Promise<T> {
   const url = `${BASE_URL}${path}`
   const res = await fetch(url, {

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -1231,9 +1231,6 @@ msgstr "Could not read this PDF. The file may be corrupted or password-protected
 msgid "Cover"
 msgstr "Cover"
 
-#~ msgid "Cover of {0}"
-#~ msgstr "Cover of {0}"
-
 msgid "Cover of {title}"
 msgstr "Cover of {title}"
 
@@ -1870,9 +1867,6 @@ msgstr "Flat Vector"
 msgid "Flexible"
 msgstr "Flexible"
 
-#~ msgid "Footer Text"
-#~ msgstr "Footer Text"
-
 #. placeholder {0}: i18n._(preset.title)
 #. placeholder {1}: recommendedOption.label
 msgid "For {0}, we recommend {1}."
@@ -2033,12 +2027,6 @@ msgstr "Hide AI edit history"
 
 msgid "Hide error details"
 msgstr "Hide error details"
-
-#~ msgid "Hide Pruned"
-#~ msgstr "Hide Pruned"
-
-#~ msgid "Hide pruned images"
-#~ msgstr "Hide pruned images"
 
 msgid "Hide pruned terms"
 msgstr "Hide pruned terms"
@@ -2501,9 +2489,6 @@ msgstr "Match Design"
 msgid "Match each stage of the water cycle to its definition:"
 msgstr "Match each stage of the water cycle to its definition:"
 
-#~ msgid "Math"
-#~ msgstr "Math"
-
 msgid "Max Iterations"
 msgstr "Max Iterations"
 
@@ -2512,9 +2497,6 @@ msgstr "Max Refinements"
 
 msgid "Max review/revise rounds per section before accepting the current rendering"
 msgstr "Max review/revise rounds per section before accepting the current rendering"
-
-#~ msgid "Max Side"
-#~ msgstr "Max Side"
 
 msgid "Max side (px)"
 msgstr "Max side (px)"
@@ -3292,9 +3274,6 @@ msgstr "Prune image"
 msgid "Prune section from flow"
 msgstr "Prune section from flow"
 
-#~ msgid "Prune text"
-#~ msgstr "Prune text"
-
 msgid "Prune this term — it will be hidden from output and excluded from future regenerations."
 msgstr "Prune this term — it will be hidden from output and excluded from future regenerations."
 
@@ -3953,12 +3932,6 @@ msgstr "Show error details"
 
 msgid "Show fewer"
 msgstr "Show fewer"
-
-#~ msgid "Show Pruned"
-#~ msgstr "Show Pruned"
-
-#~ msgid "Show pruned images"
-#~ msgstr "Show pruned images"
 
 msgid "Show pruned terms"
 msgstr "Show pruned terms"

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -1231,6 +1231,9 @@ msgstr "Could not read this PDF. The file may be corrupted or password-protected
 msgid "Cover"
 msgstr "Cover"
 
+#~ msgid "Cover of {0}"
+#~ msgstr "Cover of {0}"
+
 msgid "Cover of {title}"
 msgstr "Cover of {title}"
 

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -1231,11 +1231,8 @@ msgstr "No se pudo leer este PDF. El archivo puede estar dañado o protegido con
 msgid "Cover"
 msgstr "Portada"
 
-#~ msgid "Cover of {0}"
-#~ msgstr ""
-
 msgid "Cover of {title}"
-msgstr "Portada de {0}"
+msgstr "Portada de {title}"
 
 msgid "Create a manual glossary entry that stays in the book even if AI glossary generation is rerun."
 msgstr "Crea una entrada manual del glosario que permanezca en el libro aunque se vuelva a ejecutar la generación del glosario con IA."
@@ -1870,9 +1867,6 @@ msgstr "Vector plano"
 msgid "Flexible"
 msgstr "Flexible"
 
-#~ msgid "Footer Text"
-#~ msgstr "Texto de pie de página"
-
 #. placeholder {0}: i18n._(preset.title)
 #. placeholder {1}: recommendedOption.label
 msgid "For {0}, we recommend {1}."
@@ -2033,12 +2027,6 @@ msgstr "Ocultar historial de edición con IA"
 
 msgid "Hide error details"
 msgstr "Ocultar detalles del error"
-
-#~ msgid "Hide Pruned"
-#~ msgstr "Ocultar eliminadas"
-
-#~ msgid "Hide pruned images"
-#~ msgstr "Ocultar imágenes eliminadas"
 
 msgid "Hide pruned terms"
 msgstr "Ocultar términos podados"
@@ -2501,9 +2489,6 @@ msgstr "Coincidir con el diseño"
 msgid "Match each stage of the water cycle to its definition:"
 msgstr "Asocia cada etapa del ciclo del agua con su definición:"
 
-#~ msgid "Math"
-#~ msgstr "Matemáticas"
-
 msgid "Max Iterations"
 msgstr "Iteraciones máximas"
 
@@ -2512,9 +2497,6 @@ msgstr "Refinamientos máximos"
 
 msgid "Max review/revise rounds per section before accepting the current rendering"
 msgstr "Máximo de rondas de revisión/corrección por sección antes de aceptar el renderizado actual"
-
-#~ msgid "Max Side"
-#~ msgstr "Lado Máximo"
 
 msgid "Max side (px)"
 msgstr "Lado máximo (px)"
@@ -3292,9 +3274,6 @@ msgstr "Eliminar imagen"
 msgid "Prune section from flow"
 msgstr "Eliminar sección del flujo"
 
-#~ msgid "Prune text"
-#~ msgstr "Eliminar texto"
-
 msgid "Prune this term — it will be hidden from output and excluded from future regenerations."
 msgstr "Podar este término — se ocultará de la salida y se excluirá de futuras regeneraciones."
 
@@ -3953,12 +3932,6 @@ msgstr "Mostrar detalles del error"
 
 msgid "Show fewer"
 msgstr "Show fewer"
-
-#~ msgid "Show Pruned"
-#~ msgstr "Mostrar eliminadas"
-
-#~ msgid "Show pruned images"
-#~ msgstr "Mostrar imágenes eliminadas"
 
 msgid "Show pruned terms"
 msgstr "Mostrar términos podados"

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -1231,6 +1231,9 @@ msgstr "No se pudo leer este PDF. El archivo puede estar dañado o protegido con
 msgid "Cover"
 msgstr "Portada"
 
+#~ msgid "Cover of {0}"
+#~ msgstr ""
+
 msgid "Cover of {title}"
 msgstr "Portada de {0}"
 

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -1232,9 +1232,6 @@ msgstr "Impossible de lire ce PDF. Le fichier est peut-être corrompu ou protég
 msgid "Cover"
 msgstr "Couverture"
 
-#~ msgid "Cover of {0}"
-#~ msgstr ""
-
 msgid "Cover of {title}"
 msgstr "Couverture de {title}"
 
@@ -1871,9 +1868,6 @@ msgstr "Vecteur plat"
 msgid "Flexible"
 msgstr "Flexible"
 
-#~ msgid "Footer Text"
-#~ msgstr "Pied de page Texte"
-
 #. placeholder {0}: i18n._(preset.title)
 #. placeholder {1}: recommendedOption.label
 msgid "For {0}, we recommend {1}."
@@ -2034,12 +2028,6 @@ msgstr "Masquer l'historique des modifications IA"
 
 msgid "Hide error details"
 msgstr "Masquer les détails de l’erreur"
-
-#~ msgid "Hide Pruned"
-#~ msgstr "Masquer les élagués"
-
-#~ msgid "Hide pruned images"
-#~ msgstr "Masquer les images élaguées"
 
 msgid "Hide pruned terms"
 msgstr "Masquer les termes élagués"
@@ -2502,9 +2490,6 @@ msgstr "Correspondance avec le design"
 msgid "Match each stage of the water cycle to its definition:"
 msgstr "Associez chaque étape du cycle de l'eau à sa définition :"
 
-#~ msgid "Math"
-#~ msgstr "Math"
-
 msgid "Max Iterations"
 msgstr "Itérations max"
 
@@ -2513,9 +2498,6 @@ msgstr "Raffinements max"
 
 msgid "Max review/revise rounds per section before accepting the current rendering"
 msgstr "Nombre maximum de tours de revue/correction par section avant d'accepter le rendu actuel"
-
-#~ msgid "Max Side"
-#~ msgstr "Côté max."
 
 msgid "Max side (px)"
 msgstr "Côté max. (px)"
@@ -3293,9 +3275,6 @@ msgstr "Élaguer l'image"
 msgid "Prune section from flow"
 msgstr "Élaguer la section du flux"
 
-#~ msgid "Prune text"
-#~ msgstr "Élaguer le texte"
-
 msgid "Prune this term — it will be hidden from output and excluded from future regenerations."
 msgstr "Élaguer ce terme — il sera masqué de la sortie et exclu des régénérations futures."
 
@@ -3954,12 +3933,6 @@ msgstr "Afficher les détails de l’erreur"
 
 msgid "Show fewer"
 msgstr "Afficher moins"
-
-#~ msgid "Show Pruned"
-#~ msgstr "Afficher les élagués"
-
-#~ msgid "Show pruned images"
-#~ msgstr "Afficher les images élaguées"
 
 msgid "Show pruned terms"
 msgstr "Afficher les termes élagués"

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -1232,6 +1232,9 @@ msgstr "Impossible de lire ce PDF. Le fichier est peut-être corrompu ou protég
 msgid "Cover"
 msgstr "Couverture"
 
+#~ msgid "Cover of {0}"
+#~ msgstr ""
+
 msgid "Cover of {title}"
 msgstr "Couverture de {title}"
 

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -1231,6 +1231,9 @@ msgstr "Não foi possível ler este PDF. O arquivo pode estar corrompido ou prot
 msgid "Cover"
 msgstr "Capa"
 
+#~ msgid "Cover of {0}"
+#~ msgstr ""
+
 msgid "Cover of {title}"
 msgstr "Capa de {0}"
 

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -1231,11 +1231,8 @@ msgstr "Não foi possível ler este PDF. O arquivo pode estar corrompido ou prot
 msgid "Cover"
 msgstr "Capa"
 
-#~ msgid "Cover of {0}"
-#~ msgstr ""
-
 msgid "Cover of {title}"
-msgstr "Capa de {0}"
+msgstr "Capa de {title}"
 
 msgid "Create a manual glossary entry that stays in the book even if AI glossary generation is rerun."
 msgstr "Crie uma entrada manual de glossário que permaneça no livro mesmo se a geração de glossário por IA for executada novamente."
@@ -1870,9 +1867,6 @@ msgstr "Vetor plano"
 msgid "Flexible"
 msgstr "Flexível"
 
-#~ msgid "Footer Text"
-#~ msgstr "Texto de rodapé"
-
 #. placeholder {0}: i18n._(preset.title)
 #. placeholder {1}: recommendedOption.label
 msgid "For {0}, we recommend {1}."
@@ -2033,12 +2027,6 @@ msgstr "Ocultar histórico de edições com IA"
 
 msgid "Hide error details"
 msgstr "Ocultar detalhes do erro"
-
-#~ msgid "Hide Pruned"
-#~ msgstr "Ocultar removidas"
-
-#~ msgid "Hide pruned images"
-#~ msgstr "Ocultar imagens removidas"
 
 msgid "Hide pruned terms"
 msgstr "Ocultar termos podados"
@@ -2501,9 +2489,6 @@ msgstr "Combinar com o design"
 msgid "Match each stage of the water cycle to its definition:"
 msgstr "Associe cada estágio do ciclo da água à sua definição:"
 
-#~ msgid "Math"
-#~ msgstr "Matemática"
-
 msgid "Max Iterations"
 msgstr "Iterações máximas"
 
@@ -2512,9 +2497,6 @@ msgstr "Refinamentos máximos"
 
 msgid "Max review/revise rounds per section before accepting the current rendering"
 msgstr "Máximo de rodadas de revisão/correção por seção antes de aceitar a renderização atual"
-
-#~ msgid "Max Side"
-#~ msgstr "Lado Máximo"
 
 msgid "Max side (px)"
 msgstr "Lado máximo (px)"
@@ -3292,9 +3274,6 @@ msgstr "Remover imagem"
 msgid "Prune section from flow"
 msgstr "Remover seção do fluxo"
 
-#~ msgid "Prune text"
-#~ msgstr "Remover texto"
-
 msgid "Prune this term — it will be hidden from output and excluded from future regenerations."
 msgstr "Podar este termo — ele será ocultado da saída e excluído de regenerações futuras."
 
@@ -3953,12 +3932,6 @@ msgstr "Mostrar detalhes do erro"
 
 msgid "Show fewer"
 msgstr "Show fewer"
-
-#~ msgid "Show Pruned"
-#~ msgstr "Mostrar removidas"
-
-#~ msgid "Show pruned images"
-#~ msgstr "Mostrar imagens removidas"
 
 msgid "Show pruned terms"
 msgstr "Mostrar termos podados"

--- a/apps/studio/src/routes/index.tsx
+++ b/apps/studio/src/routes/index.tsx
@@ -40,6 +40,7 @@ import {
   getStageDescriptionI18n,
 } from "@/components/pipeline/pipeline-i18n"
 import type { BookSummary } from "@/api/client"
+import { getBookCoverUrl } from "@/api/client"
 
 type BookSortKey = "modified" | "created" | "alphabetical"
 
@@ -203,6 +204,12 @@ function BookRow({
     () => new Set(book.completedStages),
     [book.completedStages],
   )
+  const [coverFailed, setCoverFailed] = useState(false)
+  const showCover = book.pageCount > 0 && !coverFailed
+  const coverUrl = useMemo(
+    () => getBookCoverUrl(book.label, book.modifiedAt),
+    [book.label, book.modifiedAt],
+  )
   const dateFormatter = useMemo(
     () =>
       new Intl.DateTimeFormat(i18n.locale, {
@@ -219,12 +226,32 @@ function BookRow({
         <Link
           to="/books/$label/$step"
           params={{ label: book.label, step: "extract" }}
-          className="flex-1 min-w-0 p-5"
+          className="flex flex-1 min-w-0 gap-4 p-5"
         >
+          {/* Cover thumbnail */}
+          <div className="flex h-24 w-[72px] shrink-0 items-center justify-center overflow-hidden rounded-md border bg-muted">
+            {showCover ? (
+              (() => {
+                const title = book.title ?? book.label
+                return (
+                  <img
+                    src={coverUrl}
+                    alt={t`Cover of ${title}`}
+                    className="h-full w-full object-cover"
+                    loading="lazy"
+                    onError={() => setCoverFailed(true)}
+                  />
+                )
+              })()
+            ) : (
+              <BookOpen className="h-7 w-7 text-muted-foreground" />
+            )}
+          </div>
+
+          <div className="min-w-0 flex-1">
           {/* Top: title + badges */}
           <div className="flex items-start justify-between gap-3 mb-3">
             <div className="flex items-center gap-2.5 min-w-0">
-              <BookOpen className="h-5 w-5 text-muted-foreground shrink-0" />
               <h3 className="font-semibold text-base truncate">
                 {book.title ?? book.label}
               </h3>
@@ -318,6 +345,7 @@ function BookRow({
             completedSet={completedSet}
             pipelineStages={pipelineStages}
           />
+          </div>
         </Link>
 
         {/* Actions — always visible */}


### PR DESCRIPTION
## Summary
- New `GET /books/:label/cover` endpoint serves the first extracted page image (with path-traversal guard and 1-day cache header).
- Book list rows on the landing page now render a 72x96 cover thumbnail next to each book; falls back to the `BookOpen` icon when no pages have been extracted yet or the image fails to load.
- Cache key is `?v=<modifiedAt>`, so the thumbnail refreshes when the book is rebuilt.

## Test plan
- [ ] Open the studio landing page and confirm thumbnails appear for books with extracted pages.
- [ ] Confirm the icon fallback renders for new/unextracted books and on broken cover URLs.
- [ ] Re-run extract on an existing book and verify the thumbnail updates (cache invalidation via `modifiedAt`).