### PR TITLE
fix(studio): size fixed-layout pages by book-wide spread width

### DIFF
--- a/apps/studio/src/components/pipeline/stages/PreviewView.tsx
+++ b/apps/studio/src/components/pipeline/stages/PreviewView.tsx
@@ -41,7 +41,12 @@ export function PreviewView({ bookLabel }: { bookLabel: string }) {
   // page's intrinsic size from the iframe body's inline width/height and
   // CSS-scale the iframe to fit, mirroring the storyboard preview.
   // null = reflowable (no scaling).
-  const [fixedLayoutSize, setFixedLayoutSize] = useState<{ width: number; height: number } | null>(null)
+  // `referenceWidth` is the book-wide widest page (a full spread in spread
+  // mode), read from `#content`'s `data-fl-reference-width`. Scaling off it —
+  // not this page's own width — keeps every page at one uniform scale, so a
+  // single cover/end page renders centered at half-width rather than upscaled
+  // to fill the pane. Falls back to the page's own width when absent.
+  const [fixedLayoutSize, setFixedLayoutSize] = useState<{ height: number; referenceWidth: number } | null>(null)
   const [availableWidth, setAvailableWidth] = useState(0)
   const { panelOpen } = useDebugPanelState()
   const [isSubmittingPackage, setIsSubmittingPackage] = useState(false)
@@ -127,11 +132,27 @@ export function PreviewView({ bookLabel }: { bookLabel: string }) {
 
       // Detect fixed-layout pages — `package-web.ts` emits inline
       // `style="...width:Wpx;height:Hpx..."` on `<body>` for fixed-layout
-      // page HTML. Parse those values; null otherwise.
+      // page HTML. Parse those values; null otherwise. The book-wide
+      // reference width lives on `#content`'s `data-fl-reference-width`.
       const body = iframe.contentDocument.body
       const w = parsePxStyle(body?.style.width)
       const h = parsePxStyle(body?.style.height)
-      setFixedLayoutSize(w !== null && h !== null ? { width: w, height: h } : null)
+      const contentEl = iframe.contentDocument.getElementById("content")
+      const refRaw = contentEl?.getAttribute("data-fl-reference-width")
+      const ref = refRaw ? parseFloat(refRaw) : NaN
+      if (w !== null && h !== null && body) {
+        // The iframe is laid out at the book's reference (spread) width so the
+        // reader's full-width bottom dock — fixed to the iframe viewport —
+        // stays one constant width on every page (see iframeStyle). Center this
+        // page's (possibly narrower) body within that viewport so a single
+        // cover/end page sits in the middle with the dock spanning the whole
+        // panel beneath it. Overrides the produced page's inline `margin:0`.
+        body.style.marginLeft = "auto"
+        body.style.marginRight = "auto"
+        setFixedLayoutSize({ height: h, referenceWidth: Number.isFinite(ref) && ref > 0 ? ref : w })
+      } else {
+        setFixedLayoutSize(null)
+      }
 
       setCurrentPreviewPage({ sectionId, href, title, hasImages, hasActivity, signLanguageEnabled })
     } catch {
@@ -159,7 +180,7 @@ export function PreviewView({ bookLabel }: { bookLabel: string }) {
   }, [ready])
 
   const scale = fixedLayoutSize && availableWidth > 0
-    ? Math.min(1, availableWidth / fixedLayoutSize.width)
+    ? Math.min(1, availableWidth / fixedLayoutSize.referenceWidth)
     : 1
 
   const packaging = isSubmittingPackage || isTaskRunning("package-adt")
@@ -293,15 +314,19 @@ export function PreviewView({ bookLabel }: { bookLabel: string }) {
   }
 
   if (ready) {
-    // Fixed-layout: render the iframe at the page's native pixel
-    // dimensions and CSS-scale it via transform so it fits the wrapper
-    // width without horizontal scroll. The sizing div takes the *scaled*
-    // dimensions (the iframe's layout box stays at native size despite
-    // the transform, so we wrap it to keep page layout honest).
+    // Fixed-layout: lay the iframe out at the book's reference (spread) width —
+    // not this page's own width — and CSS-scale it via transform to fit the
+    // pane. Using the constant reference width keeps the reader's bottom dock
+    // (fixed to the iframe viewport, full-width) one consistent width on every
+    // page; a single page's narrower body is centered within that viewport
+    // (see syncCurrentPreviewPage), so the cover sits in the middle with the
+    // dock spanning the whole panel. The sizing div takes the *scaled*
+    // dimensions (the iframe's layout box stays at native size despite the
+    // transform, so we wrap it to keep page layout honest).
     // Reflowable: iframe fills the wrapper as before.
     const iframeStyle: CSSProperties = fixedLayoutSize
       ? {
-          width: fixedLayoutSize.width,
+          width: fixedLayoutSize.referenceWidth,
           height: fixedLayoutSize.height,
           transform: `scale(${scale})`,
           transformOrigin: "0 0",
@@ -309,9 +334,12 @@ export function PreviewView({ bookLabel }: { bookLabel: string }) {
       : { width: "100%", height: "100%" }
     const sizerStyle: CSSProperties = fixedLayoutSize
       ? {
-          width: fixedLayoutSize.width * scale,
+          width: fixedLayoutSize.referenceWidth * scale,
           height: fixedLayoutSize.height * scale,
           overflow: "hidden",
+          // Center the reader within the pane when it's narrower than the pane
+          // (large screens, scale capped at 1×).
+          margin: "0 auto",
         }
       : { width: "100%", height: "100%" }
     return (

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/BookPreviewFrame.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/BookPreviewFrame.tsx
@@ -229,9 +229,15 @@ export const BookPreviewFrame = forwardRef<BookPreviewFrameHandle, BookPreviewFr
    * When the page is fixed-layout, `#content` has explicit pixel width/height
    * (viewport coords from the renderer). Scaling off these instead of the
    * fixed `DEFAULT_RENDER_WIDTH` makes the content fill the available preview area.
+   * `referenceWidth` is the book-wide widest page (a full spread in spread
+   * mode), stamped on `#content` as `data-fl-reference-width`; scaling off it
+   * — rather than this page's own width — keeps every page at one uniform
+   * scale, so a single cover/end page renders centered at half-width instead
+   * of being upscaled 2× to fill the panel. Falls back to the page's own
+   * width when the attribute is absent (older content / ad-hoc renders).
    * null for reflowable pages.
    */
-  const [fixedLayoutSize, setFixedLayoutSize] = useState<{ width: number; height: number } | null>(null)
+  const [fixedLayoutSize, setFixedLayoutSize] = useState<{ width: number; height: number; referenceWidth: number } | null>(null)
   const [availableWidth, setAvailableWidth] = useState(DEFAULT_RENDER_WIDTH)
   const readyRef = useRef(false)
   const latestHtmlRef = useRef("")
@@ -365,7 +371,10 @@ ${autoFitScript}
     const styleW = contentEl ? parsePxStyle(contentEl.style.width) : null
     const styleH = contentEl ? parsePxStyle(contentEl.style.height) : null
     if (contentEl && styleW !== null && styleH !== null) {
-      setFixedLayoutSize({ width: styleW, height: styleH })
+      const refRaw = contentEl.dataset.flReferenceWidth
+      const ref = refRaw ? parseFloat(refRaw) : NaN
+      const referenceWidth = Number.isFinite(ref) && ref > 0 ? ref : styleW
+      setFixedLayoutSize({ width: styleW, height: styleH, referenceWidth })
       return
     }
 
@@ -614,14 +623,16 @@ ${selectors}:hover {
     return () => ro.disconnect()
   }, [])
 
-  // Fixed-layout: scale off the page viewport so content fills the preview
-  // area, upscaling small pages (PDFs whose natural width is below the panel)
-  // up to FL_MAX_SCALE so they don't render boxed with side whitespace.
+  // Fixed-layout: scale off the book-wide reference (spread) width so every
+  // page shares one scale — a full spread fills the panel, a single cover/end
+  // page renders centered at its natural fraction (e.g. half) of the panel
+  // rather than being upscaled to fill it. Small books (reference width below
+  // the panel) still upscale up to FL_MAX_SCALE so they don't render boxed.
   // Reflowable: fit to the device-frame base width, desktop capped at 1× and
   // mobile/tablet grown up to a target visible width for legibility.
   useEffect(() => {
     if (fixedLayoutSize) {
-      setScale(Math.min(FL_MAX_SCALE, availableWidth / fixedLayoutSize.width))
+      setScale(Math.min(FL_MAX_SCALE, availableWidth / fixedLayoutSize.referenceWidth))
       return
     }
     const fitScale = Math.max(0, availableWidth / baseWidth)

--- a/packages/pipeline/src/__tests__/fixed-layout-rendering.test.ts
+++ b/packages/pipeline/src/__tests__/fixed-layout-rendering.test.ts
@@ -367,6 +367,23 @@ describe("renderFixedLayoutPage", () => {
     expect(html).toContain("height:300px")
   })
 
+  it("omits data-fl-reference-width when no reference width is given", () => {
+    const html = renderFixedLayoutPage(makeSection(), "/images").sections[0].html
+
+    expect(html).not.toContain("data-fl-reference-width")
+  })
+
+  it("stamps data-fl-reference-width on #content when given, before the style", () => {
+    // A single page (width 400) in a book whose widest spread is 800. Viewers
+    // scale by availableWidth/800 so this page renders centered at half-width.
+    const html = renderFixedLayoutPage(makeSection(), "/images", 800).sections[0].html
+
+    expect(html).toContain('data-fl-reference-width="800"')
+    // Attribute precedes `style` so package-web's per-page viewport regex
+    // still reads this page's own dimensions, not the reference width.
+    expect(html).toMatch(/data-fl-reference-width="800"\s+style="[^"]*width:400px;height:300px/)
+  })
+
   it("includes illustration image reference", () => {
     const html = renderFixedLayoutPage(makeSection(), "/images").sections[0].html
 
@@ -958,6 +975,84 @@ describe("processFixedLayoutPages", () => {
 
       expect(html).toContain('data-id="pg001_im001"')
       expect(html).not.toContain('data-id="pg001_im002"')
+    } finally {
+      storage.close()
+    }
+  })
+
+  it("stamps the book-wide widest page as data-fl-reference-width on every page", () => {
+    const booksRoot = fs.mkdtempSync(path.join(os.tmpdir(), "adt-fixlayout-test-"))
+    tmpDirs.push(booksRoot)
+
+    const storage = createBookStorage("test-book", booksRoot)
+    try {
+      // A spread-mode book: a narrow standalone cover (width 400) followed by
+      // a double-width spread (width 800). Both pages must carry the same
+      // reference width (800) so viewers scale them identically — the cover
+      // renders centered at half-width instead of being upscaled to fill.
+      const coverText: PositionedTextOutput = {
+        drawItems: [{ kind: "image", imageId: "pg001_im001", bounds: { x: 0, y: 0, width: 400, height: 600 } }],
+        pageWidth: 400,
+        pageHeight: 600,
+        renderWidth: 400,
+        renderHeight: 600,
+      }
+      const spreadText: PositionedTextOutput = {
+        drawItems: [{ kind: "image", imageId: "pg002_im001", bounds: { x: 0, y: 0, width: 800, height: 600 } }],
+        pageWidth: 800,
+        pageHeight: 600,
+        renderWidth: 800,
+        renderHeight: 600,
+      }
+
+      storage.putExtractedPage({
+        pageId: "pg001",
+        pageNumber: 1,
+        text: "",
+        pageImage: makeImage("pg001_page", "pg001", 400, 600),
+        images: [makeImage("pg001_im001", "pg001", 400, 600, { x: 0, y: 0, width: 400, height: 600 })],
+        positionedText: coverText,
+      })
+      storage.putExtractedPage({
+        pageId: "pg002",
+        pageNumber: 2,
+        text: "",
+        pageImage: makeImage("pg002_page", "pg002", 800, 600),
+        images: [makeImage("pg002_im001", "pg002", 800, 600, { x: 0, y: 0, width: 800, height: 600 })],
+        positionedText: spreadText,
+      })
+
+      storage.putNodeData("positioned-text", "pg001", coverText)
+      storage.putNodeData("positioned-text", "pg002", spreadText)
+      storage.putNodeData("image-filtering", "pg001", {
+        images: [
+          { imageId: "pg001_page", isPruned: true, reason: "full-page render" },
+          { imageId: "pg001_im001", isPruned: false },
+        ],
+      })
+      storage.putNodeData("image-filtering", "pg002", {
+        images: [
+          { imageId: "pg002_page", isPruned: true, reason: "full-page render" },
+          { imageId: "pg002_im001", isPruned: false },
+        ],
+      })
+
+      processFixedLayoutPages(storage, "/images")
+
+      const getHtml = (pageId: string) =>
+        (storage.getLatestNodeData("web-rendering", pageId)!.data as {
+          sections: Array<{ html: string }>
+        }).sections[0].html
+
+      const coverHtml = getHtml("pg001")
+      const spreadHtml = getHtml("pg002")
+
+      // Both pages reference the widest page (800), not their own width.
+      expect(coverHtml).toContain('data-fl-reference-width="800"')
+      expect(spreadHtml).toContain('data-fl-reference-width="800"')
+      // The cover still carries its own viewport (400) in the style rule.
+      expect(coverHtml).toContain("width:400px;height:600px")
+      expect(spreadHtml).toContain("width:800px;height:600px")
     } finally {
       storage.close()
     }

--- a/packages/pipeline/src/fixed-layout-rendering.ts
+++ b/packages/pipeline/src/fixed-layout-rendering.ts
@@ -340,6 +340,17 @@ function withBundledFallback(fontFamily: string): string {
 export function renderFixedLayoutPage(
   section: PageSectioningSection,
   imageUrlPrefix: string,
+  /**
+   * Book-wide reference width — the widest page in the book (a full spread in
+   * spread mode). When provided, it's stamped onto `#content` as
+   * `data-fl-reference-width` so viewers scale every page by the SAME factor
+   * (availableWidth / referenceWidth) instead of each page's own width. A
+   * single page (cover/end, half a spread's width) then renders centered at
+   * half the panel width — the same apparent page size as one half of a
+   * spread — rather than being upscaled 2× to fill the panel. Omitted in
+   * unit tests / ad-hoc renders, where viewers fall back to per-page width.
+   */
+  referenceWidth?: number,
 ): WebRenderingOutput {
   const viewport = section.viewport
   if (!viewport) {
@@ -439,7 +450,12 @@ export function renderFixedLayoutPage(
 
   const hasFitTargets = elements.some((el) => el.includes("data-adt-fit=\"1\""))
   const fitScript = hasFitTargets ? `\n${FIT_SCRIPT}` : ""
-  const html = `<div id="content" style="position:relative;width:${viewport.width}px;height:${viewport.height}px;margin:0 auto;overflow:hidden">
+  // Keep the attribute before `style` so the per-page viewport regex in
+  // package-web (`/width:(\d+)px;height:(\d+)px/`) still reads the page's own
+  // dimensions from the style rule, not this book-wide value.
+  const refWidthAttr =
+    referenceWidth !== undefined ? ` data-fl-reference-width="${Math.round(referenceWidth)}"` : ""
+  const html = `<div id="content"${refWidthAttr} style="position:relative;width:${viewport.width}px;height:${viewport.height}px;margin:0 auto;overflow:hidden">
 ${elements.join("\n")}${fitScript}
 </div>`
 
@@ -466,6 +482,16 @@ export function processFixedLayoutPages(
   imageUrlPrefix: string,
 ): void {
   const pages = storage.getPages()
+
+  // Pass 1: resolve each page's viewport + inputs. We collect these up front
+  // so we can compute the book-wide reference (spread) width before rendering
+  // — that value must be identical on every page (see renderFixedLayoutPage).
+  const prepared: Array<{
+    page: (typeof pages)[number]
+    viewport: { width: number; height: number }
+    drawItems: DrawItem[]
+    availableImageIds: Set<string>
+  }> = []
 
   for (const page of pages) {
     // Render whatever image-filtering left unpruned. The wizard writes
@@ -498,7 +524,17 @@ export function processFixedLayoutPages(
     if (!viewport) continue
 
     const drawItems: DrawItem[] = positionedText?.drawItems ?? []
+    prepared.push({ page, viewport, drawItems, availableImageIds })
+  }
 
+  // The widest page is the book's reference width: a full spread in spread
+  // mode, or just the common page width otherwise. Stamped onto every page so
+  // viewers scale uniformly and single (cover/end) pages render centered at
+  // their natural fraction of the panel instead of being upscaled to fill it.
+  const referenceWidth = prepared.reduce((max, p) => Math.max(max, p.viewport.width), 0)
+
+  // Pass 2: section + render each page with the shared reference width.
+  for (const { page, viewport, drawItems, availableImageIds } of prepared) {
     const sectioning = sectionFixedLayoutPage({
       pageId: page.pageId,
       pageNumber: page.pageNumber,
@@ -511,6 +547,7 @@ export function processFixedLayoutPages(
     const rendering = renderFixedLayoutPage(
       sectioning.sections[0],
       imageUrlPrefix,
+      referenceWidth,
     )
     storage.putNodeData("web-rendering", page.pageId, rendering)
   }


### PR DESCRIPTION
Fixed-layout pages were each scaled to fill the preview width off their own width, so in spread mode a single cover/end page (half a spread's width) rendered ~2× larger than the spreads. This computes the book-wide reference (widest) page once in `processFixedLayoutPages`, stamps it on `#content` as `data-fl-reference-width`, and scales every page by that shared width in both the storyboard preview (`BookPreviewFrame`) and the produced-book preview (`PreviewView`) — so single pages now render centered at their natural fraction of the panel and every page reads as one identical size. In `PreviewView` the iframe is additionally laid out at the reference width so the reader's full-width bottom dock stays one constant width on every page, with the narrower single-page body centered within the viewport. Viewers fall back to per-page width when the attribute is absent (no regression for reflowable or older content). Added unit tests for the attribute emission and book-wide max; `pnpm typecheck`, lint, and the full pipeline test suite (639 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)