### PR TITLE
feat: cancel a running pipeline stage and keep completed work

### DIFF
--- a/apps/api/src/routes/stages.ts
+++ b/apps/api/src/routes/stages.ts
@@ -134,6 +134,16 @@ export function createStageRoutes(
     return c.json({ status: result.status, label, fromStage, toStage })
   })
 
+  // POST /books/:label/stages/cancel — Stop the active run, keep completed work.
+  // Stages stop scheduling new work and any unfinished step is recorded as
+  // not-complete, so downstream stages stay gated. Re-running resumes cheaply
+  // (completed per-page work is persisted and cached LLM calls are reused).
+  app.post("/books/:label/stages/cancel", (c) => {
+    const { label } = c.req.param()
+    const result = stageService.cancelStageRun(label)
+    return c.json({ cancelled: result.cancelled, label })
+  })
+
   // GET /books/:label/step-status — Unified stage + step status
   // DB step_runs is the single source of truth for step/stage state.
   // Only "queued" comes from the in-memory run queue.
@@ -284,6 +294,11 @@ export function createStageRoutes(
                     label: event.label,
                     error: event.error,
                   }),
+                })
+              } else if (event.type === "stage-run-cancelled") {
+                await stream.writeSSE({
+                  event: "cancelled",
+                  data: JSON.stringify({ label: event.label }),
                 })
               } else if (event.type === "task") {
                 await stream.writeSSE({

--- a/apps/api/src/services/book-event-bus.ts
+++ b/apps/api/src/services/book-event-bus.ts
@@ -4,6 +4,7 @@ export type BookSSEEvent =
   | { type: "progress"; data: ProgressEvent }
   | { type: "stage-run-complete"; label: string }
   | { type: "stage-run-error"; label: string; error: string }
+  | { type: "stage-run-cancelled"; label: string }
   | { type: "queue-next"; label: string; fromStage: string; toStage: string }
   | { type: "task"; data: TaskEvent }
 

--- a/apps/api/src/services/stage-runner.test.ts
+++ b/apps/api/src/services/stage-runner.test.ts
@@ -166,6 +166,50 @@ function seedStoryboardBook(booksDir: string, label: string): void {
   }
 }
 
+function seedStoryboardBookPages(
+  booksDir: string,
+  label: string,
+  pageIds: string[]
+): void {
+  const storage = createBookStorage(label, booksDir)
+  try {
+    pageIds.forEach((pageId, idx) => {
+      storage.putExtractedPage({
+        pageId,
+        pageNumber: idx + 1,
+        text: "Page text",
+        pageImage: {
+          imageId: `${pageId}_page`,
+          buffer: Buffer.from("fake-page-image"),
+          format: "png",
+          hash: `hash-page-${pageId}`,
+          width: 800,
+          height: 600,
+        },
+        images: [],
+      })
+      storage.putNodeData("page-sectioning", pageId, {
+        reasoning: "existing sectioning",
+        sections: [
+          {
+            sectionId: `${pageId}_sec001`,
+            sectionType: "content",
+            backgroundColor: "#ffffff",
+            textColor: "#000000",
+            pageNumber: idx + 1,
+            isPruned: false,
+            nodes: [
+              { nodeId: `${pageId}_n001`, isPruned: false, role: "text", text: "Hello" },
+            ],
+          },
+        ],
+      })
+    })
+  } finally {
+    storage.close()
+  }
+}
+
 function seedTextAndSpeechBook(booksDir: string, label: string): void {
   const storage = createBookStorage(label, booksDir)
   try {
@@ -372,6 +416,89 @@ describe("createStageRunner storyboard render-only", () => {
           event.type === "step-complete" && event.step === "page-sectioning"
       )
     ).toBe(false)
+  })
+})
+
+describe("createStageRunner cancellation", () => {
+  let tmpDir = ""
+
+  beforeEach(() => {
+    renderPageMock.mockReset()
+  })
+
+  afterEach(() => {
+    if (tmpDir) {
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+      tmpDir = ""
+    }
+  })
+
+  it("cancels storyboard mid-run: keeps rendered pages and leaves the step not complete", async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "stage-runner-cancel-"))
+    const booksDir = path.join(tmpDir, "books")
+    const promptsDir = path.join(tmpDir, "prompts")
+    const configPath = path.join(tmpDir, "config.yaml")
+    fs.mkdirSync(promptsDir, { recursive: true })
+    // concurrency: 1 so the run awaits each page; the abort then takes effect
+    // before the next page is scheduled.
+    fs.writeFileSync(
+      configPath,
+      `role_types:
+  section_text: Main body text
+structure_types:
+  paragraph: Paragraph
+concurrency: 1
+`
+    )
+    seedStoryboardBookPages(booksDir, "cancel-storyboard", ["pg001", "pg002"])
+
+    const controller = new AbortController()
+    renderPageMock.mockImplementation(async () => {
+      // Abort as soon as the first page renders; the second must not start.
+      controller.abort()
+      return { sections: [] }
+    })
+
+    const events: ProgressEvent[] = []
+    const runner = createStageRunner()
+    await runner.run(
+      "cancel-storyboard",
+      {
+        booksDir,
+        apiKey: "sk-test",
+        promptsDir,
+        configPath,
+        fromStage: "storyboard",
+        toStage: "storyboard",
+        signal: controller.signal,
+      },
+      { emit: (event) => events.push(event) }
+    )
+
+    // Scheduling stopped after the abort — only the first page rendered.
+    expect(renderPageMock).toHaveBeenCalledTimes(1)
+
+    // The interrupted step must NOT be marked complete (that would let the next
+    // stage treat a partial step as finished). It surfaces as a step error.
+    expect(
+      events.some((e) => e.type === "step-complete" && e.step === "web-rendering")
+    ).toBe(false)
+    expect(
+      events.some((e) => e.type === "step-error" && e.step === "web-rendering")
+    ).toBe(true)
+
+    const storage = createBookStorage("cancel-storyboard", booksDir)
+    try {
+      const step = storage.getStepRuns().find((s) => s.step === "web-rendering")
+      expect(step?.status).toBe("error")
+      expect(step?.error).toContain("re-run to resume")
+      // The page that finished before the cancel is kept.
+      expect(storage.getLatestNodeData("web-rendering", "pg001")).not.toBeNull()
+      // The page that never started has no rendering.
+      expect(storage.getLatestNodeData("web-rendering", "pg002")).toBeNull()
+    } finally {
+      storage.close()
+    }
   })
 })
 

