### PR TITLE
fix: restore activity Submit button in storyboard embed preview

### DIFF
--- a/apps/adt-runtime/src/app/lifecycle.ts
+++ b/apps/adt-runtime/src/app/lifecycle.ts
@@ -39,6 +39,7 @@ import {
   dockReadyAtom,
   dockWidthAtom,
   easyReadModeAtom,
+  embedModeAtom,
   glossaryModeAtom,
   iconSizeAtom,
   reduceMotionAtom,
@@ -71,6 +72,11 @@ function readCurrentSectionId(): string | null {
 function readIsActivityPage(): boolean {
   if (typeof document === "undefined") return false
   return !!document.querySelector('section[data-section-type^="activity_"]')
+}
+
+function readIsEmbedMode(): boolean {
+  if (typeof window === "undefined") return false
+  return new URLSearchParams(window.location.search).get("embed") === "1"
 }
 
 function readCurrentPageNumber(): number | null {
@@ -171,6 +177,7 @@ export async function bootRuntime(): Promise<void> {
     const isActivity = readIsActivityPage()
     store.set(isActivityPageAtom, isActivity)
     store.set(activityModeAtom, isActivity)
+    store.set(embedModeAtom, readIsEmbedMode())
 
     applyDOMTranslations()
 

--- a/apps/adt-runtime/src/features/activity/components/ActivityDock.tsx
+++ b/apps/adt-runtime/src/features/activity/components/ActivityDock.tsx
@@ -4,13 +4,17 @@ import { useTranslation } from "@/features/language/hooks/useTranslation";
 import { useAtomValue } from "jotai";
 import { activityModeAtom } from "@/features/activity/state/activity.atoms";
 import { useDockContext } from "@/features/dock/context/dock-context";
+import { embedModeAtom } from "@/shared/state/ui.atoms";
 
 export function ActivityDock() {
   const { t } = useTranslation();
   const { isCompact, shouldHide, isTop } = useDockContext();
   const activityMode = useAtomValue(activityModeAtom);
-  const topClassname = isCompact ? "top-21" : "top-18";
-  const bottomClassname = isCompact ? "bottom-21" : "bottom-18";
+  const embed = useAtomValue(embedModeAtom);
+  // In embed mode the BottomDock is hidden, so sit flush near the edge
+  // instead of leaving room above the (absent) reader dock.
+  const topClassname = embed ? "top-3" : isCompact ? "top-21" : "top-18";
+  const bottomClassname = embed ? "bottom-3" : isCompact ? "bottom-21" : "bottom-18";
 
   if (!activityMode) return null;
 

--- a/apps/adt-runtime/src/features/dock/components/BottomDock.tsx
+++ b/apps/adt-runtime/src/features/dock/components/BottomDock.tsx
@@ -1,6 +1,6 @@
 import { useAtomValue } from "jotai";
 import { appConfigAtom } from "@/shared/state/config.atoms";
-import { dockReadyAtom } from "@/shared/state/ui.atoms";
+import { dockReadyAtom, embedModeAtom } from "@/shared/state/ui.atoms";
 import { BookMetadata } from "@/features/dock/components/BookMetadata";
 import { DockMenu } from "@/features/dock/components/DockMenu";
 import { DockSkeleton } from "@/features/dock/components/DockSkeleton";
@@ -73,6 +73,9 @@ function DockContainer({ children }: DockContainerProps) {
 
 export function BottomDock() {
   const ready = useAtomValue(dockReadyAtom);
+  const embed = useAtomValue(embedModeAtom);
+
+  if (embed) return null;
 
   if (!ready) {
     return (

--- a/apps/adt-runtime/src/shared/state/ui.atoms.ts
+++ b/apps/adt-runtime/src/shared/state/ui.atoms.ts
@@ -31,6 +31,10 @@ export const themeAtom = persistedStringAtom("theme", "dark")
 
 export const dockReadyAtom = ephemeralAtom(false)
 export const dockHiddenAtom = ephemeralAtom(false)
+// True when the runtime is mounted inside a `?embed=1` preview iframe (e.g.
+// the Studio storyboard activity preview). BottomDock hides itself so only
+// the activity Submit/Skip controls remain visible.
+export const embedModeAtom = ephemeralAtom(false)
 export const sidebarOpenAtom = ephemeralAtom(false)
 export const navOpenAtom = ephemeralAtom(false)
 export const navScrollPositionAtom = ephemeralAtom(0)

--- a/packages/pipeline/src/package-web.ts
+++ b/packages/pipeline/src/package-web.ts
@@ -1108,17 +1108,17 @@ ${fallbackHeadingHtml}${contentBlock}
       : ""
   }
 
-  // In embed mode, hide all interface chrome except the submit/reset buttons
+  // In embed mode, hide non-essential chrome. The React runtime mounts the
+  // activity Submit/Skip buttons inside #nav-container, so it must stay
+  // visible — BottomDock self-hides via embedModeAtom (see ui.atoms.ts).
   const embedStyles = opts.embed
     ? `
     <style>
       /* Hide navigation, sidebar, and other chrome in embed mode */
-      #nav-container, #back-forward-buttons, #nav-popup,
+      #back-forward-buttons, #nav-popup,
       #open-sidebar, #sidebar, #tts-quick-toggle-button, #play-bar,
       #sl-quick-toggle-button, #sign-language-video,
       #explain-me-button, #eli5-content, #notepad-button, #notepad-content { display: none !important; }
-      /* Keep submit/reset container fixed at bottom-right in embed mode */
-      #submit-reset-container { position: fixed !important; bottom: 1rem; right: 1rem; z-index: 50; }
     </style>`
     : ""
 
@@ -1140,7 +1140,7 @@ ${mathScript}${embedStyles}</head>
 ${mainBlock}
 ${answersScript}
     <div class="relative z-50" id="interface-container"></div>
-    <div class="relative z-50" id="nav-container"${opts.embed ? ' style="display:none"' : ""}></div>
+    <div class="relative z-50" id="nav-container"></div>
 ${opts.embed
       ? `    <script src="./assets/base.bundle.min.js?v=${escapeAttr(opts.bundleVersion)}" type="module"></script>`
       : `    <script src="./assets/offline-preloader.js"></script>


### PR DESCRIPTION
## Summary
- Add `embedModeAtom` set at boot from `?embed=1` so the runtime knows when it's rendered inside the Studio storyboard preview iframe.
- Hide `BottomDock` and reposition `ActivityDock` flush to the edge (`top-3`/`bottom-3`) in embed mode so only the Submit/Skip controls remain.
- Stop hiding `#nav-container` and drop the obsolete `#submit-reset-container` positioning hack in `package-web.ts`, since the React runtime now mounts the activity controls inside `#nav-container`.

## Test plan
- [ ] Open a storyboard activity preview in Studio and confirm the Submit button is visible and functional.
- [ ] Confirm the regular reader still shows the BottomDock and activity dock positioning is unchanged outside embed mode.