### PR TITLE
Auto-start extract after book creation

### DIFF
--- a/apps/studio/src/components/wizard/BookCreationWizard.tsx
+++ b/apps/studio/src/components/wizard/BookCreationWizard.tsx
@@ -5,6 +5,8 @@ import { Eye, ArrowLeft, ArrowRight, Zap, Loader2 } from "lucide-react"
 import { useStore } from "@tanstack/react-form"
 import { useNavigate } from "@tanstack/react-router"
 import { Button } from "@/components/ui/button"
+import { api } from "@/api/client"
+import { useApiKey } from "@/hooks/use-api-key"
 import { useBooks, useCreateBook } from "@/hooks/use-books"
 import { useWizard } from "./index"
 import { useWizardForm } from "./wizardForm"
@@ -195,6 +197,7 @@ export function BookCreationWizard() {
   const { phase, currentStep, setCurrentStep, stepDirection, previewFocus } = useWizard()
   const form = useWizardForm()
   const createMutation = useCreateBook()
+  const { apiKey, hasApiKey, anthropicKey, googleKey, customBaseUrl, customApiKey, azureKey, azureRegion, geminiKey } = useApiKey()
   const { data: books, isPending: booksLoading } = useBooks()
   const [previewOpen, setPreviewOpen] = useState(false)
   const [submitError, setSubmitError] = useState<string | null>(null)
@@ -265,6 +268,28 @@ export function BookCreationWizard() {
         pdf: values.file!,
         config: buildConfigOverrides(values),
       })
+
+      // Kick off extraction automatically so the user lands on the book home
+      // with the Extract stage already running.
+      if (hasApiKey) {
+        try {
+          await api.runStages(
+            book.label,
+            apiKey,
+            { fromStage: "extract", toStage: "extract" },
+            {
+              anthropicApiKey: anthropicKey || undefined,
+              googleApiKey: googleKey || undefined,
+              customBaseUrl: customBaseUrl || undefined,
+              customApiKey: customApiKey || undefined,
+              azure: { key: azureKey, region: azureRegion },
+              geminiApiKey: geminiKey || undefined,
+            },
+          )
+        } catch (pipelineError) {
+          console.error("[wizard] extract kickoff failed:", pipelineError)
+        }
+      }
 
       navigate({ to: "/books/$label/$step", params: { label: book.label, step: "book" } })
     } catch (error) {


### PR DESCRIPTION
## Summary
- Start the Extract stage automatically after a book is created when an API key is available.
- Forward saved provider credentials to the stage run so configured providers continue to work.
- Continue navigating to the book home if the kickoff request fails, logging the failure for debugging.

## Validation
- pnpm typecheck