### PR TITLE
 chore(desktop): bump to 0.7.0-rc.8 and refresh issue form versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/accessibility.yml
+++ b/.github/ISSUE_TEMPLATE/accessibility.yml
@@ -68,6 +68,8 @@ body:
       label: Version
       description: What version of ADT Studio are you running? Check Help → About, or see https://github.com/unicef/adt-studio/releases.
       options:
+        - v0.7.0-rc.8
+        - v0.7.0-rc.7
         - v0.7.0-rc.6
         - v0.6.0
         - v0.5.1
@@ -78,8 +80,6 @@ body:
         - v0.4.5
         - v0.4.4
         - v0.4.3
-        - v0.4.2
-        - v0.4.1
         - Older / unsure
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -78,6 +78,8 @@ body:
       label: Version
       description: What version of ADT Studio are you running? Check Help → About, or see https://github.com/unicef/adt-studio/releases.
       options:
+        - v0.7.0-rc.8
+        - v0.7.0-rc.7
         - v0.7.0-rc.6
         - v0.6.0
         - v0.5.1
@@ -88,8 +90,6 @@ body:
         - v0.4.5
         - v0.4.4
         - v0.4.3
-        - v0.4.2
-        - v0.4.1
         - Older / unsure
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -53,6 +53,8 @@ body:
     attributes:
       label: Version (optional)
       options:
+        - v0.7.0-rc.8
+        - v0.7.0-rc.7
         - v0.7.0-rc.6
         - v0.6.0
         - v0.5.1
@@ -63,8 +65,6 @@ body:
         - v0.4.5
         - v0.4.4
         - v0.4.3
-        - v0.4.2
-        - v0.4.1
         - Older / unsure
         - Not applicable
   - type: dropdown

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adt/desktop",
-  "version": "0.7.0-rc.7",
+  "version": "0.7.0-rc.8",
   "description": "An Electron Version of ADT STUDIO",
   "main": "./out/main/index.js",
   "private": true,


### PR DESCRIPTION
  ## Summary
  - Bump `@adt/desktop` to `0.7.0-rc.8`.
  - Add `v0.7.0-rc.8` and the previously-missing `v0.7.0-rc.7` to the version dropdowns in the bug report,
  accessibility, and question issue forms so users on either RC can self-identify when filing issues.