### PR TITLE
fix(studio): prevent a11y preview pill from overlapping TTS button

### DIFF
--- a/apps/studio/src/components/pipeline/stages/PreviewAccessibilityCard.tsx
+++ b/apps/studio/src/components/pipeline/stages/PreviewAccessibilityCard.tsx
@@ -11,6 +11,7 @@ import {
   CircleHelp,
   FileWarning,
   Loader2,
+  X,
 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { AccessibilityCurrentPagePanel } from "@/components/accessibility/AccessibilityCurrentPagePanel"
@@ -108,14 +109,23 @@ export function PreviewAccessibilityCard({
 }: PreviewAccessibilityCardProps) {
   const { t, i18n } = useLingui()
   const storageKey = `adt-preview-a11y-card:${label}`
+  const minifiedStorageKey = `adt-preview-a11y-card-minified:${label}`
   const [collapsed, setCollapsed] = useState<boolean>(() => {
     if (typeof window === "undefined") {
       return true
     }
     return window.sessionStorage.getItem(storageKey) !== "expanded"
   })
-  const [showCollapsedCard, setShowCollapsedCard] = useState(() => collapsed && !panelOpen)
-  const [collapsedCardVisible, setCollapsedCardVisible] = useState(() => collapsed && !panelOpen)
+  const [minified, setMinified] = useState<boolean>(() => {
+    if (typeof window === "undefined") {
+      return false
+    }
+    return window.sessionStorage.getItem(minifiedStorageKey) === "minified"
+  })
+  const [showCollapsedCard, setShowCollapsedCard] = useState(() => collapsed && !panelOpen && !minified)
+  const [collapsedCardVisible, setCollapsedCardVisible] = useState(() => collapsed && !panelOpen && !minified)
+  const [showMiniIcon, setShowMiniIcon] = useState(() => collapsed && !panelOpen && minified)
+  const [miniIconVisible, setMiniIconVisible] = useState(() => collapsed && !panelOpen && minified)
 
   useEffect(() => {
     if (typeof window === "undefined") {
@@ -123,6 +133,19 @@ export function PreviewAccessibilityCard({
     }
     window.sessionStorage.setItem(storageKey, collapsed ? "collapsed" : "expanded")
   }, [collapsed, storageKey])
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return
+    }
+    window.sessionStorage.setItem(minifiedStorageKey, minified ? "minified" : "expanded")
+  }, [minified, minifiedStorageKey])
+
+  useEffect(() => {
+    if (!collapsed) {
+      setMinified(false)
+    }
+  }, [collapsed])
 
   useEffect(() => {
     if (panelOpen) {
@@ -135,10 +158,18 @@ export function PreviewAccessibilityCard({
   }, [collapsed, onExpandedChange])
 
   useEffect(() => {
-    if (!collapsed || panelOpen || otherCardExpanded) {
+    if (!collapsed || panelOpen || otherCardExpanded || minified) {
       setCollapsedCardVisible(false)
-      setShowCollapsedCard(false)
-      return
+      if (typeof window === "undefined") {
+        setShowCollapsedCard(false)
+        return
+      }
+      const unmountId = window.setTimeout(() => {
+        setShowCollapsedCard(false)
+      }, 200)
+      return () => {
+        window.clearTimeout(unmountId)
+      }
     }
 
     if (typeof window === "undefined") {
@@ -157,7 +188,40 @@ export function PreviewAccessibilityCard({
     return () => {
       window.clearTimeout(timeoutId)
     }
-  }, [collapsed, otherCardExpanded, panelOpen])
+  }, [collapsed, otherCardExpanded, panelOpen, minified])
+
+  useEffect(() => {
+    if (!collapsed || panelOpen || !minified) {
+      setMiniIconVisible(false)
+      if (typeof window === "undefined") {
+        setShowMiniIcon(false)
+        return
+      }
+      const unmountId = window.setTimeout(() => {
+        setShowMiniIcon(false)
+      }, 200)
+      return () => {
+        window.clearTimeout(unmountId)
+      }
+    }
+
+    if (typeof window === "undefined") {
+      setShowMiniIcon(true)
+      setMiniIconVisible(true)
+      return
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setShowMiniIcon(true)
+      window.requestAnimationFrame(() => {
+        setMiniIconVisible(true)
+      })
+    }, 140)
+
+    return () => {
+      window.clearTimeout(timeoutId)
+    }
+  }, [collapsed, minified, panelOpen])
 
   const violationCount = assessment?.summary.violationCount ?? 0
   const incompleteCount = assessment?.summary.incompleteCount ?? 0
@@ -185,40 +249,82 @@ export function PreviewAccessibilityCard({
       : null
 
   if (collapsed) {
-    if (!showCollapsedCard) {
+    if (!showCollapsedCard && !showMiniIcon) {
       return null
     }
 
     return (
-      <button
-        type="button"
-        className={cn(
-          "fixed bottom-4 right-14 z-40 flex w-[min(22.5rem,calc(100vw-2rem))] items-start gap-3 rounded-2xl border bg-background/95 px-3.5 py-3 text-left shadow-md backdrop-blur-sm transition-all duration-150 ease-out supports-[backdrop-filter]:bg-background/90",
-          collapsedCardVisible ? "translate-y-0 opacity-100" : "pointer-events-none translate-y-1 opacity-0",
-        )}
-        onClick={() => setCollapsed(false)}
-        title={t`Show accessibility summary`}
-      >
-        <div className="mt-0.5 shrink-0">
-          <StatusIcon
-            isLoading={isLoading}
-            error={error}
-            violationCount={violationCount}
-            incompleteCount={incompleteCount}
-            collapsed
-          />
-        </div>
-
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center justify-between gap-3 text-sm">
-            <span className="font-medium"><Trans>Accessibility</Trans></span>
-            {overallSummary ? <span className="shrink-0 text-[11px] text-muted-foreground">{overallSummary}</span> : null}
+      <>
+        {showMiniIcon ? (
+          <button
+            type="button"
+            className={cn(
+              "fixed bottom-4 right-20 z-40 flex h-9 w-9 origin-center items-center justify-center rounded-full border bg-background/95 shadow-md backdrop-blur-sm transition-all duration-200 ease-out hover:bg-background supports-[backdrop-filter]:bg-background/90",
+              miniIconVisible ? "scale-100 opacity-100 hover:scale-110" : "pointer-events-none scale-50 opacity-0",
+            )}
+            onClick={() => setMinified(false)}
+            title={t`Show accessibility summary`}
+          >
+            <StatusIcon
+              isLoading={isLoading}
+              error={error}
+              violationCount={violationCount}
+              incompleteCount={incompleteCount}
+              collapsed
+            />
+          </button>
+        ) : null}
+        {showCollapsedCard ? (
+          <div
+            className={cn(
+              "fixed bottom-4 right-20 z-40 flex w-[min(22.5rem,calc(100vw-2rem))] origin-bottom-right items-start gap-2 rounded-2xl border bg-background/95 py-3 pl-3.5 pr-2 shadow-md backdrop-blur-sm transition-all duration-200 ease-out supports-[backdrop-filter]:bg-background/90",
+              collapsedCardVisible
+                ? "translate-y-0 scale-100 opacity-100"
+                : "pointer-events-none translate-y-1 scale-90 opacity-0",
+            )}
+          >
+        <button
+          type="button"
+          className="flex min-w-0 flex-1 items-start gap-3 text-left"
+          onClick={() => setCollapsed(false)}
+          title={t`Show accessibility summary`}
+        >
+          <div className="mt-0.5 shrink-0">
+            <StatusIcon
+              isLoading={isLoading}
+              error={error}
+              violationCount={violationCount}
+              incompleteCount={incompleteCount}
+              collapsed
+            />
           </div>
-          <div className="mt-1 text-[11px] leading-relaxed text-muted-foreground">{pageSummary}</div>
-        </div>
 
-        <ChevronRight className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-      </button>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center justify-between gap-3 text-sm">
+              <span className="font-medium"><Trans>Accessibility</Trans></span>
+              {overallSummary ? <span className="shrink-0 text-[11px] text-muted-foreground">{overallSummary}</span> : null}
+            </div>
+            <div className="mt-1 text-[11px] leading-relaxed text-muted-foreground">{pageSummary}</div>
+          </div>
+
+          <ChevronRight className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        </button>
+
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-6 w-6 shrink-0 rounded-full text-muted-foreground transition-colors duration-150 ease-out hover:text-foreground"
+              onClick={(event) => {
+                event.stopPropagation()
+                setMinified(true)
+              }}
+              title={t`Minimize accessibility summary`}
+            >
+              <X className="h-3.5 w-3.5" />
+            </Button>
+          </div>
+        ) : null}
+      </>
     )
   }
 

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -2582,6 +2582,9 @@ msgstr "Min Size (px)"
 msgid "Minimize"
 msgstr "Minimize"
 
+msgid "Minimize accessibility summary"
+msgstr "Minimize accessibility summary"
+
 msgid "Minimum image dimension"
 msgstr "Minimum image dimension"
 

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -2582,6 +2582,9 @@ msgstr "Tamaño Mín (px)"
 msgid "Minimize"
 msgstr "Minimizar"
 
+msgid "Minimize accessibility summary"
+msgstr "Minimizar resumen de accesibilidad"
+
 msgid "Minimum image dimension"
 msgstr "Dimensión mínima de imagen"
 

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -2583,6 +2583,9 @@ msgstr "Taille min (px)"
 msgid "Minimize"
 msgstr "Réduire"
 
+msgid "Minimize accessibility summary"
+msgstr "Réduire le résumé d'accessibilité"
+
 msgid "Minimum image dimension"
 msgstr "Dimension minimale d'image"
 

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -2582,6 +2582,9 @@ msgstr "Tamanho Mín (px)"
 msgid "Minimize"
 msgstr "Minimizar"
 
+msgid "Minimize accessibility summary"
+msgstr "Minimizar resumo de acessibilidade"
+
 msgid "Minimum image dimension"
 msgstr "Dimensão mínima da imagem"
 


### PR DESCRIPTION
## Summary

The accessibility alert pill in the Preview step (`PreviewAccessibilityCard`) was overlapping the TTS quick-toggle button rendered inside the preview iframe. The pill anchored at `fixed bottom-4 right-14` placed its right edge at 3.5rem from the viewport edge, which falls inside the TTS button's horizontal band (right 1–4rem), so the two collided in the bottom-right corner and the pill obscured the TTS control.

## Changes

- Moved the collapsed pill to `right-20`, putting a 1rem horizontal gap between it and the TTS button column
- Added a minimize affordance: an `X` button on the pill shrinks it into a small circular status-icon button at the same anchor; clicking the icon brings the pill back. State persists per-book in `sessionStorage` and resets when the full card is opened
- Added smooth scale + opacity cross-morph between the pill and the mini icon (200ms, anchored at the pill's bottom-right corner / icon center) so the grow/shrink feels continuous

## Test plan

- [ ] Pill no longer overlaps the TTS button on the Preview step
- [ ] Clicking X smoothly shrinks the pill into the mini icon
- [ ] Clicking the mini icon smoothly grows it back
- [ ] Clicking the pill body still opens the full accessibility card
- [ ] Minimized state persists across reload within the session
- [ ] Opening then collapsing the full card clears the minimized flag (pill reappears)