--- a/apps/api/src/services/stage-runner.ts
+++ b/apps/api/src/services/stage-runner.ts
@@ -114,6 +114,10 @@ function toErrorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err)
 }
 
+/** Recorded as the step error when a run is cancelled mid-step. */
+const CANCEL_MESSAGE =
+  "Cancelled before this step finished. Completed pages are kept — re-run to resume."
+
 function isGeminiTtsRateLimitMessage(message: string): boolean {
   return /\(429\)|quota exceeded|rate limit|too many requests/i.test(message)
 }
@@ -152,10 +156,14 @@ export function buildStageRunnerImageClassifyConfig(
 async function processWithConcurrency<T>(
   items: T[],
   concurrency: number,
-  fn: (item: T) => Promise<void>
+  fn: (item: T) => Promise<void>,
+  signal?: AbortSignal,
 ): Promise<void> {
   const executing = new Set<Promise<void>>()
   for (const item of items) {
+    // Cancellation: stop scheduling new work. In-flight items are still awaited
+    // below so their persisted output is never lost or written after teardown.
+    if (signal?.aborted) break
     const p = fn(item).finally(() => {
       executing.delete(p)
     })
@@ -228,6 +236,7 @@ interface GenerateSpeechWordTimestampsOptions {
   textByLanguage: Map<string, Map<string, string>>
   concurrency: number
   progress: StageRunProgress
+  signal?: AbortSignal
 }
 
 async function generateSpeechWordTimestamps(
@@ -246,6 +255,7 @@ async function generateSpeechWordTimestamps(
     textByLanguage,
     concurrency,
     progress,
+    signal,
   } = options
 
   const entriesByLanguage = new Map<string, Record<string, WordTimestampEntry>>()
@@ -315,6 +325,7 @@ async function generateSpeechWordTimestamps(
         emitWordTimestampStepProgress(progress, completed, workItems.length, failedItems.length)
       }
     },
+    signal,
   )
 
   return { entriesByLanguage, failedItems }
@@ -364,6 +375,16 @@ export function createStageRunner(): StageRunner {
       try {
         const trackingProgress: StageRunProgress = {
           emit(event) {
+            // If a cancel has already landed, an in-flight step's "complete"
+            // event must NOT mark the step done — that would let the next stage
+            // treat a partial step as finished. Record it as a non-complete
+            // terminal state instead so the stage stays gated and the user can
+            // resume (per-page work that finished is already persisted).
+            if (options.signal?.aborted && event.type === "step-complete") {
+              completionStorage.recordStepError(event.step, CANCEL_MESSAGE)
+              progress.emit({ type: "step-error", step: event.step, error: CANCEL_MESSAGE })
+              return
+            }
             if (event.type === "step-start") {
               completionStorage.markStepStarted(event.step)
             } else if (event.type === "step-complete") {
@@ -380,8 +401,20 @@ export function createStageRunner(): StageRunner {
         }
 
         for (let i = fromIndex; i <= toIndex; i++) {
+          if (options.signal?.aborted) break
           const stage = STAGE_ORDER[i]
           await STAGE_RUNNERS[stage](label, options, trackingProgress)
+          if (options.signal?.aborted) break
+        }
+
+        if (options.signal?.aborted) {
+          // Safety net: any step still "running" when the cancel landed (and not
+          // already converted above) becomes a non-complete terminal state.
+          for (const row of completionStorage.getStepRuns()) {
+            if (row.status === "running") {
+              completionStorage.recordStepError(row.step, CANCEL_MESSAGE)
+            }
+          }
         }
       } finally {
         completionStorage.close()
@@ -565,22 +598,22 @@ async function runExtractStep(
 
     await runFilterPass(
       label, pages, storage, imageClassifyConfig,
-      effectiveConcurrency, pageResults, failedPages, progress
+      effectiveConcurrency, pageResults, failedPages, progress, options.signal
     )
 
     await runMeaningfulnessPass(
       label, pages, storage, meaningfulnessConfig, meaningfulnessModel,
-      effectiveConcurrency, pageResults, failedPages, progress
+      effectiveConcurrency, pageResults, failedPages, progress, options.signal
     )
 
     await runSegmentationPass(
       label, pages, storage, segmentationConfig, segmentationModel,
-      effectiveConcurrency, pageResults, progress
+      effectiveConcurrency, pageResults, progress, options.signal
     )
 
     await runCroppingPass(
       label, pages, storage, croppingConfig, croppingModel,
-      effectiveConcurrency, pageResults, progress
+      effectiveConcurrency, pageResults, progress, options.signal
     )
 
     if (failedPages.length > 0) {
@@ -736,6 +769,7 @@ async function runSectioningStep(
           })
         }
       },
+      options.signal,
     )
 
     if (failedPages.length > 0) {
@@ -865,6 +899,7 @@ async function runStoryboardStep(
       `[stage-run] ${label}: rendering storyboard for ${totalPages} pages (concurrency=${effectiveConcurrency})`
     )
 
+    progress.emit({ type: "step-start", step: "web-rendering" })
     let completedRendering = 0
     const failedPages: string[] = []
 
@@ -946,7 +981,8 @@ async function runStoryboardStep(
             error: `${page.pageId} failed: ${msg}`,
           })
         }
-      }
+      },
+      options.signal,
     )
 
     if (failedPages.length > 0) {
@@ -1221,7 +1257,8 @@ async function runCaptionsStep(
             error: `${page.pageId} failed: ${msg}`,
           })
         }
