### PR TITLE
fix: resolve config folder path for reviewer validation

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -42,14 +42,6 @@ const configFolderPath = path.resolve(
   process.env.CONFIG_FOLDER_PATH ?? path.join(projectRoot, "config")
 )
 
-console.table({
-  path: projectRoot,
-  booksDir,
-  promptsDir,
-  configPath,
-  configFolderPath,
-})
-
 let webAssetsDir: string
 const adtResourcesZip = process.env.ADT_RESOURCES_ZIP
 if (adtResourcesZip && fs.existsSync(adtResourcesZip)) {

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -38,6 +38,18 @@ const promptsDir = path.resolve(process.env.PROMPTS_DIR ?? path.join(projectRoot
 const configPath = path.resolve(
   process.env.CONFIG_PATH ?? path.join(projectRoot, "config.yaml")
 )
+const configFolderPath = path.resolve(
+  process.env.CONFIG_FOLDER_PATH ?? path.join(projectRoot, "config")
+)
+
+console.table({
+  path: projectRoot,
+  booksDir,
+  promptsDir,
+  configPath,
+  configFolderPath,
+})
+
 let webAssetsDir: string
 const adtResourcesZip = process.env.ADT_RESOURCES_ZIP
 if (adtResourcesZip && fs.existsSync(adtResourcesZip)) {
@@ -100,7 +112,7 @@ app.route("/api", createTaskRoutes(taskService))
 app.route("/api", createPresetRoutes(configPath))
 app.route("/api", createAdtPreviewRoutes(booksDir, webAssetsDir, configPath))
 app.route("/api", createSpeechConfigRoutes(configPath))
-app.route("/api", createReviewerValidationRoutes(booksDir, configPath))
+app.route("/api", createReviewerValidationRoutes(booksDir, configFolderPath, configPath))
 app.route("/api", createSignLanguageVideoRoutes(booksDir))
 
 export default app

--- a/apps/api/src/routes/reviewer-validation.test.ts
+++ b/apps/api/src/routes/reviewer-validation.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import fs from "node:fs"
 import os from "node:os"
 import path from "node:path"
+import { fileURLToPath } from "node:url"
 import { Hono } from "hono"
 import { createBookStorage } from "@adt/storage"
 import type { ReviewerPageValidationRecord, ReviewerValidationSession } from "@adt/types"
@@ -9,6 +10,10 @@ import { errorHandler } from "../middleware/error-handler.js"
 import { createReviewerValidationRoutes } from "./reviewer-validation.js"
 
 const label = "validation-book"
+const configFolderPath = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../../../config",
+)
 
 
 function enableReviewerValidation(configPath: string) {
@@ -68,7 +73,7 @@ describe("Reviewer validation routes", () => {
 
     app = new Hono()
     app.onError(errorHandler)
-    app.route("/api", createReviewerValidationRoutes(tmpDir, configPath))
+    app.route("/api", createReviewerValidationRoutes(tmpDir, configFolderPath, configPath))
   })
 
   afterEach(() => {
@@ -252,7 +257,7 @@ describe("Reviewer validation routes", () => {
 
     app = new Hono()
     app.onError(errorHandler)
-    app.route("/api", createReviewerValidationRoutes(tmpDir, configPath))
+    app.route("/api", createReviewerValidationRoutes(tmpDir, configFolderPath, configPath))
 
     const res = await app.request(`/api/books/${label}/validation/catalog`)
     expect(res.status).toBe(200)

--- a/apps/api/src/routes/reviewer-validation.ts
+++ b/apps/api/src/routes/reviewer-validation.ts
@@ -15,7 +15,7 @@ import {
 } from "../services/reviewer-validation-service.js"
 import { getReviewerValidationCatalog, isReviewerValidationEnabled } from "../services/reviewer-validation-catalog.js"
 
-export function createReviewerValidationRoutes(booksDir: string, configPath?: string): Hono {
+export function createReviewerValidationRoutes(booksDir: string, configFolderPath: string, configPath?: string, ): Hono {
   const app = new Hono()
 
   app.get("/books/:label/validation/catalog", (c) => {
@@ -23,7 +23,7 @@ export function createReviewerValidationRoutes(booksDir: string, configPath?: st
     const config = configPath ? loadBookConfig(safeLabel, booksDir, configPath) : null
     return c.json({
       enabled: isReviewerValidationEnabled(config?.reviewer_validation),
-      ...getReviewerValidationCatalog(config?.reviewer_validation),
+      ...getReviewerValidationCatalog(configFolderPath, config?.reviewer_validation),
     })
   })
 
@@ -46,7 +46,7 @@ export function createReviewerValidationRoutes(booksDir: string, configPath?: st
     if (!isReviewerValidationEnabled(config?.reviewer_validation)) {
       throw new HTTPException(409, { message: "Reviewer validation is disabled for this book" })
     }
-    const catalogSnapshot = getReviewerValidationCatalog(config?.reviewer_validation)
+    const catalogSnapshot = getReviewerValidationCatalog(configFolderPath, config?.reviewer_validation)
     const saved = saveReviewerValidationSession(label, booksDir, {
       ...parsed.data,
       catalog_snapshot: parsed.data.catalog_snapshot ?? catalogSnapshot,

--- a/apps/api/src/services/reviewer-validation-catalog.ts
+++ b/apps/api/src/services/reviewer-validation-catalog.ts
@@ -1,6 +1,4 @@
 import fs from "node:fs"
-import path from "node:path"
-import { fileURLToPath } from "node:url"
 import yaml from "js-yaml"
 import {
   ReviewerValidationCatalogSnapshot,
@@ -8,15 +6,11 @@ import {
   type ReviewerValidationConfig as ReviewerValidationConfigType,
 } from "@adt/types"
 
-const DEFAULT_REVIEWER_VALIDATION_PATH = path.resolve(
-  path.dirname(fileURLToPath(import.meta.url)),
-  "../../../../config/reviewer_validation.yaml",
-)
 
 function loadDefaultReviewerValidationConfig(
-  defaultsPath = DEFAULT_REVIEWER_VALIDATION_PATH,
+  defaultsPath: string,
 ): ReviewerValidationConfigType {
-  const content = fs.readFileSync(defaultsPath, "utf-8")
+  const content = fs.readFileSync(`${defaultsPath}/reviewer_validation.yaml`, "utf-8")
   const parsed = yaml.load(content)
   return ReviewerValidationConfig.parse(parsed ?? {})
 }
@@ -27,8 +21,8 @@ export function isReviewerValidationEnabled(config?: ReviewerValidationConfigTyp
 }
 
 export function getReviewerValidationCatalog(
+  defaultsPath: string,
   config?: ReviewerValidationConfigType | null,
-  defaultsPath?: string,
 ) {
   const defaults = loadDefaultReviewerValidationConfig(defaultsPath)
   const overrides = ReviewerValidationConfig.parse(config ?? {})

--- a/apps/desktop/src/main/api-server/index.ts
+++ b/apps/desktop/src/main/api-server/index.ts
@@ -46,6 +46,7 @@ async function startApiServer(): Promise<{
       BOOKS_DIR: paths.booksDir,
       PROMPTS_DIR: paths.promptsDir,
       CONFIG_PATH: paths.configPath,
+      PROJECT_ROOT: paths.root,
       ADT_RESOURCES_ZIP: paths.adtResourcesZip,
       WEB_ASSETS_DIR: paths.webAssetsDir,
       ADT_ENVIRONMENT: "electron",


### PR DESCRIPTION
## Summary
- The reviewer validation catalog previously resolved its defaults via `import.meta.url`, which breaks when the API is bundled (e.g. inside the Electron desktop build) because the bundled file is no longer at its source-tree location relative to `config/`.
- Pass the config folder path explicitly through `createReviewerValidationRoutes` → `getReviewerValidationCatalog`, sourced from a new `CONFIG_FOLDER_PATH` env var (defaults to `<projectRoot>/config`).
- Electron main now forwards `PROJECT_ROOT` to the spawned API so the resolved path matches the packaged app's layout.

## Test plan
- [ ] `pnpm dev` — open a book and load the reviewer validation catalog; verify it loads without ENOENT
- [ ] `pnpm build:desktop` then launch the packaged app — open reviewer validation and confirm the catalog resolves
- [ ] Open reviewer checklist page;

Closes #403