### PR TITLE
feat: default storyboard image edits to gpt-image-2

### DIFF
--- a/apps/api/src/routes/pages.ts
+++ b/apps/api/src/routes/pages.ts
@@ -190,7 +190,7 @@ async function executeAiImageGeneration(params: AiImageGenParams): Promise<{
   try {
     generated = await generateImageWithCache({
       apiKey,
-      modelId: "openai:gpt-image-1.5",
+      modelId: "openai:gpt-image-2",
       prompt: finalPrompt,
       size: size as `${number}x${number}`,
       referenceImages,
@@ -1587,7 +1587,7 @@ export function createPageRoutes(
     }
   })
 
-  // POST /books/:label/images/ai-generate — Generate image via gpt-image-1.5
+  // POST /books/:label/images/ai-generate — Generate image via gpt-image-2
   app.post("/books/:label/images/ai-generate", async (c) => {
     try {
       const { label } = c.req.param()

--- a/apps/studio/src/components/pipeline/components/ModelSelect.tsx
+++ b/apps/studio/src/components/pipeline/components/ModelSelect.tsx
@@ -256,8 +256,6 @@ export const IMAGE_MODEL_GROUPS: ModelGroup[] = [
     provider: "openai",
     models: [
       "gpt-image-2",
-      "gpt-image-1.5",
-      "gpt-image-1",
       "dall-e-3",
     ],
   },

--- a/packages/llm/src/__tests__/image.test.ts
+++ b/packages/llm/src/__tests__/image.test.ts
@@ -32,7 +32,7 @@ describe("generateImageWithCache", () => {
 
     const first = await generateImageWithCache({
       apiKey: "sk-test",
-      modelId: "openai:gpt-image-1.5",
+      modelId: "openai:gpt-image-2",
       prompt: "a bright diagram",
       size: "1024x1024",
       cacheDir,
@@ -40,7 +40,7 @@ describe("generateImageWithCache", () => {
 
     const second = await generateImageWithCache({
       apiKey: "sk-test",
-      modelId: "openai:gpt-image-1.5",
+      modelId: "openai:gpt-image-2",
       prompt: "a bright diagram",
       size: "1024x1024",
       cacheDir,
@@ -89,7 +89,7 @@ describe("generateImageWithCache", () => {
 
     const result = await generateImageWithCache({
       apiKey: "sk-test",
-      modelId: "openai:gpt-image-1.5",
+      modelId: "openai:gpt-image-2",
       prompt: "make it cleaner",
       size: "1024x1024",
       referenceImages: [

--- a/packages/pipeline/src/image-translation.ts
+++ b/packages/pipeline/src/image-translation.ts
@@ -3,7 +3,7 @@ import { generateImageWithCache, pngDimensions, type LlmLogEntry } from "@adt/ll
 import { normalizeLocale } from "./language-context.js"
 
 export interface ImageTranslationConfig {
-  /** OpenAI image model id (e.g. "openai:gpt-image-1.5"). */
+  /** OpenAI image model id (e.g. "openai:gpt-image-2"). */
   modelId: string
   /** Liquid-rendered prompt to send with the image. */
   prompt: string

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -33,7 +33,7 @@ export type PageSectioningConfig = z.infer<typeof PageSectioningConfig>
 
 export const ImageTranslationConfig = StepConfig.extend({
   enabled: z.boolean().optional(),
-  /** Image model id (e.g. "openai:gpt-image-1.5"). When unset, the step is a no-op. */
+  /** Image model id (e.g. "openai:gpt-image-2"). When unset, the step is a no-op. */
   image_model: z.string().optional(),
   /** Image IDs the user has chosen to translate. Empty = no images regenerated. */
   selected_image_ids: z.array(z.string()).optional(),


### PR DESCRIPTION
## Summary
- Switch the storyboard AI image generate/edit endpoint (`/books/:label/images/ai-generate`) from `gpt-image-1.5` to `gpt-image-2`.
- Drop `gpt-image-1.5` and `gpt-image-1` from the image-model picker so only `gpt-image-2` and `dall-e-3` are selectable.
- Update JSDoc examples (`ImageTranslationConfig`, types `ImageTranslationConfig.image_model`) and image-cache test fixtures to `gpt-image-2` so the documented default matches the runtime default.

## Test plan
- [ ] Generate an image from the storyboard and confirm the request uses `gpt-image-2`.
- [ ] Edit an image with a reference from the storyboard and confirm it routes through `gpt-image-2`.
- [ ] Open the image-translation language settings and confirm the model picker only shows `gpt-image-2` and `dall-e-3`.
- [ ] `pnpm test` passes for `packages/llm`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)