### PR TITLE
refactor(studio): consolidate icon-circle empty states across pipeline stages

### DIFF
--- a/apps/studio/src/components/pipeline/components/StageEmptyState.tsx
+++ b/apps/studio/src/components/pipeline/components/StageEmptyState.tsx
@@ -1,7 +1,17 @@
 import type { LucideIcon } from "lucide-react"
 import type { ReactNode } from "react"
 
-export type EmptyStateColor = "orange" | "teal" | "pink" | "violet" | "sky"
+export type EmptyStateColor =
+  | "orange"
+  | "teal"
+  | "pink"
+  | "violet"
+  | "sky"
+  | "blue"
+  | "lime"
+  | "amber"
+  | "rose"
+  | "cyan"
 
 interface ColorClasses {
   iconBg: string
@@ -14,6 +24,11 @@ const COLOR_CLASSES: Record<EmptyStateColor, ColorClasses> = {
   pink: { iconBg: "bg-pink-50", iconColor: "text-pink-300" },
   violet: { iconBg: "bg-violet-50", iconColor: "text-violet-300" },
   sky: { iconBg: "bg-sky-50", iconColor: "text-sky-300" },
+  blue: { iconBg: "bg-blue-50", iconColor: "text-blue-300" },
+  lime: { iconBg: "bg-lime-50", iconColor: "text-lime-300" },
+  amber: { iconBg: "bg-amber-50", iconColor: "text-amber-300" },
+  rose: { iconBg: "bg-rose-50", iconColor: "text-rose-300" },
+  cyan: { iconBg: "bg-cyan-50", iconColor: "text-cyan-300" },
 }
 
 interface StageEmptyStateProps {

--- a/apps/studio/src/components/pipeline/components/StageEmptyState.tsx
+++ b/apps/studio/src/components/pipeline/components/StageEmptyState.tsx
@@ -1,0 +1,45 @@
+import type { LucideIcon } from "lucide-react"
+import type { ReactNode } from "react"
+
+export type EmptyStateColor = "orange" | "teal" | "pink" | "violet" | "sky"
+
+interface ColorClasses {
+  iconBg: string
+  iconColor: string
+}
+
+const COLOR_CLASSES: Record<EmptyStateColor, ColorClasses> = {
+  orange: { iconBg: "bg-orange-50", iconColor: "text-orange-300" },
+  teal: { iconBg: "bg-teal-50", iconColor: "text-teal-300" },
+  pink: { iconBg: "bg-pink-50", iconColor: "text-pink-300" },
+  violet: { iconBg: "bg-violet-50", iconColor: "text-violet-300" },
+  sky: { iconBg: "bg-sky-50", iconColor: "text-sky-300" },
+}
+
+interface StageEmptyStateProps {
+  icon: LucideIcon
+  color: EmptyStateColor
+  title: ReactNode
+  subtitle?: ReactNode
+  cta?: ReactNode
+}
+
+export function StageEmptyState({
+  icon: Icon,
+  color,
+  title,
+  subtitle,
+  cta,
+}: StageEmptyStateProps) {
+  const { iconBg, iconColor } = COLOR_CLASSES[color]
+  return (
+    <div className="flex flex-col items-center justify-center text-muted-foreground flex-1">
+      <div className={`w-12 h-12 rounded-full ${iconBg} flex items-center justify-center mb-3`}>
+        <Icon className={`w-6 h-6 ${iconColor}`} />
+      </div>
+      <p className="text-sm font-medium">{title}</p>
+      {subtitle && <p className="text-xs mt-1">{subtitle}</p>}
+      {cta && <div className="mt-3">{cta}</div>}
+    </div>
+  )
+}

--- a/apps/studio/src/components/pipeline/components/StepViewRouter.tsx
+++ b/apps/studio/src/components/pipeline/components/StepViewRouter.tsx
@@ -172,7 +172,7 @@ export function StepViewRouter({
 
         {/* Step content */}
         {entry.fullHeight ? (
-          <div className="flex-1 min-h-0 overflow-auto">
+          <div className="flex flex-1 flex-col min-h-0 overflow-auto">
             <View
               bookLabel={bookLabel}
               stageSlug={step}
@@ -181,7 +181,7 @@ export function StepViewRouter({
             />
           </div>
         ) : (
-          <div className="flex-1 min-h-0 overflow-auto p-4">
+          <div className="flex flex-1 flex-col min-h-0 overflow-auto p-4">
             <View
               bookLabel={bookLabel}
               stageSlug={step}

--- a/apps/studio/src/components/pipeline/stages/captions/CaptionsView.tsx
+++ b/apps/studio/src/components/pipeline/stages/captions/CaptionsView.tsx
@@ -10,6 +10,7 @@ import { useBookRun } from "@/hooks/use-book-run"
 import { useApiKey } from "@/hooks/use-api-key"
 import { invalidateStoryboardDependents } from "@/hooks/use-page-mutations"
 import { StageRunCard } from "../../components/StageRunCard"
+import { StageEmptyState } from "../../components/StageEmptyState"
 import { useSectionNav } from "@/routes/books.$label"
 import { Trans } from "@lingui/react/macro"
 import { useLingui } from "@lingui/react/macro"
@@ -261,12 +262,11 @@ function PageCaptions({
 
   if (filterSectionIndex != null && filteredCaptions.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
-        <div className="w-12 h-12 rounded-full bg-teal-50 flex items-center justify-center mb-3">
-          <ImageIcon className="w-6 h-6 text-teal-300" />
-        </div>
-        <p className="text-sm font-medium">{t`No images in this section`}</p>
-      </div>
+      <StageEmptyState
+        icon={ImageIcon}
+        color="teal"
+        title={t`No images in this section`}
+      />
     )
   }
 
@@ -444,34 +444,34 @@ export function CaptionsView({ bookLabel, selectedPageId, onSelectPage }: { book
 
   if (selectedPageId && displayPages.length === 0 && pagesWithImages.length > 0) {
     return (
-      <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
-        <div className="w-12 h-12 rounded-full bg-teal-50 flex items-center justify-center mb-3">
-          <ImageIcon className="w-6 h-6 text-teal-300" />
-        </div>
-        <p className="text-sm font-medium">{t`No images on this page`}</p>
-        <button
-          type="button"
-          onClick={() => onSelectPage?.(null)}
-          className="mt-3 text-xs font-medium text-teal-600 hover:text-teal-700 hover:underline transition-colors"
-        >
-          {t`Show all`}
-        </button>
-      </div>
+      <StageEmptyState
+        icon={ImageIcon}
+        color="teal"
+        title={t`No images on this page`}
+        cta={
+          <button
+            type="button"
+            onClick={() => onSelectPage?.(null)}
+            className="text-xs font-medium text-teal-600 hover:text-teal-700 hover:underline transition-colors"
+          >
+            {t`Show all`}
+          </button>
+        }
+      />
     )
   }
 
   const singlePageEmptyState = selectedPageId ? (
-    <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
-      <div className="w-12 h-12 rounded-full bg-teal-50 flex items-center justify-center mb-3">
-        <ImageIcon className="w-6 h-6 text-teal-300" />
-      </div>
-      <p className="text-sm font-medium">{t`No captions for this page`}</p>
-      <p className="text-xs mt-1">{t`This page has no captioned images`}</p>
-    </div>
+    <StageEmptyState
+      icon={ImageIcon}
+      color="teal"
+      title={t`No captions for this page`}
+      subtitle={t`This page has no captioned images`}
+    />
   ) : undefined
 
   return (
-    <div className="space-y-4">
+    <div className="flex flex-1 flex-col gap-4">
       {selectedPageId && (
         <div className="flex justify-end px-4 pt-3">
           <button

--- a/apps/studio/src/components/pipeline/stages/extract/ExtractView.tsx
+++ b/apps/studio/src/components/pipeline/stages/extract/ExtractView.tsx
@@ -9,6 +9,7 @@ import { useApiKey } from "@/hooks/use-api-key"
 import { ExtractPageDetail } from "./components/ExtractPageDetail"
 import { useStepHeader } from "../../components/StepViewRouter"
 import { StageRunCard } from "../../components/StageRunCard"
+import { StageEmptyState } from "../../components/StageEmptyState"
 import type { PageSummaryItem } from "@/api/client"
 
 /** Returns true once the element has scrolled into view. */
@@ -316,9 +317,12 @@ export function ExtractView({ bookLabel, selectedPageId: selectedPageIdProp, onS
           disabled={!extractError || !hasApiKey || extractRunning}
         />
       ) : pageList.length === 0 ? (
-        <p className="text-sm text-muted-foreground">
-          <Trans>No pages extracted yet. Run the pipeline to extract content.</Trans>
-        </p>
+        <StageEmptyState
+          icon={FileText}
+          color="blue"
+          title={t`No pages extracted yet`}
+          subtitle={t`Run the pipeline to extract content`}
+        />
       ) : (
         <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
           {pageList.map((page) => (

--- a/apps/studio/src/components/pipeline/stages/languages/LanguageView.tsx
+++ b/apps/studio/src/components/pipeline/stages/languages/LanguageView.tsx
@@ -14,6 +14,7 @@ import { useBookTasks } from "@/hooks/use-book-tasks"
 import { useStageMissingCounts } from "@/hooks/use-stage-missing-counts"
 import { useApiKey } from "@/hooks/use-api-key"
 import { StageRunCard } from "../../components/StageRunCard"
+import { StageEmptyState } from "../../components/StageEmptyState"
 import { useVirtualizer } from "@tanstack/react-virtual"
 import { cn } from "@/lib/utils"
 import { normalizeLocale } from "@/lib/languages"
@@ -888,13 +889,12 @@ export function LanguageView({ bookLabel, stageSlug = "translate", selectedPageI
           <span className="text-sm">{t`Resolving source language...`}</span>
         </div>
       ) : selectedPageId && displayEntries.length === 0 && entries.length > 0 ? (
-        <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
-          <div className="w-12 h-12 rounded-full bg-pink-50 flex items-center justify-center mb-3">
-            <Languages className="w-6 h-6 text-pink-300" />
-          </div>
-          <p className="text-sm font-medium">{t`No translations for this page`}</p>
-          <p className="text-xs mt-1">{t`This page has no translatable text entries`}</p>
-        </div>
+        <StageEmptyState
+          icon={Languages}
+          color="pink"
+          title={t`No translations for this page`}
+          subtitle={t`This page has no translatable text entries`}
+        />
       ) : (
       <div ref={scrollRef} className="flex-1 min-h-0 overflow-y-auto px-4 pb-4">
         <div style={{ height: virtualizer.getTotalSize(), width: "100%", position: "relative" }}>

--- a/apps/studio/src/components/pipeline/stages/languages/LanguageView.tsx
+++ b/apps/studio/src/components/pipeline/stages/languages/LanguageView.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useCallback, useMemo, type ChangeEvent } from "react"
 import { createPortal } from "react-dom"
 import { Link } from "@tanstack/react-router"
-import { Check, ChevronDown, ChevronRight, ChevronUp, Languages, Loader2, Play, Pause, Plus, RotateCcw, Save, Settings, Trash2, Type, Upload, WandSparkles, X } from "lucide-react"
+import { AudioLines, Check, ChevronDown, ChevronRight, ChevronUp, Languages, Loader2, Play, Pause, Plus, RotateCcw, Save, Settings, Trash2, Type, Upload, WandSparkles, X } from "lucide-react"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { api, getAudioUrl, BASE_URL } from "@/api/client"
 import type { TextCatalogEntry, VersionEntry, WordTimestamp, WordTimestampEntry } from "@/api/client"
@@ -890,10 +890,10 @@ export function LanguageView({ bookLabel, stageSlug = "translate", selectedPageI
         </div>
       ) : selectedPageId && displayEntries.length === 0 && entries.length > 0 ? (
         <StageEmptyState
-          icon={Languages}
-          color="pink"
-          title={t`No translations for this page`}
-          subtitle={t`This page has no translatable text entries`}
+          icon={isSpeechStage ? AudioLines : Languages}
+          color={isSpeechStage ? "rose" : "pink"}
+          title={isSpeechStage ? t`No audio for this page` : t`No translations for this page`}
+          subtitle={isSpeechStage ? t`This page has no entries to synthesize` : t`This page has no translatable text entries`}
         />
       ) : (
       <div ref={scrollRef} className="flex-1 min-h-0 overflow-y-auto px-4 pb-4">

--- a/apps/studio/src/components/pipeline/stages/quizzes/QuizzesView.tsx
+++ b/apps/studio/src/components/pipeline/stages/quizzes/QuizzesView.tsx
@@ -10,6 +10,7 @@ import { useStepHeader } from "../../components/StepViewRouter"
 import { useBookRun } from "@/hooks/use-book-run"
 import { useApiKey } from "@/hooks/use-api-key"
 import { StageRunCard } from "../../components/StageRunCard"
+import { StageEmptyState } from "../../components/StageEmptyState"
 import { getRequestedPageId, getQuizImageRenderState } from "./lib/quizzes-image-state"
 import { useLingui } from "@lingui/react/macro"
 
@@ -399,13 +400,12 @@ export function QuizzesView({ bookLabel, selectedPageId }: { bookLabel: string; 
 
   if (selectedPageId && displayQuizzes.length === 0 && quizzes.length > 0) {
     return (
-      <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
-        <div className="w-12 h-12 rounded-full bg-orange-50 flex items-center justify-center mb-3">
-          <HelpCircle className="w-6 h-6 text-orange-300" />
-        </div>
-        <p className="text-sm font-medium">{t`No quizzes for this page`}</p>
-        <p className="text-xs mt-1">{t`Quizzes are linked to other pages in this book`}</p>
-      </div>
+      <StageEmptyState
+        icon={HelpCircle}
+        color="orange"
+        title={t`No quizzes for this page`}
+        subtitle={t`Quizzes are linked to other pages in this book`}
+      />
     )
   }
 

--- a/apps/studio/src/components/pipeline/stages/sectioning/SectioningView.tsx
+++ b/apps/studio/src/components/pipeline/stages/sectioning/SectioningView.tsx
@@ -5,6 +5,7 @@ import { useStepHeader } from "../../components/StepViewRouter"
 import { useBookRun } from "@/hooks/use-book-run"
 import { useApiKey } from "@/hooks/use-api-key"
 import { StageRunCard } from "../../components/StageRunCard"
+import { StageEmptyState } from "../../components/StageEmptyState"
 import { SectioningPageDetail } from "./SectioningPageDetail"
 import { SectioningOverview } from "../storyboard/components/SectioningOverview"
 import { Trans } from "@lingui/react/macro"
@@ -248,13 +249,12 @@ export function SectioningView({ bookLabel, selectedPageId: selectedPageIdProp, 
 
   if (page.sectioningTree.sections.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
-        <div className="w-12 h-12 rounded-full bg-sky-50 flex items-center justify-center mb-3">
-          <LayoutGrid className="w-6 h-6 text-sky-300" />
-        </div>
-        <p className="text-sm font-medium"><Trans>No sections for this page</Trans></p>
-        <p className="text-xs mt-1"><Trans>This page has no sectioning output</Trans></p>
-      </div>
+      <StageEmptyState
+        icon={LayoutGrid}
+        color="sky"
+        title={<Trans>No sections for this page</Trans>}
+        subtitle={<Trans>This page has no sectioning output</Trans>}
+      />
     )
   }
 

--- a/apps/studio/src/components/pipeline/stages/storyboard/StoryboardView.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/StoryboardView.tsx
@@ -5,6 +5,7 @@ import { useStepHeader } from "../../components/StepViewRouter"
 import { useBookRun } from "@/hooks/use-book-run"
 import { useApiKey } from "@/hooks/use-api-key"
 import { StageRunCard } from "../../components/StageRunCard"
+import { StageEmptyState } from "../../components/StageEmptyState"
 import { StoryboardSectionDetail } from "./components/StoryboardSectionDetail"
 import { SectioningOverview } from "./components/SectioningOverview"
 import { useSectionNav } from "@/routes/books.$label"
@@ -342,13 +343,12 @@ export function StoryboardView({ bookLabel, selectedPageId: selectedPageIdProp, 
 
   if (sectionCount === 0) {
     return (
-      <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
-        <div className="w-12 h-12 rounded-full bg-violet-50 flex items-center justify-center mb-3">
-          <LayoutGrid className="w-6 h-6 text-violet-300" />
-        </div>
-        <p className="text-sm font-medium"><Trans>No sections for this page</Trans></p>
-        <p className="text-xs mt-1"><Trans>This page has no storyboard sections</Trans></p>
-      </div>
+      <StageEmptyState
+        icon={LayoutGrid}
+        color="violet"
+        title={<Trans>No sections for this page</Trans>}
+        subtitle={<Trans>This page has no storyboard sections</Trans>}
+      />
     )
   }
 

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
@@ -49,6 +49,7 @@ import { useBookTasks } from "@/hooks/use-book-tasks"
 import { useBookRun } from "@/hooks/use-book-run"
 import { invalidateStoryboardDependents } from "@/hooks/use-page-mutations"
 import { useStepHeader } from "../../../components/StepViewRouter"
+import { StageEmptyState } from "../../../components/StageEmptyState"
 import {
   BookPreviewFrame,
   type BookPreviewFrameHandle,
@@ -2107,13 +2108,12 @@ export function StoryboardSectionDetail({
             <p className="text-sm font-medium">{t`Rendering this section...`}</p>
           </div>
         ) : (
-          <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
-            <div className="w-12 h-12 rounded-full bg-violet-50 flex items-center justify-center mb-3">
-              <LayoutGrid className="w-6 h-6 text-violet-300" />
-            </div>
-            <p className="text-sm font-medium">{t`No rendered content for this section`}</p>
-            <p className="text-xs mt-1">{t`This section has no storyboard rendering yet`}</p>
-          </div>
+          <StageEmptyState
+            icon={LayoutGrid}
+            color="violet"
+            title={t`No rendered content for this section`}
+            subtitle={t`This section has no storyboard rendering yet`}
+          />
         )}
 
       </div>

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
@@ -2068,13 +2068,12 @@ export function StoryboardSectionDetail({
         ref={scrollContainerRef}
       >
         {!section ? (
-          <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
-            <div className="w-12 h-12 rounded-full bg-muted/50 flex items-center justify-center mb-3">
-              <LayoutGrid className="w-6 h-6 text-muted-foreground/40" />
-            </div>
-            <p className="text-sm font-medium">{t`No sections on this page`}</p>
-            <p className="text-xs mt-1">{t`All sections have been deleted`}</p>
-          </div>
+          <StageEmptyState
+            icon={LayoutGrid}
+            color="violet"
+            title={t`No sections on this page`}
+            subtitle={t`All sections have been deleted`}
+          />
         ) : renderedSection?.html ? (
           <>
             {activityPreviewMode ? (

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -3317,6 +3317,9 @@ msgstr "No API key for {0} yet. Add one in Book settings to enable this provider
 msgid "No assessment"
 msgstr "No assessment"
 
+msgid "No audio for this page"
+msgstr "No audio for this page"
+
 msgid "No books match your search"
 msgstr "No books match your search"
 
@@ -4498,6 +4501,9 @@ msgstr "Run Storyboard to generate sections you can match sign-language videos t
 msgid "Run the pipeline"
 msgstr "Run the pipeline"
 
+msgid "Run the pipeline to extract content"
+msgstr "Run the pipeline to extract content"
+
 msgid "Run TOC"
 msgstr "Run TOC"
 
@@ -5427,6 +5433,9 @@ msgstr "This is Pip! He is a happy caramel dog with a very wiggly tail. Pip love
 
 msgid "This page has no captioned images"
 msgstr "This page has no captioned images"
+
+msgid "This page has no entries to synthesize"
+msgstr "This page has no entries to synthesize"
 
 msgid "This page has no sectioning output"
 msgstr "This page has no sectioning output"

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -3317,6 +3317,9 @@ msgstr "Aún no hay clave API para {0}. Añade una en la configuración del libr
 msgid "No assessment"
 msgstr "No assessment"
 
+msgid "No audio for this page"
+msgstr "No hay audio para esta página"
+
 msgid "No books match your search"
 msgstr "Ningún libro coincide con tu búsqueda"
 
@@ -4498,6 +4501,9 @@ msgstr "Ejecuta Storyboard para generar secciones a las que puedas asignar video
 msgid "Run the pipeline"
 msgstr "Ejecutar el pipeline"
 
+msgid "Run the pipeline to extract content"
+msgstr "Ejecuta la canalización para extraer contenido"
+
 msgid "Run TOC"
 msgstr "Ejecutar TOC"
 
@@ -5427,6 +5433,9 @@ msgstr "¡Este es Pip! Es un perro caramelo feliz con una cola muy movida. A Pip
 
 msgid "This page has no captioned images"
 msgstr "Esta página no tiene imágenes con leyendas"
+
+msgid "This page has no entries to synthesize"
+msgstr "Esta página no tiene entradas para sintetizar"
 
 msgid "This page has no sectioning output"
 msgstr "Esta página no tiene salida de seccionamiento"

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -3319,6 +3319,9 @@ msgstr "Pas encore de clé API pour {0}. Ajoutez-en une dans les paramètres du 
 msgid "No assessment"
 msgstr "Aucune évaluation"
 
+msgid "No audio for this page"
+msgstr "Pas de son pour cette page"
+
 msgid "No books match your search"
 msgstr "Aucun livre ne correspond à votre recherche"
 
@@ -4500,6 +4503,9 @@ msgstr "Exécutez le storyboard pour générer des sections auxquelles vous pouv
 msgid "Run the pipeline"
 msgstr "Exécuter le pipeline"
 
+msgid "Run the pipeline to extract content"
+msgstr "Exécutez le pipeline pour extraire le contenu"
+
 msgid "Run TOC"
 msgstr "Exécuter la table des matières"
 
@@ -5429,6 +5435,9 @@ msgstr "Voici Pip ! C'est un joyeux chien caramel avec une queue très remuante.
 
 msgid "This page has no captioned images"
 msgstr "Cette page n'a pas d'images légendées"
+
+msgid "This page has no entries to synthesize"
+msgstr "Cette page n'a pas d'entrées à synthétiser"
 
 msgid "This page has no sectioning output"
 msgstr "Cette page n'a pas de sortie de sectionnement"

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -3317,6 +3317,9 @@ msgstr "Ainda não há chave de API para {0}. Adicione uma nas configurações d
 msgid "No assessment"
 msgstr "No assessment"
 
+msgid "No audio for this page"
+msgstr "Sem áudio para esta página"
+
 msgid "No books match your search"
 msgstr "Nenhum livro corresponde à sua busca"
 
@@ -4498,6 +4501,9 @@ msgstr "Execute Storyboard para gerar seções que você pode associar a vídeos
 msgid "Run the pipeline"
 msgstr "Executar o pipeline"
 
+msgid "Run the pipeline to extract content"
+msgstr "Execute o pipeline para extrair conteúdo"
+
 msgid "Run TOC"
 msgstr "Executar Sumário"
 
@@ -5427,6 +5433,9 @@ msgstr "Este é o Pip! Ele é um cachorro caramelo feliz com um rabo muito agita
 
 msgid "This page has no captioned images"
 msgstr "Esta página não tem imagens legendadas"
+
+msgid "This page has no entries to synthesize"
+msgstr "Esta página não tem entradas para sintetizar"
 
 msgid "This page has no sectioning output"
 msgstr "Esta página não tem saída de seccionamento"


### PR DESCRIPTION
## Summary

Consolidates 8 near-identical icon-circle empty-state instances into a single shared `StageEmptyState` component at `apps/studio/src/components/pipeline/components/StageEmptyState.tsx`. Part of #387.

- Typed `color: "orange" | "teal" | "pink" | "violet" | "sky"` prop drives the icon background (`bg-X-50`) and tint (`text-X-300`) via an internal map. Tailwind class strings are spelled out so static extraction picks them up.
- `icon` (a `LucideIcon`), `title`, optional `subtitle`, and optional `cta` are slot-based — callers stay in control of copy and any actions.
- Net: 8 inline `<div className="flex flex-col items-center justify-center py-16 …">…</div>` blocks → 4–6 lines of `<StageEmptyState …/>` each.

## Migrated sites

| File | Site |
|---|---|
| `captions/CaptionsView.tsx` | "No images in this section" (PageCaptions filter) |
| `captions/CaptionsView.tsx` | "No images on this page" (with "Show all" CTA) |
| `captions/CaptionsView.tsx` | "No captions for this page" (passed to PageCaptions) |
| `quizzes/QuizzesView.tsx` | "No quizzes for this page" |
| `languages/LanguageView.tsx` | "No translations for this page" |
| `sectioning/SectioningView.tsx` | "No sections for this page" |
| `storyboard/StoryboardView.tsx` | "No sections for this page" |
| `storyboard/components/StoryboardSectionDetail.tsx` | "No rendered content for this section" |

## Open question: how often should users land here?

The whole pattern exists because the per-page sidebar (`StageSidebar` in the book-level layout) lists **every page** regardless of whether the current stage has any output for that page. So when a user clicks a page that has no captions / no quizzes / no translations, they land on a polite "nothing here" panel. The empty state is mostly papering over a navigation issue.

**A potentially better approach** (worth discussing before we invest further in the empty state itself): surface which pages actually have content for the current stage in the sidebar — either:

- **Indicator route (less destructive):** a small colored dot or count badge on each `PageRow` in `StageSidebar.tsx` when the stage has data for that page. Users can see at a glance which pages are worth opening. The shared `StageEmptyState` from this PR stays in place and is **combined with** the row indicators — it's still the destination when the user opens a page with no content, just less frequently reached.

  Quick mock-up on the Captions stage:

<img width="1710" height="1112" alt="8obGdg5EmAN" src="https://github.com/user-attachments/assets/e570f59e-f64f-484f-9abf-7e1533b5e8fc" />


- **Filter route:** add a toggle in the sidebar header — "Show only pages with X" — that hides rows with no content for the current stage. The shared `StageEmptyState` remains as the **fallback** for the cases the filter doesn't cover (e.g. deep links to a page with no content, freshly emptied content while the filter is off).

  Quick mock-up on the Captions stage with the toggle on:

<img width="1710" height="1112" alt="8obGfF9BGvS" src="https://github.com/user-attachments/assets/1e429f72-c7ab-4b51-b712-4a8be82389a1" />