### PR TITLE
fix(electron): fix image replacement and AI image generation in desktop

### DIFF
--- a/packages/llm/src/__tests__/image.test.ts
+++ b/packages/llm/src/__tests__/image.test.ts
@@ -3,29 +3,6 @@ import os from "node:os"
 import path from "node:path"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
-const {
-  experimentalGenerateImage,
-  openaiImage,
-  createOpenAI,
-} = vi.hoisted(() => {
-  const experimentalGenerateImage = vi.fn()
-  const openaiImage = vi.fn((modelId: string) => ({ modelId }))
-  const createOpenAI = vi.fn(() => ({ image: openaiImage }))
-  return {
-    experimentalGenerateImage,
-    openaiImage,
-    createOpenAI,
-  }
-})
-
-vi.mock("ai", () => ({
-  experimental_generateImage: experimentalGenerateImage,
-}))
-
-vi.mock("@ai-sdk/openai", () => ({
-  createOpenAI,
-}))
-
 import { generateImageWithCache } from "../image.js"
 
 describe("generateImageWithCache", () => {
@@ -34,9 +11,6 @@ describe("generateImageWithCache", () => {
 
   beforeEach(() => {
     cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), "adt-image-cache-"))
-    experimentalGenerateImage.mockReset()
-    openaiImage.mockClear()
-    createOpenAI.mockClear()
     fetchMock.mockReset()
     vi.stubGlobal("fetch", fetchMock)
   })
@@ -47,12 +21,14 @@ describe("generateImageWithCache", () => {
   })
 
   it("caches generation results for identical prompts", async () => {
-    experimentalGenerateImage.mockResolvedValue({
-      image: {
-        base64: Buffer.from("generated").toString("base64"),
-        mimeType: "image/png",
-      },
-    })
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: [{ b64_json: Buffer.from("generated").toString("base64") }],
+        }),
+        { status: 200 }
+      )
+    )
 
     const first = await generateImageWithCache({
       apiKey: "sk-test",
@@ -73,8 +49,32 @@ describe("generateImageWithCache", () => {
     expect(first.cached).toBe(false)
     expect(second.cached).toBe(true)
     expect(second.base64).toBe(first.base64)
-    expect(experimentalGenerateImage).toHaveBeenCalledTimes(1)
-    expect(openaiImage).toHaveBeenCalledWith("gpt-image-1.5")
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("https://api.openai.com/v1/images/generations")
+  })
+
+  it("does not send response_format to /images/generations", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: [{ b64_json: Buffer.from("generated").toString("base64") }],
+        }),
+        { status: 200 }
+      )
+    )
+
+    await generateImageWithCache({
+      apiKey: "sk-test",
+      modelId: "openai:gpt-image-2",
+      prompt: "a bright diagram",
+      size: "1024x1024",
+    })
+
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit
+    const body = JSON.parse(init.body as string) as Record<string, unknown>
+    expect(body).not.toHaveProperty("response_format")
+    expect(body.model).toBe("gpt-image-2")
+    expect(body.output_format).toBe("png")
   })
 
   it("uses the image edits endpoint when reference images are provided", async () => {
@@ -103,6 +103,5 @@ describe("generateImageWithCache", () => {
     expect(result.mimeType).toBe("image/png")
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock.mock.calls[0]?.[0]).toBe("https://api.openai.com/v1/images/edits")
-    expect(experimentalGenerateImage).not.toHaveBeenCalled()
   })
 })

--- a/packages/llm/src/image.ts
+++ b/packages/llm/src/image.ts
@@ -1,6 +1,4 @@
 import { randomUUID } from "node:crypto"
-import { experimental_generateImage } from "ai"
-import { createOpenAI } from "@ai-sdk/openai"
 import { computeHash, readCache, writeCache } from "./cache.js"
 import { sanitizeMessages, type LlmLogEntry } from "./log.js"
 import { createLogger, type LogLevel } from "./logger.js"
@@ -182,6 +180,44 @@ function buildMessages(
   ]
 }
 
