### PR TITLE
fix(storyboard): close element popup on outside click

### DIFF
--- a/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
@@ -509,10 +509,23 @@ export function StoryboardSectionDetail({
   const [selectedElementClasses, setSelectedElementClasses] = useState<string[] | null>(null)
   const previewFrameRef = useRef<BookPreviewFrameHandle>(null)
   const scrollContainerRef = useRef<HTMLDivElement>(null)
+  const toolbarRef = useRef<HTMLDivElement>(null)
 
   // Clear cached classes when element is deselected
   useEffect(() => {
     if (!selectedElement) setSelectedElementClasses(null)
+  }, [selectedElement])
+
+  // Close toolbar when clicking outside of it
+  useEffect(() => {
+    if (!selectedElement) return
+    const handler = (e: MouseEvent) => {
+      if (toolbarRef.current && !toolbarRef.current.contains(e.target as Node)) {
+        setSelectedElement(null)
+      }
+    }
+    document.addEventListener("mousedown", handler)
+    return () => document.removeEventListener("mousedown", handler)
   }, [selectedElement])
 
   // Track current pageId so async callbacks can detect stale closures
@@ -2235,6 +2248,7 @@ export function StoryboardSectionDetail({
 
       {/* Floating popover for selected element */}
       {selectedElement && selectedInfo && (
+        <div ref={toolbarRef}>
         <SectionEditToolbar
           dataId={selectedElement.dataId}
           rect={selectedElement.rect}
@@ -2259,6 +2273,7 @@ export function StoryboardSectionDetail({
           elementClasses={selectedElementClasses ?? undefined}
           onClassesChange={handleClassesChange}
         />
+        </div>
       )}
 
       {/* Slide-out section data panel */}


### PR DESCRIPTION
## Summary

- The floating `SectionEditToolbar` popup remained visible when the user clicked the Edit button to open `SectionEditPanel`, because clicking Edit only set `panelOpen = true` without clearing `selectedElement`
- The toolbar sits at `z-50` while the panel is `z-30`, so the popup overlaid the panel
- Added a `mousedown` listener on `document` (active only while an element is selected) that clears `selectedElement` whenever the user clicks outside the toolbar container — the same pattern already used for the crop/replace dropdown menus inside the toolbar

## Test plan

- [ ] Click an element in the storyboard preview → toolbar appears
- [ ] Click the "Edit" button → toolbar disappears and the edit panel slides open cleanly
- [ ] Click an element → click anywhere else on the page outside the toolbar → toolbar closes
- [ ] Click an element → interact with toolbar buttons (prune, crop menu, etc.) → toolbar stays open

Fixes #396