### PR TITLE
fix(studio): enable Fixed Layout storyboard render strategy

### DIFF
--- a/apps/studio/src/components/pipeline/stages/storyboard/StoryboardLandingPage.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/StoryboardLandingPage.tsx
@@ -35,7 +35,7 @@ import { useStageStatus } from "@/hooks/use-stage-status"
 import { useBookRun } from "@/hooks/use-book-run"
 import { useApiKey } from "@/hooks/use-api-key"
 import {
-  listSelectableRenderStrategies,
+  listDefaultRenderStrategies,
   normalizeDefaultRenderStrategy,
 } from "@/lib/render-strategy"
 import { RenderStrategyVisual } from "./components/RenderStrategyVisual"
@@ -70,8 +70,7 @@ const LANDING_STRATEGY_ITEMS: LandingStrategyEntry[] = [
   },
   {
     id: "fixed_layout",
-    description: msg`Strict grid template that repeats across pages.`,
-    comingSoon: true,
+    description: msg`Preserves the source PDF's exact page layout — images and positioned text rendered in place.`,
   },
   {
     id: "two_column_story",
@@ -186,7 +185,7 @@ export function StoryboardLandingPage({ bookLabel }: { bookLabel: string }) {
       strategies,
     )
     setDefaultRenderStrategy(normalized)
-    const selectable = new Set(listSelectableRenderStrategies(strategies))
+    const selectable = new Set(listDefaultRenderStrategies(strategies))
     setRenderStrategyItems(
       LANDING_STRATEGY_ITEMS.filter(
         (item) => item.comingSoon || selectable.has(item.id),

--- a/apps/studio/src/components/pipeline/stages/storyboard/StoryboardSettings.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/StoryboardSettings.tsx
@@ -36,7 +36,7 @@ import { msg } from "@lingui/core/macro"
 import { useLingui } from "@lingui/react/macro"
 import { i18n } from "@lingui/core"
 import {
-  listSelectableRenderStrategies,
+  listDefaultRenderStrategies,
   normalizeDefaultRenderStrategy,
 } from "@/lib/render-strategy"
 import { getSectionTypeLabel } from "@/lib/section-constants"
@@ -50,6 +50,7 @@ function titleCase(slug: string): string {
 const STRATEGY_LABEL_MSGS: Record<string, ReturnType<typeof msg>> = {
   llm: msg`AI Generated`,
   "llm-overlay": msg`AI Overlay`,
+  fixed_layout: msg`Fixed Layout`,
 }
 
 function strategyDisplayName(slug: string): string {
@@ -63,6 +64,7 @@ const STRATEGY_DESCRIPTION_MSGS: Record<string, ReturnType<typeof msg>> = {
   "llm-overlay": msg`LLM positions text over background images`,
   two_column: msg`Fixed two-column template layout`,
   two_column_story: msg`Two-column template for story content`,
+  fixed_layout: msg`Preserves the source PDF's exact page layout`,
 }
 
 function strategyDescription(name: string): string {
@@ -276,7 +278,7 @@ export function StoryboardSettings({ bookLabel, headerTarget, tab = "general" }:
     )
     setDefaultRenderStrategy(normalizedDefaultRenderStrategy)
 
-    setRenderStrategyNames(listSelectableRenderStrategies(strategies))
+    setRenderStrategyNames(listDefaultRenderStrategies(strategies))
 
     // Styleguide
     setStyleguide(typeof merged.styleguide === "string" ? merged.styleguide : "")

--- a/apps/studio/src/lib/render-strategy.test.ts
+++ b/apps/studio/src/lib/render-strategy.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 import {
+  listDefaultRenderStrategies,
   listSelectableRenderStrategies,
   normalizeDefaultRenderStrategy,
 } from "./render-strategy"
@@ -15,6 +16,32 @@ describe("listSelectableRenderStrategies", () => {
     expect(listSelectableRenderStrategies(strategies)).toEqual([
       "llm",
       "two_column",
+    ])
+  })
+
+  it("filters out fixed_layout (not a per-section override)", () => {
+    const strategies = {
+      llm: { render_type: "llm" },
+      fixed_layout: { render_type: "fixed_layout" },
+    }
+
+    expect(listSelectableRenderStrategies(strategies)).toEqual(["llm"])
+  })
+})
+
+describe("listDefaultRenderStrategies", () => {
+  it("includes fixed_layout but still excludes activities", () => {
+    const strategies = {
+      llm: { render_type: "llm" },
+      two_column: { render_type: "template" },
+      fixed_layout: { render_type: "fixed_layout" },
+      activity_multiple_choice: { render_type: "activity" },
+    }
+
+    expect(listDefaultRenderStrategies(strategies)).toEqual([
+      "llm",
+      "two_column",
+      "fixed_layout",
     ])
   })
 })
@@ -58,6 +85,29 @@ describe("normalizeDefaultRenderStrategy", () => {
     }
 
     expect(normalizeDefaultRenderStrategy("missing", strategies)).toBe(
+      "two_column"
+    )
+  })
+
+  it("allows fixed_layout as an explicit default", () => {
+    const strategies = {
+      llm: { render_type: "llm" },
+      two_column: { render_type: "template" },
+      fixed_layout: { render_type: "fixed_layout" },
+    }
+
+    expect(normalizeDefaultRenderStrategy("fixed_layout", strategies)).toBe(
+      "fixed_layout"
+    )
+  })
+
+  it("never auto-falls-back to fixed_layout", () => {
+    const strategies = {
+      two_column: { render_type: "template" },
+      fixed_layout: { render_type: "fixed_layout" },
+    }
+
+    expect(normalizeDefaultRenderStrategy("dynamic", strategies)).toBe(
       "two_column"
     )
   })

--- a/apps/studio/src/lib/render-strategy.ts
+++ b/apps/studio/src/lib/render-strategy.ts
@@ -15,9 +15,25 @@ export function listSelectableRenderStrategies(
   })
 }
 
+/**
+ * Strategies that may be picked as the book-wide default. Same as
+ * {@link listSelectableRenderStrategies} but also includes `fixed_layout`,
+ * which is a valid whole-book rendering mode even though it cannot be assigned
+ * to an individual section.
+ */
+export function listDefaultRenderStrategies(
+  strategies: RenderStrategyMap
+): string[] {
+  return Object.keys(strategies).filter(
+    (name) => strategies[name]?.render_type !== "activity"
+  )
+}
+
 export function chooseDefaultRenderStrategyFallback(
   strategies: RenderStrategyMap
 ): string {
+  // Prefer a reflowable strategy for the auto-fallback — `fixed_layout`
+  // should only ever become the default when explicitly requested.
   const selectable = listSelectableRenderStrategies(strategies)
   if (selectable.includes("two_column")) return "two_column"
   return selectable[0] ?? ""
@@ -28,13 +44,13 @@ export function normalizeDefaultRenderStrategy(
   strategies: RenderStrategyMap
 ): string {
   const trimmed = (requested ?? "").trim()
-  const selectable = listSelectableRenderStrategies(strategies)
+  const candidates = listDefaultRenderStrategies(strategies)
 
-  if (selectable.length === 0) return ""
+  if (candidates.length === 0) return ""
   if (!trimmed || trimmed === "dynamic") {
     return chooseDefaultRenderStrategyFallback(strategies)
   }
-  if (selectable.includes(trimmed)) return trimmed
+  if (candidates.includes(trimmed)) return trimmed
 
   return chooseDefaultRenderStrategyFallback(strategies)
 }

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -4007,6 +4007,12 @@ msgstr "Precipitation"
 msgid "Prefer terms central to the book's subject matter. Skip generic vocabulary and proper nouns that don't carry meaning beyond the page."
 msgstr "Prefer terms central to the book's subject matter. Skip generic vocabulary and proper nouns that don't carry meaning beyond the page."
 
+msgid "Preserves the source PDF's exact page layout"
+msgstr "Preserves the source PDF's exact page layout"
+
+msgid "Preserves the source PDF's exact page layout — images and positioned text rendered in place."
+msgstr "Preserves the source PDF's exact page layout — images and positioned text rendered in place."
+
 msgid "Preset"
 msgstr "Preset"
 
@@ -5166,8 +5172,8 @@ msgstr "Stretch"
 msgid "Strict"
 msgstr "Strict"
 
-msgid "Strict grid template that repeats across pages."
-msgstr "Strict grid template that repeats across pages."
+#~ msgid "Strict grid template that repeats across pages."
+#~ msgstr "Strict grid template that repeats across pages."
 
 msgid "Strikethrough"
 msgstr "Strikethrough"

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -4007,6 +4007,12 @@ msgstr "Precipitación"
 msgid "Prefer terms central to the book's subject matter. Skip generic vocabulary and proper nouns that don't carry meaning beyond the page."
 msgstr "Prefiere términos centrales al tema del libro. Omite vocabulario genérico y nombres propios que no tienen significado más allá de la página."
 
+msgid "Preserves the source PDF's exact page layout"
+msgstr "Conserva el diseño de página exacto del PDF original"
+
+msgid "Preserves the source PDF's exact page layout — images and positioned text rendered in place."
+msgstr "Conserva el diseño de página exacto del PDF original: imágenes y texto posicionado representados en su lugar."
+
 msgid "Preset"
 msgstr "Preajuste"
 
@@ -5166,8 +5172,8 @@ msgstr "Estirar"
 msgid "Strict"
 msgstr "Estricto"
 
-msgid "Strict grid template that repeats across pages."
-msgstr "Plantilla de cuadrícula estricta que se repite a través de las páginas."
+#~ msgid "Strict grid template that repeats across pages."
+#~ msgstr "Plantilla de cuadrícula estricta que se repite a través de las páginas."
 
 msgid "Strikethrough"
 msgstr "Tachado"

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -4009,6 +4009,12 @@ msgstr "Précipitations"
 msgid "Prefer terms central to the book's subject matter. Skip generic vocabulary and proper nouns that don't carry meaning beyond the page."
 msgstr "Privilégiez les termes centraux au sujet du livre. Évitez le vocabulaire générique et les noms propres qui n'ont pas de signification au-delà de la page."
 
+msgid "Preserves the source PDF's exact page layout"
+msgstr "Préserve la mise en page exacte du PDF source"
+
+msgid "Preserves the source PDF's exact page layout — images and positioned text rendered in place."
+msgstr "Préserve la mise en page exacte du PDF source — images et texte positionné rendus à leur emplacement."
+
 msgid "Preset"
 msgstr "Preset"
 
@@ -5168,8 +5174,8 @@ msgstr "Étirer"
 msgid "Strict"
 msgstr "Strict"
 
-msgid "Strict grid template that repeats across pages."
-msgstr "Modèle de grille strict qui se répète sur les pages."
+#~ msgid "Strict grid template that repeats across pages."
+#~ msgstr "Modèle de grille strict qui se répète sur les pages."
 
 msgid "Strikethrough"
 msgstr "Barré"

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -4007,6 +4007,12 @@ msgstr "Precipitação"
 msgid "Prefer terms central to the book's subject matter. Skip generic vocabulary and proper nouns that don't carry meaning beyond the page."
 msgstr "Prefira termos centrais ao assunto do livro. Pule vocabulário genérico e nomes próprios que não carregam significado além da página."
 
+msgid "Preserves the source PDF's exact page layout"
+msgstr "Preserva o layout de página exato do PDF de origem"
+
+msgid "Preserves the source PDF's exact page layout — images and positioned text rendered in place."
+msgstr "Preserva o layout de página exato do PDF de origem — imagens e texto posicionado renderizados no lugar."
+
 msgid "Preset"
 msgstr "Predefinido"
 
@@ -5166,8 +5172,8 @@ msgstr "Esticar"
 msgid "Strict"
 msgstr "Rigoroso"
 
-msgid "Strict grid template that repeats across pages."
-msgstr "Modelo de grade estrito que se repete nas páginas."
+#~ msgid "Strict grid template that repeats across pages."
+#~ msgstr "Modelo de grade estrito que se repete nas páginas."
 
 msgid "Strikethrough"
 msgstr "Tachado"

--- a/config.yaml
+++ b/config.yaml
@@ -189,6 +189,8 @@ render_strategies:
     render_type: template
     config:
       template: one_column_render
+  fixed_layout:
+    render_type: fixed_layout
   activity_multiple_choice:
     render_type: activity
     config:


### PR DESCRIPTION
The Storyboard **Fixed Layout** option was permanently greyed out as "Coming soon" even though the fixed-layout rendering pipeline is fully implemented and wired through the API. This registers a `fixed_layout` render strategy in `config.yaml` and surfaces it as a selectable book-wide default in both the storyboard landing page and settings, while keeping it excluded from per-section overrides (it's a whole-book mode). A new `listDefaultRenderStrategies` helper lets `fixed_layout` be chosen as the default without ever becoming an automatic fallback, and `normalizeDefaultRenderStrategy` now preserves the selection across reloads. Added unit tests and translated the two new strings across all locales (`es`, `fr`, `pt-BR`).

Verified: render-strategy tests pass (11/11), studio typecheck clean, `pnpm lint` 0 errors, i18n catalogs 0 missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)