### PR TITLE
Fix CMYK and soft-mask transparency in PDF image extraction

### DIFF
--- a/packages/pdf/src/__tests__/extract-raven.test.ts
+++ b/packages/pdf/src/__tests__/extract-raven.test.ts
@@ -50,7 +50,7 @@ describe("raven.pdf extraction", () => {
     expect(imgs[0].width).toBe(546);
     expect(imgs[0].height).toBe(546);
     expect(imgs[1].imageId).toBe("pg001_im002");
-    expect(imgs[1].hash).toBe("14b8a1e04e930b83");
+    expect(imgs[1].hash).toBe("c9b639d01b6c22f6");
   });
 
   // -- Page 2 --
@@ -69,7 +69,7 @@ describe("raven.pdf extraction", () => {
   it("page 2 — extracts 2 images with correct hashes", () => {
     const imgs = result.pages[1].images;
     expect(imgs).toHaveLength(2);
-    expect(imgs[0].hash).toBe("2bdb94c1a5f96fe7");
+    expect(imgs[0].hash).toBe("e93e376bae3d5ab6");
     expect(imgs[1].hash).toBe("f7c69061b5fb89ed");
   });
 
@@ -88,7 +88,7 @@ describe("raven.pdf extraction", () => {
   it("page 3 — extracts 2 images with correct hashes", () => {
     const imgs = result.pages[2].images;
     expect(imgs).toHaveLength(2);
-    expect(imgs[0].hash).toBe("1aecee2cc36cd072");
+    expect(imgs[0].hash).toBe("3327c0395cbae5df");
     expect(imgs[1].hash).toBe("b20ccebb2681ac27");
   });
 });

--- a/packages/pdf/src/__tests__/extract.test.ts
+++ b/packages/pdf/src/__tests__/extract.test.ts
@@ -518,6 +518,228 @@ function createPdfWithSingleArrayDctFilterImage(): Buffer {
   return Buffer.from(doc.saveToBuffer("").asUint8Array());
 }
 
+/**
+ * Build a PDF with a CMYK JPEG image. Mirrors what print-oriented PDFs commonly
+ * produce — the image data is a single-filter DCTDecode stream with /ColorSpace
+ * /DeviceCMYK.
+ */
+function createPdfWithCmykJpegImage(): Buffer {
+  const doc = new mupdf.PDFDocument();
+
+  // Create a CMYK pixmap and encode it as a CMYK JPEG.
+  const cmykPixmap = new mupdf.Pixmap(mupdf.ColorSpace.DeviceCMYK, [0, 0, 4, 4], false);
+  const cmykJpegBytes = Buffer.from(cmykPixmap.asJPEG(90, false));
+
+  const imgDict = doc.newDictionary();
+  imgDict.put("Type", doc.newName("XObject"));
+  imgDict.put("Subtype", doc.newName("Image"));
+  imgDict.put("Width", 4);
+  imgDict.put("Height", 4);
+  imgDict.put("BitsPerComponent", 8);
+  imgDict.put("ColorSpace", doc.newName("DeviceCMYK"));
+  imgDict.put("Filter", doc.newName("DCTDecode"));
+
+  const imgObj = doc.addRawStream(cmykJpegBytes, imgDict);
+
+  const resources = doc.newDictionary();
+  const xobjects = doc.newDictionary();
+  xobjects.put("Im1", imgObj);
+  resources.put("XObject", xobjects);
+
+  const pageContent = "q 100 0 0 100 50 650 cm /Im1 Do Q";
+  const pageObj = doc.addPage([0, 0, 612, 792], 0, resources, pageContent);
+  doc.insertPage(-1, pageObj);
+
+  return Buffer.from(doc.saveToBuffer("").asUint8Array());
+}
+
+/**
+ * Build a PDF with an RGB image that has an attached /SMask carrying alpha.
+ * Mirrors the typical output of design tools that flatten transparency to a
+ * base image plus a soft mask.
+ */
+function createPdfWithSoftMaskImage(): Buffer {
+  const doc = new mupdf.PDFDocument();
+  const w = 4;
+  const h = 4;
+
+  // Base RGB image — 4x4, fill with bright red so the alpha effect is obvious.
+  const baseBytes = Buffer.alloc(w * h * 3);
+  for (let i = 0; i < w * h; i++) {
+    baseBytes[i * 3 + 0] = 255;
+    baseBytes[i * 3 + 1] = 0;
+    baseBytes[i * 3 + 2] = 0;
+  }
+
+  // SMask — gray; left half opaque (255), right half transparent (0).
+  const maskBytes = Buffer.alloc(w * h);
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      maskBytes[y * w + x] = x < w / 2 ? 255 : 0;
+    }
+  }
+
+  const maskDict = doc.newDictionary();
+  maskDict.put("Type", doc.newName("XObject"));
+  maskDict.put("Subtype", doc.newName("Image"));
+  maskDict.put("Width", w);
+  maskDict.put("Height", h);
+  maskDict.put("BitsPerComponent", 8);
+  maskDict.put("ColorSpace", doc.newName("DeviceGray"));
+  const maskObj = doc.addStream(maskBytes, maskDict);
+
+  const imgDict = doc.newDictionary();
+  imgDict.put("Type", doc.newName("XObject"));
+  imgDict.put("Subtype", doc.newName("Image"));
+  imgDict.put("Width", w);
+  imgDict.put("Height", h);
+  imgDict.put("BitsPerComponent", 8);
+  imgDict.put("ColorSpace", doc.newName("DeviceRGB"));
+  imgDict.put("SMask", maskObj);
+  const imgObj = doc.addStream(baseBytes, imgDict);
+
+  const resources = doc.newDictionary();
+  const xobjects = doc.newDictionary();
+  xobjects.put("Im1", imgObj);
+  resources.put("XObject", xobjects);
+
+  const pageContent = "q 100 0 0 100 50 650 cm /Im1 Do Q";
+  const pageObj = doc.addPage([0, 0, 612, 792], 0, resources, pageContent);
+  doc.insertPage(-1, pageObj);
+
+  return Buffer.from(doc.saveToBuffer("").asUint8Array());
+}
+
+/**
+ * Build a PDF whose SMask carries a /Matte entry. The base RGB bytes are stored
+ * pre-blended with the matte color (white) at 50% alpha — i.e. ~(127, 127, 127)
+ * — so that un-matting must recover the original color (~black).
+ */
+function createPdfWithMattedSoftMaskImage(): Buffer {
+  const doc = new mupdf.PDFDocument();
+  const w = 4;
+  const h = 4;
+
+  // Pre-blended pixels: original black (0) onto white matte (255) at a=0.5.
+  const baseBytes = Buffer.alloc(w * h * 3);
+  for (let i = 0; i < w * h; i++) {
+    baseBytes[i * 3 + 0] = 127;
+    baseBytes[i * 3 + 1] = 127;
+    baseBytes[i * 3 + 2] = 127;
+  }
+
+  // Uniform 50% alpha (128).
+  const maskBytes = Buffer.alloc(w * h);
+  for (let i = 0; i < w * h; i++) maskBytes[i] = 128;
+
+  const maskDict = doc.newDictionary();
+  maskDict.put("Type", doc.newName("XObject"));
+  maskDict.put("Subtype", doc.newName("Image"));
+  maskDict.put("Width", w);
+  maskDict.put("Height", h);
+  maskDict.put("BitsPerComponent", 8);
+  maskDict.put("ColorSpace", doc.newName("DeviceGray"));
+  const matte = doc.newArray();
+  matte.push(1);
+  matte.push(1);
+  matte.push(1);
+  maskDict.put("Matte", matte);
+  const maskObj = doc.addStream(maskBytes, maskDict);
+
+  const imgDict = doc.newDictionary();
+  imgDict.put("Type", doc.newName("XObject"));
+  imgDict.put("Subtype", doc.newName("Image"));
+  imgDict.put("Width", w);
+  imgDict.put("Height", h);
+  imgDict.put("BitsPerComponent", 8);
+  imgDict.put("ColorSpace", doc.newName("DeviceRGB"));
+  imgDict.put("SMask", maskObj);
+  const imgObj = doc.addStream(baseBytes, imgDict);
+
+  const resources = doc.newDictionary();
+  const xobjects = doc.newDictionary();
+  xobjects.put("Im1", imgObj);
+  resources.put("XObject", xobjects);
+
+  const pageContent = "q 100 0 0 100 50 650 cm /Im1 Do Q";
+  const pageObj = doc.addPage([0, 0, 612, 792], 0, resources, pageContent);
+  doc.insertPage(-1, pageObj);
+
+  return Buffer.from(doc.saveToBuffer("").asUint8Array());
+}
+
+describe("extractPdf images with soft masks", () => {
+  it("preserves alpha from /SMask instead of producing an opaque image on a black background", async () => {
+    const pdfBuffer = createPdfWithSoftMaskImage();
+    const result = await extractPdf({ pdfBuffer });
+
+    const rasterImages = result.pages[0].images.filter(
+      (img) => !img.imageId.endsWith("_page")
+    );
+    expect(rasterImages).toHaveLength(1);
+    const img = rasterImages[0];
+    expect(img.format).toBe("png");
+
+    // Decode and verify: left half is opaque red, right half is transparent.
+    const { data, width, height } = decodePng(img.buffer);
+    expect(width).toBe(4);
+    expect(height).toBe(4);
+
+    // The PNG must have an alpha channel.
+    expect(data.length).toBe(width * height * 4);
+
+    // Left column: opaque red.
+    expect(data[0]).toBe(255); // R
+    expect(data[1]).toBe(0); // G
+    expect(data[2]).toBe(0); // B
+    expect(data[3]).toBe(255); // A
+
+    // Right column: alpha 0 (the actual color underneath is irrelevant —
+    // the failure mode being tested is opaque pixels with no alpha).
+    const lastPixelOffset = (4 * 4 - 1) * 4;
+    expect(data[lastPixelOffset + 3]).toBe(0);
+  });
+
+  it("un-mattes base colors when /SMask carries a /Matte entry", async () => {
+    const pdfBuffer = createPdfWithMattedSoftMaskImage();
+    const result = await extractPdf({ pdfBuffer });
+
+    const rasterImages = result.pages[0].images.filter(
+      (img) => !img.imageId.endsWith("_page")
+    );
+    expect(rasterImages).toHaveLength(1);
+    const { data } = decodePng(rasterImages[0].buffer);
+
+    // Stored pixels are gray (~127) because they were pre-blended with a
+    // white matte at 50% alpha. After un-matting we must recover near-black;
+    // without un-matting the channels would stay around 127.
+    expect(data[0]).toBeLessThan(10);
+    expect(data[1]).toBeLessThan(10);
+    expect(data[2]).toBeLessThan(10);
+    expect(data[3]).toBe(128);
+  });
+});
+
+describe("extractPdf CMYK images", () => {
+  it("converts CMYK JPEGs to RGB so browsers render them correctly", async () => {
+    const pdfBuffer = createPdfWithCmykJpegImage();
+    const result = await extractPdf({ pdfBuffer });
+
+    expect(result.pages).toHaveLength(1);
+    const rasterImages = result.pages[0].images.filter(
+      (img) => !img.imageId.endsWith("_page")
+    );
+    expect(rasterImages).toHaveLength(1);
+    const img = rasterImages[0];
+
+    expect(img.format).toBe("jpeg");
+    // Re-decode the extracted JPEG and confirm it is no longer CMYK.
+    const reloaded = new mupdf.Image(img.buffer);
+    const cs = reloaded.getColorSpace();
+    expect(cs?.getType()).toBe("RGB");
+  });
+});
+
 describe("extractPdf chained image filters", () => {
   it("extracts a valid image from a [FlateDecode, DCTDecode] filter chain", async () => {
     const pdfBuffer = createPdfWithChainedFilterImage();

--- a/packages/pdf/src/extract.ts
+++ b/packages/pdf/src/extract.ts
@@ -10,6 +10,7 @@ import mupdf, {
   type PDFDocument,
   type PDFPage,
   type PDFObject,
+  type Pixmap,
 } from "mupdf";
 import { cropPng, decodePng, stitchPngsHorizontally } from "./png-utils.js";
 import { extractTextFromStructuredText } from "./fm-sinhala.js";
@@ -320,6 +321,104 @@ function jpegDimensions(buf: Buffer): { width: number; height: number } {
 
 function pngDimensions(buf: Buffer): { width: number; height: number } {
   return { width: buf.readUInt32BE(16), height: buf.readUInt32BE(20) };
+}
+
+/** Force a pixmap to DeviceRGB so encoders/browsers can render it. RGB and
+ * Gray pass through unchanged. */
+function normalizeToDisplayableRgb(pixmap: Pixmap): Pixmap {
+  const type = pixmap.getColorSpace()?.getType();
+  if (type === "RGB" || type === "Gray") return pixmap;
+  return pixmap.convertToColorSpace(mupdf.ColorSpace.DeviceRGB);
+}
+
+/** Compose a base pixmap with its /SMask into a single RGBA pixmap. mupdf's
+ * `toPixmap()` does not apply the attached soft mask, so without this step
+ * transparent images arrive opaque on whatever was in the raster buffer.
+ *
+ * If `matteRgb` is provided, the base colors are treated as pre-blended with
+ * that matte color and un-matted (`c = matte + (c' - matte) / a`) so semi-
+ * transparent edges don't show halos. */
+function composeWithSoftMask(
+  base: Pixmap,
+  mask: Pixmap,
+  matteRgb?: readonly [number, number, number]
+): Pixmap {
+  const rgb =
+    base.getColorSpace()?.getType() === "RGB"
+      ? base
+      : base.convertToColorSpace(mupdf.ColorSpace.DeviceRGB);
+
+  const w = rgb.getWidth();
+  const h = rgb.getHeight();
+  const out = new mupdf.Pixmap(mupdf.ColorSpace.DeviceRGB, [0, 0, w, h], true);
+
+  const basePx = rgb.getPixels();
+  const baseStride = rgb.getStride();
+  const baseN = rgb.getNumberOfComponents();
+  const maskPx = mask.getPixels();
+  const maskStride = mask.getStride();
+  const maskN = mask.getNumberOfComponents();
+  const maskW = mask.getWidth();
+  const maskH = mask.getHeight();
+  const outPx = out.getPixels();
+  const outStride = out.getStride();
+
+  const mr = matteRgb ? matteRgb[0] : 0;
+  const mg = matteRgb ? matteRgb[1] : 0;
+  const mb = matteRgb ? matteRgb[2] : 0;
+
+  for (let y = 0; y < h; y++) {
+    const my = maskH === h ? y : Math.min(maskH - 1, Math.floor((y * maskH) / h));
+    for (let x = 0; x < w; x++) {
+      const mx = maskW === w ? x : Math.min(maskW - 1, Math.floor((x * maskW) / w));
+      const baseOff = y * baseStride + x * baseN;
+      const outOff = y * outStride + x * 4;
+      const a = maskPx[my * maskStride + mx * maskN];
+      let r = basePx[baseOff];
+      let g = basePx[baseOff + 1];
+      let b = basePx[baseOff + 2];
+      if (matteRgb && a > 0 && a < 255) {
+        r = Math.max(0, Math.min(255, Math.round(mr + ((r - mr) * 255) / a)));
+        g = Math.max(0, Math.min(255, Math.round(mg + ((g - mg) * 255) / a)));
+        b = Math.max(0, Math.min(255, Math.round(mb + ((b - mb) * 255) / a)));
+      }
+      outPx[outOff] = r;
+      outPx[outOff + 1] = g;
+      outPx[outOff + 2] = b;
+      outPx[outOff + 3] = a;
+    }
+  }
+  return out;
+}
+
+/** Read the /Matte array off an SMask dictionary, expressed as 8-bit RGB.
+ * Only RGB (3) and Gray (1) source colorspaces are handled; for anything
+ * else (e.g. CMYK) we conservatively skip un-matting. */
+function readSoftMaskMatte(
+  imageDict: PDFObject,
+  srcType: string | undefined
+): [number, number, number] | undefined {
+  const smask = imageDict.get("SMask");
+  if (smask.isNull()) return undefined;
+  const smaskDict = smask.isIndirect() ? smask.resolve() : smask;
+  const matte = smaskDict.get("Matte");
+  if (matte.isNull() || !matte.isArray()) return undefined;
+
+  const toByte = (v: number) =>
+    Math.max(0, Math.min(255, Math.round(v * 255)));
+
+  if (matte.length === 3 && srcType === "RGB") {
+    return [
+      toByte(matte.get(0).asNumber()),
+      toByte(matte.get(1).asNumber()),
+      toByte(matte.get(2).asNumber()),
+    ];
+  }
+  if (matte.length === 1 && srcType === "Gray") {
+    const g = toByte(matte.get(0).asNumber());
+    return [g, g, g];
+  }
+  return undefined;
 }
 
 /** Returns true if every pixel in the RGBA PNG is fully transparent (alpha === 0). */
@@ -654,30 +753,36 @@ function extractRasterImagesFromPdf(
         // filter decoding, so we must not treat those as raw JPEG bytes.
         const isSingleFilter = filterNames.length === 1;
 
-        if (filterName === "DCTDecode" && isSingleFilter) {
-          // Check colorspace — CMYK JPEGs need conversion (browsers can't display them)
-          const cs = resolved.get("ColorSpace");
-          const isCmyk =
-            (!cs.isNull() && cs.isName() && cs.asName() === "DeviceCMYK") ||
-            (!cs.isNull() && cs.isArray() && cs.get(0).asName() === "ICCBased" &&
-              cs.get(1).resolve().get("N").asNumber() === 4);
+        const image = doc.loadImage(streamObj);
+        const softMask = image.getMask();
+        const srcType = image.getColorSpace()?.getType();
+        const canRawExtract =
+          softMask === null &&
+          filterName === "DCTDecode" &&
+          isSingleFilter &&
+          (srcType === "RGB" || srcType === "Gray");
 
-          if (isCmyk) {
-            // CMYK JPEG: decode through mupdf for color conversion → re-encode as JPEG
-            const image = doc.loadImage(streamObj);
-            const pixmap = image.toPixmap();
-            buf = Buffer.from(pixmap.asJPEG(90, true));
-            format = "jpeg";
-          } else {
-            // RGB/Gray JPEG: extract raw bytes directly
-            buf = Buffer.from(streamObj.readRawStream().asUint8Array());
-            format = "jpeg";
-          }
+        if (canRawExtract) {
+          // Fast path: RGB/Gray JPEG with no transparency — copy bytes as-is.
+          buf = Buffer.from(streamObj.readRawStream().asUint8Array());
+          format = "jpeg";
+        } else if (softMask !== null) {
+          // Must be PNG to preserve the alpha we recover from the SMask.
+          const matteRgb = readSoftMaskMatte(resolved, srcType);
+          const composed = composeWithSoftMask(
+            image.toPixmap(),
+            softMask.toPixmap(),
+            matteRgb
+          );
+          buf = Buffer.from(composed.asPNG());
+          format = "png";
+        } else if (filterName === "DCTDecode" && isSingleFilter) {
+          // Single-filter JPEG with non-displayable colorspace (CMYK, Lab, etc.)
+          buf = Buffer.from(normalizeToDisplayableRgb(image.toPixmap()).asJPEG(90, false));
+          format = "jpeg";
         } else {
-          // Multi-filter chains or non-JPEG: decode through mupdf → PNG
-          const image = doc.loadImage(streamObj);
-          const pixmap = image.toPixmap();
-          buf = Buffer.from(pixmap.asPNG());
+          // Multi-filter chains or non-JPEG: PNG can't encode CMYK/Lab/etc.
+          buf = Buffer.from(normalizeToDisplayableRgb(image.toPixmap()).asPNG());
           format = "png";
         }
 


### PR DESCRIPTION
## Summary
- CMYK JPEGs now decode through mupdf and re-encode as RGB so browsers can render them; raw extraction is reserved for single-filter RGB/Gray DCT streams with no soft mask.
- Images with an `/SMask` are composed with their alpha into an RGBA PNG instead of arriving opaque, with `/Matte` un-matting applied when the SMask carries a matte color (handles RGB-3 and Gray-1; CMYK falls through unchanged).
- Added unit tests covering CMYK JPEG conversion, plain SMask alpha recovery, and matted SMask un-matting; updated three raven.pdf hashes that legitimately changed under the new pipeline.

## Test plan
- [x] `pnpm vitest run packages/pdf/src/__tests__/extract.test.ts` — 32 passing
- [x] `pnpm vitest run packages/pdf/src/__tests__/extract-raven.test.ts` — 12 passing
- [x] `pnpm typecheck`