-      }
+      },
+      options.signal,
     )
 
     if (failedPages.length > 0) {
@@ -1562,7 +1599,8 @@ async function runTranslateStep(
             page: completedBatches,
             totalPages: totalBatches,
           })
-        }
+        },
+        options.signal,
       )
 
       for (const lang of targetLanguages) {
@@ -1729,7 +1767,7 @@ async function runTranslateStep(
               totalPages: total,
             })
           }
-        })
+        }, options.signal)
 
         progress.emit({ type: "step-complete", step: "image-translation" })
         console.log(`[stage-run] ${label}: image translation complete (${completed}/${total})`)
@@ -2045,7 +2083,8 @@ async function runSpeechStep(
 
         completedItems++
         emitSpeechStepProgress(progress, completedItems, totalItems, failedItems.length)
-      }
+      },
+      options.signal,
     )
 
     if (failedItems.length > 0) {
@@ -2091,6 +2130,7 @@ async function runSpeechStep(
         textByLanguage,
         concurrency: effectiveConcurrency,
         progress,
+        signal: options.signal,
       })
       wordTimestampsByLang = generatedWordTimestamps.entriesByLanguage
       timestampFailedItems = generatedWordTimestamps.failedItems
@@ -2140,6 +2180,7 @@ async function runFilterPass(
   results: Map<string, ImageClassificationOutput>,
   failedPages: string[],
   progress: StageRunProgress,
+  signal?: AbortSignal,
 ): Promise<void> {
   const total = pages.length
   let completed = 0
@@ -2169,7 +2210,7 @@ async function runFilterPass(
         totalPages: total,
       })
     }
