### PR TITLE
fix: /Matte un-matting and non-RGB colorspaces in PDF image extraction

### DIFF
--- a/packages/pdf/src/__tests__/extract.test.ts
+++ b/packages/pdf/src/__tests__/extract.test.ts
@@ -518,6 +518,228 @@ function createPdfWithSingleArrayDctFilterImage(): Buffer {
   return Buffer.from(doc.saveToBuffer("").asUint8Array());
 }
 
+/**
+ * Build a PDF with a CMYK JPEG image. Mirrors what print-oriented PDFs commonly
+ * produce — the image data is a single-filter DCTDecode stream with /ColorSpace
+ * /DeviceCMYK.
+ */
+function createPdfWithCmykJpegImage(): Buffer {
+  const doc = new mupdf.PDFDocument();
+
+  // Create a CMYK pixmap and encode it as a CMYK JPEG.
+  const cmykPixmap = new mupdf.Pixmap(mupdf.ColorSpace.DeviceCMYK, [0, 0, 4, 4], false);
+  const cmykJpegBytes = Buffer.from(cmykPixmap.asJPEG(90, false));
+
+  const imgDict = doc.newDictionary();
+  imgDict.put("Type", doc.newName("XObject"));
+  imgDict.put("Subtype", doc.newName("Image"));
+  imgDict.put("Width", 4);
+  imgDict.put("Height", 4);
+  imgDict.put("BitsPerComponent", 8);
+  imgDict.put("ColorSpace", doc.newName("DeviceCMYK"));
+  imgDict.put("Filter", doc.newName("DCTDecode"));
+
+  const imgObj = doc.addRawStream(cmykJpegBytes, imgDict);
+
+  const resources = doc.newDictionary();
+  const xobjects = doc.newDictionary();
+  xobjects.put("Im1", imgObj);
+  resources.put("XObject", xobjects);
+
+  const pageContent = "q 100 0 0 100 50 650 cm /Im1 Do Q";
+  const pageObj = doc.addPage([0, 0, 612, 792], 0, resources, pageContent);
+  doc.insertPage(-1, pageObj);
+
+  return Buffer.from(doc.saveToBuffer("").asUint8Array());
+}
+
+/**
+ * Build a PDF with an RGB image that has an attached /SMask carrying alpha.
+ * Mirrors the typical output of design tools that flatten transparency to a
+ * base image plus a soft mask.
+ */
+function createPdfWithSoftMaskImage(): Buffer {
+  const doc = new mupdf.PDFDocument();
+  const w = 4;
+  const h = 4;
+
+  // Base RGB image — 4x4, fill with bright red so the alpha effect is obvious.
+  const baseBytes = Buffer.alloc(w * h * 3);
+  for (let i = 0; i < w * h; i++) {
+    baseBytes[i * 3 + 0] = 255;
+    baseBytes[i * 3 + 1] = 0;
+    baseBytes[i * 3 + 2] = 0;
+  }
+
+  // SMask — gray; left half opaque (255), right half transparent (0).
+  const maskBytes = Buffer.alloc(w * h);
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      maskBytes[y * w + x] = x < w / 2 ? 255 : 0;
+    }
+  }
+
+  const maskDict = doc.newDictionary();
+  maskDict.put("Type", doc.newName("XObject"));
+  maskDict.put("Subtype", doc.newName("Image"));
+  maskDict.put("Width", w);
+  maskDict.put("Height", h);
+  maskDict.put("BitsPerComponent", 8);
+  maskDict.put("ColorSpace", doc.newName("DeviceGray"));
+  const maskObj = doc.addStream(maskBytes, maskDict);
+
+  const imgDict = doc.newDictionary();
+  imgDict.put("Type", doc.newName("XObject"));
+  imgDict.put("Subtype", doc.newName("Image"));
+  imgDict.put("Width", w);
+  imgDict.put("Height", h);
+  imgDict.put("BitsPerComponent", 8);
+  imgDict.put("ColorSpace", doc.newName("DeviceRGB"));
+  imgDict.put("SMask", maskObj);
+  const imgObj = doc.addStream(baseBytes, imgDict);
+
+  const resources = doc.newDictionary();
+  const xobjects = doc.newDictionary();
+  xobjects.put("Im1", imgObj);
+  resources.put("XObject", xobjects);
+
+  const pageContent = "q 100 0 0 100 50 650 cm /Im1 Do Q";
+  const pageObj = doc.addPage([0, 0, 612, 792], 0, resources, pageContent);
+  doc.insertPage(-1, pageObj);
+
+  return Buffer.from(doc.saveToBuffer("").asUint8Array());
+}
+
+/**
+ * Build a PDF whose SMask carries a /Matte entry. The base RGB bytes are stored
+ * pre-blended with the matte color (white) at 50% alpha — i.e. ~(127, 127, 127)
+ * — so that un-matting must recover the original color (~black).
+ */
+function createPdfWithMattedSoftMaskImage(): Buffer {
+  const doc = new mupdf.PDFDocument();
+  const w = 4;
+  const h = 4;
+
+  // Pre-blended pixels: original black (0) onto white matte (255) at a=0.5.
+  const baseBytes = Buffer.alloc(w * h * 3);
+  for (let i = 0; i < w * h; i++) {
+    baseBytes[i * 3 + 0] = 127;
+    baseBytes[i * 3 + 1] = 127;
+    baseBytes[i * 3 + 2] = 127;
+  }
+
+  // Uniform 50% alpha (128).
+  const maskBytes = Buffer.alloc(w * h);
+  for (let i = 0; i < w * h; i++) maskBytes[i] = 128;
+
+  const maskDict = doc.newDictionary();
+  maskDict.put("Type", doc.newName("XObject"));
+  maskDict.put("Subtype", doc.newName("Image"));
+  maskDict.put("Width", w);
+  maskDict.put("Height", h);
+  maskDict.put("BitsPerComponent", 8);
+  maskDict.put("ColorSpace", doc.newName("DeviceGray"));
+  const matte = doc.newArray();
+  matte.push(1);
+  matte.push(1);
+  matte.push(1);
+  maskDict.put("Matte", matte);
+  const maskObj = doc.addStream(maskBytes, maskDict);
+
+  const imgDict = doc.newDictionary();
+  imgDict.put("Type", doc.newName("XObject"));
+  imgDict.put("Subtype", doc.newName("Image"));
+  imgDict.put("Width", w);
+  imgDict.put("Height", h);
+  imgDict.put("BitsPerComponent", 8);
+  imgDict.put("ColorSpace", doc.newName("DeviceRGB"));
+  imgDict.put("SMask", maskObj);
+  const imgObj = doc.addStream(baseBytes, imgDict);
+
+  const resources = doc.newDictionary();
+  const xobjects = doc.newDictionary();
+  xobjects.put("Im1", imgObj);
+  resources.put("XObject", xobjects);
+
+  const pageContent = "q 100 0 0 100 50 650 cm /Im1 Do Q";
+  const pageObj = doc.addPage([0, 0, 612, 792], 0, resources, pageContent);
+  doc.insertPage(-1, pageObj);
+
+  return Buffer.from(doc.saveToBuffer("").asUint8Array());
+}
+
+describe("extractPdf images with soft masks", () => {
+  it("preserves alpha from /SMask instead of producing an opaque image on a black background", async () => {
+    const pdfBuffer = createPdfWithSoftMaskImage();
+    const result = await extractPdf({ pdfBuffer });
+
+    const rasterImages = result.pages[0].images.filter(
+      (img) => !img.imageId.endsWith("_page")
+    );
+    expect(rasterImages).toHaveLength(1);
+    const img = rasterImages[0];
+    expect(img.format).toBe("png");
+
+    // Decode and verify: left half is opaque red, right half is transparent.
+    const { data, width, height } = decodePng(img.buffer);
+    expect(width).toBe(4);
+    expect(height).toBe(4);
+
+    // The PNG must have an alpha channel.
+    expect(data.length).toBe(width * height * 4);
+
+    // Left column: opaque red.
+    expect(data[0]).toBe(255); // R
+    expect(data[1]).toBe(0); // G
+    expect(data[2]).toBe(0); // B
+    expect(data[3]).toBe(255); // A
+
+    // Right column: alpha 0 (the actual color underneath is irrelevant —
+    // the failure mode being tested is opaque pixels with no alpha).
+    const lastPixelOffset = (4 * 4 - 1) * 4;
+    expect(data[lastPixelOffset + 3]).toBe(0);
+  });
+
+  it("un-mattes base colors when /SMask carries a /Matte entry", async () => {
+    const pdfBuffer = createPdfWithMattedSoftMaskImage();
+    const result = await extractPdf({ pdfBuffer });
+
+    const rasterImages = result.pages[0].images.filter(
+      (img) => !img.imageId.endsWith("_page")
+    );
+    expect(rasterImages).toHaveLength(1);
+    const { data } = decodePng(rasterImages[0].buffer);
+
+    // Stored pixels are gray (~127) because they were pre-blended with a
+    // white matte at 50% alpha. After un-matting we must recover near-black;
+    // without un-matting the channels would stay around 127.
+    expect(data[0]).toBeLessThan(10);
+    expect(data[1]).toBeLessThan(10);
+    expect(data[2]).toBeLessThan(10);
+    expect(data[3]).toBe(128);
+  });
+});
+
+describe("extractPdf CMYK images", () => {
+  it("converts CMYK JPEGs to RGB so browsers render them correctly", async () => {
+    const pdfBuffer = createPdfWithCmykJpegImage();
+    const result = await extractPdf({ pdfBuffer });
+
+    expect(result.pages).toHaveLength(1);
+    const rasterImages = result.pages[0].images.filter(
+      (img) => !img.imageId.endsWith("_page")
+    );
+    expect(rasterImages).toHaveLength(1);
+    const img = rasterImages[0];
+
+    expect(img.format).toBe("jpeg");
+    // Re-decode the extracted JPEG and confirm it is no longer CMYK.
+    const reloaded = new mupdf.Image(img.buffer);
+    const cs = reloaded.getColorSpace();
+    expect(cs?.getType()).toBe("RGB");
+  });
+});
+
 describe("extractPdf chained image filters", () => {
   it("extracts a valid image from a [FlateDecode, DCTDecode] filter chain", async () => {
     const pdfBuffer = createPdfWithChainedFilterImage();

--- a/packages/pdf/src/extract.ts
+++ b/packages/pdf/src/extract.ts
@@ -411,6 +411,43 @@ function pngDimensions(buf: Buffer): { width: number; height: number } {
   return { width: buf.readUInt32BE(16), height: buf.readUInt32BE(20) };
 }
 
+/** Force a pixmap to DeviceRGB so encoders/browsers can render it. RGB and
+ * Gray pass through unchanged; CMYK, Lab, ICCBased-non-RGB, etc. convert. */
+function normalizeToDisplayableRgb(pixmap: Pixmap): Pixmap {
+  const type = pixmap.getColorSpace()?.getType();
+  if (type === "RGB" || type === "Gray") return pixmap;
+  return pixmap.convertToColorSpace(mupdf.ColorSpace.DeviceRGB);
+}
+
+/** Read the /Matte array off an SMask dictionary, expressed as 8-bit RGB.
+ * Only RGB (3) and Gray (1) source colorspaces are handled; for anything
+ * else (e.g. CMYK) we conservatively skip un-matting. */
+function readSoftMaskMatte(
+  smaskObj: PDFObject,
+  srcType: string | undefined
+): [number, number, number] | undefined {
+  if (smaskObj.isNull()) return undefined;
+  const smaskDict = smaskObj.isIndirect() ? smaskObj.resolve() : smaskObj;
+  const matte = smaskDict.get("Matte");
+  if (matte.isNull() || !matte.isArray()) return undefined;
+
+  const toByte = (v: number) =>
+    Math.max(0, Math.min(255, Math.round(v * 255)));
+
+  if (matte.length === 3 && srcType === "RGB") {
+    return [
+      toByte(matte.get(0).asNumber()),
+      toByte(matte.get(1).asNumber()),
+      toByte(matte.get(2).asNumber()),
+    ];
+  }
+  if (matte.length === 1 && srcType === "Gray") {
+    const g = toByte(matte.get(0).asNumber());
+    return [g, g, g];
+  }
+  return undefined;
+}
+
 /**
  * Combine a color pixmap with a grayscale alpha mask (from an image's SMask)
  * into an RGBA PNG. PDF SMasks provide the transparency that
@@ -420,14 +457,31 @@ function pngDimensions(buf: Buffer): { width: number; height: number } {
  * If color and mask dimensions differ we fall back to sampling the mask at
  * the matching position (nearest-neighbour), which handles the common case
  * of a lower-resolution SMask.
+ *
+ * If `matteRgb` is provided, the base RGB has been pre-blended with that
+ * matte color and is un-matted (`c = matte + (c' - matte) * 255 / a`) so
+ * semi-transparent edges don't show colored halos.
  */
-function compositeColorAndMask(color: Pixmap, mask: Pixmap): Buffer {
-  const width = color.getWidth();
-  const height = color.getHeight();
-  const colorComponents = color.getNumberOfComponents();
-  const colorAlpha = color.getAlpha();
+function compositeColorAndMask(
+  color: Pixmap,
+  mask: Pixmap,
+  matteRgb?: readonly [number, number, number]
+): Buffer {
+  // The pixel-reading loop below assumes RGB or Gray byte layout. Convert
+  // anything else (CMYK, Lab, ICCBased-non-RGB, …) to DeviceRGB up front,
+  // otherwise we'd read CMY bytes as RGB and silently drop K.
+  const csType = color.getColorSpace()?.getType();
+  const rgb =
+    csType === "RGB" || csType === "Gray"
+      ? color
+      : color.convertToColorSpace(mupdf.ColorSpace.DeviceRGB);
+
+  const width = rgb.getWidth();
+  const height = rgb.getHeight();
+  const colorComponents = rgb.getNumberOfComponents();
+  const colorAlpha = rgb.getAlpha();
   const colorStride = colorComponents + (colorAlpha ? 1 : 0);
-  const colorPixels = color.getPixels();
+  const colorPixels = rgb.getPixels();
 
   const mWidth = mask.getWidth();
   const mHeight = mask.getHeight();
@@ -435,6 +489,10 @@ function compositeColorAndMask(color: Pixmap, mask: Pixmap): Buffer {
   const maskAlpha = mask.getAlpha();
   const maskStride = maskComponents + (maskAlpha ? 1 : 0);
   const maskPixels = mask.getPixels();
+
+  const mr = matteRgb ? matteRgb[0] : 0;
+  const mg = matteRgb ? matteRgb[1] : 0;
+  const mb = matteRgb ? matteRgb[2] : 0;
 
   const png = new PNG({ width, height });
   for (let y = 0; y < height; y++) {
@@ -444,20 +502,28 @@ function compositeColorAndMask(color: Pixmap, mask: Pixmap): Buffer {
       const srcIdx = (y * width + x) * colorStride;
       const maskIdx = (my * mWidth + mx) * maskStride;
       const dstIdx = (y * width + x) * 4;
+      let r: number, g: number, b: number;
       // Color channels: grayscale → replicate, RGB → copy direct.
       if (colorComponents === 1) {
-        const g = colorPixels[srcIdx];
-        png.data[dstIdx] = g;
-        png.data[dstIdx + 1] = g;
-        png.data[dstIdx + 2] = g;
+        const v = colorPixels[srcIdx];
+        r = v; g = v; b = v;
       } else {
-        png.data[dstIdx] = colorPixels[srcIdx];
-        png.data[dstIdx + 1] = colorPixels[srcIdx + 1];
-        png.data[dstIdx + 2] = colorPixels[srcIdx + 2];
+        r = colorPixels[srcIdx];
+        g = colorPixels[srcIdx + 1];
+        b = colorPixels[srcIdx + 2];
       }
       // Alpha from mask: mupdf SMask pixmaps are typically grayscale with the
       // value itself representing alpha (higher = more opaque).
-      png.data[dstIdx + 3] = maskPixels[maskIdx];
+      const a = maskPixels[maskIdx];
+      if (matteRgb && a > 0 && a < 255) {
+        r = Math.max(0, Math.min(255, Math.round(mr + ((r - mr) * 255) / a)));
+        g = Math.max(0, Math.min(255, Math.round(mg + ((g - mg) * 255) / a)));
+        b = Math.max(0, Math.min(255, Math.round(mb + ((b - mb) * 255) / a)));
+      }
+      png.data[dstIdx] = r;
+      png.data[dstIdx + 1] = g;
+      png.data[dstIdx + 2] = b;
+      png.data[dstIdx + 3] = a;
     }
   }
   return PNG.sync.write(png);
@@ -1500,37 +1566,37 @@ function extractRasterImagesFromPdf(
         const smaskObj = resolved.get("SMask");
         const hasSMask = !smaskObj.isNull();
 
-        if (filterName === "DCTDecode" && isSingleFilter && !hasSMask) {
-          // Check colorspace — CMYK JPEGs need conversion (browsers can't display them)
-          const cs = resolved.get("ColorSpace");
-          const isCmyk =
-            (!cs.isNull() && cs.isName() && cs.asName() === "DeviceCMYK") ||
-            (!cs.isNull() && cs.isArray() && cs.get(0).asName() === "ICCBased" &&
-              cs.get(1).resolve().get("N").asNumber() === 4);
+        const image = doc.loadImage(streamObj);
+        const srcType = image.getColorSpace()?.getType();
+        const canRawExtract =
+          !hasSMask &&
+          filterName === "DCTDecode" &&
+          isSingleFilter &&
+          (srcType === "RGB" || srcType === "Gray");
 
-          if (isCmyk) {
-            // CMYK JPEG: decode through mupdf for color conversion → re-encode as JPEG
-            const image = doc.loadImage(streamObj);
-            const pixmap = image.toPixmap();
-            buf = Buffer.from(pixmap.asJPEG(90, true));
-            format = "jpeg";
-          } else {
-            // RGB/Gray JPEG (no SMask): extract raw bytes directly
-            buf = Buffer.from(streamObj.readRawStream().asUint8Array());
-            format = "jpeg";
-          }
+        if (canRawExtract) {
+          // Fast path: RGB/Gray JPEG with no transparency — copy bytes as-is.
+          buf = Buffer.from(streamObj.readRawStream().asUint8Array());
+          format = "jpeg";
         } else if (hasSMask) {
-          // Composite color + soft-mask into an RGBA PNG.
-          const colorPixmap = doc.loadImage(streamObj).toPixmap();
+          // Composite color + soft-mask into an RGBA PNG, un-matting if the
+          // SMask carries a /Matte entry (avoids colored halos at edges).
+          const colorPixmap = image.toPixmap();
           const smaskStream = smaskObj.isIndirect() ? smaskObj : resolved.get("SMask");
           const maskPixmap = doc.loadImage(smaskStream).toPixmap();
-          buf = compositeColorAndMask(colorPixmap, maskPixmap);
+          const matteRgb = readSoftMaskMatte(smaskObj, srcType);
+          buf = compositeColorAndMask(colorPixmap, maskPixmap, matteRgb);
           format = "png";
+        } else if (filterName === "DCTDecode" && isSingleFilter) {
+          // Single-filter JPEG with non-displayable colorspace (CMYK, Lab,
+          // ICCBased non-RGB, etc.) — decode, convert to RGB, re-encode.
+          buf = Buffer.from(normalizeToDisplayableRgb(image.toPixmap()).asJPEG(90, false));
+          format = "jpeg";
         } else {
-          // Multi-filter chains or non-JPEG without SMask: decode through mupdf → PNG
-          const image = doc.loadImage(streamObj);
-          const pixmap = image.toPixmap();
-          buf = Buffer.from(pixmap.asPNG());
+          // Multi-filter chains or non-JPEG without SMask: decode through
+          // mupdf → PNG. Normalize to RGB first since PNG can't encode
+          // CMYK/Lab/etc.
+          buf = Buffer.from(normalizeToDisplayableRgb(image.toPixmap()).asPNG());
           format = "png";
         }
 


### PR DESCRIPTION
## Summary
- Adds `/Matte` un-matting for SMasks (`c = matte + (c' − matte) · 255 / a`), eliminating colored halos at semi-transparent edges.
- Tightens the DCT fast-path to RGB/Gray sources only; CMYK, Lab, and ICCBased-non-RGB now decode through mupdf and re-encode as displayable RGB JPEGs instead of arriving as unrenderable bytes.
- Normalizes the SMask composer's base pixmap to DeviceRGB so CMYK+SMask images no longer drop the K channel, and routes the multi-filter / non-JPEG branch through `normalizeToDisplayableRgb()` before PNG encoding.
- Adds three synthetic-PDF tests covering CMYK JPEG, plain SMask alpha preservation, and `/Matte` un-matting.

## Test plan
- [x] `pnpm typecheck`
- [x] `npx vitest run packages/pdf` (143/143 passing, including the 3 new tests; raven baselines unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)