### PR TITLE
[Wizard] adjust PDF preview card layout for better grid alignment

### DIFF
--- a/apps/studio/src/components/wizard/stepUpload/index.tsx
+++ b/apps/studio/src/components/wizard/stepUpload/index.tsx
@@ -57,8 +57,8 @@ function PdfPreviewCard({
   const displayTitle = suggestLabel(file) || file.name
 
   return (
-    <div className={cn("w-full max-w-2xl border border-slate-200 rounded-lg overflow-hidden grid grid-cols-[2fr_1fr] bg-white", CARD_HEIGHT)}>
-      <div className="flex flex-col">
+    <div className={cn("w-full max-w-2xl border border-slate-200 rounded-lg overflow-hidden grid grid-cols-3 bg-white", CARD_HEIGHT)}>
+      <div className="flex flex-col col-span-2">
         <div className="px-5 pt-5 pb-3 space-y-1">
           <p className="font-semibold text-lg leading-snug line-clamp-2 text-slate-900">
             {displayTitle}


### PR DESCRIPTION
## Summary
- Fix book cover thumbnail being hidden in the PDF upload preview card when the title or authors text is long
- The card used `grid-cols-[2fr_1fr]` which allowed the left column to overflow and obscure the right column; replacing with `grid-cols-3` + `col-span-2` enforces strict column boundaries so the cover is always visible


| Before | After |
|--------|-------|
| <img width="960" alt="before" src="https://github.com/user-attachments/assets/a2e4c9c4-ff2b-40bc-a958-f2863035db7f" /> | <img width="960" alt="after" src="https://github.com/user-attachments/assets/28e6d733-332e-4ad0-b589-2e32311e832d" /> | 