-  })
+  }, signal)
   progress.emit({ type: "step-complete", step: "image-filtering" })
 }
 
@@ -2183,6 +2224,7 @@ async function runMeaningfulnessPass(
   results: Map<string, ImageClassificationOutput>,
   failedPages: string[],
   progress: StageRunProgress,
+  signal?: AbortSignal,
 ): Promise<void> {
   if (!config || !model) {
     progress.emit({ type: "step-skip", step: "image-meaningfulness" })
@@ -2252,7 +2294,7 @@ async function runMeaningfulnessPass(
         totalPages: total,
       })
     }
-  })
+  }, signal)
   progress.emit({ type: "step-complete", step: "image-meaningfulness" })
 }
 
@@ -2265,6 +2307,7 @@ async function runSegmentationPass(
   concurrency: number,
   results: Map<string, ImageClassificationOutput>,
   progress: StageRunProgress,
+  signal?: AbortSignal,
 ): Promise<void> {
   if (!config || !model) {
     progress.emit({ type: "step-skip", step: "image-segmentation" })
@@ -2359,7 +2402,7 @@ async function runSegmentationPass(
         totalPages: total,
       })
     }
-  })
+  }, signal)
   progress.emit({ type: "step-complete", step: "image-segmentation" })
 }
 
@@ -2372,6 +2415,7 @@ async function runCroppingPass(
   concurrency: number,
   results: Map<string, ImageClassificationOutput>,
   progress: StageRunProgress,
+  signal?: AbortSignal,
 ): Promise<void> {
   if (!config || !model) {
     progress.emit({ type: "step-skip", step: "image-cropping" })
@@ -2458,6 +2502,6 @@ async function runCroppingPass(
         totalPages: total,
       })
     }
-  })
+  }, signal)
   progress.emit({ type: "step-complete", step: "image-cropping" })
 }

