### PR TITLE
fix(adt): persist book settings across pages on file://

### DIFF
--- a/assets/adt/modules/cookies.js
+++ b/assets/adt/modules/cookies.js
@@ -1,11 +1,37 @@
+const STORAGE_NAMESPACE = (() => {
+   try {
+      return window.location.pathname.substring(0, window.location.pathname.lastIndexOf("/") + 1);
+   } catch {
+      return "/";
+   }
+})();
+
+const lsKey = (name) => `${STORAGE_NAMESPACE}${name}`;
+
+const lsSet = (name, value) => {
+   try { window.localStorage.setItem(lsKey(name), String(value || "")); } catch {}
+};
+
+const lsGet = (name) => {
+   try { return window.localStorage.getItem(lsKey(name)); } catch { return null; }
+};
+
+const lsRemove = (name) => {
+   try { window.localStorage.removeItem(lsKey(name)); } catch {}
+};
+
 /**
  * Sets a cookie with the given name, value, expiration (in days), and path.
+ * Also mirrors the value to localStorage (namespaced by the current path) so
+ * settings persist when the package is opened directly via file:// where
+ * cookies are blocked or scoped per-file.
  * @param {string} name - The name of the cookie.
  * @param {string} value - The value to store.
  * @param {number} [days=7] - Number of days until the cookie expires.
  * @param {string} [path="/"] - The path where the cookie is valid.
  */
 export const setCookie = (name, value, days = 7, path = "/") => {
+   lsSet(name, value);
    let expires = "";
    if (days) {
       const date = new Date();
@@ -16,11 +42,14 @@ export const setCookie = (name, value, days = 7, path = "/") => {
 };
 
 /**
- * Retrieves the value of a cookie by name.
+ * Retrieves the value of a cookie by name. Reads from localStorage first
+ * (works on file://) and falls back to document.cookie.
  * @param {string} name - The name of the cookie to retrieve.
  * @returns {string|null} The cookie value, or null if not found.
  */
 export const getCookie = (name) => {
+   const fromLS = lsGet(name);
+   if (fromLS !== null) return fromLS;
    const nameEQ = name + "=";
    const ca = document.cookie.split(";");
    for (let i = 0; i < ca.length; i++) {
@@ -32,10 +61,11 @@ export const getCookie = (name) => {
 };
 
 /**
- * Erases a cookie by name and path.
+ * Erases a cookie by name and path. Also clears the mirrored localStorage entry.
  * @param {string} name - The name of the cookie to erase.
  * @param {string} [path="/"] - The path where the cookie is valid.
  */
 export const eraseCookie = (name, path = "/") => {
+   lsRemove(name);
    document.cookie = name + "=; Max-Age=-99999999; path=" + path;
 };

--- a/assets/adt/modules/interface.js
+++ b/assets/adt/modules/interface.js
@@ -435,11 +435,6 @@ export const switchLanguage = async () => {
     // Update language state
     setState("currentLanguage", dropdown.value);
 
-    // Persist language choice. In webpub/EPUB mode, cookies don't persist across
-    // page navigations so also write to localStorage. On the web, only use cookies
-    // (scoped by basePath) to avoid cross-book conflicts on the same origin.
-    const isWebpub = window.appConfig?.features?.showNavigationControls === false;
-    if (isWebpub) localStorage.setItem("currentLanguage", state.currentLanguage);
     const basePath = window.location.pathname.substring(
       0,
       window.location.pathname.lastIndexOf("/") + 1


### PR DESCRIPTION
Closes #394
Closes #293

## Summary

Settings in the exported ADT book (language, TTS, glossary, sign language, easy-read, audio speed, etc.) reset on every page navigation when the package is opened directly from disk (double-clicking `index.html`, EPUB readers, or any `file://` context).

### Root cause

Settings are persisted via `document.cookie` in `assets/adt/modules/cookies.js`. Modern browsers block or per-file-scope cookies on `file://` URLs, so each navigation loads with empty cookies and falls back to defaults.

This isn't a new regression — it's a pre-existing limitation that only became visible now that the exported package can be opened by just clicking `index.html`. Previously a local HTTP server was required for the navigation JS to work, and cookies persist fine over HTTP, which is why the bug never surfaced.

The team had already partially worked around this for a single setting (`currentLanguage` in webpub mode wrote to `localStorage` as a fallback), but the workaround was never extended to TTS, glossary, sign language, or other toggles.

## Changes

- `assets/adt/modules/cookies.js` — `setCookie` / `getCookie` / `eraseCookie` now mirror to and read from `localStorage` (namespaced by the page's basePath, so multiple books on the same origin don't clobber each other). Cookie behavior is unchanged; localStorage is added as a fallback that survives `file://`.
- `assets/adt/modules/interface.js` — removed the now-redundant `isWebpub`-only `localStorage.setItem("currentLanguage", ...)` workaround.

## Why this is a temporary fix

This unblocks tomorrow's presentation by making every existing setting persist correctly on `file://` without touching call sites. It keeps cookies in place alongside localStorage to preserve any existing hosted-deployment behavior.

## Follow-up

The file is still called `cookies.js` and exports `setCookie` / `getCookie`, but the implementation is now primarily a localStorage wrapper with cookies as a secondary mirror. We should follow up with a proper rename / refactor — likely `storage.js` with `setItem` / `getItem`, dropping cookies entirely if no hosted deployment depends on them — and update all call sites in one pass. Out of scope for this PR.

## Test plan

- [ ] Export a book to ADT format
- [ ] Open exported `index.html` directly (`file://`) — verify language, TTS, glossary, sign-language toggles persist when navigating between pages
- [ ] Serve the exported book over HTTP (e.g. `python -m http.server`) — verify same persistence still works
- [ ] Preview stage in Studio still works (no regression on the iframe-served path)
- [ ] Existing users with cookies set get their values seeded into localStorage on first read (no preference loss after upgrade)