+// Direct fetch instead of @ai-sdk/openai for the generations endpoint: that SDK
+// auto-injects `response_format: "b64_json"` for any model not in its hardcoded
+// `hasDefaultResponseFormat` set (currently just "gpt-image-1"), and the OpenAI
+// API rejects that parameter for newer gpt-image-* variants —
+// "Unknown parameter: 'response_format'".
+async function callOpenAiImageApi(options: {
+  apiKey: string
+  endpoint: "generations" | "edits"
+  body: string | FormData
+  jsonBody?: boolean
+  abortSignal?: AbortSignal
+}): Promise<CachedImageResult> {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${options.apiKey}`,
+  }
+  if (options.jsonBody) headers["Content-Type"] = "application/json"
+
+  const response = await fetch(`https://api.openai.com/v1/images/${options.endpoint}`, {
+    method: "POST",
+    headers,
+    body: options.body,
+    signal: options.abortSignal,
+  })
+
+  const text = await response.text()
+  if (!response.ok) {
+    throw new Error(parseOpenAiError(text, response.status))
+  }
+
+  const data = JSON.parse(text) as { data?: Array<{ b64_json?: string }> }
+  const base64 = data.data?.[0]?.b64_json
+  if (!base64) {
+    throw new Error("No image data returned from OpenAI")
+  }
+
+  return { base64, mimeType: "image/png" }
+}
+
 async function generateFreshImage(options: {
   apiKey: string
   modelId: string
@@ -189,23 +225,20 @@ async function generateFreshImage(options: {
   size?: `${number}x${number}`
   abortSignal?: AbortSignal
 }): Promise<CachedImageResult> {
-  const provider = createOpenAI({ apiKey: options.apiKey })
-  const result = await experimental_generateImage({
-    model: provider.image(options.modelId),
+  const body: Record<string, unknown> = {
+    model: options.modelId,
     prompt: options.prompt,
-    size: options.size,
-    abortSignal: options.abortSignal,
-    providerOptions: {
-      openai: {
-        output_format: "png",
-      },
-    },
-  })
-
-  return {
-    base64: result.image.base64,
-    mimeType: result.image.mimeType,
+    output_format: "png",
   }
+  if (options.size) body.size = options.size
+
+  return callOpenAiImageApi({
+    apiKey: options.apiKey,
+    endpoint: "generations",
+    body: JSON.stringify(body),
+    jsonBody: true,
+    abortSignal: options.abortSignal,
+  })
 }
 
 async function editImage(options: {
@@ -219,9 +252,7 @@ async function editImage(options: {
   const formData = new FormData()
   formData.append("model", options.modelId)
   formData.append("prompt", options.prompt)
-  if (options.size) {
-    formData.append("size", options.size)
-  }
+  if (options.size) formData.append("size", options.size)
   formData.append("output_format", "png")
 
   for (const [index, image] of options.referenceImages.entries()) {
@@ -232,34 +263,12 @@ async function editImage(options: {
     )
   }
 
-  const response = await fetch("https://api.openai.com/v1/images/edits", {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${options.apiKey}`,
-    },
+  return callOpenAiImageApi({
+    apiKey: options.apiKey,
+    endpoint: "edits",
     body: formData,
-    signal: options.abortSignal,
+    abortSignal: options.abortSignal,
   })
-
-  const body = await response.text()
-  if (!response.ok) {
-    throw new Error(parseOpenAiError(body, response.status))
-  }
-
-  const data = JSON.parse(body) as {
-    data?: Array<{
-      b64_json?: string
-    }>
-  }
-  const base64 = data.data?.[0]?.b64_json
-  if (!base64) {
-    throw new Error("No image data returned from OpenAI")
-  }
-
-  return {
-    base64,
-    mimeType: "image/png",
-  }
 }
 
 function emitLog(options: {


### PR DESCRIPTION
## Summary

- **AI image generation fails with "Unknown parameter: 'response_format'"**: `@ai-sdk/openai` injects `response_format: "b64_json"` for any model not in its hardcoded `hasDefaultResponseFormat` set (currently only `"gpt-image-1"`), and the OpenAI API rejects that parameter for `gpt-image-2` and other newer variants. Fixed by bypassing the SDK entirely and using raw `fetch` to `/v1/images/generations`.

- **Refactor**: Extracted `callOpenAiImageApi` as a shared helper used by both `generateFreshImage` and `editImage`, removing the duplicated fetch/auth/error-parsing logic.
