### PR TITLE
feat(studio): add Kosovo and Montenegro variants to Serbian language

### DIFF
--- a/apps/studio/src/lib/languages.ts
+++ b/apps/studio/src/lib/languages.ts
@@ -243,7 +243,9 @@ export const SUPPORTED_LANGUAGES: Language[] = [
   ]},
   { code: "sr", name: "Serbian", countries: [
     { code: "rs", name: "Serbia" },
+    { code: "xk", name: "Kosovo" },
     { code: "ba", name: "Bosnia and Herzegovina" },
+    { code: "me", name: "Montenegro" },
   ]},
   { code: "si", name: "Sinhala", countries: [
     { code: "lk", name: "Sri Lanka" },


### PR DESCRIPTION
Adds Kosovo (`xk`) and Montenegro (`me`) as suggested regional variants for Serbian (`sr`) in `SUPPORTED_LANGUAGES`. Picking these surfaces "Serbian (Kosovo)" / "Serbian (Montenegro)" in the language picker, and that regional display name flows into the LLM language context so the Extract pipeline targets the correct regional dialect. Kosovo was already present in `ALL_COUNTRIES` but was only reachable via the full country list, not as a first-class suggestion. This is a data-only change with no new translatable strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)