### PR TITLE
feat(runtime): port sorting & matching activities to the React runtime

### DIFF
--- a/apps/adt-runtime/src/app/lifecycle.ts
+++ b/apps/adt-runtime/src/app/lifecycle.ts
@@ -65,6 +65,8 @@ import { initializeMultiSelectActivity } from "@/features/activity/runtime/activ
 import { initializeFillInTheBlankActivity } from "@/features/activity/runtime/activity-fill-in-the-blank"
 import { initializeOpenEndedActivity } from "@/features/activity/runtime/activity-open-ended"
 import { initializeTrueFalseActivity } from "@/features/activity/runtime/activity-true-false"
+import { initializeSortingActivity } from "@/features/activity/runtime/activity-sorting"
+import { initializeMatchingActivity } from "@/features/activity/runtime/activity-matching"
 
 function readCurrentSectionId(): string | null {
   if (typeof document === "undefined") return null
@@ -193,6 +195,8 @@ export async function bootRuntime(): Promise<void> {
     initializeFillInTheBlankActivity()
     initializeOpenEndedActivity()
     initializeTrueFalseActivity()
+    initializeSortingActivity()
+    initializeMatchingActivity()
   } finally {
     // Always clear the dock skeleton — even on partial-load failures the dock
     // should reveal whatever data DID make it into atoms.

--- a/apps/adt-runtime/src/features/activity/runtime/activity-matching.test.ts
+++ b/apps/adt-runtime/src/features/activity/runtime/activity-matching.test.ts
@@ -1,0 +1,200 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from "vitest"
+import { getDefaultStore } from "jotai"
+import { initializeMatchingActivity } from "./activity-matching"
+import {
+  confettiTriggerAtom,
+  skipEnabledAtom,
+  submitEnabledAtom,
+  submitStateAtom,
+  validateHandlerAtom,
+} from "../state/activity.atoms"
+import { pagesAtom, currentSectionIdAtom } from "../../navigation/state/nav.atoms"
+
+const store = getDefaultStore()
+
+function setup(opts?: { sectionId?: string }): void {
+  const sectionId = opts?.sectionId ?? "pg004_sec001"
+  document.body.innerHTML = `
+    <section data-section-type="activity_matching" data-section-id="${sectionId}">
+      <div class="flex flex-row gap-4">
+        <div class="grow grid grid-cols-1 gap-4 text-center">
+          <div class="bg-yellow-100 activity-item" data-activity-item="item-1"
+               data-id="t1" draggable="true" tabindex="0" role="button" aria-label="Apple" id="apple">Apple</div>
+          <div class="bg-teal-100 activity-item" data-activity-item="item-2"
+               data-id="t2" draggable="true" tabindex="0" role="button" aria-label="Banana" id="banana">Banana</div>
+        </div>
+        <div class="grid grid-cols-2 gap-4">
+          <div class="border dropzone" tabindex="0" role="button" aria-label="Apple image" id="target1">
+            <img src="images/apple.png" alt="apple" data-id="img1" />
+            <div id="dropzone-1" class="dropzone-slot" aria-live="polite"></div>
+          </div>
+          <div class="border dropzone" tabindex="0" role="button" aria-label="Banana image" id="target2">
+            <img src="images/banana.png" alt="banana" data-id="img2" />
+            <div id="dropzone-2" class="dropzone-slot" aria-live="polite"></div>
+          </div>
+        </div>
+      </div>
+    </section>
+  `
+  window.correctAnswers = {
+    "item-1": "dropzone-1",
+    "item-2": "dropzone-2",
+  }
+}
+
+function itemFor(itemId: string): HTMLElement {
+  return document.querySelector<HTMLElement>(`.activity-item[data-activity-item='${itemId}']`)!
+}
+
+function zoneFor(slotId: string): HTMLElement {
+  return document.getElementById(slotId)!.closest<HTMLElement>(".dropzone")!
+}
+
+function slotContains(slotId: string, itemId: string): boolean {
+  return !!document
+    .getElementById(slotId)!
+    .querySelector(`.activity-item[data-activity-item='${itemId}']`)
+}
+
+/** Select an item, then click a drop zone to place it. */
+function selectAndPlace(itemId: string, slotId: string): void {
+  itemFor(itemId).click()
+  zoneFor(slotId).click()
+}
+
+beforeEach(() => {
+  document.body.innerHTML = ""
+  window.correctAnswers = undefined
+  store.set(submitEnabledAtom, false)
+  store.set(skipEnabledAtom, false)
+  store.set(submitStateAtom, "submit")
+  store.set(validateHandlerAtom, () => null)
+  store.set(confettiTriggerAtom, 0)
+  store.set(pagesAtom, [
+    { section_id: "pg004_sec001", href: "pg004_sec001.html" },
+    { section_id: "pg005_sec001", href: "pg005_sec001.html" },
+  ])
+  store.set(currentSectionIdAtom, "pg004_sec001")
+})
+
+describe("initializeMatchingActivity", () => {
+  it("does nothing when no matching section is present", () => {
+    document.body.innerHTML = `<section data-section-type="text_only"></section>`
+    expect(initializeMatchingActivity()).toBeNull()
+  })
+
+  it("returns null when there are items but no drop zones", () => {
+    document.body.innerHTML = `
+      <section data-section-type="activity_matching">
+        <div class="activity-item" data-activity-item="item-1">Apple</div>
+      </section>`
+    expect(initializeMatchingActivity()).toBeNull()
+  })
+
+  it("places a selected item into a drop zone and enables submit", () => {
+    setup()
+    initializeMatchingActivity()
+    expect(store.get(submitEnabledAtom)).toBe(false)
+
+    selectAndPlace("item-1", "dropzone-1")
+
+    expect(slotContains("dropzone-1", "item-1")).toBe(true)
+    expect(itemFor("item-1").classList.contains("placed-in-dropzone")).toBe(true)
+    expect(store.get(submitEnabledAtom)).toBe(true)
+  })
+
+  it("returns a placed item to the bank when clicked", () => {
+    setup()
+    initializeMatchingActivity()
+    selectAndPlace("item-1", "dropzone-1")
+    expect(store.get(submitEnabledAtom)).toBe(true)
+
+    itemFor("item-1").click()
+
+    expect(slotContains("dropzone-1", "item-1")).toBe(false)
+    expect(itemFor("item-1").classList.contains("placed-in-dropzone")).toBe(false)
+    expect(store.get(submitEnabledAtom)).toBe(false)
+  })
+
+  it("evicts the existing card when a slot already holds one (1:1 matching)", () => {
+    setup()
+    initializeMatchingActivity()
+    selectAndPlace("item-1", "dropzone-1")
+    // Now place item-2 into the same slot — item-1 should be evicted home.
+    selectAndPlace("item-2", "dropzone-1")
+
+    expect(slotContains("dropzone-1", "item-2")).toBe(true)
+    expect(slotContains("dropzone-1", "item-1")).toBe(false)
+    expect(itemFor("item-1").classList.contains("placed-in-dropzone")).toBe(false)
+  })
+
+  it("marks all items correct and advances to next when fully matched", () => {
+    setup()
+    initializeMatchingActivity()
+    selectAndPlace("item-1", "dropzone-1")
+    selectAndPlace("item-2", "dropzone-2")
+
+    const before = store.get(confettiTriggerAtom)
+    store.get(validateHandlerAtom)?.()
+
+    expect(itemFor("item-1").querySelector(".validation-mark")?.textContent).toBe("✓")
+    expect(itemFor("item-2").querySelector(".validation-mark")?.textContent).toBe("✓")
+    expect(store.get(submitStateAtom)).toBe("next")
+    expect(store.get(confettiTriggerAtom)).toBe(before + 1)
+  })
+
+  it("marks a wrong match incorrect and stays in submit state", () => {
+    setup()
+    initializeMatchingActivity()
+    selectAndPlace("item-1", "dropzone-2") // wrong
+    selectAndPlace("item-2", "dropzone-1") // wrong
+
+    store.get(validateHandlerAtom)?.()
+
+    expect(itemFor("item-1").querySelector(".validation-mark")?.textContent).toBe("✗")
+    expect(itemFor("item-1").getAttribute("aria-invalid")).toBe("true")
+    expect(store.get(submitStateAtom)).toBe("submit")
+  })
+
+  it("does not advance when not every item is matched", () => {
+    setup()
+    initializeMatchingActivity()
+    selectAndPlace("item-1", "dropzone-1") // correct, but item-2 unplaced
+
+    store.get(validateHandlerAtom)?.()
+
+    expect(itemFor("item-1").querySelector(".validation-mark")?.textContent).toBe("✓")
+    expect(store.get(submitStateAtom)).toBe("submit")
+    expect(store.get(confettiTriggerAtom)).toBe(0)
+  })
+
+  it("clears verdict styling when an item is moved after validation", () => {
+    setup()
+    initializeMatchingActivity()
+    selectAndPlace("item-1", "dropzone-2") // wrong
+    selectAndPlace("item-2", "dropzone-1") // wrong
+    store.get(validateHandlerAtom)?.()
+    expect(document.querySelectorAll(".validation-mark").length).toBe(2)
+
+    itemFor("item-1").click() // remove → verdicts wiped
+
+    expect(document.querySelectorAll(".validation-mark").length).toBe(0)
+  })
+
+  it("supports the legacy role=region slot selector", () => {
+    document.body.innerHTML = `
+      <section data-section-type="activity_matching" data-section-id="pg004_sec001">
+        <div class="grow grid">
+          <div class="activity-item" data-activity-item="item-1" aria-label="Apple">Apple</div>
+        </div>
+        <div class="dropzone" id="target1">
+          <div id="dropzone-1" role="region"></div>
+        </div>
+      </section>`
+    window.correctAnswers = { "item-1": "dropzone-1" }
+    initializeMatchingActivity()
+    selectAndPlace("item-1", "dropzone-1")
+    expect(slotContains("dropzone-1", "item-1")).toBe(true)
+  })
+})

--- a/apps/adt-runtime/src/features/activity/runtime/activity-matching.ts
+++ b/apps/adt-runtime/src/features/activity/runtime/activity-matching.ts
@@ -91,6 +91,13 @@ const VERDICT_MARK_CLASS = "validation-mark"
 interface Item {
   el: HTMLElement
   itemId: string
+  /**
+   * The card's accessible name, captured once at init from the pristine
+   * aria-label/text. `place()` rewrites the element's aria-label into a
+   * composite ("X — placed. Press Enter to remove."), so we can't re-derive
+   * the bare label from the DOM later — keep the original here.
+   */
+  label: string
   /** Where the card lives in the bank, so removal restores original order. */
   home: { parent: HTMLElement; index: number }
   /** Slot id the card currently occupies, or null when in the bank. */
@@ -134,7 +141,13 @@ export function initializeMatchingActivity(): (() => void) | null {
     const parent = el.parentElement
     if (!parent) return
     const index = Array.from(parent.children).indexOf(el)
-    items.set(itemId, { el, itemId, home: { parent, index }, slotId: null })
+    items.set(itemId, {
+      el,
+      itemId,
+      label: itemLabel(el),
+      home: { parent, index },
+      slotId: null,
+    })
   })
 
   const dropzones = Array.from(section.querySelectorAll<HTMLElement>(".dropzone"))
@@ -181,7 +194,7 @@ export function initializeMatchingActivity(): (() => void) | null {
     item.el.classList.add(...SELECTED_CLASSES)
     highlightZones(true)
     announceToScreenReader(
-      `${tr("matching-selected", "Selected")}: ${itemLabel(item.el)}. ` +
+      `${tr("matching-selected", "Selected")}: ${item.label}. ` +
         tr("matching-choose-zone", "Choose a drop zone to place it in."),
     )
   }
@@ -211,7 +224,7 @@ export function initializeMatchingActivity(): (() => void) | null {
     item.slotId = null
     item.el.classList.remove(PLACED_CLASS, ...SELECTED_CLASSES)
     item.el.removeAttribute("title")
-    item.el.setAttribute("aria-label", itemLabel(item.el))
+    item.el.setAttribute("aria-label", item.label)
   }
 
   const place = (item: Item, slotId: string) => {
@@ -233,7 +246,7 @@ export function initializeMatchingActivity(): (() => void) | null {
     item.el.setAttribute("title", tr("click-to-remove", "Click to remove"))
     item.el.setAttribute(
       "aria-label",
-      `${itemLabel(item.el)} — ${tr("matching-placed", "placed")}. ${tr(
+      `${item.label} — ${tr("matching-placed", "placed")}. ${tr(
         "matching-press-to-remove",
         "Press Enter to remove.",
       )}`,
@@ -243,7 +256,7 @@ export function initializeMatchingActivity(): (() => void) | null {
     highlightZones(false)
     playActivitySound("drop")
     refreshSubmit()
-    announceToScreenReader(`${itemLabel(item.el)} ${tr("matching-placed", "placed")}.`)
+    announceToScreenReader(`${item.label} ${tr("matching-placed", "placed")}.`)
   }
 
   const remove = (item: Item) => {
@@ -253,7 +266,7 @@ export function initializeMatchingActivity(): (() => void) | null {
     playActivitySound("reset")
     refreshSubmit()
     announceToScreenReader(
-      `${itemLabel(item.el)} ${tr("matching-returned", "returned to available options.")}`,
+      `${item.label} ${tr("matching-returned", "returned to available options.")}`,
     )
     item.el.focus()
   }

--- a/apps/adt-runtime/src/features/activity/runtime/activity-matching.ts
+++ b/apps/adt-runtime/src/features/activity/runtime/activity-matching.ts
@@ -1,0 +1,443 @@
+import { getDefaultStore } from "jotai"
+import { combine } from "@atlaskit/pragmatic-drag-and-drop/combine"
+import {
+  draggable,
+  dropTargetForElements,
+} from "@atlaskit/pragmatic-drag-and-drop/element/adapter"
+import { translationsAtom } from "@/features/language/state/language.atoms"
+import { pagesAtom, currentSectionIdAtom } from "@/features/navigation/state/nav.atoms"
+import {
+  confettiTriggerAtom,
+  skipEnabledAtom,
+  skipHandlerAtom,
+  submitEnabledAtom,
+  submitLabelAtom,
+  submitStateAtom,
+  validateHandlerAtom,
+} from "@/features/activity/state/activity.atoms"
+import { playActivitySound } from "@/features/activity/runtime/sounds"
+import { showActivityProgressToast } from "@/features/activity/lib/progress-toast"
+import { announceToScreenReader } from "@/shared/lib/aria-live"
+
+/**
+ * `activity_matching` — learners match draggable `.activity-item` cards to
+ * image drop zones. Ported from the legacy `matching.js`.
+ *
+ * Each drop zone (`.dropzone`) wraps an image plus an inner slot
+ * (`.dropzone-slot`, `id="dropzone-N"`). The answer key maps each item id
+ * (`data-activity-item`) to the slot id it belongs in. Matching is 1:1 — a slot
+ * holds a single card; dropping a card onto an occupied slot returns the
+ * displaced card to the bank.
+ *
+ * Two interaction paths, mirroring the legacy module and `activity-sorting`:
+ *   1. Pointer drag — drag a card onto a drop zone (pragmatic-drag-and-drop).
+ *   2. Click / keyboard — click a card to select it (zones highlight), then
+ *      click a zone (or focus it + Enter/Space) to place it. Clicking a placed
+ *      card returns it to the bank.
+ *
+ * As in the sorting port, the single card element is MOVED between the bank and
+ * the slot rather than cloned, so placement state lives in `item.slotId`.
+ *
+ * NOTE: the current `activity_matching` prompt emits `.dropzone-slot` inner
+ * containers; older generated books used `div[role="region"]`. We resolve the
+ * slot by either selector for backward compatibility.
+ */
+const MATCHING_SELECTOR = 'section[data-section-type="activity_matching"]'
+const SLOT_SELECTOR = ".dropzone-slot, div[role='region']"
+
+function tr(key: string, fallback: string): string {
+  const dict = getDefaultStore().get(translationsAtom)
+  return dict[key] || fallback
+}
+
+declare global {
+  interface Window {
+    /** For matching, maps each item id to the slot id (`dropzone-N`) it belongs in. */
+    correctAnswers?: Record<string, unknown>
+  }
+}
+
+function readCorrectAnswers(section: HTMLElement): Record<string, string> {
+  const attr = section.getAttribute("data-correct-answers")
+  if (attr) {
+    try {
+      return mapToStrings(JSON.parse(attr) as Record<string, unknown>)
+    } catch {
+      // fall through
+    }
+  }
+  if (typeof window !== "undefined" && window.correctAnswers) {
+    return mapToStrings(window.correctAnswers)
+  }
+  return {}
+}
+
+function mapToStrings(obj: Record<string, unknown>): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const [k, v] of Object.entries(obj)) out[k] = String(v)
+  return out
+}
+
+// ---------------------------------------------------------------------------
+// Visual styling. Selection border + verdict marks mirror the legacy classes.
+// ---------------------------------------------------------------------------
+const SELECTED_CLASSES = ["border-4", "border-blue-500"] as const
+const ZONE_HIGHLIGHT_CLASSES = ["bg-blue-100", "border-blue-400"] as const
+const PLACED_CLASS = "placed-in-dropzone"
+const CORRECT_CLASSES = ["border", "border-green-300"] as const
+const INCORRECT_CLASSES = ["border", "border-red-300"] as const
+const VERDICT_MARK_CLASS = "validation-mark"
+
+interface Item {
+  el: HTMLElement
+  itemId: string
+  /** Where the card lives in the bank, so removal restores original order. */
+  home: { parent: HTMLElement; index: number }
+  /** Slot id the card currently occupies, or null when in the bank. */
+  slotId: string | null
+}
+
+function getItemId(el: HTMLElement): string | null {
+  return el.getAttribute("data-activity-item")
+}
+
+function itemLabel(el: HTMLElement): string {
+  return (
+    el.getAttribute("aria-label")?.split(" - ")[0]?.trim() ||
+    (el.textContent ?? "").replace(/\s+/g, " ").trim()
+  )
+}
+
+function findNextPageHref(): string | null {
+  const store = getDefaultStore()
+  const pages = store.get(pagesAtom)
+  const currentId = store.get(currentSectionIdAtom)
+  if (!currentId) return null
+  const idx = pages.findIndex((p) => p.section_id === currentId)
+  if (idx < 0 || idx >= pages.length - 1) return null
+  return pages[idx + 1].href
+}
+
+export function initializeMatchingActivity(): (() => void) | null {
+  if (typeof document === "undefined") return null
+  const section = document.querySelector<HTMLElement>(MATCHING_SELECTOR)
+  if (!section) return null
+
+  const store = getDefaultStore()
+  const correctAnswers = readCorrectAnswers(section)
+  const hasNextPage = findNextPageHref() !== null
+
+  const items = new Map<string, Item>()
+  section.querySelectorAll<HTMLElement>(".activity-item").forEach((el) => {
+    const itemId = getItemId(el)
+    if (!itemId || items.has(itemId)) return
+    const parent = el.parentElement
+    if (!parent) return
+    const index = Array.from(parent.children).indexOf(el)
+    items.set(itemId, { el, itemId, home: { parent, index }, slotId: null })
+  })
+
+  const dropzones = Array.from(section.querySelectorAll<HTMLElement>(".dropzone"))
+
+  if (items.size === 0 || dropzones.length === 0) return null
+
+  // Map each slot id (`dropzone-N`) → its slot element + outer drop zone.
+  const slotById = new Map<string, { slot: HTMLElement; zone: HTMLElement }>()
+  for (const zone of dropzones) {
+    const slot = zone.querySelector<HTMLElement>(SLOT_SELECTOR)
+    if (slot?.id) slotById.set(slot.id, { slot, zone })
+  }
+
+  if (slotById.size === 0) return null
+
+  let selectedId: string | null = null
+  let validated = false
+
+  const anyPlaced = () => [...items.values()].some((i) => i.slotId !== null)
+
+  const itemFromEl = (el: HTMLElement): Item | null => {
+    const id = getItemId(el)
+    return id ? (items.get(id) ?? null) : null
+  }
+
+  const highlightZones = (on: boolean) => {
+    for (const { slot } of slotById.values()) {
+      const zone = slot.closest<HTMLElement>(".dropzone") ?? slot
+      zone.classList.toggle(ZONE_HIGHLIGHT_CLASSES[0], on)
+      zone.classList.toggle(ZONE_HIGHLIGHT_CLASSES[1], on)
+    }
+  }
+
+  const clearSelection = () => {
+    if (selectedId) items.get(selectedId)?.el.classList.remove(...SELECTED_CLASSES)
+    selectedId = null
+    highlightZones(false)
+  }
+
+  const select = (item: Item) => {
+    if (item.slotId !== null) return
+    clearSelection()
+    selectedId = item.itemId
+    item.el.classList.add(...SELECTED_CLASSES)
+    highlightZones(true)
+    announceToScreenReader(
+      `${tr("matching-selected", "Selected")}: ${itemLabel(item.el)}. ` +
+        tr("matching-choose-zone", "Choose a drop zone to place it in."),
+    )
+  }
+
+  const clearItemVerdict = (item: Item) => {
+    item.el.classList.remove(...CORRECT_CLASSES, ...INCORRECT_CLASSES)
+    item.el.querySelectorAll(`.${VERDICT_MARK_CLASS}`).forEach((m) => m.remove())
+    item.el.setAttribute("aria-invalid", "false")
+  }
+
+  const clearAllVerdicts = () => {
+    for (const item of items.values()) clearItemVerdict(item)
+    validated = false
+  }
+
+  const refreshSubmit = () => {
+    store.set(submitStateAtom, "submit")
+    store.set(submitLabelAtom, null)
+    store.set(submitEnabledAtom, anyPlaced())
+  }
+
+  const returnHome = (item: Item) => {
+    clearItemVerdict(item)
+    const { parent, index } = item.home
+    const ref = parent.children[index] ?? null
+    parent.insertBefore(item.el, ref)
+    item.slotId = null
+    item.el.classList.remove(PLACED_CLASS, ...SELECTED_CLASSES)
+    item.el.removeAttribute("title")
+    item.el.setAttribute("aria-label", itemLabel(item.el))
+  }
+
+  const place = (item: Item, slotId: string) => {
+    const entry = slotById.get(slotId)
+    if (!entry) return
+    if (validated) clearAllVerdicts()
+
+    // 1:1 matching — if the slot already holds a different card, send it home.
+    const existing = entry.slot.querySelector<HTMLElement>(".activity-item")
+    if (existing && existing !== item.el) {
+      const existingItem = itemFromEl(existing)
+      if (existingItem) returnHome(existingItem)
+    }
+
+    entry.slot.appendChild(item.el)
+    item.slotId = slotId
+    item.el.classList.remove(...SELECTED_CLASSES)
+    item.el.classList.add(PLACED_CLASS)
+    item.el.setAttribute("title", tr("click-to-remove", "Click to remove"))
+    item.el.setAttribute(
+      "aria-label",
+      `${itemLabel(item.el)} — ${tr("matching-placed", "placed")}. ${tr(
+        "matching-press-to-remove",
+        "Press Enter to remove.",
+      )}`,
+    )
+
+    if (selectedId === item.itemId) selectedId = null
+    highlightZones(false)
+    playActivitySound("drop")
+    refreshSubmit()
+    announceToScreenReader(`${itemLabel(item.el)} ${tr("matching-placed", "placed")}.`)
+  }
+
+  const remove = (item: Item) => {
+    if (item.slotId === null) return
+    if (validated) clearAllVerdicts()
+    returnHome(item)
+    playActivitySound("reset")
+    refreshSubmit()
+    announceToScreenReader(
+      `${itemLabel(item.el)} ${tr("matching-returned", "returned to available options.")}`,
+    )
+    item.el.focus()
+  }
+
+  const onItemClick = (item: Item) => {
+    if (item.slotId !== null) remove(item)
+    else if (selectedId === item.itemId) clearSelection()
+    else select(item)
+  }
+
+  const onZoneClick = (slotId: string) => {
+    if (!selectedId) return
+    const item = items.get(selectedId)
+    if (item) place(item, slotId)
+  }
+
+  // ---- wire listeners + drag-and-drop ------------------------------------
+  const cleanups: Array<() => void> = []
+
+  for (const item of items.values()) {
+    const onClick = (e: Event) => {
+      e.preventDefault()
+      onItemClick(item)
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault()
+        onItemClick(item)
+      }
+    }
+    item.el.addEventListener("click", onClick)
+    item.el.addEventListener("keydown", onKey)
+    if (!item.el.hasAttribute("tabindex")) item.el.setAttribute("tabindex", "0")
+    if (!item.el.hasAttribute("role")) item.el.setAttribute("role", "button")
+    item.el.style.cursor = "pointer"
+
+    const dndCleanup = draggable({
+      element: item.el,
+      getInitialData: () => ({ itemId: item.itemId }),
+      onDragStart: () => highlightZones(true),
+      onDrop: () => highlightZones(false),
+    })
+
+    cleanups.push(() => {
+      item.el.removeEventListener("click", onClick)
+      item.el.removeEventListener("keydown", onKey)
+      dndCleanup()
+    })
+  }
+
+  for (const { slot, zone } of slotById.values()) {
+    const slotId = slot.id
+    const onClick = (e: Event) => {
+      // Clicking a placed card removes it (its own handler runs) — don't also
+      // treat the bubbled zone click as a placement.
+      if ((e.target as HTMLElement | null)?.closest(".activity-item")) return
+      onZoneClick(slotId)
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (selectedId && (e.key === "Enter" || e.key === " ")) {
+        e.preventDefault()
+        onZoneClick(slotId)
+      }
+    }
+    zone.addEventListener("click", onClick)
+    zone.addEventListener("keydown", onKey)
+    if (!zone.hasAttribute("tabindex")) zone.setAttribute("tabindex", "0")
+    if (!zone.hasAttribute("role")) zone.setAttribute("role", "button")
+    zone.style.cursor = "pointer"
+
+    const dropCleanup = dropTargetForElements({
+      element: zone,
+      getData: () => ({ slotId }),
+      onDragEnter: () => zone.classList.add(...ZONE_HIGHLIGHT_CLASSES),
+      onDragLeave: () => zone.classList.remove(...ZONE_HIGHLIGHT_CLASSES),
+      onDrop: ({ source }) => {
+        zone.classList.remove(...ZONE_HIGHLIGHT_CLASSES)
+        const itemId = source.data.itemId
+        if (typeof itemId !== "string") return
+        const item = items.get(itemId)
+        if (item) place(item, slotId)
+      },
+    })
+
+    cleanups.push(() => {
+      zone.removeEventListener("click", onClick)
+      zone.removeEventListener("keydown", onKey)
+      dropCleanup()
+    })
+  }
+
+  const markItem = (item: Item, isCorrect: boolean) => {
+    clearItemVerdict(item)
+    item.el.classList.add(...(isCorrect ? CORRECT_CLASSES : INCORRECT_CLASSES))
+    item.el.setAttribute("aria-invalid", isCorrect ? "false" : "true")
+    const mark = document.createElement("span")
+    mark.className = `${VERDICT_MARK_CLASS} ml-2 inline-flex align-middle font-bold ${
+      isCorrect ? "text-green-700" : "text-red-700"
+    }`
+    mark.textContent = isCorrect ? "✓" : "✗"
+    mark.setAttribute("aria-hidden", "true")
+    item.el.appendChild(mark)
+  }
+
+  const handleValidate = () => {
+    if (store.get(submitStateAtom) === "next") {
+      const href = findNextPageHref()
+      if (href) window.location.href = href
+      return
+    }
+
+    const placed = [...items.values()].filter((i) => i.slotId !== null)
+    if (placed.length === 0) return
+
+    clearAllVerdicts()
+
+    let correct = 0
+    for (const item of placed) {
+      const isCorrect = item.slotId === correctAnswers[item.itemId]
+      markItem(item, isCorrect)
+      if (isCorrect) correct++
+    }
+
+    const total = items.size
+    const unplaced = total - placed.length
+    const allCorrect = correct === total
+    validated = true
+
+    playActivitySound(allCorrect ? "success" : "error")
+
+    showActivityProgressToast(
+      { total, correct, unfilled: unplaced },
+      { emptyLabel: tr("activity-progress-remaining", "remaining") },
+    )
+
+    if (allCorrect) {
+      announceToScreenReader(
+        tr("matching-correct-answers", "Great job! Everything is matched correctly."),
+      )
+      store.set(confettiTriggerAtom, store.get(confettiTriggerAtom) + 1)
+      store.set(submitStateAtom, "next")
+      store.set(submitLabelAtom, null)
+      store.set(submitEnabledAtom, hasNextPage)
+    } else {
+      announceToScreenReader(
+        unplaced > 0
+          ? tr("matching-not-complete", "Please match every item before submitting.")
+          : tr("matching-try-again", "Some items are matched incorrectly. Try again."),
+      )
+      refreshSubmit()
+    }
+  }
+
+  const handleSkip = () => {
+    const href = findNextPageHref()
+    if (href) window.location.href = href
+  }
+
+  section.setAttribute("role", "group")
+  const applyLocalizedAria = () => {
+    section.setAttribute(
+      "aria-label",
+      tr("matching-options-label", "Match each item to the correct image"),
+    )
+  }
+  applyLocalizedAria()
+
+  store.set(validateHandlerAtom, () => handleValidate)
+  store.set(skipHandlerAtom, () => handleSkip)
+  store.set(submitStateAtom, "submit")
+  store.set(submitLabelAtom, null)
+  store.set(submitEnabledAtom, false)
+  store.set(skipEnabledAtom, hasNextPage)
+
+  const unsubTranslations = store.sub(translationsAtom, applyLocalizedAria)
+
+  const dndCleanup = combine(...cleanups)
+
+  return () => {
+    dndCleanup()
+    unsubTranslations()
+    store.set(validateHandlerAtom, () => null)
+    store.set(skipHandlerAtom, () => null)
+    store.set(submitEnabledAtom, false)
+    store.set(skipEnabledAtom, false)
+  }
+}

--- a/apps/adt-runtime/src/features/activity/runtime/activity-sorting.test.ts
+++ b/apps/adt-runtime/src/features/activity/runtime/activity-sorting.test.ts
@@ -1,0 +1,232 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from "vitest"
+import { getDefaultStore } from "jotai"
+import { initializeSortingActivity } from "./activity-sorting"
+import {
+  confettiTriggerAtom,
+  skipEnabledAtom,
+  submitEnabledAtom,
+  submitStateAtom,
+  validateHandlerAtom,
+} from "../state/activity.atoms"
+import { pagesAtom, currentSectionIdAtom } from "../../navigation/state/nav.atoms"
+
+const store = getDefaultStore()
+
+function setup(opts?: { sectionId?: string }): void {
+  const sectionId = opts?.sectionId ?? "pg004_sec001"
+  document.body.innerHTML = `
+    <section data-section-type="activity_sorting" data-section-id="${sectionId}">
+      <div class="grid grid-cols-3 gap-4">
+        <div>
+          <div class="grid grid-cols-2 gap-4" role="listbox">
+            <p class="word-card" data-activity-item="item-1" draggable="true" tabindex="0" role="option">
+              <span data-id="t1">Apple</span>
+            </p>
+            <p class="word-card" data-activity-item="item-2" draggable="true" tabindex="0" role="option">
+              <span data-id="t2">Carrot</span>
+            </p>
+            <p class="word-card" data-activity-item="item-3" draggable="true" tabindex="0" role="option">
+              <span data-id="t3">Banana</span>
+            </p>
+          </div>
+        </div>
+        <div class="grid gap-3">
+          <div class="category bg-yellow-200" data-activity-category="fruits" tabindex="0" role="listbox">
+            <label class="font-semibold" data-id="c1">Fruits</label>
+            <ul class="word-list flex flex-wrap"></ul>
+          </div>
+          <div class="category bg-blue-200" data-activity-category="veggies" tabindex="0" role="listbox">
+            <label class="font-semibold" data-id="c2">Vegetables</label>
+            <ul class="word-list flex flex-wrap"></ul>
+          </div>
+        </div>
+      </div>
+    </section>
+  `
+  // item-1 (Apple) + item-3 (Banana) are fruits; item-2 (Carrot) is a veggie.
+  window.correctAnswers = {
+    "item-1": "fruits",
+    "item-2": "veggies",
+    "item-3": "fruits",
+  }
+}
+
+function cardFor(itemId: string): HTMLElement {
+  return document.querySelector<HTMLElement>(
+    `.word-card[data-activity-item='${itemId}']`,
+  )!
+}
+
+function categoryFor(catId: string): HTMLElement {
+  return document.querySelector<HTMLElement>(
+    `.category[data-activity-category='${catId}']`,
+  )!
+}
+
+function placedCardIn(catId: string, itemId: string): HTMLElement | null {
+  return categoryFor(catId).querySelector<HTMLElement>(
+    `.word-list .word-card[data-activity-item='${itemId}']`,
+  )
+}
+
+/** Select a bank card, then place it into a category via click. */
+function selectAndPlace(itemId: string, catId: string): void {
+  cardFor(itemId).click()
+  categoryFor(catId).click()
+}
+
+beforeEach(() => {
+  document.body.innerHTML = ""
+  window.correctAnswers = undefined
+  store.set(submitEnabledAtom, false)
+  store.set(skipEnabledAtom, false)
+  store.set(submitStateAtom, "submit")
+  store.set(validateHandlerAtom, () => null)
+  store.set(confettiTriggerAtom, 0)
+  store.set(pagesAtom, [
+    { section_id: "pg004_sec001", href: "pg004_sec001.html" },
+    { section_id: "pg005_sec001", href: "pg005_sec001.html" },
+  ])
+  store.set(currentSectionIdAtom, "pg004_sec001")
+})
+
+describe("initializeSortingActivity", () => {
+  it("does nothing when no sorting section is present", () => {
+    document.body.innerHTML = `<section data-section-type="text_only"></section>`
+    expect(initializeSortingActivity()).toBeNull()
+  })
+
+  it("returns null when a section has cards but no categories", () => {
+    document.body.innerHTML = `
+      <section data-section-type="activity_sorting">
+        <p class="word-card" data-activity-item="item-1"><span>Apple</span></p>
+      </section>`
+    expect(initializeSortingActivity()).toBeNull()
+  })
+
+  it("places a selected card into a category and enables submit", () => {
+    setup()
+    initializeSortingActivity()
+    expect(store.get(submitEnabledAtom)).toBe(false)
+
+    selectAndPlace("item-1", "fruits")
+
+    expect(placedCardIn("fruits", "item-1")).not.toBeNull()
+    expect(cardFor("item-1").classList.contains("placed-word")).toBe(true)
+    expect(store.get(submitEnabledAtom)).toBe(true)
+  })
+
+  it("returns a placed card to the bank when clicked, disabling submit", () => {
+    setup()
+    initializeSortingActivity()
+    selectAndPlace("item-1", "fruits")
+    expect(store.get(submitEnabledAtom)).toBe(true)
+
+    // Click the now-placed card to remove it.
+    cardFor("item-1").click()
+
+    expect(placedCardIn("fruits", "item-1")).toBeNull()
+    expect(cardFor("item-1").classList.contains("placed-word")).toBe(false)
+    expect(store.get(submitEnabledAtom)).toBe(false)
+  })
+
+  it("marks all cards correct and advances to next when fully correct", () => {
+    setup()
+    initializeSortingActivity()
+    selectAndPlace("item-1", "fruits")
+    selectAndPlace("item-2", "veggies")
+    selectAndPlace("item-3", "fruits")
+
+    const before = store.get(confettiTriggerAtom)
+    store.get(validateHandlerAtom)?.()
+
+    expect(cardFor("item-1").querySelector(".validation-mark")?.textContent).toBe("✓")
+    expect(cardFor("item-2").querySelector(".validation-mark")?.textContent).toBe("✓")
+    expect(cardFor("item-3").querySelector(".validation-mark")?.textContent).toBe("✓")
+    expect(store.get(submitStateAtom)).toBe("next")
+    expect(store.get(confettiTriggerAtom)).toBe(before + 1)
+  })
+
+  it("marks a wrong placement incorrect and stays in submit state", () => {
+    setup()
+    initializeSortingActivity()
+    selectAndPlace("item-1", "veggies") // wrong — Apple is a fruit
+    selectAndPlace("item-2", "veggies")
+    selectAndPlace("item-3", "fruits")
+
+    store.get(validateHandlerAtom)?.()
+
+    const mark = cardFor("item-1").querySelector(".validation-mark")
+    expect(mark?.textContent).toBe("✗")
+    expect(cardFor("item-1").getAttribute("aria-invalid")).toBe("true")
+    expect(store.get(submitStateAtom)).toBe("submit")
+  })
+
+  it("does not advance when not every card is placed", () => {
+    setup()
+    initializeSortingActivity()
+    selectAndPlace("item-1", "fruits") // only one of three placed, and correct
+
+    store.get(validateHandlerAtom)?.()
+
+    // The single placed card is correct, but the activity isn't complete.
+    expect(cardFor("item-1").querySelector(".validation-mark")?.textContent).toBe("✓")
+    expect(store.get(submitStateAtom)).toBe("submit")
+    expect(store.get(confettiTriggerAtom)).toBe(0)
+  })
+
+  it("clears verdict styling when a card is moved after validation", () => {
+    setup()
+    initializeSortingActivity()
+    selectAndPlace("item-1", "veggies") // wrong
+    selectAndPlace("item-2", "veggies")
+    selectAndPlace("item-3", "fruits")
+    store.get(validateHandlerAtom)?.()
+    expect(cardFor("item-1").querySelector(".validation-mark")).not.toBeNull()
+
+    // Remove the wrong card — verdict marks should be wiped from all cards.
+    cardFor("item-1").click()
+
+    expect(document.querySelectorAll(".validation-mark").length).toBe(0)
+  })
+
+  it("toggles selection off when the selected card is clicked again", () => {
+    setup()
+    initializeSortingActivity()
+    const apple = cardFor("item-1")
+    apple.click()
+    expect(apple.style.outline).not.toBe("") // blue selection outline applied
+    apple.click()
+    expect(apple.style.outline).toBe("") // outline cleared on deselect
+  })
+
+  it("enforces a clear bordered, rounded card look regardless of generated classes", () => {
+    setup()
+    sortingCardBorderProbe()
+  })
+})
+
+/**
+ * The runtime overrides faint renderer borders with inline styles so a card is
+ * unmistakably a draggable card. Verifies the base look, the placed (blue)
+ * look, and verdict (green/red) borders.
+ */
+function sortingCardBorderProbe(): void {
+  initializeSortingActivity()
+  const apple = cardFor("item-1")
+
+  // Base: visible 2px border + rounded corners in the bank.
+  expect(apple.style.border).toContain("2px solid")
+  expect(apple.style.borderRadius).not.toBe("")
+
+  // Placed: border switches to the blue "placed" color.
+  selectAndPlace("item-1", "fruits")
+  expect(apple.style.border).toContain("rgb(37, 99, 235)")
+
+  // Validate everything correct → green border on the correct card.
+  selectAndPlace("item-2", "veggies")
+  selectAndPlace("item-3", "fruits")
+  store.get(validateHandlerAtom)?.()
+  expect(apple.style.border).toContain("rgb(22, 163, 74)")
+}

--- a/apps/adt-runtime/src/features/activity/runtime/activity-sorting.ts
+++ b/apps/adt-runtime/src/features/activity/runtime/activity-sorting.ts
@@ -131,6 +131,14 @@ function applyPlacementStyle(el: HTMLElement, placed: boolean): void {
 interface Card {
   el: HTMLElement
   itemId: string
+  /**
+   * The card's accessible name, captured once at init. `place()` rewrites the
+   * element's aria-label into a composite ("X — placed in Y. Press Enter to
+   * remove."), so it can't be re-derived from the DOM later. Image-only cards
+   * carry their name in aria-label rather than visible text, so we fall back
+   * to it here.
+   */
+  label: string
   /** Where the card lives in the bank, so removal restores original order. */
   home: { parent: HTMLElement; index: number }
   /** Currently-assigned category id, or null when sitting in the bank. */
@@ -142,7 +150,9 @@ function getItemId(el: HTMLElement): string | null {
 }
 
 function cardLabel(el: HTMLElement): string {
-  return (el.textContent ?? "").replace(/\s+/g, " ").trim()
+  const text = (el.textContent ?? "").replace(/\s+/g, " ").trim()
+  // Image-only cards have no text leaf — their name lives in aria-label.
+  return text || el.getAttribute("aria-label")?.trim() || ""
 }
 
 function categoryName(category: HTMLElement): string {
@@ -182,7 +192,13 @@ export function initializeSortingActivity(): (() => void) | null {
     const parent = el.parentElement
     if (!parent) return
     const index = Array.from(parent.children).indexOf(el)
-    cards.set(itemId, { el, itemId, home: { parent, index }, category: null })
+    cards.set(itemId, {
+      el,
+      itemId,
+      label: cardLabel(el),
+      home: { parent, index },
+      category: null,
+    })
   })
 
   const categories = Array.from(
@@ -227,7 +243,7 @@ export function initializeSortingActivity(): (() => void) | null {
     const first = categories[0]
     announceToScreenReader(
       tr("sorting-selected-word", "Selected") +
-        `: ${cardLabel(card.el)}. ` +
+        `: ${card.label}. ` +
         tr(
           "sorting-choose-category",
           "Choose a category to place it in, or press Enter on a category.",
@@ -268,7 +284,7 @@ export function initializeSortingActivity(): (() => void) | null {
     card.el.setAttribute("role", "button")
     card.el.setAttribute(
       "aria-label",
-      `${cardLabel(card.el)} — ${tr("sorting-placed-in", "placed in")} ${categoryName(
+      `${card.label} — ${tr("sorting-placed-in", "placed in")} ${categoryName(
         category,
       )}. ${tr("sorting-press-to-remove", "Press Enter to remove.")}`,
     )
@@ -279,7 +295,7 @@ export function initializeSortingActivity(): (() => void) | null {
     refreshSubmit()
 
     announceToScreenReader(
-      `${cardLabel(card.el)} ${tr("sorting-placed-in", "placed in")} ${categoryName(category)}.`,
+      `${card.label} ${tr("sorting-placed-in", "placed in")} ${categoryName(category)}.`,
     )
   }
 
@@ -297,12 +313,12 @@ export function initializeSortingActivity(): (() => void) | null {
     applyPlacementStyle(card.el, false)
     card.el.setAttribute("draggable", "true")
     card.el.setAttribute("role", "option")
-    card.el.setAttribute("aria-label", cardLabel(card.el))
+    card.el.setAttribute("aria-label", card.label)
 
     playActivitySound("reset")
     refreshSubmit()
     announceToScreenReader(
-      `${cardLabel(card.el)} ${tr(
+      `${card.label} ${tr(
         "sorting-returned",
         "returned to available options.",
       )}`,

--- a/apps/adt-runtime/src/features/activity/runtime/activity-sorting.ts
+++ b/apps/adt-runtime/src/features/activity/runtime/activity-sorting.ts
@@ -1,0 +1,516 @@
+import { getDefaultStore } from "jotai"
+import { combine } from "@atlaskit/pragmatic-drag-and-drop/combine"
+import {
+  draggable,
+  dropTargetForElements,
+} from "@atlaskit/pragmatic-drag-and-drop/element/adapter"
+import { translationsAtom } from "@/features/language/state/language.atoms"
+import { pagesAtom, currentSectionIdAtom } from "@/features/navigation/state/nav.atoms"
+import {
+  confettiTriggerAtom,
+  skipEnabledAtom,
+  skipHandlerAtom,
+  submitEnabledAtom,
+  submitLabelAtom,
+  submitStateAtom,
+  validateHandlerAtom,
+} from "@/features/activity/state/activity.atoms"
+import { playActivitySound } from "@/features/activity/runtime/sounds"
+import { showActivityProgressToast } from "@/features/activity/lib/progress-toast"
+import { announceToScreenReader } from "@/shared/lib/aria-live"
+
+/**
+ * `activity_sorting` — learners place draggable word cards into labelled
+ * category buckets. Ported from the legacy `sorting.js`.
+ *
+ * Two interaction paths, mirroring the legacy module:
+ *   1. Pointer drag — drag a `.word-card` onto a `.category` drop zone
+ *      (powered by pragmatic-drag-and-drop so it also works on touch).
+ *   2. Click / keyboard — click a card to SELECT it (categories highlight),
+ *      then click a category (or focus it and press Enter/Space) to PLACE the
+ *      selected card there. Clicking a placed card returns it to the bank.
+ *
+ * Unlike the legacy module, which CLONED the card into the category and
+ * disabled the original, this port MOVES the single card element between the
+ * word bank and the category's `<ul class="word-list">`. There is therefore
+ * never a "disabled original" to keep in sync — placement state lives entirely
+ * in `card.category`.
+ *
+ * Validation compares each placed card's category against
+ * `window.correctAnswers` (an item-id → category-id map injected by
+ * `packages/pipeline/src/package-web.ts:renderPageHtml`). The activity passes
+ * only when every card is placed AND every placement is correct.
+ */
+const SORTING_SELECTOR = 'section[data-section-type="activity_sorting"]'
+
+function tr(key: string, fallback: string): string {
+  const dict = getDefaultStore().get(translationsAtom)
+  return dict[key] || fallback
+}
+
+declare global {
+  interface Window {
+    /**
+     * For sorting, maps each item id (`data-activity-item`) to the id of the
+     * category (`data-activity-category`) it belongs in.
+     */
+    correctAnswers?: Record<string, unknown>
+  }
+}
+
+function readCorrectAnswers(section: HTMLElement): Record<string, string> {
+  const attr = section.getAttribute("data-correct-answers")
+  if (attr) {
+    try {
+      const parsed = JSON.parse(attr) as Record<string, unknown>
+      return mapToStrings(parsed)
+    } catch {
+      // fall through
+    }
+  }
+  if (typeof window !== "undefined" && window.correctAnswers) {
+    return mapToStrings(window.correctAnswers)
+  }
+  return {}
+}
+
+function mapToStrings(obj: Record<string, unknown>): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const [k, v] of Object.entries(obj)) out[k] = String(v)
+  return out
+}
+
+// ---------------------------------------------------------------------------
+// Visual styling. Selection + drag-highlight mirror the legacy classes so the
+// look matches existing books; verdict styling reuses the legacy green/red
+// wash plus a ✓/✗ mark span.
+// ---------------------------------------------------------------------------
+// The renderer emits varying card borders (often a near-invisible
+// `border-gray-200` on a white card) which makes a draggable card hard to
+// recognize. The runtime enforces a clear, consistent look via INLINE styles —
+// inline styles win over Tailwind classes regardless of CSS source order, so
+// the affordance is guaranteed for every book without re-rendering.
+const CARD_RADIUS = "0.75rem" // rounded-xl
+const CARD_BORDER_WIDTH = "2px"
+const CARD_BORDER_BASE = "rgb(100, 116, 139)" // slate-500 — clearly visible on white
+const CARD_BORDER_PLACED = "rgb(37, 99, 235)" // blue-600 — signals "placed"
+const CARD_BORDER_CORRECT = "rgb(22, 163, 74)" // green-600
+const CARD_BORDER_INCORRECT = "rgb(220, 38, 38)" // red-600
+const SELECT_OUTLINE = "rgb(37, 99, 235)" // blue-600
+const CARD_SHADOW = "0 1px 3px rgba(0, 0, 0, 0.12)"
+const CARD_SHADOW_PLACED = "0 2px 8px rgba(0, 0, 0, 0.18)"
+const CATEGORY_HIGHLIGHT_CLASSES = ["bg-blue-100", "border-blue-400"] as const
+const PLACED_FLAG_CLASS = "placed-word" // selector hook + external CSS contract
+const VERDICT_MARK_CLASS = "validation-mark"
+
+function setCardBorder(el: HTMLElement, color: string): void {
+  el.style.border = `${CARD_BORDER_WIDTH} solid ${color}`
+}
+
+function setSelectedOutline(el: HTMLElement, on: boolean): void {
+  el.style.outline = on ? `3px solid ${SELECT_OUTLINE}` : ""
+  el.style.outlineOffset = on ? "2px" : ""
+}
+
+/**
+ * Reset a card to its non-verdict look for its current placement state: a
+ * slate-bordered "draggable" card in the bank, or a blue-bordered "placed" card
+ * in a category. Also strips any verdict mark + aria-invalid so the same call
+ * doubles as "clear verdict". The border radius is set once at init and left
+ * untouched here.
+ */
+function applyPlacementStyle(el: HTMLElement, placed: boolean): void {
+  el.querySelectorAll(`.${VERDICT_MARK_CLASS}`).forEach((m) => m.remove())
+  el.setAttribute("aria-invalid", "false")
+  setCardBorder(el, placed ? CARD_BORDER_PLACED : CARD_BORDER_BASE)
+  el.style.boxShadow = placed ? CARD_SHADOW_PLACED : CARD_SHADOW
+  el.style.cursor = placed ? "pointer" : "grab"
+  el.classList.toggle(PLACED_FLAG_CLASS, placed)
+}
+
+interface Card {
+  el: HTMLElement
+  itemId: string
+  /** Where the card lives in the bank, so removal restores original order. */
+  home: { parent: HTMLElement; index: number }
+  /** Currently-assigned category id, or null when sitting in the bank. */
+  category: string | null
+}
+
+function getItemId(el: HTMLElement): string | null {
+  return el.getAttribute("data-activity-item")
+}
+
+function cardLabel(el: HTMLElement): string {
+  return (el.textContent ?? "").replace(/\s+/g, " ").trim()
+}
+
+function categoryName(category: HTMLElement): string {
+  return (
+    category.getAttribute("aria-label") ||
+    category.querySelector(".font-semibold, label")?.textContent?.replace(/\s+/g, " ").trim() ||
+    category.getAttribute("data-activity-category") ||
+    ""
+  )
+}
+
+function findNextPageHref(): string | null {
+  const store = getDefaultStore()
+  const pages = store.get(pagesAtom)
+  const currentId = store.get(currentSectionIdAtom)
+  if (!currentId) return null
+  const idx = pages.findIndex((p) => p.section_id === currentId)
+  if (idx < 0 || idx >= pages.length - 1) return null
+  return pages[idx + 1].href
+}
+
+export function initializeSortingActivity(): (() => void) | null {
+  if (typeof document === "undefined") return null
+  const section = document.querySelector<HTMLElement>(SORTING_SELECTOR)
+  if (!section) return null
+
+  const store = getDefaultStore()
+  const correctAnswers = readCorrectAnswers(section)
+  const hasNextPage = findNextPageHref() !== null
+
+  // Snapshot every word card and remember its home position so a removed card
+  // can return to its original slot in the bank.
+  const cards = new Map<string, Card>()
+  section.querySelectorAll<HTMLElement>(".word-card").forEach((el) => {
+    const itemId = getItemId(el)
+    if (!itemId || cards.has(itemId)) return
+    const parent = el.parentElement
+    if (!parent) return
+    const index = Array.from(parent.children).indexOf(el)
+    cards.set(itemId, { el, itemId, home: { parent, index }, category: null })
+  })
+
+  const categories = Array.from(
+    section.querySelectorAll<HTMLElement>(".category[data-activity-category]"),
+  )
+
+  if (cards.size === 0 || categories.length === 0) return null
+
+  const categoryById = new Map<string, HTMLElement>()
+  for (const cat of categories) {
+    const id = cat.getAttribute("data-activity-category")
+    if (id) categoryById.set(id, cat)
+  }
+
+  let selectedId: string | null = null
+  let validated = false
+
+  const anyPlaced = () => [...cards.values()].some((c) => c.category !== null)
+
+  const highlightCategories = (on: boolean) => {
+    for (const cat of categories) {
+      cat.classList.toggle(CATEGORY_HIGHLIGHT_CLASSES[0], on)
+      cat.classList.toggle(CATEGORY_HIGHLIGHT_CLASSES[1], on)
+    }
+  }
+
+  const clearSelection = () => {
+    if (selectedId) {
+      const card = cards.get(selectedId)
+      if (card) setSelectedOutline(card.el, false)
+    }
+    selectedId = null
+    highlightCategories(false)
+  }
+
+  const select = (card: Card) => {
+    if (card.category !== null) return
+    clearSelection()
+    selectedId = card.itemId
+    setSelectedOutline(card.el, true)
+    highlightCategories(true)
+    const first = categories[0]
+    announceToScreenReader(
+      tr("sorting-selected-word", "Selected") +
+        `: ${cardLabel(card.el)}. ` +
+        tr(
+          "sorting-choose-category",
+          "Choose a category to place it in, or press Enter on a category.",
+        ),
+    )
+    first?.focus()
+  }
+
+  // Drop verdict styling and restore the card to its placement look (blue if
+  // still placed, slate if back in the bank).
+  const clearCardVerdict = (card: Card) => {
+    applyPlacementStyle(card.el, card.category !== null)
+  }
+
+  const clearAllVerdicts = () => {
+    for (const card of cards.values()) clearCardVerdict(card)
+    validated = false
+  }
+
+  const refreshSubmit = () => {
+    store.set(submitStateAtom, "submit")
+    store.set(submitLabelAtom, null)
+    store.set(submitEnabledAtom, anyPlaced())
+  }
+
+  const place = (card: Card, catId: string) => {
+    const category = categoryById.get(catId)
+    if (!category) return
+    const list = category.querySelector<HTMLElement>(".word-list") ?? category
+
+    if (validated) clearAllVerdicts()
+
+    list.appendChild(card.el)
+    card.category = catId
+    setSelectedOutline(card.el, false)
+    applyPlacementStyle(card.el, true)
+    card.el.setAttribute("draggable", "false")
+    card.el.setAttribute("role", "button")
+    card.el.setAttribute(
+      "aria-label",
+      `${cardLabel(card.el)} — ${tr("sorting-placed-in", "placed in")} ${categoryName(
+        category,
+      )}. ${tr("sorting-press-to-remove", "Press Enter to remove.")}`,
+    )
+
+    if (selectedId === card.itemId) selectedId = null
+    highlightCategories(false)
+    playActivitySound("drop")
+    refreshSubmit()
+
+    announceToScreenReader(
+      `${cardLabel(card.el)} ${tr("sorting-placed-in", "placed in")} ${categoryName(category)}.`,
+    )
+  }
+
+  const remove = (card: Card) => {
+    if (card.category === null) return
+    if (validated) clearAllVerdicts()
+
+    // Restore the card to its home slot, preserving original bank order.
+    const { parent, index } = card.home
+    const ref = parent.children[index] ?? null
+    parent.insertBefore(card.el, ref)
+
+    card.category = null
+    setSelectedOutline(card.el, false)
+    applyPlacementStyle(card.el, false)
+    card.el.setAttribute("draggable", "true")
+    card.el.setAttribute("role", "option")
+    card.el.setAttribute("aria-label", cardLabel(card.el))
+
+    playActivitySound("reset")
+    refreshSubmit()
+    announceToScreenReader(
+      `${cardLabel(card.el)} ${tr(
+        "sorting-returned",
+        "returned to available options.",
+      )}`,
+    )
+    card.el.focus()
+  }
+
+  // Click toggles between select (bank) and remove (placed).
+  const onCardClick = (card: Card) => {
+    if (card.category !== null) remove(card)
+    else if (selectedId === card.itemId) clearSelection()
+    else select(card)
+  }
+
+  const onCategoryClick = (catId: string) => {
+    if (!selectedId) return
+    const card = cards.get(selectedId)
+    if (card) place(card, catId)
+  }
+
+  // ---- wire listeners + drag-and-drop ------------------------------------
+  const cleanups: Array<() => void> = []
+
+  for (const card of cards.values()) {
+    const onClick = (e: Event) => {
+      e.preventDefault()
+      onCardClick(card)
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault()
+        onCardClick(card)
+      }
+    }
+    card.el.addEventListener("click", onClick)
+    card.el.addEventListener("keydown", onKey)
+    if (!card.el.hasAttribute("tabindex")) card.el.setAttribute("tabindex", "0")
+    if (!card.el.hasAttribute("role")) card.el.setAttribute("role", "option")
+
+    // Images inside cards must not start their own native drag.
+    card.el.querySelectorAll("img").forEach((img) => {
+      img.setAttribute("draggable", "false")
+      ;(img as HTMLElement).style.pointerEvents = "none"
+    })
+
+    // Enforce a clear, consistent draggable-card look. Inline styles override
+    // the renderer's faint border classes, so text, image, and image+text
+    // cards all read as a single rounded, bordered, liftable card.
+    card.el.style.borderRadius = CARD_RADIUS
+    applyPlacementStyle(card.el, false)
+
+    const dndCleanup = draggable({
+      element: card.el,
+      canDrag: () => card.category === null,
+      getInitialData: () => ({ itemId: card.itemId }),
+      onDragStart: () => highlightCategories(true),
+      onDrop: () => highlightCategories(false),
+    })
+
+    cleanups.push(() => {
+      card.el.removeEventListener("click", onClick)
+      card.el.removeEventListener("keydown", onKey)
+      dndCleanup()
+    })
+  }
+
+  for (const category of categories) {
+    const catId = category.getAttribute("data-activity-category")
+    if (!catId) continue
+
+    const onClick = (e: Event) => {
+      // Clicking a placed card inside the category should remove it, not place
+      // a new one — that card's own click handler runs first; bail here.
+      if ((e.target as HTMLElement | null)?.closest(".placed-word")) return
+      onCategoryClick(catId)
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (selectedId && (e.key === "Enter" || e.key === " ")) {
+        e.preventDefault()
+        onCategoryClick(catId)
+      }
+    }
+    category.addEventListener("click", onClick)
+    category.addEventListener("keydown", onKey)
+    if (!category.hasAttribute("tabindex")) category.setAttribute("tabindex", "0")
+    if (!category.hasAttribute("role")) category.setAttribute("role", "listbox")
+
+    const dropCleanup = dropTargetForElements({
+      element: category,
+      getData: () => ({ catId }),
+      onDragEnter: () => {
+        category.classList.add(...CATEGORY_HIGHLIGHT_CLASSES)
+      },
+      onDragLeave: () => {
+        category.classList.remove(...CATEGORY_HIGHLIGHT_CLASSES)
+      },
+      onDrop: ({ source }) => {
+        category.classList.remove(...CATEGORY_HIGHLIGHT_CLASSES)
+        const itemId = source.data.itemId
+        if (typeof itemId !== "string") return
+        const card = cards.get(itemId)
+        if (card) place(card, catId)
+      },
+    })
+
+    cleanups.push(() => {
+      category.removeEventListener("click", onClick)
+      category.removeEventListener("keydown", onKey)
+      dropCleanup()
+    })
+  }
+
+  const markCard = (card: Card, isCorrect: boolean) => {
+    card.el.querySelectorAll(`.${VERDICT_MARK_CLASS}`).forEach((m) => m.remove())
+    setCardBorder(card.el, isCorrect ? CARD_BORDER_CORRECT : CARD_BORDER_INCORRECT)
+    card.el.setAttribute("aria-invalid", isCorrect ? "false" : "true")
+    const mark = document.createElement("span")
+    mark.className = `${VERDICT_MARK_CLASS} ml-2 inline-flex items-center text-lg ${
+      isCorrect ? "text-green-700" : "text-red-700"
+    }`
+    mark.textContent = isCorrect ? "✓" : "✗"
+    mark.setAttribute("aria-hidden", "true")
+    card.el.appendChild(mark)
+  }
+
+  const handleValidate = () => {
+    if (store.get(submitStateAtom) === "next") {
+      const href = findNextPageHref()
+      if (href) window.location.href = href
+      return
+    }
+
+    const placed = [...cards.values()].filter((c) => c.category !== null)
+    if (placed.length === 0) return
+
+    clearAllVerdicts()
+
+    let correct = 0
+    for (const card of placed) {
+      const isCorrect = card.category === correctAnswers[card.itemId]
+      markCard(card, isCorrect)
+      if (isCorrect) correct++
+    }
+
+    const total = cards.size
+    const unplaced = total - placed.length
+    const allCorrect = correct === total
+    validated = true
+
+    playActivitySound(allCorrect ? "success" : "error")
+
+    // total / correct / unfilled feed the shared toast, whose internal
+    // identity wrong = total − correct − unfilled then recovers the incorrect
+    // count. "remaining" relabels the empty bucket for unplaced cards.
+    showActivityProgressToast(
+      { total, correct, unfilled: unplaced },
+      { emptyLabel: tr("activity-progress-remaining", "remaining") },
+    )
+
+    if (allCorrect) {
+      announceToScreenReader(
+        tr("sorting-correct-answer", "Great job! Your answer is correct."),
+      )
+      store.set(confettiTriggerAtom, store.get(confettiTriggerAtom) + 1)
+      store.set(submitStateAtom, "next")
+      store.set(submitLabelAtom, null)
+      store.set(submitEnabledAtom, hasNextPage)
+    } else {
+      announceToScreenReader(
+        unplaced > 0
+          ? tr("sorting-not-complete", "Please place every word before submitting.")
+          : tr("sorting-try-again", "Some words are in the wrong category. Try again."),
+      )
+      refreshSubmit()
+    }
+  }
+
+  const handleSkip = () => {
+    const href = findNextPageHref()
+    if (href) window.location.href = href
+  }
+
+  section.setAttribute("role", "group")
+  const applyLocalizedAria = () => {
+    section.setAttribute(
+      "aria-label",
+      tr("sorting-options-label", "Sort each word into the correct category"),
+    )
+  }
+  applyLocalizedAria()
+
+  store.set(validateHandlerAtom, () => handleValidate)
+  store.set(skipHandlerAtom, () => handleSkip)
+  store.set(submitStateAtom, "submit")
+  store.set(submitLabelAtom, null)
+  store.set(submitEnabledAtom, false)
+  store.set(skipEnabledAtom, hasNextPage)
+
+  const unsubTranslations = store.sub(translationsAtom, applyLocalizedAria)
+
+  const dndCleanup = combine(...cleanups)
+
+  return () => {
+    dndCleanup()
+    unsubTranslations()
+    store.set(validateHandlerAtom, () => null)
+    store.set(skipHandlerAtom, () => null)
+    store.set(submitEnabledAtom, false)
+    store.set(skipEnabledAtom, false)
+  }
+}

--- a/prompts/activity_sorting.liquid
+++ b/prompts/activity_sorting.liquid
@@ -14,11 +14,11 @@ You are an expert frontend engineer creating beautiful, kid-friendly HTML pages 
 ### CRITICAL Requirements
 1. Layout Shell - Start with page wrapper `<div class="flex justify-center items-start min-h-[calc(100dvh-100px)]">`
 2. ONE top-level `<section>` tag with `data-section-type` equal to the provided section type and `data-section-id` equal to the provided section ID. Do NOT add `role="activity"`
-3. Use ONLY provided text IDs and image IDs for `data-id` values (never invent IDs)
-4. ALL text elements MUST have `data-id` matching a provided text ID
+3. Use provided text IDs and image IDs for `data-id` values. The ONE exception: visible text you must generate for the activity (category headings) uses `data-id="activity_gen_<slug>"` — see "Generated category labels" below. Never reuse an unrelated provided ID to label something else.
+4. ALL visible text elements MUST have a `data-id` — either a provided text ID, or an `activity_gen_<slug>` id for text you generate (categories)
 5. ALL images MUST have `data-id` matching a provided image ID
-6. Text for each text ID must match the provided text exactly (no paraphrasing, no added text, no punctuation changes)
-7. Do not output visible raw text outside an element with a valid provided `data-id`
+6. Text for a PROVIDED text ID must match the provided text exactly (no paraphrasing, no added text, no punctuation changes); generated `activity_gen_*` labels are your own concise wording
+7. Do not output visible raw text outside an element that has a `data-id` (a provided one, or an `activity_gen_*` id for generated text)
 8. If validator feedback says an exact expected value (for example section ID), use that exact value
 9. For text leaves, default to `<span>`. Use block elements (`<p>`, `<h1>`–`<h6>`, `<li>`) ONLY when the leaf is semantically a standalone block — a full paragraph of prose, a heading, a list item, or preformatted content. Short labels, captions, option text, and inline fragments MUST use `<span>` to avoid unwanted line breaks. If a `<span>` needs block-level layout, apply `block` or `inline-block` Tailwind classes rather than switching to `<p>`/`<div>`.
 
@@ -37,22 +37,38 @@ IMPORTANT: Your reasoning MUST be written in English, regardless of the activity
 
 **Word Cards (draggable items):**
 - Class: `word-card` (NOT `activity-item`) - REQUIRED
-- Attribute: `data-activity-item="unique-id"` - REQUIRED
-- Attribute: `data-id="text-id"` - REQUIRED
+- Attribute: `data-activity-item="unique-id"` - REQUIRED (on the card wrapper)
 - Attribute: `draggable="true"`
-- Base styling: `text-center border border-gray-300 bg-gray-50 p-2 rounded-md hover:bg-gray-100 cursor-pointer transition duration-300 hover:bg-yellow-300 transform hover:scale-105`
+- Base styling: `text-center border-2 border-slate-400 bg-white p-2 rounded-xl shadow-sm hover:bg-yellow-100 cursor-pointer transition duration-300 transform hover:scale-105` — a card MUST have a clearly visible border (use `border-2` and a mid-tone color like `border-slate-400`, never a faint `border-gray-200`) and rounded corners (`rounded-xl`) so it reads as a draggable card.
+- Use `<p class="word-card" ...>` for a plain text card, or `<div class="word-card" ...>` when the card holds an image (or image + text).
+
+**Word card content — a card can be TEXT, an IMAGE, or BOTH:**
+- A word card is ONE draggable unit. Everything that belongs to a sortable item — its text AND/OR its picture — MUST live INSIDE that item's `word-card`, so it all moves together when the card is dragged into a category.
+- ❌ NEVER place a sortable item's image in a separate column/grid or as a sibling of the card. If a picture identifies a specific item, it goes INSIDE that item's `word-card`.
+- ✅ A single decorative illustration for the WHOLE activity (not tied to one item) may still sit in its own context column — but anything an item is identified by belongs in the card.
+- Put `data-id` on the leaf elements INSIDE the card (the text `<span data-id="...">` and/or the `<img data-id="...">`), not on the `word-card` wrapper. Each `<img>` needs a provided image ID in `data-id` plus a meaningful `alt`.
+- Constrain card images so they fit the card and the category bucket: `class="h-auto max-h-24 w-auto object-contain"`. Stack image-over-text with `flex flex-col items-center gap-2` on the card.
+- Keep the card's text as PLAIN text inside the card. Do NOT wrap it in a colored/grey background pill or chip (e.g. `bg-gray-100 rounded-xl`) — the card's own border is the visual boundary, and an inner background box looks like a separate label.
 
 **Categories (drop zones):**
 - Class: `category` - REQUIRED
 - Attribute: `data-activity-category="category-name"` - REQUIRED
+- Visible heading: a `<label>` (or heading) holding the category name. Category names are usually NOT in the source text, so you GENERATE them — see "Generated category labels" below.
 - Must contain: `<ul class="word-list"></ul>` - REQUIRED (empty initially)
 - Color-coded backgrounds: `bg-yellow-200`, `bg-blue-200`, `bg-green-200`, `bg-red-200`, `bg-purple-200`
 
+**Generated category labels (overrides the "never invent IDs" rule for these only):**
+- Sorting categories are part of the activity you create; their names rarely exist as a provided text ID. For visible text you generate that has no provided text ID — category headings especially — give its element a GENERATED id of the form `data-id="activity_gen_<slug>"` (e.g. `data-id="activity_gen_cat_naturales"`).
+- This is the ONLY sanctioned way to add new visible text. `activity_gen_*` ids are accepted by the validator and are added to the translation catalog, so the label is stored, editable, and translated like any other text.
+- Do NOT emit a category heading as raw text with no `data-id`, and do NOT borrow an unrelated provided text ID just to satisfy the rule.
+- Each `activity_gen_*` id must be unique within the page.
+
 **Layout structure:**
 - Use 3-column grid: `grid grid-cols-3 max-lg:grid-cols-1 gap-4`
-- Image column (if present): `col-span-1`
+- Optional CONTEXT image column (a single illustration for the whole activity): `col-span-1`. Do NOT use this column for per-item images — those go inside the cards.
 - Word bank column: `col-span-1` with `grid grid-cols-2 gap-4` for items
 - Categories column: `col-span-1` with `grid gap-3`
+- When the cards themselves contain images, skip the context column and give the word bank more room (e.g. a 2-column layout of word bank + categories).
 
 Example sorting activity:
 ```html
@@ -74,13 +90,13 @@ Example sorting activity:
     <div class="grid gap-3 activity-text" role="listbox">
       <div class="category bg-yellow-200 border border-yellow-300 rounded p-2 min-h-[3rem]"
            data-activity-category="category1" tabindex="0" role="listbox">
-        <label class="font-semibold text-center" data-id="text-17-12">Category 1</label>
+        <label class="font-semibold text-center" data-id="activity_gen_cat1">Category 1</label>
         <ul class="word-list flex flex-wrap"></ul>
       </div>
 
       <div class="category bg-blue-200 border border-blue-300 rounded p-2 min-h-[3rem]"
            data-activity-category="category2" tabindex="0" role="listbox">
-        <label class="font-semibold text-center" data-id="text-17-13">Category 2</label>
+        <label class="font-semibold text-center" data-id="activity_gen_cat2">Category 2</label>
         <ul class="word-list flex flex-wrap"></ul>
       </div>
     </div>
@@ -88,9 +104,33 @@ Example sorting activity:
 </section>
 ```
 
+Word card content variants (each is a single draggable `word-card`):
+```html
+<!-- Text only -->
+<p class="word-card text-center border-2 border-slate-400 bg-white p-2 rounded-xl shadow-sm hover:bg-yellow-100 cursor-pointer transition duration-300 transform hover:scale-105"
+   data-activity-item="word1" draggable="true" tabindex="0" role="option">
+  <span data-id="text-17-8">Word 1</span>
+</p>
+
+<!-- Image + text (image and text drag together as one card; text stays plain, no background pill) -->
+<div class="word-card flex flex-col items-center gap-2 border-2 border-slate-400 bg-white p-2 rounded-xl shadow-sm hover:bg-yellow-100 cursor-pointer transition duration-300 transform hover:scale-105"
+     data-activity-item="word2" draggable="true" tabindex="0" role="option">
+  <img class="h-auto max-h-24 w-auto object-contain" data-id="img-17-2" src="images/image2.png" alt="Description of word 2">
+  <span data-id="text-17-9">Word 2</span>
+</div>
+
+<!-- Image only (no text leaf — describe the card with aria-label) -->
+<div class="word-card flex items-center justify-center border-2 border-slate-400 bg-white p-2 rounded-xl shadow-sm hover:bg-yellow-100 cursor-pointer transition duration-300 transform hover:scale-105"
+     data-activity-item="word3" draggable="true" tabindex="0" role="option" aria-label="Description of word 3">
+  <img class="h-auto max-h-24 w-auto object-contain" data-id="img-17-3" src="images/image3.png" alt="Description of word 3">
+</div>
+```
+
 **Key requirements:**
 - Word cards use `word-card` class, NOT `activity-item`
-- Each word card needs both `data-activity-item` AND `data-id` attributes
+- Every word card needs `data-activity-item` on the wrapper; the text and image leaves INSIDE carry `data-id`
+- A card's image MUST be nested inside that card's `word-card` (never in a separate column) so the image and text drag as one unit
+- Card images use a provided image ID for `data-id`, a meaningful `alt`, and a size constraint (e.g. `h-auto max-h-24 object-contain`); an image-only card also needs an `aria-label` on the card itself
 - Categories must have `category` class and `data-activity-category` attribute
 - Each category must contain empty `<ul class="word-list"></ul>` for JavaScript functionality
 - Use color-coded category backgrounds for visual differentiation


### PR DESCRIPTION
Ports the last two interactive activities — **sorting** and **matching** — from the legacy reader into `adt-runtime`, each with pointer drag-and-drop plus click/keyboard placement, click-to-remove, validation against `window.correctAnswers`, and dock submit/"next" wiring with confetti, progress toast, and sounds. Sorting cards support text, image, or image+text content (media stays inside the card while dragging) and get an enforced clear bordered/rounded look via inline styles so they read as draggable cards regardless of generated markup; both initializers are wired into the boot lifecycle and covered by new vitest suites (19 tests). It also updates the sorting generation prompt to nest per-item media inside `word-card`s, drop the grey text pill, and label generated category headers with translatable `activity_gen_*` data-ids — fixing a validator "text node outside any data-id" error for invented category names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)