### PR TITLE
Fully localize the Validation step (es/fr/pt-BR)

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -62,6 +62,7 @@
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.0",
     "ai": "^4.0.0",
+    "axe-core": "^4.11.0",
     "babel-plugin-macros": "^3.1.0",
     "eslint": "^9",
     "eslint-plugin-lingui": "^0.11.0",

--- a/apps/studio/src/components/accessibility/AccessibilityCurrentPagePanel.tsx
+++ b/apps/studio/src/components/accessibility/AccessibilityCurrentPagePanel.tsx
@@ -2,6 +2,7 @@ import { Fragment, useMemo } from "react"
 import type { AccessibilityFinding, AccessibilityPageResult } from "@adt/types"
 import { Trans, useLingui } from "@lingui/react/macro"
 import type { PageAccessibilitySummary } from "@/lib/accessibility-summary"
+import { useAxeRuleTranslator } from "@/lib/axe-rule-locale"
 import { ExternalLink } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { cn } from "@/lib/utils"
@@ -158,6 +159,7 @@ function FindingCard({
   onFindingHover?: (finding: AccessibilityFinding | null) => void
 }) {
   const { t } = useLingui()
+  const axeRules = useAxeRuleTranslator()
   const severity = getFindingSeverity(finding.impact)
 
   return (
@@ -190,7 +192,7 @@ function FindingCard({
         )}
       </div>
       <div className="flex items-start justify-between gap-2">
-        <div className="text-sm font-medium leading-snug">{finding.help}</div>
+        <div className="text-sm font-medium leading-snug">{axeRules.help(finding.id, finding.help)}</div>
         {finding.helpUrl ? (
           <a href={finding.helpUrl} target="_blank" rel="noopener noreferrer" className="shrink-0">
             <code className="inline-flex items-center gap-1 rounded bg-muted px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground hover:text-foreground">
@@ -200,7 +202,7 @@ function FindingCard({
           </a>
         ) : null}
       </div>
-      <LinkifiedText text={finding.description} className="text-xs leading-relaxed text-muted-foreground" />
+      <LinkifiedText text={axeRules.description(finding.id, finding.description)} className="text-xs leading-relaxed text-muted-foreground" />
       {finding.nodes.length > 0 ? (
         <div className="space-y-1.5">
           <div className="text-xs font-medium text-muted-foreground"><Trans>Nodes</Trans></div>

--- a/apps/studio/src/components/pipeline/stages/PreviewValidationCard.tsx
+++ b/apps/studio/src/components/pipeline/stages/PreviewValidationCard.tsx
@@ -837,7 +837,7 @@ export function PreviewValidationCard({
                       </div>
                     </div>
                     <Badge variant={needsChanges > 0 ? "destructive" : "outline"} className="text-[11px]">
-                      {needsChanges > 0 ? `${needsChanges} flagged` : `${section.criteria.length - reviewed} pending`}
+                      {needsChanges > 0 ? t`${needsChanges} flagged` : t`${section.criteria.length - reviewed} pending`}
                     </Badge>
                   </summary>
 

--- a/apps/studio/src/components/validation/AccessibilityValidationTabs.test.tsx
+++ b/apps/studio/src/components/validation/AccessibilityValidationTabs.test.tsx
@@ -12,7 +12,12 @@ function templateToString(strings: TemplateStringsArray, values: unknown[]) {
     text += strings[index]
     if (index < values.length) text += String(values[index])
   }
-  return text
+  // Resolve inline ICU plurals (e.g. "1 {count, plural, one {item} other {items}}")
+  // the way real Lingui would, using the count rendered immediately before.
+  return text.replace(
+    /(\d+)\s+\{[^,}]+, plural, one \{([^}]*)\} other \{([^}]*)\}\}/g,
+    (_match, count, one, other) => `${count} ${Number(count) === 1 ? one : other}`,
+  )
 }
 
 const i18n = {

--- a/apps/studio/src/components/validation/AccessibilityValidationTabs.tsx
+++ b/apps/studio/src/components/validation/AccessibilityValidationTabs.tsx
@@ -12,6 +12,7 @@ import { Textarea } from "@/components/ui/textarea"
 import { useBookConfig, useUpdateBookConfig } from "@/hooks/use-book-config"
 import { useAccessibilityAssessment } from "@/hooks/use-debug"
 import { buildAccessibilityOverview, buildFrequentAccessibilityFindings, getAccessibilityCategoryLabel } from "@/lib/accessibility-summary"
+import { useAxeRuleTranslator } from "@/lib/axe-rule-locale"
 import { cn } from "@/lib/utils"
 
 interface AccessibilityTabProps {
@@ -200,7 +201,9 @@ function FrequentFindingCard({
   onFilterCategory: (category: AccessibilityCategoryKey) => void
 }) {
   const { t, i18n } = useLingui()
+  const axeRules = useAxeRuleTranslator()
   const coveragePercent = Math.round(finding.pageCoverage * 100)
+  const count = finding.count
 
   return (
     <div className="rounded-lg border px-3 py-3">
@@ -233,10 +236,10 @@ function FrequentFindingCard({
             {getAccessibilityCategoryLabel(i18n, finding.categoryKey)}
           </Badge>
         </div>
-        <div className="text-sm font-semibold tabular-nums">{finding.reviewOnly ? t`${finding.count} ${finding.count === 1 ? "manual review item" : "manual review items"}` : t`${finding.count} ${finding.count === 1 ? "issue" : "issues"}`}</div>
+        <div className="text-sm font-semibold tabular-nums">{finding.reviewOnly ? t`${count} {count, plural, one {manual review item} other {manual review items}}` : t`${count} {count, plural, one {issue} other {issues}}`}</div>
       </div>
       <div className="mt-2 flex items-center justify-between gap-2">
-        <span className="font-medium">{finding.help}</span>
+        <span className="font-medium">{axeRules.help(finding.id, finding.help)}</span>
         {finding.helpUrl ? (
           <a href={finding.helpUrl} target="_blank" rel="noopener noreferrer" className="inline-flex shrink-0 items-center gap-1.5 text-[11px] text-muted-foreground hover:text-foreground">
             <code>{finding.id}</code>
@@ -246,7 +249,7 @@ function FrequentFindingCard({
           <code className="shrink-0 text-[11px] text-muted-foreground">{finding.id}</code>
         )}
       </div>
-      <div className="mt-1 text-xs text-muted-foreground">{finding.description}</div>
+      <div className="mt-1 text-xs text-muted-foreground">{axeRules.description(finding.id, finding.description)}</div>
 
       <div className="mt-3 space-y-1">
         <div className="flex items-center justify-between text-[11px] text-muted-foreground">

--- a/apps/studio/src/components/validation/ReviewerValidationSummaryTab.tsx
+++ b/apps/studio/src/components/validation/ReviewerValidationSummaryTab.tsx
@@ -364,6 +364,7 @@ export function ReviewerValidationSummaryTab({
 
   const anyRecordQueryLoading = sessionRecordQueries.some((query) => query.isLoading)
   const anyRecordQueryError = sessionRecordQueries.find((query) => query.error)?.error
+  const pagesReviewed = activeMetrics.pagesReviewed
 
   if (sessions.isLoading || anyRecordQueryLoading || (!activeCatalog && catalog.isLoading)) {
     return <LoadingState message={t`Loading reviewer validation summary...`} />
@@ -528,7 +529,7 @@ export function ReviewerValidationSummaryTab({
                   </span>
                 ) : (
                   <span>
-                    {t`${activeMetrics.pagesReviewed} ${activeMetrics.pagesReviewed === 1 ? "page" : "pages"} reviewed so far`}
+                    {t`${pagesReviewed} {pagesReviewed, plural, one {page} other {pages}} reviewed so far`}
                   </span>
                 )}
                 {activeProgress.criteriaPerPage > 0 ? (

--- a/apps/studio/src/lib/axe-rule-locale.ts
+++ b/apps/studio/src/lib/axe-rule-locale.ts
@@ -1,0 +1,55 @@
+import { useEffect, useMemo, useState } from "react"
+import { useLingui } from "@lingui/react"
+
+type AxeRuleMessages = { help?: string; description?: string }
+type AxeRuleMap = Record<string, AxeRuleMessages>
+
+// axe-core ships per-locale rule text keyed by rule id. Findings are stored in
+// English (the canonical assessment), so we translate the rule-level help and
+// description at render time based on the active UI locale. Loaders are lazy so
+// only the active locale's catalog is fetched, and never for the source locale.
+const AXE_LOCALE_LOADERS: Record<string, () => Promise<{ default: { rules?: AxeRuleMap } }>> = {
+  es: () => import("axe-core/locales/es.json"),
+  fr: () => import("axe-core/locales/fr.json"),
+  "pt-BR": () => import("axe-core/locales/pt_BR.json"),
+}
+
+export interface AxeRuleTranslator {
+  help: (ruleId: string, fallback: string) => string
+  description: (ruleId: string, fallback: string) => string
+}
+
+export function useAxeRuleTranslator(): AxeRuleTranslator {
+  const { i18n } = useLingui()
+  const locale = i18n.locale
+  const [rules, setRules] = useState<AxeRuleMap | null>(null)
+
+  useEffect(() => {
+    const loader = AXE_LOCALE_LOADERS[locale]
+    if (!loader) {
+      setRules(null)
+      return
+    }
+
+    let cancelled = false
+    void loader()
+      .then((mod) => {
+        if (!cancelled) setRules(mod.default.rules ?? {})
+      })
+      .catch(() => {
+        if (!cancelled) setRules(null)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [locale])
+
+  return useMemo(
+    () => ({
+      help: (ruleId, fallback) => rules?.[ruleId]?.help ?? fallback,
+      description: (ruleId, fallback) => rules?.[ruleId]?.description ?? fallback,
+    }),
+    [rules],
+  )
+}

--- a/apps/studio/src/lib/axe-rule-locale.ts
+++ b/apps/studio/src/lib/axe-rule-locale.ts
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react"
-import { useLingui } from "@lingui/react"
+import { i18n } from "@lingui/core"
 
 type AxeRuleMessages = { help?: string; description?: string }
 type AxeRuleMap = Record<string, AxeRuleMessages>
@@ -20,9 +20,12 @@ export interface AxeRuleTranslator {
 }
 
 export function useAxeRuleTranslator(): AxeRuleTranslator {
-  const { i18n } = useLingui()
-  const locale = i18n.locale
+  const [locale, setLocale] = useState(() => i18n.locale)
   const [rules, setRules] = useState<AxeRuleMap | null>(null)
+
+  // Track the active locale via the shared lingui instance rather than the
+  // React context, so this works in any tree (and in tests) without a provider.
+  useEffect(() => i18n.on("change", () => setLocale(i18n.locale)), [])
 
   useEffect(() => {
     const loader = AXE_LOCALE_LOADERS[locale]

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -65,17 +65,6 @@ msgstr "(template)"
 msgid "{0} — type country or Enter for base"
 msgstr "{0} — type country or Enter for base"
 
-#. placeholder {0}: finding.count
-#. placeholder {1}: finding.count === 1 ? "issue" : "issues"
-#. placeholder {1}: finding.count === 1 ? "manual review item" : "manual review items"
-msgid "{0} {1}"
-msgstr "{0} {1}"
-
-#. placeholder {0}: activeMetrics.pagesReviewed
-#. placeholder {1}: activeMetrics.pagesReviewed === 1 ? "page" : "pages"
-msgid "{0} {1} reviewed so far"
-msgstr "{0} {1} reviewed so far"
-
 #. placeholder {0}: bbox.w
 #. placeholder {1}: bbox.h
 #. placeholder {2}: points.length
@@ -143,6 +132,10 @@ msgstr "{0} of {1} items"
 msgid "{0} pages"
 msgstr "{0} pages"
 
+#. placeholder {0}: section.criteria.length - reviewed
+msgid "{0} pending"
+msgstr "{0} pending"
+
 #. placeholder {0}: String(displayQuizzes.length)
 msgid "{0} questions"
 msgstr "{0} questions"
@@ -192,6 +185,12 @@ msgstr "{0}m ago"
 #. placeholder {0}: String(Math.floor(diff / 1000))
 msgid "{0}s ago"
 msgstr "{0}s ago"
+
+msgid "{count} {count, plural, one {issue} other {issues}}"
+msgstr "{count} {count, plural, one {issue} other {issues}}"
+
+msgid "{count} {count, plural, one {manual review item} other {manual review items}}"
+msgstr "{count} {count, plural, one {manual review item} other {manual review items}}"
 
 msgid "{count} translations"
 msgstr "{count} translations"
@@ -246,11 +245,17 @@ msgstr "{missingForCurrentStage} entry/entries are missing audio. Re-run to gene
 msgid "{missingForCurrentStage} entry/entries are missing translations. Re-run to fill the missing items."
 msgstr "{missingForCurrentStage} entry/entries are missing translations. Re-run to fill the missing items."
 
+msgid "{needsChanges} flagged"
+msgstr "{needsChanges} flagged"
+
 msgid "{pageCount} {pageCount, plural, one {page} other {pages}}"
 msgstr "{pageCount} {pageCount, plural, one {page} other {pages}}"
 
 msgid "{pageCount} pages"
 msgstr "{pageCount} pages"
+
+msgid "{pagesReviewed} {pagesReviewed, plural, one {page} other {pages}} reviewed so far"
+msgstr "{pagesReviewed} {pagesReviewed, plural, one {page} other {pages}} reviewed so far"
 
 msgid "{regionCount} {regionCount, plural, one {region} other {regions}} detected"
 msgstr "{regionCount} {regionCount, plural, one {region} other {regions}} detected"
@@ -625,9 +630,6 @@ msgstr "Add Book"
 
 msgid "Add checklist item to this section"
 msgstr "Add checklist item to this section"
-
-#~ msgid "Add class"
-#~ msgstr "Add class"
 
 msgid "Add custom instructions"
 msgstr "Add custom instructions"
@@ -1652,9 +1654,6 @@ msgstr "Custom Layout Demo"
 msgid "Custom section {index}"
 msgstr "Custom section {index}"
 
-#~ msgid "Custom:"
-#~ msgstr "Custom:"
-
 msgid "Debug mode is not enabled."
 msgstr "Debug mode is not enabled."
 
@@ -2065,9 +2064,6 @@ msgstr "Enter a valid minimum dimension (whole number ≥ 0)"
 
 msgid "Enter a valid project name"
 msgstr "Enter a valid project name"
-
-#~ msgid "Enter hex color and press Enter"
-#~ msgstr "Enter hex color and press Enter"
 
 msgid "EPUB"
 msgstr "EPUB"
@@ -3428,9 +3424,6 @@ msgstr "No link"
 msgid "No log entries found yet."
 msgstr "No log entries found yet."
 
-#~ msgid "No matches"
-#~ msgstr "No matches"
-
 msgid "No matches for \"{search}\""
 msgstr "No matches for \"{search}\""
 
@@ -4013,9 +4006,6 @@ msgstr "Preset"
 msgid "Presets add recommendations and specific settings for your use case. You still choose each option step by step, and you can go back to select a different preset at any time."
 msgstr "Presets add recommendations and specific settings for your use case. You still choose each option step by step, and you can go back to select a different preset at any time."
 
-#~ msgid "Press Enter to add"
-#~ msgstr "Press Enter to add"
-
 msgid "Prev"
 msgstr "Prev"
 
@@ -4332,9 +4322,6 @@ msgstr "Render Reasoning"
 msgid "Render Strategy"
 msgstr "Render Strategy"
 
-#~ msgid "rendering"
-#~ msgstr "rendering"
-
 msgid "Rendering Prompt"
 msgstr "Rendering Prompt"
 
@@ -4382,9 +4369,6 @@ msgstr "Reset to inherited defaults"
 
 msgid "Resolving source language..."
 msgstr "Resolving source language..."
-
-#~ msgid "Responsive / State variants"
-#~ msgstr "Responsive / State variants"
 
 msgid "Restart and install"
 msgstr "Restart and install"
@@ -5696,9 +5680,6 @@ msgstr "Two-column template for story content"
 msgid "Type"
 msgstr "Type"
 
-#~ msgid "Type class name or search..."
-#~ msgstr "Type class name or search..."
-
 msgid "Typed Sections"
 msgstr "Typed Sections"
 
@@ -5758,9 +5739,6 @@ msgstr "Unprune image"
 
 msgid "Unsaved changes"
 msgstr "Unsaved changes"
-
-#~ msgid "Unsaved:"
-#~ msgstr "Unsaved:"
 
 msgid "Untangling nested divs with care..."
 msgstr "Untangling nested divs with care..."
@@ -5879,9 +5857,6 @@ msgstr "Validation Errors ({0})"
 
 msgid "Variables"
 msgstr "Variables"
-
-#~ msgid "Variant:"
-#~ msgstr "Variant:"
 
 msgid "Variations"
 msgstr "Variations"

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -65,17 +65,6 @@ msgstr "(plantilla)"
 msgid "{0} — type country or Enter for base"
 msgstr "{0} — escribe el país o pulsa Enter para el básico"
 
-#. placeholder {0}: finding.count
-#. placeholder {1}: finding.count === 1 ? "issue" : "issues"
-#. placeholder {1}: finding.count === 1 ? "manual review item" : "manual review items"
-msgid "{0} {1}"
-msgstr "{0} {1}"
-
-#. placeholder {0}: activeMetrics.pagesReviewed
-#. placeholder {1}: activeMetrics.pagesReviewed === 1 ? "page" : "pages"
-msgid "{0} {1} reviewed so far"
-msgstr "{0} {1} revisadas hasta ahora"
-
 #. placeholder {0}: bbox.w
 #. placeholder {1}: bbox.h
 #. placeholder {2}: points.length
@@ -143,6 +132,10 @@ msgstr "{0} de {1} elementos"
 msgid "{0} pages"
 msgstr "{0} páginas"
 
+#. placeholder {0}: section.criteria.length - reviewed
+msgid "{0} pending"
+msgstr "{0} pendientes"
+
 #. placeholder {0}: String(displayQuizzes.length)
 msgid "{0} questions"
 msgstr "{0} preguntas"
@@ -192,6 +185,12 @@ msgstr "Hace {0}min"
 #. placeholder {0}: String(Math.floor(diff / 1000))
 msgid "{0}s ago"
 msgstr "Hace {0}s"
+
+msgid "{count} {count, plural, one {issue} other {issues}}"
+msgstr "{count} {count, plural, one {problema} other {problemas}}"
+
+msgid "{count} {count, plural, one {manual review item} other {manual review items}}"
+msgstr "{count} {count, plural, one {elemento de revisión manual} other {elementos de revisión manual}}"
 
 msgid "{count} translations"
 msgstr "{count} traducciones"
@@ -246,11 +245,17 @@ msgstr "{missingForCurrentStage} entrada(s) sin audio. Vuelve a ejecutar para ge
 msgid "{missingForCurrentStage} entry/entries are missing translations. Re-run to fill the missing items."
 msgstr "{missingForCurrentStage} entrada(s) sin traducción. Vuelve a ejecutar para completar los elementos faltantes."
 
+msgid "{needsChanges} flagged"
+msgstr "{needsChanges} marcados"
+
 msgid "{pageCount} {pageCount, plural, one {page} other {pages}}"
 msgstr "{pageCount} {pageCount, plural, one {página} other {páginas}}"
 
 msgid "{pageCount} pages"
 msgstr "{pageCount} páginas"
+
+msgid "{pagesReviewed} {pagesReviewed, plural, one {page} other {pages}} reviewed so far"
+msgstr "{pagesReviewed} {pagesReviewed, plural, one {página} other {páginas}} revisadas hasta ahora"
 
 msgid "{regionCount} {regionCount, plural, one {region} other {regions}} detected"
 msgstr "{regionCount} {regionCount, plural, one {region} other {regions}} detected"
@@ -625,9 +630,6 @@ msgstr "Agregar libro"
 
 msgid "Add checklist item to this section"
 msgstr "Añadir elemento de la lista a esta sección"
-
-#~ msgid "Add class"
-#~ msgstr "Agregar clase"
 
 msgid "Add custom instructions"
 msgstr "Añadir instrucciones personalizadas"
@@ -1652,9 +1654,6 @@ msgstr "Demostración de Diseño Personalizado"
 msgid "Custom section {index}"
 msgstr "Sección personalizada {index}"
 
-#~ msgid "Custom:"
-#~ msgstr "Personalizado:"
-
 msgid "Debug mode is not enabled."
 msgstr "El modo de depuración no está habilitado."
 
@@ -2065,9 +2064,6 @@ msgstr "Introduce una dimensión mínima válida (número entero ≥ 0)"
 
 msgid "Enter a valid project name"
 msgstr "Introduce un nombre de proyecto válido"
-
-#~ msgid "Enter hex color and press Enter"
-#~ msgstr "Ingresa un color hex y presiona Enter"
 
 msgid "EPUB"
 msgstr "EPUB"
@@ -3428,9 +3424,6 @@ msgstr "Sin enlace"
 msgid "No log entries found yet."
 msgstr "Aún no hay entradas de registro."
 
-#~ msgid "No matches"
-#~ msgstr "Sin resultados"
-
 msgid "No matches for \"{search}\""
 msgstr "Sin resultados para \"{0}\""
 
@@ -4013,9 +4006,6 @@ msgstr "Preajuste"
 msgid "Presets add recommendations and specific settings for your use case. You still choose each option step by step, and you can go back to select a different preset at any time."
 msgstr "Los preajustes añaden recomendaciones y configuraciones específicas para tu caso. Aún eliges cada opción paso a paso, y puedes volver a seleccionar un preajuste diferente en cualquier momento."
 
-#~ msgid "Press Enter to add"
-#~ msgstr "Presiona Enter para agregar"
-
 msgid "Prev"
 msgstr "Anterior"
 
@@ -4332,9 +4322,6 @@ msgstr "Razonamiento de renderizado"
 msgid "Render Strategy"
 msgstr "Estrategia de renderización"
 
-#~ msgid "rendering"
-#~ msgstr "renderización"
-
 msgid "Rendering Prompt"
 msgstr "Prompt de renderización"
 
@@ -4382,9 +4369,6 @@ msgstr "Restablecer a los valores heredados"
 
 msgid "Resolving source language..."
 msgstr "Resolviendo idioma de origen..."
-
-#~ msgid "Responsive / State variants"
-#~ msgstr "Variantes responsivas / de estado"
 
 msgid "Restart and install"
 msgstr "Reiniciar e instalar"
@@ -5696,9 +5680,6 @@ msgstr "Plantilla de dos columnas para contenido narrativo"
 msgid "Type"
 msgstr "Tipo"
 
-#~ msgid "Type class name or search..."
-#~ msgstr "Escriba nombre de clase o busque..."
-
 msgid "Typed Sections"
 msgstr "Secciones Escritas"
 
@@ -5758,9 +5739,6 @@ msgstr "Restaurar imagen"
 
 msgid "Unsaved changes"
 msgstr "Cambios sin guardar"
-
-#~ msgid "Unsaved:"
-#~ msgstr "Sin guardar:"
 
 msgid "Untangling nested divs with care..."
 msgstr "Desenredando divs anidados con cuidado..."
@@ -5879,9 +5857,6 @@ msgstr "Errores de validación ({0})"
 
 msgid "Variables"
 msgstr "Variables"
-
-#~ msgid "Variant:"
-#~ msgstr "Variante:"
 
 msgid "Variations"
 msgstr "Variaciones"

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -258,7 +258,7 @@ msgid "{pagesReviewed} {pagesReviewed, plural, one {page} other {pages}} reviewe
 msgstr "{pagesReviewed} {pagesReviewed, plural, one {página} other {páginas}} revisadas hasta ahora"
 
 msgid "{regionCount} {regionCount, plural, one {region} other {regions}} detected"
-msgstr "{regionCount} {regionCount, plural, one {region} other {regions}} detected"
+msgstr "{regionCount} {regionCount, plural, one {región} other {regiones}} detectada(s)"
 
 #. placeholder {0}: reviewCount === 1 ? "manual review item" : "manual review items"
 msgid "{reviewCount} {0}"
@@ -484,19 +484,19 @@ msgid "Accept reasonable web redesigns. Reject only for functional defects (visi
 msgstr "Aceptar rediseños web razonables. Rechazar solo por defectos funcionales (tokens de marcador de posición visibles, contenido faltante, superposición, desbordamiento). Menos rechazos."
 
 msgid "Accessibility"
-msgstr "Accessibility"
+msgstr "Accesibilidad"
 
 msgid "Accessibility assessment configuration"
 msgstr "Configuración de la evaluación de accesibilidad"
 
 msgid "Accessibility check failed for this page"
-msgstr "Accessibility check failed for this page"
+msgstr "La comprobación de accesibilidad falló para esta página"
 
 msgid "Accessibility Findings"
-msgstr "Accessibility Findings"
+msgstr "Hallazgos de accesibilidad"
 
 msgid "Accessibility results are temporarily unavailable."
-msgstr "Accessibility results are temporarily unavailable."
+msgstr "Los resultados de accesibilidad no están disponibles temporalmente."
 
 msgid "Accessibility Summary"
 msgstr "Resumen de accesibilidad"
@@ -754,7 +754,7 @@ msgid "AI Edit"
 msgstr "Edición con IA"
 
 msgid "AI edit failed"
-msgstr "AI edit failed"
+msgstr "La edición con IA falló"
 
 msgid "AI edit history"
 msgstr "Historial de edición con IA"
@@ -922,7 +922,7 @@ msgid "Apply page background colors"
 msgstr "Aplicar colores de fondo de página"
 
 msgid "Apply Segmentation"
-msgstr "Apply Segmentation"
+msgstr "Aplicar segmentación"
 
 msgid "AR"
 msgstr "AR"
@@ -1289,7 +1289,7 @@ msgid "Checked"
 msgstr "Revisados"
 
 msgid "Checking accessibility"
-msgstr "Checking accessibility"
+msgstr "Comprobando accesibilidad"
 
 msgid "Checking for updates…"
 msgstr "Buscando actualizaciones…"
@@ -1373,10 +1373,10 @@ msgid "Click to select an image"
 msgstr "Haz clic para seleccionar una imagen"
 
 msgid "Clone failed"
-msgstr "Clone failed"
+msgstr "La clonación falló"
 
 msgid "Close"
-msgstr "Close"
+msgstr "Cerrar"
 
 msgid "Close edit panel"
 msgstr "Cerrar panel de edición"
@@ -1391,7 +1391,7 @@ msgid "Collapse"
 msgstr "Contraer"
 
 msgid "Collapse accessibility summary"
-msgstr "Collapse accessibility summary"
+msgstr "Contraer resumen de accesibilidad"
 
 msgid "Collapse all sections"
 msgstr "Contraer todas las secciones"
@@ -1562,7 +1562,7 @@ msgid "Cover"
 msgstr "Portada"
 
 msgid "Cover of {title}"
-msgstr "Portada de {0}"
+msgstr "Portada de {title}"
 
 msgid "Coverage"
 msgstr "Cobertura"
@@ -1613,7 +1613,7 @@ msgid "Criteria reviewed"
 msgstr "Criterios revisados"
 
 msgid "critical"
-msgstr "critical"
+msgstr "crítico"
 
 msgid "Critical"
 msgstr "Crítico"
@@ -1750,7 +1750,7 @@ msgid "Delete element"
 msgstr "Eliminar elemento"
 
 msgid "Delete failed"
-msgstr "Delete failed"
+msgstr "La eliminación falló"
 
 msgid "Delete section"
 msgstr "Eliminar sección"
@@ -1863,7 +1863,7 @@ msgid "Drag to move"
 msgstr "Arrastrar para mover"
 
 msgid "Drag to move boxes, drag edges/corners to resize"
-msgstr "Drag to move boxes, drag edges/corners to resize"
+msgstr "Arrastra para mover los recuadros, arrastra los bordes/esquinas para redimensionar"
 
 msgid "Drag vertices to reshape. Click midpoints (+) to add points. Right-click a vertex to remove it."
 msgstr "Arrastra los vértices para cambiar la forma. Haz clic en los puntos medios (+) para agregar puntos. Haz clic derecho en un vértice para eliminarlo."
@@ -2054,7 +2054,7 @@ msgid "Engineering handbooks"
 msgstr "Manuales de ingeniería"
 
 msgid "English"
-msgstr "English"
+msgstr "Inglés"
 
 msgid "Enhancements"
 msgstr "Mejoras"
@@ -2540,7 +2540,7 @@ msgid "História e Sociedade - Vol. 1"
 msgstr "Historia y Sociedad - Vol. 1"
 
 msgid "Hit"
-msgstr "Hit"
+msgstr "Acierto"
 
 msgid "Home / Chapter 1"
 msgstr "Inicio / Capítulo 1"
@@ -2660,7 +2660,7 @@ msgid "Image unavailable"
 msgstr "Imagen no disponible"
 
 msgid "Image upload failed"
-msgstr "Image upload failed"
+msgstr "La carga de la imagen falló"
 
 msgid "images"
 msgstr "imágenes"
@@ -2971,7 +2971,7 @@ msgid "Loading logs..."
 msgstr "Cargando registros..."
 
 msgid "Loading page-level findings"
-msgstr "Loading page-level findings"
+msgstr "Cargando hallazgos a nivel de página"
 
 msgid "Loading page..."
 msgstr "Cargando página..."
@@ -2986,7 +2986,7 @@ msgid "Loading preview..."
 msgstr "Cargando vista previa..."
 
 msgid "Loading prompt..."
-msgstr "Loading prompt..."
+msgstr "Cargando prompt..."
 
 msgid "Loading quizzes..."
 msgstr "Cargando quizzes..."
@@ -3016,7 +3016,7 @@ msgid "Loading table of contents..."
 msgstr "Cargando tabla de contenidos..."
 
 msgid "Loading template..."
-msgstr "Loading template..."
+msgstr "Cargando plantilla..."
 
 msgid "Loading text catalog..."
 msgstr "Cargando catálogo de textos..."
@@ -3127,7 +3127,7 @@ msgid "Merge facing pages as spreads"
 msgstr "Combinar páginas enfrentadas como dobles"
 
 msgid "Merge failed"
-msgstr "Merge failed"
+msgstr "La combinación falló"
 
 msgid "merge into next page"
 msgstr "fusionar en la página siguiente"
@@ -3211,7 +3211,7 @@ msgid "Minimum size threshold"
 msgstr "Umbral de tamaño mínimo"
 
 msgid "minor"
-msgstr "minor"
+msgstr "menor"
 
 msgid "Minor"
 msgstr "Menor"
@@ -3220,7 +3220,7 @@ msgid "Mirrors the original book's activity layout as closely as possible."
 msgstr "Refleja el diseño de actividades del libro original lo más cerca posible."
 
 msgid "Miss"
-msgstr "Miss"
+msgstr "Fallo"
 
 msgid "Misses"
 msgstr "Fallos"
@@ -3244,7 +3244,7 @@ msgid "Model"
 msgstr "Modelo"
 
 msgid "moderate"
-msgstr "moderate"
+msgstr "moderado"
 
 msgid "Moderate"
 msgstr "Moderado"
@@ -3322,7 +3322,7 @@ msgid "No accessibility assessment has been generated yet. Package the ADT outpu
 msgstr "Aún no se ha generado ninguna evaluación de accesibilidad. Empaqueta la salida ADT para crear una."
 
 msgid "No accessibility findings were reported for this page."
-msgstr "No accessibility findings were reported for this page."
+msgstr "No se reportaron hallazgos de accesibilidad para esta página."
 
 msgid "No AI edits yet for this section."
 msgstr "Aún no hay ediciones con IA para esta sección."
@@ -3332,7 +3332,7 @@ msgid "No API key for {0} yet. Add one in Book settings to enable this provider.
 msgstr "Aún no hay clave API para {0}. Añade una en la configuración del libro para habilitar este proveedor."
 
 msgid "No assessment"
-msgstr "No assessment"
+msgstr "Sin evaluación"
 
 msgid "No audio for this page"
 msgstr "No hay audio para esta página"
@@ -3425,7 +3425,7 @@ msgid "No log entries found yet."
 msgstr "Aún no hay entradas de registro."
 
 msgid "No matches for \"{search}\""
-msgstr "Sin resultados para \"{0}\""
+msgstr "Sin resultados para \"{search}\""
 
 msgid "No matching sections"
 msgstr "No hay secciones coincidentes"
@@ -3491,7 +3491,7 @@ msgid "No sections yet"
 msgstr "Aún no hay secciones"
 
 msgid "No segmentation needed for this image"
-msgstr "No segmentation needed for this image"
+msgstr "No se necesita segmentación para esta imagen"
 
 msgid "No storyboard sections found. Run Storyboard to generate sections you can match videos to."
 msgstr "No se encontraron secciones de storyboard. Ejecuta Storyboard para generar secciones a las que puedas asignar videos."
@@ -3521,7 +3521,7 @@ msgid "No voice mappings configured."
 msgstr "No hay asignaciones de voz configuradas."
 
 msgid "Nodes"
-msgstr "Nodes"
+msgstr "Nodos"
 
 msgid "noise"
 msgstr "ruido"
@@ -3560,7 +3560,7 @@ msgid "OCR & cleanup"
 msgstr "OCR y limpieza"
 
 msgid "of"
-msgstr "of"
+msgstr "de"
 
 msgid "Off"
 msgstr "Apagado"
@@ -3602,7 +3602,7 @@ msgid "Opacity"
 msgstr "Opacidad"
 
 msgid "Open a page in Preview to show its page-specific accessibility findings here."
-msgstr "Open a page in Preview to show its page-specific accessibility findings here."
+msgstr "Abre una página en Vista previa para mostrar aquí sus hallazgos de accesibilidad específicos de la página."
 
 msgid "Open a page in Preview to start recording reviewer validation findings."
 msgstr "Abre una página en Vista previa para empezar a registrar los hallazgos de validación del revisor."
@@ -3611,7 +3611,7 @@ msgid "Open a page to review"
 msgstr "Abre una página para revisar"
 
 msgid "Open a page to see page-level findings"
-msgstr "Open a page to see page-level findings"
+msgstr "Abre una página para ver los hallazgos a nivel de página"
 
 msgid "Open edit panel"
 msgstr "Abrir panel de edición"
@@ -3620,7 +3620,7 @@ msgid "Open in any EPUB 3 reader, e-reader, or accessibility tool."
 msgstr "Ábrelo en cualquier lector EPUB 3, lector electrónico o herramienta de accesibilidad."
 
 msgid "Open page preview for {pageId}"
-msgstr "Abrir vista previa de la página {0}"
+msgstr "Abrir vista previa de la página {pageId}"
 
 msgid "Open Preview"
 msgstr "Abrir Vista previa"
@@ -3750,7 +3750,7 @@ msgid "Package and preview the final ADT web application."
 msgstr "Empaqueta y previsualiza la aplicación web ADT final."
 
 msgid "Package preview to generate results"
-msgstr "Package preview to generate results"
+msgstr "Empaqueta la vista previa para generar resultados"
 
 msgid "Package the book for distribution. Pick a format, choose what content goes in, and we'll bundle everything into a downloadable archive."
 msgstr "Empaqueta el libro para distribución. Elige un formato, selecciona qué contenido incluir, y empaquetaremos todo en un archivo descargable."
@@ -3780,7 +3780,7 @@ msgstr "Página"
 #. placeholder {0}: String(pageNumber)
 #. placeholder {0}: String(selectedPage.pageNumber)
 msgid "Page {0}"
-msgstr "Página {0}"
+msgstr "Página {pageId}"
 
 #. placeholder {0}: page.pageNumber
 #. placeholder {1}: i + 1
@@ -3791,7 +3791,7 @@ msgid "Page {n}"
 msgstr "Página {n}"
 
 msgid "Page {pageId}"
-msgstr "Página {0}"
+msgstr "Página {pageId}"
 
 msgid "Page coverage"
 msgstr "Cobertura de páginas"
@@ -3812,7 +3812,7 @@ msgid "Page Mode"
 msgstr "Modo de Página"
 
 msgid "Page preview {pageId}"
-msgstr "Vista previa de la página {0}"
+msgstr "Vista previa de la página {pageId}"
 
 msgid "Page Range"
 msgstr "Rango de páginas"
@@ -4046,7 +4046,7 @@ msgid "Prompt"
 msgstr "Prompt"
 
 msgid "Prompt template not found."
-msgstr "Prompt template not found."
+msgstr "No se encontró la plantilla de prompt."
 
 msgid "Provider"
 msgstr "Proveedor"
@@ -4083,7 +4083,7 @@ msgid "Pruned Images"
 msgstr "Imágenes eliminadas"
 
 msgid "Pruned: {reason}"
-msgstr "Eliminado: {0}"
+msgstr "Eliminado: {reason}"
 
 msgid "PT"
 msgstr "PT"
@@ -4143,7 +4143,7 @@ msgid "Re-render (your edits will be preserved)"
 msgstr "Re-renderizar (tus ediciones se preservarán)"
 
 msgid "Re-render failed"
-msgstr "Re-render failed"
+msgstr "El re-renderizado falló"
 
 msgid "Re-render section"
 msgstr "Re-renderizar sección"
@@ -4158,7 +4158,7 @@ msgid "Re-run"
 msgstr "Re-ejecutar"
 
 msgid "Re-run {stageLabel}"
-msgstr "Reejecutar {0}"
+msgstr "Reejecutar {stageLabel}"
 
 msgid "Re-run {stageLabel}?"
 msgstr "¿Re-ejecutar {stageLabel}?"
@@ -4246,7 +4246,7 @@ msgid "Refresh validation"
 msgstr "Actualizar validación"
 
 msgid "Refreshing results for this packaged preview."
-msgstr "Refreshing results for this packaged preview."
+msgstr "Actualizando resultados para esta vista previa empaquetada."
 
 msgid "Regenerate definition, variations, and emoji"
 msgstr "Regenerar definición, variaciones y emoji"
@@ -4393,7 +4393,7 @@ msgid "Resume target: page {0}"
 msgstr "Objetivo de reanudación: página {0}"
 
 msgid "Retries"
-msgstr "Retries"
+msgstr "Reintentos"
 
 msgid "Retry"
 msgstr "Reintentar"
@@ -4423,7 +4423,7 @@ msgid "Reviewer checklist"
 msgstr "Lista de verificación del revisor"
 
 msgid "Reviewer Checklist"
-msgstr "Reviewer Checklist"
+msgstr "Lista de verificación del revisor"
 
 msgid "Reviewer checklist reviews are currently disabled."
 msgstr "Las revisiones de la lista de verificación del revisor están desactivadas actualmente."
@@ -4469,7 +4469,7 @@ msgid "Run {0} first"
 msgstr "Ejecuta {0} primero"
 
 msgid "Run {stageLabel}"
-msgstr "Ejecutar {0}"
+msgstr "Ejecutar {stageLabel}"
 
 msgid "Run {upstreamLabel} first"
 msgstr "Ejecuta {upstreamLabel} primero"
@@ -4532,7 +4532,7 @@ msgid "Run Translation"
 msgstr "Ejecutar Traducción"
 
 msgid "Run whole-book validation checks and configure accessibility assessment settings."
-msgstr "Run whole-book validation checks and configure accessibility assessment settings."
+msgstr "Ejecuta comprobaciones de validación de todo el libro y configura los ajustes de evaluación de accesibilidad."
 
 msgid "Run-only tags"
 msgstr "Etiquetas de ejecución exclusiva"
@@ -4541,7 +4541,7 @@ msgid "RUNNING"
 msgstr "EN CURSO"
 
 msgid "Running Validation..."
-msgstr "Running Validation..."
+msgstr "Ejecutando validación..."
 
 msgid "Running..."
 msgstr "Ejecutando..."
@@ -4607,7 +4607,7 @@ msgid "Save checklist"
 msgstr "Guardar lista de verificación"
 
 msgid "Save failed"
-msgstr "Save failed"
+msgstr "El guardado falló"
 
 msgid "Save page review"
 msgstr "Guardar revisión de página"
@@ -4761,19 +4761,19 @@ msgid "Segment"
 msgstr "Segmentar"
 
 msgid "Segment Preview"
-msgstr "Segment Preview"
+msgstr "Vista previa del segmento"
 
 msgid "Segmentation apply failed"
-msgstr "Segmentation apply failed"
+msgstr "La aplicación de la segmentación falló"
 
 msgid "Segmentation failed"
-msgstr "Segmentation failed"
+msgstr "La segmentación falló"
 
 msgid "Segmentation preview"
-msgstr "Segmentation preview"
+msgstr "Vista previa de la segmentación"
 
 msgid "Segmentation produced no valid segments"
-msgstr "Segmentation produced no valid segments"
+msgstr "La segmentación no produjo segmentos válidos"
 
 msgid "Segmentation Prompt"
 msgstr "Indicación de segmentación"
@@ -4848,7 +4848,7 @@ msgid "Selected images"
 msgstr "Imágenes seleccionadas"
 
 msgid "Selected: {styleImageId}"
-msgstr "Seleccionada: {0}"
+msgstr "Seleccionada: {styleImageId}"
 
 msgid "Selecting \"None\" lets the LLM choose its own styling for each page."
 msgstr "Seleccionar \\\"Ninguno\\\" permite al LLM elegir su propio estilo para cada página."
@@ -4860,7 +4860,7 @@ msgid "Separator"
 msgstr "Separador"
 
 msgid "serious"
-msgstr "serious"
+msgstr "grave"
 
 msgid "Serious"
 msgstr "Grave"
@@ -4899,7 +4899,7 @@ msgid "Short, simple sentences for kindergarten through 5th grade."
 msgstr "Oraciones cortas y simples para jardín de infancia hasta 5º grado."
 
 msgid "Show accessibility summary"
-msgstr "Show accessibility summary"
+msgstr "Mostrar resumen de accesibilidad"
 
 msgid "Show AI edit history"
 msgstr "Mostrar historial de edición con IA"
@@ -5118,10 +5118,10 @@ msgid "Step {step} of {0}"
 msgstr "Paso {step} de {0}"
 
 msgid "Step failed"
-msgstr "Step failed"
+msgstr "El paso falló"
 
 msgid "Step run failed"
-msgstr "Step run failed"
+msgstr "La ejecución del paso falló"
 
 msgid "Storyboard"
 msgstr "Storyboard"
@@ -5193,7 +5193,7 @@ msgid "Styleguide Preview"
 msgstr "Vista previa de guía de estilo"
 
 msgid "Styleguide Preview — {styleguide}"
-msgstr "Vista previa de guía de estilo — {0}"
+msgstr "Vista previa de guía de estilo — {styleguide}"
 
 msgid "Success"
 msgstr "Éxito"
@@ -5238,13 +5238,13 @@ msgid "Takes liberties and produces something similar."
 msgstr "Toma libertades y produce algo similar."
 
 msgid "Task Running"
-msgstr "Task Running"
+msgstr "Tarea en ejecución"
 
 msgid "Task running..."
 msgstr "Tarea en ejecución..."
 
 msgid "Tasks Running"
-msgstr "Tasks Running"
+msgstr "Tareas en ejecución"
 
 msgid "Teaching the pixels new tricks..."
 msgstr "Enseñando nuevos trucos a los píxeles..."
@@ -5262,7 +5262,7 @@ msgid "Template"
 msgstr "Plantilla"
 
 msgid "Template not found."
-msgstr "Template not found."
+msgstr "No se encontró la plantilla."
 
 msgid "Template One Column"
 msgstr "Plantilla Una Columna"
@@ -5702,7 +5702,7 @@ msgid "Unassigned"
 msgstr "Sin asignar"
 
 msgid "Unavailable"
-msgstr "Unavailable"
+msgstr "No disponible"
 
 msgid "Uncategorized"
 msgstr "Sin categoría"
@@ -5717,7 +5717,7 @@ msgid "University academic publications"
 msgstr "Publicaciones académicas universitarias"
 
 msgid "unknown"
-msgstr "unknown"
+msgstr "desconocido"
 
 msgid "Unknown"
 msgstr "Desconocido"
@@ -5729,10 +5729,10 @@ msgid "Unknown stage"
 msgstr "Etapa desconocida"
 
 msgid "Unknown step slug: {step}"
-msgstr "Slug de etapa desconocido: {0}"
+msgstr "Slug de etapa desconocido: {step}"
 
 msgid "Unknown step: {step}"
-msgstr "Paso desconocido: {0}"
+msgstr "Paso desconocido: {step}"
 
 msgid "Unprune image"
 msgstr "Restaurar imagen"

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -74,7 +74,7 @@ msgstr "{0} {1}"
 #. placeholder {0}: activeMetrics.pagesReviewed
 #. placeholder {1}: activeMetrics.pagesReviewed === 1 ? "page" : "pages"
 msgid "{0} {1} reviewed so far"
-msgstr "{0} {1} reviewed so far"
+msgstr "{0} {1} revisadas hasta ahora"
 
 #. placeholder {0}: bbox.w
 #. placeholder {1}: bbox.h
@@ -88,7 +88,7 @@ msgstr "{0} audios"
 
 #. placeholder {0}: activeProgress.criteriaPerPage
 msgid "{0} checks per page"
-msgstr "{0} checks per page"
+msgstr "{0} comprobaciones por página"
 
 #. placeholder {0}: entries.length
 msgid "{0} entries"
@@ -96,7 +96,7 @@ msgstr "{0} entradas"
 
 #. placeholder {0}: activeMetrics.flagged.length
 msgid "{0} flagged findings in this review"
-msgstr "{0} flagged findings in this review"
+msgstr "{0} hallazgos marcados en esta revisión"
 
 #. placeholder {0}: selectedImageIds.length
 #. placeholder {1}: selectedImageIds.length === 1 ? "" : "s"
@@ -118,7 +118,7 @@ msgstr "{0} elementos"
 
 #. placeholder {0}: counts.needsChanges
 msgid "{0} items need changes on this page"
-msgstr "{0} items need changes on this page"
+msgstr "{0} elementos requieren cambios en esta página"
 
 #. placeholder {0}: String(outputLanguages.length)
 msgid "{0} languages"
@@ -127,12 +127,12 @@ msgstr "{0} idiomas"
 #. placeholder {0}: activeMetrics.pagesReviewed
 #. placeholder {1}: activeProgress.assignedPageCount
 msgid "{0} of {1} assigned pages reviewed"
-msgstr "{0} of {1} assigned pages reviewed"
+msgstr "{0} de {1} páginas asignadas revisadas"
 
 #. placeholder {0}: activeMetrics.pagesReviewed
 #. placeholder {1}: activeProgress.totalBookPages
 msgid "{0} of {1} book pages reviewed"
-msgstr "{0} of {1} book pages reviewed"
+msgstr "{0} de {1} páginas del libro revisadas"
 
 #. placeholder {0}: visibleFindings.length
 #. placeholder {1}: visibleFindingsUniverse.length
@@ -170,7 +170,7 @@ msgstr "{0}/{1} audio"
 
 #. placeholder {0}: counts.reviewed
 msgid "{0}/{criteriaCount} checked"
-msgstr "{0}/{criteriaCount} checked"
+msgstr "{0}/{criteriaCount} revisados"
 
 #. placeholder {0}: String(selectedPageIds.size)
 msgid "{0}/5 pages selected"
@@ -178,7 +178,7 @@ msgstr "{0}/5 páginas seleccionadas"
 
 #. placeholder {0}: activeProgress.percent
 msgid "{0}% complete"
-msgstr "{0}% complete"
+msgstr "{0}% completado"
 
 #. placeholder {0}: Math.floor(elapsed / 60)
 #. placeholder {1}: elapsed % 60
@@ -261,7 +261,7 @@ msgstr "{reviewCount} {0}"
 
 #. placeholder {0}: section.criteria.length
 msgid "{reviewed}/{0} checked"
-msgstr "{reviewed}/{0} checked"
+msgstr "{reviewed}/{0} revisados"
 
 msgid "{sections} sections"
 msgstr "{sections} secciones"
@@ -314,7 +314,7 @@ msgid "1 image selected"
 msgstr "1 imagen seleccionada"
 
 msgid "1 item needs changes on this page"
-msgstr "1 item needs changes on this page"
+msgstr "1 elemento requiere cambios en esta página"
 
 msgid "1 selected image is no longer in the storyboard."
 msgstr "1 imagen seleccionada ya no está en el guion gráfico."
@@ -482,7 +482,7 @@ msgid "Accessibility"
 msgstr "Accessibility"
 
 msgid "Accessibility assessment configuration"
-msgstr "Accessibility assessment configuration"
+msgstr "Configuración de la evaluación de accesibilidad"
 
 msgid "Accessibility check failed for this page"
 msgstr "Accessibility check failed for this page"
@@ -494,7 +494,7 @@ msgid "Accessibility results are temporarily unavailable."
 msgstr "Accessibility results are temporarily unavailable."
 
 msgid "Accessibility Summary"
-msgstr "Accessibility Summary"
+msgstr "Resumen de accesibilidad"
 
 msgid "Accessibility, from the first <0>page.</0>"
 msgstr "Accesibilidad, desde la primera <0>página.</0>"
@@ -506,19 +506,19 @@ msgid "Actions disabled while storyboard is running"
 msgstr "Acciones deshabilitadas mientras el storyboard se está ejecutando"
 
 msgid "active checklist items"
-msgstr "active checklist items"
+msgstr "elementos activos de la lista"
 
 msgid "active item"
-msgstr "active item"
+msgstr "elemento activo"
 
 msgid "active items"
-msgstr "active items"
+msgstr "elementos activos"
 
 msgid "Active reviewer session"
-msgstr "Active reviewer session"
+msgstr "Sesión activa del revisor"
 
 msgid "active sections"
-msgstr "active sections"
+msgstr "secciones activas"
 
 msgid "Activities"
 msgstr "Actividades"
@@ -624,7 +624,7 @@ msgid "Add Book"
 msgstr "Agregar libro"
 
 msgid "Add checklist item to this section"
-msgstr "Add checklist item to this section"
+msgstr "Añadir elemento de la lista a esta sección"
 
 #~ msgid "Add class"
 #~ msgstr "Agregar clase"
@@ -660,10 +660,10 @@ msgid "Add languages to translate the book content into."
 msgstr "Agrega idiomas para traducir el contenido del libro."
 
 msgid "Add reviewer guidance."
-msgstr "Add reviewer guidance."
+msgstr "Añade orientación para el revisor."
 
 msgid "Add section"
-msgstr "Add section"
+msgstr "Añadir sección"
 
 msgid "Add sizing field"
 msgstr "Agregar campo de tamaño"
@@ -733,7 +733,7 @@ msgid "Adventure Tales - Vol. 1"
 msgstr "Cuentos de Aventura - Vol. 1"
 
 msgid "Affected pages"
-msgstr "Affected pages"
+msgstr "Páginas afectadas"
 
 msgid "After"
 msgstr "Después"
@@ -806,7 +806,7 @@ msgid "All"
 msgstr "Todo"
 
 msgid "All Categories"
-msgstr "All Categories"
+msgstr "Todas las categorías"
 
 msgid "All issues and manual review items"
 msgstr "Todos los problemas y elementos de revisión manual"
@@ -824,7 +824,7 @@ msgid "All set"
 msgstr "Todo listo"
 
 msgid "All Severities"
-msgstr "All Severities"
+msgstr "Todas las severidades"
 
 msgid "All steps"
 msgstr "Todas las etapas"
@@ -951,7 +951,7 @@ msgid "Are you sure you want to generate word-level timestamps for {langDisplay}
 msgstr "¿Estás seguro de que deseas generar marcas de tiempo a nivel de palabra para {langDisplay}?"
 
 msgid "areas"
-msgstr "areas"
+msgstr "áreas"
 
 msgid "Arrange extracted content into a structured storyboard with pages, sections, and layouts."
 msgstr "Organiza el contenido extraído en un storyboard estructurado con páginas, secciones y diseños."
@@ -1284,7 +1284,7 @@ msgid "Check for updates"
 msgstr "Buscar actualizaciones"
 
 msgid "Checked"
-msgstr "Checked"
+msgstr "Revisados"
 
 msgid "Checking accessibility"
 msgstr "Checking accessibility"
@@ -1293,7 +1293,7 @@ msgid "Checking for updates…"
 msgstr "Buscando actualizaciones…"
 
 msgid "Checklist item"
-msgstr "Checklist item"
+msgstr "Elemento de la lista"
 
 msgid "choice"
 msgstr "opción"
@@ -1320,7 +1320,7 @@ msgid "Choose Provider"
 msgstr "Elegir proveedor"
 
 msgid "Choose which per-page validation items reviewers must check, customize the wording and guidance, and add your own checklist items for this document."
-msgstr "Choose which per-page validation items reviewers must check, customize the wording and guidance, and add your own checklist items for this document."
+msgstr "Elige qué elementos de validación por página deben verificar los revisores, personaliza la redacción y la orientación, y añade tus propios elementos de la lista para este documento."
 
 msgid "Ciências da Natureza - Ensino Fundamental"
 msgstr "Ciencias de la Naturaleza - Educación Primaria"
@@ -1338,7 +1338,7 @@ msgid "Clear"
 msgstr "Borrar"
 
 msgid "Clear all"
-msgstr "Clear all"
+msgstr "Borrar todo"
 
 msgid "Clear language"
 msgstr "Borrar idioma"
@@ -1395,7 +1395,7 @@ msgid "Collapse all sections"
 msgstr "Contraer todas las secciones"
 
 msgid "Collapse validation"
-msgstr "Collapse validation"
+msgstr "Contraer validación"
 
 msgid "Color"
 msgstr "Color"
@@ -1416,22 +1416,22 @@ msgid "Coming soon"
 msgstr "Próximamente"
 
 msgid "Comment"
-msgstr "Comment"
+msgstr "Comentario"
 
 msgid "Comments"
-msgstr "Comments"
+msgstr "Comentarios"
 
 msgid "Completion"
 msgstr "Finalización"
 
 msgid "Completion across all pages in this book for the active reviewer session."
-msgstr "Completion across all pages in this book for the active reviewer session."
+msgstr "Avance de todas las páginas de este libro en la sesión activa del revisor."
 
 msgid "Completion across pages that have been opened and reviewed in this session."
-msgstr "Completion across pages that have been opened and reviewed in this session."
+msgstr "Avance de las páginas que se han abierto y revisado en esta sesión."
 
 msgid "Completion across the assigned page range for this reviewer session."
-msgstr "Completion across the assigned page range for this reviewer session."
+msgstr "Avance del rango de páginas asignado a esta sesión del revisor."
 
 msgid "Comprehensive"
 msgstr "Integral"
@@ -1501,21 +1501,21 @@ msgstr "Continuar"
 
 #. placeholder {0}: resumeTarget.pageNumber ?? resumeTarget.pageId
 msgid "Continue on page {0}"
-msgstr "Continue on page {0}"
+msgstr "Continuar en la página {0}"
 
 #. placeholder {0}: resumeTarget.pageNumber ?? resumeTarget.pageId
 msgid "Continue page {0}"
-msgstr "Continue page {0}"
+msgstr "Continuar página {0}"
 
 #. placeholder {0}: resumeTarget?.pageNumber ?? resumeTarget?.pageId
 msgid "Continue reviewer validation on page {0}"
-msgstr "Continue reviewer validation on page {0}"
+msgstr "Continuar la validación del revisor en la página {0}"
 
 msgid "Continuing will reset your current configuration."
 msgstr "Continuar restablecerá su configuración actual."
 
 msgid "Control which axe checks run during packaging for this document. Changes apply on the next package run."
-msgstr "Control which axe checks run during packaging for this document. Changes apply on the next package run."
+msgstr "Controla qué comprobaciones de axe se ejecutan durante el empaquetado de este documento. Los cambios se aplican en la próxima ejecución de empaquetado."
 
 msgid "Controls how page content is grouped during the sectioning step."
 msgstr "Controla cómo se agrupa el contenido de la página durante el paso de seccionamiento."
@@ -1578,7 +1578,7 @@ msgid "Create a new image from a text description"
 msgstr "Crea una nueva imagen a partir de una descripción de texto"
 
 msgid "Create a reviewer session for this book."
-msgstr "Create a reviewer session for this book."
+msgstr "Crea una sesión de revisor para este libro."
 
 msgid "Create ADT"
 msgstr "Crear ADT"
@@ -1590,7 +1590,7 @@ msgid "Create from scratch using your description"
 msgstr "Crear desde cero con tu descripción"
 
 msgid "Create session"
-msgstr "Create session"
+msgstr "Crear sesión"
 
 msgid "Created {createdLabel}"
 msgstr "Creado el {createdLabel}"
@@ -1605,16 +1605,16 @@ msgid "Credits"
 msgstr "Créditos"
 
 msgid "criteria reviewed"
-msgstr "criteria reviewed"
+msgstr "criterios revisados"
 
 msgid "Criteria reviewed"
-msgstr "Criteria reviewed"
+msgstr "Criterios revisados"
 
 msgid "critical"
 msgstr "critical"
 
 msgid "Critical"
-msgstr "Critical"
+msgstr "Crítico"
 
 msgid "Crop"
 msgstr "Recortar"
@@ -1632,10 +1632,10 @@ msgid "Current"
 msgstr "Actual"
 
 msgid "Current effective values"
-msgstr "Current effective values"
+msgstr "Valores efectivos actuales"
 
 msgid "Current Preview Page"
-msgstr "Current Preview Page"
+msgstr "Página actual de Vista previa"
 
 msgid "Current version"
 msgstr "Versión actual"
@@ -1650,7 +1650,7 @@ msgid "Custom Layout Demo"
 msgstr "Demostración de Diseño Personalizado"
 
 msgid "Custom section {index}"
-msgstr "Custom section {index}"
+msgstr "Sección personalizada {index}"
 
 #~ msgid "Custom:"
 #~ msgstr "Personalizado:"
@@ -1674,7 +1674,7 @@ msgid "Default model"
 msgstr "Modelo predeterminado"
 
 msgid "Default N/A"
-msgstr "Default N/A"
+msgstr "N/D por defecto"
 
 msgid "Default Prompt"
 msgstr "Prompt predeterminado"
@@ -1692,10 +1692,10 @@ msgid "Default voice used when not specified for a language."
 msgstr "Voz predeterminada usada cuando no se especifica para un idioma."
 
 msgid "Defaulted to N/A because Easy Read output is not currently available for this book."
-msgstr "Defaulted to N/A because Easy Read output is not currently available for this book."
+msgstr "Establecido como N/D por defecto porque la salida de Lectura fácil no está actualmente disponible para este libro."
 
 msgid "Defaulted to N/A because Glossary has not been generated for this book yet."
-msgstr "Defaulted to N/A because Glossary has not been generated for this book yet."
+msgstr "Establecido como N/D por defecto porque aún no se ha generado el Glosario para este libro."
 
 #. placeholder {0}: reason.language
 msgid "Defaulted to N/A because no Speech audio is available for {0}."
@@ -1706,28 +1706,28 @@ msgstr "No aplica de forma predeterminada porque aún no hay audio de voz dispon
 
 #. placeholder {0}: reason.language
 msgid "Defaulted to N/A because no translation output is available for {0}."
-msgstr "Defaulted to N/A because no translation output is available for {0}."
+msgstr "Establecido como N/D por defecto porque no hay traducción disponible para {0}."
 
 msgid "Defaulted to N/A because no translation output is available yet."
-msgstr "Defaulted to N/A because no translation output is available yet."
+msgstr "Establecido como N/D por defecto porque aún no hay traducción disponible."
 
 msgid "Defaulted to N/A because sign language is not enabled for this book."
-msgstr "Defaulted to N/A because sign language is not enabled for this book."
+msgstr "Establecido como N/D por defecto porque la lengua de signos no está activada para este libro."
 
 msgid "Defaulted to N/A because Speech audio has not been generated yet."
 msgstr "No aplica de forma predeterminada porque el audio de voz aún no se ha generado."
 
 msgid "Defaulted to N/A because this page does not contain an interactive activity or exercise."
-msgstr "Defaulted to N/A because this page does not contain an interactive activity or exercise."
+msgstr "Establecido como N/D por defecto porque esta página no contiene una actividad o ejercicio interactivo."
 
 msgid "Defaulted to N/A because this page does not contain any images."
-msgstr "Defaulted to N/A because this page does not contain any images."
+msgstr "Establecido como N/D por defecto porque esta página no contiene imágenes."
 
 msgid "Defaulted to N/A because Translation has not been generated yet."
-msgstr "Defaulted to N/A because Translation has not been generated yet."
+msgstr "Establecido como N/D por defecto porque aún no se ha generado la traducción."
 
 msgid "Defaulted to N/A until this reviewer session has a language selected."
-msgstr "Defaulted to N/A until this reviewer session has a language selected."
+msgstr "Establecido como N/D por defecto hasta que esta sesión del revisor tenga un idioma seleccionado."
 
 msgid "Defaults"
 msgstr "Valores predeterminados"
@@ -1772,10 +1772,10 @@ msgid "Describe the image"
 msgstr "Describe la imagen"
 
 msgid "Describe the issue or note why this criterion needs attention"
-msgstr "Describe the issue or note why this criterion needs attention"
+msgstr "Describe el problema o explica por qué este criterio requiere atención"
 
 msgid "Describe what the reviewer should check."
-msgstr "Describe what the reviewer should check."
+msgstr "Describe lo que el revisor debe verificar."
 
 msgid "Description"
 msgstr "Descripción"
@@ -1817,19 +1817,19 @@ msgid "Direction"
 msgstr "Dirección"
 
 msgid "Disable reviewer validation"
-msgstr "Disable reviewer validation"
+msgstr "Desactivar validación del revisor"
 
 msgid "Disable type"
 msgstr "Desactivar tipo"
 
 msgid "Disabled"
-msgstr "Disabled"
+msgstr "Desactivado"
 
 msgid "Disabled axe rules"
-msgstr "Disabled axe rules"
+msgstr "Reglas de axe desactivadas"
 
 msgid "Disabled rules"
-msgstr "Disabled rules"
+msgstr "Reglas desactivadas"
 
 msgid "Discard"
 msgstr "Descartar"
@@ -2014,7 +2014,7 @@ msgid "Empty section — add a container below to start"
 msgstr "Sección vacía — añade un contenedor abajo para empezar"
 
 msgid "en"
-msgstr "en"
+msgstr "es"
 
 msgid "EN"
 msgstr "EN"
@@ -2022,28 +2022,28 @@ msgstr "EN"
 #. placeholder {0}: criterion.label
 #. placeholder {0}: section.label
 msgid "Enable {0}"
-msgstr "Enable {0}"
+msgstr "Activar {0}"
 
 msgid "Enable for scanned books where two pages appear on a single PDF page."
 msgstr "Activa para libros escaneados donde dos páginas aparecen en una sola página del PDF."
 
 msgid "Enable or disable reviewer-authored checklist reviews for this book. Automated accessibility assessment remains available either way."
-msgstr "Enable or disable reviewer-authored checklist reviews for this book. Automated accessibility assessment remains available either way."
+msgstr "Activa o desactiva las revisiones de lista de verificación creadas por el revisor para este libro. La evaluación automatizada de accesibilidad sigue disponible de cualquier forma."
 
 msgid "Enable reviewer validation"
-msgstr "Enable reviewer validation"
+msgstr "Activar validación del revisor"
 
 msgid "Enabled"
-msgstr "Enabled"
+msgstr "Activado"
 
 msgid "Enabled axe tags"
-msgstr "Enabled axe tags"
+msgstr "Etiquetas de axe activadas"
 
 msgid "End"
 msgstr "Fin"
 
 msgid "End page"
-msgstr "End page"
+msgstr "Página final"
 
 msgid "Endpoint"
 msgstr "Endpoint"
@@ -2121,7 +2121,7 @@ msgid "Exclude from render"
 msgstr "Excluir de la renderización"
 
 msgid "Existing reviewer sessions keep their own checklist snapshot. New checklist changes apply to newly created sessions."
-msgstr "Existing reviewer sessions keep their own checklist snapshot. New checklist changes apply to newly created sessions."
+msgstr "Las sesiones existentes del revisor mantienen su propia instantánea de la lista de verificación. Los cambios nuevos en la lista se aplican a las sesiones que se creen a partir de ahora."
 
 msgid "Expand"
 msgstr "Expandir"
@@ -2195,14 +2195,14 @@ msgid "Failed to create book."
 msgstr "Error al crear el libro."
 
 msgid "Failed to create reviewer session"
-msgstr "Failed to create reviewer session"
+msgstr "No se pudo crear la sesión del revisor"
 
 msgid "Failed to generate glossary entry."
 msgstr "No se pudo generar la entrada del glosario."
 
 #. placeholder {0}: error.message
 msgid "Failed to load accessibility results: {0}"
-msgstr "Failed to load accessibility results: {0}"
+msgstr "No se pudieron cargar los resultados de accesibilidad: {0}"
 
 #. placeholder {0}: error.message
 msgid "Failed to load books: {0}"
@@ -2216,21 +2216,21 @@ msgstr "Error al cargar la imagen de la página"
 
 #. placeholder {0}: anyRecordQueryError.message
 msgid "Failed to load reviewer page results: {0}"
-msgstr "Failed to load reviewer page results: {0}"
+msgstr "No se pudieron cargar los resultados de página del revisor: {0}"
 
 #. placeholder {0}: catalog.error.message
 msgid "Failed to load reviewer validation checklist: {0}"
-msgstr "Failed to load reviewer validation checklist: {0}"
+msgstr "No se pudo cargar la lista de verificación de validación del revisor: {0}"
 
 #. placeholder {0}: sessions.error.message
 msgid "Failed to load reviewer validation sessions: {0}"
-msgstr "Failed to load reviewer validation sessions: {0}"
+msgstr "No se pudieron cargar las sesiones de validación del revisor: {0}"
 
 msgid "Failed to load stats:"
 msgstr "Error al cargar estadísticas:"
 
 msgid "Failed to load validation checklist:"
-msgstr "Failed to load validation checklist:"
+msgstr "No se pudo cargar la lista de verificación de validación:"
 
 msgid "Failed to read archive"
 msgstr "Error al leer el archivo"
@@ -2272,7 +2272,7 @@ msgid "Filter terms…"
 msgstr "Filtrar términos…"
 
 msgid "Filtered by:"
-msgstr "Filtered by:"
+msgstr "Filtrado por:"
 
 msgid "Final Page"
 msgstr "Página Final"
@@ -2299,13 +2299,13 @@ msgid "Fixed-layout books use the original page images as backgrounds with posit
 msgstr "Los libros de diseño fijo usan las imágenes originales de las páginas como fondo con texto posicionado extraído del PDF. La detección de actividades, extracción de figuras, recorte o segmentación de imágenes no aplican a este diseño."
 
 msgid "flagged"
-msgstr "flagged"
+msgstr "marcados"
 
 msgid "Flagged by review area"
-msgstr "Flagged by review area"
+msgstr "Marcados por área de revisión"
 
 msgid "Flagged findings"
-msgstr "Flagged findings"
+msgstr "Hallazgos marcados"
 
 msgid "Flat Vector"
 msgstr "Vector plano"
@@ -2325,7 +2325,7 @@ msgid "Format"
 msgstr "Formato"
 
 msgid "Forms & controls"
-msgstr "Forms & controls"
+msgstr "Formularios y controles"
 
 msgid "FR"
 msgstr "FR"
@@ -2745,7 +2745,7 @@ msgid "Install on quit"
 msgstr "Instalar al salir"
 
 msgid "Institution"
-msgstr "Institution"
+msgstr "Institución"
 
 msgid "Interactive"
 msgstr "Interactivo"
@@ -2776,19 +2776,19 @@ msgstr "Ítem"
 
 #. placeholder {0}: criterionIndex + 1
 msgid "Item {0}"
-msgstr "Item {0}"
+msgstr "Elemento {0}"
 
 msgid "Item ID..."
 msgstr "ID del elemento..."
 
 msgid "Items marked as needing changes for this reviewer session."
-msgstr "Items marked as needing changes for this reviewer session."
+msgstr "Elementos marcados como que requieren cambios para esta sesión del revisor."
 
 msgid "its original language"
 msgstr "su idioma original"
 
 msgid "Jane Reviewer"
-msgstr "Jane Reviewer"
+msgstr "Jane Revisora"
 
 msgid "Justify"
 msgstr "Justificar"
@@ -2812,7 +2812,7 @@ msgid "Key must start with sk-"
 msgstr "La clave debe empezar con sk-"
 
 msgid "Keyboard & navigation"
-msgstr "Keyboard & navigation"
+msgstr "Teclado y navegación"
 
 #. placeholder {0}: entry.level
 msgid "L{0}"
@@ -2957,7 +2957,7 @@ msgid "LMS-ready with completion tracking"
 msgstr "Listo para LMS con seguimiento de finalización"
 
 msgid "Loading accessibility summary..."
-msgstr "Loading accessibility summary..."
+msgstr "Cargando resumen de accesibilidad..."
 
 msgid "Loading Book..."
 msgstr "Cargando libro..."
@@ -2996,13 +2996,13 @@ msgid "Loading quizzes..."
 msgstr "Cargando quizzes..."
 
 msgid "Loading reviewer checklist…"
-msgstr "Loading reviewer checklist…"
+msgstr "Cargando lista de verificación del revisor…"
 
 msgid "Loading reviewer validation summary..."
-msgstr "Loading reviewer validation summary..."
+msgstr "Cargando resumen de validación del revisor..."
 
 msgid "Loading reviewer validation…"
-msgstr "Loading reviewer validation…"
+msgstr "Cargando validación del revisor…"
 
 msgid "Loading sectioning data..."
 msgstr "Cargando datos de sección..."
@@ -3119,7 +3119,7 @@ msgid "Media"
 msgstr "Medios"
 
 msgid "Media & timing"
-msgstr "Media & timing"
+msgstr "Multimedia y temporización"
 
 msgid "Medical references"
 msgstr "Referencias médicas"
@@ -3218,7 +3218,7 @@ msgid "minor"
 msgstr "minor"
 
 msgid "Minor"
-msgstr "Minor"
+msgstr "Menor"
 
 msgid "Mirrors the original book's activity layout as closely as possible."
 msgstr "Refleja el diseño de actividades del libro original lo más cerca posible."
@@ -3251,7 +3251,7 @@ msgid "moderate"
 msgstr "moderate"
 
 msgid "Moderate"
-msgstr "Moderate"
+msgstr "Moderado"
 
 msgid "Modified {modifiedLabel}"
 msgstr "Modificado el {modifiedLabel}"
@@ -3269,7 +3269,7 @@ msgid "my-book-slug"
 msgstr "mi-libro-slug"
 
 msgid "N/A"
-msgstr "N/A"
+msgstr "N/D"
 
 msgid "Natural, expressive voices. Best general-purpose default."
 msgstr "Voces naturales y expresivas. Mejor opción predeterminada de propósito general."
@@ -3278,10 +3278,10 @@ msgid "Nav"
 msgstr "Navegación"
 
 msgid "Navigate within Preview to capture page-specific review notes"
-msgstr "Navigate within Preview to capture page-specific review notes"
+msgstr "Navega dentro de Vista previa para capturar notas de revisión específicas de la página"
 
 msgid "Needs changes"
-msgstr "Needs changes"
+msgstr "Requiere cambios"
 
 msgid "Needs rebuild"
 msgstr "Requiere reconstrucción"
@@ -3293,13 +3293,13 @@ msgid "New"
 msgstr "Nuevo"
 
 msgid "New checklist item"
-msgstr "New checklist item"
+msgstr "Nuevo elemento de la lista"
 
 msgid "New Entry"
 msgstr "Nueva entrada"
 
 msgid "New session"
-msgstr "New session"
+msgstr "Nueva sesión"
 
 msgid "New version"
 msgstr "Nueva versión"
@@ -3323,7 +3323,7 @@ msgid "Next Step"
 msgstr "Siguiente Paso"
 
 msgid "No accessibility assessment has been generated yet. Package the ADT output to create one."
-msgstr "No accessibility assessment has been generated yet. Package the ADT output to create one."
+msgstr "Aún no se ha generado ninguna evaluación de accesibilidad. Empaqueta la salida ADT para crear una."
 
 msgid "No accessibility findings were reported for this page."
 msgstr "No accessibility findings were reported for this page."
@@ -3351,7 +3351,7 @@ msgid "No captions for this page"
 msgstr "Sin leyendas para esta página"
 
 msgid "No changes flagged on this page"
-msgstr "No changes flagged on this page"
+msgstr "No se marcaron cambios en esta página"
 
 msgid "No colors found"
 msgstr "No se encontraron colores"
@@ -3366,7 +3366,7 @@ msgid "No data"
 msgstr "Sin datos"
 
 msgid "No disabled rules"
-msgstr "No disabled rules"
+msgstr "Sin reglas desactivadas"
 
 msgid "No extracted text yet. Run the pipeline first."
 msgstr "Aún no se extrajo texto. Ejecuta el pipeline primero."
@@ -3375,7 +3375,7 @@ msgid "No fields to add"
 msgstr "No hay campos para agregar"
 
 msgid "No finding categories reported."
-msgstr "No finding categories reported."
+msgstr "No se reportaron categorías de hallazgos."
 
 msgid "No findings"
 msgstr "Sin hallazgos"
@@ -3384,7 +3384,7 @@ msgid "No findings this page"
 msgstr "Sin hallazgos en esta página"
 
 msgid "No flagged findings in reviewed pages"
-msgstr "No flagged findings in reviewed pages"
+msgstr "Sin hallazgos marcados en las páginas revisadas"
 
 msgid "No image"
 msgstr "Sin imagen"
@@ -3414,7 +3414,7 @@ msgid "No issues or manual review items were reported."
 msgstr "No se reportaron problemas ni elementos de revisión manual."
 
 msgid "No items are currently flagged as needing changes in this reviewer session."
-msgstr "No items are currently flagged as needing changes in this reviewer session."
+msgstr "Actualmente no hay elementos marcados como que requieran cambios en esta sesión del revisor."
 
 msgid "No language-specific prompts configured."
 msgstr "No hay prompts por idioma configurados."
@@ -3474,10 +3474,10 @@ msgid "No rendered content for this section"
 msgstr "Sin contenido renderizado para esta sección"
 
 msgid "No review areas are currently flagged in this reviewer session."
-msgstr "No review areas are currently flagged in this reviewer session."
+msgstr "Actualmente no hay áreas de revisión marcadas en esta sesión del revisor."
 
 msgid "No reviewer validation sessions have been started yet. Open Preview to create a reviewer session and begin recording page-level findings."
-msgstr "No reviewer validation sessions have been started yet. Open Preview to create a reviewer session and begin recording page-level findings."
+msgstr "Aún no se han iniciado sesiones de validación del revisor. Abre Vista previa para crear una sesión de revisor y empezar a registrar hallazgos a nivel de página."
 
 msgid "No sectioning data available."
 msgstr "No hay datos de sección disponibles."
@@ -3543,7 +3543,7 @@ msgid "Not generated"
 msgstr "No generado"
 
 msgid "Not reviewed"
-msgstr "Not reviewed"
+msgstr "No revisado"
 
 msgid "Note"
 msgstr "Nota"
@@ -3582,7 +3582,7 @@ msgid "One column for every section. Clean and predictable."
 msgstr "Una columna para cada sección. Limpio y predecible."
 
 msgid "One tag per line or comma-separated. Leave as-is to keep the current package defaults."
-msgstr "One tag per line or comma-separated. Leave as-is to keep the current package defaults."
+msgstr "Una etiqueta por línea o separadas por comas. Déjalo tal cual para mantener los valores predeterminados actuales del paquete."
 
 msgid "Only images that appear in the storyboard (have captions) can be selected."
 msgstr "Solo se pueden seleccionar imágenes que aparezcan en el storyboard (con subtítulos)."
@@ -3612,10 +3612,10 @@ msgid "Open a page in Preview to show its page-specific accessibility findings h
 msgstr "Open a page in Preview to show its page-specific accessibility findings here."
 
 msgid "Open a page in Preview to start recording reviewer validation findings."
-msgstr "Open a page in Preview to start recording reviewer validation findings."
+msgstr "Abre una página en Vista previa para empezar a registrar los hallazgos de validación del revisor."
 
 msgid "Open a page to review"
-msgstr "Open a page to review"
+msgstr "Abre una página para revisar"
 
 msgid "Open a page to see page-level findings"
 msgstr "Open a page to see page-level findings"
@@ -3630,10 +3630,10 @@ msgid "Open page preview for {pageId}"
 msgstr "Abrir vista previa de la página {0}"
 
 msgid "Open Preview"
-msgstr "Open Preview"
+msgstr "Abrir Vista previa"
 
 msgid "Open Validation"
-msgstr "Open Validation"
+msgstr "Abrir validación"
 
 msgid "OpenAI"
 msgstr "OpenAI"
@@ -3657,7 +3657,7 @@ msgid "Optional instructions for the LLM..."
 msgstr "Instrucciones opcionales para el LLM..."
 
 msgid "Optional notes about the review scope or assignments"
-msgstr "Optional notes about the review scope or assignments"
+msgstr "Notas opcionales sobre el alcance de la revisión o las asignaciones"
 
 msgid "Optional notes to steer how captions are generated. Use Auto-fill to start from the book's title, language, and summary."
 msgstr "Notas opcionales para guiar cómo se generan los subtítulos. Usa Autocompletar para comenzar desde el título, idioma y resumen del libro."
@@ -3666,10 +3666,10 @@ msgid "Optional notes to steer how the glossary is generated. Use Auto-fill to s
 msgstr "Notas opcionales para guiar cómo se genera el glosario. Usa Autocompletar para comenzar desde el título, idioma y resumen del libro."
 
 msgid "Optional page-level summary or handoff note"
-msgstr "Optional page-level summary or handoff note"
+msgstr "Resumen opcional a nivel de página o nota de transferencia"
 
 msgid "Optional suggestion for fixing or improving this item"
-msgstr "Optional suggestion for fixing or improving this item"
+msgstr "Sugerencia opcional para corregir o mejorar este elemento"
 
 msgid "Optional. Add notes about tone, focus, or vocabulary. Use Auto-fill to start from the book's title, language, and summary."
 msgstr "Opcional. Añade notas sobre tono, enfoque o vocabulario. Usa Autocompletar para comenzar desde el título, idioma y resumen del libro."
@@ -3721,7 +3721,7 @@ msgid "Output Tokens"
 msgstr "Tokens de salida"
 
 msgid "Overall page note"
-msgstr "Overall page note"
+msgstr "Nota general de la página"
 
 msgid "Overview"
 msgstr "Vista general"
@@ -3769,10 +3769,10 @@ msgid "Packaging"
 msgstr "Empaquetando"
 
 msgid "Packaging failed"
-msgstr "Packaging failed"
+msgstr "Empaquetado fallido"
 
 msgid "Packaging validation results..."
-msgstr "Packaging validation results..."
+msgstr "Empaquetando resultados de validación..."
 
 msgid "Padding"
 msgstr "Padding"
@@ -3801,7 +3801,7 @@ msgid "Page {pageId}"
 msgstr "Página {0}"
 
 msgid "Page coverage"
-msgstr "Page coverage"
+msgstr "Cobertura de páginas"
 
 msgid "Page Grouping"
 msgstr "Agrupación de Páginas"
@@ -3842,13 +3842,13 @@ msgstr "páginas"
 #. placeholder {0}: activeSession.session.start_page ?? "?"
 #. placeholder {1}: activeSession.session.end_page ?? "?"
 msgid "Pages {0}–{1}"
-msgstr "Pages {0}–{1}"
+msgstr "Páginas {0}–{1}"
 
 msgid "Pages per Quiz"
 msgstr "Páginas por quiz"
 
 msgid "Pages reviewed"
-msgstr "Pages reviewed"
+msgstr "Páginas revisadas"
 
 msgid "Paper Collage"
 msgstr "Collage en papel"
@@ -3869,10 +3869,10 @@ msgid "Parts"
 msgstr "Partes"
 
 msgid "Pass"
-msgstr "Pass"
+msgstr "Aprobado"
 
 msgid "Passed"
-msgstr "Passed"
+msgstr "Aprobados"
 
 msgid "Patterns in the noise"
 msgstr "Patrones en el ruido"
@@ -4238,7 +4238,7 @@ msgid "Recommended for {0}"
 msgstr "Recomendado para {0}"
 
 msgid "Record reviewer findings for the current page and save them to the active validation session."
-msgstr "Record reviewer findings for the current page and save them to the active validation session."
+msgstr "Registra los hallazgos del revisor para la página actual y guárdalos en la sesión de validación activa."
 
 msgid "Recrop from page"
 msgstr "Recortar desde la página"
@@ -4253,7 +4253,7 @@ msgid "Refinement Prompt"
 msgstr "Prompt de refinamiento"
 
 msgid "Refresh validation"
-msgstr "Refresh validation"
+msgstr "Actualizar validación"
 
 msgid "Refreshing results for this packaged preview."
 msgstr "Refreshing results for this packaged preview."
@@ -4294,7 +4294,7 @@ msgid "Remove all sign-language videos?"
 msgstr "¿Eliminar todos los videos de lenguaje de señas?"
 
 msgid "Remove checklist item"
-msgstr "Remove checklist item"
+msgstr "Quitar elemento de la lista"
 
 msgid "Remove entry"
 msgstr "Eliminar entrada"
@@ -4312,7 +4312,7 @@ msgid "Remove PDF"
 msgstr "Eliminar PDF"
 
 msgid "Remove section"
-msgstr "Remove section"
+msgstr "Quitar sección"
 
 msgid "Remove term"
 msgstr "Eliminar término"
@@ -4360,10 +4360,10 @@ msgid "Replace this audio file"
 msgstr "Reemplazar este archivo de audio"
 
 msgid "Require comment on failure"
-msgstr "Require comment on failure"
+msgstr "Requerir comentario en caso de fallo"
 
 msgid "Require suggested modification"
-msgstr "Require suggested modification"
+msgstr "Requerir modificación sugerida"
 
 msgid "Required"
 msgstr "Requerido"
@@ -4372,13 +4372,13 @@ msgid "Required Fields"
 msgstr "Campos Requeridos"
 
 msgid "Reset to defaults"
-msgstr "Reset to defaults"
+msgstr "Restablecer valores predeterminados"
 
 msgid "Reset to inherited"
 msgstr "Restablecer a heredado"
 
 msgid "Reset to inherited defaults"
-msgstr "Reset to inherited defaults"
+msgstr "Restablecer a los valores heredados"
 
 msgid "Resolving source language..."
 msgstr "Resolviendo idioma de origen..."
@@ -4402,11 +4402,11 @@ msgid "Restore this term — it will be eligible again on the next regeneration.
 msgstr "Restaurar este término — será elegible nuevamente en la próxima regeneración."
 
 msgid "Resume target"
-msgstr "Resume target"
+msgstr "Objetivo de reanudación"
 
 #. placeholder {0}: resumeTarget.pageNumber ?? resumeTarget.pageId
 msgid "Resume target: page {0}"
-msgstr "Resume target: page {0}"
+msgstr "Objetivo de reanudación: página {0}"
 
 msgid "Retries"
 msgstr "Retries"
@@ -4418,13 +4418,13 @@ msgid "Retry Export"
 msgstr "Reintentar exportación"
 
 msgid "Review areas with the most items marked as needing changes in this session."
-msgstr "Review areas with the most items marked as needing changes in this session."
+msgstr "Áreas de revisión con más elementos marcados como que requieren cambios en esta sesión."
 
 msgid "Review one session at a time to inspect page coverage and flagged findings."
-msgstr "Review one session at a time to inspect page coverage and flagged findings."
+msgstr "Revisa una sesión a la vez para inspeccionar la cobertura de páginas y los hallazgos marcados."
 
 msgid "Review progress"
-msgstr "Review progress"
+msgstr "Progreso de la revisión"
 
 msgid "Review pruned sections"
 msgstr "Revisar secciones podadas"
@@ -4436,34 +4436,34 @@ msgid "Review the source PDF details below and continue to configure how your bo
 msgstr "Revisa los detalles del PDF fuente a continuación y continúa configurando cómo se convertirá tu libro en un Libro de Texto Digital Accesible."
 
 msgid "Reviewer checklist"
-msgstr "Reviewer checklist"
+msgstr "Lista de verificación del revisor"
 
 msgid "Reviewer Checklist"
 msgstr "Reviewer Checklist"
 
 msgid "Reviewer checklist reviews are currently disabled."
-msgstr "Reviewer checklist reviews are currently disabled."
+msgstr "Las revisiones de la lista de verificación del revisor están desactivadas actualmente."
 
 msgid "Reviewer checklist settings saved."
-msgstr "Reviewer checklist settings saved."
+msgstr "Configuración de la lista de verificación del revisor guardada."
 
 msgid "Reviewer guidance"
-msgstr "Reviewer guidance"
+msgstr "Orientación para el revisor"
 
 msgid "Reviewer name"
-msgstr "Reviewer name"
+msgstr "Nombre del revisor"
 
 msgid "Reviewer name is required."
-msgstr "Reviewer name is required."
+msgstr "Se requiere el nombre del revisor."
 
 msgid "Reviewer Validation"
-msgstr "Reviewer Validation"
+msgstr "Validación del revisor"
 
 msgid "Reviewer validation checklist"
-msgstr "Reviewer validation checklist"
+msgstr "Lista de verificación de validación del revisor"
 
 msgid "Reviewer validation summary"
-msgstr "Reviewer validation summary"
+msgstr "Resumen de validación del revisor"
 
 msgid "Rewriting the story of this section..."
 msgstr "Reescribiendo la historia de esta sección..."
@@ -4551,7 +4551,7 @@ msgid "Run whole-book validation checks and configure accessibility assessment s
 msgstr "Run whole-book validation checks and configure accessibility assessment settings."
 
 msgid "Run-only tags"
-msgstr "Run-only tags"
+msgstr "Etiquetas de ejecución exclusiva"
 
 msgid "RUNNING"
 msgstr "EN CURSO"
@@ -4620,22 +4620,22 @@ msgid "Save changes first to preview the latest version"
 msgstr "Guarda los cambios primero para previsualizar la versión más reciente"
 
 msgid "Save checklist"
-msgstr "Save checklist"
+msgstr "Guardar lista de verificación"
 
 msgid "Save failed"
 msgstr "Save failed"
 
 msgid "Save page review"
-msgstr "Save page review"
+msgstr "Guardar revisión de página"
 
 msgid "Save selection"
 msgstr "Guardar selección"
 
 msgid "Save settings"
-msgstr "Save settings"
+msgstr "Guardar configuración"
 
 msgid "Saved. Re-package Preview to apply."
-msgstr "Saved. Re-package Preview to apply."
+msgstr "Guardado. Vuelve a empaquetar Vista previa para aplicar."
 
 msgid "Saving..."
 msgstr "Guardando..."
@@ -4723,7 +4723,7 @@ msgid "Section 3.2"
 msgstr "Sección 3.2"
 
 msgid "Section label"
-msgstr "Section label"
+msgstr "Etiqueta de la sección"
 
 msgid "Section Mode"
 msgstr "Modo de Sección"
@@ -4819,7 +4819,7 @@ msgid "Select a render strategy to preview how your book pages will be laid out.
 msgstr "Selecciona una estrategia de renderizado para previsualizar cómo se dispondrán las páginas de tu libro."
 
 msgid "Select a reviewer session to inspect its progress and findings."
-msgstr "Select a reviewer session to inspect its progress and findings."
+msgstr "Selecciona una sesión del revisor para inspeccionar su progreso y hallazgos."
 
 msgid "Select a section mode to continue"
 msgstr "Selecciona un modo de sección para continuar"
@@ -4843,7 +4843,7 @@ msgid "Select node type..."
 msgstr "Seleccionar tipo de nodo..."
 
 msgid "Select reviewer session"
-msgstr "Select reviewer session"
+msgstr "Seleccionar sesión de revisor"
 
 msgid "Select section mode"
 msgstr "Seleccionar modo de sección"
@@ -4879,16 +4879,16 @@ msgid "serious"
 msgstr "serious"
 
 msgid "Serious"
-msgstr "Serious"
+msgstr "Grave"
 
 msgid "Session comments"
-msgstr "Session comments"
+msgstr "Comentarios de la sesión"
 
 msgid "Sessions"
-msgstr "Sessions"
+msgstr "Sesiones"
 
 msgid "Sessions let different reviewers capture findings independently, including language-specific reviews."
-msgstr "Sessions let different reviewers capture findings independently, including language-specific reviews."
+msgstr "Las sesiones permiten que distintos revisores registren hallazgos de forma independiente, incluyendo revisiones específicas por idioma."
 
 msgid "Set a Gemini API key to generate audio"
 msgstr "Configura una clave de API de Gemini para generar audio"
@@ -4925,7 +4925,7 @@ msgstr "Mostrar todas"
 
 #. placeholder {0}: pages.length
 msgid "Show all {0}"
-msgstr "Show all {0}"
+msgstr "Mostrar todos los {0}"
 
 msgid "Show all translations"
 msgstr "Mostrar todas las traducciones"
@@ -4934,13 +4934,13 @@ msgid "Show error details"
 msgstr "Mostrar detalles del error"
 
 msgid "Show fewer"
-msgstr "Show fewer"
+msgstr "Mostrar menos"
 
 msgid "Show pruned terms"
 msgstr "Mostrar términos podados"
 
 msgid "Show reviewer validation"
-msgstr "Show reviewer validation"
+msgstr "Mostrar validación del revisor"
 
 msgid "Show:"
 msgstr "Mostrar:"
@@ -5106,16 +5106,16 @@ msgid "Start"
 msgstr "Inicio"
 
 msgid "Start a reviewer session"
-msgstr "Start a reviewer session"
+msgstr "Iniciar una sesión de revisor"
 
 msgid "Start from a PDF"
 msgstr "Empieza con un PDF"
 
 msgid "Start page"
-msgstr "Start page"
+msgstr "Página inicial"
 
 msgid "Start reviewer validation"
-msgstr "Start reviewer validation"
+msgstr "Iniciar validación del revisor"
 
 msgid "Start typing to see words from the book…"
 msgstr "Empieza a escribir para ver palabras del libro…"
@@ -5176,7 +5176,7 @@ msgid "Structure"
 msgstr "Estructura"
 
 msgid "Structure & semantics"
-msgstr "Structure & semantics"
+msgstr "Estructura y semántica"
 
 msgid "Structure each page into a content tree of sections and nodes for downstream rendering."
 msgstr "Estructura cada página en un árbol de contenido de secciones y nodos para la renderización posterior."
@@ -5218,10 +5218,10 @@ msgid "Successfully uploaded"
 msgstr "Subido con éxito"
 
 msgid "Suggested modification"
-msgstr "Suggested modification"
+msgstr "Modificación sugerida"
 
 msgid "Suggested modification:"
-msgstr "Suggested modification:"
+msgstr "Modificación sugerida:"
 
 msgid "Summary Prompt"
 msgstr "Indicación de resumen"
@@ -5242,7 +5242,7 @@ msgid "Table of Contents"
 msgstr "Índice"
 
 msgid "Tables"
-msgstr "Tables"
+msgstr "Tablas"
 
 msgid "Tablet"
 msgstr "Tableta"
@@ -5302,7 +5302,7 @@ msgid "Text & Single Image"
 msgstr "Texto e imagen única"
 
 msgid "Text alternatives"
-msgstr "Text alternatives"
+msgstr "Alternativas de texto"
 
 msgid "Text Catalog"
 msgstr "Catálogo de texto"
@@ -5453,7 +5453,7 @@ msgid "These features improve access for people with disabilities. Running them 
 msgstr "Estas funciones mejoran el acceso para personas con discapacidades. Ejecutarlas antes de exportar ayuda a que su libro cumpla con los estándares de accesibilidad ADT."
 
 msgid "These values reflect either the saved book override or the latest packaged defaults."
-msgstr "These values reflect either the saved book override or the latest packaged defaults."
+msgstr "Estos valores reflejan la anulación guardada del libro o los valores predeterminados del último empaquetado."
 
 msgid "This book has no pages. Make sure the extraction and storyboard stages produced content before generating {stageName}."
 msgstr "Este libro no tiene páginas. Asegúrate de que las etapas de extracción y storyboard produjeron contenido antes de generar {stageName}."
@@ -5493,7 +5493,7 @@ msgid "This page has no translatable text entries"
 msgstr "Esta página no tiene entradas de texto traducibles"
 
 msgid "This page has not been reviewed yet"
-msgstr "This page has not been reviewed yet"
+msgstr "Esta página aún no se ha revisado"
 
 msgid "This permanently deletes every uploaded video and clears all section assignments. This can't be undone."
 msgstr "Esto elimina permanentemente cada video subido y borra todas las asignaciones de secciones. Esto no se puede deshacer."
@@ -5508,7 +5508,7 @@ msgid "This section has no storyboard rendering yet"
 msgstr "Esta sección aún no tiene renderización de storyboard"
 
 msgid "This session is using an older reviewer checklist snapshot. Newer checklist settings will apply only to newly created reviewer sessions."
-msgstr "This session is using an older reviewer checklist snapshot. Newer checklist settings will apply only to newly created reviewer sessions."
+msgstr "Esta sesión está utilizando una instantánea anterior de la lista de verificación del revisor. Las nuevas configuraciones de la lista se aplicarán solo a las sesiones de revisor que se creen a partir de ahora."
 
 msgid "This text is only perceptible to assistive technologies."
 msgstr "Este texto solo es perceptible para tecnologías de asistencia."
@@ -5604,7 +5604,7 @@ msgid "Total Tokens"
 msgstr "Tokens totales"
 
 msgid "Track reviewer progress and review findings captured from Preview."
-msgstr "Track reviewer progress and review findings captured from Preview."
+msgstr "Sigue el progreso del revisor y revisa los hallazgos capturados desde Vista previa."
 
 msgid "Translate"
 msgstr "Traducir"
@@ -5673,7 +5673,7 @@ msgid "Turn any PDF into a fully accessible book — audio, translations, struct
 msgstr "Convierte cualquier PDF en un libro totalmente accesible — audio, traducciones, diseños HTML estructurados — todo generado a partir de tu archivo fuente, <0>todo editable</0>, <1>todo tuyo</1>."
 
 msgid "Turn this on to show the Validation review card in Preview and the Reviewer Validation tab in the Validation step."
-msgstr "Turn this on to show the Validation review card in Preview and the Reviewer Validation tab in the Validation step."
+msgstr "Activa esto para mostrar la tarjeta de revisión de Validación en Vista previa y la pestaña Validación del revisor en el paso de Validación."
 
 msgid "Two authentication methods are supported: Bearer tokens passed in the Authorization header, and API keys passed as a query parameter. Bearer tokens are preferred for server-to-server requests due to their short expiry window."
 msgstr "Se admiten dos métodos de autenticación: tokens Bearer pasados en el encabezado de Autorización y claves de API pasadas como un parámetro de consulta. Se prefieren los tokens Bearer para solicitudes de servidor a servidor debido a su corta ventana de expiración."
@@ -5709,7 +5709,7 @@ msgid "Typography"
 msgstr "Tipografía"
 
 msgid "Unable to load reviewer checklist settings."
-msgstr "Unable to load reviewer checklist settings."
+msgstr "No se pudo cargar la configuración de la lista de verificación del revisor."
 
 msgid "Unable to render PDF preview."
 msgstr "No se puede renderizar la vista previa del PDF."
@@ -5724,7 +5724,7 @@ msgid "Unavailable"
 msgstr "Unavailable"
 
 msgid "Uncategorized"
-msgstr "Uncategorized"
+msgstr "Sin categoría"
 
 msgid "Underline"
 msgstr "Subrayado"
@@ -5739,10 +5739,10 @@ msgid "unknown"
 msgstr "unknown"
 
 msgid "Unknown"
-msgstr "Unknown"
+msgstr "Desconocido"
 
 msgid "Unknown criterion"
-msgstr "Unknown criterion"
+msgstr "Criterio desconocido"
 
 msgid "Unknown stage"
 msgstr "Etapa desconocida"
@@ -5856,7 +5856,7 @@ msgid "Use Spread for printed books with facing-page layouts (covers stay solo, 
 msgstr "Usa Extendido para libros impresos con diseños de páginas enfrentadas (las portadas se mantienen solas, luego 2+3, 4+5, …). Usa Individual cuando cada página PDF deba procesarse por separado."
 
 msgid "Use this for checks you intentionally want to suppress, such as known false positives."
-msgstr "Use this for checks you intentionally want to suppress, such as known false positives."
+msgstr "Usa esto para comprobaciones que quieras suprimir intencionadamente, como falsos positivos conocidos."
 
 msgid "Use this format to back up the project or move it to another machine."
 msgstr "Usa este formato para respaldar el proyecto o moverlo a otra máquina."
@@ -5871,7 +5871,7 @@ msgid "Used for Gemini models — both LLM (gemini-2.5-pro, etc.) and TTS (gemin
 msgstr "Utilizada para modelos Gemini — tanto LLM (gemini-2.5-pro, etc.) como TTS (gemini-2.5-pro-preview-tts, etc.)"
 
 msgid "Validation"
-msgstr "Validation"
+msgstr "Validación"
 
 #. placeholder {0}: data.validationErrors.length
 msgid "Validation Errors ({0})"
@@ -5918,7 +5918,7 @@ msgid "View image"
 msgstr "Ver imagen"
 
 msgid "Visual & sensory cues"
-msgstr "Visual & sensory cues"
+msgstr "Indicaciones visuales y sensoriales"
 
 msgid "Visual Layout"
 msgstr "Diseño Visual"
@@ -6050,7 +6050,7 @@ msgid "While editing"
 msgstr "Mientras editas"
 
 msgid "Whole-book checks for packaged ADT output, plus reviewer findings captured from Preview."
-msgstr "Whole-book checks for packaged ADT output, plus reviewer findings captured from Preview."
+msgstr "Comprobaciones de todo el libro para la salida ADT empaquetada, además de hallazgos del revisor capturados desde Vista previa."
 
 msgid "Wide multilingual coverage with neural voices for many locales."
 msgstr "Amplia cobertura multilingüe con voces neuronales para muchos lugares."

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -1061,7 +1061,7 @@ msgstr "Arrière-plan"
 
 #. placeholder {0}: section.backgroundColor
 msgid "Background: {0}"
-msgstr "Background: {0}"
+msgstr "Arrière-plan : {0}"
 
 msgid "base"
 msgstr "base"
@@ -1070,7 +1070,7 @@ msgid "Base Language"
 msgstr "Base Langue"
 
 msgid "Base URL"
-msgstr "Base URL"
+msgstr "URL de base"
 
 msgid "Basic Information"
 msgstr "Informations de base"
@@ -1191,7 +1191,7 @@ msgid "cached"
 msgstr "en cache"
 
 msgid "Cached"
-msgstr "Cached"
+msgstr "En cache"
 
 msgid "Cached response"
 msgstr "Réponse en cache"
@@ -1234,7 +1234,7 @@ msgid "Captions support accessibility."
 msgstr "Les sous-titres soutiennent l'accessibilité."
 
 msgid "carousel"
-msgstr "carousel"
+msgstr "carrousel"
 
 msgid "Cartoon"
 msgstr "Dessin animé"
@@ -1444,7 +1444,7 @@ msgid "Compressed archive · ~ 42 MB"
 msgstr "Archive compressée · ~ 42 Mo"
 
 msgid "Concise"
-msgstr "Concise"
+msgstr "Concis"
 
 msgid "Condensation"
 msgstr "Condensation"
@@ -2542,7 +2542,7 @@ msgid "História e Sociedade - Vol. 1"
 msgstr "História e Sociedade - Vol. 1"
 
 msgid "Hit"
-msgstr "Hit"
+msgstr "Succès"
 
 msgid "Home / Chapter 1"
 msgstr "Accueil / Chapitre 1"
@@ -2901,7 +2901,7 @@ msgid "Link"
 msgstr "Lien"
 
 msgid "Linked to: {value}"
-msgstr "Linked to: {value}"
+msgstr "Lié à : {value}"
 
 msgid "List"
 msgstr "Liste"
@@ -2913,25 +2913,25 @@ msgid "Listening to the data"
 msgstr "Écouter les données"
 
 msgid "Live"
-msgstr "Live"
+msgstr "En direct"
 
 msgid "LLM Calls"
 msgstr "Appels LLM"
 
 msgid "LLM crop"
-msgstr "LLM crop"
+msgstr "Recadrage LLM"
 
 msgid "LLM cropping"
-msgstr "LLM cropping"
+msgstr "Recadrage LLM"
 
 msgid "LLM generates HTML from section content"
 msgstr "Le LLM génère le HTML à partir du contenu de la section"
 
 msgid "LLM image cropping"
-msgstr "LLM image cropping"
+msgstr "Recadrage d'images par LLM"
 
 msgid "LLM image segmentation"
-msgstr "LLM image segmentation"
+msgstr "Segmentation d'images par LLM"
 
 msgid "LLM meaningfulness filter"
 msgstr "Filtre de pertinence LLM"
@@ -2940,7 +2940,7 @@ msgid "LLM positions text over background images"
 msgstr "Le LLM positionne le texte sur les images d'arrière-plan"
 
 msgid "LLM segmentation"
-msgstr "LLM segmentation"
+msgstr "Segmentation LLM"
 
 msgid "LLM-based cropping to remove stray text, artifacts, and excessive whitespace from extracted images."
 msgstr "Recadrage basé sur le LLM pour supprimer le texte parasite, les artefacts et les espaces blancs excessifs des images extraites."
@@ -3523,7 +3523,7 @@ msgid "No voice mappings configured."
 msgstr "Aucune correspondance de voix configurée."
 
 msgid "Nodes"
-msgstr "Nodes"
+msgstr "Nœuds"
 
 msgid "noise"
 msgstr "bruit"
@@ -3688,11 +3688,11 @@ msgid "Original language"
 msgstr "Langue originale"
 
 msgid "Original PDF"
-msgstr "Original PDF"
+msgstr "PDF original"
 
 #. placeholder {0}: i18n._(selectedBook.title)
 msgid "Original PDF - {0}"
-msgstr "Original PDF - {0}"
+msgstr "PDF original - {0}"
 
 msgid "osmosis"
 msgstr "osmose"
@@ -3770,7 +3770,7 @@ msgid "Packaging validation results..."
 msgstr "Empaquetage des résultats de validation..."
 
 msgid "Padding"
-msgstr "Padding"
+msgstr "Marge intérieure"
 
 msgid "page"
 msgstr "page"
@@ -4003,7 +4003,7 @@ msgid "Prefer terms central to the book's subject matter. Skip generic vocabular
 msgstr "Privilégiez les termes centraux au sujet du livre. Évitez le vocabulaire générique et les noms propres qui n'ont pas de signification au-delà de la page."
 
 msgid "Preset"
-msgstr "Preset"
+msgstr "Préréglage"
 
 msgid "Presets add recommendations and specific settings for your use case. You still choose each option step by step, and you can go back to select a different preset at any time."
 msgstr "Les préréglages ajoutent des recommandations et des paramètres spécifiques à votre cas d'utilisation. Vous choisissez toujours chaque option étape par étape, et vous pouvez revenir à tout moment pour sélectionner un autre préréglage."
@@ -4051,13 +4051,13 @@ msgid "Prompt template not found."
 msgstr "Invite modèle non trouvé."
 
 msgid "Provider"
-msgstr "Provider"
+msgstr "Fournisseur"
 
 msgid "Provides consistent HTML/CSS patterns for LLM-generated pages."
 msgstr "Fournit des modèles HTML/CSS cohérents pour les pages générées par le LLM."
 
 msgid "Prune"
-msgstr "Prune"
+msgstr "Élaguer"
 
 msgid "Prune element"
 msgstr "Élaguer l'élément"
@@ -4136,10 +4136,10 @@ msgid "Re-enable type"
 msgstr "Réactiver le type"
 
 msgid "Re-package ADT"
-msgstr "Re-package ADT"
+msgstr "Ré-empaqueter ADT"
 
 msgid "Re-render"
-msgstr "Re-render"
+msgstr "Re-rendu"
 
 msgid "Re-render (your edits will be preserved)"
 msgstr "Re-rendu (vos modifications seront conservées)"
@@ -4645,7 +4645,7 @@ msgid "SCORM Export"
 msgstr "Exportation SCORM"
 
 msgid "SCORM Package"
-msgstr "SCORM Package"
+msgstr "Paquet SCORM"
 
 msgid "Screen readers cannot interpret images without text alternatives. Adding captions ensures blind and low-vision readers understand every illustration."
 msgstr "Les lecteurs d'écran ne peuvent pas interpréter les images sans alternatives textuelles. Ajouter des légendes garantit que les lecteurs aveugles et malvoyants comprennent chaque illustration."
@@ -4998,7 +4998,7 @@ msgid "Skipped"
 msgstr "Ignoré"
 
 msgid "Sky"
-msgstr "Sky"
+msgstr "Ciel"
 
 msgid "slide"
 msgstr "diapositive"
@@ -5189,7 +5189,7 @@ msgid "Style reference image"
 msgstr "Image de référence de style"
 
 msgid "Styleguide"
-msgstr "Styleguide"
+msgstr "Guide de style"
 
 msgid "Styleguide Preview"
 msgstr "Aperçu du guide de style"
@@ -5213,7 +5213,7 @@ msgid "Summary Prompt"
 msgstr "Résumé Invite"
 
 msgid "Sun"
-msgstr "Sun"
+msgstr "Soleil"
 
 msgid "SW"
 msgstr "SW"
@@ -5551,7 +5551,7 @@ msgid "Titles taken verbatim from typed section headings."
 msgstr "Titres repris textuellement des titres de sections tapés."
 
 msgid "to"
-msgstr "to"
+msgstr "à"
 
 msgid "to stream API logs here."
 msgstr "pour diffuser les journaux API ici."

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -67,17 +67,6 @@ msgstr "(modèle)"
 msgid "{0} — type country or Enter for base"
 msgstr "{0} — tapez un pays ou Entrée pour base"
 
-#. placeholder {0}: finding.count
-#. placeholder {1}: finding.count === 1 ? "issue" : "issues"
-#. placeholder {1}: finding.count === 1 ? "manual review item" : "manual review items"
-msgid "{0} {1}"
-msgstr "{0} {1}"
-
-#. placeholder {0}: activeMetrics.pagesReviewed
-#. placeholder {1}: activeMetrics.pagesReviewed === 1 ? "page" : "pages"
-msgid "{0} {1} reviewed so far"
-msgstr "{0} {1} révisé(s) jusqu'à présent"
-
 #. placeholder {0}: bbox.w
 #. placeholder {1}: bbox.h
 #. placeholder {2}: points.length
@@ -145,6 +134,10 @@ msgstr "{0} sur {1} éléments"
 msgid "{0} pages"
 msgstr "{0} pages"
 
+#. placeholder {0}: section.criteria.length - reviewed
+msgid "{0} pending"
+msgstr "{0} en attente"
+
 #. placeholder {0}: String(displayQuizzes.length)
 msgid "{0} questions"
 msgstr "{0} questions"
@@ -194,6 +187,12 @@ msgstr "il y a {0} min"
 #. placeholder {0}: String(Math.floor(diff / 1000))
 msgid "{0}s ago"
 msgstr "il y a {0} s"
+
+msgid "{count} {count, plural, one {issue} other {issues}}"
+msgstr "{count} {count, plural, one {problème} other {problèmes}}"
+
+msgid "{count} {count, plural, one {manual review item} other {manual review items}}"
+msgstr "{count} {count, plural, one {élément de révision manuelle} other {éléments de révision manuelle}}"
 
 msgid "{count} translations"
 msgstr "{count} traductions"
@@ -248,11 +247,17 @@ msgstr "{missingForCurrentStage} entrée(s) sans audio. Relancez pour générer 
 msgid "{missingForCurrentStage} entry/entries are missing translations. Re-run to fill the missing items."
 msgstr "{missingForCurrentStage} entrée(s) sans traduction. Relancez pour compléter les éléments manquants."
 
+msgid "{needsChanges} flagged"
+msgstr "{needsChanges} signalés"
+
 msgid "{pageCount} {pageCount, plural, one {page} other {pages}}"
 msgstr "{pageCount} {pageCount, plural, one {page} other {pages}}"
 
 msgid "{pageCount} pages"
 msgstr "{pageCount} pages"
+
+msgid "{pagesReviewed} {pagesReviewed, plural, one {page} other {pages}} reviewed so far"
+msgstr "{pagesReviewed} {pagesReviewed, plural, one {page} other {pages}} révisées jusqu'à présent"
 
 msgid "{regionCount} {regionCount, plural, one {region} other {regions}} detected"
 msgstr "{regionCount} {regionCount, plural, one {region} other {regions}} détectée(s)"
@@ -627,9 +632,6 @@ msgstr "Ajouter un livre"
 
 msgid "Add checklist item to this section"
 msgstr "Ajouter un élément de liste de contrôle à cette section"
-
-#~ msgid "Add class"
-#~ msgstr "Ajouter une classe"
 
 msgid "Add custom instructions"
 msgstr "Ajouter des instructions personnalisées"
@@ -1654,9 +1656,6 @@ msgstr "Démo de mise en page personnalisée"
 msgid "Custom section {index}"
 msgstr "Section personnalisée {index}"
 
-#~ msgid "Custom:"
-#~ msgstr "Personnalisé:"
-
 msgid "Debug mode is not enabled."
 msgstr "Le mode débogage n'est pas activé."
 
@@ -2067,9 +2066,6 @@ msgstr "Saisissez une dimension minimale valide (nombre entier ≥ 0)"
 
 msgid "Enter a valid project name"
 msgstr "Saisissez un nom de projet valide"
-
-#~ msgid "Enter hex color and press Enter"
-#~ msgstr "Saisissez une couleur hexadécimale et appuyez sur Entrée"
 
 msgid "EPUB"
 msgstr "EPUB"
@@ -3430,9 +3426,6 @@ msgstr "Aucun lien"
 msgid "No log entries found yet."
 msgstr "Aucune entrée de journal trouvée."
 
-#~ msgid "No matches"
-#~ msgstr "Aucune correspondance"
-
 msgid "No matches for \"{search}\""
 msgstr "Aucun résultat pour \\\"{search}\\\""
 
@@ -4015,9 +4008,6 @@ msgstr "Preset"
 msgid "Presets add recommendations and specific settings for your use case. You still choose each option step by step, and you can go back to select a different preset at any time."
 msgstr "Les préréglages ajoutent des recommandations et des paramètres spécifiques à votre cas d'utilisation. Vous choisissez toujours chaque option étape par étape, et vous pouvez revenir à tout moment pour sélectionner un autre préréglage."
 
-#~ msgid "Press Enter to add"
-#~ msgstr "Appuyez sur Entrée pour ajouter"
-
 msgid "Prev"
 msgstr "Préc."
 
@@ -4334,9 +4324,6 @@ msgstr "Raisonnement de rendu"
 msgid "Render Strategy"
 msgstr "Stratégie de rendu"
 
-#~ msgid "rendering"
-#~ msgstr "rendu"
-
 msgid "Rendering Prompt"
 msgstr "Rendering Invite"
 
@@ -4384,9 +4371,6 @@ msgstr "Réinitialiser aux valeurs par défaut héritées"
 
 msgid "Resolving source language..."
 msgstr "Résolution de la langue source..."
-
-#~ msgid "Responsive / State variants"
-#~ msgstr "Variantes responsives / d'état"
 
 msgid "Restart and install"
 msgstr "Redémarrer et installer"
@@ -5698,9 +5682,6 @@ msgstr "Modèle à deux colonnes pour le contenu narratif"
 msgid "Type"
 msgstr "Type"
 
-#~ msgid "Type class name or search..."
-#~ msgstr "Tapez un nom de classe ou recherchez..."
-
 msgid "Typed Sections"
 msgstr "Sections tapées"
 
@@ -5760,9 +5741,6 @@ msgstr "Restaurer l'image"
 
 msgid "Unsaved changes"
 msgstr "Modifications non enregistrées"
-
-#~ msgid "Unsaved:"
-#~ msgstr "Non enregistré :"
 
 msgid "Untangling nested divs with care..."
 msgstr "Démêlage des divs imbriqués avec soin..."
@@ -5881,9 +5859,6 @@ msgstr "Validation Erreurs ({0})"
 
 msgid "Variables"
 msgstr "Variables"
-
-#~ msgid "Variant:"
-#~ msgstr "Variant:"
 
 msgid "Variations"
 msgstr "Variantes"

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -65,17 +65,6 @@ msgstr "(template)"
 msgid "{0} — type country or Enter for base"
 msgstr "{0} — digite o país ou pressione Enter para o padrão"
 
-#. placeholder {0}: finding.count
-#. placeholder {1}: finding.count === 1 ? "issue" : "issues"
-#. placeholder {1}: finding.count === 1 ? "manual review item" : "manual review items"
-msgid "{0} {1}"
-msgstr "{0} {1}"
-
-#. placeholder {0}: activeMetrics.pagesReviewed
-#. placeholder {1}: activeMetrics.pagesReviewed === 1 ? "page" : "pages"
-msgid "{0} {1} reviewed so far"
-msgstr "{0} {1} revisadas até agora"
-
 #. placeholder {0}: bbox.w
 #. placeholder {1}: bbox.h
 #. placeholder {2}: points.length
@@ -143,6 +132,10 @@ msgstr "{0} de {1} itens"
 msgid "{0} pages"
 msgstr "{0} páginas"
 
+#. placeholder {0}: section.criteria.length - reviewed
+msgid "{0} pending"
+msgstr "{0} pendentes"
+
 #. placeholder {0}: String(displayQuizzes.length)
 msgid "{0} questions"
 msgstr "{0} questões"
@@ -192,6 +185,12 @@ msgstr "Há {0}min"
 #. placeholder {0}: String(Math.floor(diff / 1000))
 msgid "{0}s ago"
 msgstr "Há {0}s"
+
+msgid "{count} {count, plural, one {issue} other {issues}}"
+msgstr "{count} {count, plural, one {problema} other {problemas}}"
+
+msgid "{count} {count, plural, one {manual review item} other {manual review items}}"
+msgstr "{count} {count, plural, one {item de revisão manual} other {itens de revisão manual}}"
 
 msgid "{count} translations"
 msgstr "{count} traduções"
@@ -246,11 +245,17 @@ msgstr "{missingForCurrentStage} entrada(s) sem áudio. Execute novamente para g
 msgid "{missingForCurrentStage} entry/entries are missing translations. Re-run to fill the missing items."
 msgstr "{missingForCurrentStage} entrada(s) sem tradução. Execute novamente para preencher os itens faltantes."
 
+msgid "{needsChanges} flagged"
+msgstr "{needsChanges} sinalizados"
+
 msgid "{pageCount} {pageCount, plural, one {page} other {pages}}"
 msgstr "{pageCount} {pageCount, plural, one {página} other {páginas}}"
 
 msgid "{pageCount} pages"
 msgstr "{pageCount} páginas"
+
+msgid "{pagesReviewed} {pagesReviewed, plural, one {page} other {pages}} reviewed so far"
+msgstr "{pagesReviewed} {pagesReviewed, plural, one {página} other {páginas}} revisadas até agora"
 
 msgid "{regionCount} {regionCount, plural, one {region} other {regions}} detected"
 msgstr "{regionCount} {regionCount, plural, one {region} other {regions}} detected"
@@ -625,9 +630,6 @@ msgstr "Adicionar livro"
 
 msgid "Add checklist item to this section"
 msgstr "Adicionar item da lista de verificação a esta seção"
-
-#~ msgid "Add class"
-#~ msgstr "Adicionar classe"
 
 msgid "Add custom instructions"
 msgstr "Adicionar instruções personalizadas"
@@ -1652,9 +1654,6 @@ msgstr "Demonstração de Layout Personalizado"
 msgid "Custom section {index}"
 msgstr "Seção personalizada {index}"
 
-#~ msgid "Custom:"
-#~ msgstr "Personalizado:"
-
 msgid "Debug mode is not enabled."
 msgstr "Modo de depuração não está ativado."
 
@@ -2065,9 +2064,6 @@ msgstr "Insira uma dimensão mínima válida (número inteiro ≥ 0)"
 
 msgid "Enter a valid project name"
 msgstr "Insira um nome de projeto válido"
-
-#~ msgid "Enter hex color and press Enter"
-#~ msgstr "Digite uma cor hex e pressione Enter"
 
 msgid "EPUB"
 msgstr "EPUB"
@@ -3428,9 +3424,6 @@ msgstr "Sem link"
 msgid "No log entries found yet."
 msgstr "Nenhuma entrada de registro encontrada ainda."
 
-#~ msgid "No matches"
-#~ msgstr "Sem resultados"
-
 msgid "No matches for \"{search}\""
 msgstr "Nenhum resultado para \"{0}\""
 
@@ -4013,9 +4006,6 @@ msgstr "Predefinido"
 msgid "Presets add recommendations and specific settings for your use case. You still choose each option step by step, and you can go back to select a different preset at any time."
 msgstr "As predefinições adicionam recomendações e configurações específicas para o seu caso de uso. Você ainda escolhe cada opção etapa por etapa e pode voltar para selecionar outra predefinição a qualquer momento."
 
-#~ msgid "Press Enter to add"
-#~ msgstr "Pressione Enter para adicionar"
-
 msgid "Prev"
 msgstr "Anterior"
 
@@ -4332,9 +4322,6 @@ msgstr "Raciocínio de renderização"
 msgid "Render Strategy"
 msgstr "Estratégia de renderização"
 
-#~ msgid "rendering"
-#~ msgstr "renderização"
-
 msgid "Rendering Prompt"
 msgstr "Prompt de renderização"
 
@@ -4382,9 +4369,6 @@ msgstr "Redefinir para os padrões herdados"
 
 msgid "Resolving source language..."
 msgstr "Resolvendo idioma de origem..."
-
-#~ msgid "Responsive / State variants"
-#~ msgstr "Variantes responsivas / de estado"
 
 msgid "Restart and install"
 msgstr "Reiniciar e instalar"
@@ -5696,9 +5680,6 @@ msgstr "Template de duas colunas para conteúdo narrativo"
 msgid "Type"
 msgstr "Tipo"
 
-#~ msgid "Type class name or search..."
-#~ msgstr "Digite nome da classe ou pesquise..."
-
 msgid "Typed Sections"
 msgstr "Seções Classificadas"
 
@@ -5758,9 +5739,6 @@ msgstr "Restaurar imagem"
 
 msgid "Unsaved changes"
 msgstr "Alterações não salvas"
-
-#~ msgid "Unsaved:"
-#~ msgstr "Não salvo:"
 
 msgid "Untangling nested divs with care..."
 msgstr "Desembaraçando divs aninhadas com cuidado..."
@@ -5879,9 +5857,6 @@ msgstr "Erros de validação ({0})"
 
 msgid "Variables"
 msgstr "Variáveis"
-
-#~ msgid "Variant:"
-#~ msgstr "Variante:"
 
 msgid "Variations"
 msgstr "Variações"

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -13,7 +13,7 @@ msgstr ""
 "Plural-Forms: \n"
 
 msgid " · {needsChanges} need changes"
-msgstr " · {needsChanges} need changes"
+msgstr " · {needsChanges} precisam de alterações"
 
 msgid " and "
 msgstr " e "
@@ -74,7 +74,7 @@ msgstr "{0} {1}"
 #. placeholder {0}: activeMetrics.pagesReviewed
 #. placeholder {1}: activeMetrics.pagesReviewed === 1 ? "page" : "pages"
 msgid "{0} {1} reviewed so far"
-msgstr "{0} {1} reviewed so far"
+msgstr "{0} {1} revisadas até agora"
 
 #. placeholder {0}: bbox.w
 #. placeholder {1}: bbox.h
@@ -88,7 +88,7 @@ msgstr "{0} áudios"
 
 #. placeholder {0}: activeProgress.criteriaPerPage
 msgid "{0} checks per page"
-msgstr "{0} checks per page"
+msgstr "{0} verificações por página"
 
 #. placeholder {0}: entries.length
 msgid "{0} entries"
@@ -96,7 +96,7 @@ msgstr "{0} entradas"
 
 #. placeholder {0}: activeMetrics.flagged.length
 msgid "{0} flagged findings in this review"
-msgstr "{0} flagged findings in this review"
+msgstr "{0} achados sinalizados nesta revisão"
 
 #. placeholder {0}: selectedImageIds.length
 #. placeholder {1}: selectedImageIds.length === 1 ? "" : "s"
@@ -118,7 +118,7 @@ msgstr "{0} itens"
 
 #. placeholder {0}: counts.needsChanges
 msgid "{0} items need changes on this page"
-msgstr "{0} items need changes on this page"
+msgstr "{0} itens precisam de alterações nesta página"
 
 #. placeholder {0}: String(outputLanguages.length)
 msgid "{0} languages"
@@ -127,12 +127,12 @@ msgstr "{0} idiomas"
 #. placeholder {0}: activeMetrics.pagesReviewed
 #. placeholder {1}: activeProgress.assignedPageCount
 msgid "{0} of {1} assigned pages reviewed"
-msgstr "{0} of {1} assigned pages reviewed"
+msgstr "{0} de {1} páginas atribuídas revisadas"
 
 #. placeholder {0}: activeMetrics.pagesReviewed
 #. placeholder {1}: activeProgress.totalBookPages
 msgid "{0} of {1} book pages reviewed"
-msgstr "{0} of {1} book pages reviewed"
+msgstr "{0} de {1} páginas do livro revisadas"
 
 #. placeholder {0}: visibleFindings.length
 #. placeholder {1}: visibleFindingsUniverse.length
@@ -170,7 +170,7 @@ msgstr "{0}/{1} áudio"
 
 #. placeholder {0}: counts.reviewed
 msgid "{0}/{criteriaCount} checked"
-msgstr "{0}/{criteriaCount} checked"
+msgstr "{0}/{criteriaCount} verificados"
 
 #. placeholder {0}: String(selectedPageIds.size)
 msgid "{0}/5 pages selected"
@@ -178,7 +178,7 @@ msgstr "{0}/5 páginas selecionadas"
 
 #. placeholder {0}: activeProgress.percent
 msgid "{0}% complete"
-msgstr "{0}% complete"
+msgstr "{0}% concluído"
 
 #. placeholder {0}: Math.floor(elapsed / 60)
 #. placeholder {1}: elapsed % 60
@@ -314,7 +314,7 @@ msgid "1 image selected"
 msgstr "1 imagem selecionada"
 
 msgid "1 item needs changes on this page"
-msgstr "1 item needs changes on this page"
+msgstr "1 item precisa de alterações nesta página"
 
 msgid "1 selected image is no longer in the storyboard."
 msgstr "1 imagem selecionada não está mais no storyboard."
@@ -482,7 +482,7 @@ msgid "Accessibility"
 msgstr "Accessibility"
 
 msgid "Accessibility assessment configuration"
-msgstr "Accessibility assessment configuration"
+msgstr "Configuração da avaliação de acessibilidade"
 
 msgid "Accessibility check failed for this page"
 msgstr "Accessibility check failed for this page"
@@ -494,7 +494,7 @@ msgid "Accessibility results are temporarily unavailable."
 msgstr "Accessibility results are temporarily unavailable."
 
 msgid "Accessibility Summary"
-msgstr "Accessibility Summary"
+msgstr "Resumo de Acessibilidade"
 
 msgid "Accessibility, from the first <0>page.</0>"
 msgstr "Acessibilidade, desde a primeira <0>página.</0>"
@@ -506,19 +506,19 @@ msgid "Actions disabled while storyboard is running"
 msgstr "Ações desabilitadas enquanto o storyboard está em execução"
 
 msgid "active checklist items"
-msgstr "active checklist items"
+msgstr "itens ativos da lista de verificação"
 
 msgid "active item"
-msgstr "active item"
+msgstr "item ativo"
 
 msgid "active items"
-msgstr "active items"
+msgstr "itens ativos"
 
 msgid "Active reviewer session"
-msgstr "Active reviewer session"
+msgstr "Sessão de revisor ativa"
 
 msgid "active sections"
-msgstr "active sections"
+msgstr "seções ativas"
 
 msgid "Activities"
 msgstr "Atividades"
@@ -624,7 +624,7 @@ msgid "Add Book"
 msgstr "Adicionar livro"
 
 msgid "Add checklist item to this section"
-msgstr "Add checklist item to this section"
+msgstr "Adicionar item da lista de verificação a esta seção"
 
 #~ msgid "Add class"
 #~ msgstr "Adicionar classe"
@@ -660,10 +660,10 @@ msgid "Add languages to translate the book content into."
 msgstr "Adicione idiomas para traduzir o conteúdo do livro."
 
 msgid "Add reviewer guidance."
-msgstr "Add reviewer guidance."
+msgstr "Adicione orientação para o revisor."
 
 msgid "Add section"
-msgstr "Add section"
+msgstr "Adicionar seção"
 
 msgid "Add sizing field"
 msgstr "Adicionar campo de dimensionamento"
@@ -733,7 +733,7 @@ msgid "Adventure Tales - Vol. 1"
 msgstr "Contos de Aventura - Vol. 1"
 
 msgid "Affected pages"
-msgstr "Affected pages"
+msgstr "Páginas afetadas"
 
 msgid "After"
 msgstr "Depois"
@@ -806,7 +806,7 @@ msgid "All"
 msgstr "Tudo"
 
 msgid "All Categories"
-msgstr "All Categories"
+msgstr "Todas as Categorias"
 
 msgid "All issues and manual review items"
 msgstr "Todos os problemas e itens de revisão manual"
@@ -824,7 +824,7 @@ msgid "All set"
 msgstr "Tudo pronto"
 
 msgid "All Severities"
-msgstr "All Severities"
+msgstr "Todas as Severidades"
 
 msgid "All steps"
 msgstr "Todas as etapas"
@@ -951,7 +951,7 @@ msgid "Are you sure you want to generate word-level timestamps for {langDisplay}
 msgstr "Tem certeza de que deseja gerar marcações de tempo por palavra para {langDisplay}?"
 
 msgid "areas"
-msgstr "areas"
+msgstr "áreas"
 
 msgid "Arrange extracted content into a structured storyboard with pages, sections, and layouts."
 msgstr "Organiza o conteúdo extraído em um storyboard estruturado com páginas, seções e layouts."
@@ -1284,7 +1284,7 @@ msgid "Check for updates"
 msgstr "Verificar atualizações"
 
 msgid "Checked"
-msgstr "Checked"
+msgstr "Verificados"
 
 msgid "Checking accessibility"
 msgstr "Checking accessibility"
@@ -1293,7 +1293,7 @@ msgid "Checking for updates…"
 msgstr "Verificando atualizações…"
 
 msgid "Checklist item"
-msgstr "Checklist item"
+msgstr "Item da lista de verificação"
 
 msgid "choice"
 msgstr "escolha"
@@ -1320,7 +1320,7 @@ msgid "Choose Provider"
 msgstr "Escolher provedor"
 
 msgid "Choose which per-page validation items reviewers must check, customize the wording and guidance, and add your own checklist items for this document."
-msgstr "Choose which per-page validation items reviewers must check, customize the wording and guidance, and add your own checklist items for this document."
+msgstr "Escolha quais itens de validação por página os revisores devem verificar, personalize o texto e a orientação e adicione seus próprios itens da lista de verificação para este documento."
 
 msgid "Ciências da Natureza - Ensino Fundamental"
 msgstr "Ciências da Natureza - Ensino Fundamental"
@@ -1338,7 +1338,7 @@ msgid "Clear"
 msgstr "Limpar"
 
 msgid "Clear all"
-msgstr "Clear all"
+msgstr "Limpar todos"
 
 msgid "Clear language"
 msgstr "Limpar idioma"
@@ -1395,7 +1395,7 @@ msgid "Collapse all sections"
 msgstr "Recolher todas as seções"
 
 msgid "Collapse validation"
-msgstr "Collapse validation"
+msgstr "Recolher validação"
 
 msgid "Color"
 msgstr "Cor"
@@ -1416,22 +1416,22 @@ msgid "Coming soon"
 msgstr "Em breve"
 
 msgid "Comment"
-msgstr "Comment"
+msgstr "Comentário"
 
 msgid "Comments"
-msgstr "Comments"
+msgstr "Comentários"
 
 msgid "Completion"
 msgstr "Conclusão"
 
 msgid "Completion across all pages in this book for the active reviewer session."
-msgstr "Completion across all pages in this book for the active reviewer session."
+msgstr "Conclusão em todas as páginas deste livro para a sessão de revisor ativa."
 
 msgid "Completion across pages that have been opened and reviewed in this session."
-msgstr "Completion across pages that have been opened and reviewed in this session."
+msgstr "Conclusão entre as páginas que foram abertas e revisadas nesta sessão."
 
 msgid "Completion across the assigned page range for this reviewer session."
-msgstr "Completion across the assigned page range for this reviewer session."
+msgstr "Conclusão no intervalo de páginas atribuído para esta sessão de revisor."
 
 msgid "Comprehensive"
 msgstr "Abrangente"
@@ -1501,21 +1501,21 @@ msgstr "Continuar"
 
 #. placeholder {0}: resumeTarget.pageNumber ?? resumeTarget.pageId
 msgid "Continue on page {0}"
-msgstr "Continue on page {0}"
+msgstr "Continuar na página {0}"
 
 #. placeholder {0}: resumeTarget.pageNumber ?? resumeTarget.pageId
 msgid "Continue page {0}"
-msgstr "Continue page {0}"
+msgstr "Continuar página {0}"
 
 #. placeholder {0}: resumeTarget?.pageNumber ?? resumeTarget?.pageId
 msgid "Continue reviewer validation on page {0}"
-msgstr "Continue reviewer validation on page {0}"
+msgstr "Continuar validação do revisor na página {0}"
 
 msgid "Continuing will reset your current configuration."
 msgstr "Continuar irá redefinir sua configuração atual."
 
 msgid "Control which axe checks run during packaging for this document. Changes apply on the next package run."
-msgstr "Control which axe checks run during packaging for this document. Changes apply on the next package run."
+msgstr "Controle quais verificações do axe são executadas durante o empacotamento deste documento. As alterações se aplicam na próxima execução do empacotamento."
 
 msgid "Controls how page content is grouped during the sectioning step."
 msgstr "Controla como o conteúdo da página é agrupado durante a etapa de secionamento."
@@ -1578,7 +1578,7 @@ msgid "Create a new image from a text description"
 msgstr "Crie uma nova imagem a partir de uma descrição de texto"
 
 msgid "Create a reviewer session for this book."
-msgstr "Create a reviewer session for this book."
+msgstr "Crie uma sessão de revisor para este livro."
 
 msgid "Create ADT"
 msgstr "Criar ADT"
@@ -1590,7 +1590,7 @@ msgid "Create from scratch using your description"
 msgstr "Criar do zero usando sua descrição"
 
 msgid "Create session"
-msgstr "Create session"
+msgstr "Criar sessão"
 
 msgid "Created {createdLabel}"
 msgstr "Criado em {createdLabel}"
@@ -1605,16 +1605,16 @@ msgid "Credits"
 msgstr "Créditos"
 
 msgid "criteria reviewed"
-msgstr "criteria reviewed"
+msgstr "critérios revisados"
 
 msgid "Criteria reviewed"
-msgstr "Criteria reviewed"
+msgstr "Critérios revisados"
 
 msgid "critical"
 msgstr "critical"
 
 msgid "Critical"
-msgstr "Critical"
+msgstr "Crítico"
 
 msgid "Crop"
 msgstr "Recortar"
@@ -1632,10 +1632,10 @@ msgid "Current"
 msgstr "Atual"
 
 msgid "Current effective values"
-msgstr "Current effective values"
+msgstr "Valores efetivos atuais"
 
 msgid "Current Preview Page"
-msgstr "Current Preview Page"
+msgstr "Página atual do Pré-visualização"
 
 msgid "Current version"
 msgstr "Versão atual"
@@ -1650,7 +1650,7 @@ msgid "Custom Layout Demo"
 msgstr "Demonstração de Layout Personalizado"
 
 msgid "Custom section {index}"
-msgstr "Custom section {index}"
+msgstr "Seção personalizada {index}"
 
 #~ msgid "Custom:"
 #~ msgstr "Personalizado:"
@@ -1674,7 +1674,7 @@ msgid "Default model"
 msgstr "Modelo padrão"
 
 msgid "Default N/A"
-msgstr "Default N/A"
+msgstr "N/A padrão"
 
 msgid "Default Prompt"
 msgstr "Prompt padrão"
@@ -1692,10 +1692,10 @@ msgid "Default voice used when not specified for a language."
 msgstr "Voz padrão usada quando não especificada para um idioma."
 
 msgid "Defaulted to N/A because Easy Read output is not currently available for this book."
-msgstr "Defaulted to N/A because Easy Read output is not currently available for this book."
+msgstr "Padrão N/A porque a saída de Leitura Fácil não está disponível para este livro no momento."
 
 msgid "Defaulted to N/A because Glossary has not been generated for this book yet."
-msgstr "Defaulted to N/A because Glossary has not been generated for this book yet."
+msgstr "Padrão N/A porque o Glossário ainda não foi gerado para este livro."
 
 #. placeholder {0}: reason.language
 msgid "Defaulted to N/A because no Speech audio is available for {0}."
@@ -1706,28 +1706,28 @@ msgstr "Padrão N/A porque ainda não há áudio de voz disponível."
 
 #. placeholder {0}: reason.language
 msgid "Defaulted to N/A because no translation output is available for {0}."
-msgstr "Defaulted to N/A because no translation output is available for {0}."
+msgstr "Padrão N/A porque não há saída de tradução disponível para {0}."
 
 msgid "Defaulted to N/A because no translation output is available yet."
-msgstr "Defaulted to N/A because no translation output is available yet."
+msgstr "Padrão N/A porque ainda não há saída de tradução disponível."
 
 msgid "Defaulted to N/A because sign language is not enabled for this book."
-msgstr "Defaulted to N/A because sign language is not enabled for this book."
+msgstr "Padrão N/A porque a língua de sinais não está ativada para este livro."
 
 msgid "Defaulted to N/A because Speech audio has not been generated yet."
 msgstr "Padrão N/A porque o áudio de voz ainda não foi gerado."
 
 msgid "Defaulted to N/A because this page does not contain an interactive activity or exercise."
-msgstr "Defaulted to N/A because this page does not contain an interactive activity or exercise."
+msgstr "Padrão N/A porque esta página não contém uma atividade ou exercício interativo."
 
 msgid "Defaulted to N/A because this page does not contain any images."
-msgstr "Defaulted to N/A because this page does not contain any images."
+msgstr "Padrão N/A porque esta página não contém imagens."
 
 msgid "Defaulted to N/A because Translation has not been generated yet."
-msgstr "Defaulted to N/A because Translation has not been generated yet."
+msgstr "Padrão N/A porque a Tradução ainda não foi gerada."
 
 msgid "Defaulted to N/A until this reviewer session has a language selected."
-msgstr "Defaulted to N/A until this reviewer session has a language selected."
+msgstr "Padrão N/A até que esta sessão de revisor tenha um idioma selecionado."
 
 msgid "Defaults"
 msgstr "Padrões"
@@ -1772,10 +1772,10 @@ msgid "Describe the image"
 msgstr "Descreva a imagem"
 
 msgid "Describe the issue or note why this criterion needs attention"
-msgstr "Describe the issue or note why this criterion needs attention"
+msgstr "Descreva o problema ou anote por que este critério precisa de atenção"
 
 msgid "Describe what the reviewer should check."
-msgstr "Describe what the reviewer should check."
+msgstr "Descreva o que o revisor deve verificar."
 
 msgid "Description"
 msgstr "Descrição"
@@ -1817,19 +1817,19 @@ msgid "Direction"
 msgstr "Direção"
 
 msgid "Disable reviewer validation"
-msgstr "Disable reviewer validation"
+msgstr "Desativar validação do revisor"
 
 msgid "Disable type"
 msgstr "Desativar tipo"
 
 msgid "Disabled"
-msgstr "Disabled"
+msgstr "Desativado"
 
 msgid "Disabled axe rules"
-msgstr "Disabled axe rules"
+msgstr "Regras do axe desativadas"
 
 msgid "Disabled rules"
-msgstr "Disabled rules"
+msgstr "Regras desativadas"
 
 msgid "Discard"
 msgstr "Descartar"
@@ -2014,7 +2014,7 @@ msgid "Empty section — add a container below to start"
 msgstr "Seção vazia — adicione um contêiner abaixo para começar"
 
 msgid "en"
-msgstr "en"
+msgstr "pt-BR"
 
 msgid "EN"
 msgstr "EN"
@@ -2022,28 +2022,28 @@ msgstr "EN"
 #. placeholder {0}: criterion.label
 #. placeholder {0}: section.label
 msgid "Enable {0}"
-msgstr "Enable {0}"
+msgstr "Ativar {0}"
 
 msgid "Enable for scanned books where two pages appear on a single PDF page."
 msgstr "Ative para livros digitalizados em que duas páginas aparecem em uma única página do PDF."
 
 msgid "Enable or disable reviewer-authored checklist reviews for this book. Automated accessibility assessment remains available either way."
-msgstr "Enable or disable reviewer-authored checklist reviews for this book. Automated accessibility assessment remains available either way."
+msgstr "Ative ou desative as revisões de lista de verificação criadas pelo revisor para este livro. A avaliação automatizada de acessibilidade permanece disponível em qualquer caso."
 
 msgid "Enable reviewer validation"
-msgstr "Enable reviewer validation"
+msgstr "Ativar validação do revisor"
 
 msgid "Enabled"
-msgstr "Enabled"
+msgstr "Ativado"
 
 msgid "Enabled axe tags"
-msgstr "Enabled axe tags"
+msgstr "Tags do axe ativadas"
 
 msgid "End"
 msgstr "Fim"
 
 msgid "End page"
-msgstr "End page"
+msgstr "Página final"
 
 msgid "Endpoint"
 msgstr "Endpoint"
@@ -2121,7 +2121,7 @@ msgid "Exclude from render"
 msgstr "Excluir da renderização"
 
 msgid "Existing reviewer sessions keep their own checklist snapshot. New checklist changes apply to newly created sessions."
-msgstr "Existing reviewer sessions keep their own checklist snapshot. New checklist changes apply to newly created sessions."
+msgstr "As sessões de revisor existentes mantêm seu próprio snapshot da lista de verificação. Novas alterações da lista de verificação aplicam-se a sessões recém-criadas."
 
 msgid "Expand"
 msgstr "Expandir"
@@ -2195,14 +2195,14 @@ msgid "Failed to create book."
 msgstr "Falha ao criar livro."
 
 msgid "Failed to create reviewer session"
-msgstr "Failed to create reviewer session"
+msgstr "Falha ao criar sessão de revisor"
 
 msgid "Failed to generate glossary entry."
 msgstr "Falha ao gerar a entrada do glossário."
 
 #. placeholder {0}: error.message
 msgid "Failed to load accessibility results: {0}"
-msgstr "Failed to load accessibility results: {0}"
+msgstr "Falha ao carregar os resultados de acessibilidade: {0}"
 
 #. placeholder {0}: error.message
 msgid "Failed to load books: {0}"
@@ -2216,21 +2216,21 @@ msgstr "Falha ao carregar imagem da página"
 
 #. placeholder {0}: anyRecordQueryError.message
 msgid "Failed to load reviewer page results: {0}"
-msgstr "Failed to load reviewer page results: {0}"
+msgstr "Falha ao carregar os resultados de página do revisor: {0}"
 
 #. placeholder {0}: catalog.error.message
 msgid "Failed to load reviewer validation checklist: {0}"
-msgstr "Failed to load reviewer validation checklist: {0}"
+msgstr "Falha ao carregar a lista de verificação de validação do revisor: {0}"
 
 #. placeholder {0}: sessions.error.message
 msgid "Failed to load reviewer validation sessions: {0}"
-msgstr "Failed to load reviewer validation sessions: {0}"
+msgstr "Falha ao carregar as sessões de validação do revisor: {0}"
 
 msgid "Failed to load stats:"
 msgstr "Falha ao carregar estatísticas:"
 
 msgid "Failed to load validation checklist:"
-msgstr "Failed to load validation checklist:"
+msgstr "Falha ao carregar a lista de verificação de validação:"
 
 msgid "Failed to read archive"
 msgstr "Falha ao ler o arquivo"
@@ -2272,7 +2272,7 @@ msgid "Filter terms…"
 msgstr "Filtrar termos…"
 
 msgid "Filtered by:"
-msgstr "Filtered by:"
+msgstr "Filtrado por:"
 
 msgid "Final Page"
 msgstr "Página Final"
@@ -2299,13 +2299,13 @@ msgid "Fixed-layout books use the original page images as backgrounds with posit
 msgstr "Livros de layout fixo usam as imagens originais das páginas como fundo com texto posicionado extraído do PDF. Detecção de atividades, extração de figuras, recorte ou segmentação de imagens não se aplicam a este layout."
 
 msgid "flagged"
-msgstr "flagged"
+msgstr "sinalizados"
 
 msgid "Flagged by review area"
-msgstr "Flagged by review area"
+msgstr "Sinalizados por área de revisão"
 
 msgid "Flagged findings"
-msgstr "Flagged findings"
+msgstr "Achados sinalizados"
 
 msgid "Flat Vector"
 msgstr "Vetor plano"
@@ -2325,7 +2325,7 @@ msgid "Format"
 msgstr "Formato"
 
 msgid "Forms & controls"
-msgstr "Forms & controls"
+msgstr "Formulários e controles"
 
 msgid "FR"
 msgstr "FR"
@@ -2745,7 +2745,7 @@ msgid "Install on quit"
 msgstr "Instalar ao sair"
 
 msgid "Institution"
-msgstr "Institution"
+msgstr "Instituição"
 
 msgid "Interactive"
 msgstr "Interativo"
@@ -2782,13 +2782,13 @@ msgid "Item ID..."
 msgstr "ID do item..."
 
 msgid "Items marked as needing changes for this reviewer session."
-msgstr "Items marked as needing changes for this reviewer session."
+msgstr "Itens marcados como necessitando alterações nesta sessão de revisor."
 
 msgid "its original language"
 msgstr "sua língua original"
 
 msgid "Jane Reviewer"
-msgstr "Jane Reviewer"
+msgstr "Maria Revisora"
 
 msgid "Justify"
 msgstr "Justificar"
@@ -2812,7 +2812,7 @@ msgid "Key must start with sk-"
 msgstr "A chave deve começar com sk-"
 
 msgid "Keyboard & navigation"
-msgstr "Keyboard & navigation"
+msgstr "Teclado e navegação"
 
 #. placeholder {0}: entry.level
 msgid "L{0}"
@@ -2957,7 +2957,7 @@ msgid "LMS-ready with completion tracking"
 msgstr "Pronto para LMS com rastreamento de conclusão"
 
 msgid "Loading accessibility summary..."
-msgstr "Loading accessibility summary..."
+msgstr "Carregando resumo de acessibilidade..."
 
 msgid "Loading Book..."
 msgstr "Carregando livro..."
@@ -2996,13 +2996,13 @@ msgid "Loading quizzes..."
 msgstr "Carregando quizzes..."
 
 msgid "Loading reviewer checklist…"
-msgstr "Loading reviewer checklist…"
+msgstr "Carregando lista de verificação do revisor…"
 
 msgid "Loading reviewer validation summary..."
-msgstr "Loading reviewer validation summary..."
+msgstr "Carregando resumo da validação do revisor..."
 
 msgid "Loading reviewer validation…"
-msgstr "Loading reviewer validation…"
+msgstr "Carregando validação do revisor…"
 
 msgid "Loading sectioning data..."
 msgstr "Carregando dados de seção..."
@@ -3119,7 +3119,7 @@ msgid "Media"
 msgstr "Mídia"
 
 msgid "Media & timing"
-msgstr "Media & timing"
+msgstr "Mídia e tempo"
 
 msgid "Medical references"
 msgstr "Referências médicas"
@@ -3218,7 +3218,7 @@ msgid "minor"
 msgstr "minor"
 
 msgid "Minor"
-msgstr "Minor"
+msgstr "Menor"
 
 msgid "Mirrors the original book's activity layout as closely as possible."
 msgstr "Espelha o layout de atividades do livro original o mais próximo possível."
@@ -3251,7 +3251,7 @@ msgid "moderate"
 msgstr "moderate"
 
 msgid "Moderate"
-msgstr "Moderate"
+msgstr "Moderado"
 
 msgid "Modified {modifiedLabel}"
 msgstr "Modificado em {modifiedLabel}"
@@ -3278,10 +3278,10 @@ msgid "Nav"
 msgstr "Navegação"
 
 msgid "Navigate within Preview to capture page-specific review notes"
-msgstr "Navigate within Preview to capture page-specific review notes"
+msgstr "Navegue no Pré-visualização para capturar notas de revisão específicas da página"
 
 msgid "Needs changes"
-msgstr "Needs changes"
+msgstr "Precisa de alterações"
 
 msgid "Needs rebuild"
 msgstr "Precisa ser reconstruído"
@@ -3293,13 +3293,13 @@ msgid "New"
 msgstr "Novo"
 
 msgid "New checklist item"
-msgstr "New checklist item"
+msgstr "Novo item da lista de verificação"
 
 msgid "New Entry"
 msgstr "Nova entrada"
 
 msgid "New session"
-msgstr "New session"
+msgstr "Nova sessão"
 
 msgid "New version"
 msgstr "Nova versão"
@@ -3323,7 +3323,7 @@ msgid "Next Step"
 msgstr "Próximo Passo"
 
 msgid "No accessibility assessment has been generated yet. Package the ADT output to create one."
-msgstr "No accessibility assessment has been generated yet. Package the ADT output to create one."
+msgstr "Nenhuma avaliação de acessibilidade foi gerada ainda. Empacote a saída ADT para criar uma."
 
 msgid "No accessibility findings were reported for this page."
 msgstr "No accessibility findings were reported for this page."
@@ -3351,7 +3351,7 @@ msgid "No captions for this page"
 msgstr "Sem legendas para esta página"
 
 msgid "No changes flagged on this page"
-msgstr "No changes flagged on this page"
+msgstr "Nenhuma alteração sinalizada nesta página"
 
 msgid "No colors found"
 msgstr "Nenhuma cor encontrada"
@@ -3366,7 +3366,7 @@ msgid "No data"
 msgstr "Sem dados"
 
 msgid "No disabled rules"
-msgstr "No disabled rules"
+msgstr "Nenhuma regra desativada"
 
 msgid "No extracted text yet. Run the pipeline first."
 msgstr "Nenhum texto extraído ainda. Execute o pipeline primeiro."
@@ -3375,7 +3375,7 @@ msgid "No fields to add"
 msgstr "Nenhum campo para adicionar"
 
 msgid "No finding categories reported."
-msgstr "No finding categories reported."
+msgstr "Nenhuma categoria de achado relatada."
 
 msgid "No findings"
 msgstr "Sem descobertas"
@@ -3384,7 +3384,7 @@ msgid "No findings this page"
 msgstr "Sem descobertas nesta página"
 
 msgid "No flagged findings in reviewed pages"
-msgstr "No flagged findings in reviewed pages"
+msgstr "Nenhum achado sinalizado nas páginas revisadas"
 
 msgid "No image"
 msgstr "Sem imagem"
@@ -3414,7 +3414,7 @@ msgid "No issues or manual review items were reported."
 msgstr "Nenhum problema ou item de revisão manual foi relatado."
 
 msgid "No items are currently flagged as needing changes in this reviewer session."
-msgstr "No items are currently flagged as needing changes in this reviewer session."
+msgstr "Nenhum item está atualmente sinalizado como necessitando alterações nesta sessão de revisor."
 
 msgid "No language-specific prompts configured."
 msgstr "Nenhum prompt por idioma configurado."
@@ -3474,10 +3474,10 @@ msgid "No rendered content for this section"
 msgstr "Sem conteúdo renderizado para esta seção"
 
 msgid "No review areas are currently flagged in this reviewer session."
-msgstr "No review areas are currently flagged in this reviewer session."
+msgstr "Nenhuma área de revisão está atualmente sinalizada nesta sessão de revisor."
 
 msgid "No reviewer validation sessions have been started yet. Open Preview to create a reviewer session and begin recording page-level findings."
-msgstr "No reviewer validation sessions have been started yet. Open Preview to create a reviewer session and begin recording page-level findings."
+msgstr "Nenhuma sessão de validação do revisor foi iniciada ainda. Abra o Pré-visualização para criar uma sessão de revisor e começar a registrar achados no nível da página."
 
 msgid "No sectioning data available."
 msgstr "Nenhum dado de seção disponível."
@@ -3543,7 +3543,7 @@ msgid "Not generated"
 msgstr "Não gerado"
 
 msgid "Not reviewed"
-msgstr "Not reviewed"
+msgstr "Não revisado"
 
 msgid "Note"
 msgstr "Nota"
@@ -3582,7 +3582,7 @@ msgid "One column for every section. Clean and predictable."
 msgstr "Uma coluna para cada seção. Limpo e previsível."
 
 msgid "One tag per line or comma-separated. Leave as-is to keep the current package defaults."
-msgstr "One tag per line or comma-separated. Leave as-is to keep the current package defaults."
+msgstr "Uma tag por linha ou separadas por vírgula. Deixe como está para manter os padrões atuais do pacote."
 
 msgid "Only images that appear in the storyboard (have captions) can be selected."
 msgstr "Só é possível selecionar imagens que aparecem no storyboard (com legendas)."
@@ -3612,10 +3612,10 @@ msgid "Open a page in Preview to show its page-specific accessibility findings h
 msgstr "Open a page in Preview to show its page-specific accessibility findings here."
 
 msgid "Open a page in Preview to start recording reviewer validation findings."
-msgstr "Open a page in Preview to start recording reviewer validation findings."
+msgstr "Abra uma página no Pré-visualização para começar a registrar achados de validação do revisor."
 
 msgid "Open a page to review"
-msgstr "Open a page to review"
+msgstr "Abra uma página para revisar"
 
 msgid "Open a page to see page-level findings"
 msgstr "Open a page to see page-level findings"
@@ -3630,10 +3630,10 @@ msgid "Open page preview for {pageId}"
 msgstr "Abrir pré-visualização da página {0}"
 
 msgid "Open Preview"
-msgstr "Open Preview"
+msgstr "Abrir Pré-visualização"
 
 msgid "Open Validation"
-msgstr "Open Validation"
+msgstr "Abrir Validação"
 
 msgid "OpenAI"
 msgstr "OpenAI"
@@ -3657,7 +3657,7 @@ msgid "Optional instructions for the LLM..."
 msgstr "Instruções opcionais para o LLM..."
 
 msgid "Optional notes about the review scope or assignments"
-msgstr "Optional notes about the review scope or assignments"
+msgstr "Notas opcionais sobre o escopo da revisão ou atribuições"
 
 msgid "Optional notes to steer how captions are generated. Use Auto-fill to start from the book's title, language, and summary."
 msgstr "Notas opcionais para orientar como as legendas são geradas. Use Preenchimento automático para começar com o título, idioma e resumo do livro."
@@ -3666,10 +3666,10 @@ msgid "Optional notes to steer how the glossary is generated. Use Auto-fill to s
 msgstr "Notas opcionais para orientar como o glossário é gerado. Use Preenchimento automático para começar com o título, idioma e resumo do livro."
 
 msgid "Optional page-level summary or handoff note"
-msgstr "Optional page-level summary or handoff note"
+msgstr "Resumo opcional no nível da página ou nota de transferência"
 
 msgid "Optional suggestion for fixing or improving this item"
-msgstr "Optional suggestion for fixing or improving this item"
+msgstr "Sugestão opcional para corrigir ou melhorar este item"
 
 msgid "Optional. Add notes about tone, focus, or vocabulary. Use Auto-fill to start from the book's title, language, and summary."
 msgstr "Opcional. Adicione notas sobre tom, foco ou vocabulário. Use Preenchimento automático para começar com o título, idioma e resumo do livro."
@@ -3721,7 +3721,7 @@ msgid "Output Tokens"
 msgstr "Tokens de saída"
 
 msgid "Overall page note"
-msgstr "Overall page note"
+msgstr "Nota geral da página"
 
 msgid "Overview"
 msgstr "Visão geral"
@@ -3769,10 +3769,10 @@ msgid "Packaging"
 msgstr "Empacotando"
 
 msgid "Packaging failed"
-msgstr "Packaging failed"
+msgstr "Falha no empacotamento"
 
 msgid "Packaging validation results..."
-msgstr "Packaging validation results..."
+msgstr "Empacotando resultados da validação..."
 
 msgid "Padding"
 msgstr "Padding"
@@ -3801,7 +3801,7 @@ msgid "Page {pageId}"
 msgstr "Página {0}"
 
 msgid "Page coverage"
-msgstr "Page coverage"
+msgstr "Cobertura de páginas"
 
 msgid "Page Grouping"
 msgstr "Agrupamento de Páginas"
@@ -3842,13 +3842,13 @@ msgstr "páginas"
 #. placeholder {0}: activeSession.session.start_page ?? "?"
 #. placeholder {1}: activeSession.session.end_page ?? "?"
 msgid "Pages {0}–{1}"
-msgstr "Pages {0}–{1}"
+msgstr "Páginas {0}–{1}"
 
 msgid "Pages per Quiz"
 msgstr "Páginas por quiz"
 
 msgid "Pages reviewed"
-msgstr "Pages reviewed"
+msgstr "Páginas revisadas"
 
 msgid "Paper Collage"
 msgstr "Colagem em papel"
@@ -3869,10 +3869,10 @@ msgid "Parts"
 msgstr "Partes"
 
 msgid "Pass"
-msgstr "Pass"
+msgstr "Aprovado"
 
 msgid "Passed"
-msgstr "Passed"
+msgstr "Aprovados"
 
 msgid "Patterns in the noise"
 msgstr "Padrões no ruído"
@@ -4238,7 +4238,7 @@ msgid "Recommended for {0}"
 msgstr "Recomendado para {0}"
 
 msgid "Record reviewer findings for the current page and save them to the active validation session."
-msgstr "Record reviewer findings for the current page and save them to the active validation session."
+msgstr "Registre os achados do revisor para a página atual e salve-os na sessão de validação ativa."
 
 msgid "Recrop from page"
 msgstr "Recortar da página"
@@ -4253,7 +4253,7 @@ msgid "Refinement Prompt"
 msgstr "Prompt de refinamento"
 
 msgid "Refresh validation"
-msgstr "Refresh validation"
+msgstr "Atualizar validação"
 
 msgid "Refreshing results for this packaged preview."
 msgstr "Refreshing results for this packaged preview."
@@ -4294,7 +4294,7 @@ msgid "Remove all sign-language videos?"
 msgstr "Remover todos os vídeos em linguagem de sinais?"
 
 msgid "Remove checklist item"
-msgstr "Remove checklist item"
+msgstr "Remover item da lista de verificação"
 
 msgid "Remove entry"
 msgstr "Remover entrada"
@@ -4312,7 +4312,7 @@ msgid "Remove PDF"
 msgstr "Remover PDF"
 
 msgid "Remove section"
-msgstr "Remove section"
+msgstr "Remover seção"
 
 msgid "Remove term"
 msgstr "Remover termo"
@@ -4360,10 +4360,10 @@ msgid "Replace this audio file"
 msgstr "Substituir este arquivo de áudio"
 
 msgid "Require comment on failure"
-msgstr "Require comment on failure"
+msgstr "Exigir comentário em caso de falha"
 
 msgid "Require suggested modification"
-msgstr "Require suggested modification"
+msgstr "Exigir modificação sugerida"
 
 msgid "Required"
 msgstr "Obrigatório"
@@ -4372,13 +4372,13 @@ msgid "Required Fields"
 msgstr "Campos Obrigatórios"
 
 msgid "Reset to defaults"
-msgstr "Reset to defaults"
+msgstr "Restaurar padrões"
 
 msgid "Reset to inherited"
 msgstr "Redefinir para herdado"
 
 msgid "Reset to inherited defaults"
-msgstr "Reset to inherited defaults"
+msgstr "Redefinir para os padrões herdados"
 
 msgid "Resolving source language..."
 msgstr "Resolvendo idioma de origem..."
@@ -4402,11 +4402,11 @@ msgid "Restore this term — it will be eligible again on the next regeneration.
 msgstr "Restaurar este termo — ele será elegível novamente na próxima regeneração."
 
 msgid "Resume target"
-msgstr "Resume target"
+msgstr "Alvo de retomada"
 
 #. placeholder {0}: resumeTarget.pageNumber ?? resumeTarget.pageId
 msgid "Resume target: page {0}"
-msgstr "Resume target: page {0}"
+msgstr "Retomar em: página {0}"
 
 msgid "Retries"
 msgstr "Retries"
@@ -4418,13 +4418,13 @@ msgid "Retry Export"
 msgstr "Tentar exportar novamente"
 
 msgid "Review areas with the most items marked as needing changes in this session."
-msgstr "Review areas with the most items marked as needing changes in this session."
+msgstr "Áreas de revisão com mais itens marcados como necessitando alterações nesta sessão."
 
 msgid "Review one session at a time to inspect page coverage and flagged findings."
-msgstr "Review one session at a time to inspect page coverage and flagged findings."
+msgstr "Revise uma sessão por vez para inspecionar a cobertura de páginas e os achados sinalizados."
 
 msgid "Review progress"
-msgstr "Review progress"
+msgstr "Progresso da revisão"
 
 msgid "Review pruned sections"
 msgstr "Revisar seções excluídas"
@@ -4436,34 +4436,34 @@ msgid "Review the source PDF details below and continue to configure how your bo
 msgstr "Revise os detalhes do PDF de origem abaixo e continue a configurar como seu livro será convertido em um Livro Didático Digital Acessível."
 
 msgid "Reviewer checklist"
-msgstr "Reviewer checklist"
+msgstr "Lista de verificação do revisor"
 
 msgid "Reviewer Checklist"
 msgstr "Reviewer Checklist"
 
 msgid "Reviewer checklist reviews are currently disabled."
-msgstr "Reviewer checklist reviews are currently disabled."
+msgstr "As revisões da lista de verificação do revisor estão desativadas no momento."
 
 msgid "Reviewer checklist settings saved."
-msgstr "Reviewer checklist settings saved."
+msgstr "Configurações da lista de verificação do revisor salvas."
 
 msgid "Reviewer guidance"
-msgstr "Reviewer guidance"
+msgstr "Orientação para o revisor"
 
 msgid "Reviewer name"
-msgstr "Reviewer name"
+msgstr "Nome do revisor"
 
 msgid "Reviewer name is required."
-msgstr "Reviewer name is required."
+msgstr "O nome do revisor é obrigatório."
 
 msgid "Reviewer Validation"
-msgstr "Reviewer Validation"
+msgstr "Validação do Revisor"
 
 msgid "Reviewer validation checklist"
-msgstr "Reviewer validation checklist"
+msgstr "Lista de verificação de validação do revisor"
 
 msgid "Reviewer validation summary"
-msgstr "Reviewer validation summary"
+msgstr "Resumo da validação do revisor"
 
 msgid "Rewriting the story of this section..."
 msgstr "Reescrevendo a história desta seção..."
@@ -4551,7 +4551,7 @@ msgid "Run whole-book validation checks and configure accessibility assessment s
 msgstr "Run whole-book validation checks and configure accessibility assessment settings."
 
 msgid "Run-only tags"
-msgstr "Run-only tags"
+msgstr "Tags exclusivas de execução"
 
 msgid "RUNNING"
 msgstr "EM EXECUÇÃO"
@@ -4620,22 +4620,22 @@ msgid "Save changes first to preview the latest version"
 msgstr "Salve as alterações primeiro para visualizar a versão mais recente"
 
 msgid "Save checklist"
-msgstr "Save checklist"
+msgstr "Salvar lista de verificação"
 
 msgid "Save failed"
 msgstr "Save failed"
 
 msgid "Save page review"
-msgstr "Save page review"
+msgstr "Salvar revisão da página"
 
 msgid "Save selection"
 msgstr "Salvar seleção"
 
 msgid "Save settings"
-msgstr "Save settings"
+msgstr "Salvar configurações"
 
 msgid "Saved. Re-package Preview to apply."
-msgstr "Saved. Re-package Preview to apply."
+msgstr "Salvo. Reempacote o Pré-visualização para aplicar."
 
 msgid "Saving..."
 msgstr "Salvando..."
@@ -4723,7 +4723,7 @@ msgid "Section 3.2"
 msgstr "Seção 3.2"
 
 msgid "Section label"
-msgstr "Section label"
+msgstr "Rótulo da seção"
 
 msgid "Section Mode"
 msgstr "Modo de Seção"
@@ -4819,7 +4819,7 @@ msgid "Select a render strategy to preview how your book pages will be laid out.
 msgstr "Selecione uma estratégia de renderização para pré-visualizar como as páginas do seu livro serão dispostas."
 
 msgid "Select a reviewer session to inspect its progress and findings."
-msgstr "Select a reviewer session to inspect its progress and findings."
+msgstr "Selecione uma sessão de revisor para inspecionar seu progresso e achados."
 
 msgid "Select a section mode to continue"
 msgstr "Selecione um modo de seção para continuar"
@@ -4843,7 +4843,7 @@ msgid "Select node type..."
 msgstr "Selecionar tipo de nó..."
 
 msgid "Select reviewer session"
-msgstr "Select reviewer session"
+msgstr "Selecionar sessão de revisor"
 
 msgid "Select section mode"
 msgstr "Selecionar modo de seção"
@@ -4879,16 +4879,16 @@ msgid "serious"
 msgstr "serious"
 
 msgid "Serious"
-msgstr "Serious"
+msgstr "Sério"
 
 msgid "Session comments"
-msgstr "Session comments"
+msgstr "Comentários da sessão"
 
 msgid "Sessions"
-msgstr "Sessions"
+msgstr "Sessões"
 
 msgid "Sessions let different reviewers capture findings independently, including language-specific reviews."
-msgstr "Sessions let different reviewers capture findings independently, including language-specific reviews."
+msgstr "As sessões permitem que diferentes revisores capturem achados de forma independente, incluindo revisões específicas por idioma."
 
 msgid "Set a Gemini API key to generate audio"
 msgstr "Defina uma chave de API do Gemini para gerar áudio"
@@ -4925,7 +4925,7 @@ msgstr "Mostrar todas"
 
 #. placeholder {0}: pages.length
 msgid "Show all {0}"
-msgstr "Show all {0}"
+msgstr "Mostrar todos os {0}"
 
 msgid "Show all translations"
 msgstr "Mostrar todas as traduções"
@@ -4934,13 +4934,13 @@ msgid "Show error details"
 msgstr "Mostrar detalhes do erro"
 
 msgid "Show fewer"
-msgstr "Show fewer"
+msgstr "Mostrar menos"
 
 msgid "Show pruned terms"
 msgstr "Mostrar termos podados"
 
 msgid "Show reviewer validation"
-msgstr "Show reviewer validation"
+msgstr "Mostrar validação do revisor"
 
 msgid "Show:"
 msgstr "Mostrar:"
@@ -5106,16 +5106,16 @@ msgid "Start"
 msgstr "Início"
 
 msgid "Start a reviewer session"
-msgstr "Start a reviewer session"
+msgstr "Iniciar uma sessão de revisor"
 
 msgid "Start from a PDF"
 msgstr "Comece com um PDF"
 
 msgid "Start page"
-msgstr "Start page"
+msgstr "Página inicial"
 
 msgid "Start reviewer validation"
-msgstr "Start reviewer validation"
+msgstr "Iniciar validação do revisor"
 
 msgid "Start typing to see words from the book…"
 msgstr "Comece a digitar para ver palavras do livro…"
@@ -5176,7 +5176,7 @@ msgid "Structure"
 msgstr "Estrutura"
 
 msgid "Structure & semantics"
-msgstr "Structure & semantics"
+msgstr "Estrutura e semântica"
 
 msgid "Structure each page into a content tree of sections and nodes for downstream rendering."
 msgstr "Estruture cada página em uma árvore de conteúdo de seções e nós para renderização posterior."
@@ -5218,10 +5218,10 @@ msgid "Successfully uploaded"
 msgstr "Enviado com sucesso"
 
 msgid "Suggested modification"
-msgstr "Suggested modification"
+msgstr "Modificação sugerida"
 
 msgid "Suggested modification:"
-msgstr "Suggested modification:"
+msgstr "Modificação sugerida:"
 
 msgid "Summary Prompt"
 msgstr "Prompt de resumo"
@@ -5242,7 +5242,7 @@ msgid "Table of Contents"
 msgstr "Sumário"
 
 msgid "Tables"
-msgstr "Tables"
+msgstr "Tabelas"
 
 msgid "Tablet"
 msgstr "Tablet"
@@ -5302,7 +5302,7 @@ msgid "Text & Single Image"
 msgstr "Texto e imagem única"
 
 msgid "Text alternatives"
-msgstr "Text alternatives"
+msgstr "Alternativas textuais"
 
 msgid "Text Catalog"
 msgstr "Catálogo de texto"
@@ -5453,7 +5453,7 @@ msgid "These features improve access for people with disabilities. Running them 
 msgstr "Esses recursos melhoram o acesso para pessoas com deficiência. Executá-los antes de exportar ajuda seu livro a atender aos padrões de acessibilidade ADT."
 
 msgid "These values reflect either the saved book override or the latest packaged defaults."
-msgstr "These values reflect either the saved book override or the latest packaged defaults."
+msgstr "Estes valores refletem a substituição salva do livro ou os padrões empacotados mais recentes."
 
 msgid "This book has no pages. Make sure the extraction and storyboard stages produced content before generating {stageName}."
 msgstr "Este livro não tem páginas. Certifique-se de que as etapas de extração e storyboard produziram conteúdo antes de gerar {stageName}."
@@ -5493,7 +5493,7 @@ msgid "This page has no translatable text entries"
 msgstr "Esta página não tem entradas de texto traduzíveis"
 
 msgid "This page has not been reviewed yet"
-msgstr "This page has not been reviewed yet"
+msgstr "Esta página ainda não foi revisada"
 
 msgid "This permanently deletes every uploaded video and clears all section assignments. This can't be undone."
 msgstr "Isso exclui permanentemente todos os vídeos enviados e limpa todas as atribuições de seção. Isso não pode ser desfeito."
@@ -5508,7 +5508,7 @@ msgid "This section has no storyboard rendering yet"
 msgstr "Esta seção ainda não tem renderização de storyboard"
 
 msgid "This session is using an older reviewer checklist snapshot. Newer checklist settings will apply only to newly created reviewer sessions."
-msgstr "This session is using an older reviewer checklist snapshot. Newer checklist settings will apply only to newly created reviewer sessions."
+msgstr "Esta sessão está usando um snapshot mais antigo da lista de verificação do revisor. Novas configurações de lista de verificação serão aplicadas apenas a sessões de revisor recém-criadas."
 
 msgid "This text is only perceptible to assistive technologies."
 msgstr "Este texto é perceptível apenas para tecnologias assistivas."
@@ -5604,7 +5604,7 @@ msgid "Total Tokens"
 msgstr "Total de tokens"
 
 msgid "Track reviewer progress and review findings captured from Preview."
-msgstr "Track reviewer progress and review findings captured from Preview."
+msgstr "Acompanhe o progresso do revisor e analise os achados capturados no Pré-visualização."
 
 msgid "Translate"
 msgstr "Traduzir"
@@ -5673,7 +5673,7 @@ msgid "Turn any PDF into a fully accessible book — audio, translations, struct
 msgstr "Transforme qualquer PDF em um livro totalmente acessível — áudio, traduções, layouts HTML estruturados — tudo gerado a partir do seu arquivo fonte, <0>tudo editável</0>, <1>tudo seu</1>."
 
 msgid "Turn this on to show the Validation review card in Preview and the Reviewer Validation tab in the Validation step."
-msgstr "Turn this on to show the Validation review card in Preview and the Reviewer Validation tab in the Validation step."
+msgstr "Ative esta opção para mostrar o cartão de revisão de Validação no Pré-visualização e a aba Validação do Revisor na etapa de Validação."
 
 msgid "Two authentication methods are supported: Bearer tokens passed in the Authorization header, and API keys passed as a query parameter. Bearer tokens are preferred for server-to-server requests due to their short expiry window."
 msgstr "Dois métodos de autenticação são suportados: tokens Bearer passados no cabeçalho de autorização e chaves de API passadas como um parâmetro de consulta. Tokens Bearer são preferidos para solicitações de servidor para servidor devido à sua curta janela de expiração."
@@ -5709,7 +5709,7 @@ msgid "Typography"
 msgstr "Tipografia"
 
 msgid "Unable to load reviewer checklist settings."
-msgstr "Unable to load reviewer checklist settings."
+msgstr "Não foi possível carregar as configurações da lista de verificação do revisor."
 
 msgid "Unable to render PDF preview."
 msgstr "Não foi possível renderizar a pré-visualização do PDF."
@@ -5724,7 +5724,7 @@ msgid "Unavailable"
 msgstr "Unavailable"
 
 msgid "Uncategorized"
-msgstr "Uncategorized"
+msgstr "Sem categoria"
 
 msgid "Underline"
 msgstr "Sublinhado"
@@ -5739,10 +5739,10 @@ msgid "unknown"
 msgstr "unknown"
 
 msgid "Unknown"
-msgstr "Unknown"
+msgstr "Desconhecido"
 
 msgid "Unknown criterion"
-msgstr "Unknown criterion"
+msgstr "Critério desconhecido"
 
 msgid "Unknown stage"
 msgstr "Etapa desconhecida"
@@ -5856,7 +5856,7 @@ msgid "Use Spread for printed books with facing-page layouts (covers stay solo, 
 msgstr "Use Spread para livros impressos com layouts de páginas opostas (capas ficam sozinhas, depois 2+3, 4+5, …). Use Single quando cada página do PDF deve ser processada individualmente."
 
 msgid "Use this for checks you intentionally want to suppress, such as known false positives."
-msgstr "Use this for checks you intentionally want to suppress, such as known false positives."
+msgstr "Use isto para verificações que você deseja suprimir intencionalmente, como falsos positivos conhecidos."
 
 msgid "Use this format to back up the project or move it to another machine."
 msgstr "Use este formato para fazer backup do projeto ou movê-lo para outra máquina."
@@ -5871,7 +5871,7 @@ msgid "Used for Gemini models — both LLM (gemini-2.5-pro, etc.) and TTS (gemin
 msgstr "Utilizada para modelos Gemini — tanto LLM (gemini-2.5-pro, etc.) quanto TTS (gemini-2.5-pro-preview-tts, etc.)"
 
 msgid "Validation"
-msgstr "Validation"
+msgstr "Validação"
 
 #. placeholder {0}: data.validationErrors.length
 msgid "Validation Errors ({0})"
@@ -5918,7 +5918,7 @@ msgid "View image"
 msgstr "Ver imagem"
 
 msgid "Visual & sensory cues"
-msgstr "Visual & sensory cues"
+msgstr "Pistas visuais e sensoriais"
 
 msgid "Visual Layout"
 msgstr "Layout Visual"
@@ -6050,7 +6050,7 @@ msgid "While editing"
 msgstr "Durante a edição"
 
 msgid "Whole-book checks for packaged ADT output, plus reviewer findings captured from Preview."
-msgstr "Whole-book checks for packaged ADT output, plus reviewer findings captured from Preview."
+msgstr "Verificações de livro inteiro para a saída ADT empacotada, além de achados do revisor capturados no Pré-visualização."
 
 msgid "Wide multilingual coverage with neural voices for many locales."
 msgstr "Ampla cobertura multilíngue com vozes neurais para muitos locais."

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -52,7 +52,7 @@ msgid "(no instruction text)"
 msgstr "(sem texto de instrução)"
 
 msgid "(no target)"
-msgstr "(no target)"
+msgstr "(sem alvo)"
 
 #. placeholder {0}: sections[0].pageNumber
 msgid "(p.{0})"
@@ -258,7 +258,7 @@ msgid "{pagesReviewed} {pagesReviewed, plural, one {page} other {pages}} reviewe
 msgstr "{pagesReviewed} {pagesReviewed, plural, one {página} other {páginas}} revisadas até agora"
 
 msgid "{regionCount} {regionCount, plural, one {region} other {regions}} detected"
-msgstr "{regionCount} {regionCount, plural, one {region} other {regions}} detected"
+msgstr "{regionCount} {regionCount, plural, one {região} other {regiões}} detectada(s)"
 
 #. placeholder {0}: reviewCount === 1 ? "manual review item" : "manual review items"
 msgid "{reviewCount} {0}"
@@ -484,19 +484,19 @@ msgid "Accept reasonable web redesigns. Reject only for functional defects (visi
 msgstr "Aceite reformulações web razoáveis. Rejeite apenas por defeitos funcionais (tokens de espaço reservado visíveis, conteúdo ausente, sobreposição, transbordo). Menos rejeições."
 
 msgid "Accessibility"
-msgstr "Accessibility"
+msgstr "Acessibilidade"
 
 msgid "Accessibility assessment configuration"
 msgstr "Configuração da avaliação de acessibilidade"
 
 msgid "Accessibility check failed for this page"
-msgstr "Accessibility check failed for this page"
+msgstr "A verificação de acessibilidade falhou para esta página"
 
 msgid "Accessibility Findings"
-msgstr "Accessibility Findings"
+msgstr "Resultados de Acessibilidade"
 
 msgid "Accessibility results are temporarily unavailable."
-msgstr "Accessibility results are temporarily unavailable."
+msgstr "Os resultados de acessibilidade estão temporariamente indisponíveis."
 
 msgid "Accessibility Summary"
 msgstr "Resumo de Acessibilidade"
@@ -754,7 +754,7 @@ msgid "AI Edit"
 msgstr "Edição com IA"
 
 msgid "AI edit failed"
-msgstr "AI edit failed"
+msgstr "Falha na edição com IA"
 
 msgid "AI edit history"
 msgstr "Histórico de edições com IA"
@@ -922,7 +922,7 @@ msgid "Apply page background colors"
 msgstr "Aplicar cores de fundo da página"
 
 msgid "Apply Segmentation"
-msgstr "Apply Segmentation"
+msgstr "Aplicar Segmentação"
 
 msgid "AR"
 msgstr "AR"
@@ -1289,7 +1289,7 @@ msgid "Checked"
 msgstr "Verificados"
 
 msgid "Checking accessibility"
-msgstr "Checking accessibility"
+msgstr "Verificando acessibilidade"
 
 msgid "Checking for updates…"
 msgstr "Verificando atualizações…"
@@ -1373,10 +1373,10 @@ msgid "Click to select an image"
 msgstr "Clique para selecionar uma imagem"
 
 msgid "Clone failed"
-msgstr "Clone failed"
+msgstr "Falha ao clonar"
 
 msgid "Close"
-msgstr "Close"
+msgstr "Fechar"
 
 msgid "Close edit panel"
 msgstr "Fechar painel de edição"
@@ -1391,7 +1391,7 @@ msgid "Collapse"
 msgstr "Recolher"
 
 msgid "Collapse accessibility summary"
-msgstr "Collapse accessibility summary"
+msgstr "Recolher resumo de acessibilidade"
 
 msgid "Collapse all sections"
 msgstr "Recolher todas as seções"
@@ -1481,7 +1481,7 @@ msgid "Consulting the style council..."
 msgstr "Consultando o conselho de estilo..."
 
 msgid "Container"
-msgstr "Container"
+msgstr "Contêiner"
 
 msgid "Container node types the LLM may produce in the content tree during sectioning."
 msgstr "Tipos de nós contêineres que o LLM pode produzir na árvore de conteúdo durante o seccionamento."
@@ -1562,7 +1562,7 @@ msgid "Cover"
 msgstr "Capa"
 
 msgid "Cover of {title}"
-msgstr "Capa de {0}"
+msgstr "Capa de {title}"
 
 msgid "Coverage"
 msgstr "Cobertura"
@@ -1613,7 +1613,7 @@ msgid "Criteria reviewed"
 msgstr "Critérios revisados"
 
 msgid "critical"
-msgstr "critical"
+msgstr "crítico"
 
 msgid "Critical"
 msgstr "Crítico"
@@ -1750,7 +1750,7 @@ msgid "Delete element"
 msgstr "Excluir elemento"
 
 msgid "Delete failed"
-msgstr "Delete failed"
+msgstr "Falha ao excluir"
 
 msgid "Delete section"
 msgstr "Excluir seção"
@@ -1863,7 +1863,7 @@ msgid "Drag to move"
 msgstr "Arrastar para mover"
 
 msgid "Drag to move boxes, drag edges/corners to resize"
-msgstr "Drag to move boxes, drag edges/corners to resize"
+msgstr "Arraste para mover as caixas, arraste as bordas/cantos para redimensionar"
 
 msgid "Drag vertices to reshape. Click midpoints (+) to add points. Right-click a vertex to remove it."
 msgstr "Arraste os vértices para remodelar. Clique nos pontos médios (+) para adicionar pontos. Clique com o botão direito em um vértice para removê-lo."
@@ -2540,7 +2540,7 @@ msgid "História e Sociedade - Vol. 1"
 msgstr "História e Sociedade - Vol. 1"
 
 msgid "Hit"
-msgstr "Hit"
+msgstr "Acerto"
 
 msgid "Home / Chapter 1"
 msgstr "Início / Capítulo 1"
@@ -2660,7 +2660,7 @@ msgid "Image unavailable"
 msgstr "Imagem indisponível"
 
 msgid "Image upload failed"
-msgstr "Image upload failed"
+msgstr "Falha no envio da imagem"
 
 msgid "images"
 msgstr "imagens"
@@ -2971,7 +2971,7 @@ msgid "Loading logs..."
 msgstr "Carregando registros..."
 
 msgid "Loading page-level findings"
-msgstr "Loading page-level findings"
+msgstr "Carregando achados no nível da página"
 
 msgid "Loading page..."
 msgstr "Carregando página..."
@@ -2986,7 +2986,7 @@ msgid "Loading preview..."
 msgstr "Carregando pré-visualização..."
 
 msgid "Loading prompt..."
-msgstr "Loading prompt..."
+msgstr "Carregando prompt..."
 
 msgid "Loading quizzes..."
 msgstr "Carregando quizzes..."
@@ -3016,7 +3016,7 @@ msgid "Loading table of contents..."
 msgstr "Carregando sumário..."
 
 msgid "Loading template..."
-msgstr "Loading template..."
+msgstr "Carregando modelo..."
 
 msgid "Loading text catalog..."
 msgstr "Carregando catálogo de textos..."
@@ -3127,7 +3127,7 @@ msgid "Merge facing pages as spreads"
 msgstr "Mesclar páginas adjacentes como duplas"
 
 msgid "Merge failed"
-msgstr "Merge failed"
+msgstr "Falha ao mesclar"
 
 msgid "merge into next page"
 msgstr "mesclar na próxima página"
@@ -3211,7 +3211,7 @@ msgid "Minimum size threshold"
 msgstr "Limite mínimo de tamanho"
 
 msgid "minor"
-msgstr "minor"
+msgstr "menor"
 
 msgid "Minor"
 msgstr "Menor"
@@ -3220,7 +3220,7 @@ msgid "Mirrors the original book's activity layout as closely as possible."
 msgstr "Espelha o layout de atividades do livro original o mais próximo possível."
 
 msgid "Miss"
-msgstr "Miss"
+msgstr "Falha"
 
 msgid "Misses"
 msgstr "Perdas"
@@ -3244,7 +3244,7 @@ msgid "Model"
 msgstr "Modelo"
 
 msgid "moderate"
-msgstr "moderate"
+msgstr "moderado"
 
 msgid "Moderate"
 msgstr "Moderado"
@@ -3322,7 +3322,7 @@ msgid "No accessibility assessment has been generated yet. Package the ADT outpu
 msgstr "Nenhuma avaliação de acessibilidade foi gerada ainda. Empacote a saída ADT para criar uma."
 
 msgid "No accessibility findings were reported for this page."
-msgstr "No accessibility findings were reported for this page."
+msgstr "Nenhum achado de acessibilidade foi relatado para esta página."
 
 msgid "No AI edits yet for this section."
 msgstr "Ainda não há edições com IA para esta seção."
@@ -3332,7 +3332,7 @@ msgid "No API key for {0} yet. Add one in Book settings to enable this provider.
 msgstr "Ainda não há chave de API para {0}. Adicione uma nas configurações do Livro para ativar este provedor."
 
 msgid "No assessment"
-msgstr "No assessment"
+msgstr "Sem avaliação"
 
 msgid "No audio for this page"
 msgstr "Sem áudio para esta página"
@@ -3425,7 +3425,7 @@ msgid "No log entries found yet."
 msgstr "Nenhuma entrada de registro encontrada ainda."
 
 msgid "No matches for \"{search}\""
-msgstr "Nenhum resultado para \"{0}\""
+msgstr "Nenhum resultado para \"{search}\""
 
 msgid "No matching sections"
 msgstr "Nenhuma seção correspondente"
@@ -3491,7 +3491,7 @@ msgid "No sections yet"
 msgstr "Nenhuma seção ainda"
 
 msgid "No segmentation needed for this image"
-msgstr "No segmentation needed for this image"
+msgstr "Nenhuma segmentação necessária para esta imagem"
 
 msgid "No storyboard sections found. Run Storyboard to generate sections you can match videos to."
 msgstr "Nenhuma seção de storyboard encontrada. Execute o Storyboard para gerar seções que você pode associar a vídeos."
@@ -3521,7 +3521,7 @@ msgid "No voice mappings configured."
 msgstr "Nenhum mapeamento de voz configurado."
 
 msgid "Nodes"
-msgstr "Nodes"
+msgstr "Nós"
 
 msgid "noise"
 msgstr "ruído"
@@ -3560,7 +3560,7 @@ msgid "OCR & cleanup"
 msgstr "OCR e limpeza"
 
 msgid "of"
-msgstr "of"
+msgstr "de"
 
 msgid "Off"
 msgstr "Desligado"
@@ -3602,7 +3602,7 @@ msgid "Opacity"
 msgstr "Opacidade"
 
 msgid "Open a page in Preview to show its page-specific accessibility findings here."
-msgstr "Open a page in Preview to show its page-specific accessibility findings here."
+msgstr "Abra uma página no Pré-visualização para mostrar aqui seus achados de acessibilidade específicos da página."
 
 msgid "Open a page in Preview to start recording reviewer validation findings."
 msgstr "Abra uma página no Pré-visualização para começar a registrar achados de validação do revisor."
@@ -3611,7 +3611,7 @@ msgid "Open a page to review"
 msgstr "Abra uma página para revisar"
 
 msgid "Open a page to see page-level findings"
-msgstr "Open a page to see page-level findings"
+msgstr "Abra uma página para ver os achados no nível da página"
 
 msgid "Open edit panel"
 msgstr "Abrir painel de edição"
@@ -3620,7 +3620,7 @@ msgid "Open in any EPUB 3 reader, e-reader, or accessibility tool."
 msgstr "Abra em qualquer leitor EPUB 3, leitor eletrônico ou ferramenta de acessibilidade."
 
 msgid "Open page preview for {pageId}"
-msgstr "Abrir pré-visualização da página {0}"
+msgstr "Abrir pré-visualização da página {pageId}"
 
 msgid "Open Preview"
 msgstr "Abrir Pré-visualização"
@@ -3750,7 +3750,7 @@ msgid "Package and preview the final ADT web application."
 msgstr "Empacota e pré-visualiza a aplicação web ADT final."
 
 msgid "Package preview to generate results"
-msgstr "Package preview to generate results"
+msgstr "Empacote a pré-visualização para gerar resultados"
 
 msgid "Package the book for distribution. Pick a format, choose what content goes in, and we'll bundle everything into a downloadable archive."
 msgstr "Empacote o livro para distribuição. Escolha um formato, decida o que vai dentro e nós agruparemos tudo em um arquivo para download."
@@ -3780,7 +3780,7 @@ msgstr "Página"
 #. placeholder {0}: String(pageNumber)
 #. placeholder {0}: String(selectedPage.pageNumber)
 msgid "Page {0}"
-msgstr "Página {0}"
+msgstr "Página {pageId}"
 
 #. placeholder {0}: page.pageNumber
 #. placeholder {1}: i + 1
@@ -3791,7 +3791,7 @@ msgid "Page {n}"
 msgstr "Página {n}"
 
 msgid "Page {pageId}"
-msgstr "Página {0}"
+msgstr "Página {pageId}"
 
 msgid "Page coverage"
 msgstr "Cobertura de páginas"
@@ -3812,7 +3812,7 @@ msgid "Page Mode"
 msgstr "Modo de Página"
 
 msgid "Page preview {pageId}"
-msgstr "Pré-visualização da página {0}"
+msgstr "Pré-visualização da página {pageId}"
 
 msgid "Page Range"
 msgstr "Intervalo de páginas"
@@ -4046,7 +4046,7 @@ msgid "Prompt"
 msgstr "Prompt"
 
 msgid "Prompt template not found."
-msgstr "Prompt template not found."
+msgstr "Modelo de prompt não encontrado."
 
 msgid "Provider"
 msgstr "Provedor"
@@ -4083,7 +4083,7 @@ msgid "Pruned Images"
 msgstr "Imagens removidas"
 
 msgid "Pruned: {reason}"
-msgstr "Removido: {0}"
+msgstr "Removido: {reason}"
 
 msgid "PT"
 msgstr "PT"
@@ -4143,7 +4143,7 @@ msgid "Re-render (your edits will be preserved)"
 msgstr "Rerenderizar (suas edições serão preservadas)"
 
 msgid "Re-render failed"
-msgstr "Re-render failed"
+msgstr "Falha ao rerenderizar"
 
 msgid "Re-render section"
 msgstr "Rerenderizar seção"
@@ -4158,7 +4158,7 @@ msgid "Re-run"
 msgstr "Reexecutar"
 
 msgid "Re-run {stageLabel}"
-msgstr "Reexecutar {0}"
+msgstr "Reexecutar {stageLabel}"
 
 msgid "Re-run {stageLabel}?"
 msgstr "Reexecutar {stageLabel}?"
@@ -4246,7 +4246,7 @@ msgid "Refresh validation"
 msgstr "Atualizar validação"
 
 msgid "Refreshing results for this packaged preview."
-msgstr "Refreshing results for this packaged preview."
+msgstr "Atualizando os resultados desta pré-visualização empacotada."
 
 msgid "Regenerate definition, variations, and emoji"
 msgstr "Regenerar definição, variações e emoji"
@@ -4393,7 +4393,7 @@ msgid "Resume target: page {0}"
 msgstr "Retomar em: página {0}"
 
 msgid "Retries"
-msgstr "Retries"
+msgstr "Tentativas"
 
 msgid "Retry"
 msgstr "Tentar novamente"
@@ -4423,7 +4423,7 @@ msgid "Reviewer checklist"
 msgstr "Lista de verificação do revisor"
 
 msgid "Reviewer Checklist"
-msgstr "Reviewer Checklist"
+msgstr "Lista de Verificação do Revisor"
 
 msgid "Reviewer checklist reviews are currently disabled."
 msgstr "As revisões da lista de verificação do revisor estão desativadas no momento."
@@ -4469,7 +4469,7 @@ msgid "Run {0} first"
 msgstr "Execute {0} primeiro"
 
 msgid "Run {stageLabel}"
-msgstr "Executar {0}"
+msgstr "Executar {stageLabel}"
 
 msgid "Run {upstreamLabel} first"
 msgstr "Execute {upstreamLabel} primeiro"
@@ -4532,7 +4532,7 @@ msgid "Run Translation"
 msgstr "Executar Tradução"
 
 msgid "Run whole-book validation checks and configure accessibility assessment settings."
-msgstr "Run whole-book validation checks and configure accessibility assessment settings."
+msgstr "Execute verificações de validação do livro inteiro e configure as definições de avaliação de acessibilidade."
 
 msgid "Run-only tags"
 msgstr "Tags exclusivas de execução"
@@ -4541,7 +4541,7 @@ msgid "RUNNING"
 msgstr "EM EXECUÇÃO"
 
 msgid "Running Validation..."
-msgstr "Running Validation..."
+msgstr "Executando Validação..."
 
 msgid "Running..."
 msgstr "Executando..."
@@ -4607,7 +4607,7 @@ msgid "Save checklist"
 msgstr "Salvar lista de verificação"
 
 msgid "Save failed"
-msgstr "Save failed"
+msgstr "Falha ao salvar"
 
 msgid "Save page review"
 msgstr "Salvar revisão da página"
@@ -4761,19 +4761,19 @@ msgid "Segment"
 msgstr "Segmentar"
 
 msgid "Segment Preview"
-msgstr "Segment Preview"
+msgstr "Pré-visualização do Segmento"
 
 msgid "Segmentation apply failed"
-msgstr "Segmentation apply failed"
+msgstr "Falha ao aplicar a segmentação"
 
 msgid "Segmentation failed"
-msgstr "Segmentation failed"
+msgstr "Falha na segmentação"
 
 msgid "Segmentation preview"
-msgstr "Segmentation preview"
+msgstr "Pré-visualização da segmentação"
 
 msgid "Segmentation produced no valid segments"
-msgstr "Segmentation produced no valid segments"
+msgstr "A segmentação não produziu segmentos válidos"
 
 msgid "Segmentation Prompt"
 msgstr "Prompt de segmentação"
@@ -4848,7 +4848,7 @@ msgid "Selected images"
 msgstr "Imagens selecionadas"
 
 msgid "Selected: {styleImageId}"
-msgstr "Selecionada: {0}"
+msgstr "Selecionada: {styleImageId}"
 
 msgid "Selecting \"None\" lets the LLM choose its own styling for each page."
 msgstr "Selecionar \\\"Nenhum\\\" permite que o LLM escolha seu próprio estilo para cada página."
@@ -4860,7 +4860,7 @@ msgid "Separator"
 msgstr "Separador"
 
 msgid "serious"
-msgstr "serious"
+msgstr "sério"
 
 msgid "Serious"
 msgstr "Sério"
@@ -4899,7 +4899,7 @@ msgid "Short, simple sentences for kindergarten through 5th grade."
 msgstr "Frases curtas e simples para jardim de infância até o 5º ano."
 
 msgid "Show accessibility summary"
-msgstr "Show accessibility summary"
+msgstr "Mostrar resumo de acessibilidade"
 
 msgid "Show AI edit history"
 msgstr "Mostrar histórico de edições com IA"
@@ -5118,10 +5118,10 @@ msgid "Step {step} of {0}"
 msgstr "Passo {step} de {0}"
 
 msgid "Step failed"
-msgstr "Step failed"
+msgstr "Falha na etapa"
 
 msgid "Step run failed"
-msgstr "Step run failed"
+msgstr "Falha na execução da etapa"
 
 msgid "Storyboard"
 msgstr "Storyboard"
@@ -5193,7 +5193,7 @@ msgid "Styleguide Preview"
 msgstr "Pré-visualização do guia de estilo"
 
 msgid "Styleguide Preview — {styleguide}"
-msgstr "Pré-visualização do guia de estilo — {0}"
+msgstr "Pré-visualização do guia de estilo — {styleguide}"
 
 msgid "Success"
 msgstr "Sucesso"
@@ -5238,13 +5238,13 @@ msgid "Takes liberties and produces something similar."
 msgstr "Toma liberdades e produz algo semelhante."
 
 msgid "Task Running"
-msgstr "Task Running"
+msgstr "Tarefa em Execução"
 
 msgid "Task running..."
 msgstr "Tarefa em execução..."
 
 msgid "Tasks Running"
-msgstr "Tasks Running"
+msgstr "Tarefas em Execução"
 
 msgid "Teaching the pixels new tricks..."
 msgstr "Ensinando novos truques aos pixels..."
@@ -5262,7 +5262,7 @@ msgid "Template"
 msgstr "Modelo"
 
 msgid "Template not found."
-msgstr "Template not found."
+msgstr "Modelo não encontrado."
 
 msgid "Template One Column"
 msgstr "Modelo Uma Coluna"
@@ -5702,7 +5702,7 @@ msgid "Unassigned"
 msgstr "Não atribuído"
 
 msgid "Unavailable"
-msgstr "Unavailable"
+msgstr "Indisponível"
 
 msgid "Uncategorized"
 msgstr "Sem categoria"
@@ -5717,7 +5717,7 @@ msgid "University academic publications"
 msgstr "Publicações acadêmicas universitárias"
 
 msgid "unknown"
-msgstr "unknown"
+msgstr "desconhecido"
 
 msgid "Unknown"
 msgstr "Desconhecido"
@@ -5729,10 +5729,10 @@ msgid "Unknown stage"
 msgstr "Etapa desconhecida"
 
 msgid "Unknown step slug: {step}"
-msgstr "Slug de etapa desconhecido: {0}"
+msgstr "Slug de etapa desconhecido: {step}"
 
 msgid "Unknown step: {step}"
-msgstr "Etapa desconhecida: {0}"
+msgstr "Etapa desconhecida: {step}"
 
 msgid "Unprune image"
 msgstr "Restaurar imagem"

--- a/apps/studio/src/vite-env.d.ts
+++ b/apps/studio/src/vite-env.d.ts
@@ -14,6 +14,13 @@ declare module "*.po" {
   export { messages }
 }
 
+declare module "axe-core/locales/*.json" {
+  const data: {
+    rules?: Record<string, { help?: string; description?: string }>
+  }
+  export default data
+}
+
 interface ElectronApiLogEntry {
   stream: "stdout" | "stderr"
   line: string

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -447,6 +447,9 @@ importers:
       ai:
         specifier: ^4.0.0
         version: 4.3.19(react@19.2.4)(zod@3.25.76)
+      axe-core:
+        specifier: ^4.11.0
+        version: 4.11.1
       babel-plugin-macros:
         specifier: ^3.1.0
         version: 3.1.0


### PR DESCRIPTION
## What & why

The Validation step rendered in English for non-English users. Two distinct gaps:

1. **Catalog gap** — the validation feature (#185) shipped `es.po`/`pt-BR.po` with the English source duplicated into `msgstr`, so the whole step (accessibility summary, reviewer validation, checklist settings, preview review card) showed English. French was already translated in #283.
2. **Dynamic / data text** — count labels interpolated their plural *words* as English literals inside ``t` ` ``, and the axe-core accessibility finding titles/descriptions come from the engine and are stored in English.

## Changes

- **Translate validation-step strings** into es and pt-BR (~180 each).
- **ICU plurals for dynamic counts** — `issue/issues`, `manual review item(s)`, `page(s)`, `flagged`, `pending` now localize properly (were English literals interpolated inside ``t` ` ``). Also wraps a hardcoded `flagged`/`pending` badge label.
- **Localize axe-core findings at display time** — new `useAxeRuleTranslator` hook looks up each finding's rule id in axe-core's per-locale rule catalog (`es`/`fr`/`pt_BR`) and swaps in the localized `help`/`description`, falling back to the stored English. Wired into the Validation step and the per-page accessibility panel. `axe-core` (already used by `packages/pipeline`) is declared as a studio devDependency so Vite inlines only the locale JSON as lazy chunks — the engine is never bundled.
- Update `en/es/fr/pt-BR` catalogs and prune obsolete keys.

## Notes / limits

- The canonical assessment stays English; localization is display-time only, so it works for existing books with no re-packaging.
- Per-node `failureSummary` detail stays English (composed dynamically by axe, not a static rule string).
- Albanian (`sq`) has no axe locale, so finding text falls back to English there.

## Verification

- `lingui compile --strict` passes — 0 missing in es/fr/pt-BR; plain `extract` is idempotent (CI-safe)
- `tsc --noEmit` clean; `pnpm lint` 0 errors; `pnpm build` succeeds (locale catalogs become lazy chunks: es 7.6kB / pt_BR 9.2kB / fr 10kB gzip)