--- a/apps/api/src/services/stage-service.ts
+++ b/apps/api/src/services/stage-service.ts
@@ -2,7 +2,7 @@ import { STAGE_ORDER, type ProgressEvent } from "@adt/types"
 import type { StageName } from "@adt/types"
 import type { BookEventBus } from "./book-event-bus.js"
 
-export type StageRunStatus = "idle" | "running" | "completed" | "failed"
+export type StageRunStatus = "idle" | "running" | "completed" | "failed" | "cancelled"
 
 export interface StageRunJob {
   label: string
@@ -24,6 +24,8 @@ export interface QueuedStageRun {
 interface BookRunState {
   active: StageRunJob | null
   queue: QueuedStageRun[]
+  /** AbortController for the active run, used to cancel it. */
+  controller: AbortController | null
 }
 
 export interface BookRunStatus {
@@ -49,6 +51,12 @@ export interface StageRunOptions {
   azureSpeechRegion?: string
   geminiApiKey?: string
   beforeRun?: () => void
+  /**
+   * When aborted, the run is cancelled: stages stop scheduling new work, in-flight
+   * work is allowed to settle, and any unfinished step is recorded as not-complete
+   * so the next stage stays gated. Completed per-page work is already persisted.
+   */
+  signal?: AbortSignal
 }
 
 export interface StageRunProgress {
@@ -71,6 +79,8 @@ export interface StageService {
     label: string,
     options: StageRunOptions
   ): { status: "started" | "queued"; id: string }
+  /** Cancel the active run (if any) and drop everything queued. */
+  cancelStageRun(label: string): { cancelled: boolean }
 }
 
 let nextId = 1
@@ -84,7 +94,7 @@ export function createStageService(
   function getOrCreateState(label: string): BookRunState {
     let state = books.get(label)
     if (!state) {
-      state = { active: null, queue: [] }
+      state = { active: null, queue: [], controller: null }
       books.set(label, state)
     }
     return state
@@ -95,6 +105,10 @@ export function createStageService(
     job: StageRunJob,
     options: StageRunOptions
   ): Promise<void> {
+    const state = getOrCreateState(label)
+    const controller = new AbortController()
+    state.controller = controller
+
     const progress: StageRunProgress = {
       emit(event: ProgressEvent) {
         eventBus.emit(label, { type: "progress", data: event })
@@ -103,17 +117,33 @@ export function createStageService(
 
     try {
       options.beforeRun?.()
-      await runner.run(label, options, progress)
-      job.status = "completed"
-      job.completedAt = Date.now()
-      eventBus.emit(label, { type: "stage-run-complete", label })
+      await runner.run(label, { ...options, signal: controller.signal }, progress)
+      if (controller.signal.aborted) {
+        job.status = "cancelled"
+        job.completedAt = Date.now()
+        eventBus.emit(label, { type: "stage-run-cancelled", label })
+      } else {
+        job.status = "completed"
+        job.completedAt = Date.now()
+        eventBus.emit(label, { type: "stage-run-complete", label })
+      }
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err)
-      console.error(`[stage-run] ${label} failed:`, message)
-      job.status = "failed"
-      job.error = message
-      job.completedAt = Date.now()
-      eventBus.emit(label, { type: "stage-run-error", label, error: message })
+      if (controller.signal.aborted) {
+        // A cancel can surface as a thrown error from an interrupted stage.
+        // Treat any failure during an aborted run as a cancellation.
+        job.status = "cancelled"
+        job.completedAt = Date.now()
+        eventBus.emit(label, { type: "stage-run-cancelled", label })
+      } else {
+        const message = err instanceof Error ? err.message : String(err)
+        console.error(`[stage-run] ${label} failed:`, message)
+        job.status = "failed"
+        job.error = message
+        job.completedAt = Date.now()
+        eventBus.emit(label, { type: "stage-run-error", label, error: message })
+      }
+    } finally {
+      if (state.controller === controller) state.controller = null
     }
 
     drainQueue(label)
@@ -214,6 +244,18 @@ export function createStageService(
       executeJob(label, job, options).catch(() => {})
 
       return { status: "started", id }
+    },
+
+    cancelStageRun(label: string): { cancelled: boolean } {
+      const state = books.get(label)
+      if (!state) return { cancelled: false }
+      // Drop queued runs so "cancel" means stop — not "stop current, start next".
+      state.queue = []
+      if (state.active?.status === "running" && state.controller) {
+        state.controller.abort()
+        return { cancelled: true }
+      }
+      return { cancelled: false }
     },
   }
 }

--- a/apps/studio/src/api/client.ts
+++ b/apps/studio/src/api/client.ts
@@ -588,6 +588,11 @@ export const api = {
       }
     ),
 
+  cancelRun: (label: string) =>
+    request<{ cancelled: boolean; label: string }>(`/books/${label}/stages/cancel`, {
+      method: "POST",
+    }),
+
   getStagesStatus: (label: string) =>
     request<StageRunStatus>(`/books/${label}/stages/status`),
 

--- a/apps/studio/src/components/pipeline/components/StageRunCard.tsx
+++ b/apps/studio/src/components/pipeline/components/StageRunCard.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode } from "react"
-import { Check, Loader2, Minus, Play, RotateCcw, XCircle } from "lucide-react"
+import { Check, Loader2, Minus, Play, RotateCcw, X, XCircle } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Card, CardHeader, CardTitle, CardContent, CardFooter } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
@@ -62,7 +62,7 @@ export function StageRunCard({
 }: StageRunCardProps) {
   const { t } = useLingui()
   const stage = STAGES.find((s) => s.slug === stageSlug) ?? STAGES[0]
-  const { stageState, stepState, stepProgress, stepError, error } = useBookRun()
+  const { stageState, stepState, stepProgress, stepError, error, cancelRun } = useBookRun()
   const stageStatus = stageState(stageSlug)
   const subSteps = STAGE_SUB_STEPS[stageSlug as StageName] ?? []
   const Icon = stage.icon
@@ -159,14 +159,19 @@ export function StageRunCard({
         {showRunButton && (
           <div className="shrink-0">
             {isRunning ? (
-              <div
-                onClick={(e) => { e.stopPropagation(); e.preventDefault() }}
+              <button
+                type="button"
+                onClick={(e) => { e.stopPropagation(); e.preventDefault(); cancelRun() }}
+                title={t`Cancel run`}
                 className={cn(
-                "flex items-center justify-center w-12 h-12 rounded-full opacity-60 cursor-default",
-                color, "text-white",
-              )}>
-                <Loader2 className="w-5 h-5 animate-spin" />
-              </div>
+                  "group flex items-center justify-center w-12 h-12 rounded-full text-white transition-colors cursor-pointer",
+                  color,
+                  "hover:bg-red-600",
+                )}
+              >
+                <Loader2 className="w-5 h-5 animate-spin group-hover:hidden" />
+                <X className="w-5 h-5 hidden group-hover:block" />
+              </button>
             ) : (
               <Button
                 variant="ghost"

--- a/apps/studio/src/hooks/use-book-run.ts
+++ b/apps/studio/src/hooks/use-book-run.ts
@@ -66,6 +66,8 @@ export interface BookRunContextValue {
   isStatusLoading: boolean
   /** Queue a stage run */
   queueRun(options: QueueRunOptions): void
+  /** Cancel the active run. Completed pages are kept; re-run to resume. */
+  cancelRun(): void
 }
 
 const BookRunContext = createContext<BookRunContextValue | null>(null)
@@ -231,6 +233,14 @@ export function useBookRunStatus(label: string): BookRunContextValue {
       invalidateBookQueries(queryClient, label)
     })
 
+    // Run cancelled — the interrupted step is recorded as not-complete in the DB.
+    // Refetch to reconcile; completed pages are preserved.
+    es.addEventListener("cancelled", () => {
+      progressRef.current.clear()
+      queryClient.invalidateQueries({ queryKey: stepStatusKey(label) })
+      invalidateBookQueries(queryClient, label)
+    })
+
     es.addEventListener("error", (e) => {
       if (es.readyState === EventSource.CLOSED) return
       const me = e as MessageEvent
@@ -383,6 +393,16 @@ export function useBookRunStatus(label: string): BookRunContextValue {
   )
 
   // ------------------------------------------------------------------
+  // cancelRun — stop the active run; the authoritative state arrives via
+  // the "cancelled" SSE event (after in-flight work settles).
+  // ------------------------------------------------------------------
+  const cancelRun = useCallback(() => {
+    api.cancelRun(label).catch(() => {
+      // Ignore — the SSE stream reconciles the real state.
+    })
+  }, [label])
+
+  // ------------------------------------------------------------------
   // Accessors
   // ------------------------------------------------------------------
   const stageState = useCallback(
@@ -428,6 +448,7 @@ export function useBookRunStatus(label: string): BookRunContextValue {
     isRunning,
     isStatusLoading: isPending,
     queueRun,
+    cancelRun,
   }
 }
 

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -1195,6 +1195,9 @@ msgstr "Calls"
 msgid "Cancel"
 msgstr "Cancel"
 
+msgid "Cancel run"
+msgstr "Cancel run"
+
 #. placeholder {0}: String(MAX_ENTRIES)
 msgid "capped at {0}"
 msgstr "capped at {0}"

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -1195,6 +1195,9 @@ msgstr "Llamadas"
 msgid "Cancel"
 msgstr "Cancelar"
 
+msgid "Cancel run"
+msgstr "Cancelar ejecución"
+
 #. placeholder {0}: String(MAX_ENTRIES)
 msgid "capped at {0}"
 msgstr "limitado a {0}"

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -1197,6 +1197,9 @@ msgstr "Appels"
 msgid "Cancel"
 msgstr "Annuler"
 
+msgid "Cancel run"
+msgstr "Annuler l'exécution"
+
 #. placeholder {0}: String(MAX_ENTRIES)
 msgid "capped at {0}"
 msgstr "limité à {0}"

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -1195,6 +1195,9 @@ msgstr "Chamadas"
 msgid "Cancel"
 msgstr "Cancelar"
 
+msgid "Cancel run"
+msgstr "Cancelar execução"
+
 #. placeholder {0}: String(MAX_ENTRIES)
 msgid "capped at {0}"
 msgstr "limitado a {0}"


### PR DESCRIPTION
Adds a Cancel control to running pipeline stages so users can stop a stuck or slow run without losing finished work. Cancelling aborts the active run (and drops anything queued), stops scheduling new per-page work while letting in-flight items settle, and records the interrupted step as **not-complete** — so downstream stages stay gated and a re-run resumes cheaply from the LLM cache. On the backend this adds an `AbortController` per run plus `cancelStageRun` in `stage-service`, a `POST /books/:label/stages/cancel` route and `stage-run-cancelled` SSE event, and threads an `AbortSignal` through every stage's `processWithConcurrency` loop, with the progress wrapper converting a `step-complete` to a step error when aborted (plus a reconciliation safety net) so a partial step can never count as done. On the frontend it adds `api.cancelRun`, `useBookRun().cancelRun()`, a `cancelled` SSE handler, and turns the `StageRunCard` spinner into a hover-to-cancel button (translated for en/es/fr/pt-BR). Verified with `pnpm typecheck`, the existing API suite (146 tests), studio lint, full i18n catalogs, and a new `stage-runner` test proving a cancelled storyboard keeps rendered pages and leaves `web-rendering` not-complete.

Known follow-ups (documented, out of scope here): aborting in-flight model calls for instant cancel of a hung page, true incremental resume that doesn't re-render kept pages, and per-page skip/prune.

🤖 Generated with [Claude Code](https://claude.com/claude-code)