### PR TITLE
feat: add Albanian language with Kosovo/Balkan dialect support

### DIFF
--- a/apps/studio/src/lib/languages.ts
+++ b/apps/studio/src/lib/languages.ts
@@ -10,6 +10,14 @@ export interface Language {
 }
 
 export const SUPPORTED_LANGUAGES: Language[] = [
+  { code: "sq", name: "Albanian", countries: [
+    { code: "al", name: "Albania" },
+    { code: "xk", name: "Kosovo" },
+    { code: "mk", name: "North Macedonia" },
+    { code: "me", name: "Montenegro" },
+    { code: "rs", name: "Serbia" },
+    { code: "gr", name: "Greece" },
+  ]},
   { code: "ar", name: "Arabic", countries: [
     { code: "eg", name: "Egypt" },
     { code: "sa", name: "Saudi Arabia" },
@@ -397,6 +405,7 @@ export const ALL_COUNTRIES: Country[] = [
   { code: "ke", name: "Kenya" },
   { code: "kp", name: "North Korea" },
   { code: "kr", name: "South Korea" },
+  { code: "xk", name: "Kosovo" },
   { code: "kw", name: "Kuwait" },
   { code: "kg", name: "Kyrgyzstan" },
   { code: "la", name: "Laos" },
@@ -413,6 +422,7 @@ export const ALL_COUNTRIES: Country[] = [
   { code: "mx", name: "Mexico" },
   { code: "md", name: "Moldova" },
   { code: "mn", name: "Mongolia" },
+  { code: "me", name: "Montenegro" },
   { code: "ma", name: "Morocco" },
   { code: "mz", name: "Mozambique" },
   { code: "mm", name: "Myanmar" },
@@ -423,6 +433,7 @@ export const ALL_COUNTRIES: Country[] = [
   { code: "ni", name: "Nicaragua" },
   { code: "ne", name: "Niger" },
   { code: "ng", name: "Nigeria" },
+  { code: "mk", name: "North Macedonia" },
   { code: "no", name: "Norway" },
   { code: "om", name: "Oman" },
   { code: "pk", name: "Pakistan" },


### PR DESCRIPTION
## Summary

Adds Albanian (`sq`) to `SUPPORTED_LANGUAGES` so Albanian-language books are pickable in the Studio and processable through the Extract pipeline. Includes country variants for Albania, Kosovo, North Macedonia, Montenegro, Serbia, and Greece, and adds Kosovo, Montenegro, and North Macedonia to `ALL_COUNTRIES`. No other changes are required — the Extract stage's `book-summary` step resolves the language name via `Intl.DisplayNames` (`sq` → "Albanian") and no allowlist gates extraction; interface translations under `assets/adt/interface_translations/sq/` already exist.

## Test plan

- [ ] Verify Albanian appears in the language picker with all six country variants
- [ ] Run Extract stage on an Albanian-language PDF and confirm `book-summary` prompt context shows "Albanian" / "Albanian (Albania)" etc.