### PR TITLE
fix(studio): translate Convert PDF wizard step

### DIFF
--- a/apps/studio/src/components/wizard/stepUpload/index.tsx
+++ b/apps/studio/src/components/wizard/stepUpload/index.tsx
@@ -1,7 +1,7 @@
-/* eslint-disable lingui/no-unlocalized-strings -- wizard strings are finalized later */
 import { useCallback, useEffect, useRef, useState } from "react"
 import { useNavigate } from "@tanstack/react-router"
 import { useStore } from "@tanstack/react-form"
+import { Trans, useLingui } from "@lingui/react/macro"
 import {
   ArrowLeft,
   ArrowRight,
@@ -47,6 +47,7 @@ function PdfPreviewCard({
   pageCount: number
   onReplace: () => void
 }) {
+  const { t } = useLingui()
   const { pages, isLoading } = usePdfPreviewPages({
     file,
     mode: "first",
@@ -70,13 +71,13 @@ function PdfPreviewCard({
 
         <div className="px-5 pb-4">
           <p className="text-[10px] font-semibold uppercase tracking-wider text-slate-400 mb-2">
-            PDF info
+            <Trans>PDF info</Trans>
           </p>
           <div className="space-y-2 text-xs text-slate-500">
             <div className="flex items-center gap-2">
               <FileText className="w-3.5 h-3.5 text-slate-400 shrink-0" />
               <span>
-                {pageCount} {pageCount === 1 ? "page" : "pages"}
+                {t`${pageCount} {pageCount, plural, one {page} other {pages}}`}
               </span>
             </div>
           </div>
@@ -91,7 +92,7 @@ function PdfPreviewCard({
             className="h-8 px-3 text-xs"
           >
             <Upload className="h-3.5 w-3.5 mr-1.5" />
-            Replace PDF
+            <Trans>Replace PDF</Trans>
           </Button>
         </div>
       </div>
@@ -118,6 +119,7 @@ function PdfPreviewCard({
 }
 
 export function StepUpload() {
+  const { t } = useLingui()
   const navigate = useNavigate()
   const { setPhase, stepDirection } = useWizard()
   const form = useWizardForm()
@@ -183,7 +185,7 @@ export function StepUpload() {
       } catch {
         if (cancelled) return
         setPreviewError(
-          "Could not read this PDF. The file may be corrupted or password-protected.",
+          t`Could not read this PDF. The file may be corrupted or password-protected.`,
         )
       } finally {
         if (!cancelled) setPreviewLoading(false)
@@ -241,11 +243,11 @@ export function StepUpload() {
 
   return (
     <div className="flex flex-1 min-h-0 flex-col h-full bg-white">
-      <StudioTopBar brandLinksHome trailingTitle="Add Book" />
+      <StudioTopBar brandLinksHome trailingTitle={t`Add Book`} />
       <FileDropOverlay
         overlay={overlay}
-        dropLabel="Drop PDF here"
-        errorLabel="Only PDF files are supported"
+        dropLabel={<Trans>Drop PDF here</Trans>}
+        errorLabel={<Trans>Only PDF files are supported</Trans>}
         accent="blue"
       />
 
@@ -259,7 +261,7 @@ export function StepUpload() {
       >
         <div className="flex flex-col items-center gap-1">
           <h1 className="text-2xl sm:text-[30px] font-semibold leading-tight sm:leading-9 tracking-[-0.75px] text-[#030303] text-center">
-            Convert a PDF
+            <Trans>Convert a PDF</Trans>
           </h1>
           <div className="max-w-xl grid [&>*]:col-start-1 [&>*]:row-start-1">
             <p
@@ -268,8 +270,10 @@ export function StepUpload() {
                 showPreview ? "opacity-0 pointer-events-none" : "opacity-100",
               )}
             >
-              Upload the source PDF of your book and we&apos;ll turn it into an Accessible
-              Digital Textbook with interactive activities and adaptive layouts.
+              <Trans>
+                Upload the source PDF of your book and we'll turn it into an Accessible
+                Digital Textbook with interactive activities and adaptive layouts.
+              </Trans>
             </p>
             <p
               className={cn(
@@ -277,8 +281,10 @@ export function StepUpload() {
                 showPreview ? "opacity-100" : "opacity-0 pointer-events-none",
               )}
             >
-              Review the source PDF details below and continue to configure how your book
-              will be converted into an Accessible Digital Textbook.
+              <Trans>
+                Review the source PDF details below and continue to configure how your book
+                will be converted into an Accessible Digital Textbook.
+              </Trans>
             </p>
           </div>
         </div>
@@ -305,7 +311,7 @@ export function StepUpload() {
                 <AlertCircle className="w-4 h-4 text-red-500 shrink-0 mt-0.5" />
                 <div className="flex-1 min-w-0">
                   <p className="text-sm font-medium text-red-700">
-                    Couldn&apos;t read this PDF
+                    <Trans>Couldn't read this PDF</Trans>
                   </p>
                   <p className="text-xs text-red-600/80 mt-0.5 leading-relaxed">
                     {previewError}
@@ -329,7 +335,7 @@ export function StepUpload() {
                 tabIndex={showPreview ? -1 : 0}
                 onClick={openFilePicker}
                 onKeyDown={(e) => e.key === "Enter" && openFilePicker()}
-                aria-label="Upload PDF or drag and drop"
+                aria-label={t`Upload PDF or drag and drop`}
                 className={cn(
                   "flex flex-col items-center justify-center gap-2 border-2 border-dashed rounded-lg w-full max-w-md h-full cursor-pointer transition-colors duration-300",
                   accepted
@@ -366,7 +372,7 @@ export function StepUpload() {
                       </svg>
                     </div>
                     <span className="text-sm font-medium text-emerald-600">
-                      PDF accepted
+                      <Trans>PDF accepted</Trans>
                     </span>
                   </div>
                   <div
@@ -379,7 +385,7 @@ export function StepUpload() {
                   >
                     <Loader2 className="h-5 w-5 text-[#2b7fff] animate-spin" />
                     <span className="text-sm text-[#737373]">
-                      Reading PDF...
+                      <Trans>Reading PDF...</Trans>
                     </span>
                   </div>
                   <div
@@ -402,7 +408,11 @@ export function StepUpload() {
                         hasError ? "text-red-500" : "text-[#737373]",
                       )}
                     >
-                      {hasError ? "Try another file" : "Upload PDF or drag and drop"}
+                      {hasError ? (
+                        <Trans>Try another file</Trans>
+                      ) : (
+                        <Trans>Upload PDF or drag and drop</Trans>
+                      )}
                     </span>
                   </div>
                 </div>
@@ -428,7 +438,7 @@ export function StepUpload() {
                     type="button"
                     onClick={clearFile}
                     className="absolute -top-2 -right-2 flex h-6 w-6 items-center justify-center rounded-full bg-white border border-[#e5e5e5] text-[#737373] hover:text-[#ef4444] hover:border-[#ef4444]/50 transition-colors shadow-sm"
-                    aria-label="Remove PDF"
+                    aria-label={t`Remove PDF`}
                   >
                     <Trash2 className="h-3 w-3" />
                   </button>
@@ -445,14 +455,14 @@ export function StepUpload() {
             className="h-9 px-3 py-2 bg-[#f5f5f5] text-[#262626] hover:bg-[#e5e5e5] border-0"
           >
             <ArrowLeft className="h-4 w-4 mr-1.5" />
-            Back
+            <Trans>Back</Trans>
           </Button>
           <Button
             disabled={!hasPreview || previewLoading}
             onClick={handleContinue}
             className="h-9 px-3 py-2 text-white bg-[#2b7fff] hover:bg-[#2b7fff]/90 disabled:opacity-50 border-0"
           >
-            Continue
+            <Trans>Continue</Trans>
             <ArrowRight className="h-4 w-4 ml-1.5" />
           </Button>
         </div>

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -220,6 +220,9 @@ msgstr "{missingForCurrentStage} entry/entries are missing audio. Re-run to gene
 msgid "{missingForCurrentStage} entry/entries are missing translations. Re-run to fill the missing items."
 msgstr "{missingForCurrentStage} entry/entries are missing translations. Re-run to fill the missing items."
 
+msgid "{pageCount} {pageCount, plural, one {page} other {pages}}"
+msgstr "{pageCount} {pageCount, plural, one {page} other {pages}}"
+
 msgid "{pageCount} pages"
 msgstr "{pageCount} pages"
 
@@ -1207,6 +1210,9 @@ msgstr "Controls how page content is grouped during the sectioning step."
 msgid "Conversion of light into chemical energy."
 msgstr "Conversion of light into chemical energy."
 
+msgid "Convert a PDF"
+msgstr "Convert a PDF"
+
 msgid "Convert any textbook into an accessible digital edition — audio, structured layouts, translations, and sign-language, built in from the very first page."
 msgstr "Convert any textbook into an accessible digital edition — audio, structured layouts, translations, and sign-language, built in from the very first page."
 
@@ -1227,6 +1233,9 @@ msgstr "Coral reefs cover less than 1% of the ocean floor, yet they support roug
 
 msgid "Could not read this PDF. The file may be corrupted or password-protected."
 msgstr "Could not read this PDF. The file may be corrupted or password-protected."
+
+msgid "Couldn't read this PDF"
+msgstr "Couldn't read this PDF"
 
 msgid "Cover"
 msgstr "Cover"
@@ -3130,11 +3139,17 @@ msgstr "Payload"
 msgid "PDF"
 msgstr "PDF"
 
+msgid "PDF accepted"
+msgstr "PDF accepted"
+
 msgid "PDF Extraction"
 msgstr "PDF Extraction"
 
 msgid "PDF File"
 msgstr "PDF File"
+
+msgid "PDF info"
+msgstr "PDF info"
 
 msgid "PDF page {pageLabel} preview"
 msgstr "PDF page {pageLabel} preview"
@@ -3368,6 +3383,9 @@ msgstr "Readers see"
 msgid "Reading archive..."
 msgstr "Reading archive..."
 
+msgid "Reading PDF..."
+msgstr "Reading PDF..."
+
 msgid "Readium Web Publication format for standards-based digital distribution platforms."
 msgstr "Readium Web Publication format for standards-based digital distribution platforms."
 
@@ -3449,6 +3467,9 @@ msgstr "Remove from group"
 
 msgid "Remove manual glossary term"
 msgstr "Remove manual glossary term"
+
+msgid "Remove PDF"
+msgstr "Remove PDF"
 
 msgid "Remove section"
 msgstr "Remove section"
@@ -3555,6 +3576,9 @@ msgstr "Review progress"
 
 msgid "Review the project details below and confirm the import."
 msgstr "Review the project details below and confirm the import."
+
+msgid "Review the source PDF details below and continue to configure how your book will be converted into an Accessible Digital Textbook."
+msgstr "Review the source PDF details below and continue to configure how your book will be converted into an Accessible Digital Textbook."
 
 msgid "Reviewer checklist"
 msgstr "Reviewer checklist"
@@ -4616,6 +4640,9 @@ msgstr "Upload sign language videos and assign them to sections."
 
 msgid "Upload Style Guide"
 msgstr "Upload Style Guide"
+
+msgid "Upload the source PDF of your book and we'll turn it into an Accessible Digital Textbook with interactive activities and adaptive layouts."
+msgstr "Upload the source PDF of your book and we'll turn it into an Accessible Digital Textbook with interactive activities and adaptive layouts."
 
 msgid "Upload to an LMS as a SCORM 1.2 package with completion tracking and offline support."
 msgstr "Upload to an LMS as a SCORM 1.2 package with completion tracking and offline support."

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -220,6 +220,9 @@ msgstr "{missingForCurrentStage} entrada(s) sin audio. Vuelve a ejecutar para ge
 msgid "{missingForCurrentStage} entry/entries are missing translations. Re-run to fill the missing items."
 msgstr "{missingForCurrentStage} entrada(s) sin traducción. Vuelve a ejecutar para completar los elementos faltantes."
 
+msgid "{pageCount} {pageCount, plural, one {page} other {pages}}"
+msgstr "{pageCount} {pageCount, plural, one {página} other {páginas}}"
+
 msgid "{pageCount} pages"
 msgstr "{pageCount} páginas"
 
@@ -1207,6 +1210,9 @@ msgstr "Controla cómo se agrupa el contenido de la página durante el paso de s
 msgid "Conversion of light into chemical energy."
 msgstr "Conversión de luz en energía química."
 
+msgid "Convert a PDF"
+msgstr "Convertir un PDF"
+
 msgid "Convert any textbook into an accessible digital edition — audio, structured layouts, translations, and sign-language, built in from the very first page."
 msgstr "Convierte cualquier libro en una edición digital accesible — audio, diseños estructurados, traducciones y lengua de signos, integrados desde la primera página."
 
@@ -1227,6 +1233,9 @@ msgstr "Los arrecifes de coral cubren menos del 1% del fondo oceánico, pero sos
 
 msgid "Could not read this PDF. The file may be corrupted or password-protected."
 msgstr "No se pudo leer este PDF. El archivo puede estar dañado o protegido con contraseña."
+
+msgid "Couldn't read this PDF"
+msgstr "No se pudo leer este PDF"
 
 msgid "Cover"
 msgstr "Portada"
@@ -3130,11 +3139,17 @@ msgstr "Carga útil"
 msgid "PDF"
 msgstr "PDF"
 
+msgid "PDF accepted"
+msgstr "PDF aceptado"
+
 msgid "PDF Extraction"
 msgstr "Extracción de PDF"
 
 msgid "PDF File"
 msgstr "Archivo PDF"
+
+msgid "PDF info"
+msgstr "Información del PDF"
 
 msgid "PDF page {pageLabel} preview"
 msgstr "Vista previa de la página PDF {pageLabel}"
@@ -3368,6 +3383,9 @@ msgstr "Los lectores ven"
 msgid "Reading archive..."
 msgstr "Leyendo archivo..."
 
+msgid "Reading PDF..."
+msgstr "Leyendo PDF..."
+
 msgid "Readium Web Publication format for standards-based digital distribution platforms."
 msgstr "Formato Readium Web Publication para plataformas de distribución digital basadas en estándares."
 
@@ -3449,6 +3467,9 @@ msgstr "Quitar del grupo"
 
 msgid "Remove manual glossary term"
 msgstr "Eliminar término manual del glosario"
+
+msgid "Remove PDF"
+msgstr "Eliminar PDF"
 
 msgid "Remove section"
 msgstr "Remove section"
@@ -3555,6 +3576,9 @@ msgstr "Review progress"
 
 msgid "Review the project details below and confirm the import."
 msgstr "Revisa los detalles del proyecto a continuación y confirma la importación."
+
+msgid "Review the source PDF details below and continue to configure how your book will be converted into an Accessible Digital Textbook."
+msgstr "Revisa los detalles del PDF de origen a continuación y continúa para configurar cómo se convertirá tu libro en un Libro de Texto Digital Accesible."
 
 msgid "Reviewer checklist"
 msgstr "Reviewer checklist"
@@ -4616,6 +4640,9 @@ msgstr "Sube videos de lengua de señas y asígnalos a secciones."
 
 msgid "Upload Style Guide"
 msgstr "Subir Guía de Estilo"
+
+msgid "Upload the source PDF of your book and we'll turn it into an Accessible Digital Textbook with interactive activities and adaptive layouts."
+msgstr "Sube el PDF de origen de tu libro y lo convertiremos en un Libro de Texto Digital Accesible con actividades interactivas y diseños adaptativos."
 
 msgid "Upload to an LMS as a SCORM 1.2 package with completion tracking and offline support."
 msgstr "Sube a un LMS como paquete SCORM 1.2 con seguimiento de finalización y soporte sin conexión."

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -221,6 +221,9 @@ msgstr "{missingForCurrentStage} entrée(s) sans audio. Relancez pour générer 
 msgid "{missingForCurrentStage} entry/entries are missing translations. Re-run to fill the missing items."
 msgstr "{missingForCurrentStage} entrée(s) sans traduction. Relancez pour compléter les éléments manquants."
 
+msgid "{pageCount} {pageCount, plural, one {page} other {pages}}"
+msgstr "{pageCount} {pageCount, plural, one {page} other {pages}}"
+
 msgid "{pageCount} pages"
 msgstr "{pageCount} pages"
 
@@ -1208,6 +1211,9 @@ msgstr "Contrôle la façon dont le contenu des pages est regroupé lors de l'é
 msgid "Conversion of light into chemical energy."
 msgstr "Conversion de la lumière en énergie chimique."
 
+msgid "Convert a PDF"
+msgstr "Convertir un PDF"
+
 msgid "Convert any textbook into an accessible digital edition — audio, structured layouts, translations, and sign-language, built in from the very first page."
 msgstr "Transformez n'importe quel livre en une édition numérique accessible — audio, mises en page structurées, traductions et langue des signes, intégrés dès la toute première page."
 
@@ -1228,6 +1234,9 @@ msgstr "Les récifs coralliens couvrent moins de 1 % du fond océanique, mais il
 
 msgid "Could not read this PDF. The file may be corrupted or password-protected."
 msgstr "Impossible de lire ce PDF. Le fichier est peut-être corrompu ou protégé par un mot de passe."
+
+msgid "Couldn't read this PDF"
+msgstr "Impossible de lire ce PDF"
 
 msgid "Cover"
 msgstr "Couverture"
@@ -3131,11 +3140,17 @@ msgstr "Charge utile"
 msgid "PDF"
 msgstr "PDF"
 
+msgid "PDF accepted"
+msgstr "PDF accepté"
+
 msgid "PDF Extraction"
 msgstr "Extraction PDF"
 
 msgid "PDF File"
 msgstr "Fichier PDF"
+
+msgid "PDF info"
+msgstr "Infos du PDF"
 
 msgid "PDF page {pageLabel} preview"
 msgstr "Aperçu de la page PDF {pageLabel}"
@@ -3369,6 +3384,9 @@ msgstr "Les lecteurs voient"
 msgid "Reading archive..."
 msgstr "Lecture de l'archive..."
 
+msgid "Reading PDF..."
+msgstr "Lecture du PDF..."
+
 msgid "Readium Web Publication format for standards-based digital distribution platforms."
 msgstr "Format de publication Web Readium pour les plateformes de distribution numérique basées sur des normes."
 
@@ -3450,6 +3468,9 @@ msgstr "Retirer du groupe"
 
 msgid "Remove manual glossary term"
 msgstr "Supprimer le terme manuel du glossaire"
+
+msgid "Remove PDF"
+msgstr "Supprimer le PDF"
 
 msgid "Remove section"
 msgstr "Retirer section"
@@ -3556,6 +3577,9 @@ msgstr "Progression de la révision"
 
 msgid "Review the project details below and confirm the import."
 msgstr "Vérifiez les détails du projet ci-dessous et confirmez l'importation."
+
+msgid "Review the source PDF details below and continue to configure how your book will be converted into an Accessible Digital Textbook."
+msgstr "Examinez les détails du PDF source ci-dessous, puis continuez pour configurer la conversion de votre livre en Manuel Numérique Accessible."
 
 msgid "Reviewer checklist"
 msgstr "Liste de contrôle du réviseur"
@@ -4617,6 +4641,9 @@ msgstr "Téléversez des vidéos en langue des signes et assignez-les aux sectio
 
 msgid "Upload Style Guide"
 msgstr "Téléverser un guide de style"
+
+msgid "Upload the source PDF of your book and we'll turn it into an Accessible Digital Textbook with interactive activities and adaptive layouts."
+msgstr "Téléversez le PDF source de votre livre et nous le transformerons en Manuel Numérique Accessible, avec activités interactives et mises en page adaptatives."
 
 msgid "Upload to an LMS as a SCORM 1.2 package with completion tracking and offline support."
 msgstr "Téléchargez vers un LMS en tant que package SCORM 1.2 avec suivi de l'achèvement et support hors ligne."

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -220,6 +220,9 @@ msgstr "{missingForCurrentStage} entrada(s) sem áudio. Execute novamente para g
 msgid "{missingForCurrentStage} entry/entries are missing translations. Re-run to fill the missing items."
 msgstr "{missingForCurrentStage} entrada(s) sem tradução. Execute novamente para preencher os itens faltantes."
 
+msgid "{pageCount} {pageCount, plural, one {page} other {pages}}"
+msgstr "{pageCount} {pageCount, plural, one {página} other {páginas}}"
+
 msgid "{pageCount} pages"
 msgstr "{pageCount} páginas"
 
@@ -1207,6 +1210,9 @@ msgstr "Controla como o conteúdo da página é agrupado durante a etapa de seci
 msgid "Conversion of light into chemical energy."
 msgstr "Conversão de luz em energia química."
 
+msgid "Convert a PDF"
+msgstr "Converter um PDF"
+
 msgid "Convert any textbook into an accessible digital edition — audio, structured layouts, translations, and sign-language, built in from the very first page."
 msgstr "Converta qualquer livro em uma edição digital acessível — áudio, layouts estruturados, traduções e língua de sinais, integrados desde a primeira página."
 
@@ -1227,6 +1233,9 @@ msgstr "Os recifes de coral cobrem menos de 1% do fundo do oceano, mas sustentam
 
 msgid "Could not read this PDF. The file may be corrupted or password-protected."
 msgstr "Não foi possível ler este PDF. O arquivo pode estar corrompido ou protegido por senha."
+
+msgid "Couldn't read this PDF"
+msgstr "Não foi possível ler este PDF"
 
 msgid "Cover"
 msgstr "Capa"
@@ -3130,11 +3139,17 @@ msgstr "Payload"
 msgid "PDF"
 msgstr "PDF"
 
+msgid "PDF accepted"
+msgstr "PDF aceito"
+
 msgid "PDF Extraction"
 msgstr "Extração de PDF"
 
 msgid "PDF File"
 msgstr "Arquivo PDF"
+
+msgid "PDF info"
+msgstr "Informações do PDF"
 
 msgid "PDF page {pageLabel} preview"
 msgstr "Pré-visualização da página PDF {pageLabel}"
@@ -3368,6 +3383,9 @@ msgstr "Leitores veem"
 msgid "Reading archive..."
 msgstr "Lendo arquivo..."
 
+msgid "Reading PDF..."
+msgstr "Lendo PDF..."
+
 msgid "Readium Web Publication format for standards-based digital distribution platforms."
 msgstr "Formato Readium Web Publication para plataformas de distribuição digital baseadas em padrões."
 
@@ -3449,6 +3467,9 @@ msgstr "Remover do grupo"
 
 msgid "Remove manual glossary term"
 msgstr "Remover termo manual do glossário"
+
+msgid "Remove PDF"
+msgstr "Remover PDF"
 
 msgid "Remove section"
 msgstr "Remove section"
@@ -3555,6 +3576,9 @@ msgstr "Review progress"
 
 msgid "Review the project details below and confirm the import."
 msgstr "Revise os detalhes do projeto abaixo e confirme a importação."
+
+msgid "Review the source PDF details below and continue to configure how your book will be converted into an Accessible Digital Textbook."
+msgstr "Revise os detalhes do PDF de origem abaixo e continue para configurar como seu livro será convertido em um Livro Didático Digital Acessível."
 
 msgid "Reviewer checklist"
 msgstr "Reviewer checklist"
@@ -4616,6 +4640,9 @@ msgstr "Envie vídeos de língua de sinais e atribua-os às seções."
 
 msgid "Upload Style Guide"
 msgstr "Enviar Guia de Estilo"
+
+msgid "Upload the source PDF of your book and we'll turn it into an Accessible Digital Textbook with interactive activities and adaptive layouts."
+msgstr "Envie o PDF de origem do seu livro e o transformaremos em um Livro Didático Digital Acessível com atividades interativas e layouts adaptativos."
 
 msgid "Upload to an LMS as a SCORM 1.2 package with completion tracking and offline support."
 msgstr "Faça upload para um LMS como pacote SCORM 1.2 com rastreamento de conclusão e suporte offline."


### PR DESCRIPTION
## Summary
- The first step of the book creation wizard (`StepUpload` / "Convert PDF") had hardcoded English strings behind a file-level `eslint-disable lingui/no-unlocalized-strings`. Even users with `es`, `fr`, or `pt-BR` selected saw English.
- Wrapped every user-visible string in `<Trans>` / `t` macros (page title, descriptions, drop zone states, error messages, preview card, buttons, aria-labels, plural for page count).
- Removed the file-level eslint-disable directive — the step now passes the lingui rule on its own.
- Ran `pnpm --filter @adt/studio extract` and translated all 9 new entries into `pt-BR`, `es`, and `fr`. Catalog is back to 0 missing strings across all locales.

## Test plan
- [ ] `pnpm typecheck` passes
- [ ] `pnpm --filter @adt/studio lint` passes
- [ ] `pnpm --filter @adt/studio extract` reports 0 missing strings for all locales
- [ ] Manually open the "Add Book" flow in each locale (en / pt-BR / es / fr) and confirm:
  - title, description, drop zone, "PDF accepted", "Reading PDF…", error states, preview card, page count plural, and Back/Continue buttons all render in the chosen language