### PR TITLE
fix(desktop): add zip target for macOS to enable auto-update

### DIFF
--- a/apps/desktop/electron-builder.js
+++ b/apps/desktop/electron-builder.js
@@ -62,7 +62,7 @@ const config = {
     allowToChangeInstallationDirectory: true,
   },
   mac: {
-    target: ["dmg"],
+    target: ["dmg", "zip"],
     icon: "build/icon.icns",
     category: "public.app-category.developer-tools",
     type: "distribution",


### PR DESCRIPTION
## Summary

Adds `zip` to the macOS targets in `electron-builder.js` so each release publishes both `.dmg` and `.zip` artifacts.

## Why

`electron-updater` cannot apply macOS updates from a `.dmg` — it requires a `.zip` of the `.app` bundle. With only the DMG published, `latest-mac.yml` listed a single DMG entry and the in-app updater failed with:

```
ZIP file not provided: [{ url: "adt-studio-<version>.dmg", ... }]
```

Adding the `zip` target makes electron-builder generate the ZIP (plus blockmap for differential downloads) and emit a `latest-mac.yml` that references the ZIP under `path:` and as the first entry in `files:`, which is what the updater expects.

## Test plan

- [ ] `pnpm --filter @adt/desktop build:mac` produces `adt-studio-<version>.dmg`, `adt-studio-<version>-arm64-mac.zip`, and matching `.blockmap` files in `apps/desktop/release/`
- [ ] Generated `latest-mac.yml` lists the ZIP (not the DMG) under `path:`
- [ ] Cut a release with the new artifacts uploaded and verify auto-update from a previous version completes end-to-end on macOS