### PR TITLE
fix(desktop): bundle tw-animate-css with API server runtime

### DIFF
--- a/apps/api/scripts/install-server-runtime.mjs
+++ b/apps/api/scripts/install-server-runtime.mjs
@@ -25,6 +25,7 @@ const stub = {
     esbuild: p.devDependencies.esbuild,
     tailwindcss: p.dependencies.tailwindcss,
     "@tailwindcss/postcss": p.dependencies["@tailwindcss/postcss"],
+    "tw-animate-css": p.dependencies["tw-animate-css"],
     postcss: p.dependencies.postcss,
     jsdom: p.dependencies.jsdom,
   },


### PR DESCRIPTION
## Summary
- Adds `tw-animate-css` to the runtime deps installed alongside the bundled API server in `apps/api/scripts/install-server-runtime.mjs`, so it resolves at runtime in the packaged Electron app.
- Same external-package pattern documented in `AGENTS.md` for packages that can't be bundled by esbuild (jsdom, tailwindcss, postcss, etc.) — `tw-animate-css` was missing from that list and failed to resolve when the renderer's Tailwind pipeline reached it.

## Test plan
- [ ] `pnpm build:desktop` succeeds
- [ ] Launch the packaged desktop app and confirm the Studio renderer loads without a `tw-animate-css` resolution error
- [ ] Verify Tailwind animations driven by `tw-animate-css` render correctly in the packaged app
