### PR TITLE
feat(quizzes): landing-page mode toggle, stackable consecutive quizzes

### DIFF
--- a/apps/api/src/routes/quizzes.ts
+++ b/apps/api/src/routes/quizzes.ts
@@ -116,6 +116,10 @@ export function createQuizRoutes(
   const GenerateOneBody = z.object({
     pageIds: z.array(z.string().min(1)).min(1).max(5),
     afterPageId: z.string().min(1),
+    // "replace" swaps out the quiz(zes) already at this position; "after" stacks
+    // the new quiz right after them so quizzes can sit consecutively (e.g. a run
+    // of quizzes at the end of the book). Defaults to "replace" for back-compat.
+    placement: z.enum(["replace", "after"]).optional().default("replace"),
   })
 
   app.post("/books/:label/quizzes/generate-one", async (c) => {
@@ -147,10 +151,23 @@ export function createQuizRoutes(
         message: `Invalid body: ${parsed.error.message}`,
       })
     }
-    const { pageIds, afterPageId } = parsed.data
+    const { pageIds, afterPageId, placement } = parsed.data
 
     const storage = createBookStorage(safeLabel, booksDir)
     try {
+      // A running quiz-generation stage rewrites the entire quiz set when it
+      // finishes, so a quiz added mid-run would be silently clobbered. Reject
+      // until the run completes (the UI also hides the entry points).
+      const quizStep = storage
+        .getStepRuns()
+        .find((r) => r.step === "quiz-generation")
+      if (quizStep?.status === "running") {
+        throw new HTTPException(409, {
+          message:
+            "Quiz generation is currently running. Wait for it to finish before adding a quiz.",
+        })
+      }
+
       const appConfig = loadBookConfig(safeLabel, booksDir, configPath)
       const metadataRow = storage.getLatestNodeData("metadata", "book")
       const metadata = metadataRow?.data as { language_code?: string | null } | null
@@ -211,20 +228,22 @@ export function createQuizRoutes(
       const newQuiz: Quiz = { ...generated, afterPageId }
 
       // Add to the existing quiz set (or start a fresh one). A position can hold
-      // at most one quiz, so a new quiz at an occupied afterPageId replaces the
-      // one already there. Then re-order by book position and renumber so
-      // quizIndex stays sequential.
+      // multiple quizzes shown one after another. With placement "after" the new
+      // quiz is appended so it lands after any quizzes already at this position;
+      // with "replace" the quiz(zes) currently at this position are dropped first.
+      // Then re-order by book position and renumber so quizIndex stays sequential.
+      // The sort is stable, so quizzes sharing an afterPageId keep their relative
+      // order and the appended quiz stays last among them.
       const existingRow = storage.getLatestNodeData("quiz-generation", "book")
       const existing = existingRow
         ? (existingRow.data as QuizGenerationOutput)
         : null
 
-      const quizzes = [
-        ...(existing?.quizzes ?? []).filter(
-          (q) => q.afterPageId !== afterPageId
-        ),
-        newQuiz,
-      ]
+      const priorQuizzes =
+        placement === "after"
+          ? (existing?.quizzes ?? [])
+          : (existing?.quizzes ?? []).filter((q) => q.afterPageId !== afterPageId)
+      const quizzes = [...priorQuizzes, newQuiz]
       quizzes.sort(
         (a, b) =>
           (pageNumberById.get(a.afterPageId) ?? 0) -
@@ -242,6 +261,10 @@ export function createQuizRoutes(
       }
 
       const version = storage.putNodeData("quiz-generation", "book", output)
+      // Adding a quiz by hand produces the same output as running the stage, so
+      // mark the step done — otherwise the quizzes stage never lights up as
+      // completed for books whose quizzes were all added one at a time.
+      storage.markStepCompleted("quiz-generation")
       return c.json({ quiz: newQuiz, version })
     } finally {
       storage.close()

--- a/apps/studio/src/api/client.ts
+++ b/apps/studio/src/api/client.ts
@@ -933,7 +933,11 @@ export const api = {
   generateQuiz: (
     label: string,
     apiKey: string,
-    body: { pageIds: string[]; afterPageId: string },
+    body: {
+      pageIds: string[]
+      afterPageId: string
+      placement?: "replace" | "after"
+    },
     providerCredentials?: StageRunProviderCredentials
   ) =>
     request<{ quiz: QuizItem; version: number }>(

--- a/apps/studio/src/components/pipeline/stages/quizzes/AddQuizDialog.tsx
+++ b/apps/studio/src/components/pipeline/stages/quizzes/AddQuizDialog.tsx
@@ -15,6 +15,10 @@ import { api } from "@/api/client"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import {
+  SegmentedControl,
+  type SegmentedControlOption,
+} from "@/components/ui/segmented-control"
+import {
   Dialog,
   DialogContent,
   DialogFooter,
@@ -24,10 +28,13 @@ import {
 import { usePages, usePageImage } from "@/hooks/use-pages"
 import { useQuizzes } from "@/hooks/use-quizzes"
 import { useApiKey } from "@/hooks/use-api-key"
+import { useStageStatus } from "@/hooks/use-stage-status"
 
 const MAX_SOURCE_PAGES = 5
 
 type PageRef = { pageId: string; pageNumber: number }
+/** How a new quiz relates to quizzes already sitting at the chosen position. */
+type QuizPlacement = "after" | "replace"
 
 /** A page thumbnail in the bottom filmstrip. Click navigates; the corner badge toggles selection. */
 function FilmstripThumb({
@@ -149,7 +156,7 @@ function InsertGap({
       aria-pressed={active}
       title={
         hasExistingQuiz
-          ? t`A quiz already sits here — generating will replace it`
+          ? t`A quiz already sits here — add another after it or replace it`
           : t`Insert the quiz here`
       }
       className="group relative flex h-28 w-8 shrink-0 items-center justify-center"
@@ -209,12 +216,17 @@ export function AddQuizDialog({
   } = useApiKey()
   const queryClient = useQueryClient()
   const navigate = useNavigate()
+  // A running (or queued) quiz-generation stage rewrites the whole quiz set when
+  // it finishes, which would clobber a hand-added quiz — so block adding until
+  // it's done.
+  const { isRunning: stageRunning } = useStageStatus("quizzes")
 
   const [selected, setSelected] = useState<string[]>([])
   const [afterPageId, setAfterPageId] = useState("")
   const [afterTouched, setAfterTouched] = useState(false)
   const [currentIndex, setCurrentIndex] = useState(0)
   const [generating, setGenerating] = useState(false)
+  const [placement, setPlacement] = useState<QuizPlacement>("after")
   const [error, setError] = useState<string | null>(null)
 
   const renderedPages = useMemo(
@@ -222,12 +234,16 @@ export function AddQuizDialog({
     [pages]
   )
 
-  // Positions (afterPageId) that already hold a quiz. Generating at one of
-  // these replaces the quiz there instead of adding a second one.
-  const occupiedAfterPageIds = useMemo(
-    () => new Set((existingQuizzes?.quizzes?.quizzes ?? []).map((q) => q.afterPageId)),
-    [existingQuizzes]
-  )
+  // How many quizzes already sit at each position (afterPageId). A position can
+  // hold several quizzes shown one after another, so generating at an occupied
+  // spot lets the user stack a new quiz after them or replace what's there.
+  const quizCountByAfterPageId = useMemo(() => {
+    const counts = new Map<string, number>()
+    for (const q of existingQuizzes?.quizzes?.quizzes ?? []) {
+      counts.set(q.afterPageId, (counts.get(q.afterPageId) ?? 0) + 1)
+    }
+    return counts
+  }, [existingQuizzes])
 
   useEffect(() => {
     if (open) {
@@ -236,6 +252,7 @@ export function AddQuizDialog({
       setAfterTouched(false)
       setCurrentIndex(0)
       setGenerating(false)
+      setPlacement("after")
       setError(null)
     }
   }, [open])
@@ -256,7 +273,23 @@ export function AddQuizDialog({
 
   const current = renderedPages[currentIndex] as PageRef | undefined
   const atLimit = selected.length >= MAX_SOURCE_PAGES
-  const willReplace = !!afterPageId && occupiedAfterPageIds.has(afterPageId)
+  const occupiedCount = afterPageId
+    ? quizCountByAfterPageId.get(afterPageId) ?? 0
+    : 0
+  const isOccupied = occupiedCount > 0
+
+  const placementOptions: SegmentedControlOption<QuizPlacement>[] = [
+    { value: "after", label: t`Add after` },
+    { value: "replace", label: t`Replace` },
+  ]
+
+  const generateLabel = !isOccupied
+    ? t`Generate quiz`
+    : placement === "replace"
+      ? occupiedCount > 1
+        ? t`Replace quizzes`
+        : t`Replace quiz`
+      : t`Add quiz here`
 
   const { data: currentImage } = usePageImage(bookLabel, current?.pageId ?? "", {
     enabled: !!current,
@@ -281,17 +314,30 @@ export function AddQuizDialog({
   const pickPlacement = (pageId: string) => {
     setAfterTouched(true)
     setAfterPageId(pageId)
+    // Each newly chosen position starts on the additive (non-destructive) action.
+    setPlacement("after")
   }
 
   const handleGenerate = async () => {
-    if (!hasApiKey || selected.length === 0 || !afterPageId || generating) return
+    if (
+      !hasApiKey ||
+      selected.length === 0 ||
+      !afterPageId ||
+      generating ||
+      stageRunning
+    )
+      return
     setGenerating(true)
     setError(null)
     try {
       await api.generateQuiz(
         bookLabel,
         apiKey,
-        { pageIds: selected, afterPageId },
+        {
+          pageIds: selected,
+          afterPageId,
+          placement: isOccupied ? placement : "after",
+        },
         {
           anthropicApiKey: anthropicKey || undefined,
           googleApiKey: googleKey || undefined,
@@ -300,9 +346,16 @@ export function AddQuizDialog({
           geminiApiKey: geminiKey || undefined,
         }
       )
-      await queryClient.invalidateQueries({
-        queryKey: ["books", bookLabel, "quizzes"],
-      })
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: ["books", bookLabel, "quizzes"],
+        }),
+        // Adding a quiz marks the quiz-generation step done server-side; refresh
+        // step-status so the quizzes stage lights up as completed right away.
+        queryClient.invalidateQueries({
+          queryKey: ["books", bookLabel, "step-status"],
+        }),
+      ])
       onOpenChange(false)
       navigate({
         to: "/books/$label/$step",
@@ -454,7 +507,9 @@ export function AddQuizDialog({
                     />
                     <InsertGap
                       active={afterPageId === page.pageId}
-                      hasExistingQuiz={occupiedAfterPageIds.has(page.pageId)}
+                      hasExistingQuiz={
+                        (quizCountByAfterPageId.get(page.pageId) ?? 0) > 0
+                      }
                       onSelect={() => pickPlacement(page.pageId)}
                     />
                   </div>
@@ -464,12 +519,32 @@ export function AddQuizDialog({
           </>
         )}
 
-        {willReplace && !generating && (
+        {stageRunning && (
           <div className="mx-6 flex items-start gap-2 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-800">
-            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden />
+            <Loader2 className="mt-0.5 h-4 w-4 shrink-0 animate-spin" aria-hidden />
             <span>
-              {t`A quiz already exists at this position. Generating will replace the current quiz here.`}
+              {t`Quizzes are generating. Wait for the run to finish before adding a quiz.`}
             </span>
+          </div>
+        )}
+
+        {isOccupied && !generating && !stageRunning && (
+          <div className="mx-6 flex flex-col gap-2.5 rounded-md border border-amber-200 bg-amber-50/70 px-3 py-2.5">
+            <div className="flex items-start gap-2 text-sm text-amber-800">
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden />
+              <span>
+                {occupiedCount > 1
+                  ? t`This position already has ${occupiedCount} quizzes. Add another after them, or replace them.`
+                  : t`This position already has a quiz. Add another right after it, or replace it.`}
+              </span>
+            </div>
+            <SegmentedControl
+              options={placementOptions}
+              value={placement}
+              onValueChange={setPlacement}
+              color="#ea580c"
+              className="h-9 max-w-xs"
+            />
           </div>
         )}
 
@@ -488,7 +563,11 @@ export function AddQuizDialog({
           <Button
             onClick={handleGenerate}
             disabled={
-              generating || !hasApiKey || selected.length === 0 || !afterPageId
+              generating ||
+              !hasApiKey ||
+              selected.length === 0 ||
+              !afterPageId ||
+              stageRunning
             }
             className="border-0 bg-orange-600 text-white hover:bg-orange-700"
           >
@@ -497,10 +576,8 @@ export function AddQuizDialog({
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                 {t`Generating…`}
               </>
-            ) : willReplace ? (
-              t`Replace quiz`
             ) : (
-              t`Generate quiz`
+              generateLabel
             )}
           </Button>
         </DialogFooter>

--- a/apps/studio/src/components/pipeline/stages/quizzes/QuizzesLandingPage.tsx
+++ b/apps/studio/src/components/pipeline/stages/quizzes/QuizzesLandingPage.tsx
@@ -1,6 +1,12 @@
 import { useState, useEffect } from "react"
+import { Plus } from "lucide-react"
 import { Trans, useLingui } from "@lingui/react/macro"
+import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
+import {
+  SegmentedControl,
+  type SegmentedControlOption,
+} from "@/components/ui/segmented-control"
 import { LandingPageShell } from "@/components/pipeline/components/LandingPageShell"
 import { PrereqGuard } from "@/components/pipeline/components/PrereqGuard"
 import {
@@ -14,8 +20,11 @@ import { useBookRun } from "@/hooks/use-book-run"
 import { useApiKey } from "@/hooks/use-api-key"
 import { usePersistConfig } from "@/hooks/use-persist-config"
 import { QuizzesPreview } from "./components/QuizzesPreview"
+import { AddQuizDialog } from "./AddQuizDialog"
 
 const DEFAULT_PAGES_PER_QUIZ = 3
+
+type QuizMode = "frequency" | "specific"
 
 export function QuizzesLandingPage({ bookLabel }: { bookLabel: string }) {
   const { t } = useLingui()
@@ -28,6 +37,8 @@ export function QuizzesLandingPage({ bookLabel }: { bookLabel: string }) {
   const storyboardStatus = useStageStatus("storyboard")
   const storyboardReady = storyboardStatus.isCompleted
 
+  const [mode, setMode] = useState<QuizMode>("frequency")
+  const [showAddQuiz, setShowAddQuiz] = useState(false)
   const [pagesPerQuiz, setPagesPerQuiz] = useState(String(DEFAULT_PAGES_PER_QUIZ))
 
   useEffect(() => {
@@ -60,7 +71,14 @@ export function QuizzesLandingPage({ bookLabel }: { bookLabel: string }) {
       Run Storyboard first — quizzes are written from the content placed into
       pages by Storyboard.
     </Trans>
+  ) : status.isRunning ? (
+    <Trans>Quizzes are generating. Wait for the run to finish before adding a quiz.</Trans>
   ) : undefined
+
+  const modeOptions: SegmentedControlOption<QuizMode>[] = [
+    { value: "frequency", label: t`Every few pages` },
+    { value: "specific", label: t`Specific pages` },
+  ]
 
   return (
     <LandingPageShell
@@ -80,7 +98,8 @@ export function QuizzesLandingPage({ bookLabel }: { bookLabel: string }) {
       rerunLabel={<Trans>Re-run</Trans>}
       previewLabel={t`Quiz Preview`}
       onRun={handleRun}
-      preview={<QuizzesPreview pagesPerQuiz={Number(pagesPerQuiz)} />}
+      hideRunButton={mode === "specific"}
+      preview={<QuizzesPreview pagesPerQuiz={Number(pagesPerQuiz)} mode={mode} />}
     >
       <div className="flex flex-col gap-2">
         <h1 className="text-[26px] font-semibold leading-tight tracking-tight text-[#0a0a0a]">
@@ -89,8 +108,8 @@ export function QuizzesLandingPage({ bookLabel }: { bookLabel: string }) {
         <p className="text-[14px] text-[#737373] leading-relaxed">
           <Trans>
             Generate multiple-choice comprehension quizzes from the book's
-            content. Set how often a quiz appears, then run the stage to create
-            them across the whole book.
+            content. Create them automatically across the whole book, or add a
+            single quiz from specific pages.
           </Trans>
         </p>
       </div>
@@ -108,28 +127,83 @@ export function QuizzesLandingPage({ bookLabel }: { bookLabel: string }) {
 
       <SettingsCard>
         <SettingsField
-          label={<Trans>Quiz frequency</Trans>}
+          label={<Trans>How to add quizzes</Trans>}
           hint={
-            <Trans>
-              How many pages of content go into each quiz. A lower number means
-              more quizzes across the book.
-            </Trans>
+            mode === "frequency" ? (
+              <Trans>
+                Automatically create quizzes across the whole book at a set
+                frequency.
+              </Trans>
+            ) : (
+              <Trans>
+                Create one quiz from specific pages and place it exactly where
+                you want it in the book.
+              </Trans>
+            )
           }
         >
-          <div className="flex items-center gap-2">
-            <Input
-              type="number"
-              min={1}
-              value={pagesPerQuiz}
-              onChange={(e) => handleFrequencyChange(e.target.value)}
-              className="w-24 h-9"
-            />
-            <span className="text-[13px] text-[#737373]">
-              <Trans>pages per quiz</Trans>
-            </span>
-          </div>
+          <SegmentedControl
+            options={modeOptions}
+            value={mode}
+            onValueChange={setMode}
+          />
         </SettingsField>
+
+        {mode === "frequency" ? (
+          <SettingsField
+            label={<Trans>Quiz frequency</Trans>}
+            hint={
+              <Trans>
+                How many pages of content go into each quiz. A lower number
+                means more quizzes across the book.
+              </Trans>
+            }
+          >
+            <div className="flex items-center gap-2">
+              <Input
+                type="number"
+                min={1}
+                value={pagesPerQuiz}
+                onChange={(e) => handleFrequencyChange(e.target.value)}
+                className="w-24 h-9"
+              />
+              <span className="text-[13px] text-[#737373]">
+                <Trans>pages per quiz</Trans>
+              </span>
+            </div>
+          </SettingsField>
+        ) : (
+          <SettingsField
+            label={<Trans>Add a quiz</Trans>}
+            hint={
+              <Trans>
+                Choose the source pages and where the quiz lands in the page
+                editor.
+              </Trans>
+            }
+          >
+            <Button
+              onClick={() => setShowAddQuiz(true)}
+              disabled={!hasApiKey || !storyboardReady || status.isRunning}
+              className="h-10 gap-1.5 border-0 bg-orange-600 px-4 text-white hover:bg-orange-700"
+            >
+              <Plus className="h-4 w-4" />
+              <Trans>Add a quiz</Trans>
+            </Button>
+            {disabledReason && (
+              <p className="text-xs text-[#737373] leading-relaxed">
+                {disabledReason}
+              </p>
+            )}
+          </SettingsField>
+        )}
       </SettingsCard>
+
+      <AddQuizDialog
+        open={showAddQuiz}
+        onOpenChange={setShowAddQuiz}
+        bookLabel={bookLabel}
+      />
     </LandingPageShell>
   )
 }

--- a/apps/studio/src/components/pipeline/stages/quizzes/QuizzesSettings.tsx
+++ b/apps/studio/src/components/pipeline/stages/quizzes/QuizzesSettings.tsx
@@ -17,6 +17,7 @@ import {
 import { useBookConfig, useUpdateBookConfig } from "@/hooks/use-book-config"
 import { useActiveConfig } from "@/hooks/use-debug"
 import { useApiKey } from "@/hooks/use-api-key"
+import { useStageStatus } from "@/hooks/use-stage-status"
 import { api } from "@/api/client"
 import { PromptViewer } from "@/components/pipeline/components/PromptViewer"
 import { useBookRun } from "@/hooks/use-book-run"
@@ -39,6 +40,7 @@ export function QuizzesSettings({ bookLabel, headerTarget, tab = "general" }: { 
   const updateConfig = useUpdateBookConfig()
   const { apiKey, hasApiKey } = useApiKey()
   const { queueRun } = useBookRun()
+  const quizzesStatus = useStageStatus("quizzes")
   const navigate = useNavigate()
   const [showRerunDialog, setShowRerunDialog] = useState(false)
   const [showAddQuiz, setShowAddQuiz] = useState(false)
@@ -159,18 +161,22 @@ export function QuizzesSettings({ bookLabel, headerTarget, tab = "general" }: { 
                 size="sm"
                 variant="outline"
                 className="h-8 shrink-0 gap-1.5"
-                disabled={!hasApiKey}
+                disabled={!hasApiKey || quizzesStatus.isRunning}
                 onClick={() => setShowAddQuiz(true)}
               >
                 <Plus className="h-3.5 w-3.5" />
                 {t`Add quiz`}
               </Button>
             </div>
-            {!hasApiKey && (
+            {!hasApiKey ? (
               <p className="text-xs text-muted-foreground">
                 {t`Add an API key in Book settings to generate a quiz.`}
               </p>
-            )}
+            ) : quizzesStatus.isRunning ? (
+              <p className="text-xs text-muted-foreground">
+                {t`Quizzes are generating. Wait for the run to finish before adding a quiz.`}
+              </p>
+            ) : null}
           </div>
 
           {sectionTypeKeys.length > 0 && (

--- a/apps/studio/src/components/pipeline/stages/quizzes/components/QuizIndex.tsx
+++ b/apps/studio/src/components/pipeline/stages/quizzes/components/QuizIndex.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button"
 import { useQuizzes } from "@/hooks/use-quizzes"
 import { usePages } from "@/hooks/use-pages"
 import { useApiKey } from "@/hooks/use-api-key"
+import { useStageStatus } from "@/hooks/use-stage-status"
 import type { QuizItem } from "@/api/client"
 import { formatPageNumbers } from "../lib/format-page-numbers"
 import { AddQuizDialog } from "../AddQuizDialog"
@@ -185,6 +186,7 @@ export function QuizIndex({
   const { data } = useQuizzes(bookLabel)
   const { data: pages } = usePages(bookLabel)
   const { hasApiKey } = useApiKey()
+  const quizzesStatus = useStageStatus("quizzes")
   const [showAdd, setShowAdd] = useState(false)
   const quizzes = data?.quizzes?.quizzes ?? []
 
@@ -205,8 +207,14 @@ export function QuizIndex({
           variant="outline"
           size="sm"
           className="h-7 w-full gap-1.5 text-xs"
-          disabled={!hasApiKey}
-          title={hasApiKey ? undefined : t`Add an API key in Book settings to add a quiz.`}
+          disabled={!hasApiKey || quizzesStatus.isRunning}
+          title={
+            !hasApiKey
+              ? t`Add an API key in Book settings to add a quiz.`
+              : quizzesStatus.isRunning
+                ? t`Quizzes are generating. Wait for the run to finish before adding a quiz.`
+                : undefined
+          }
           onClick={() => setShowAdd(true)}
         >
           <Plus className="h-3.5 w-3.5" />

--- a/apps/studio/src/components/pipeline/stages/quizzes/components/QuizzesPreview.tsx
+++ b/apps/studio/src/components/pipeline/stages/quizzes/components/QuizzesPreview.tsx
@@ -17,7 +17,13 @@ const SAMPLE_OPTIONS: SampleOption[] = [
   { text: msg`They release oxygen directly into the air.` },
 ]
 
-export function QuizzesPreview({ pagesPerQuiz }: { pagesPerQuiz: number }) {
+export function QuizzesPreview({
+  pagesPerQuiz,
+  mode = "frequency",
+}: {
+  pagesPerQuiz: number
+  mode?: "frequency" | "specific"
+}) {
   const frequency = Number.isFinite(pagesPerQuiz) && pagesPerQuiz > 0 ? pagesPerQuiz : 3
 
   return (
@@ -36,7 +42,11 @@ export function QuizzesPreview({ pagesPerQuiz }: { pagesPerQuiz: number }) {
               <Trans>Quiz</Trans>
             </h2>
             <span className="ml-auto text-[10px] font-medium text-[#a3a3a3]">
-              <Trans>1 quiz / {frequency} pages</Trans>
+              {mode === "specific" ? (
+                <Trans>Single quiz</Trans>
+              ) : (
+                <Trans>1 quiz / {frequency} pages</Trans>
+              )}
             </span>
           </div>
 

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -412,11 +412,14 @@ msgstr "A new version is available for download."
 msgid "A question worth asking"
 msgstr "A question worth asking"
 
-msgid "A quiz already exists at this position. Generating will replace the current quiz here."
-msgstr "A quiz already exists at this position. Generating will replace the current quiz here."
+#~ msgid "A quiz already exists at this position. Generating will replace the current quiz here."
+#~ msgstr "A quiz already exists at this position. Generating will replace the current quiz here."
 
-msgid "A quiz already sits here — generating will replace it"
-msgstr "A quiz already sits here — generating will replace it"
+msgid "A quiz already sits here — add another after it or replace it"
+msgstr "A quiz already sits here — add another after it or replace it"
+
+#~ msgid "A quiz already sits here — generating will replace it"
+#~ msgstr "A quiz already sits here — generating will replace it"
 
 msgid "A scenic view at dusk."
 msgstr "A scenic view at dusk."
@@ -614,6 +617,9 @@ msgstr "Add a language to see translations appear here."
 msgid "Add a quiz"
 msgstr "Add a quiz"
 
+msgid "Add after"
+msgstr "Add after"
+
 msgid "Add an API key in Book settings to add a quiz."
 msgstr "Add an API key in Book settings to add a quiz."
 
@@ -688,6 +694,9 @@ msgstr "Add languages to translate the book content into."
 
 msgid "Add quiz"
 msgstr "Add quiz"
+
+msgid "Add quiz here"
+msgstr "Add quiz here"
 
 msgid "Add reviewer guidance."
 msgstr "Add reviewer guidance."
@@ -1046,6 +1055,9 @@ msgstr "Auto-scroll"
 msgid "Automatically adapts the layout based on each page's content using AI."
 msgstr "Automatically adapts the layout based on each page's content using AI."
 
+msgid "Automatically create quizzes across the whole book at a set frequency."
+msgstr "Automatically create quizzes across the whole book at a set frequency."
+
 msgid "Avg Duration"
 msgstr "Avg Duration"
 
@@ -1352,6 +1364,9 @@ msgstr "Choose images..."
 msgid "Choose Provider"
 msgstr "Choose Provider"
 
+msgid "Choose the source pages and where the quiz lands in the page editor."
+msgstr "Choose the source pages and where the quiz lands in the page editor."
+
 #~ msgid "Choose up to {MAX_SOURCE_PAGES} pages whose content the quiz question is based on."
 #~ msgstr "Choose up to {MAX_SOURCE_PAGES} pages whose content the quiz question is based on."
 
@@ -1627,6 +1642,9 @@ msgstr "Create descriptive captions for images to improve accessibility."
 
 msgid "Create from scratch using your description"
 msgstr "Create from scratch using your description"
+
+msgid "Create one quiz from specific pages and place it exactly where you want it in the book."
+msgstr "Create one quiz from specific pages and place it exactly where you want it in the book."
 
 msgid "Create session"
 msgstr "Create session"
@@ -2141,6 +2159,9 @@ msgstr "Est. Cost"
 msgid "Evaporation"
 msgstr "Evaporation"
 
+msgid "Every few pages"
+msgstr "Every few pages"
+
 msgid "Every notable concept and named entity."
 msgstr "Every notable concept and named entity."
 
@@ -2450,8 +2471,11 @@ msgstr "Generate from pages"
 msgid "Generate missing Gemini audio"
 msgstr "Generate missing Gemini audio"
 
-msgid "Generate multiple-choice comprehension quizzes from the book's content. Set how often a quiz appears, then run the stage to create them across the whole book."
-msgstr "Generate multiple-choice comprehension quizzes from the book's content. Set how often a quiz appears, then run the stage to create them across the whole book."
+msgid "Generate multiple-choice comprehension quizzes from the book's content. Create them automatically across the whole book, or add a single quiz from specific pages."
+msgstr "Generate multiple-choice comprehension quizzes from the book's content. Create them automatically across the whole book, or add a single quiz from specific pages."
+
+#~ msgid "Generate multiple-choice comprehension quizzes from the book's content. Set how often a quiz appears, then run the stage to create them across the whole book."
+#~ msgstr "Generate multiple-choice comprehension quizzes from the book's content. Set how often a quiz appears, then run the stage to create them across the whole book."
 
 msgid "Generate new"
 msgstr "Generate new"
@@ -2626,6 +2650,9 @@ msgstr "How it works"
 
 msgid "How many pages of content go into each quiz. A lower number means more quizzes across the book."
 msgstr "How many pages of content go into each quiz. A lower number means more quizzes across the book."
+
+msgid "How to add quizzes"
+msgstr "How to add quizzes"
 
 msgid "HTML"
 msgstr "HTML"
@@ -4254,6 +4281,9 @@ msgstr "Quiz Section Types"
 msgid "Quizzes"
 msgstr "Quizzes"
 
+msgid "Quizzes are generating. Wait for the run to finish before adding a quiz."
+msgstr "Quizzes are generating. Wait for the run to finish before adding a quiz."
+
 msgid "Quizzes are linked to other pages in this book"
 msgstr "Quizzes are linked to other pages in this book"
 
@@ -4488,6 +4518,9 @@ msgstr "Replace PDF"
 
 msgid "Replace quiz"
 msgstr "Replace quiz"
+
+msgid "Replace quizzes"
+msgstr "Replace quizzes"
 
 msgid "Replace this audio file"
 msgstr "Replace this audio file"
@@ -5135,6 +5168,9 @@ msgstr "Single Mode"
 msgid "Single Page"
 msgstr "Single Page"
 
+msgid "Single quiz"
+msgstr "Single quiz"
+
 msgid "Single value"
 msgstr "Single value"
 
@@ -5216,6 +5252,9 @@ msgstr "Spanish"
 
 msgid "Specialized workflows"
 msgstr "Specialized workflows"
+
+msgid "Specific pages"
+msgstr "Specific pages"
 
 msgid "Speech"
 msgstr "Speech"
@@ -5663,6 +5702,12 @@ msgstr "This page has not been reviewed yet"
 
 msgid "This permanently deletes every uploaded video and clears all section assignments. This can't be undone."
 msgstr "This permanently deletes every uploaded video and clears all section assignments. This can't be undone."
+
+msgid "This position already has {occupiedCount} quizzes. Add another after them, or replace them."
+msgstr "This position already has {occupiedCount} quizzes. Add another after them, or replace them."
+
+msgid "This position already has a quiz. Add another right after it, or replace it."
+msgstr "This position already has a quiz. Add another right after it, or replace it."
 
 msgid "This prompt instructs the LLM how to evaluate the rendered HTML against the original page. Selection above controls which template is used."
 msgstr "This prompt instructs the LLM how to evaluate the rendered HTML against the original page. Selection above controls which template is used."

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -412,11 +412,14 @@ msgstr "Una nueva versión está disponible para descargar."
 msgid "A question worth asking"
 msgstr "Una pregunta que vale la pena hacer"
 
-msgid "A quiz already exists at this position. Generating will replace the current quiz here."
-msgstr "Ya existe un cuestionario en esta posición. Al generarlo se reemplazará el cuestionario actual."
+#~ msgid "A quiz already exists at this position. Generating will replace the current quiz here."
+#~ msgstr "Ya existe un cuestionario en esta posición. Al generarlo se reemplazará el cuestionario actual."
 
-msgid "A quiz already sits here — generating will replace it"
-msgstr "Aquí ya hay un cuestionario; al generarlo se reemplazará"
+msgid "A quiz already sits here — add another after it or replace it"
+msgstr "Aquí ya hay un cuestionario; añade otro después o reemplázalo"
+
+#~ msgid "A quiz already sits here — generating will replace it"
+#~ msgstr "Aquí ya hay un cuestionario; al generarlo se reemplazará"
 
 msgid "A scenic view at dusk."
 msgstr "Una vista panorámica al anochecer."
@@ -614,6 +617,9 @@ msgstr "Añade un idioma para ver las traducciones aquí."
 msgid "Add a quiz"
 msgstr "Añadir un cuestionario"
 
+msgid "Add after"
+msgstr "Añadir después"
+
 msgid "Add an API key in Book settings to add a quiz."
 msgstr "Añade una clave de API en los ajustes del libro para agregar un cuestionario."
 
@@ -688,6 +694,9 @@ msgstr "Agrega idiomas para traducir el contenido del libro."
 
 msgid "Add quiz"
 msgstr "Añadir cuestionario"
+
+msgid "Add quiz here"
+msgstr "Añadir cuestionario aquí"
 
 msgid "Add reviewer guidance."
 msgstr "Añade orientación para el revisor."
@@ -1046,6 +1055,9 @@ msgstr "Desplazamiento automático"
 msgid "Automatically adapts the layout based on each page's content using AI."
 msgstr "Adapta automáticamente el diseño según el contenido de cada página usando IA."
 
+msgid "Automatically create quizzes across the whole book at a set frequency."
+msgstr "Crea cuestionarios automáticamente en todo el libro con una frecuencia determinada."
+
 msgid "Avg Duration"
 msgstr "Duración media"
 
@@ -1352,6 +1364,9 @@ msgstr "Elegir imágenes..."
 msgid "Choose Provider"
 msgstr "Elegir proveedor"
 
+msgid "Choose the source pages and where the quiz lands in the page editor."
+msgstr "Elige las páginas de origen y dónde se ubica el cuestionario en el editor de páginas."
+
 #~ msgid "Choose up to {MAX_SOURCE_PAGES} pages whose content the quiz question is based on."
 #~ msgstr "Elige hasta {MAX_SOURCE_PAGES} páginas en cuyo contenido se basará la pregunta del cuestionario."
 
@@ -1627,6 +1642,9 @@ msgstr "Crea subtítulos descriptivos para las imágenes para mejorar la accesib
 
 msgid "Create from scratch using your description"
 msgstr "Crear desde cero con tu descripción"
+
+msgid "Create one quiz from specific pages and place it exactly where you want it in the book."
+msgstr "Crea un único cuestionario a partir de páginas específicas y colócalo exactamente donde quieras dentro del libro."
 
 msgid "Create session"
 msgstr "Crear sesión"
@@ -2141,6 +2159,9 @@ msgstr "Costo estimado"
 msgid "Evaporation"
 msgstr "Evaporación"
 
+msgid "Every few pages"
+msgstr "Cada pocas páginas"
+
 msgid "Every notable concept and named entity."
 msgstr "Cada concepto notable y entidad nombrada."
 
@@ -2450,8 +2471,11 @@ msgstr "Generar desde páginas"
 msgid "Generate missing Gemini audio"
 msgstr "Generar audio de Gemini faltante"
 
-msgid "Generate multiple-choice comprehension quizzes from the book's content. Set how often a quiz appears, then run the stage to create them across the whole book."
-msgstr "Genera cuestionarios de comprensión de opción múltiple a partir del contenido del libro. Define con qué frecuencia aparece un cuestionario y luego ejecuta la etapa para crearlos en todo el libro."
+msgid "Generate multiple-choice comprehension quizzes from the book's content. Create them automatically across the whole book, or add a single quiz from specific pages."
+msgstr "Genera cuestionarios de comprensión de opción múltiple a partir del contenido del libro. Créalos automáticamente en todo el libro o añade un único cuestionario a partir de páginas específicas."
+
+#~ msgid "Generate multiple-choice comprehension quizzes from the book's content. Set how often a quiz appears, then run the stage to create them across the whole book."
+#~ msgstr "Genera cuestionarios de comprensión de opción múltiple a partir del contenido del libro. Define con qué frecuencia aparece un cuestionario y luego ejecuta la etapa para crearlos en todo el libro."
 
 msgid "Generate new"
 msgstr "Generar nueva"
@@ -2626,6 +2650,9 @@ msgstr "Cómo funciona"
 
 msgid "How many pages of content go into each quiz. A lower number means more quizzes across the book."
 msgstr "Cuántas páginas de contenido entran en cada cuestionario. Un número menor significa más cuestionarios a lo largo del libro."
+
+msgid "How to add quizzes"
+msgstr "Cómo añadir cuestionarios"
 
 msgid "HTML"
 msgstr "HTML"
@@ -4254,6 +4281,9 @@ msgstr "Tipos de sección del quiz"
 msgid "Quizzes"
 msgstr "Cuestionarios"
 
+msgid "Quizzes are generating. Wait for the run to finish before adding a quiz."
+msgstr "Se están generando los cuestionarios. Espera a que termine la ejecución antes de añadir un cuestionario."
+
 msgid "Quizzes are linked to other pages in this book"
 msgstr "Los quizzes están vinculados a otras páginas de este libro"
 
@@ -4488,6 +4518,9 @@ msgstr "Reemplazar PDF"
 
 msgid "Replace quiz"
 msgstr "Reemplazar cuestionario"
+
+msgid "Replace quizzes"
+msgstr "Reemplazar cuestionarios"
 
 msgid "Replace this audio file"
 msgstr "Reemplazar este archivo de audio"
@@ -5135,6 +5168,9 @@ msgstr "Modo Único"
 msgid "Single Page"
 msgstr "Página Única"
 
+msgid "Single quiz"
+msgstr "Cuestionario único"
+
 msgid "Single value"
 msgstr "Valor único"
 
@@ -5216,6 +5252,9 @@ msgstr "Español"
 
 msgid "Specialized workflows"
 msgstr "Flujos de trabajo especializados"
+
+msgid "Specific pages"
+msgstr "Páginas específicas"
 
 msgid "Speech"
 msgstr "Voz"
@@ -5663,6 +5702,12 @@ msgstr "Esta página aún no se ha revisado"
 
 msgid "This permanently deletes every uploaded video and clears all section assignments. This can't be undone."
 msgstr "Esto elimina permanentemente cada video subido y borra todas las asignaciones de secciones. Esto no se puede deshacer."
+
+msgid "This position already has {occupiedCount} quizzes. Add another after them, or replace them."
+msgstr "Esta posición ya tiene {occupiedCount} cuestionarios. Añade otro después de ellos o reemplázalos."
+
+msgid "This position already has a quiz. Add another right after it, or replace it."
+msgstr "Esta posición ya tiene un cuestionario. Añade otro justo después o reemplázalo."
 
 msgid "This prompt instructs the LLM how to evaluate the rendered HTML against the original page. Selection above controls which template is used."
 msgstr "Este aviso instruye al LLM cómo evaluar el HTML renderizado contra la página original. La selección arriba controla qué plantilla se usa."

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -414,11 +414,14 @@ msgstr "Une nouvelle version est disponible au téléchargement."
 msgid "A question worth asking"
 msgstr "Une question qui mérite d'être posée"
 
-msgid "A quiz already exists at this position. Generating will replace the current quiz here."
-msgstr "Un quiz existe déjà à cette position. Le générer remplacera le quiz actuel."
+#~ msgid "A quiz already exists at this position. Generating will replace the current quiz here."
+#~ msgstr "Un quiz existe déjà à cette position. Le générer remplacera le quiz actuel."
 
-msgid "A quiz already sits here — generating will replace it"
-msgstr "Un quiz se trouve déjà ici — le générer le remplacera"
+msgid "A quiz already sits here — add another after it or replace it"
+msgstr "Un quiz se trouve déjà ici — ajoutez-en un autre à la suite ou remplacez-le"
+
+#~ msgid "A quiz already sits here — generating will replace it"
+#~ msgstr "Un quiz se trouve déjà ici — le générer le remplacera"
 
 msgid "A scenic view at dusk."
 msgstr "Un panorama au crépuscule."
@@ -616,6 +619,9 @@ msgstr "Ajoutez une langue pour voir les traductions apparaître ici."
 msgid "Add a quiz"
 msgstr "Ajouter un quiz"
 
+msgid "Add after"
+msgstr "Ajouter à la suite"
+
 msgid "Add an API key in Book settings to add a quiz."
 msgstr "Ajoutez une clé d'API dans les paramètres du livre pour ajouter un quiz."
 
@@ -690,6 +696,9 @@ msgstr "Ajoutez des langues pour traduire le contenu du livre."
 
 msgid "Add quiz"
 msgstr "Ajouter un quiz"
+
+msgid "Add quiz here"
+msgstr "Ajouter le quiz ici"
 
 msgid "Add reviewer guidance."
 msgstr "Ajouter des consignes pour le réviseur."
@@ -1048,6 +1057,9 @@ msgstr "Défilement automatique"
 msgid "Automatically adapts the layout based on each page's content using AI."
 msgstr "Adapte automatiquement la mise en page en fonction du contenu de chaque page grâce à l'IA."
 
+msgid "Automatically create quizzes across the whole book at a set frequency."
+msgstr "Créez automatiquement des quiz dans tout le livre selon une fréquence définie."
+
 msgid "Avg Duration"
 msgstr "Avg Durée"
 
@@ -1354,6 +1366,9 @@ msgstr "Choisir des images..."
 msgid "Choose Provider"
 msgstr "Choisir le fournisseur"
 
+msgid "Choose the source pages and where the quiz lands in the page editor."
+msgstr "Choisissez les pages sources et l'emplacement du quiz dans l'éditeur de pages."
+
 #~ msgid "Choose up to {MAX_SOURCE_PAGES} pages whose content the quiz question is based on."
 #~ msgstr "Choisissez jusqu'à {MAX_SOURCE_PAGES} pages dont le contenu servira de base à la question du quiz."
 
@@ -1629,6 +1644,9 @@ msgstr "Créez des légendes descriptives pour les images afin d'améliorer l'ac
 
 msgid "Create from scratch using your description"
 msgstr "Créer à partir de zéro en utilisant votre description"
+
+msgid "Create one quiz from specific pages and place it exactly where you want it in the book."
+msgstr "Créez un seul quiz à partir de pages spécifiques et placez-le exactement où vous le souhaitez dans le livre."
 
 msgid "Create session"
 msgstr "Créer une session"
@@ -2143,6 +2161,9 @@ msgstr "Est. Coût"
 msgid "Evaporation"
 msgstr "Évaporation"
 
+msgid "Every few pages"
+msgstr "Toutes les quelques pages"
+
 msgid "Every notable concept and named entity."
 msgstr "Chaque concept notable et entité nommée."
 
@@ -2452,8 +2473,11 @@ msgstr "Générer à partir des pages"
 msgid "Generate missing Gemini audio"
 msgstr "Générer l'audio Gemini manquant"
 
-msgid "Generate multiple-choice comprehension quizzes from the book's content. Set how often a quiz appears, then run the stage to create them across the whole book."
-msgstr "Générez des quiz de compréhension à choix multiples à partir du contenu du livre. Définissez la fréquence d'apparition d'un quiz, puis exécutez l'étape pour les créer dans tout le livre."
+msgid "Generate multiple-choice comprehension quizzes from the book's content. Create them automatically across the whole book, or add a single quiz from specific pages."
+msgstr "Générez des quiz de compréhension à choix multiples à partir du contenu du livre. Créez-les automatiquement dans tout le livre ou ajoutez un seul quiz à partir de pages spécifiques."
+
+#~ msgid "Generate multiple-choice comprehension quizzes from the book's content. Set how often a quiz appears, then run the stage to create them across the whole book."
+#~ msgstr "Générez des quiz de compréhension à choix multiples à partir du contenu du livre. Définissez la fréquence d'apparition d'un quiz, puis exécutez l'étape pour les créer dans tout le livre."
 
 msgid "Generate new"
 msgstr "Générer nouveau"
@@ -2628,6 +2652,9 @@ msgstr "Comment ça marche"
 
 msgid "How many pages of content go into each quiz. A lower number means more quizzes across the book."
 msgstr "Combien de pages de contenu entrent dans chaque quiz. Un nombre plus faible signifie plus de quiz dans le livre."
+
+msgid "How to add quizzes"
+msgstr "Comment ajouter des quiz"
 
 msgid "HTML"
 msgstr "HTML"
@@ -4256,6 +4283,9 @@ msgstr "Types de section de quiz"
 msgid "Quizzes"
 msgstr "Quiz"
 
+msgid "Quizzes are generating. Wait for the run to finish before adding a quiz."
+msgstr "Les quiz sont en cours de génération. Attendez la fin de l'exécution avant d'ajouter un quiz."
+
 msgid "Quizzes are linked to other pages in this book"
 msgstr "Les quiz sont liés à d'autres pages de ce livre"
 
@@ -4490,6 +4520,9 @@ msgstr "Remplacer le PDF"
 
 msgid "Replace quiz"
 msgstr "Remplacer le quiz"
+
+msgid "Replace quizzes"
+msgstr "Remplacer les quiz"
 
 msgid "Replace this audio file"
 msgstr "Remplacer ce fichier audio"
@@ -5137,6 +5170,9 @@ msgstr "Mode simple"
 msgid "Single Page"
 msgstr "Page unique"
 
+msgid "Single quiz"
+msgstr "Quiz unique"
+
 msgid "Single value"
 msgstr "Valeur unique"
 
@@ -5218,6 +5254,9 @@ msgstr "Espagnol"
 
 msgid "Specialized workflows"
 msgstr "Flux de travail spécialisés"
+
+msgid "Specific pages"
+msgstr "Pages spécifiques"
 
 msgid "Speech"
 msgstr "Parole"
@@ -5665,6 +5704,12 @@ msgstr "Cette page n'a pas encore été révisée"
 
 msgid "This permanently deletes every uploaded video and clears all section assignments. This can't be undone."
 msgstr "Cela supprime définitivement chaque vidéo téléchargée et efface toutes les affectations de sections. Cela ne peut pas être annulé."
+
+msgid "This position already has {occupiedCount} quizzes. Add another after them, or replace them."
+msgstr "Cette position contient déjà {occupiedCount} quiz. Ajoutez-en un autre à la suite ou remplacez-les."
+
+msgid "This position already has a quiz. Add another right after it, or replace it."
+msgstr "Cette position contient déjà un quiz. Ajoutez-en un autre juste après ou remplacez-le."
 
 msgid "This prompt instructs the LLM how to evaluate the rendered HTML against the original page. Selection above controls which template is used."
 msgstr "Cette invite indique au LLM comment évaluer le HTML rendu par rapport à la page originale. La sélection ci-dessus contrôle le modèle utilisé."

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -412,11 +412,14 @@ msgstr "Uma nova versão está disponível para download."
 msgid "A question worth asking"
 msgstr "Uma pergunta que vale a pena fazer"
 
-msgid "A quiz already exists at this position. Generating will replace the current quiz here."
-msgstr "Já existe um questionário nesta posição. Gerar irá substituir o questionário atual."
+#~ msgid "A quiz already exists at this position. Generating will replace the current quiz here."
+#~ msgstr "Já existe um questionário nesta posição. Gerar irá substituir o questionário atual."
 
-msgid "A quiz already sits here — generating will replace it"
-msgstr "Já existe um questionário aqui — gerar irá substituí-lo"
+msgid "A quiz already sits here — add another after it or replace it"
+msgstr "Já existe um questionário aqui — adicione outro depois ou substitua-o"
+
+#~ msgid "A quiz already sits here — generating will replace it"
+#~ msgstr "Já existe um questionário aqui — gerar irá substituí-lo"
 
 msgid "A scenic view at dusk."
 msgstr "Uma vista cênica ao entardecer."
@@ -614,6 +617,9 @@ msgstr "Adicione um idioma para ver as traduções aparecerem aqui."
 msgid "Add a quiz"
 msgstr "Adicionar um questionário"
 
+msgid "Add after"
+msgstr "Adicionar depois"
+
 msgid "Add an API key in Book settings to add a quiz."
 msgstr "Adicione uma chave de API nas configurações do livro para adicionar um questionário."
 
@@ -688,6 +694,9 @@ msgstr "Adicione idiomas para traduzir o conteúdo do livro."
 
 msgid "Add quiz"
 msgstr "Adicionar questionário"
+
+msgid "Add quiz here"
+msgstr "Adicionar questionário aqui"
 
 msgid "Add reviewer guidance."
 msgstr "Adicione orientação para o revisor."
@@ -1046,6 +1055,9 @@ msgstr "Rolagem automática"
 msgid "Automatically adapts the layout based on each page's content using AI."
 msgstr "Adapta automaticamente o layout com base no conteúdo de cada página usando IA."
 
+msgid "Automatically create quizzes across the whole book at a set frequency."
+msgstr "Crie questionários automaticamente em todo o livro com uma frequência definida."
+
 msgid "Avg Duration"
 msgstr "Duração média"
 
@@ -1352,6 +1364,9 @@ msgstr "Escolher imagens..."
 msgid "Choose Provider"
 msgstr "Escolher provedor"
 
+msgid "Choose the source pages and where the quiz lands in the page editor."
+msgstr "Escolha as páginas de origem e onde o questionário será inserido no editor de páginas."
+
 #~ msgid "Choose up to {MAX_SOURCE_PAGES} pages whose content the quiz question is based on."
 #~ msgstr "Escolha até {MAX_SOURCE_PAGES} páginas cujo conteúdo servirá de base para a pergunta do questionário."
 
@@ -1627,6 +1642,9 @@ msgstr "Cria legendas descritivas para imagens para melhorar a acessibilidade."
 
 msgid "Create from scratch using your description"
 msgstr "Criar do zero usando sua descrição"
+
+msgid "Create one quiz from specific pages and place it exactly where you want it in the book."
+msgstr "Crie um único questionário a partir de páginas específicas e coloque-o exatamente onde quiser no livro."
 
 msgid "Create session"
 msgstr "Criar sessão"
@@ -2141,6 +2159,9 @@ msgstr "Custo estimado"
 msgid "Evaporation"
 msgstr "Evaporação"
 
+msgid "Every few pages"
+msgstr "A cada poucas páginas"
+
 msgid "Every notable concept and named entity."
 msgstr "Todo conceito notável e entidade nomeada."
 
@@ -2450,8 +2471,11 @@ msgstr "Gerar a partir das páginas"
 msgid "Generate missing Gemini audio"
 msgstr "Gerar áudio faltante do Gemini"
 
-msgid "Generate multiple-choice comprehension quizzes from the book's content. Set how often a quiz appears, then run the stage to create them across the whole book."
-msgstr "Gere questionários de compreensão de múltipla escolha a partir do conteúdo do livro. Defina com que frequência um questionário aparece e execute a etapa para criá-los em todo o livro."
+msgid "Generate multiple-choice comprehension quizzes from the book's content. Create them automatically across the whole book, or add a single quiz from specific pages."
+msgstr "Gere questionários de compreensão de múltipla escolha a partir do conteúdo do livro. Crie-os automaticamente em todo o livro ou adicione um único questionário a partir de páginas específicas."
+
+#~ msgid "Generate multiple-choice comprehension quizzes from the book's content. Set how often a quiz appears, then run the stage to create them across the whole book."
+#~ msgstr "Gere questionários de compreensão de múltipla escolha a partir do conteúdo do livro. Defina com que frequência um questionário aparece e execute a etapa para criá-los em todo o livro."
 
 msgid "Generate new"
 msgstr "Gerar nova"
@@ -2626,6 +2650,9 @@ msgstr "Como funciona"
 
 msgid "How many pages of content go into each quiz. A lower number means more quizzes across the book."
 msgstr "Quantas páginas de conteúdo entram em cada questionário. Um número menor significa mais questionários ao longo do livro."
+
+msgid "How to add quizzes"
+msgstr "Como adicionar questionários"
 
 msgid "HTML"
 msgstr "HTML"
@@ -4254,6 +4281,9 @@ msgstr "Tipos de seção do quiz"
 msgid "Quizzes"
 msgstr "Questionários"
 
+msgid "Quizzes are generating. Wait for the run to finish before adding a quiz."
+msgstr "Os questionários estão sendo gerados. Aguarde o término da execução antes de adicionar um questionário."
+
 msgid "Quizzes are linked to other pages in this book"
 msgstr "Os quizzes estão vinculados a outras páginas deste livro"
 
@@ -4488,6 +4518,9 @@ msgstr "Substituir PDF"
 
 msgid "Replace quiz"
 msgstr "Substituir questionário"
+
+msgid "Replace quizzes"
+msgstr "Substituir questionários"
 
 msgid "Replace this audio file"
 msgstr "Substituir este arquivo de áudio"
@@ -5135,6 +5168,9 @@ msgstr "Modo individual"
 msgid "Single Page"
 msgstr "Página Única"
 
+msgid "Single quiz"
+msgstr "Questionário único"
+
 msgid "Single value"
 msgstr "Valor único"
 
@@ -5216,6 +5252,9 @@ msgstr "Espanhol"
 
 msgid "Specialized workflows"
 msgstr "Fluxos de trabalho especializados"
+
+msgid "Specific pages"
+msgstr "Páginas específicas"
 
 msgid "Speech"
 msgstr "Fala"
@@ -5663,6 +5702,12 @@ msgstr "Esta página ainda não foi revisada"
 
 msgid "This permanently deletes every uploaded video and clears all section assignments. This can't be undone."
 msgstr "Isso exclui permanentemente todos os vídeos enviados e limpa todas as atribuições de seção. Isso não pode ser desfeito."
+
+msgid "This position already has {occupiedCount} quizzes. Add another after them, or replace them."
+msgstr "Esta posição já tem {occupiedCount} questionários. Adicione outro depois deles ou substitua-os."
+
+msgid "This position already has a quiz. Add another right after it, or replace it."
+msgstr "Esta posição já tem um questionário. Adicione outro logo depois ou substitua-o."
 
 msgid "This prompt instructs the LLM how to evaluate the rendered HTML against the original page. Selection above controls which template is used."
 msgstr "Este prompt instrui o LLM sobre como avaliar o HTML renderizado em relação à página original. A seleção acima controla qual modelo é usado."


### PR DESCRIPTION
Adds a frequency vs. specific-page mode toggle to the Quizzes landing page, letting users either auto-generate quizzes across the whole book or add a single quiz from specific pages via the existing Add a quiz dialog. Quizzes can now sit consecutively at the same position: the dialog offers a replace vs. add-after choice when a position is occupied, and the API appends (stable-sorted) rather than always replacing. Adding a quiz by hand now marks the quizzes stage as completed, since the manual write previously never recorded step completion. Manual adds are blocked while the quizzes stage is running — disabled across all three entry points and the dialog, plus a 409 server-side guard — so an in-flight run can't clobber a hand-added quiz. All new user-facing strings are translated across en/es/fr/pt-BR.