### PR TITLE
feat(i18n): add Albanian (Kosovo) locale to Studio

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,7 +160,7 @@ Or create a new tag in the GitHub UI pointing at `main`.
 
 ## Internationalization (i18n)
 
-The Studio app uses **Lingui v5** for i18n. All user-visible text in `apps/studio/` must be translated to all supported locales: **`en`, `pt-BR`, `es`, `fr`**.
+The Studio app uses **Lingui v5** for i18n. All user-visible text in `apps/studio/` must be translated to all supported locales: **`en`, `pt-BR`, `es`, `fr`, `sq`**.
 
 ### Rules
 - **Every user-visible string must be wrapped** in a Lingui macro — no raw string literals in JSX or component output
@@ -168,7 +168,7 @@ The Studio app uses **Lingui v5** for i18n. All user-visible text in `apps/studi
   - In JSX content: `<Trans>Your string</Trans>`
   - In non-React code (utils, constants): `msg\`Your string\`` + `i18n._()` at runtime
 - **After adding or changing any string**, run `pnpm --filter @adt/studio extract` to update all `.po` catalog files and commit them alongside the code change
-- **All locales must be fully translated** — no empty `msgstr` entries in `es.po`, `pt-BR.po`, or `fr.po`
+- **All locales must be fully translated** — no empty `msgstr` entries in `es.po`, `pt-BR.po`, `fr.po`, or `sq.po`
 - CI enforces both rules automatically via the `i18n` job in `.github/workflows/ci.yml`
 
 ### Available locales
@@ -177,6 +177,7 @@ Defined in `apps/studio/src/i18n/locales.ts` (single source of truth for locale 
 - `pt-BR` — Portuguese (Brazil)
 - `es` — Spanish
 - `fr` — French
+- `sq` — Albanian (Kosovo)
 
 ### ESLint — hardcoded string detection
 The `lingui/no-unlocalized-strings` rule in `apps/studio/eslint.config.js` flags raw strings that should be wrapped in a macro. It has an `ignoreNames` list for prop names whose values are never user-visible (e.g. `variant`, `className`, `href`).

--- a/apps/studio/lingui.config.ts
+++ b/apps/studio/lingui.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "@lingui/conf"
 
 export default defineConfig({
-  locales: ["en", "pt-BR", "es", "fr"],
+  locales: ["en", "pt-BR", "es", "fr", "sq"],
   sourceLocale: "en",
   catalogs: [
     {

--- a/apps/studio/src/components/LocaleSwitcher.tsx
+++ b/apps/studio/src/components/LocaleSwitcher.tsx
@@ -18,6 +18,7 @@ const LOCALE_LABEL_MESSAGES: Record<AppLocale, MessageDescriptor> = {
   "pt-BR": msg`Portuguese (BR)`,
   es: msg`Spanish`,
   fr: msg`French`,
+  sq: msg`Albanian`,
 };
 
 function localeCode(loc: AppLocale): string {

--- a/apps/studio/src/i18n/locales.ts
+++ b/apps/studio/src/i18n/locales.ts
@@ -10,7 +10,7 @@
  *
  * See docs/I18N_ADD_LANGUAGE.md for the full guide.
  */
-export const LOCALES = ["en", "pt-BR", "es", "fr"] as const
+export const LOCALES = ["en", "pt-BR", "es", "fr", "sq"] as const
 export type AppLocale = (typeof LOCALES)[number]
 
 /** Flag emoji for each locale, shown in the language switcher UI. */
@@ -19,6 +19,7 @@ export const LOCALE_FLAGS: Record<AppLocale, string> = {
   "pt-BR": "🇧🇷",
   es: "🇪🇸",
   fr: "🇫🇷",
+  sq: "🇽🇰",
 }
 
 /**
@@ -30,4 +31,5 @@ export const LOCALE_NAMES: Record<string, string> = {
   "pt-BR": "Brazilian Portuguese",
   es: "Spanish",
   fr: "French",
+  sq: "Albanian",
 }

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -933,6 +933,9 @@ msgstr "AI-powered layout that preserves the original page as a background with 
 msgid "AIza..."
 msgstr "AIza..."
 
+msgid "Albanian"
+msgstr "Albanian"
+
 msgid "Align"
 msgstr "Align"
 

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -69,12 +69,6 @@ msgstr "(template)"
 msgid "{0} — type country or Enter for base"
 msgstr "{0} — type country or Enter for base"
 
-#~ msgid "{0} {1}"
-#~ msgstr "{0} {1}"
-
-#~ msgid "{0} {1} reviewed so far"
-#~ msgstr "{0} {1} reviewed so far"
-
 #. placeholder {0}: progress?.page
 #. placeholder {1}: progress?.totalPages
 msgid "{0} / {1}"
@@ -89,9 +83,6 @@ msgstr "{0} × {1}px · {2} points"
 #. placeholder {0}: String(totalAudioFiles)
 msgid "{0} audio"
 msgstr "{0} audio"
-
-#~ msgid "{0} blocks"
-#~ msgstr "{0} blocks"
 
 #. placeholder {0}: activeProgress.criteriaPerPage
 msgid "{0} checks per page"
@@ -170,9 +161,6 @@ msgstr "{0} of {1} images"
 msgid "{0} of {1} items"
 msgstr "{0} of {1} items"
 
-#~ msgid "{0} on page"
-#~ msgstr "{0} on page"
-
 #. placeholder {0}: String(displayPages.length)
 msgid "{0} pages"
 msgstr "{0} pages"
@@ -184,12 +172,6 @@ msgstr "{0} pending"
 #. placeholder {0}: String(displayQuizzes.length)
 msgid "{0} questions"
 msgstr "{0} questions"
-
-#~ msgid "{0} section block(s)"
-#~ msgstr "{0} section block(s)"
-
-#~ msgid "{0} section block(s) on this page"
-#~ msgstr "{0} section block(s) on this page"
 
 #. placeholder {0}: String(group.blocks.length)
 msgid "{0} sections"
@@ -727,9 +709,6 @@ msgstr "Add an API key in Book settings to run TOC generation."
 msgid "Add an API key in Book settings to run translation."
 msgstr "Add an API key in Book settings to run translation."
 
-#~ msgid "Add an API key to generate Easy Read content."
-#~ msgstr "Add an API key to generate Easy Read content."
-
 msgid "Add at least one output language to run translation."
 msgstr "Add at least one output language to run translation."
 
@@ -742,14 +721,8 @@ msgstr "Add caption…"
 msgid "Add checklist item to this section"
 msgstr "Add checklist item to this section"
 
-#~ msgid "Add class"
-#~ msgstr "Add class"
-
 msgid "Add custom instructions"
 msgstr "Add custom instructions"
-
-#~ msgid "Add emojis"
-#~ msgstr "Add emojis"
 
 msgid "Add entry"
 msgstr "Add entry"
@@ -1884,9 +1857,6 @@ msgstr "Custom Layout Demo"
 msgid "Custom section {index}"
 msgstr "Custom section {index}"
 
-#~ msgid "Custom:"
-#~ msgstr "Custom:"
-
 msgid "Debug mode is not enabled."
 msgstr "Debug mode is not enabled."
 
@@ -2100,9 +2070,6 @@ msgstr "Discard"
 msgid "Discard unsaved changes?"
 msgstr "Discard unsaved changes?"
 
-#~ msgid "Dismiss"
-#~ msgstr "Dismiss"
-
 msgid "Display"
 msgstr "Display"
 
@@ -2233,9 +2200,6 @@ msgstr "Easy Read"
 
 msgid "Easy Read adapts the text placed on each page by Storyboard. Finish Storyboard before running this stage."
 msgstr "Easy Read adapts the text placed on each page by Storyboard. Finish Storyboard before running this stage."
-
-#~ msgid "Easy Read audio"
-#~ msgstr "Easy Read audio"
 
 msgid "Easy Read Preview"
 msgstr "Easy Read Preview"
@@ -2379,9 +2343,6 @@ msgstr "Enter a valid minimum dimension (whole number ≥ 0)"
 
 msgid "Enter a valid project name"
 msgstr "Enter a valid project name"
-
-#~ msgid "Enter hex color and press Enter"
-#~ msgstr "Enter hex color and press Enter"
 
 msgid "entries"
 msgstr "entries"
@@ -2627,9 +2588,6 @@ msgstr "Filter pages…"
 msgid "Filter quizzes…"
 msgstr "Filter quizzes…"
 
-#~ msgid "Filter terms…"
-#~ msgstr "Filter terms…"
-
 msgid "Filtered by:"
 msgstr "Filtered by:"
 
@@ -2717,9 +2675,6 @@ msgstr "Full control over render strategies, pruning, and filters."
 msgid "Full project backup & transfer"
 msgstr "Full project backup & transfer"
 
-#~ msgid "Full-size source page preview for the selected quiz."
-#~ msgstr "Full-size source page preview for the selected quiz."
-
 msgid "Full-size source page preview."
 msgstr "Full-size source page preview."
 
@@ -2774,12 +2729,6 @@ msgstr "Generate comprehension quizzes and activities based on the book content.
 msgid "Generate descriptive captions for every image in the book. Pick a reading level so captions match your audience, and add custom instructions if you want to nudge the tone or focus."
 msgstr "Generate descriptive captions for every image in the book. Pick a reading level so captions match your audience, and add custom instructions if you want to nudge the tone or focus."
 
-#~ msgid "Generate Easy Read audio"
-#~ msgstr "Generate Easy Read audio"
-
-#~ msgid "Generate editable Easy Read blocks for the ADT toggle."
-#~ msgstr "Generate editable Easy Read blocks for the ADT toggle."
-
 msgid "Generate from pages"
 msgstr "Generate from pages"
 
@@ -2821,9 +2770,6 @@ msgstr "Generated section"
 
 msgid "Generates a short summary of the book used to seed downstream prompts."
 msgstr "Generates a short summary of the book used to seed downstream prompts."
-
-#~ msgid "Generates audio for Easy Read texts. In the ADT, Easy Read mode uses that audio when available and falls back to the original voice otherwise."
-#~ msgstr "Generates audio for Easy Read texts. In the ADT, Easy Read mode uses that audio when available and falls back to the original voice otherwise."
 
 msgid "Generates comprehension questions and activities from the book."
 msgstr "Generates comprehension questions and activities from the book."
@@ -2947,9 +2893,6 @@ msgstr "Hide AI edit history"
 
 msgid "Hide error details"
 msgstr "Hide error details"
-
-#~ msgid "Hide pruned terms"
-#~ msgstr "Hide pruned terms"
 
 msgid "High"
 msgstr "High"
@@ -3563,9 +3506,6 @@ msgstr "Manage all sections"
 msgid "Manage sign-language videos"
 msgstr "Manage sign-language videos"
 
-#~ msgid "manual"
-#~ msgstr "manual"
-
 msgid "Manual only"
 msgstr "Manual only"
 
@@ -3900,9 +3840,6 @@ msgstr "No data"
 msgid "No disabled rules"
 msgstr "No disabled rules"
 
-#~ msgid "No Easy Read block is available for this page."
-#~ msgstr "No Easy Read block is available for this page."
-
 msgid "No Easy Read for this page"
 msgstr "No Easy Read for this page"
 
@@ -3966,17 +3903,11 @@ msgstr "No language-specific prompts configured."
 msgid "No languages configured. Add languages in the Language settings."
 msgstr "No languages configured. Add languages in the Language settings."
 
-#~ msgid "No link"
-#~ msgstr "No link"
-
 msgid "No log entries found yet."
 msgstr "No log entries found yet."
 
 msgid "No manual terms yet"
 msgstr "No manual terms yet"
-
-#~ msgid "No matches"
-#~ msgstr "No matches"
 
 msgid "No matches for \"{search}\""
 msgstr "No matches for \"{search}\""
@@ -4077,17 +4008,11 @@ msgstr "No source image"
 msgid "No storyboard sections found. Run Storyboard to generate sections you can match videos to."
 msgstr "No storyboard sections found. Run Storyboard to generate sections you can match videos to."
 
-#~ msgid "No terms match your filter."
-#~ msgstr "No terms match your filter."
-
 msgid "No terms match your search"
 msgstr "No terms match your search"
 
 msgid "No terms to show"
 msgstr "No terms to show"
-
-#~ msgid "No terms to show."
-#~ msgstr "No terms to show."
 
 msgid "No text"
 msgstr "No text"
@@ -4415,16 +4340,10 @@ msgstr "Page"
 msgid "Page {0}"
 msgstr "Page {0}"
 
-#~ msgid "Page {0} - Section {1}"
-#~ msgstr "Page {0} - Section {1}"
-
 #. placeholder {0}: page.pageNumber
 #. placeholder {1}: i + 1
 msgid "Page {0} — Section {1}"
 msgstr "Page {0} — Section {1}"
-
-#~ msgid "Page {0} · Section {1}"
-#~ msgstr "Page {0} · Section {1}"
 
 #. placeholder {0}: String(pageNumber)
 msgid "Page {0} captions"
@@ -4464,9 +4383,6 @@ msgstr "Page Mode"
 
 msgid "Page preview"
 msgstr "Page preview"
-
-#~ msgid "Page preview {pageId}"
-#~ msgstr "Page preview {pageId}"
 
 msgid "Page Range"
 msgstr "Page Range"
@@ -4678,9 +4594,6 @@ msgstr "Preset"
 msgid "Presets add recommendations and specific settings for your use case. You still choose each option step by step, and you can go back to select a different preset at any time."
 msgstr "Presets add recommendations and specific settings for your use case. You still choose each option step by step, and you can go back to select a different preset at any time."
 
-#~ msgid "Press Enter to add"
-#~ msgstr "Press Enter to add"
-
 msgid "Prev"
 msgstr "Prev"
 
@@ -4761,9 +4674,6 @@ msgstr "pruned"
 
 msgid "Pruned"
 msgstr "Pruned"
-
-#~ msgid "Pruned ({0})"
-#~ msgstr "Pruned ({0})"
 
 msgid "Pruned Images"
 msgstr "Pruned Images"
@@ -5072,9 +4982,6 @@ msgstr "Render Reasoning"
 msgid "Render Strategy"
 msgstr "Render Strategy"
 
-#~ msgid "rendering"
-#~ msgstr "rendering"
-
 msgid "Rendering Prompt"
 msgstr "Rendering Prompt"
 
@@ -5134,9 +5041,6 @@ msgstr "Reset zoom"
 
 msgid "Resolving source language..."
 msgstr "Resolving source language..."
-
-#~ msgid "Responsive / State variants"
-#~ msgstr "Responsive / State variants"
 
 msgid "Restart and install"
 msgstr "Restart and install"
@@ -5257,9 +5161,6 @@ msgstr "Run Easy Read"
 msgid "Run Extract"
 msgstr "Run Extract"
 
-#~ msgid "Run Extract first — sectioning needs extracted page text and images."
-#~ msgstr "Run Extract first — sectioning needs extracted page text and images."
-
 msgid "Run Glossary"
 msgstr "Run Glossary"
 
@@ -5274,9 +5175,6 @@ msgstr "Run Quizzes"
 
 msgid "Run Sectioning"
 msgstr "Run Sectioning"
-
-#~ msgid "Run Sectioning first — storyboard needs typed sections to render."
-#~ msgstr "Run Sectioning first — storyboard needs typed sections to render."
 
 msgid "Run Speech"
 msgstr "Run Speech"
@@ -5415,9 +5313,6 @@ msgstr "Save checklist"
 
 msgid "Save failed"
 msgstr "Save failed"
-
-#~ msgid "Save or discard edits before regenerating"
-#~ msgstr "Save or discard edits before regenerating"
 
 msgid "Save page review"
 msgstr "Save page review"
@@ -5566,9 +5461,6 @@ msgstr "Sectioning mode"
 
 msgid "Sectioning Mode"
 msgstr "Sectioning Mode"
-
-#~ msgid "Sectioning needs the page text and images that Extract produces. Finish Extract before running this stage."
-#~ msgstr "Sectioning needs the page text and images that Extract produces. Finish Extract before running this stage."
 
 msgid "Sectioning Pages..."
 msgstr "Sectioning Pages..."
@@ -5769,9 +5661,6 @@ msgstr "Show fewer"
 msgid "Show only the terms you added manually"
 msgstr "Show only the terms you added manually"
 
-#~ msgid "Show pruned terms"
-#~ msgstr "Show pruned terms"
-
 msgid "Show reviewer validation"
 msgstr "Show reviewer validation"
 
@@ -5917,12 +5806,6 @@ msgstr "Speech"
 msgid "Speech Generation"
 msgstr "Speech Generation"
 
-#~ msgid "Speech generation includes Easy Read audio. The ADT uses it while Easy Read mode is active."
-#~ msgstr "Speech generation includes Easy Read audio. The ADT uses it while Easy Read mode is active."
-
-#~ msgid "Speech generation uses original text only. Easy Read mode will fall back to original audio."
-#~ msgstr "Speech generation uses original text only. Easy Read mode will fall back to original audio."
-
 msgid "Speech narrates the translated text Language produces. Finish Language before running this stage."
 msgstr "Speech narrates the translated text Language produces. Finish Language before running this stage."
 
@@ -6014,9 +5897,6 @@ msgstr "Storyboard Overview"
 msgid "Storyboard Preview"
 msgstr "Storyboard Preview"
 
-#~ msgid "Storyboard renders the typed sections produced by Sectioning. Finish Sectioning before running this stage."
-#~ msgstr "Storyboard renders the typed sections produced by Sectioning. Finish Sectioning before running this stage."
-
 msgid "Storybook"
 msgstr "Storybook"
 
@@ -6025,9 +5905,6 @@ msgstr "Stretch"
 
 msgid "Strict"
 msgstr "Strict"
-
-#~ msgid "Strict grid template that repeats across pages."
-#~ msgstr "Strict grid template that repeats across pages."
 
 msgid "Strikethrough"
 msgstr "Strikethrough"
@@ -6649,9 +6526,6 @@ msgstr "Two-column template for story content"
 msgid "Type"
 msgstr "Type"
 
-#~ msgid "Type class name or search..."
-#~ msgstr "Type class name or search..."
-
 msgid "Typed Sections"
 msgstr "Typed Sections"
 
@@ -6711,9 +6585,6 @@ msgstr "Unprune image"
 
 msgid "Unsaved changes"
 msgstr "Unsaved changes"
-
-#~ msgid "Unsaved:"
-#~ msgstr "Unsaved:"
 
 msgid "Untangling nested divs with care..."
 msgstr "Untangling nested divs with care..."
@@ -6851,9 +6722,6 @@ msgstr "Validation Errors ({0})"
 
 msgid "Variables"
 msgstr "Variables"
-
-#~ msgid "Variant:"
-#~ msgstr "Variant:"
 
 msgid "Variations"
 msgstr "Variations"
@@ -7014,9 +6882,6 @@ msgstr "When describing images, mention any culturally specific objects, locatio
 
 msgid "When enabled, background colors from the styleguide are applied to the full page body."
 msgstr "When enabled, background colors from the styleguide are applied to the full page body."
-
-#~ msgid "When enabled, speech generation also creates audio for Easy Read texts. The ADT uses that audio while Easy Read mode is active and falls back to the original audio when it is missing."
-#~ msgstr "When enabled, speech generation also creates audio for Easy Read texts. The ADT uses that audio while Easy Read mode is active and falls back to the original audio when it is missing."
 
 msgid "When enabled, text labels near vector images (e.g. chart dimensions, speech bubbles) are grouped together and extracted as raster crops. Disable to extract only the core vector shapes without text."
 msgstr "When enabled, text labels near vector images (e.g. chart dimensions, speech bubbles) are grouped together and extracted as raster crops. Disable to extract only the core vector shapes without text."

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -933,6 +933,9 @@ msgstr "Diseño impulsado por IA que preserva la página original como fondo con
 msgid "AIza..."
 msgstr "AIza..."
 
+msgid "Albanian"
+msgstr "Albanés"
+
 msgid "Align"
 msgstr "Alinear"
 

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -69,12 +69,6 @@ msgstr "(plantilla)"
 msgid "{0} — type country or Enter for base"
 msgstr "{0} — escribe el país o pulsa Enter para el básico"
 
-#~ msgid "{0} {1}"
-#~ msgstr "{0} {1}"
-
-#~ msgid "{0} {1} reviewed so far"
-#~ msgstr "{0} {1} reviewed so far"
-
 #. placeholder {0}: progress?.page
 #. placeholder {1}: progress?.totalPages
 msgid "{0} / {1}"
@@ -89,9 +83,6 @@ msgstr "{0} × {1}px · {2} puntos"
 #. placeholder {0}: String(totalAudioFiles)
 msgid "{0} audio"
 msgstr "{0} audios"
-
-#~ msgid "{0} blocks"
-#~ msgstr "{0} bloques"
 
 #. placeholder {0}: activeProgress.criteriaPerPage
 msgid "{0} checks per page"
@@ -170,9 +161,6 @@ msgstr "{0} de {1} imágenes"
 msgid "{0} of {1} items"
 msgstr "{0} de {1} elementos"
 
-#~ msgid "{0} on page"
-#~ msgstr "{0} en la página"
-
 #. placeholder {0}: String(displayPages.length)
 msgid "{0} pages"
 msgstr "{0} páginas"
@@ -184,12 +172,6 @@ msgstr "{0} pendientes"
 #. placeholder {0}: String(displayQuizzes.length)
 msgid "{0} questions"
 msgstr "{0} preguntas"
-
-#~ msgid "{0} section block(s)"
-#~ msgstr "{0} bloque(s) de sección"
-
-#~ msgid "{0} section block(s) on this page"
-#~ msgstr "{0} bloque(s) de sección en esta página"
 
 #. placeholder {0}: String(group.blocks.length)
 msgid "{0} sections"
@@ -727,9 +709,6 @@ msgstr "Añade una clave API en la configuración del libro para ejecutar la gen
 msgid "Add an API key in Book settings to run translation."
 msgstr "Añade una clave API en la configuración del libro para ejecutar traducción."
 
-#~ msgid "Add an API key to generate Easy Read content."
-#~ msgstr "Agrega una clave de API para generar contenido de Lectura Fácil."
-
 msgid "Add at least one output language to run translation."
 msgstr "Añade al menos un idioma de salida para ejecutar traducción."
 
@@ -742,14 +721,8 @@ msgstr "Agregar leyenda…"
 msgid "Add checklist item to this section"
 msgstr "Add checklist item to this section"
 
-#~ msgid "Add class"
-#~ msgstr "Agregar clase"
-
 msgid "Add custom instructions"
 msgstr "Añadir instrucciones personalizadas"
-
-#~ msgid "Add emojis"
-#~ msgstr "Añadir emojis"
 
 msgid "Add entry"
 msgstr "Agregar entrada"
@@ -1884,9 +1857,6 @@ msgstr "Demostración de Diseño Personalizado"
 msgid "Custom section {index}"
 msgstr "Custom section {index}"
 
-#~ msgid "Custom:"
-#~ msgstr "Personalizado:"
-
 msgid "Debug mode is not enabled."
 msgstr "El modo de depuración no está habilitado."
 
@@ -2100,9 +2070,6 @@ msgstr "Descartar"
 msgid "Discard unsaved changes?"
 msgstr "¿Descartar cambios no guardados?"
 
-#~ msgid "Dismiss"
-#~ msgstr "Cerrar"
-
 msgid "Display"
 msgstr "Visualización"
 
@@ -2233,9 +2200,6 @@ msgstr "Lectura Fácil"
 
 msgid "Easy Read adapts the text placed on each page by Storyboard. Finish Storyboard before running this stage."
 msgstr "Lectura Fácil adapta el texto que el Storyboard coloca en cada página. Termina el Storyboard antes de ejecutar esta etapa."
-
-#~ msgid "Easy Read audio"
-#~ msgstr "Audio de Lectura Fácil"
 
 msgid "Easy Read Preview"
 msgstr "Vista previa de Lectura Fácil"
@@ -2379,9 +2343,6 @@ msgstr "Introduce una dimensión mínima válida (número entero ≥ 0)"
 
 msgid "Enter a valid project name"
 msgstr "Introduce un nombre de proyecto válido"
-
-#~ msgid "Enter hex color and press Enter"
-#~ msgstr "Ingresa un color hex y presiona Enter"
 
 msgid "entries"
 msgstr "entradas"
@@ -2627,9 +2588,6 @@ msgstr "Filtrar páginas…"
 msgid "Filter quizzes…"
 msgstr "Filtrar cuestionarios…"
 
-#~ msgid "Filter terms…"
-#~ msgstr "Filtrar términos…"
-
 msgid "Filtered by:"
 msgstr "Filtered by:"
 
@@ -2717,9 +2675,6 @@ msgstr "Control total sobre estrategias de renderizado, poda y filtros."
 msgid "Full project backup & transfer"
 msgstr "Respaldo y transferencia completa del proyecto"
 
-#~ msgid "Full-size source page preview for the selected quiz."
-#~ msgstr "Vista previa a tamaño completo de la página de origen del quiz seleccionado."
-
 msgid "Full-size source page preview."
 msgstr "Vista previa de página de origen a tamaño completo."
 
@@ -2774,12 +2729,6 @@ msgstr "Genera cuestionarios y actividades de comprensión basados en el conteni
 msgid "Generate descriptive captions for every image in the book. Pick a reading level so captions match your audience, and add custom instructions if you want to nudge the tone or focus."
 msgstr "Genera subtítulos descriptivos para cada imagen del libro. Elige un nivel de lectura para que los subtítulos coincidan con tu audiencia y añade instrucciones personalizadas si deseas ajustar el tono o enfoque."
 
-#~ msgid "Generate Easy Read audio"
-#~ msgstr "Generar audio de Lectura Fácil"
-
-#~ msgid "Generate editable Easy Read blocks for the ADT toggle."
-#~ msgstr "Genera bloques editables de Lectura Fácil para el interruptor del ADT."
-
 msgid "Generate from pages"
 msgstr "Generar desde páginas"
 
@@ -2821,9 +2770,6 @@ msgstr "Sección generada"
 
 msgid "Generates a short summary of the book used to seed downstream prompts."
 msgstr "Genera un resumen corto del libro para iniciar indicaciones posteriores."
-
-#~ msgid "Generates audio for Easy Read texts. In the ADT, Easy Read mode uses that audio when available and falls back to the original voice otherwise."
-#~ msgstr "Genera audio para los textos de Lectura Fácil. En el ADT, el modo Lectura Fácil usa ese audio cuando está disponible y recurre a la voz original en caso contrario."
 
 msgid "Generates comprehension questions and activities from the book."
 msgstr "Genera preguntas de comprensión y actividades del libro."
@@ -2947,9 +2893,6 @@ msgstr "Ocultar historial de edición con IA"
 
 msgid "Hide error details"
 msgstr "Ocultar detalles del error"
-
-#~ msgid "Hide pruned terms"
-#~ msgstr "Ocultar términos podados"
 
 msgid "High"
 msgstr "Alto"
@@ -3563,9 +3506,6 @@ msgstr "Gestionar todas las secciones"
 msgid "Manage sign-language videos"
 msgstr "Gestionar videos de lenguaje de señas"
 
-#~ msgid "manual"
-#~ msgstr "manual"
-
 msgid "Manual only"
 msgstr "Solo manual"
 
@@ -3900,9 +3840,6 @@ msgstr "Sin datos"
 msgid "No disabled rules"
 msgstr "No disabled rules"
 
-#~ msgid "No Easy Read block is available for this page."
-#~ msgstr "No hay ningún bloque de Lectura Fácil disponible para esta página."
-
 msgid "No Easy Read for this page"
 msgstr "No hay Lectura Fácil para esta página"
 
@@ -3966,17 +3903,11 @@ msgstr "No hay prompts por idioma configurados."
 msgid "No languages configured. Add languages in the Language settings."
 msgstr "No hay idiomas configurados. Agrega idiomas en la configuración de Idioma."
 
-#~ msgid "No link"
-#~ msgstr "Sin enlace"
-
 msgid "No log entries found yet."
 msgstr "Aún no hay entradas de registro."
 
 msgid "No manual terms yet"
 msgstr "Aún no hay términos manuales"
-
-#~ msgid "No matches"
-#~ msgstr "Sin resultados"
 
 msgid "No matches for \"{search}\""
 msgstr "Sin resultados para \"{0}\""
@@ -4077,17 +4008,11 @@ msgstr "No hay imagen de origen"
 msgid "No storyboard sections found. Run Storyboard to generate sections you can match videos to."
 msgstr "No se encontraron secciones de storyboard. Ejecuta Storyboard para generar secciones a las que puedas asignar videos."
 
-#~ msgid "No terms match your filter."
-#~ msgstr "Ningún término coincide con tu filtro."
-
 msgid "No terms match your search"
 msgstr "No hay términos que coincidan con tu búsqueda"
 
 msgid "No terms to show"
 msgstr "No hay términos para mostrar"
-
-#~ msgid "No terms to show."
-#~ msgstr "No hay términos para mostrar."
 
 msgid "No text"
 msgstr "Sin texto"
@@ -4415,16 +4340,10 @@ msgstr "Página"
 msgid "Page {0}"
 msgstr "Página {0}"
 
-#~ msgid "Page {0} - Section {1}"
-#~ msgstr "Página {0} - Sección {1}"
-
 #. placeholder {0}: page.pageNumber
 #. placeholder {1}: i + 1
 msgid "Page {0} — Section {1}"
 msgstr "Página {0} — Sección {1}"
-
-#~ msgid "Page {0} · Section {1}"
-#~ msgstr "Página {0} · Sección {1}"
 
 #. placeholder {0}: String(pageNumber)
 msgid "Page {0} captions"
@@ -4464,9 +4383,6 @@ msgstr "Modo de Página"
 
 msgid "Page preview"
 msgstr "Vista previa de la página"
-
-#~ msgid "Page preview {pageId}"
-#~ msgstr "Vista previa de la página {0}"
 
 msgid "Page Range"
 msgstr "Rango de páginas"
@@ -4678,9 +4594,6 @@ msgstr "Preajuste"
 msgid "Presets add recommendations and specific settings for your use case. You still choose each option step by step, and you can go back to select a different preset at any time."
 msgstr "Los preajustes añaden recomendaciones y configuraciones específicas para tu caso. Aún eliges cada opción paso a paso, y puedes volver a seleccionar un preajuste diferente en cualquier momento."
 
-#~ msgid "Press Enter to add"
-#~ msgstr "Presiona Enter para agregar"
-
 msgid "Prev"
 msgstr "Anterior"
 
@@ -4761,9 +4674,6 @@ msgstr "eliminado"
 
 msgid "Pruned"
 msgstr "Eliminado"
-
-#~ msgid "Pruned ({0})"
-#~ msgstr "Podado ({0})"
 
 msgid "Pruned Images"
 msgstr "Imágenes eliminadas"
@@ -5072,9 +4982,6 @@ msgstr "Razonamiento de renderizado"
 msgid "Render Strategy"
 msgstr "Estrategia de renderización"
 
-#~ msgid "rendering"
-#~ msgstr "renderización"
-
 msgid "Rendering Prompt"
 msgstr "Prompt de renderización"
 
@@ -5134,9 +5041,6 @@ msgstr "Restablecer zoom"
 
 msgid "Resolving source language..."
 msgstr "Resolviendo idioma de origen..."
-
-#~ msgid "Responsive / State variants"
-#~ msgstr "Variantes responsivas / de estado"
 
 msgid "Restart and install"
 msgstr "Reiniciar e instalar"
@@ -5257,9 +5161,6 @@ msgstr "Ejecutar Lectura Fácil"
 msgid "Run Extract"
 msgstr "Ejecutar Extracción"
 
-#~ msgid "Run Extract first — sectioning needs extracted page text and images."
-#~ msgstr "Ejecuta Extracción primero — el seccionamiento necesita texto e imágenes extraídas de la página."
-
 msgid "Run Glossary"
 msgstr "Ejecutar Glosario"
 
@@ -5274,9 +5175,6 @@ msgstr "Ejecutar Cuestionarios"
 
 msgid "Run Sectioning"
 msgstr "Ejecutar Seccionamiento"
-
-#~ msgid "Run Sectioning first — storyboard needs typed sections to render."
-#~ msgstr "Ejecuta Seccionamiento primero — el storyboard necesita secciones escritas para renderizar."
 
 msgid "Run Speech"
 msgstr "Ejecutar Voz"
@@ -5415,9 +5313,6 @@ msgstr "Save checklist"
 
 msgid "Save failed"
 msgstr "Save failed"
-
-#~ msgid "Save or discard edits before regenerating"
-#~ msgstr "Guarda o descarta los cambios antes de regenerar"
 
 msgid "Save page review"
 msgstr "Save page review"
@@ -5566,9 +5461,6 @@ msgstr "Modo de sección"
 
 msgid "Sectioning Mode"
 msgstr "Modo de sección"
-
-#~ msgid "Sectioning needs the page text and images that Extract produces. Finish Extract before running this stage."
-#~ msgstr "El seccionamiento necesita el texto e imágenes de la página que produce Extracción. Termina Extracción antes de ejecutar esta etapa."
 
 msgid "Sectioning Pages..."
 msgstr "Seccionando páginas..."
@@ -5769,9 +5661,6 @@ msgstr "Show fewer"
 msgid "Show only the terms you added manually"
 msgstr "Mostrar solo los términos que agregaste manualmente"
 
-#~ msgid "Show pruned terms"
-#~ msgstr "Mostrar términos podados"
-
 msgid "Show reviewer validation"
 msgstr "Show reviewer validation"
 
@@ -5917,12 +5806,6 @@ msgstr "Voz"
 msgid "Speech Generation"
 msgstr "Generación de voz"
 
-#~ msgid "Speech generation includes Easy Read audio. The ADT uses it while Easy Read mode is active."
-#~ msgstr "La generación de voz incluye audio de Lectura Fácil. El ADT lo usa mientras el modo Lectura Fácil está activo."
-
-#~ msgid "Speech generation uses original text only. Easy Read mode will fall back to original audio."
-#~ msgstr "La generación de voz usa solo el texto original. El modo Lectura Fácil recurrirá al audio original."
-
 msgid "Speech narrates the translated text Language produces. Finish Language before running this stage."
 msgstr "La voz narra el texto traducido que produce Idioma. Termina Idioma antes de ejecutar esta etapa."
 
@@ -6014,9 +5897,6 @@ msgstr "Vista general del Storyboard"
 msgid "Storyboard Preview"
 msgstr "Vista previa del Storyboard"
 
-#~ msgid "Storyboard renders the typed sections produced by Sectioning. Finish Sectioning before running this stage."
-#~ msgstr "El Storyboard renderiza las secciones escritas producidas por el Seccionamiento. Termina el Seccionamiento antes de ejecutar esta etapa."
-
 msgid "Storybook"
 msgstr "Libro de cuentos"
 
@@ -6025,9 +5905,6 @@ msgstr "Estirar"
 
 msgid "Strict"
 msgstr "Estricto"
-
-#~ msgid "Strict grid template that repeats across pages."
-#~ msgstr "Plantilla de cuadrícula estricta que se repite a través de las páginas."
 
 msgid "Strikethrough"
 msgstr "Tachado"
@@ -6649,9 +6526,6 @@ msgstr "Plantilla de dos columnas para contenido narrativo"
 msgid "Type"
 msgstr "Tipo"
 
-#~ msgid "Type class name or search..."
-#~ msgstr "Escriba nombre de clase o busque..."
-
 msgid "Typed Sections"
 msgstr "Secciones Escritas"
 
@@ -6711,9 +6585,6 @@ msgstr "Restaurar imagen"
 
 msgid "Unsaved changes"
 msgstr "Cambios sin guardar"
-
-#~ msgid "Unsaved:"
-#~ msgstr "Sin guardar:"
 
 msgid "Untangling nested divs with care..."
 msgstr "Desenredando divs anidados con cuidado..."
@@ -6851,9 +6722,6 @@ msgstr "Errores de validación ({0})"
 
 msgid "Variables"
 msgstr "Variables"
-
-#~ msgid "Variant:"
-#~ msgstr "Variante:"
 
 msgid "Variations"
 msgstr "Variaciones"
@@ -7014,9 +6882,6 @@ msgstr "Al describir imágenes, menciona cualquier objeto, ubicación o personaj
 
 msgid "When enabled, background colors from the styleguide are applied to the full page body."
 msgstr "Cuando está activado, los colores de fondo de la guía de estilo se aplican al cuerpo completo de la página."
-
-#~ msgid "When enabled, speech generation also creates audio for Easy Read texts. The ADT uses that audio while Easy Read mode is active and falls back to the original audio when it is missing."
-#~ msgstr "Cuando está habilitado, la generación de voz también crea audio para los textos de Lectura Fácil. El ADT usa ese audio mientras el modo Lectura Fácil está activo y recurre al audio original cuando falta."
 
 msgid "When enabled, text labels near vector images (e.g. chart dimensions, speech bubbles) are grouped together and extracted as raster crops. Disable to extract only the core vector shapes without text."
 msgstr "Cuando está activado, las etiquetas de texto cercanas a imágenes vectoriales (p. ej. dimensiones de gráficos, globos de diálogo) se agrupan y extraen como recortes rasterizados. Desactive para extraer solo las formas vectoriales sin texto."

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -935,6 +935,9 @@ msgstr "Mise en page assistée par IA qui conserve la page originale en arrière
 msgid "AIza..."
 msgstr "AIza..."
 
+msgid "Albanian"
+msgstr "Albanais"
+
 msgid "Align"
 msgstr "Aligner"
 

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -71,12 +71,6 @@ msgstr "(modèle)"
 msgid "{0} — type country or Enter for base"
 msgstr "{0} — tapez un pays ou Entrée pour base"
 
-#~ msgid "{0} {1}"
-#~ msgstr "{0} {1}"
-
-#~ msgid "{0} {1} reviewed so far"
-#~ msgstr "{0} {1} révisé(s) jusqu'à présent"
-
 #. placeholder {0}: progress?.page
 #. placeholder {1}: progress?.totalPages
 msgid "{0} / {1}"
@@ -91,9 +85,6 @@ msgstr "{0} × {1}px · {2} points"
 #. placeholder {0}: String(totalAudioFiles)
 msgid "{0} audio"
 msgstr "{0} audio"
-
-#~ msgid "{0} blocks"
-#~ msgstr "{0} blocs"
 
 #. placeholder {0}: activeProgress.criteriaPerPage
 msgid "{0} checks per page"
@@ -172,9 +163,6 @@ msgstr "{0} sur {1} images"
 msgid "{0} of {1} items"
 msgstr "{0} sur {1} éléments"
 
-#~ msgid "{0} on page"
-#~ msgstr "{0} sur la page"
-
 #. placeholder {0}: String(displayPages.length)
 msgid "{0} pages"
 msgstr "{0} pages"
@@ -186,12 +174,6 @@ msgstr "{0} en attente"
 #. placeholder {0}: String(displayQuizzes.length)
 msgid "{0} questions"
 msgstr "{0} questions"
-
-#~ msgid "{0} section block(s)"
-#~ msgstr "{0} bloc(s) de section"
-
-#~ msgid "{0} section block(s) on this page"
-#~ msgstr "{0} bloc(s) de section sur cette page"
 
 #. placeholder {0}: String(group.blocks.length)
 msgid "{0} sections"
@@ -729,9 +711,6 @@ msgstr "Ajoutez une clé API dans les paramètres du livre pour exécuter la gé
 msgid "Add an API key in Book settings to run translation."
 msgstr "Ajoutez une clé API dans les paramètres du livre pour exécuter la traduction."
 
-#~ msgid "Add an API key to generate Easy Read content."
-#~ msgstr "Ajoutez une clé API pour générer du contenu Lecture Facile."
-
 msgid "Add at least one output language to run translation."
 msgstr "Ajoutez au moins une langue de sortie pour exécuter la traduction."
 
@@ -744,14 +723,8 @@ msgstr "Ajouter une légende…"
 msgid "Add checklist item to this section"
 msgstr "Ajouter un élément de liste de contrôle à cette section"
 
-#~ msgid "Add class"
-#~ msgstr "Ajouter une classe"
-
 msgid "Add custom instructions"
 msgstr "Ajouter des instructions personnalisées"
-
-#~ msgid "Add emojis"
-#~ msgstr "Ajouter des emojis"
 
 msgid "Add entry"
 msgstr "Ajouter une entrée"
@@ -1886,9 +1859,6 @@ msgstr "Démo de mise en page personnalisée"
 msgid "Custom section {index}"
 msgstr "Section personnalisée {index}"
 
-#~ msgid "Custom:"
-#~ msgstr "Personnalisé:"
-
 msgid "Debug mode is not enabled."
 msgstr "Le mode débogage n'est pas activé."
 
@@ -2102,9 +2072,6 @@ msgstr "Abandonner"
 msgid "Discard unsaved changes?"
 msgstr "Ignorer les modifications non enregistrées ?"
 
-#~ msgid "Dismiss"
-#~ msgstr "Fermer"
-
 msgid "Display"
 msgstr "Affichage"
 
@@ -2235,9 +2202,6 @@ msgstr "Lecture Facile"
 
 msgid "Easy Read adapts the text placed on each page by Storyboard. Finish Storyboard before running this stage."
 msgstr "Lecture Facile adapte le texte placé sur chaque page par le Storyboard. Terminez le Storyboard avant de lancer cette étape."
-
-#~ msgid "Easy Read audio"
-#~ msgstr "Audio Lecture Facile"
 
 msgid "Easy Read Preview"
 msgstr "Aperçu Lecture Facile"
@@ -2381,9 +2345,6 @@ msgstr "Saisissez une dimension minimale valide (nombre entier ≥ 0)"
 
 msgid "Enter a valid project name"
 msgstr "Saisissez un nom de projet valide"
-
-#~ msgid "Enter hex color and press Enter"
-#~ msgstr "Saisissez une couleur hexadécimale et appuyez sur Entrée"
 
 msgid "entries"
 msgstr "entrées"
@@ -2629,9 +2590,6 @@ msgstr "Filtrer les pages…"
 msgid "Filter quizzes…"
 msgstr "Filtrer les quiz…"
 
-#~ msgid "Filter terms…"
-#~ msgstr "Filtrer les termes…"
-
 msgid "Filtered by:"
 msgstr "Filtré par :"
 
@@ -2719,9 +2677,6 @@ msgstr "Contrôle total sur les stratégies de rendu, l'élagage et les filtres.
 msgid "Full project backup & transfer"
 msgstr "Sauvegarde et transfert complet du projet"
 
-#~ msgid "Full-size source page preview for the selected quiz."
-#~ msgstr "Aperçu en taille réelle de la page source pour le quiz sélectionné."
-
 msgid "Full-size source page preview."
 msgstr "Aperçu de la page source en taille réelle."
 
@@ -2776,12 +2731,6 @@ msgstr "Générez des quiz de compréhension et des activités basés sur le con
 msgid "Generate descriptive captions for every image in the book. Pick a reading level so captions match your audience, and add custom instructions if you want to nudge the tone or focus."
 msgstr "Générez des sous-titres descriptifs pour chaque image du livre. Choisissez un niveau de lecture pour que les sous-titres correspondent à votre public, et ajoutez des instructions personnalisées si vous souhaitez ajuster le ton ou l'accent."
 
-#~ msgid "Generate Easy Read audio"
-#~ msgstr "Générer l'audio Lecture Facile"
-
-#~ msgid "Generate editable Easy Read blocks for the ADT toggle."
-#~ msgstr "Générez des blocs Lecture Facile modifiables pour le bouton de l'ADT."
-
 msgid "Generate from pages"
 msgstr "Générer à partir des pages"
 
@@ -2823,9 +2772,6 @@ msgstr "Section générée"
 
 msgid "Generates a short summary of the book used to seed downstream prompts."
 msgstr "Génère un court résumé du livre utilisé pour amorcer les invites en aval."
-
-#~ msgid "Generates audio for Easy Read texts. In the ADT, Easy Read mode uses that audio when available and falls back to the original voice otherwise."
-#~ msgstr "Génère l'audio pour les textes Lecture Facile. Dans l'ADT, le mode Lecture Facile utilise cet audio lorsqu'il est disponible et revient à la voix d'origine sinon."
 
 msgid "Generates comprehension questions and activities from the book."
 msgstr "Génère des questions de compréhension et des activités à partir du livre."
@@ -2949,9 +2895,6 @@ msgstr "Masquer l'historique des modifications IA"
 
 msgid "Hide error details"
 msgstr "Masquer les détails de l'erreur"
-
-#~ msgid "Hide pruned terms"
-#~ msgstr "Masquer les termes élagués"
 
 msgid "High"
 msgstr "Élevé"
@@ -3565,9 +3508,6 @@ msgstr "Gérer toutes les sections"
 msgid "Manage sign-language videos"
 msgstr "Gérer les vidéos en langue des signes"
 
-#~ msgid "manual"
-#~ msgstr "manuel"
-
 msgid "Manual only"
 msgstr "Manuel uniquement"
 
@@ -3902,9 +3842,6 @@ msgstr "Aucune donnée"
 msgid "No disabled rules"
 msgstr "Aucune règle désactivée"
 
-#~ msgid "No Easy Read block is available for this page."
-#~ msgstr "Aucun bloc Lecture Facile n'est disponible pour cette page."
-
 msgid "No Easy Read for this page"
 msgstr "Pas de lecture facile pour cette page"
 
@@ -3968,17 +3905,11 @@ msgstr "Aucune invite spécifique à la langue configurée."
 msgid "No languages configured. Add languages in the Language settings."
 msgstr "Aucune langue configurée. Ajoutez des langues dans les paramètres de langue."
 
-#~ msgid "No link"
-#~ msgstr "Aucun lien"
-
 msgid "No log entries found yet."
 msgstr "Aucune entrée de journal trouvée."
 
 msgid "No manual terms yet"
 msgstr "Pas encore de termes manuels"
-
-#~ msgid "No matches"
-#~ msgstr "Aucune correspondance"
 
 msgid "No matches for \"{search}\""
 msgstr "Aucun résultat pour \\\"{search}\\\""
@@ -4079,17 +4010,11 @@ msgstr "Aucune image source"
 msgid "No storyboard sections found. Run Storyboard to generate sections you can match videos to."
 msgstr "Aucune section de storyboard trouvée. Exécutez le Storyboard pour générer des sections auxquelles vous pouvez associer des vidéos."
 
-#~ msgid "No terms match your filter."
-#~ msgstr "Aucun terme ne correspond à votre filtre."
-
 msgid "No terms match your search"
 msgstr "Aucun terme ne correspond à votre recherche"
 
 msgid "No terms to show"
 msgstr "Aucun terme à afficher"
-
-#~ msgid "No terms to show."
-#~ msgstr "Aucun terme à afficher."
 
 msgid "No text"
 msgstr "Pas de texte"
@@ -4417,16 +4342,10 @@ msgstr "Page"
 msgid "Page {0}"
 msgstr "Page {0}"
 
-#~ msgid "Page {0} - Section {1}"
-#~ msgstr "Page {0} - Section {1}"
-
 #. placeholder {0}: page.pageNumber
 #. placeholder {1}: i + 1
 msgid "Page {0} — Section {1}"
 msgstr "Page {0} — Section {1}"
-
-#~ msgid "Page {0} · Section {1}"
-#~ msgstr "Page {0} · Section {1}"
 
 #. placeholder {0}: String(pageNumber)
 msgid "Page {0} captions"
@@ -4466,9 +4385,6 @@ msgstr "Mode de page"
 
 msgid "Page preview"
 msgstr "Aperçu de la page"
-
-#~ msgid "Page preview {pageId}"
-#~ msgstr "Page aperçu {pageId}"
 
 msgid "Page Range"
 msgstr "Plage de pages"
@@ -4680,9 +4596,6 @@ msgstr "Preset"
 msgid "Presets add recommendations and specific settings for your use case. You still choose each option step by step, and you can go back to select a different preset at any time."
 msgstr "Les préréglages ajoutent des recommandations et des paramètres spécifiques à votre cas d'utilisation. Vous choisissez toujours chaque option étape par étape, et vous pouvez revenir à tout moment pour sélectionner un autre préréglage."
 
-#~ msgid "Press Enter to add"
-#~ msgstr "Appuyez sur Entrée pour ajouter"
-
 msgid "Prev"
 msgstr "Préc."
 
@@ -4763,9 +4676,6 @@ msgstr "élagué"
 
 msgid "Pruned"
 msgstr "Élagué"
-
-#~ msgid "Pruned ({0})"
-#~ msgstr "Élagué ({0})"
 
 msgid "Pruned Images"
 msgstr "Images élaguées"
@@ -5074,9 +4984,6 @@ msgstr "Raisonnement de rendu"
 msgid "Render Strategy"
 msgstr "Stratégie de rendu"
 
-#~ msgid "rendering"
-#~ msgstr "rendu"
-
 msgid "Rendering Prompt"
 msgstr "Rendering Invite"
 
@@ -5136,9 +5043,6 @@ msgstr "Réinitialiser le zoom"
 
 msgid "Resolving source language..."
 msgstr "Résolution de la langue source..."
-
-#~ msgid "Responsive / State variants"
-#~ msgstr "Variantes responsives / d'état"
 
 msgid "Restart and install"
 msgstr "Redémarrer et installer"
@@ -5259,9 +5163,6 @@ msgstr "Lancer Lecture Facile"
 msgid "Run Extract"
 msgstr "Exécuter l'extraction"
 
-#~ msgid "Run Extract first — sectioning needs extracted page text and images."
-#~ msgstr "Exécutez d'abord l'extraction — le découpage a besoin du texte et des images extraits des pages."
-
 msgid "Run Glossary"
 msgstr "Exécuter le glossaire"
 
@@ -5276,9 +5177,6 @@ msgstr "Exécuter les quiz"
 
 msgid "Run Sectioning"
 msgstr "Exécuter le découpage"
-
-#~ msgid "Run Sectioning first — storyboard needs typed sections to render."
-#~ msgstr "Exécutez d'abord le découpage — le storyboard a besoin de sections tapées pour rendre."
 
 msgid "Run Speech"
 msgstr "Exécuter la parole"
@@ -5417,9 +5315,6 @@ msgstr "Enregistrer la liste de contrôle"
 
 msgid "Save failed"
 msgstr "L'enregistrement a échoué"
-
-#~ msgid "Save or discard edits before regenerating"
-#~ msgstr "Enregistrez ou annulez les modifications avant de régénérer"
 
 msgid "Save page review"
 msgstr "Enregistrer la révision de la page"
@@ -5568,9 +5463,6 @@ msgstr "Mode de sectionnement"
 
 msgid "Sectioning Mode"
 msgstr "Mode de sectionnement"
-
-#~ msgid "Sectioning needs the page text and images that Extract produces. Finish Extract before running this stage."
-#~ msgstr "Le découpage a besoin du texte et des images des pages produits par l'extraction. Terminez l'extraction avant d'exécuter cette étape."
 
 msgid "Sectioning Pages..."
 msgstr "Sectionnement des pages..."
@@ -5771,9 +5663,6 @@ msgstr "Afficher moins"
 msgid "Show only the terms you added manually"
 msgstr "Afficher uniquement les termes que vous avez ajoutés manuellement"
 
-#~ msgid "Show pruned terms"
-#~ msgstr "Afficher les termes élagués"
-
 msgid "Show reviewer validation"
 msgstr "Afficher la validation du réviseur"
 
@@ -5919,12 +5808,6 @@ msgstr "Parole"
 msgid "Speech Generation"
 msgstr "Parole Génération"
 
-#~ msgid "Speech generation includes Easy Read audio. The ADT uses it while Easy Read mode is active."
-#~ msgstr "La génération vocale inclut l'audio Lecture Facile. L'ADT l'utilise lorsque le mode Lecture Facile est actif."
-
-#~ msgid "Speech generation uses original text only. Easy Read mode will fall back to original audio."
-#~ msgstr "La génération vocale utilise uniquement le texte d'origine. Le mode Lecture Facile reviendra à l'audio d'origine."
-
 msgid "Speech narrates the translated text Language produces. Finish Language before running this stage."
 msgstr "La parole narre le texte traduit produit par la langue. Terminez la langue avant d'exécuter cette étape."
 
@@ -6016,9 +5899,6 @@ msgstr "Aperçu du storyboard"
 msgid "Storyboard Preview"
 msgstr "Aperçu du storyboard"
 
-#~ msgid "Storyboard renders the typed sections produced by Sectioning. Finish Sectioning before running this stage."
-#~ msgstr "Le storyboard rend les sections tapées produites par le découpage. Terminez le découpage avant d'exécuter cette étape."
-
 msgid "Storybook"
 msgstr "Livre d'histoires"
 
@@ -6027,9 +5907,6 @@ msgstr "Étirer"
 
 msgid "Strict"
 msgstr "Strict"
-
-#~ msgid "Strict grid template that repeats across pages."
-#~ msgstr "Modèle de grille strict qui se répète sur les pages."
 
 msgid "Strikethrough"
 msgstr "Barré"
@@ -6651,9 +6528,6 @@ msgstr "Modèle à deux colonnes pour le contenu narratif"
 msgid "Type"
 msgstr "Type"
 
-#~ msgid "Type class name or search..."
-#~ msgstr "Tapez un nom de classe ou recherchez..."
-
 msgid "Typed Sections"
 msgstr "Sections tapées"
 
@@ -6713,9 +6587,6 @@ msgstr "Restaurer l'image"
 
 msgid "Unsaved changes"
 msgstr "Modifications non enregistrées"
-
-#~ msgid "Unsaved:"
-#~ msgstr "Non enregistré :"
 
 msgid "Untangling nested divs with care..."
 msgstr "Démêlage des divs imbriqués avec soin..."
@@ -6853,9 +6724,6 @@ msgstr "Validation Erreurs ({0})"
 
 msgid "Variables"
 msgstr "Variables"
-
-#~ msgid "Variant:"
-#~ msgstr "Variant:"
 
 msgid "Variations"
 msgstr "Variantes"
@@ -7016,9 +6884,6 @@ msgstr "Lors de la description des images, mentionnez par leur nom tout objet, l
 
 msgid "When enabled, background colors from the styleguide are applied to the full page body."
 msgstr "Lorsque cette option est activée, les couleurs d'arrière-plan du guide de style sont appliquées à l'ensemble du corps de la page."
-
-#~ msgid "When enabled, speech generation also creates audio for Easy Read texts. The ADT uses that audio while Easy Read mode is active and falls back to the original audio when it is missing."
-#~ msgstr "Lorsqu'il est activé, la génération vocale crée également l'audio des textes Lecture Facile. L'ADT utilise cet audio lorsque le mode Lecture Facile est actif et revient à l'audio d'origine lorsqu'il est manquant."
 
 msgid "When enabled, text labels near vector images (e.g. chart dimensions, speech bubbles) are grouped together and extracted as raster crops. Disable to extract only the core vector shapes without text."
 msgstr "Lorsque cette option est activée, les libellés de texte proches des images vectorielles (par ex. dimensions de graphique, bulles de dialogue) sont regroupés et extraits en recadrages raster. Désactivez pour extraire uniquement les formes vectorielles sans texte."

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -933,6 +933,9 @@ msgstr "Layout impulsionado por IA que preserva a página original como fundo co
 msgid "AIza..."
 msgstr "AIza..."
 
+msgid "Albanian"
+msgstr "Albanês"
+
 msgid "Align"
 msgstr "Alinhar"
 

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -69,12 +69,6 @@ msgstr "(template)"
 msgid "{0} — type country or Enter for base"
 msgstr "{0} — digite o país ou pressione Enter para o padrão"
 
-#~ msgid "{0} {1}"
-#~ msgstr "{0} {1}"
-
-#~ msgid "{0} {1} reviewed so far"
-#~ msgstr "{0} {1} reviewed so far"
-
 #. placeholder {0}: progress?.page
 #. placeholder {1}: progress?.totalPages
 msgid "{0} / {1}"
@@ -89,9 +83,6 @@ msgstr "{0} × {1}px · {2} pontos"
 #. placeholder {0}: String(totalAudioFiles)
 msgid "{0} audio"
 msgstr "{0} áudios"
-
-#~ msgid "{0} blocks"
-#~ msgstr "{0} blocos"
 
 #. placeholder {0}: activeProgress.criteriaPerPage
 msgid "{0} checks per page"
@@ -170,9 +161,6 @@ msgstr "{0} de {1} imagens"
 msgid "{0} of {1} items"
 msgstr "{0} de {1} itens"
 
-#~ msgid "{0} on page"
-#~ msgstr "{0} na página"
-
 #. placeholder {0}: String(displayPages.length)
 msgid "{0} pages"
 msgstr "{0} páginas"
@@ -184,12 +172,6 @@ msgstr "{0} pendentes"
 #. placeholder {0}: String(displayQuizzes.length)
 msgid "{0} questions"
 msgstr "{0} questões"
-
-#~ msgid "{0} section block(s)"
-#~ msgstr "{0} bloco(s) de seção"
-
-#~ msgid "{0} section block(s) on this page"
-#~ msgstr "{0} bloco(s) de seção nesta página"
 
 #. placeholder {0}: String(group.blocks.length)
 msgid "{0} sections"
@@ -727,9 +709,6 @@ msgstr "Adicione uma chave de API nas configurações do Livro para executar a g
 msgid "Add an API key in Book settings to run translation."
 msgstr "Adicione uma chave de API nas configurações do Livro para executar tradução."
 
-#~ msgid "Add an API key to generate Easy Read content."
-#~ msgstr "Adicione uma chave de API para gerar conteúdo de Leitura Fácil."
-
 msgid "Add at least one output language to run translation."
 msgstr "Adicione pelo menos um idioma de saída para executar tradução."
 
@@ -742,14 +721,8 @@ msgstr "Adicionar legenda…"
 msgid "Add checklist item to this section"
 msgstr "Add checklist item to this section"
 
-#~ msgid "Add class"
-#~ msgstr "Adicionar classe"
-
 msgid "Add custom instructions"
 msgstr "Adicionar instruções personalizadas"
-
-#~ msgid "Add emojis"
-#~ msgstr "Adicionar emojis"
 
 msgid "Add entry"
 msgstr "Adicionar entrada"
@@ -1884,9 +1857,6 @@ msgstr "Demonstração de Layout Personalizado"
 msgid "Custom section {index}"
 msgstr "Custom section {index}"
 
-#~ msgid "Custom:"
-#~ msgstr "Personalizado:"
-
 msgid "Debug mode is not enabled."
 msgstr "Modo de depuração não está ativado."
 
@@ -2100,9 +2070,6 @@ msgstr "Descartar"
 msgid "Discard unsaved changes?"
 msgstr "Descartar alterações não salvas?"
 
-#~ msgid "Dismiss"
-#~ msgstr "Fechar"
-
 msgid "Display"
 msgstr "Exibição"
 
@@ -2233,9 +2200,6 @@ msgstr "Leitura Fácil"
 
 msgid "Easy Read adapts the text placed on each page by Storyboard. Finish Storyboard before running this stage."
 msgstr "A Leitura Fácil adapta o texto que o Storyboard coloca em cada página. Conclua o Storyboard antes de executar esta etapa."
-
-#~ msgid "Easy Read audio"
-#~ msgstr "Áudio de Leitura Fácil"
 
 msgid "Easy Read Preview"
 msgstr "Pré-visualização de Leitura Fácil"
@@ -2379,9 +2343,6 @@ msgstr "Insira uma dimensão mínima válida (número inteiro ≥ 0)"
 
 msgid "Enter a valid project name"
 msgstr "Insira um nome de projeto válido"
-
-#~ msgid "Enter hex color and press Enter"
-#~ msgstr "Digite uma cor hex e pressione Enter"
 
 msgid "entries"
 msgstr "entradas"
@@ -2627,9 +2588,6 @@ msgstr "Filtrar páginas…"
 msgid "Filter quizzes…"
 msgstr "Filtrar questionários…"
 
-#~ msgid "Filter terms…"
-#~ msgstr "Filtrar termos…"
-
 msgid "Filtered by:"
 msgstr "Filtered by:"
 
@@ -2717,9 +2675,6 @@ msgstr "Controle total sobre estratégias de renderização, poda e filtros."
 msgid "Full project backup & transfer"
 msgstr "Backup completo do projeto e transferência"
 
-#~ msgid "Full-size source page preview for the selected quiz."
-#~ msgstr "Pré-visualização em tamanho real da página de origem do quiz selecionado."
-
 msgid "Full-size source page preview."
 msgstr "Pré-visualização da página de origem em tamanho real."
 
@@ -2774,12 +2729,6 @@ msgstr "Gera questionários e atividades de compreensão com base no conteúdo d
 msgid "Generate descriptive captions for every image in the book. Pick a reading level so captions match your audience, and add custom instructions if you want to nudge the tone or focus."
 msgstr "Gere legendas descritivas para cada imagem do livro. Escolha um nível de leitura para que as legendas correspondam ao seu público e adicione instruções personalizadas se quiser ajustar o tom ou o foco."
 
-#~ msgid "Generate Easy Read audio"
-#~ msgstr "Gerar áudio de Leitura Fácil"
-
-#~ msgid "Generate editable Easy Read blocks for the ADT toggle."
-#~ msgstr "Gere blocos editáveis de Leitura Fácil para o botão do ADT."
-
 msgid "Generate from pages"
 msgstr "Gerar a partir das páginas"
 
@@ -2821,9 +2770,6 @@ msgstr "Seção gerada"
 
 msgid "Generates a short summary of the book used to seed downstream prompts."
 msgstr "Gera um resumo curto do livro usado para iniciar prompts subsequentes."
-
-#~ msgid "Generates audio for Easy Read texts. In the ADT, Easy Read mode uses that audio when available and falls back to the original voice otherwise."
-#~ msgstr "Gera áudio para os textos de Leitura Fácil. No ADT, o modo Leitura Fácil usa esse áudio quando disponível e recorre à voz original caso contrário."
 
 msgid "Generates comprehension questions and activities from the book."
 msgstr "Gera perguntas de compreensão e atividades a partir do livro."
@@ -2947,9 +2893,6 @@ msgstr "Ocultar histórico de edições com IA"
 
 msgid "Hide error details"
 msgstr "Ocultar detalhes do erro"
-
-#~ msgid "Hide pruned terms"
-#~ msgstr "Ocultar termos podados"
 
 msgid "High"
 msgstr "Alto"
@@ -3563,9 +3506,6 @@ msgstr "Gerenciar todas as seções"
 msgid "Manage sign-language videos"
 msgstr "Gerenciar vídeos em linguagem de sinais"
 
-#~ msgid "manual"
-#~ msgstr "manual"
-
 msgid "Manual only"
 msgstr "Somente manual"
 
@@ -3900,9 +3840,6 @@ msgstr "Sem dados"
 msgid "No disabled rules"
 msgstr "No disabled rules"
 
-#~ msgid "No Easy Read block is available for this page."
-#~ msgstr "Nenhum bloco de Leitura Fácil está disponível para esta página."
-
 msgid "No Easy Read for this page"
 msgstr "Sem Leitura Fácil para esta página"
 
@@ -3966,17 +3903,11 @@ msgstr "Nenhum prompt por idioma configurado."
 msgid "No languages configured. Add languages in the Language settings."
 msgstr "Nenhum idioma configurado. Adicione idiomas nas configurações de Idioma."
 
-#~ msgid "No link"
-#~ msgstr "Sem link"
-
 msgid "No log entries found yet."
 msgstr "Nenhuma entrada de registro encontrada ainda."
 
 msgid "No manual terms yet"
 msgstr "Nenhum termo manual ainda"
-
-#~ msgid "No matches"
-#~ msgstr "Sem resultados"
 
 msgid "No matches for \"{search}\""
 msgstr "Nenhum resultado para \"{0}\""
@@ -4077,17 +4008,11 @@ msgstr "Nenhuma imagem de origem"
 msgid "No storyboard sections found. Run Storyboard to generate sections you can match videos to."
 msgstr "Nenhuma seção de storyboard encontrada. Execute o Storyboard para gerar seções que você pode associar a vídeos."
 
-#~ msgid "No terms match your filter."
-#~ msgstr "Nenhum termo corresponde ao seu filtro."
-
 msgid "No terms match your search"
 msgstr "Nenhum termo corresponde à sua pesquisa"
 
 msgid "No terms to show"
 msgstr "Nenhum termo para mostrar"
-
-#~ msgid "No terms to show."
-#~ msgstr "Nenhum termo para mostrar."
 
 msgid "No text"
 msgstr "Sem texto"
@@ -4415,16 +4340,10 @@ msgstr "Página"
 msgid "Page {0}"
 msgstr "Página {0}"
 
-#~ msgid "Page {0} - Section {1}"
-#~ msgstr "Página {0} - Seção {1}"
-
 #. placeholder {0}: page.pageNumber
 #. placeholder {1}: i + 1
 msgid "Page {0} — Section {1}"
 msgstr "Página {0} — Seção {1}"
-
-#~ msgid "Page {0} · Section {1}"
-#~ msgstr "Página {0} · Seção {1}"
 
 #. placeholder {0}: String(pageNumber)
 msgid "Page {0} captions"
@@ -4464,9 +4383,6 @@ msgstr "Modo de Página"
 
 msgid "Page preview"
 msgstr "Pré-visualização da página"
-
-#~ msgid "Page preview {pageId}"
-#~ msgstr "Pré-visualização da página {0}"
 
 msgid "Page Range"
 msgstr "Intervalo de páginas"
@@ -4678,9 +4594,6 @@ msgstr "Predefinido"
 msgid "Presets add recommendations and specific settings for your use case. You still choose each option step by step, and you can go back to select a different preset at any time."
 msgstr "As predefinições adicionam recomendações e configurações específicas para o seu caso de uso. Você ainda escolhe cada opção etapa por etapa e pode voltar para selecionar outra predefinição a qualquer momento."
 
-#~ msgid "Press Enter to add"
-#~ msgstr "Pressione Enter para adicionar"
-
 msgid "Prev"
 msgstr "Anterior"
 
@@ -4761,9 +4674,6 @@ msgstr "removido"
 
 msgid "Pruned"
 msgstr "Removido"
-
-#~ msgid "Pruned ({0})"
-#~ msgstr "Podado ({0})"
 
 msgid "Pruned Images"
 msgstr "Imagens removidas"
@@ -5072,9 +4982,6 @@ msgstr "Raciocínio de renderização"
 msgid "Render Strategy"
 msgstr "Estratégia de renderização"
 
-#~ msgid "rendering"
-#~ msgstr "renderização"
-
 msgid "Rendering Prompt"
 msgstr "Prompt de renderização"
 
@@ -5134,9 +5041,6 @@ msgstr "Redefinir zoom"
 
 msgid "Resolving source language..."
 msgstr "Resolvendo idioma de origem..."
-
-#~ msgid "Responsive / State variants"
-#~ msgstr "Variantes responsivas / de estado"
 
 msgid "Restart and install"
 msgstr "Reiniciar e instalar"
@@ -5257,9 +5161,6 @@ msgstr "Executar Leitura Fácil"
 msgid "Run Extract"
 msgstr "Executar Extração"
 
-#~ msgid "Run Extract first — sectioning needs extracted page text and images."
-#~ msgstr "Execute Extração primeiro — o seccionamento precisa do texto e das imagens extraídas da página."
-
 msgid "Run Glossary"
 msgstr "Executar Glossário"
 
@@ -5274,9 +5175,6 @@ msgstr "Executar Questionários"
 
 msgid "Run Sectioning"
 msgstr "Executar Seccionamento"
-
-#~ msgid "Run Sectioning first — storyboard needs typed sections to render."
-#~ msgstr "Execute Seccionamento primeiro — o storyboard precisa de seções classificadas para renderizar."
 
 msgid "Run Speech"
 msgstr "Executar Fala"
@@ -5415,9 +5313,6 @@ msgstr "Save checklist"
 
 msgid "Save failed"
 msgstr "Save failed"
-
-#~ msgid "Save or discard edits before regenerating"
-#~ msgstr "Salve ou descarte as edições antes de regenerar"
 
 msgid "Save page review"
 msgstr "Save page review"
@@ -5566,9 +5461,6 @@ msgstr "Modo de seção"
 
 msgid "Sectioning Mode"
 msgstr "Modo de seção"
-
-#~ msgid "Sectioning needs the page text and images that Extract produces. Finish Extract before running this stage."
-#~ msgstr "O seccionamento precisa do texto e das imagens da página que a Extração produz. Termine a Extração antes de executar esta etapa."
 
 msgid "Sectioning Pages..."
 msgstr "Seccionando páginas..."
@@ -5769,9 +5661,6 @@ msgstr "Show fewer"
 msgid "Show only the terms you added manually"
 msgstr "Mostrar apenas os termos que você adicionou manualmente"
 
-#~ msgid "Show pruned terms"
-#~ msgstr "Mostrar termos podados"
-
 msgid "Show reviewer validation"
 msgstr "Show reviewer validation"
 
@@ -5917,12 +5806,6 @@ msgstr "Fala"
 msgid "Speech Generation"
 msgstr "Geração de fala"
 
-#~ msgid "Speech generation includes Easy Read audio. The ADT uses it while Easy Read mode is active."
-#~ msgstr "A geração de fala inclui áudio de Leitura Fácil. O ADT o usa enquanto o modo Leitura Fácil está ativo."
-
-#~ msgid "Speech generation uses original text only. Easy Read mode will fall back to original audio."
-#~ msgstr "A geração de fala usa apenas o texto original. O modo Leitura Fácil recorrerá ao áudio original."
-
 msgid "Speech narrates the translated text Language produces. Finish Language before running this stage."
 msgstr "A fala narra o texto traduzido que o Idioma produz. Termine o Idioma antes de executar esta etapa."
 
@@ -6014,9 +5897,6 @@ msgstr "Visão Geral do Storyboard"
 msgid "Storyboard Preview"
 msgstr "Pré-visualização do Storyboard"
 
-#~ msgid "Storyboard renders the typed sections produced by Sectioning. Finish Sectioning before running this stage."
-#~ msgstr "O Storyboard renderiza as seções classificadas produzidas pelo Seccionamento. Termine o Seccionamento antes de executar esta etapa."
-
 msgid "Storybook"
 msgstr "Livro de Histórias"
 
@@ -6025,9 +5905,6 @@ msgstr "Esticar"
 
 msgid "Strict"
 msgstr "Rigoroso"
-
-#~ msgid "Strict grid template that repeats across pages."
-#~ msgstr "Modelo de grade estrito que se repete nas páginas."
 
 msgid "Strikethrough"
 msgstr "Tachado"
@@ -6649,9 +6526,6 @@ msgstr "Template de duas colunas para conteúdo narrativo"
 msgid "Type"
 msgstr "Tipo"
 
-#~ msgid "Type class name or search..."
-#~ msgstr "Digite nome da classe ou pesquise..."
-
 msgid "Typed Sections"
 msgstr "Seções Classificadas"
 
@@ -6711,9 +6585,6 @@ msgstr "Restaurar imagem"
 
 msgid "Unsaved changes"
 msgstr "Alterações não salvas"
-
-#~ msgid "Unsaved:"
-#~ msgstr "Não salvo:"
 
 msgid "Untangling nested divs with care..."
 msgstr "Desembaraçando divs aninhadas com cuidado..."
@@ -6851,9 +6722,6 @@ msgstr "Erros de validação ({0})"
 
 msgid "Variables"
 msgstr "Variáveis"
-
-#~ msgid "Variant:"
-#~ msgstr "Variante:"
 
 msgid "Variations"
 msgstr "Variações"
@@ -7014,9 +6882,6 @@ msgstr "Ao descrever imagens, mencione qualquer objeto, local ou personagem reco
 
 msgid "When enabled, background colors from the styleguide are applied to the full page body."
 msgstr "Quando ativado, as cores de fundo do guia de estilo são aplicadas ao corpo completo da página."
-
-#~ msgid "When enabled, speech generation also creates audio for Easy Read texts. The ADT uses that audio while Easy Read mode is active and falls back to the original audio when it is missing."
-#~ msgstr "Quando ativado, a geração de fala também cria áudio para os textos de Leitura Fácil. O ADT usa esse áudio enquanto o modo Leitura Fácil está ativo e recorre ao áudio original quando está ausente."
 
 msgid "When enabled, text labels near vector images (e.g. chart dimensions, speech bubbles) are grouped together and extracted as raster crops. Disable to extract only the core vector shapes without text."
 msgstr "Quando ativado, rótulos de texto próximos a imagens vetoriais (ex.: dimensões de gráficos, balões de fala) são agrupados e extraídos como recortes rasterizados. Desative para extrair apenas as formas vetoriais sem texto."

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -1,0 +1,6975 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2026-06-02 03:47-0300\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: sq\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+msgid " · {needsChanges} need changes"
+msgstr " · {needsChanges} kërkojnë ndryshime"
+
+#. placeholder {0}: String(more)
+msgid " +{0} more"
+msgstr " +{0} më shumë"
+
+msgid " and "
+msgstr " dhe "
+
+msgid "_page"
+msgstr "_faqe"
+
+msgid "-"
+msgstr "-"
+
+msgid ", "
+msgstr ", "
+
+msgid ", and "
+msgstr ", dhe "
+
+msgid "? This will remove all extracted data and cannot be undone."
+msgstr "? Kjo do të heqë të gjitha të dhënat e nxjerra dhe nuk mund të zhbëhet."
+
+msgid "\"A landscape forged by fire.\""
+msgstr "\"Një peizazh i formuar nga zjarri.\""
+
+msgid "(active)"
+msgstr "(aktiv)"
+
+msgid "(base)"
+msgstr "(bazë)"
+
+msgid "(default)"
+msgstr "(parazgjedhje)"
+
+msgid "(empty)"
+msgstr "(bosh)"
+
+msgid "(no instruction text)"
+msgstr "(pa tekst udhëzimi)"
+
+msgid "(no target)"
+msgstr "(pa objektiv)"
+
+#. placeholder {0}: sections[0].pageNumber
+msgid "(p.{0})"
+msgstr "(f.{0})"
+
+msgid "(template)"
+msgstr "(shabllon)"
+
+#. placeholder {0}: lockedLang.name
+msgid "{0} — type country or Enter for base"
+msgstr "{0} — shkruani vendin ose Enter për bazë"
+
+#. placeholder {0}: progress?.page
+#. placeholder {1}: progress?.totalPages
+msgid "{0} / {1}"
+msgstr "{0} / {1}"
+
+#. placeholder {0}: bbox.w
+#. placeholder {1}: bbox.h
+#. placeholder {2}: points.length
+msgid "{0} × {1}px · {2} points"
+msgstr "{0} × {1}px · {2} pika"
+
+#. placeholder {0}: String(totalAudioFiles)
+msgid "{0} audio"
+msgstr "{0} audio"
+
+#. placeholder {0}: activeProgress.criteriaPerPage
+msgid "{0} checks per page"
+msgstr "{0} kontrolle për faqe"
+
+#. placeholder {0}: String(p.stats.decorative)
+msgid "{0} decorative"
+msgstr "{0} dekorative"
+
+#. placeholder {0}: entries.length
+msgid "{0} entries"
+msgstr "{0} hyrje"
+
+#. placeholder {0}: activeMetrics.flagged.length
+msgid "{0} flagged findings in this review"
+msgstr "{0} gjetje të shënuara në këtë rishikim"
+
+#. placeholder {0}: selectedImageIds.length
+#. placeholder {1}: selectedImageIds.length === 1 ? "" : "s"
+msgid "{0} image{1} selected"
+msgstr "{0} imazh{1} i zgjedhur"
+
+#. placeholder {0}: String(captions.length)
+#. placeholder {0}: String(group.captions.length)
+#. placeholder {0}: String(totalImages)
+msgid "{0} images"
+msgstr "{0} imazhe"
+
+#. placeholder {0}: String(selected.size)
+#. placeholder {0}: String(selectedImageIds.length)
+msgid "{0} images selected"
+msgstr "{0} imazhe të zgjedhura"
+
+#. placeholder {0}: String(p.imageCount)
+msgid "{0} img"
+msgstr "{0} img"
+
+#. placeholder {0}: visibleFindingsUniverse.length
+msgid "{0} items"
+msgstr "{0} elemente"
+
+#. placeholder {0}: counts.needsChanges
+msgid "{0} items need changes on this page"
+msgstr "{0} elemente kërkojnë ndryshime në këtë faqe"
+
+#. placeholder {0}: entries.length
+msgid "{0} items with unsaved changes"
+msgstr "{0} elemente me ndryshime të paruajtura"
+
+#. placeholder {0}: String(outputLanguages.length)
+msgid "{0} languages"
+msgstr "{0} gjuhë"
+
+#. placeholder {0}: String(filteredQuizzes.length)
+#. placeholder {1}: String(displayQuizzes.length)
+msgid "{0} of {1}"
+msgstr "{0} nga {1}"
+
+#. placeholder {0}: activeMetrics.pagesReviewed
+#. placeholder {1}: activeProgress.assignedPageCount
+msgid "{0} of {1} assigned pages reviewed"
+msgstr "{0} nga {1} faqe të caktuara të rishikuara"
+
+#. placeholder {0}: activeMetrics.pagesReviewed
+#. placeholder {1}: activeProgress.totalBookPages
+msgid "{0} of {1} book pages reviewed"
+msgstr "{0} nga {1} faqe të librit të rishikuara"
+
+#. placeholder {0}: String(filteredCaptions.length)
+#. placeholder {1}: String(captions.length)
+msgid "{0} of {1} images"
+msgstr "{0} nga {1} imazhe"
+
+#. placeholder {0}: visibleFindings.length
+#. placeholder {1}: visibleFindingsUniverse.length
+msgid "{0} of {1} items"
+msgstr "{0} nga {1} elemente"
+
+#. placeholder {0}: String(displayPages.length)
+msgid "{0} pages"
+msgstr "{0} faqe"
+
+#. placeholder {0}: section.criteria.length - reviewed
+msgid "{0} pending"
+msgstr "{0} në pritje"
+
+#. placeholder {0}: String(displayQuizzes.length)
+msgid "{0} questions"
+msgstr "{0} pyetje"
+
+#. placeholder {0}: String(group.blocks.length)
+msgid "{0} sections"
+msgstr "{0} seksione"
+
+#. placeholder {0}: String(stale.length)
+msgid "{0} selected images are no longer in the storyboard."
+msgstr "{0} imazhe të zgjedhura nuk janë më në storyboard."
+
+#. placeholder {0}: String(visibleCount)
+msgid "{0} terms"
+msgstr "{0} terma"
+
+#. placeholder {0}: String(displayEntries.length)
+msgid "{0} texts"
+msgstr "{0} tekste"
+
+#. placeholder {0}: outputLanguages.length
+msgid "{0} translations"
+msgstr "{0} përkthime"
+
+#. placeholder {0}: String(generatedAudioCount)
+#. placeholder {1}: String(displayEntries.length)
+msgid "{0}/{1} audio"
+msgstr "{0}/{1} audio"
+
+#. placeholder {0}: counts.reviewed
+msgid "{0}/{criteriaCount} checked"
+msgstr "{0}/{criteriaCount} të kontrolluar"
+
+#. placeholder {0}: selected.length
+msgid "{0}/{MAX_SOURCE_PAGES} selected"
+msgstr "{0}/{MAX_SOURCE_PAGES} të zgjedhura"
+
+#. placeholder {0}: String(selectedPageIds.size)
+msgid "{0}/5 pages selected"
+msgstr "{0}/5 faqe të zgjedhura"
+
+#. placeholder {0}: activeProgress.percent
+msgid "{0}% complete"
+msgstr "{0}% e përfunduar"
+
+#. placeholder {0}: String(count)
+msgid "{0}×"
+msgstr "{0}×"
+
+#. placeholder {0}: Math.floor(elapsed / 60)
+#. placeholder {1}: elapsed % 60
+msgid "{0}m {1}s"
+msgstr "{0}m {1}s"
+
+#. placeholder {0}: String(Math.floor(diff / 60_000))
+msgid "{0}m ago"
+msgstr "{0}m më parë"
+
+#. placeholder {0}: String(Math.floor(diff / 1000))
+msgid "{0}s ago"
+msgstr "{0}s më parë"
+
+msgid "{count} {count, plural, one {issue} other {issues}}"
+msgstr "{count} {count, plural, one {problem} other {probleme}}"
+
+msgid "{count} {count, plural, one {manual review item} other {manual review items}}"
+msgstr "{count} {count, plural, one {element për rishikim manual} other {elemente për rishikim manual}}"
+
+msgid "{count} translations"
+msgstr "{count} përkthime"
+
+msgid "{countSummary} this page"
+msgstr "{countSummary} në këtë faqe"
+
+msgid "{coveredSections} / {totalSections}"
+msgstr "{coveredSections} / {totalSections}"
+
+msgid "{coveredSections} of {totalSections} sections"
+msgstr "{coveredSections} nga {totalSections} seksione"
+
+msgid "{coveredSections} of {totalSections} sections covered"
+msgstr "{coveredSections} nga {totalSections} seksione të mbuluara"
+
+msgid "{disabledProvidersText} are disabled — add their API keys in Book settings to enable them."
+msgstr "{disabledProvidersText} janë të çaktivizuar — shtoni çelësat e tyre API në cilësimet e Librit për t'i aktivizuar."
+
+msgid "{disabledProvidersText} is disabled — add its API key in Book settings to enable it."
+msgstr "{disabledProvidersText} është i çaktivizuar — shtoni çelësin e tij API në cilësimet e Librit për ta aktivizuar."
+
+msgid "{elapsed}s"
+msgstr "{elapsed}s"
+
+msgid "{formatted} will be reset and need to run again before final outputs are available."
+msgstr "{formatted} do të rivendoset dhe duhet të ekzekutohet përsëri përpara se rezultatet përfundimtare të jenë të disponueshme."
+
+msgid "{generatedFeatureCount} of 6 features generated"
+msgstr "{generatedFeatureCount} nga 6 veçori të gjeneruara"
+
+#. placeholder {0}: imageCount === 1 ? "" : "s"
+msgid "{imageCount} image{0} will be translated"
+msgstr "{imageCount} imazh{0} do të përkthehet"
+
+msgid "{imageCount} images"
+msgstr "{imageCount} imazhe"
+
+#. placeholder {0}: issueCount === 1 ? "issue" : "issues"
+msgid "{issueCount} {0}"
+msgstr "{issueCount} {0}"
+
+msgid "{issuesLabel}, {reviewLabel}"
+msgstr "{issuesLabel}, {reviewLabel}"
+
+msgid "{missingAudioCount} missing"
+msgstr "{missingAudioCount} mungojnë"
+
+msgid "{missingForCurrentStage} entry/entries are missing audio. Re-run to generate the missing items."
+msgstr "{missingForCurrentStage} hyrje/hyrjet mungojnë audio. Ekzekutoni përsëri për të gjeneruar elementet që mungojnë."
+
+msgid "{missingForCurrentStage} entry/entries are missing translations. Re-run to fill the missing items."
+msgstr "{missingForCurrentStage} hyrje/hyrjet mungojnë përkthime. Ekzekutoni përsëri për të plotësuar elementet që mungojnë."
+
+msgid "{needsChanges} flagged"
+msgstr "{needsChanges} të shënuara"
+
+msgid "{pageCount} {pageCount, plural, one {page} other {pages}}"
+msgstr "{pageCount} {pageCount, plural, one {faqe} other {faqe}}"
+
+msgid "{pageCount} pages"
+msgstr "{pageCount} faqe"
+
+msgid "{pagesReviewed} {pagesReviewed, plural, one {page} other {pages}} reviewed so far"
+msgstr "{pagesReviewed} {pagesReviewed, plural, one {faqe} other {faqe}} të rishikuara deri tani"
+
+msgid "{pdfFilename} · {pageCount} pages"
+msgstr "{pdfFilename} · {pageCount} faqe"
+
+msgid "{regionCount} {regionCount, plural, one {region} other {regions}} detected"
+msgstr "{regionCount} {regionCount, plural, one {rajon} other {rajone}} të zbuluar"
+
+#. placeholder {0}: reviewCount === 1 ? "manual review item" : "manual review items"
+msgid "{reviewCount} {0}"
+msgstr "{reviewCount} {0}"
+
+#. placeholder {0}: section.criteria.length
+msgid "{reviewed}/{0} checked"
+msgstr "{reviewed}/{0} të kontrolluar"
+
+msgid "{sections} sections"
+msgstr "{sections} seksione"
+
+msgid "{stageLabel} isn't ready yet — every section in the Storyboard is currently pruned, so there's nothing to run on. Restore at least one section in Storyboard to continue."
+msgstr "{stageLabel} nuk është gati ende — çdo seksion në Storyboard është aktualisht i prerë, kështu që nuk ka asgjë për të ekzekutuar. Rivendosni të paktën një seksion në Storyboard për të vazhduar."
+
+msgid "{stageLabel} isn't ready yet — Storyboard hasn't finished, so there's nothing to work with. Finish that stage first."
+msgstr "{stageLabel} nuk është gati ende — Storyboard nuk ka përfunduar, kështu që nuk ka asgjë me të cilën të punohet. Përfundoni atë fazë fillimisht."
+
+msgid "{textCount} text leaves"
+msgstr "{textCount} gjethe teksti"
+
+#. placeholder {0}: index + 1
+msgid "{title} - page {0}"
+msgstr "{title} - faqe {0}"
+
+msgid "{totalPages} pages"
+msgstr "{totalPages} faqe"
+
+msgid "{totalPages} pages · {totalSections} sections"
+msgstr "{totalPages} faqe · {totalSections} seksione"
+
+#. placeholder {0}: String(filterSectionIndex + 1)
+msgid "/ Section {0}"
+msgstr "/ Seksioni {0}"
+
+msgid "×4"
+msgstr "×4"
+
+msgid "="
+msgstr "="
+
+msgid "● LIVE"
+msgstr "● DREJTPËRDREJTË"
+
+msgid "🌿"
+msgstr "🌿"
+
+msgid "0 = deterministic, 2 = max creativity"
+msgstr "0 = deterministik, 2 = kreativitet maksimal"
+
+msgid "0 = single pass, higher values allow iterative LLM refinement"
+msgstr "0 = kalim i vetëm, vlerat më të larta lejojnë rafinim iterativ LLM"
+
+msgid "1 hour"
+msgstr "1 orë"
+
+msgid "1 image selected"
+msgstr "1 imazh i zgjedhur"
+
+msgid "1 item needs changes on this page"
+msgstr "1 element kërkon ndryshime në këtë faqe"
+
+msgid "1 quiz / {frequency} pages"
+msgstr "1 kuiz / {frequency} faqe"
+
+msgid "1 section"
+msgstr "1 seksion"
+
+msgid "1 selected image is no longer in the storyboard."
+msgstr "1 imazh i zgjedhur nuk është më në storyboard."
+
+msgid "1.1 Background"
+msgstr "1.1 Sfondi"
+
+msgid "1.2 Scope"
+msgstr "1.2 Shtrirja"
+
+msgid "14.2 kB"
+msgstr "14.2 kB"
+
+msgid "14.2 MB"
+msgstr "14.2 MB"
+
+msgid "18 scenes"
+msgstr "18 skena"
+
+msgid "2.1 Data collection"
+msgstr "2.1 Mbledhja e të dhënave"
+
+msgid "2.2 Analysis"
+msgstr "2.2 Analiza"
+
+msgid "22 words"
+msgstr "22 fjalë"
+
+msgid "238 pages · 14.2 MB"
+msgstr "238 faqe · 14.2 MB"
+
+msgid "238 pp"
+msgstr "238 ff"
+
+msgid "3 items"
+msgstr "3 elemente"
+
+msgid "3 of 5 modules"
+msgstr "3 nga 5 module"
+
+msgid "3.2.1 — Authentication Methods"
+msgstr "3.2.1 — Metodat e Autentifikimit"
+
+msgid "36 spreads"
+msgstr "36 shpërndarje"
+
+msgid "42 figs"
+msgstr "42 figura"
+
+msgid "72 panels"
+msgstr "72 panele"
+
+msgid "A → Z"
+msgstr "A → Z"
+
+msgid "A balanced glossary for most books."
+msgstr "Një glosar i ekuilibruar për shumicën e librave."
+
+msgid "A book with this name already exists."
+msgstr "Një libër me këtë emër ekziston tashmë."
+
+msgid "A close, long-term relationship between two different species, often benefiting both."
+msgstr "Një marrëdhënie e ngushtë afatgjatë midis dy specieve të ndryshme, shpesh duke përfituar të dyja."
+
+msgid "A figure of speech that describes one thing as if it were another to draw a comparison."
+msgstr "Një figurë stilistike që përshkruan diçka sikur të ishte tjetër gjë për të bërë një krahasim."
+
+msgid "A fill-in-the-blank activity."
+msgstr "Një aktivitet me plotësim boshllëqesh."
+
+msgid "A glossary term with this word already exists."
+msgstr "Një term glosari me këtë fjalë ekziston tashmë."
+
+msgid "A long row of shelves filled with food in a big store."
+msgstr "Një rresht i gjatë rafte të mbushur me ushqim në një dyqan të madh."
+
+msgid "A matching activity where students connect related items."
+msgstr "Një aktivitet çiftëzimi ku nxënësit lidhin elementet e lidhura."
+
+msgid "A multiple choice activity."
+msgstr "Një aktivitet me zgjedhje të shumëfishtë."
+
+msgid "A new version is available for download."
+msgstr "Një version i ri është i disponueshëm për shkarkim."
+
+msgid "A question worth asking"
+msgstr "Një pyetje që vlen të bëhet"
+
+msgid "A quiz already sits here — add another after it or replace it"
+msgstr "Një kuiz ekziston tashmë këtu — shtoni një tjetër pas tij ose zëvendësojeni"
+
+msgid "A scenic view at dusk."
+msgstr "Një pamje piktoreske në muzg."
+
+msgid "A section containing only images."
+msgstr "Një seksion që përmban vetëm imazhe."
+
+msgid "A section containing only text content."
+msgstr "Një seksion që përmban vetëm përmbajtje tekstuale."
+
+msgid "A section with text and a single image."
+msgstr "Një seksion me tekst dhe një imazh të vetëm."
+
+msgid "A section with text and multiple images."
+msgstr "Një seksion me tekst dhe imazhe të shumta."
+
+msgid "A section with text in a highlighted box."
+msgstr "Një seksion me tekst në një kuti të theksuar."
+
+msgid "A select-all-that-apply activity where the learner can choose more than one option per question."
+msgstr "Një aktivitet zgjidh-të-gjitha-që-zbatohen ku nxënësi mund të zgjedhë më shumë se një opsion për pyetje."
+
+msgid "A separator page between sections."
+msgstr "Një faqe ndarëse midis seksioneve."
+
+msgid "A simplified Easy Read version makes the text accessible to readers with cognitive disabilities, learning differences, or limited reading proficiency."
+msgstr "Një version i thjeshtuar Easy Read e bën tekstin të aksesueshëm për lexuesit me aftësi të kufizuara njohëse, dallime në të mësuar, ose aftësi të kufizuara leximi."
+
+msgid "A single water molecule can take over 3,000 years to complete one full trip through the water cycle - from ocean to sky to river and back again."
+msgstr "Një molekulë e vetme uji mund të marrë mbi 3,000 vjet për të përfunduar një udhëtim të plotë nëpër ciklin e ujit - nga oqeani në qiell tek lumi dhe kthim."
+
+msgid "A sorting activity."
+msgstr "Një aktivitet renditjeje."
+
+msgid "A specific URL where an API can be accessed and a request submitted."
+msgstr "Një URL specifike ku mund të aksesohet një API dhe të dërgohet një kërkesë."
+
+msgid "A story with characters and events that stand for a deeper, often moral, meaning."
+msgstr "Një histori me personazhe dhe ngjarje që simbolizojnë një kuptim më të thellë, shpesh moral."
+
+msgid "A structured table of contents lets readers jump directly to any section, which is especially important for keyboard and assistive technology users."
+msgstr "Një tabelë e strukturuar e përmbajtjes u lejon lexuesve të kalojnë drejtpërdrejt në çdo seksion, gjë që është veçanërisht e rëndësishme për përdoruesit e tastierës dhe teknologjive ndihmëse."
+
+msgid "A style guide provides consistent HTML and CSS patterns that the LLM uses when generating pages. It controls typography, colors, spacing, and component styles so every page in your book has a unified look."
+msgstr "Një udhëzues stili ofron modele të qëndrueshme HTML dhe CSS që LLM i përdor gjatë gjenerimit të faqeve. Ai kontrollon tipografinë, ngjyrat, hapësirat dhe stilet e komponentëve, në mënyrë që çdo faqe në librin tuaj të ketë një pamje të unifikuar."
+
+msgid "A supermarket aisle with shelves of colorful cereal boxes and packaged goods, lit by overhead lights, with a single shopper in the distance."
+msgstr "Një koridor supermarketi me rafte me kuti drithërash me ngjyra dhe mallra të paketuara, i ndriçuar nga dritat sipër, me një blerës të vetëm në distancë."
+
+msgid "A table-filling activity."
+msgstr "Një aktivitet me plotësim tabele."
+
+msgid "A true or false activity."
+msgstr "Një aktivitet i vërtetë ose i gabuar."
+
+msgid "A unique identifier used as the book folder name."
+msgstr "Një identifikues unik i përdorur si emër dosje e librit."
+
+msgid "A unique string used to authenticate and authorize API requests."
+msgstr "Një varg unik i përdorur për të vërtetuar dhe autorizuar kërkesat API."
+
+msgid "A wide-angle view down a fluorescent-lit supermarket aisle, with stacked branded cereal boxes lining the left shelves and assorted packaged dry goods on the right; a lone shopper stands at the far end, providing scale to the receding perspective."
+msgstr "Një pamje me kënd të gjerë poshtë një korridori supermarketi të ndriçuar me dritë fluoreshente, me kuti drithërash të markave të grumbulluara në raftet majtas dhe mallra të thata të ndryshme të paketuara në të djathtë; një blerës i vetmuar qëndron në fund, duke dhënë shkallën e perspektivës në largim."
+
+msgid "A–Z"
+msgstr "A–Z"
+
+msgid "ABC"
+msgstr "ABC"
+
+msgid "About page grouping"
+msgstr "Grupimi i faqes informative"
+
+msgid "About section mode"
+msgstr "Modaliteti i seksionit informativ"
+
+msgid "Accent Prompt"
+msgstr "Prompt Akcenti"
+
+msgid "Accept reasonable web redesigns. Reject only for functional defects (visible placeholder tokens, missing content, overlap, overflow). Fewest rejections."
+msgstr "Pranoni ridesenimet e arsyeshme të faqes. Refuzoni vetëm për defekte funksionale (shenja të dukshme të vendmbajtësve, përmbajtje mungon, mbivendosje, tejkalim). Sa më pak refuzime."
+
+msgid "Accessibility"
+msgstr "Aksesueshmëria"
+
+msgid "Accessibility assessment configuration"
+msgstr "Konfigurimi i vlerësimit të aksesueshmërisë"
+
+msgid "Accessibility check failed for this page"
+msgstr "Kontrolli i aksesueshmërisë dështoi për këtë faqe"
+
+msgid "Accessibility Findings"
+msgstr "Gjetjet e Aksesueshmërisë"
+
+msgid "Accessibility results are temporarily unavailable."
+msgstr "Rezultatet e aksesueshmërisë janë përkohësisht të padisponueshme."
+
+msgid "Accessibility Summary"
+msgstr "Përmbledhja e Aksesueshmërisë"
+
+msgid "Accessibility, from the first <0>page.</0>"
+msgstr "Aksesueshmëria, që nga <0>faqja e parë.</0>"
+
+msgid "Accessible book"
+msgstr "Libër i aksesueshëm"
+
+msgid "Actions disabled while storyboard is running"
+msgstr "Veprimet janë çaktivizuara ndërsa storyboard-i është në ekzekutim"
+
+msgid "Active"
+msgstr "Aktiv"
+
+msgid "active checklist items"
+msgstr "elementë aktivë të listës kontrolluese"
+
+msgid "active item"
+msgstr "element aktiv"
+
+msgid "active items"
+msgstr "elementë aktivë"
+
+msgid "Active reviewer session"
+msgstr "Sesion aktiv i rishikuesit"
+
+msgid "active sections"
+msgstr "seksione aktive"
+
+msgid "Activities"
+msgstr "Aktivitetet"
+
+msgid "Activities disabled"
+msgstr "Aktivitetet çaktivizuar"
+
+msgid "Activities enabled"
+msgstr "Aktivitetet aktivizuar"
+
+msgid "Activity"
+msgstr "Aktivitet"
+
+msgid "Activity 5.1"
+msgstr "Aktiviteti 5.1"
+
+msgid "Activity Converter"
+msgstr "Konvertues Aktivitetesh"
+
+msgid "Activity Detection"
+msgstr "Zbulimi i Aktivitetit"
+
+msgid "Activity Rendering"
+msgstr "Renderimi i Aktivitetit"
+
+msgid "Activity section types are available for classification and rendering."
+msgstr "Llojet e seksioneve të aktiviteteve janë të disponueshme për klasifikim dhe renderim."
+
+msgid "Activity section types are hidden from the classifier and skipped during rendering."
+msgstr "Llojet e seksioneve të aktiviteteve janë të fshehura nga klasifikuesi dhe anashkalohen gjatë renderimit."
+
+msgid "Activity Types"
+msgstr "Llojet e Aktivitetit"
+
+msgid "Activity: Fill in a Table"
+msgstr "Aktivitet: Plotëso Tabelën"
+
+msgid "Activity: Fill in the Blank"
+msgstr "Aktivitet: Plotëso Boshllëkun"
+
+msgid "Activity: Matching"
+msgstr "Aktivitet: Përputhje"
+
+msgid "Activity: Multi-Select"
+msgstr "Aktivitet: Shumë-Zgjedhje"
+
+msgid "Activity: Multiple Choice"
+msgstr "Aktivitet: Zgjedhje e Shumëfishtë"
+
+msgid "Activity: Open-Ended Answer"
+msgstr "Aktivitet: Përgjigje e Hapur"
+
+msgid "Activity: Other"
+msgstr "Aktivitet: Tjetër"
+
+msgid "Activity: Sorting"
+msgstr "Aktivitet: Renditje"
+
+msgid "Activity: True / False"
+msgstr "Aktivitet: E Vërtetë / E Gabuar"
+
+msgid "Adaptive layouts generated per page (slower, uses API credits)"
+msgstr "Paraqitje adaptive të gjeneruara për faqe (më e ngadaltë, përdor kredite API)"
+
+msgid "Add"
+msgstr "Shto"
+
+#. placeholder {0}: String(selected.size)
+msgid "Add {0} Images"
+msgstr "Shto {0} Imazhe"
+
+msgid "Add a definition…"
+msgstr "Shto një përkufizim…"
+
+msgid "Add a language to see translations appear here."
+msgstr "Shto një gjuhë për të parë përkthimet këtu."
+
+msgid "Add a quiz"
+msgstr "Shto një kuiz"
+
+msgid "Add after"
+msgstr "Shto pas"
+
+msgid "Add an API key in Book settings to add a quiz."
+msgstr "Shto një çelës API në cilësimet e Librit për të shtuar një kuiz."
+
+msgid "Add an API key in Book settings to generate a quiz."
+msgstr "Shto një çelës API në cilësimet e Librit për të gjeneruar një kuiz."
+
+msgid "Add an API key in Book settings to generate Easy Read content."
+msgstr "Shto një çelës API në cilësimet e Librit për të gjeneruar përmbajtje Lexim të Lehtë."
+
+msgid "Add an API key in Book settings to generate quizzes."
+msgstr "Shto një çelës API në cilësimet e Librit për të gjeneruar kuize."
+
+msgid "Add an API key in Book settings to run captions."
+msgstr "Shto një çelës API në cilësimet e Librit për të ekzekutuar titujt."
+
+msgid "Add an API key in Book settings to run extraction."
+msgstr "Shto një çelës API në cilësimet e Librit për të ekzekutuar nxjerrjen."
+
+msgid "Add an API key in Book settings to run sectioning."
+msgstr "Shto një çelës API në cilësimet e Librit për të ekzekutuar ndarjen në seksione."
+
+msgid "Add an API key in Book settings to run speech."
+msgstr "Shto një çelës API në cilësimet e Librit për të ekzekutuar të folurit."
+
+msgid "Add an API key in Book settings to run storyboard."
+msgstr "Shto një çelës API në cilësimet e Librit për të ekzekutuar storyboard-in."
+
+msgid "Add an API key in Book settings to run the glossary."
+msgstr "Shto një çelës API në cilësimet e Librit për të ekzekutuar fjalorthin."
+
+msgid "Add an API key in Book settings to run TOC generation."
+msgstr "Shto një çelës API në cilësimet e Librit për të ekzekutuar gjenerimin e TOC."
+
+msgid "Add an API key in Book settings to run translation."
+msgstr "Shto një çelës API në cilësimet e Librit për të ekzekutuar përkthimin."
+
+msgid "Add at least one output language to run translation."
+msgstr "Shto të paktën një gjuhë dalëse për të ekzekutuar përkthimin."
+
+msgid "Add Book"
+msgstr "Shto Libër"
+
+msgid "Add caption…"
+msgstr "Shto titull…"
+
+msgid "Add checklist item to this section"
+msgstr "Shto element liste kontrolluese në këtë seksion"
+
+msgid "Add custom instructions"
+msgstr "Shto udhëzime të personalizuara"
+
+msgid "Add entry"
+msgstr "Shto hyrje"
+
+msgid "Add entry below"
+msgstr "Shto hyrje poshtë"
+
+msgid "Add Glossary Term"
+msgstr "Shto Term Fjalorth"
+
+msgid "Add group"
+msgstr "Shto grup"
+
+msgid "Add image"
+msgstr "Shto imazh"
+
+msgid "Add Image"
+msgstr "Shto Imazh"
+
+msgid "Add language"
+msgstr "Shto gjuhë"
+
+msgid "Add Language"
+msgstr "Shto Gjuhë"
+
+msgid "Add languages to translate the book content into."
+msgstr "Shto gjuhë për të përkthyer përmbajtjen e librit."
+
+msgid "Add quiz"
+msgstr "Shto kuiz"
+
+msgid "Add quiz here"
+msgstr "Shto kuiz këtu"
+
+msgid "Add reviewer guidance."
+msgstr "Shto udhëzime për rishikuesin."
+
+msgid "Add section"
+msgstr "Shto seksion"
+
+msgid "Add sizing field"
+msgstr "Shto fushë madhësie"
+
+msgid "Add term"
+msgstr "Shto term"
+
+msgid "Add Term"
+msgstr "Shto Term"
+
+msgid "Add text"
+msgstr "Shto tekst"
+
+msgid "Add the selected provider's API key in Book settings to run speech."
+msgstr "Shto çelësin API të ofruesit të zgjedhur në cilësimet e Librit për të ekzekutuar të folurit."
+
+msgid "Add this provider's API key in Book settings."
+msgstr "Shto çelësin API të këtij ofruesi në cilësimet e Librit."
+
+msgid "Add Translations"
+msgstr "Shto Përkthime"
+
+msgid "Add video"
+msgstr "Shto video"
+
+msgid "Add videos"
+msgstr "Shto video"
+
+msgid "Add your first book"
+msgstr "Shto librin tuaj të parë"
+
+msgid "Add your first term"
+msgstr "Shto termin tuaj të parë"
+
+msgid "added"
+msgstr "shtuar"
+
+msgid "Added manually"
+msgstr "Shtuar manualisht"
+
+msgid "Additional Languages"
+msgstr "Gjuhë Shtesë"
+
+msgid "Additional terminology may be introduced in later sections. All terms are listed in the glossary appendix at the end of this document for quick reference."
+msgstr "Terminologji shtesë mund të prezantohet në seksionet e mëvonshme. Të gjithë termat janë listuar në shtojcën e fjalorëzimit në fund të këtij dokumenti për referencë të shpejtë."
+
+msgid "ADT"
+msgstr "ADT"
+
+msgid "ADT Book"
+msgstr "Libër ADT"
+
+#. placeholder {0}: i18n._(selectedBook.title)
+msgid "ADT Book - {0}"
+msgstr "Libër ADT - {0}"
+
+msgid "ADT Package"
+msgstr "Paketë ADT"
+
+msgid "ADT Studio uses your own API keys to run the pipeline. Keys are stored locally on this device and never sent anywhere else."
+msgstr "ADT Studio përdor çelësat tuaj API për të ekzekutuar pipeline-in. Çelësat ruhen lokalisht në këtë pajisje dhe nuk dërgohen asnjëherë askund tjetër."
+
+msgid "ADT_DEBUG=1"
+msgstr "ADT_DEBUG=1"
+
+msgid "Advanced"
+msgstr "Avancuar"
+
+msgid "Advanced Settings"
+msgstr "Cilësime të Avancuara"
+
+msgid "Adventure Tales - Vol. 1"
+msgstr "Tregime Aventure - Vol. 1"
+
+msgid "Affected pages"
+msgstr "Faqet e prekura"
+
+msgid "After"
+msgstr "Pas"
+
+#. placeholder {0}: quiz.afterPageId
+msgid "After {0}"
+msgstr "Pas {0}"
+
+#. placeholder {0}: String(pageNumber)
+#. placeholder {0}: afterPage.pageNumber
+msgid "after page {0}"
+msgstr "pas faqes {0}"
+
+msgid "After page {afterNumber}"
+msgstr "Pas faqes {afterNumber}"
+
+#. placeholder {0}: String(page.pageNumber)
+msgid "after pg {0}"
+msgstr "pas f. {0}"
+
+msgid "age 8"
+msgstr "mosha 8"
+
+msgid "AI"
+msgstr "AI"
+
+msgid "AI Edit"
+msgstr "Editim me AI"
+
+msgid "AI edit failed"
+msgstr "Editimi me AI dështoi"
+
+msgid "AI edit history"
+msgstr "Historia e editimit me AI"
+
+msgid "AI editing..."
+msgstr "Duke edituar me AI..."
+
+msgid "AI Generated"
+msgstr "Gjeneruar nga AI"
+
+msgid "AI generates fresh interactive activities from each section."
+msgstr "AI gjeneron aktivitete interaktive të reja nga çdo seksion."
+
+msgid "AI Image"
+msgstr "Imazh AI"
+
+msgid "AI lays out images and text per section, matching the original book's design as closely as possible."
+msgstr "AI vendos imazhet dhe tekstin për çdo seksion, duke iu përshtatur sa më afër dizajnit origjinal të librit."
+
+msgid "AI Overlay"
+msgstr "Mbivendosje AI"
+
+msgid "AI Rendering"
+msgstr "Renderim me AI"
+
+msgid "AI sees the current image and modifies it"
+msgstr "AI sheh imazhin aktual dhe e modifikon atë"
+
+msgid "AI-powered"
+msgstr "I fuqizuar nga AI"
+
+msgid "AI-powered layout that preserves the original page as a background with text overlay."
+msgstr "Paraqitje e fuqizuar nga AI që ruan faqen origjinale si sfond me mbivendosje teksti."
+
+msgid "AIza..."
+msgstr "AIza..."
+
+msgid "Albanian"
+msgstr "Shqip"
+
+msgid "Align"
+msgstr "Rreshtim"
+
+msgid "Align center"
+msgstr "Rreshtim në qendër"
+
+msgid "Align left"
+msgstr "Rreshtim majtas"
+
+msgid "Align right"
+msgstr "Rreshtim djathtas"
+
+msgid "Aligns narration with text to enable word-level highlighting."
+msgstr "Rreshtimi i tregimit me tekstin për të aktivizuar theksimin në nivel fjalësh."
+
+msgid "All"
+msgstr "Të gjitha"
+
+msgid "All Categories"
+msgstr "Të Gjitha Kategoritë"
+
+msgid "All issues and manual review items"
+msgstr "Të gjitha problemet dhe elementet e rishikimit manual"
+
+msgid "All pages are pruned"
+msgstr "Të gjitha faqet janë prerë"
+
+msgid "All sections are covered"
+msgstr "Të gjitha seksionet janë mbuluar"
+
+msgid "All sections have been deleted"
+msgstr "Të gjitha seksionet janë fshirë"
+
+msgid "All set"
+msgstr "Gjithçka gati"
+
+msgid "All Severities"
+msgstr "Të gjitha nivelet e ashpërsisë"
+
+msgid "All steps"
+msgstr "Të gjitha hapat"
+
+msgid "Allegory"
+msgstr "Alegori"
+
+msgid "Alphabetical"
+msgstr "Alfabetik"
+
+msgid "Alt"
+msgstr "Alt"
+
+msgid "Among the Stars"
+msgstr "Mes yjeve"
+
+msgid "Amount"
+msgstr "Sasia"
+
+msgid "An activity that does not fit the standard categories."
+msgstr "Një aktivitet që nuk i përshtatet kategorive standarde."
+
+msgid "An AI image is being generated. Cancel it and navigate?"
+msgstr "Po gjenerohet një imazh me AI. Ta anulosh dhe të vazhdosh?"
+
+msgid "An open-ended answer activity."
+msgstr "Një aktivitet me përgjigje të hapur."
+
+msgid "and many more blocks across the entire book"
+msgstr "dhe shumë blloqe të tjera në të gjithë librin"
+
+msgid "and more sections across the page"
+msgstr "dhe seksione të tjera në faqe"
+
+msgid "Answer"
+msgstr "Përgjigje"
+
+msgid "Answer Prompt"
+msgstr "Prompt përgjigjeje"
+
+msgid "answer_key"
+msgstr "answer_key"
+
+msgid "Answers"
+msgstr "Përgjigjet"
+
+msgid "Anthropic"
+msgstr "Anthropic"
+
+msgid "Anthropic API Key"
+msgstr "Çelësi API Anthropic"
+
+msgid "Any content type"
+msgstr "Çdo lloj përmbajtjeje"
+
+msgid "Any OpenAI-compatible endpoint (Ollama, vLLM, Together AI, etc.). Use the \"custom:\" prefix when selecting models, e.g. custom:llama3."
+msgstr "Çdo pikë fundore e përputhshme me OpenAI (Ollama, vLLM, Together AI, etj.). Përdor prefiksin \"custom:\" kur zgjedhësh modele, p.sh. custom:llama3."
+
+msgid "Any other section type."
+msgstr "Çdo lloj tjetër seksioni."
+
+msgid "API"
+msgstr "API"
+
+msgid "API Key"
+msgstr "Çelës API"
+
+msgid "API Key (optional)"
+msgstr "Çelës API (opsional)"
+
+msgid "API key required to re-render"
+msgstr "Kërkohet çelës API për ri-renderim"
+
+msgid "API Key Settings"
+msgstr "Cilësimet e çelësit API"
+
+msgid "API Keys"
+msgstr "Çelësat API"
+
+msgid "API Logs"
+msgstr "Regjistrat API"
+
+msgid "API logs are only available in the desktop app."
+msgstr "Regjistrat API janë të disponueshëm vetëm në aplikacionin desktop."
+
+msgid "Appearance"
+msgstr "Pamja"
+
+#. placeholder {0}: pages.join(", ")
+msgid "Appears on pages {0}"
+msgstr "Shfaqet në faqet {0}"
+
+msgid "Application Programming Interface — a set of rules that allows programs to communicate."
+msgstr "Ndërfaqe Programimi Aplikacioni — një grup rregullash që lejon programet të komunikojnë."
+
+msgid "Apply"
+msgstr "Apliko"
+
+msgid "Apply page background colors"
+msgstr "Apliko ngjyrat e sfondit të faqes"
+
+msgid "Apply Segmentation"
+msgstr "Apliko segmentimin"
+
+msgid "AR"
+msgstr "AR"
+
+msgid "Archive contents"
+msgstr "Arkivo përmbajtjen"
+
+#. placeholder {0}: confirmMerge?.label ?? ""
+msgid "Are you sure you want to {0}? This action cannot be undone."
+msgstr "Jeni të sigurt që dëshironi të {0}? Ky veprim nuk mund të zhbëhet."
+
+msgid "Are you sure you want to {label}? This action cannot be undone."
+msgstr "Jeni të sigurt që dëshironi të {label}? Ky veprim nuk mund të zhbëhet."
+
+msgid "Are you sure you want to delete"
+msgstr "Jeni të sigurt që dëshironi të fshini"
+
+msgid "Are you sure you want to delete generated speech?"
+msgstr "Jeni të sigurt që dëshironi të fshini të folurit e gjeneruar?"
+
+msgid "Are you sure you want to delete this image? This action cannot be undone."
+msgstr "Jeni të sigurt që dëshironi të fshini këtë imazh? Ky veprim nuk mund të zhbëhet."
+
+msgid "Are you sure you want to delete this section? This action cannot be undone."
+msgstr "Jeni të sigurt që dëshironi të fshini këtë seksion? Ky veprim nuk mund të zhbëhet."
+
+msgid "Are you sure you want to generate word-level timestamps for {langDisplay}?"
+msgstr "Jeni të sigurt që dëshironi të gjeneroni vulat kohore në nivel fjalësh për {langDisplay}?"
+
+msgid "areas"
+msgstr "zona"
+
+msgid "Arrange extracted content into a structured storyboard with pages, sections, and layouts."
+msgstr "Organizoni përmbajtjen e nxjerrë në një storyboard të strukturuar me faqe, seksione dhe paraqitje."
+
+msgid "Article"
+msgstr "Artikull"
+
+msgid "Aside"
+msgstr "Shënim anësor"
+
+msgid "Ask AI to edit..."
+msgstr "Kërko nga AI të redaktojë..."
+
+msgid "Asking the AI to put on its creative hat..."
+msgstr "Duke i kërkuar AI të bëhet kreativ..."
+
+msgid "ASL"
+msgstr "ASL"
+
+msgid "Asset"
+msgstr "Burim"
+
+msgid "Assign..."
+msgstr "Cakto..."
+
+msgid "At the river's edge"
+msgstr "Në buzë të lumit"
+
+msgid "Audio"
+msgstr "Audio"
+
+msgid "Audio narration"
+msgstr "Tregim audio"
+
+msgid "Audio narration (largest impact on file size)"
+msgstr "Tregim audio (ndikimi më i madh në madhësinë e skedarit)"
+
+msgid "Audio Player"
+msgstr "Luajtës audio"
+
+msgid "Author"
+msgstr "Autor"
+
+msgid "Authored by {authorsList}."
+msgstr "Autorë: {authorsList}."
+
+msgid "Authors"
+msgstr "Autorët"
+
+msgid "Auto"
+msgstr "Automatik"
+
+msgid "Auto-fill from book context"
+msgstr "Plotëso automatikisht nga konteksti i librit"
+
+msgid "Auto-scroll"
+msgstr "Lëvizje automatike"
+
+msgid "Automatic"
+msgstr "Automatik"
+
+msgid "Automatically adapts the layout based on each page's content using AI."
+msgstr "Përshtaton automatikisht paraqitjen bazuar në përmbajtjen e çdo faqeje duke përdorur AI."
+
+msgid "Automatically create quizzes across the whole book at a set frequency."
+msgstr "Krijo automatikisht teste në të gjithë librin me një frekuencë të caktuar."
+
+msgid "Avg Duration"
+msgstr "Kohëzgjatja mesatare"
+
+msgid "Axe could not fully evaluate these checks in preview. Verify them in-browser or by inspection."
+msgstr "Axe nuk mund t'i vlerësonte plotësisht këto kontrolle në pamje paraprake. Verifikojini në shfletues ose me inspektim."
+
+msgid "Azure"
+msgstr "Azure"
+
+msgid "Azure Speech subscription key"
+msgstr "Çelësi i abonimit të Azure Speech"
+
+msgid "Azure Speech Subscription Key"
+msgstr "Çelësi i abonimit të Azure Speech"
+
+msgid "Azure Voice"
+msgstr "Zë Azure"
+
+msgid "Back"
+msgstr "Kthehu"
+
+msgid "Back Cover"
+msgstr "Kapaku i pasëm"
+
+msgid "Back to books"
+msgstr "Kthehu te librat"
+
+msgid "Back to Editor"
+msgstr "Kthehu te redaktori"
+
+msgid "Back to preview"
+msgstr "Kthehu te pamja paraprake"
+
+msgid "Back to Speech overview"
+msgstr "Kthehu te përmbledhja e të folurit"
+
+msgid "Back up or transfer the full project including the database, PDF, and all pipeline outputs."
+msgstr "Rezervoni ose transferoni projektin e plotë duke përfshirë bazën e të dhënave, PDF-në dhe të gjitha rezultatet e pipeline-it."
+
+msgid "Background"
+msgstr "Sfond"
+
+#. placeholder {0}: section.backgroundColor
+msgid "Background: {0}"
+msgstr "Sfond: {0}"
+
+msgid "base"
+msgstr "bazë"
+
+msgid "Base font for AI-rendered and template (reflowable) text. Fixed-layout pages keep their original fonts."
+msgstr "Fonti bazë për tekstin e renderuar nga AI dhe bazuar në shabllon (i rrjedhshëm). Faqet me paraqitje fikse mbajnë fontet origjinale."
+
+msgid "Base Language"
+msgstr "Gjuha bazë"
+
+msgid "Base URL"
+msgstr "URL bazë"
+
+msgid "Basic Information"
+msgstr "Informacion bazë"
+
+msgid "Batch size"
+msgstr "Madhësia e grupit"
+
+msgid "Be descriptive — include style, colors, mood, and composition."
+msgstr "Jini përshkrues — përfshini stilin, ngjyrat, humorin dhe kompozimin."
+
+msgid "Be descriptive — include subject, colors, mood, and composition."
+msgstr "Jini përshkrues — përfshini subjektin, ngjyrat, humorin dhe kompozimin."
+
+msgid "Bearer Token"
+msgstr "Token identifikimi"
+
+msgid "Before"
+msgstr "Para"
+
+msgid "Beneath Earth's crust, molten rock builds pressure over millennia until it finds a path to the surface."
+msgstr "Nën koren e Tokës, shkëmbi i shkrirë grumbullon presion për mijëvjeçarë derisa gjen një rrugë drejt sipërfaqes."
+
+#. placeholder {0}: i18n._(presetLabel)
+msgid "Best for {0}"
+msgstr "Më i mirë për {0}"
+
+msgid "Best for complex content like textbooks - automatically trims stray text, artifacts, and extra margins from extracted images."
+msgstr "Më i mirë për përmbajtje komplekse si tekstet shkollore — heq automatikisht tekst të humbur, artefakte dhe marzhe shtesë nga imazhet e nxjerra."
+
+msgid "Best for your preset"
+msgstr "Më i mirë për presetin tuaj"
+
+msgid "Beta"
+msgstr "Beta"
+
+msgid "Bit Rate"
+msgstr "Shpejtësia e bitit"
+
+msgid "Blocked"
+msgstr "Bllokuar"
+
+msgid "Body"
+msgstr "Trupi"
+
+msgid "Book"
+msgstr "Libër"
+
+msgid "Book creation stages"
+msgstr "Fazat e krijimit të librit"
+
+msgid "Book data is outdated and must be rebuilt."
+msgstr "Të dhënat e librit janë të vjetruara dhe duhet të rindërtohen."
+
+msgid "Book info"
+msgstr "Info libri"
+
+msgid "Book Language"
+msgstr "Gjuha e librit"
+
+msgid "Book order"
+msgstr "Rendi i librit"
+
+msgid "Book preview"
+msgstr "Pamje paraprake e librit"
+
+msgid "Book Preview"
+msgstr "Pamje paraprake e librit"
+
+msgid "Book Summary"
+msgstr "Përmbledhje e librit"
+
+msgid "Borders"
+msgstr "Kufij"
+
+msgid "Boxed Text"
+msgstr "Tekst i inkuadruar"
+
+msgid "Branch out"
+msgstr "Zgjero"
+
+msgid "Breakpoint override"
+msgstr "Anashkalim i pikës së thyerjes"
+
+msgid "Brewing a fresh batch of HTML..."
+msgstr "Duke krijuar një tufë të re HTML..."
+
+msgid "Browse and edit Liquid templates used for template-based rendering strategies."
+msgstr "Shfleto dhe redakto shabllonët Liquid të përdorur për strategjitë e renderimit të bazuar në shabllon."
+
+msgid "Browse every Storyboard section and upload, replace, or remove its sign-language video."
+msgstr "Shfleto çdo seksion të Storyboard-it dhe ngarko, zëvendëso ose hiq videon e gjuhës së shenjave."
+
+msgid "Build a glossary of key terms and definitions found in the text."
+msgstr "Ndërto një glosar me termat kryesorë dhe përkufizimet e gjetura në tekst."
+
+msgid "Build a glossary of key terms found in the book. Choose how much ground to cover, and add custom instructions to steer term selection toward what your audience needs."
+msgstr "Ndërto një glosar me termat kryesorë të gjetura në libër. Zgjidh sa material të mbulosh dhe shto udhëzime të personalizuara për të drejtuar zgjedhjen e termave drejt nevojave të audiencës."
+
+msgid "Build a navigable table of contents for the book. Decide whether entries mirror the typed section headings exactly or whether the model rephrases them into descriptive chapter titles."
+msgstr "Ndërto një tabelë përmbajtjeje të navigueshme për librin. Vendosni nëse shënimet pasqyrojnë saktësisht titujt e seksioneve të shkruara apo modeli i rifrazon ato në tituj kapitujsh përshkrues."
+
+msgid "Build the storyboard first"
+msgstr "Ndërtoni fillimisht storyboard-in"
+
+msgid "Building Preview..."
+msgstr "Duke ndërtuar pamjen paraprake..."
+
+msgid "Building Storyboard..."
+msgstr "Duke ndërtuar Storyboard-in..."
+
+msgid "Builds a glossary of key terms and definitions found in the text."
+msgstr "Ndërton një glosar me termat kryesorë dhe përkufizimet e gjetura në tekst."
+
+msgid "Builds the table of contents from the book's sections."
+msgstr "Ndërton tabelën e përmbajtjes nga seksionet e librit."
+
+msgid "Bundles the rendered book into a deployable web package."
+msgstr "Paketonn librin e renderuar në një paketë ueb të vendosshme."
+
+msgid "But the team kept walking up the mountain."
+msgstr "Por ekipi vazhdoi të ngjitej në mal."
+
+msgid "Button"
+msgstr "Buton"
+
+msgid "By Page"
+msgstr "Sipas faqes"
+
+msgid "By usage"
+msgstr "Sipas përdorimit"
+
+msgid "Cache"
+msgstr "Cache"
+
+msgid "Cache Hit Rate"
+msgstr "Shkalla e goditjeve të cache-it"
+
+msgid "Cache Hits"
+msgstr "Goditjet e cache-it"
+
+msgid "cached"
+msgstr "i ruajtur në cache"
+
+msgid "Cached"
+msgstr "Ruajtur në cache"
+
+msgid "Cached response"
+msgstr "Përgjigje e ruajtur në cache"
+
+msgid "Calculate word timestamps for all entries"
+msgstr "Llogarit vulat kohore të fjalëve për të gjitha shënimet"
+
+msgid "Calls"
+msgstr "Thirrje"
+
+msgid "Cancel"
+msgstr "Anulo"
+
+#. placeholder {0}: String(MAX_ENTRIES)
+msgid "capped at {0}"
+msgstr "kufizuar në {0}"
+
+msgid "Caption"
+msgstr "Përshkrim"
+
+#. placeholder {0}: cap.imageId
+msgid "Caption for {0}"
+msgstr "Përshkrim për {0}"
+
+msgid "Caption Prompt"
+msgstr "Udhëzim për Përshkrim"
+
+msgid "Captioned"
+msgstr "Me Përshkrim"
+
+msgid "Captioning Images..."
+msgstr "Po shtohen përshkrime imazheve..."
+
+msgid "Captions"
+msgstr "Përshkrime"
+
+msgid "Captions describe the images that Storyboard places into pages. Finish Storyboard before running this stage."
+msgstr "Përshkrimet përshkruajnë imazhet që Storyboard vendos në faqe. Përfundoni Storyboard-in para se të ekzekutoni këtë fazë."
+
+msgid "Captions make visual and audio content accessible to people who are blind or have low vision by providing information that screen readers can read aloud. Adding captions helps ensure everyone can access and understand your content."
+msgstr "Përshkrimet e bëjnë përmbajtjen vizuale dhe audio të aksesueshme për personat e verbër ose me shikim të dobët, duke ofruar informacion që lexuesit e ekranit mund ta lexojnë me zë. Shtimi i përshkrimeve ndihmon që të gjithë të kenë akses dhe të kuptojnë përmbajtjen tuaj."
+
+msgid "Captions Preview"
+msgstr "Pamje Paraprake e Përshkrimeve"
+
+msgid "Captions support accessibility."
+msgstr "Përshkrimet mbështesin aksesueshmërinë."
+
+msgid "Captions were generated by AI. Click any caption to edit it, or mark an image as decorative when no caption is needed. Click any image to zoom. Changes are saved as a new version, so you can always roll back."
+msgstr "Përshkrimet u gjeneruan nga AI. Klikoni çdo përshkrim për ta redaktuar, ose shënoni një imazh si dekorativ kur nuk nevojitet përshkrim. Klikoni çdo imazh për ta zmadhuar. Ndryshimet ruhen si version i ri, kështu që mund të riktheheni gjithmonë."
+
+msgid "carousel"
+msgstr "karusel"
+
+msgid "Cartoon"
+msgstr "Vizatim Karikaturë"
+
+msgid "Catalog Translation"
+msgstr "Përkthim Katalogu"
+
+msgid "Cell division producing two identical cells."
+msgstr "Ndarja qelizore që prodhon dy qeliza identike."
+
+msgid "Center"
+msgstr "Qendër"
+
+msgid "Change"
+msgstr "Ndrysho"
+
+msgid "Change language"
+msgstr "Ndrysho gjuhën"
+
+msgid "Change Preset"
+msgstr "Ndrysho Presetin"
+
+msgid "Chapter 1: Introduction"
+msgstr "Kapitulli 1: Hyrje"
+
+msgid "Chapter 2: Methods"
+msgstr "Kapitulli 2: Metodat"
+
+msgid "Chapter 3"
+msgstr "Kapitulli 3"
+
+msgid "Chapter 3: Results"
+msgstr "Kapitulli 3: Rezultatet"
+
+msgid "Chapter 4: Conclusion"
+msgstr "Kapitulli 4: Përfundim"
+
+msgid "Chapter 7 - Marine Biology"
+msgstr "Kapitulli 7 - Biologji Detare"
+
+msgid "Chapter books with images"
+msgstr "Libra me kapituj dhe imazhe"
+
+msgid "Chapter One"
+msgstr "Kapitulli i Parë"
+
+msgid "Chart / Graph"
+msgstr "Tabelë / Grafik"
+
+msgid "Check for updates"
+msgstr "Kontrollo për përditësime"
+
+msgid "Checked"
+msgstr "Kontrolluar"
+
+msgid "Checking accessibility"
+msgstr "Po kontrollohet aksesueshmëria"
+
+msgid "Checking for updates…"
+msgstr "Po kontrollohet për përditësime…"
+
+msgid "Checklist item"
+msgstr "Artikull liste kontrolli"
+
+msgid "choice"
+msgstr "zgjedhje"
+
+msgid "Choose a Preset"
+msgstr "Zgjidhni një Preset"
+
+msgid "Choose a preset that matches your content — textbook, storyboard, reference, or custom — and ADT Studio tailors the pipeline accordingly."
+msgstr "Zgjidhni një preset që përputhet me përmbajtjen tuaj — tekst shkollor, storyboard, referencë ose i personalizuar — dhe ADT Studio përshtat procesin në përputhje me rrethanat."
+
+msgid "Choose an existing image from this project"
+msgstr "Zgjidhni një imazh ekzistues nga ky projekt"
+
+msgid "Choose features to include in this export"
+msgstr "Zgjidhni funksionet për t'i përfshirë në këtë eksportim"
+
+msgid "Choose how the content should be formatted."
+msgstr "Zgjidhni si duhet të formatohet përmbajtja."
+
+msgid "Choose images..."
+msgstr "Zgjidhni imazhe..."
+
+msgid "Choose Provider"
+msgstr "Zgjidhni Ofruesin"
+
+msgid "Choose the source pages and where the quiz lands in the page editor."
+msgstr "Zgjidhni faqet burimore dhe ku vendoset testi në redaktorin e faqeve."
+
+msgid "Choose which per-page validation items reviewers must check, customize the wording and guidance, and add your own checklist items for this document."
+msgstr "Zgjidhni cilat artikuj validimi për faqe duhet të kontrollojnë rishikuesit, personalizoni formulimin dhe udhëzimet dhe shtoni artikujt tuaj të listës së kontrollit për këtë dokument."
+
+msgid "Ciências da Natureza - Ensino Fundamental"
+msgstr "Ciências da Natureza - Ensino Fundamental"
+
+msgid "Classic Storybook"
+msgstr "Libër Klasik Tregimesh"
+
+msgid "Classifying images…"
+msgstr "Po klasifikohen imazhet…"
+
+msgid "Clean & focused"
+msgstr "I pastër dhe i fokusuar"
+
+msgid "Clear"
+msgstr "Pastro"
+
+msgid "Clear all"
+msgstr "Pastro të gjitha"
+
+msgid "Clear filters"
+msgstr "Pastro filtrat"
+
+msgid "Clear language"
+msgstr "Pastro gjuhën"
+
+msgid "Clear model"
+msgstr "Pastro modelin"
+
+msgid "Clear search"
+msgstr "Pastro kërkimin"
+
+msgid "Clear, descriptive captions for middle and high school readers."
+msgstr "Përshkrime të qarta dhe përshkruese për lexues të shkollave të mesme."
+
+msgid "Click an image to select"
+msgstr "Klikoni një imazh për të zgjedhur"
+
+msgid "Click images to select"
+msgstr "Klikoni imazhet për të zgjedhur"
+
+msgid "Click Next to continue to language settings."
+msgstr "Klikoni Tjetër për të vazhduar te cilësimet e gjuhës."
+
+msgid "Click to edit"
+msgstr "Klikoni për të redaktuar"
+
+msgid "Click to edit caption"
+msgstr "Klikoni për të redaktuar përshkrimin"
+
+msgid "Click to pick a style reference image"
+msgstr "Klikoni për të zgjedhur një imazh referimi stili"
+
+msgid "Click to select an image"
+msgstr "Klikoni për të zgjedhur një imazh"
+
+msgid "Click to use this page"
+msgstr "Klikoni për të përdorur këtë faqe"
+
+msgid "Clone failed"
+msgstr "Klonifikimi dështoi"
+
+msgid "Close"
+msgstr "Mbyll"
+
+msgid "Close edit panel"
+msgstr "Mbyll panelin e redaktimit"
+
+msgid "Close style editor"
+msgstr "Mbyll redaktorin e stilit"
+
+msgid "Clownfish, sea turtles, and parrotfish are just a few of the thousands of species that depend on reefs for food, shelter, and nursery grounds."
+msgstr "Peshqit klovn, breshkat e detit dhe peshqit papagall janë vetëm disa nga mijëra speciet që varen nga rifet për ushqim, strehim dhe vendlindje."
+
+msgid "Collapse"
+msgstr "Mbledh"
+
+msgid "Collapse accessibility summary"
+msgstr "Mbledh përmbledhjen e aksesueshmërisë"
+
+msgid "Collapse all sections"
+msgstr "Mbledh të gjitha seksionet"
+
+msgid "Collapse validation"
+msgstr "Mbledh validimin"
+
+msgid "Collects all translatable text into a single catalog."
+msgstr "Mbledh të gjithë tekstin e përkthyeshëm në një katalog të vetëm."
+
+msgid "Color"
+msgstr "Ngjyrë"
+
+msgid "color-contrast"
+msgstr "kontrast-ngjyre"
+
+msgid "Column"
+msgstr "Kolonë"
+
+msgid "Column reverse"
+msgstr "Kolonë e anasjelltë"
+
+msgid "coming soon"
+msgstr "së shpejti"
+
+msgid "Coming soon"
+msgstr "Së shpejti"
+
+msgid "Comment"
+msgstr "Koment"
+
+msgid "Comments"
+msgstr "Komente"
+
+msgid "Completed"
+msgstr "Përfunduar"
+
+msgid "Completion"
+msgstr "Përfundim"
+
+msgid "Completion across all pages in this book for the active reviewer session."
+msgstr "Përfundimi për të gjitha faqet e këtij libri për sesionin aktiv të rishikuesit."
+
+msgid "Completion across pages that have been opened and reviewed in this session."
+msgstr "Përfundimi për faqet që janë hapur dhe rishikuar në këtë sesion."
+
+msgid "Completion across the assigned page range for this reviewer session."
+msgstr "Përfundimi për gamën e faqeve të caktuara për këtë sesion rishikuesi."
+
+msgid "Comprehensive"
+msgstr "Gjithëpërfshirës"
+
+msgid "Compressed archive · ~ 42 MB"
+msgstr "Arkiv i kompresuar · ~ 42 MB"
+
+msgid "Concise"
+msgstr "Konciz"
+
+msgid "Condensation"
+msgstr "Kondensim"
+
+msgid "Config"
+msgstr "Konfigurim"
+
+msgid "Configure activity detection and image processing options for extracted content. Hover any setting to see how it affects the preview."
+msgstr "Konfiguroni zbulimin e aktivitetit dhe opsionet e përpunimit të imazheve për përmbajtjen e ekstraktuar. Kaloni kursorin mbi çdo cilësim për të parë si ndikon në pamjen paraprake."
+
+msgid "Configure API keys for AI pipeline features."
+msgstr "Konfiguroni çelësat API për funksionet e zinxhirit të AI."
+
+msgid "Configure basic document information and file paths"
+msgstr "Konfiguroni informacionin bazë të dokumentit dhe shtigjet e skedarëve"
+
+msgid "Configure each stage — extract, storyboard, layout — then let ADT Studio build the book. Review the output, correct anything that needs a human touch."
+msgstr "Konfiguroni çdo fazë — ekstraktim, storyboard, faqosje — pastaj lëreni ADT Studio të ndërtojë librin. Rishikoni rezultatin, korrigjoni çdo gjë që kërkon prekjen e njeriut."
+
+msgid "Configure features to include in the export"
+msgstr "Konfiguroni funksionet për t'i përfshirë në eksportim"
+
+msgid "Configure voices and accents"
+msgstr "Konfiguroni zërat dhe thekset"
+
+msgid "Confirm merge"
+msgstr "Konfirmoni bashkimin"
+
+msgid "Confirm Rerun"
+msgstr "Konfirmoni Rikryerjen"
+
+msgid "Connect an AI provider"
+msgstr "Lidheni një ofrues AI"
+
+msgid "Consulting the style council..."
+msgstr "Po konsultohet këshilli i stilit..."
+
+msgid "Container"
+msgstr "Kontejner"
+
+msgid "Container node types the LLM may produce in the content tree during sectioning."
+msgstr "Llojet e nyjeve kontejner që LLM mund të prodhojë në pemën e përmbajtjes gjatë seksionimit."
+
+msgid "Container Types"
+msgstr "Llojet e Kontejnerëve"
+
+msgid "Content"
+msgstr "Përmbajtje"
+
+msgid "Content Processing"
+msgstr "Përpunim Përmbajtjeje"
+
+msgid "Contents"
+msgstr "Përmbajtja"
+
+msgid "Continue"
+msgstr "Vazhdo"
+
+#. placeholder {0}: resumeTarget.pageNumber ?? resumeTarget.pageId
+msgid "Continue on page {0}"
+msgstr "Vazhdo në faqen {0}"
+
+#. placeholder {0}: resumeTarget.pageNumber ?? resumeTarget.pageId
+msgid "Continue page {0}"
+msgstr "Vazhdo faqen {0}"
+
+#. placeholder {0}: resumeTarget?.pageNumber ?? resumeTarget?.pageId
+msgid "Continue reviewer validation on page {0}"
+msgstr "Vazhdo validimin e rishikuesit në faqen {0}"
+
+msgid "Continuing will reset your current configuration."
+msgstr "Vazhdimi do të rivendosë konfigurimin tuaj aktual."
+
+msgid "Control which axe checks run during packaging for this document. Changes apply on the next package run."
+msgstr "Kontrolloni cilat kontrolle axe ekzekutohen gjatë paketimit për këtë dokument. Ndryshimet aplikohen në ekzekutimin tjetër të paketimit."
+
+msgid "Controls how page content is grouped during the sectioning step."
+msgstr "Kontrollon si grupohet përmbajtja e faqes gjatë hapit të seksionimit."
+
+msgid "Conversion of light into chemical energy."
+msgstr "Shndërrimi i dritës në energji kimike."
+
+msgid "Convert a PDF"
+msgstr "Konverto një PDF"
+
+msgid "Convert any textbook into an accessible digital edition — audio, structured layouts, translations, and sign-language, built in from the very first page."
+msgstr "Konverto çdo tekst shkollor në një botim dixhital të aksesueshëm — audio, faqosje të strukturuara, përkthime dhe gjuhë shenjash, të integruara që nga faqja e parë."
+
+msgid "Converted"
+msgstr "Konvertuar"
+
+msgid "Copied"
+msgstr "Kopjuar"
+
+msgid "Copy"
+msgstr "Kopjo"
+
+msgid "Copy error details"
+msgstr "Kopjo detajet e gabimit"
+
+msgid "Copy error output"
+msgstr "Kopjo daljen e gabimit"
+
+msgid "Coral reefs cover less than 1% of the ocean floor, yet they support roughly 25% of all marine species. Often called the 'rainforests of the sea,' these underwater ecosystems are built by tiny animals called coral polyps."
+msgstr "Rifet koraliere mbulojnë më pak se 1% të dyshemesë së oqeanit, por mbështesin rreth 25% të të gjitha specieve detare. Shpesh të quajtura 'pyjet e shiut të detit', këto ekosisteme nënujore ndërtohen nga kafshë të vogla të quajtura polipe korali."
+
+msgid "Core Pipeline"
+msgstr "Zinxhiri Kryesor"
+
+msgid "Correct answer"
+msgstr "Përgjigje e saktë"
+
+msgid "Could not read this PDF. The file may be corrupted or password-protected."
+msgstr "Nuk u mund të lexohet ky PDF. Skedari mund të jetë i dëmtuar ose i mbrojtur me fjalëkalim."
+
+msgid "Couldn't read this PDF"
+msgstr "Nuk mund të lexohej ky PDF"
+
+msgid "Counting occurrences…"
+msgstr "Po numërohen ndodhitë…"
+
+msgid "Course"
+msgstr "Kurs"
+
+msgid "Cover"
+msgstr "Kopertinë"
+
+msgid "Cover of {title}"
+msgstr "Kopertina e {title}"
+
+msgid "Coverage"
+msgstr "Mbulim"
+
+msgid "Covered"
+msgstr "Mbuluar"
+
+msgid "Create a manual glossary entry that stays in the book even if AI glossary generation is rerun."
+msgstr "Krijoni një hyrje manuale glosari që mbetet në libër edhe nëse gjenerimi i glosariumit me AI riekzekutohet."
+
+msgid "Create a new book from a PDF"
+msgstr "Krijoni një libër të ri nga një PDF"
+
+msgid "Create a new image from a text description"
+msgstr "Krijoni një imazh të ri nga një përshkrim teksti"
+
+msgid "Create a reviewer session for this book."
+msgstr "Krijoni një sesion rishikuesi për këtë libër."
+
+msgid "Create ADT"
+msgstr "Krijo ADT"
+
+msgid "Create descriptive captions for images to improve accessibility."
+msgstr "Krijoni përshkrime përshkruese për imazhet për të përmirësuar aksesueshmërinë."
+
+msgid "Create from scratch using your description"
+msgstr "Krijo nga e para duke përdorur përshkrimin tuaj"
+
+msgid "Create one quiz from specific pages and place it exactly where you want it in the book."
+msgstr "Krijoni një test nga faqe specifike dhe vendoseni pikërisht aty ku dëshironi në libër."
+
+msgid "Create session"
+msgstr "Krijo sesion"
+
+msgid "Created {createdLabel}"
+msgstr "Krijuar {createdLabel}"
+
+msgid "Creates a ZIP archive of the full project — database, source PDF, and all pipeline outputs. Use it to back up or transfer the project to another machine."
+msgstr "Krijon një arkiv ZIP të projektit të plotë — bazën e të dhënave, PDF-in burimor dhe të gjitha rezultatet e pipeline-it. Përdore për të rezervuar ose transferuar projektin në një makinë tjetër."
+
+msgid "Creating..."
+msgstr "Po krijohet..."
+
+msgid "Credits"
+msgstr "Kreditet"
+
+msgid "criteria reviewed"
+msgstr "kritere të rishikuara"
+
+msgid "Criteria reviewed"
+msgstr "Kritere të rishikuara"
+
+msgid "critical"
+msgstr "kritik"
+
+msgid "Critical"
+msgstr "Kritik"
+
+msgid "Crop"
+msgstr "Prerje"
+
+msgid "Crop Image"
+msgstr "Preje imazhin"
+
+msgid "Crop preview"
+msgstr "Shiko prerjen"
+
+msgid "Cropping Prompt"
+msgstr "Prompt-i i prerjes"
+
+msgid "Crops each image to its visible bounding box."
+msgstr "Pret çdo imazh sipas kufirit të tij të dukshëm."
+
+msgid "Current"
+msgstr "Aktual"
+
+msgid "Current effective values"
+msgstr "Vlerat aktuale efektive"
+
+msgid "Current Preview Page"
+msgstr "Faqja aktuale e pamjes paraprake"
+
+msgid "Current version"
+msgstr "Versioni aktual"
+
+msgid "Custom"
+msgstr "I personalizuar"
+
+msgid "Custom Instructions"
+msgstr "Udhëzime të personalizuara"
+
+msgid "Custom Layout Demo"
+msgstr "Demo e paraqitjes së personalizuar"
+
+msgid "Custom section {index}"
+msgstr "Seksion i personalizuar {index}"
+
+msgid "Debug mode is not enabled."
+msgstr "Modaliteti i korrigjimit nuk është aktivizuar."
+
+msgid "Decorative"
+msgstr "Dekorativ"
+
+msgid "Decrease indent"
+msgstr "Zvogëlo dhëmbëzimin"
+
+msgid "default"
+msgstr "parazgjedhje"
+
+msgid "Default"
+msgstr "Parazgjedhje"
+
+msgid "Default (from prompt)"
+msgstr "Parazgjedhje (nga prompt-i)"
+
+msgid "Default Font"
+msgstr "Fonti parazgjedhës"
+
+msgid "Default model"
+msgstr "Modeli parazgjedhës"
+
+msgid "Default N/A"
+msgstr "Parazgjedhje N/A"
+
+msgid "Default Prompt"
+msgstr "Prompt-i parazgjedhës"
+
+msgid "Default Provider"
+msgstr "Ofruesi parazgjedhës"
+
+msgid "Default Render Strategy"
+msgstr "Strategjia parazgjedhëse e renderimit"
+
+msgid "Default Voice"
+msgstr "Zëri parazgjedhës"
+
+msgid "Default voice used when not specified for a language."
+msgstr "Zëri parazgjedhës që përdoret kur nuk është specifikuar për një gjuhë."
+
+msgid "Defaulted to N/A because Easy Read output is not currently available for this book."
+msgstr "Kaloi në N/A sepse rezultati Easy Read nuk është aktualisht i disponueshëm për këtë libër."
+
+msgid "Defaulted to N/A because Glossary has not been generated for this book yet."
+msgstr "Kaloi në N/A sepse Glosari nuk është gjeneruar ende për këtë libër."
+
+#. placeholder {0}: reason.language
+msgid "Defaulted to N/A because no Speech audio is available for {0}."
+msgstr "Kaloi në N/A sepse nuk ka audio Speech të disponueshme për {0}."
+
+msgid "Defaulted to N/A because no Speech audio is available yet."
+msgstr "Kaloi në N/A sepse nuk ka ende audio Speech të disponueshme."
+
+#. placeholder {0}: reason.language
+msgid "Defaulted to N/A because no translation output is available for {0}."
+msgstr "Kaloi në N/A sepse nuk ka rezultat përkthimi të disponueshëm për {0}."
+
+msgid "Defaulted to N/A because no translation output is available yet."
+msgstr "Kaloi në N/A sepse nuk ka ende rezultat përkthimi të disponueshëm."
+
+msgid "Defaulted to N/A because sign language is not enabled for this book."
+msgstr "Kaloi në N/A sepse gjuha e shenjave nuk është aktivizuar për këtë libër."
+
+msgid "Defaulted to N/A because Speech audio has not been generated yet."
+msgstr "Kaloi në N/A sepse audio Speech nuk është gjeneruar ende."
+
+msgid "Defaulted to N/A because this page does not contain an interactive activity or exercise."
+msgstr "Kaloi në N/A sepse kjo faqe nuk përmban një aktivitet ose ushtrim interaktiv."
+
+msgid "Defaulted to N/A because this page does not contain any images."
+msgstr "Kaloi në N/A sepse kjo faqe nuk përmban asnjë imazh."
+
+msgid "Defaulted to N/A because Translation has not been generated yet."
+msgstr "Kaloi në N/A sepse Përkthimi nuk është gjeneruar ende."
+
+msgid "Defaulted to N/A until this reviewer session has a language selected."
+msgstr "Kaloi në N/A derisa kjo sesion rishikuesi të ketë një gjuhë të zgjedhur."
+
+msgid "Defaults"
+msgstr "Parazgjedhjet"
+
+msgid "Definition"
+msgstr "Përkufizim"
+
+#. placeholder {0}: item.word
+msgid "Definition for {0}"
+msgstr "Përkufizimi për {0}"
+
+msgid "Definitions and Terminology"
+msgstr "Përkufizime dhe Terminologji"
+
+msgid "Delete"
+msgstr "Fshi"
+
+msgid "Delete all speech"
+msgstr "Fshi të gjitha fjalët"
+
+msgid "Delete book"
+msgstr "Fshi librin"
+
+msgid "Delete element"
+msgstr "Fshi elementin"
+
+msgid "Delete failed"
+msgstr "Fshirja dështoi"
+
+msgid "Delete quiz"
+msgstr "Fshi kuizin"
+
+msgid "Delete section"
+msgstr "Fshi seksionin"
+
+msgid "Delete this quiz"
+msgstr "Fshi këtë kuiz"
+
+msgid "Delete this quiz?"
+msgstr "Fshi këtë kuiz?"
+
+msgid "Delete video"
+msgstr "Fshi videon"
+
+msgid "Deleting..."
+msgstr "Po fshihet..."
+
+msgid "Deleting…"
+msgstr "Po fshihet…"
+
+msgid "Delivered"
+msgstr "Dorëzuar"
+
+msgid "Dense text, tables, glossaries. Best for technical material and documentation."
+msgstr "Tekst i dendur, tabela, glosare. Më i mirë për materiale teknike dhe dokumentacion."
+
+msgid "Describe the image"
+msgstr "Përshkruaj imazhin"
+
+msgid "Describe the issue or note why this criterion needs attention"
+msgstr "Përshkruaj problemin ose shëno pse ky kriter kërkon vëmendje"
+
+msgid "Describe this image…"
+msgstr "Përshkruaj këtë imazh…"
+
+msgid "Describe what the reviewer should check."
+msgstr "Përshkruaj çfarë duhet të kontrollojë rishikuesi."
+
+msgid "Description"
+msgstr "Përshkrim"
+
+msgid "Description..."
+msgstr "Përshkrim..."
+
+msgid "Deselect all"
+msgstr "Hiq zgjedhjen e të gjithave"
+
+msgid "Desktop"
+msgstr "Desktop"
+
+msgid "Despite the inclement weather, the expedition pressed on toward the summit, undeterred by the mounting obstacles in their path."
+msgstr "Pavarësisht motit të keq, ekspedita vazhdoi drejt majës, pa u tërhequr nga pengesat në rritje në rrugën e tyre."
+
+msgid "Detailed, technical captions for college and adult readers."
+msgstr "Tituj të detajuar dhe teknikë për lexues të universitetit dhe të rritur."
+
+msgid "Detected Font"
+msgstr "Fonti i zbuluar"
+
+msgid "Detecting figures"
+msgstr "Po zbulohen figurat"
+
+msgid "Detects activities already present in the book and transforms them into interactive HTML elements like radio buttons and text inputs."
+msgstr "Zbulon aktivitetet që gjenden tashmë në libër dhe i transformon ato në elementë HTML interaktivë si butonat radio dhe fushat e tekstit."
+
+msgid "Detects and splits composited illustrations into separate regions so each asset can be placed and refined on its own."
+msgstr "Zbulon dhe ndan ilustrimet e kompozuara në rajone të veçanta që çdo element të mund të vendoset dhe rafinohet më vete."
+
+msgid "Detects complex charts and figures that contain a mix of text, vectors and images and crops them out of the page."
+msgstr "Zbulon grafikë dhe figura komplekse që përmbajnë kombinim teksti, vektorësh dhe imazhesh dhe i pret nga faqja."
+
+msgid "Detects exercises and quizzes embedded in the book and classifies them as their own sections so they can render as interactive elements downstream."
+msgstr "Zbulon ushtrimet dhe kuizet e ngulura në libër dhe i klasifikon si seksionet e tyre që të mund të renderohën si elementë interaktivë."
+
+msgid "Diagram"
+msgstr "Diagram"
+
+msgid "Did you know?"
+msgstr "A e dije?"
+
+msgid "Direction"
+msgstr "Drejtim"
+
+msgid "Disable reviewer validation"
+msgstr "Çaktivizo validimin e rishikuesit"
+
+msgid "Disable type"
+msgstr "Çaktivizo tipin"
+
+msgid "Disabled"
+msgstr "Çaktivizuar"
+
+msgid "Disabled axe rules"
+msgstr "Rregullat axe të çaktivizuara"
+
+msgid "Disabled rules"
+msgstr "Rregullat e çaktivizuara"
+
+msgid "Discard"
+msgstr "Hidh poshtë"
+
+msgid "Discard unsaved changes?"
+msgstr "Hidh poshtë ndryshimet e paruajtura?"
+
+msgid "Display"
+msgstr "Shfaqje"
+
+msgid "Distribute through Readium-compatible reading apps and libraries."
+msgstr "Shpërnda nëpërmjet aplikacioneve dhe bibliotekave të leximit të pajtueshme me Readium."
+
+msgid "Don't have a project yet?"
+msgstr "Nuk ke ende një projekt?"
+
+msgid "Done"
+msgstr "U krye"
+
+msgid "DONE"
+msgstr "KRYER"
+
+msgid "Download a full backup of this project"
+msgstr "Shkarko një kopje rezervë të plotë të këtij projekti"
+
+msgid "Download size"
+msgstr "Madhësia e shkarkimit"
+
+msgid "Download update"
+msgstr "Shkarko përditësimin"
+
+#. placeholder {0}: Math.round(percent)
+#. placeholder {1}: formatBytes(status.bytesPerSecond)
+msgid "Downloading… {0}% · {1}/s"
+msgstr "Po shkarkohet… {0}% · {1}/s"
+
+msgid "Drag to move"
+msgstr "Tërhiq për të lëvizur"
+
+msgid "Drag to move boxes, drag edges/corners to resize"
+msgstr "Tërhiq për të lëvizur kutitë, tërhiq skajet/cepat për të ndryshuar madhësinë"
+
+msgid "Drag vertices to reshape. Click midpoints (+) to add points. Right-click a vertex to remove it."
+msgstr "Tërhiq kulmet për të ndryshuar formën. Kliko pikat e mesit (+) për të shtuar pika. Kliko me të djathtën një kulm për ta hequr."
+
+msgid "Drawn from"
+msgstr "Nxjerrë nga"
+
+msgid "Drop a PDF to get started"
+msgstr "Hidh një PDF për të filluar"
+
+msgid "Drop in a PDF and watch it flow through every stage — from raw pages to an accessible reader."
+msgstr "Hidh një PDF dhe shiko si kalon nëpër çdo fazë — nga faqet e papërpunuara deri te një lexues i aksesueshëm."
+
+msgid "Drop in a PDF to kick things off. ADT Studio organizes it into a new book project so you don't start from zero."
+msgstr "Hidh një PDF për të filluar. ADT Studio e organizon atë në një projekt të ri libri që të mos fillosh nga zeroja."
+
+msgid "Drop PDF here"
+msgstr "Hidh PDF-in këtu"
+
+msgid "Drop the bundle on any static host to serve the book as a website."
+msgstr "Hidh paketat në çdo host statik për të shërbyer librin si faqe interneti."
+
+msgid "Drop ZIP here"
+msgstr "Hidh ZIP-in këtu"
+
+msgid "Duplicate"
+msgstr "Dupliko"
+
+msgid "Duration"
+msgstr "Kohëzgjatje"
+
+msgid "Dynamic"
+msgstr "Dinamik"
+
+msgid "Dynamic Mode"
+msgstr "Modaliteti dinamik"
+
+msgid "Dynamic Overlay"
+msgstr "Mbulesë dinamike"
+
+msgid "e.g. alloy"
+msgstr "p.sh. alloy"
+
+msgid "e.g. eastus, westeurope"
+msgstr "p.sh. eastus, westeurope"
+
+msgid "e.g. emphasize cultural context, avoid technical jargon, mention colors when relevant…"
+msgstr "p.sh. theksoni kontekstin kulturor, shmangni zhargonin teknik, përmendni ngjyrat kur është e përshtatshme…"
+
+msgid "e.g. en-US-JennyNeural"
+msgstr "p.sh. en-US-JennyNeural"
+
+msgid "e.g. focus on scientific vocabulary, skip place names, define every italicized word…"
+msgstr "p.sh. fokusohuni në fjalorin shkencor, shmangni emrat e vendeve, përkufizoni çdo fjalë të kursivizuar…"
+
+msgid "e.g. fr, es-mx"
+msgstr "p.sh. fr, es-mx"
+
+msgid "e.g. http://localhost:11434/v1"
+msgstr "p.sh. http://localhost:11434/v1"
+
+msgid "e.g. Kore"
+msgstr "p.sh. Kore"
+
+msgid "e.g., A cheerful leopard family in a green forest, children's book style..."
+msgstr "p.sh., Një familje leopardësh të gëzuar në një pyll të gjelbër, stil libri për fëmijë..."
+
+msgid "e.g., A cheerful leopard family in a green forest..."
+msgstr "p.sh., Një familje leopardësh të gëzuar në një pyll të gjelbër..."
+
+msgid "e.g., Make the background brighter, add more trees..."
+msgstr "p.sh., Bëje sfondin më të ndritshëm, shto më shumë pemë..."
+
+msgid "Each block was simplified by AI. Edit any Easy Read text to refine it against the original, then Save. Changes are stored as a new version, so you can always roll back or regenerate."
+msgstr "Çdo bllok u thjeshtua nga AI. Redakto çdo tekst Easy Read për ta rafinuar ndaj origjinalit, pastaj Ruaje. Ndryshimet ruhen si version i ri, kështu që mund të kthehesh gjithmonë ose të rigjenerohet."
+
+msgid "Each iteration is one LLM call. Lower values are faster and cheaper; higher values give the reviewer more chances to fix problems."
+msgstr "Çdo iteracion është një thirrje LLM. Vlerat e ulëta janë më të shpejta dhe më të lira; vlerat e larta i japin rishikuesit më shumë mundësi për të korrigjuar problemet."
+
+msgid "Each polyp secretes a hard calcium carbonate skeleton. Over hundreds of years, millions of these skeletons build up into the massive reef structures we see today."
+msgstr "Çdo polip sekreton një skelet të fortë karbonati kalciumi. Gjatë qindra viteve, miliona prej këtyre skeletve grumbullohen duke formuar strukturat masive të rifeve që shohim sot."
+
+msgid "Each section introduces a new theme with worked examples, followed by short practice activities at the end of the page."
+msgstr "Çdo seksion prezanton një temë të re me shembuj të zgjidhur, të ndjekur nga aktivitete të shkurtra praktike në fund të faqes."
+
+msgid "Earlier stages haven't run yet"
+msgstr "Fazat e mëhershme nuk janë ekzekutuar ende"
+
+msgid "Early"
+msgstr "Herët"
+
+msgid "Easy Read"
+msgstr "Easy Read"
+
+msgid "Easy Read adapts the text placed on each page by Storyboard. Finish Storyboard before running this stage."
+msgstr "Easy Read përshtatin tekstin e vendosur në çdo faqe nga Storyboard. Përfundo Storyboard-in para se të ekzekutosh këtë fazë."
+
+msgid "Easy Read Preview"
+msgstr "Pamja paraprake e Easy Read"
+
+msgid "Easy Read Prompt"
+msgstr "Prompt-i Easy Read"
+
+msgid "Easy Read text"
+msgstr "Teksti Easy Read"
+
+msgid "Ecosystem"
+msgstr "Ekosistem"
+
+msgid "Edit"
+msgstr "Redakto"
+
+msgid "Edit & enrich"
+msgstr "Redakto dhe pasuro"
+
+msgid "Edit caption"
+msgstr "Redakto titullin"
+
+msgid "Edit in Quizzes"
+msgstr "Redakto në Kuize"
+
+msgid "Edit Prompt"
+msgstr "Redakto Prompt-in"
+
+msgid "Edit Prompts"
+msgstr "Redakto Prompt-et"
+
+msgid "Edit the Liquid/HTML template below. Changes are saved when you click Save & Rerun."
+msgstr "Redaktoni shabllonin Liquid/HTML më poshtë. Ndryshimet ruhen kur klikoni Ruaj dhe Riekzekuto."
+
+msgid "Edit this image"
+msgstr "Redakto këtë imazh"
+
+msgid "Edit this section"
+msgstr "Redakto këtë seksion"
+
+msgid "Editable per block"
+msgstr "I redaktueshëm për çdo bllok"
+
+msgid "edited"
+msgstr "redaktuar"
+
+msgid "Edited in"
+msgstr "Redaktuar në"
+
+msgid "Edited manually"
+msgstr "Redaktuar manualisht"
+
+msgid "Editing"
+msgstr "Duke redaktuar"
+
+msgid "Editing is disabled while the storyboard is running"
+msgstr "Redaktimi është i çaktivizuar ndërsa storyboard-i është duke u ekzekutuar"
+
+msgid "Editing Language"
+msgstr "Gjuha e redaktimit"
+
+msgid "Edits go to this Tailwind variant prefix"
+msgstr "Ndryshimet shkojnë tek ky prefiks i variantit Tailwind"
+
+msgid "Effort"
+msgstr "Përpjekje"
+
+msgid "Element style editor"
+msgstr "Redaktues i stilit të elementit"
+
+msgid "Elements"
+msgstr "Elementet"
+
+msgid "emoji"
+msgstr "emoji"
+
+msgid "Emoji"
+msgstr "Emoji"
+
+msgid "Empty"
+msgstr "Bosh"
+
+msgid "Empty container"
+msgstr "Kontejner bosh"
+
+msgid "Empty section"
+msgstr "Seksion bosh"
+
+msgid "Empty section — add a container below to start"
+msgstr "Seksion bosh — shtoni një kontejner më poshtë për të filluar"
+
+msgid "en"
+msgstr "en"
+
+msgid "EN"
+msgstr "EN"
+
+#. placeholder {0}: criterion.label
+#. placeholder {0}: section.label
+msgid "Enable {0}"
+msgstr "Aktivizo {0}"
+
+msgid "Enable for scanned books where two pages appear on a single PDF page."
+msgstr "Aktivizo për librat e skanuar ku dy faqe shfaqen në një faqe të vetme PDF."
+
+msgid "Enable or disable reviewer-authored checklist reviews for this book. Automated accessibility assessment remains available either way."
+msgstr "Aktivizo ose çaktivizo rishikimet e listës së kontrollit të bëra nga rishikuesi për këtë libër. Vlerësimi i automatizuar i aksesueshmërisë mbetet i disponueshëm në çdo rast."
+
+msgid "Enable reviewer validation"
+msgstr "Aktivizo validimin e rishikuesit"
+
+msgid "Enabled"
+msgstr "Aktivizuar"
+
+msgid "Enabled axe tags"
+msgstr "Etiketat axe të aktivizuara"
+
+msgid "End"
+msgstr "Fundi"
+
+msgid "End page"
+msgstr "Faqja e fundit"
+
+msgid "Endpoint"
+msgstr "Endpoint"
+
+msgid "Engineering Handbook Vol. 2"
+msgstr "Doracaku i Inxhinierisë Vol. 2"
+
+msgid "Engineering handbooks"
+msgstr "Doracakë inxhinierike"
+
+msgid "English"
+msgstr "Anglisht"
+
+msgid "Enhancements"
+msgstr "Përmirësime"
+
+msgid "Enter a valid minimum dimension (whole number ≥ 0)"
+msgstr "Shkruani një dimension minimal të vlefshëm (numër i plotë ≥ 0)"
+
+msgid "Enter a valid project name"
+msgstr "Shkruani një emër të vlefshëm projekti"
+
+msgid "entries"
+msgstr "hyrje"
+
+msgid "Entries were generated by AI. Edit a title, change its indent level, or link it to a page. Add and remove entries to match the book's structure. Changes are saved as a new version, so you can always roll back."
+msgstr "Hyrjet u gjeneruan nga AI. Redaktoni një titull, ndryshoni nivelin e dhëmbëzimit, ose lidheni me një faqe. Shtoni dhe hiqni hyrje për të përshtatur strukturën e librit. Ndryshimet ruhen si version i ri, kështu që mund të ktheheni gjithmonë."
+
+msgid "entry"
+msgstr "hyrje"
+
+msgid "Entry title"
+msgstr "Titulli i hyrjes"
+
+msgid "EPUB"
+msgstr "EPUB"
+
+msgid "EPUB 3"
+msgstr "EPUB 3"
+
+msgid "EPUB Export"
+msgstr "Eksport EPUB"
+
+msgid "Error"
+msgstr "Gabim"
+
+msgid "Error output"
+msgstr "Rezultat i gabimit"
+
+msgid "Errors"
+msgstr "Gabime"
+
+msgid "Eruptions reshape entire regions in mere days."
+msgstr "Shpërthimet riformësojnë rajone të tëra brenda vetëm disa ditësh."
+
+msgid "ES"
+msgstr "ES"
+
+msgid "Est. Cost"
+msgstr "Kosto e vlerësuar"
+
+msgid "Evaporation"
+msgstr "Avullim"
+
+msgid "Every edit and re-run is saved as a new version, so you can always roll back."
+msgstr "Çdo redaktim dhe riekzekutim ruhet si version i ri, kështu që mund të ktheheni gjithmonë."
+
+msgid "Every few pages"
+msgstr "Çdo disa faqe"
+
+msgid "Every notable concept and named entity."
+msgstr "Çdo koncept i rëndësishëm dhe entitet i emërtuar."
+
+msgid "Every page in this book has all sections pruned. There is no content available to generate {stageName} from."
+msgstr "Çdo faqe në këtë libër ka të gjitha seksionet të shkurtuara. Nuk ka përmbajtje të disponueshme për të gjeneruar {stageName}."
+
+msgid "Every page is pruned"
+msgstr "Çdo faqe është shkurtuar"
+
+msgid "Every reader opens the same book, with the features they need on tap."
+msgstr "Çdo lexues hap të njëjtin libër, me veçoritë që i nevojiten të gatshme."
+
+msgid "Every section has a video"
+msgstr "Çdo seksion ka një video"
+
+msgid "Every Storyboard section has a sign-language video assigned. You can switch to Covered or All to review or replace them."
+msgstr "Çdo seksion i Storyboard-it ka një video të gjuhës së shenjave të caktuar. Mund të kaloni te Të mbuluara ose Të gjitha për t'i rishikuar ose zëvendësuar."
+
+msgid "Example Books"
+msgstr "Libra shembull"
+
+msgid "Exclude from render"
+msgstr "Përjashto nga renderimi"
+
+msgid "Existing reviewer sessions keep their own checklist snapshot. New checklist changes apply to newly created sessions."
+msgstr "Seancat ekzistuese të rishikuesit ruajnë fotografinë e tyre të listës së kontrollit. Ndryshimet e reja të listës zbatohen për seancat e krijuara rishtazi."
+
+msgid "Expand"
+msgstr "Zgjer"
+
+msgid "Expand all sections"
+msgstr "Zgjer të gjitha seksionet"
+
+msgid "Experimental configurations"
+msgstr "Konfigurime eksperimentale"
+
+msgid "Expiry"
+msgstr "Skadimi"
+
+msgid "Explain the term in simple language."
+msgstr "Shpjegoni termin në gjuhë të thjeshtë."
+
+msgid "Export"
+msgstr "Eksporto"
+
+#. placeholder {0}: formatLabels[selectedFormat].label
+msgid "Export {0}"
+msgstr "Eksporto {0}"
+
+msgid "Export is not blocked by the stages below. As soon as Storyboard is done, you can ship a bundle. Enhancements, Localization, and Validation are optional ways to enrich the book — you can export again anytime later."
+msgstr "Eksporti nuk bllokohet nga fazat më poshtë. Sapo të përfundojë Storyboard-i, mund të dërgoni një paketë. Përmirësimet, Lokalizimi dhe Validimi janë mënyra opsionale për ta pasuruar librin — mund të eksportoni përsëri në çdo kohë."
+
+msgid "Export Options"
+msgstr "Opsionet e eksportit"
+
+msgid "Export preparation failed"
+msgstr "Përgatitja e eksportit dështoi"
+
+msgid "Export Preview"
+msgstr "Pamje paraprake e eksportit"
+
+msgid "Export the packaged book and related artifacts for delivery."
+msgstr "Eksportoni librin e paketuar dhe artefaktet përkatëse për dorëzim."
+
+msgid "Export to a reader"
+msgstr "Eksporto tek një lexues"
+
+msgid "Exporting..."
+msgstr "Duke eksportuar..."
+
+msgid "Extract"
+msgstr "Nxjerr"
+
+msgid "Extract hasn't run yet"
+msgstr "Nxjerrja nuk është ekzekutuar ende"
+
+msgid "Extract Preview"
+msgstr "Pamje paraprake e nxjerrjes"
+
+msgid "Extract text and images from each page of the PDF using AI-powered analysis."
+msgstr "Nxirrni tekst dhe imazhe nga çdo faqe e PDF-it duke përdorur analizë të bazuar në AI."
+
+msgid "Extracted"
+msgstr "Nxjerrë"
+
+msgid "Extracted Blocks"
+msgstr "Blloqe të nxjerra"
+
+#. placeholder {0}: String(count)
+msgid "Extracted Images ({0})"
+msgstr "Imazhe të nxjerra ({0})"
+
+msgid "Extracted Text"
+msgstr "Tekst i nxjerrë"
+
+msgid "Extracting..."
+msgstr "Duke nxjerrë..."
+
+msgid "Extraction Prompt"
+msgstr "Prompt-i i nxjerrjes"
+
+msgid "Extracts text and image data from each page of the PDF."
+msgstr "Nxjerr të dhëna teksti dhe imazhi nga çdo faqe e PDF-it."
+
+msgid "Extracts the correct answer key from the generated activity HTML."
+msgstr "Nxjerr çelësin e saktë të përgjigjeve nga HTML-i i gjeneruar i aktivitetit."
+
+msgid "Failed"
+msgstr "Dështoi"
+
+msgid "Failed to create book."
+msgstr "Dështoi krijimi i librit."
+
+msgid "Failed to create reviewer session"
+msgstr "Dështoi krijimi i seancës së rishikuesit"
+
+msgid "Failed to generate glossary entry."
+msgstr "Dështoi gjenerimi i hyrjes së glosariumit."
+
+msgid "Failed to generate the quiz."
+msgstr "Dështoi gjenerimi i kuizit."
+
+#. placeholder {0}: error.message
+msgid "Failed to load accessibility results: {0}"
+msgstr "Dështoi ngarkimi i rezultateve të aksesueshmërisë: {0}"
+
+#. placeholder {0}: error.message
+msgid "Failed to load books: {0}"
+msgstr "Dështoi ngarkimi i librave: {0}"
+
+msgid "Failed to load images."
+msgstr "Dështoi ngarkimi i imazheve."
+
+msgid "Failed to load page image"
+msgstr "Dështoi ngarkimi i imazhit të faqes"
+
+#. placeholder {0}: anyRecordQueryError.message
+msgid "Failed to load reviewer page results: {0}"
+msgstr "Dështoi ngarkimi i rezultateve të faqes së rishikuesit: {0}"
+
+#. placeholder {0}: catalog.error.message
+msgid "Failed to load reviewer validation checklist: {0}"
+msgstr "Dështoi ngarkimi i listës së kontrollit të validimit të rishikuesit: {0}"
+
+#. placeholder {0}: sessions.error.message
+msgid "Failed to load reviewer validation sessions: {0}"
+msgstr "Dështoi ngarkimi i seancave të validimit të rishikuesit: {0}"
+
+msgid "Failed to load stats:"
+msgstr "Dështoi ngarkimi i statistikave:"
+
+msgid "Failed to load validation checklist:"
+msgstr "Dështoi ngarkimi i listës së kontrollit të validimit:"
+
+msgid "Failed to read archive"
+msgstr "Dështoi leximi i arkivit"
+
+msgid "Failed:"
+msgstr "Dështoi:"
+
+msgid "Falls back to"
+msgstr "Kthehet te"
+
+msgid "Fast, consistent results with no AI cost"
+msgstr "Rezultate të shpejta dhe konsistente pa kosto AI"
+
+msgid "Fig 3.1 — The water cycle: evaporation, condensation, precipitation."
+msgstr "Fig 3.1 — Cikli i ujit: avullim, kondensim, reshje."
+
+msgid "figure"
+msgstr "figurë"
+
+msgid "Figure 5.1 - The water cycle: evaporation from oceans, condensation into clouds, precipitation as rain, and runoff back to the sea."
+msgstr "Figura 5.1 - Cikli i ujit: avullim nga oqeanet, kondensim në re, reshje si shi dhe rrjedhje e ujit përsëri në det."
+
+msgid "Figure Extraction"
+msgstr "Nxjerrja e figurave"
+
+msgid "File accepted"
+msgstr "Skedari u pranua"
+
+msgid "Filter by image ID or caption..."
+msgstr "Filtro sipas ID-së ose titullit të imazhit..."
+
+msgid "Filter by image ID..."
+msgstr "Filtro sipas ID-së së imazhit..."
+
+msgid "Filter by item ID..."
+msgstr "Filtro sipas ID-së së artikullit..."
+
+msgid "Filter pages…"
+msgstr "Filtro faqet…"
+
+msgid "Filter quizzes…"
+msgstr "Filtro kuizet…"
+
+msgid "Filtered by:"
+msgstr "Filtruar sipas:"
+
+msgid "Filters out decorative or non-content images on each page."
+msgstr "Filtron imazhet dekorative ose pa përmbajtje nga çdo faqe."
+
+msgid "Final Page"
+msgstr "Faqja e fundit"
+
+msgid "First"
+msgstr "E para"
+
+msgid "First images from the deep-field telescope."
+msgstr "Imazhet e para nga teleskopi i fushës së thellë."
+
+msgid "First language is the default"
+msgstr "Gjuha e parë është e parazgjedhur"
+
+msgid "Fit"
+msgstr "Përshtat"
+
+msgid "Fixed Layout"
+msgstr "Paraqitje e fiksuar"
+
+msgid "Fixed two-column template layout"
+msgstr "Paraqitje e fiksuar me dy kolona"
+
+msgid "Fixed-layout books use the original page images as backgrounds with positioned text extracted from the PDF. Activities detection, figure extraction, and image cropping or segmentation don't apply to this layout."
+msgstr "Librat me paraqitje të fiksuar përdorin imazhet origjinale të faqeve si sfond me tekst të pozicionuar të nxjerrë nga PDF-i. Zbulimi i aktiviteteve, nxjerrja e figurave dhe prerja ose segmentimi i imazheve nuk zbatohen për këtë paraqitje."
+
+msgid "flagged"
+msgstr "shënuar"
+
+msgid "Flagged by review area"
+msgstr "Shënuar sipas zonës së rishikimit"
+
+msgid "Flagged findings"
+msgstr "Gjetje të shënuara"
+
+msgid "Flat Vector"
+msgstr "Vektor i sheshtë"
+
+msgid "Flexible"
+msgstr "Fleksibël"
+
+msgid "Font"
+msgstr "Font"
+
+#. placeholder {0}: String(page.fonts.length)
+msgid "Fonts ({0})"
+msgstr "Fonte ({0})"
+
+#. placeholder {0}: i18n._(preset.title)
+#. placeholder {1}: recommendedOption.label
+msgid "For {0}, we recommend {1}."
+msgstr "Për {0}, rekomandojmë {1}."
+
+msgid "Foreword"
+msgstr "Parathënie"
+
+msgid "Format"
+msgstr "Format"
+
+msgid "Forms & controls"
+msgstr "Formularë dhe kontrolle"
+
+msgid "FR"
+msgstr "FR"
+
+msgid "French"
+msgstr "Frëngjisht"
+
+msgid "From reference image..."
+msgstr "Nga imazhi referues..."
+
+msgid "Front Cover"
+msgstr "Kapaku i Përparmë"
+
+msgid "Full ADT bundle — HTML pages, images, audio, quizzes, and the compiled web app."
+msgstr "Paketa e plotë ADT — faqe HTML, imazhe, audio, kuize dhe aplikacioni web i kompiluar."
+
+msgid "Full control over render strategies, pruning, and filters."
+msgstr "Kontroll i plotë mbi strategjitë e renderimit, prerjes dhe filtrave."
+
+msgid "Full project backup & transfer"
+msgstr "Kopje rezervë dhe transferim i plotë i projektit"
+
+msgid "Full-size source page preview."
+msgstr "Pamje paraprake e faqes burimore në madhësi të plotë."
+
+msgid "Full-width single column layout. Ideal for reference material, documentation, and dense technical content."
+msgstr "Paraqitje me kolonë të vetme me gjerësi të plotë. Ideale për material referues, dokumentacion dhe përmbajtje teknike të dendur."
+
+msgid "Fully interactive"
+msgstr "Plotësisht interaktiv"
+
+msgid "Gap"
+msgstr "Hapësirë"
+
+msgid "Gathering the evidence"
+msgstr "Mbledhja e dëshmive"
+
+msgid "Gemini"
+msgstr "Gemini"
+
+msgid "Gemini API key is required to generate audio."
+msgstr "Çelësi API i Gemini është i nevojshëm për të gjeneruar audio."
+
+msgid "Gemini Voice"
+msgstr "Zëri Gemini"
+
+msgid "General"
+msgstr "Të përgjithshme"
+
+msgid "Generate"
+msgstr "Gjenero"
+
+msgid "Generate a simplified, easier-to-read version of every text block in the book. Readers turn it on with the Easy Read toggle in the ADT; you can review and edit each simplified block before packaging."
+msgstr "Gjenero një version të thjeshtësuar, më të lehtë për t'u lexuar të çdo blloku teksti në libër. Lexuesit e aktivizojnë me çelësin Easy Read në ADT; mund të rishikoni dhe modifikoni çdo bllok të thjeshtësuar para paketimit."
+
+msgid "Generate a single quiz from specific pages and place it at a chosen location."
+msgstr "Gjenero një kuiz të vetëm nga faqe specifike dhe vendoseni në një vend të zgjedhur."
+
+msgid "Generate and customize the table of contents for the book navigation."
+msgstr "Gjenero dhe personalizo tabelën e përmbajtjes për navigimin e librit."
+
+msgid "Generate and edit Easy Read text blocks for the ADT accessibility toggle."
+msgstr "Gjenero dhe modifiko blloqet e tekstit Easy Read për çelësin e aksesueshmërisë ADT."
+
+msgid "Generate audio narration for every page of the book. Pick a provider and choose whether to highlight each word as it's read aloud."
+msgstr "Gjenero narrativë audio për çdo faqe të librit. Zgjidh një ofrues dhe vendos nëse do të theksohet çdo fjalë ndërsa lexohet me zë."
+
+msgid "Generate audio narration for the book content."
+msgstr "Gjenero narrativë audio për përmbajtjen e librit."
+
+msgid "Generate comprehension quizzes and activities based on the book content."
+msgstr "Gjenero kuize dhe aktivitete të kuptimit bazuar në përmbajtjen e librit."
+
+msgid "Generate descriptive captions for every image in the book. Pick a reading level so captions match your audience, and add custom instructions if you want to nudge the tone or focus."
+msgstr "Gjenero tituj përshkrues për çdo imazh në libër. Zgjidh një nivel leximi që titujt të përputhen me audiencën tuaj dhe shto udhëzime të personalizuara nëse doni të ndikoni tonin ose fokusimin."
+
+msgid "Generate from pages"
+msgstr "Gjenero nga faqet"
+
+msgid "Generate missing Gemini audio"
+msgstr "Gjenero audion Gemini që mungon"
+
+msgid "Generate multiple-choice comprehension quizzes from the book's content. Create them automatically across the whole book, or add a single quiz from specific pages."
+msgstr "Gjenero kuize me zgjedhje të shumëfishta nga përmbajtja e librit. Krijo ato automatikisht në të gjithë librin ose shto një kuiz të vetëm nga faqe specifike."
+
+msgid "Generate new"
+msgstr "Gjenero të ri"
+
+msgid "Generate Prompt"
+msgstr "Gjenero Prompt"
+
+msgid "Generate quiz"
+msgstr "Gjenero kuiz"
+
+msgid "Generate Styleguide from Pages"
+msgstr "Gjenero Udhëzuesin e Stilit nga Faqet"
+
+msgid "Generate with AI"
+msgstr "Gjenero me AI"
+
+msgid "Generate word timestamps"
+msgstr "Gjenero vulat kohore të fjalëve"
+
+msgid "Generated by AI"
+msgstr "Gjeneruar nga AI"
+
+msgid "Generated from pages {fromLabel}"
+msgstr "Gjeneruar nga faqet {fromLabel}"
+
+msgid "Generated from these pages"
+msgstr "Gjeneruar nga këto faqe"
+
+msgid "Generated section"
+msgstr "Seksion i gjeneruar"
+
+msgid "Generates a short summary of the book used to seed downstream prompts."
+msgstr "Gjeneron një përmbledhje të shkurtër të librit që përdoret për të ushqyer promptet pasuese."
+
+msgid "Generates comprehension questions and activities from the book."
+msgstr "Gjeneron pyetje kuptimi dhe aktivitete nga libri."
+
+msgid "Generates descriptive alt-text for images so screen readers can describe them."
+msgstr "Gjeneron tekst alternativ përshkrues për imazhet që lexuesit e ekranit mund t'i përshkruajnë."
+
+msgid "Generates the interactive HTML for this activity type."
+msgstr "Gjeneron HTML interaktiv për këtë lloj aktiviteti."
+
+msgid "Generating Easy Read..."
+msgstr "Duke gjeneruar Easy Read..."
+
+msgid "Generating Glossary..."
+msgstr "Duke gjeneruar Glosarin..."
+
+msgid "Generating image..."
+msgstr "Duke gjeneruar imazhin..."
+
+msgid "Generating panels"
+msgstr "Duke gjeneruar panelet"
+
+msgid "Generating Quizzes..."
+msgstr "Duke gjeneruar Kuizet..."
+
+msgid "Generating Speech..."
+msgstr "Duke gjeneruar Fjalimin..."
+
+msgid "Generating TOC..."
+msgstr "Duke gjeneruar TOC..."
+
+msgid "Generating..."
+msgstr "Duke gjeneruar..."
+
+msgid "Generating…"
+msgstr "Duke gjeneruar…"
+
+msgid "Generation failed"
+msgstr "Gjenerimi dështoi"
+
+msgid "Generation failed. Please try again."
+msgstr "Gjenerimi dështoi. Ju lutemi provoni përsëri."
+
+msgid "Generation Prompt"
+msgstr "Prompt Gjenerimi"
+
+msgid "Get started"
+msgstr "Filloni"
+
+msgid "Glossary"
+msgstr "Glosarit"
+
+msgid "Glossary Generation"
+msgstr "Gjenerimi i Glosariumit"
+
+msgid "Glossary Preview"
+msgstr "Pamje Paraprake e Glosariumit"
+
+msgid "Glossary Prompt"
+msgstr "Prompt i Glosariumit"
+
+msgid "Go to {stageLabel}"
+msgstr "Shko te {stageLabel}"
+
+msgid "Go to book"
+msgstr "Shko te libri"
+
+msgid "Go to home"
+msgstr "Shko te kryefaqja"
+
+msgid "Go to Storyboard"
+msgstr "Shko te Storyboard"
+
+msgid "Google"
+msgstr "Google"
+
+msgid "Google AI API Key"
+msgstr "Çelësi API i Google AI"
+
+msgid "Google's voices with strong intonation for narrative content."
+msgstr "Zërat e Google me intonacion të fortë për përmbajtje narrative."
+
+msgid "Grade Level"
+msgstr "Niveli Shkollor"
+
+msgid "Group each page's text and images into typed sections with a structured content tree. Sections drive how downstream stages render, translate, and read the book aloud."
+msgstr "Grupo tekstin dhe imazhet e çdo faqeje në seksione të tipizuara me një pemë të strukturuar përmbajtjeje. Seksionet drejtojnë mënyrën se si fazat pasuese renderojnë, përkthejnë dhe lexojnë librin me zë."
+
+msgid "Grouping content by purpose, then laying out every section as reviewable HTML."
+msgstr "Grupimi i përmbajtjes sipas qëllimit, pastaj vendosja e çdo seksioni si HTML i rishikueshëm."
+
+msgid "Groups image regions into discrete illustrations on each page."
+msgstr "Grupon rajonet e imazheve në ilustrime të veçanta në çdo faqe."
+
+msgid "Handwriting"
+msgstr "Shkrim dore"
+
+msgid "Header"
+msgstr "Titull"
+
+msgid "heading"
+msgstr "titull"
+
+msgid "Heading"
+msgstr "Titull"
+
+msgid "Heads up: regenerating images takes considerably longer than text translation — each selected image is redrawn for every output language."
+msgstr "Vini re: rigjenerimi i imazheve kërkon kohë shumë më të gjatë se përkthimi i tekstit — çdo imazh i zgjedhur rihiqet për çdo gjuhë dalje."
+
+msgid "Height"
+msgstr "Lartësia"
+
+msgid "Hidden from screen readers, no caption needed."
+msgstr "I fshehur nga lexuesit e ekranit, nuk nevojitet titull."
+
+msgid "Hide"
+msgstr "Fshih"
+
+msgid "Hide AI edit history"
+msgstr "Fshih historikun e editimeve të AI"
+
+msgid "Hide error details"
+msgstr "Fshih detajet e gabimit"
+
+msgid "High"
+msgstr "I lartë"
+
+msgid "Higher values filter out simple or blank images."
+msgstr "Vlerat më të larta filtrojnë imazhet e thjeshta ose bosh."
+
+msgid "Highlight words"
+msgstr "Thekso fjalët"
+
+msgid "Highlights each word as it's narrated. Adds a transcription step so audio aligns with text on the page."
+msgstr "Thekson çdo fjalë ndërsa narratohet. Shton një hap transkriptimi që audio të përputhet me tekstin në faqe."
+
+msgid "Highlights the active sentence while audio plays. Skips the per-word transcription step."
+msgstr "Thekson fjalinë aktive ndërsa audio luan. Anashkalon hapin e transkriptimit për çdo fjalë."
+
+msgid "Highlights words in sync with the audio. Adds noticeable time to speech generation."
+msgstr "Thekson fjalët në sinkronizim me audion. Shton kohë të dukshme në gjenerimin e fjalimit."
+
+msgid "Hill"
+msgstr "Kodër"
+
+msgid "História e Sociedade - Vol. 1"
+msgstr "História e Sociedade - Vol. 1"
+
+msgid "Hit"
+msgstr "Goditje"
+
+msgid "Home / Chapter 1"
+msgstr "Kryefaqja / Kapitulli 1"
+
+msgid "Hover a setting to see how LLM cropping, segmentation, or the size threshold changes extracted images."
+msgstr "Vendos kursorin mbi një cilësim për të parë si ndryshon prerja LLM, segmentimi ose pragu i madhësisë imazhet e ekstraktuara."
+
+msgid "How activities are rendered in each section."
+msgstr "Si renderohen aktivitetet në çdo seksion."
+
+msgid "How captions work"
+msgstr "Si funksionojnë titujt"
+
+msgid "How closely should the visual review match the original page? The reviewer rejects renderings that don't pass — stricter settings cause more rejections and rerenders."
+msgstr "Sa ngushtë duhet të përputhet rishikimi vizual me faqen origjinale? Rishikuesi hedh poshtë renderimet që nuk kalojnë — cilësimet më strikte shkaktojnë më shumë hedhje poshtë dhe rirendime."
+
+msgid "How Easy Read works"
+msgstr "Si funksionon Easy Read"
+
+msgid "How it works"
+msgstr "Si funksionon"
+
+msgid "How many pages of content go into each quiz. A lower number means more quizzes across the book."
+msgstr "Sa faqe përmbajtjeje shkohen në çdo kuiz. Një numër më i ulët nënkupton më shumë kuize në të gjithë librin."
+
+msgid "How quizzes work"
+msgstr "Si funksionojnë kuizet"
+
+msgid "How the glossary works"
+msgstr "Si funksionon glosariumi"
+
+msgid "How the table of contents works"
+msgstr "Si funksionon tabela e përmbajtjes"
+
+msgid "How to add quizzes"
+msgstr "Si të shtohen kuizet"
+
+msgid "HTML"
+msgstr "HTML"
+
+msgid "I'll start later"
+msgstr "Do të filloj më vonë"
+
+msgid "Identify the key idea"
+msgstr "Identifiko idenë kryesore"
+
+msgid "If you don't run Image Captions, your output will not be accessible to readers who use screen readers or can't see the images."
+msgstr "Nëse nuk ekzekutoni Titujt e Imazheve, dalja juaj nuk do të jetë e aksesueshme për lexuesit që përdorin lexues ekrani ose nuk mund t'i shohin imazhet."
+
+msgid "Illustrated children's books"
+msgstr "Libra për fëmijë të ilustruar"
+
+msgid "Illustration"
+msgstr "Ilustrim"
+
+msgid "image"
+msgstr "imazh"
+
+msgid "Image"
+msgstr "Imazh"
+
+msgid "Image Alt-Text"
+msgstr "Teksti Alternativ i Imazhit"
+
+msgid "Image Captioning"
+msgstr "Titullimi i Imazheve"
+
+msgid "Image Captions"
+msgstr "Titujt e Imazheve"
+
+msgid "Image Cropping"
+msgstr "Prerja e Imazheve"
+
+msgid "Image Cropping Prompt"
+msgstr "Prompt i Prerjes së Imazheve"
+
+msgid "Image Edit Prompt"
+msgstr "Prompt i Editimit të Imazhit"
+
+msgid "Image filter size"
+msgstr "Madhësia e filtrit të imazhit"
+
+msgid "Image Filter Size"
+msgstr "Madhësia e Filtrit të Imazhit"
+
+msgid "Image Filtering"
+msgstr "Filtrimi i Imazheve"
+
+msgid "Image Filters"
+msgstr "Filtrat e Imazheve"
+
+msgid "Image fit"
+msgstr "Përshtatja e imazhit"
+
+msgid "Image generated"
+msgstr "Imazhi u gjenerua"
+
+msgid "Image Generation"
+msgstr "Gjenerimi i Imazheve"
+
+msgid "Image Generation Prompt"
+msgstr "Prompt i Gjenerimit të Imazheve"
+
+msgid "Image Meaningfulness"
+msgstr "Kuptimësia e Imazhit"
+
+msgid "Image Meaningfulness Prompt"
+msgstr "Prompt i Kuptimësisë së Imazhit"
+
+msgid "Image model"
+msgstr "Modeli i imazhit"
+
+msgid "Image not translated for this language"
+msgstr "Imazhi nuk është përkthyer për këtë gjuhë"
+
+msgid "Image processing"
+msgstr "Përpunimi i imazheve"
+
+msgid "Image Processing"
+msgstr "Përpunimi i Imazheve"
+
+msgid "Image Segmentation"
+msgstr "Segmentimi i Imazheve"
+
+msgid "Image Segmentation Prompt"
+msgstr "Prompt i Segmentimit të Imazheve"
+
+msgid "Image selection"
+msgstr "Zgjedhja e imazhit"
+
+msgid "Image Translation"
+msgstr "Përkthimi i Imazheve"
+
+msgid "Image translation prompt"
+msgstr "Prompt i përkthimit të imazhit"
+
+msgid "Image Translations"
+msgstr "Përkthimet e Imazheve"
+
+msgid "Image Type"
+msgstr "Lloji i Imazhit"
+
+msgid "Image unavailable"
+msgstr "Imazhi nuk është i disponueshëm"
+
+msgid "Image upload failed"
+msgstr "Ngarkimi i imazhit dështoi"
+
+msgid "images"
+msgstr "imazhe"
+
+msgid "Images"
+msgstr "Imazhe"
+
+msgid "Images only"
+msgstr "Vetëm imazhe"
+
+msgid "Images Only"
+msgstr "Vetëm Imazhe"
+
+msgid "Images outside the min/max size range are excluded from processing - filtering out tiny icons and oversized scans."
+msgstr "Imazhet jashtë intervalit të madhësisë min/max përjashtohen nga përpunimi — filtrohen ikonat e vogla dhe skanet shumë të mëdha."
+
+msgid "Images smaller than your minimum dimension skip segmentation - saving cost and avoiding false splits on icons."
+msgstr "Imazhet më të vogla se dimensioni juaj minimal anashkalojnë segmentimin — duke kursyer kosto dhe shmangur ndarjet e rreme në ikona."
+
+msgid "Images stay in the source language"
+msgstr "Imazhet mbeten në gjuhën burimore"
+
+msgid "Images with shortest side below min or longest side above max are pruned."
+msgstr "Imazhet me anën më të shkurtër nën minimum ose anën më të gjatë mbi maksimum hiqen."
+
+msgid "Import"
+msgstr "Importo"
+
+msgid "Import a Project"
+msgstr "Importo një projekt"
+
+msgid "Import project"
+msgstr "Importo projektin"
+
+msgid "Import Project"
+msgstr "Importo Projektin"
+
+msgid "Importing..."
+msgstr "Duke importuar..."
+
+msgid "In book:"
+msgstr "Në libër:"
+
+msgid "In case you don't want to convert the whole book, adjust the sliders to define which pages will be digitized."
+msgstr "Nëse nuk doni të konvertoni të gjithë librin, rregulloni rrëshqitësit për të përcaktuar cilat faqe do të digjitalizohen."
+
+msgid "in the book"
+msgstr "në libër"
+
+msgid "Include in render"
+msgstr "Përfshi në paraqitje"
+
+msgid "Include text overlays in vector groups"
+msgstr "Përfshi mbivendosjet e tekstit në grupet vektoriale"
+
+msgid "Increase indent"
+msgstr "Rrit dhëmbëzimin"
+
+msgid "Individual sides"
+msgstr "Anë individuale"
+
+msgid "Infographic"
+msgstr "Infografikë"
+
+msgid "Inherited from a parent element. Choose a value here to override on this element."
+msgstr "Trashëguar nga një element prind. Zgjidhni një vlerë këtu për ta anuluar në këtë element."
+
+msgid "Initial Page"
+msgstr "Faqja fillestare"
+
+msgid "Input"
+msgstr "Hyrje"
+
+msgid "Input Tokens"
+msgstr "Token-ët hyrës"
+
+msgid "Insert the quiz here"
+msgstr "Vendos kuizin këtu"
+
+msgid "Inside Cover"
+msgstr "Kapaku i brendshëm"
+
+msgid "Install on quit"
+msgstr "Instalo gjatë daljes"
+
+msgid "Institution"
+msgstr "Institucion"
+
+msgid "Interactive"
+msgstr "Interaktiv"
+
+msgid "Interactive assessment questions"
+msgstr "Pyetje vlerësuese interaktive"
+
+msgid "Interactive page: AI conversion from the original PDF."
+msgstr "Faqe interaktive: konvertim me AI nga PDF origjinal."
+
+msgid "Intro"
+msgstr "Hyrje"
+
+msgid "Introduction to Photosynthesis"
+msgstr "Hyrje në Fotosintezë"
+
+msgid "Invalid project archive"
+msgstr "Arkivë projekti e pavlefshme"
+
+msgid "Isolated asset"
+msgstr "Asete e izoluar"
+
+msgid "Issues"
+msgstr "Probleme"
+
+msgid "Italic"
+msgstr "Italike"
+
+msgid "Item"
+msgstr "Element"
+
+#. placeholder {0}: criterionIndex + 1
+msgid "Item {0}"
+msgstr "Elementi {0}"
+
+msgid "Item ID..."
+msgstr "ID e elementit..."
+
+msgid "Items marked as needing changes for this reviewer session."
+msgstr "Elementet e shënuara si që kërkojnë ndryshime për këtë sesion rishikimi."
+
+msgid "its original language"
+msgstr "gjuhën e saj origjinale"
+
+msgid "Jane Reviewer"
+msgstr "Jane Rishikuese"
+
+msgid "Jump to page"
+msgstr "Kalo te faqja"
+
+msgid "Jump to quiz"
+msgstr "Kalo te kuizi"
+
+msgid "Justify"
+msgstr "Justify"
+
+msgid "KB"
+msgstr "KB"
+
+msgid "Keep pages whole by default, but split when distinct activity types are detected on the same page."
+msgstr "Mbaji faqet të plota si parazgjedhje, por ndaji kur zbulohen lloje të ndryshme aktivitetesh në të njëjtën faqe."
+
+msgid "Keeps pages whole unless mixed activity types require splitting."
+msgstr "Mban faqet të plota nëse llojet e përziera të aktiviteteve nuk kërkojnë ndarje."
+
+msgid "Keeps the page as one section by default, but intelligently splits when it detects multiple distinct activities - such as a mix of multiple-choice, open-ended, and sorting exercises on the same page. Best for textbooks with varied exercises."
+msgstr "Mban faqen si një seksion si parazgjedhje, por ndan me inteligjencë kur zbulon aktivitete të shumta të dallueshme - si një kombinim pyetjesh me zgjedhje të shumëfishta, të hapura dhe ushtrime renditjeje në të njëjtën faqe. Më i miri për tekstet shkollore me ushtrime të ndryshme."
+
+msgid "Key must start with \"sk-\""
+msgstr "Çelësi duhet të fillojë me \"sk-\""
+
+msgid "Key must start with sk-"
+msgstr "Çelësi duhet të fillojë me sk-"
+
+msgid "Keyboard & navigation"
+msgstr "Tastierë dhe navigim"
+
+#. placeholder {0}: afterPage.pageNumber
+msgid "Knowledge check generated from the source pages, after page {0}."
+msgstr "Kontroll njohurish gjeneruar nga faqet burimore, pas faqes {0}."
+
+msgid "Knowledge check generated from the source pages."
+msgstr "Kontroll njohurish gjeneruar nga faqet burimore."
+
+#. placeholder {0}: entry.level
+msgid "L{0}"
+msgstr "N{0}"
+
+msgid "Label"
+msgstr "Etiketë"
+
+msgid "Language"
+msgstr "Gjuhë"
+
+msgid "Language-Specific Prompts"
+msgstr "Nxitje specifike për gjuhën"
+
+msgid "Languages"
+msgstr "Gjuhët"
+
+msgid "Large"
+msgstr "I madh"
+
+msgid "Large enough"
+msgstr "Mjaft i madh"
+
+msgid "Large images, narrative flow. Best for illustrated books with high-fidelity TTS voices."
+msgstr "Imazhe të mëdha, rrjedhje narrative. Më i miri për libra të ilustruar me zëra TTS të besnikërisë së lartë."
+
+msgid "Last"
+msgstr "I fundit"
+
+msgid "Last modified"
+msgstr "Modifikuar së fundmi"
+
+msgid "Launch the app with"
+msgstr "Hap aplikacionin me"
+
+msgid "Layer on translations, text-to-speech, and a glossary — all inspectable, cacheable, reversible."
+msgstr "Shtro përkthimet, tekst-në-fjalim dhe një glosar — të gjitha të inspektueshme, të ruajtura në memorie, të kthyeshme."
+
+msgid "Laying out spreads"
+msgstr "Duke paraqitur faqet e dyfishta"
+
+msgid "Layout"
+msgstr "Paraqitje"
+
+msgid "Leading"
+msgstr "Hapësira ndër-rreshta"
+
+msgid "Least used"
+msgstr "Më pak i përdorur"
+
+msgid "Leave"
+msgstr "Lër"
+
+msgid "Leave at None to run segmentation on all qualifying images (subject to pipeline rules)."
+msgstr "Lëre në Asnjë për të ekzekutuar segmentimin në të gjitha imazhet e kualifikuara (sipas rregullave të pipeline)."
+
+msgid "Leave empty if not required"
+msgstr "Lëre bosh nëse nuk kërkohet"
+
+msgid "Leave empty to output only in the book language."
+msgstr "Lëre bosh për të dalë vetëm në gjuhën e librit."
+
+msgid "Leave empty to process all pages."
+msgstr "Lëre bosh për të përpunuar të gjitha faqet."
+
+msgid "Leave empty to use the book language."
+msgstr "Lëre bosh për të përdorur gjuhën e librit."
+
+msgid "Legal and compliance manuals"
+msgstr "Manuale ligjore dhe të pajtueshmërisë"
+
+msgid "Legal Compliance Guide"
+msgstr "Udhëzues i pajtueshmërisë ligjore"
+
+msgid "Let the model write descriptive chapter titles based on each section's contents. Best for storybooks or when headings are missing."
+msgstr "Lëre modelin të shkruajë tituj përshkrues kapitujsh bazuar në përmbajtjen e çdo seksioni. Më i miri për libra tregimesh ose kur titujt mungojnë."
+
+msgid "Library apps"
+msgstr "Aplikacione biblioteke"
+
+msgid "Life in the Coral Reef"
+msgstr "Jeta në Rifin Koral"
+
+msgid "Lila wandered between the tall pines, her flashlight catching glimmers of gold among the leaves. The path narrowed, and the wind began to whisper her name."
+msgstr "Lila endej midis pishave të larta, elektriku i saj duke kapur shkëlqime ari ndërmjet gjetheve. Rruga u ngushtua dhe era filloi të pëshpërisë emrin e saj."
+
+msgid "lines"
+msgstr "rreshta"
+
+msgid "Língua Portuguesa - 3° Ano"
+msgstr "Língua Portuguesa - 3° Ano"
+
+msgid "Link"
+msgstr "Lidhje"
+
+msgid "Link page"
+msgstr "Faqe lidhje"
+
+msgid "Linked to: {value}"
+msgstr "I lidhur me: {value}"
+
+msgid "List"
+msgstr "Listë"
+
+msgid "list_item"
+msgstr "list_item"
+
+msgid "Listening to the data"
+msgstr "Duke dëgjuar të dhënat"
+
+msgid "Live"
+msgstr "Drejtpërdrejt"
+
+msgid "LLM Calls"
+msgstr "Thirrje LLM"
+
+msgid "LLM crop"
+msgstr "Prerje LLM"
+
+msgid "LLM cropping"
+msgstr "Prerje me LLM"
+
+msgid "LLM generates HTML from section content"
+msgstr "LLM gjeneron HTML nga përmbajtja e seksionit"
+
+msgid "LLM image cropping"
+msgstr "Prerje e imazhit me LLM"
+
+msgid "LLM image segmentation"
+msgstr "Segmentim i imazhit me LLM"
+
+msgid "LLM meaningfulness filter"
+msgstr "Filtër kuptimësie LLM"
+
+msgid "LLM positions text over background images"
+msgstr "LLM pozicionon tekstin mbi imazhet e sfondit"
+
+msgid "LLM segmentation"
+msgstr "Segmentim LLM"
+
+msgid "LLM-based cropping to remove stray text, artifacts, and excessive whitespace from extracted images."
+msgstr "Prerje e bazuar në LLM për të hequr tekstin e humbur, artefaktet dhe hapësirën e tepërt të bardhë nga imazhet e ekstraktuara."
+
+msgid "LLM-based filter to determine if extracted images are meaningful."
+msgstr "Filtër i bazuar në LLM për të përcaktuar nëse imazhet e ekstraktuara janë kuptimplota."
+
+msgid "LLM-based segmentation to detect and split composited images into individual segments. Requires GPT-5.2+ for accurate bounding box coordinates."
+msgstr "Segmentim i bazuar në LLM për të zbuluar dhe ndarë imazhet e kompozuara në segmente individuale. Kërkon GPT-5.2+ për koordinata të sakta të kutisë kufizuese."
+
+msgid "LMS-ready with completion tracking"
+msgstr "Gati për LMS me gjurmim të përfundimit"
+
+msgid "Loading accessibility summary..."
+msgstr "Duke ngarkuar përmbledhjen e aksesueshmërisë..."
+
+msgid "Loading Book..."
+msgstr "Duke ngarkuar librin..."
+
+msgid "Loading books..."
+msgstr "Duke ngarkuar librat..."
+
+msgid "Loading Easy Read..."
+msgstr "Duke ngarkuar Leximin e Lehtë..."
+
+msgid "Loading export..."
+msgstr "Duke ngarkuar eksportimin..."
+
+msgid "Loading glossary..."
+msgstr "Duke ngarkuar glosarin..."
+
+msgid "Loading image..."
+msgstr "Duke ngarkuar imazhin..."
+
+msgid "Loading images..."
+msgstr "Duke ngarkuar imazhet..."
+
+msgid "Loading logs..."
+msgstr "Duke ngarkuar regjistrat..."
+
+msgid "Loading page-level findings"
+msgstr "Duke ngarkuar gjetjet në nivel faqeje"
+
+msgid "Loading page..."
+msgstr "Duke ngarkuar faqen..."
+
+msgid "Loading pages..."
+msgstr "Duke ngarkuar faqet..."
+
+msgid "Loading preview"
+msgstr "Duke ngarkuar paraparjen"
+
+msgid "Loading preview..."
+msgstr "Duke ngarkuar paraparjen..."
+
+msgid "Loading prompt..."
+msgstr "Duke ngarkuar nxitjen..."
+
+msgid "Loading quiz..."
+msgstr "Duke ngarkuar kuizin..."
+
+msgid "Loading quizzes..."
+msgstr "Duke ngarkuar kuizet..."
+
+msgid "Loading reviewer checklist…"
+msgstr "Duke ngarkuar listën e kontrollit të rishikuesit…"
+
+msgid "Loading reviewer validation summary..."
+msgstr "Duke ngarkuar përmbledhjen e vërtetimit të rishikuesit..."
+
+msgid "Loading reviewer validation…"
+msgstr "Duke ngarkuar vërtetimin e rishikuesit…"
+
+msgid "Loading sectioning data..."
+msgstr "Duke ngarkuar të dhënat e seksionimit..."
+
+msgid "Loading speech instructions..."
+msgstr "Duke ngarkuar udhëzimet e fjalës..."
+
+msgid "Loading stats..."
+msgstr "Duke ngarkuar statistikat..."
+
+msgid "Loading style guides..."
+msgstr "Duke ngarkuar udhëzuesit e stilit..."
+
+msgid "Loading table of contents..."
+msgstr "Duke ngarkuar tabelën e përmbajtjes..."
+
+msgid "Loading template..."
+msgstr "Duke ngarkuar modelin..."
+
+msgid "Loading text catalog..."
+msgstr "Duke ngarkuar katalogun e tekstit..."
+
+msgid "Loading validation..."
+msgstr "Duke ngarkuar vërtetimin..."
+
+msgid "Loading voice mappings..."
+msgstr "Duke ngarkuar hartëzimet e zërit..."
+
+msgid "Loading..."
+msgstr "Duke ngarkuar..."
+
+msgid "Loading…"
+msgstr "Duke ngarkuar…"
+
+msgid "Localization"
+msgstr "Lokalizim"
+
+msgid "Logs"
+msgstr "Regjistra"
+
+msgid "Looking forward"
+msgstr "Duke shikuar përpara"
+
+msgid "Lookup definitions for key terms"
+msgstr "Kërko përkufizime për termat kyç"
+
+msgid "Lower values produce more consistent styling across pages."
+msgstr "Vlerat më të ulëta prodhojnë stil më konsistent nëpër faqe."
+
+msgid "Make sure you're uploading a .zip file exported from ADT Studio."
+msgstr "Sigurohuni që po ngarkoni një skedar .zip të eksportuar nga ADT Studio."
+
+msgid "Manage all sections"
+msgstr "Menaxho të gjitha seksionet"
+
+msgid "Manage sign-language videos"
+msgstr "Menaxho videot e gjuhës së shenjave"
+
+msgid "Manual only"
+msgstr "Vetëm manual"
+
+msgid "Manual review"
+msgstr "Rishikim manual"
+
+msgid "Many printed books are designed with facing pages in mind - illustrations that span two pages, or text that flows across a spread. Spread mode merges each pair of facing pages so content isn't split apart. The cover stays standalone, then pages are paired: 2+3, 4+5, etc."
+msgstr "Shumë libra të shtypur janë projektuar me faqet ballë për ballë në mendje - ilustrime që shtrihen në dy faqe, ose tekst që rrjedh nëpër një hapje. Modaliteti i hapjes bashkon çdo çift faqesh ballë për ballë që përmbajtja të mos ndahet. Kapaku qëndron i pavarur, pastaj faqet çiftohen: 2+3, 4+5, etj."
+
+msgid "Map"
+msgstr "Hartë"
+
+msgid "Map language codes to voice names for each TTS provider."
+msgstr "Lidh kodet e gjuhës me emrat e zërit për çdo ofrues TTS."
+
+msgid "margin"
+msgstr "margjinë"
+
+msgid "Margin"
+msgstr "Margjinë"
+
+msgid "Mark as decorative"
+msgstr "Shëno si dekorativ"
+
+msgid "Mark as decorative (hidden from screen readers)"
+msgstr "Shëno si dekorativ (i fshehur nga lexuesit e ekranit)"
+
+msgid "Match Design"
+msgstr "Përputhje Dizajni"
+
+msgid "Match each stage of the water cycle to its definition:"
+msgstr "Përputhni çdo fazë të ciklit të ujit me përkufizimin e saj:"
+
+msgid "Match Source"
+msgstr "Përputhje me Burimin"
+
+msgid "Match the book's detected style"
+msgstr "Përputhje me stilin e zbuluar të librit"
+
+msgid "Matches the original book design with some flexibility."
+msgstr "Përputhet me dizajnin origjinal të librit me pak fleksibilitet."
+
+msgid "Max height"
+msgstr "Lartësia maksimale"
+
+msgid "Max Iterations"
+msgstr "Iteracione Maksimale"
+
+msgid "Max Refinements"
+msgstr "Rafinimi Maksimal"
+
+msgid "Max review/revise rounds per section before accepting the current rendering"
+msgstr "Raunde maksimale të rishikimit/rishkrimit për seksion para pranimit të renderimit aktual"
+
+msgid "Max side (px)"
+msgstr "Anë maksimale (px)"
+
+msgid "Max Size (px)"
+msgstr "Madhësia Maksimale (px)"
+
+msgid "Max width"
+msgstr "Gjerësia maksimale"
+
+msgid "Maximize"
+msgstr "Maksimizo"
+
+msgid "Meaningfulness Prompt"
+msgstr "Kërkesë e Kuptimploteë"
+
+msgid "Media"
+msgstr "Media"
+
+msgid "Media & timing"
+msgstr "Media & kohëzgjatja"
+
+msgid "Medical references"
+msgstr "Referenca mjekësore"
+
+msgid "Medium"
+msgstr "Mesatar"
+
+msgid "Merge facing pages as spreads"
+msgstr "Bashko faqet ballë-përballë si hapësira"
+
+msgid "Merge failed"
+msgstr "Bashkimi dështoi"
+
+msgid "merge into next page"
+msgstr "bashko me faqen tjetër"
+
+msgid "Merge into next page"
+msgstr "Bashko me faqen tjetër"
+
+msgid "merge into previous page"
+msgstr "bashko me faqen e mëparshme"
+
+msgid "Merge into previous page"
+msgstr "Bashko me faqen e mëparshme"
+
+msgid "merge with next"
+msgstr "bashko me të ardhshmin"
+
+msgid "Merge with next"
+msgstr "Bashko me të ardhshmin"
+
+msgid "merge with next section"
+msgstr "bashko me seksionin tjetër"
+
+msgid "merge with previous"
+msgstr "bashko me të mëparshmit"
+
+msgid "Merge with previous"
+msgstr "Bashko me të mëparshmit"
+
+msgid "merge with previous section"
+msgstr "bashko me seksionin e mëparshëm"
+
+msgid "Messages"
+msgstr "Mesazhe"
+
+msgid "Metadata"
+msgstr "Metadatë"
+
+msgid "Metadata Extraction Prompt"
+msgstr "Kërkesë e Nxjerrjes së Metadatave"
+
+msgid "Metadata Prompt"
+msgstr "Kërkesë e Metadatave"
+
+msgid "Metaphor"
+msgstr "Metaforë"
+
+msgid "Method"
+msgstr "Metodë"
+
+msgid "Middle"
+msgstr "Mesi"
+
+msgid "Min complexity"
+msgstr "Kompleksiteti minimal"
+
+msgid "Min height"
+msgstr "Lartësia minimale"
+
+msgid "Min image dimension (px)"
+msgstr "Dimensioni minimal i imazhit (px)"
+
+msgid "Min side (px)"
+msgstr "Anë minimale (px)"
+
+msgid "Min Size (px)"
+msgstr "Madhësia Minimale (px)"
+
+msgid "Min width"
+msgstr "Gjerësia minimale"
+
+msgid "Minimize"
+msgstr "Minimizo"
+
+msgid "Minimize accessibility summary"
+msgstr "Minimizo përmbledhjen e aksesueshmërisë"
+
+msgid "Minimum image dimension"
+msgstr "Dimensioni minimal i imazhit"
+
+msgid "Minimum size threshold"
+msgstr "Pragu minimal i madhësisë"
+
+msgid "minor"
+msgstr "i vogël"
+
+msgid "Minor"
+msgstr "I vogël"
+
+msgid "Mirrors the original book's activity layout as closely as possible."
+msgstr "Pasqyron sa më shumë të jetë e mundur strukturën e aktiviteteve të librit origjinal."
+
+msgid "Miss"
+msgstr "Mungesë"
+
+msgid "Misses"
+msgstr "Mungesa"
+
+msgid "Missing"
+msgstr "Mungon"
+
+msgid "Mission 01"
+msgstr "Misioni 01"
+
+msgid "mitosis"
+msgstr "mitozë"
+
+msgid "Mixed Content Project"
+msgstr "Projekt me Përmbajtje të Përzier"
+
+msgid "Mobile"
+msgstr "Celular"
+
+msgid "Model"
+msgstr "Model"
+
+msgid "moderate"
+msgstr "i moderuar"
+
+msgid "Moderate"
+msgstr "I moderuar"
+
+msgid "Modified {modifiedLabel}"
+msgstr "Modifikuar {modifiedLabel}"
+
+msgid "Monospace"
+msgstr "Monospace"
+
+msgid "More info"
+msgstr "Më shumë informacion"
+
+msgid "Most used"
+msgstr "Më i përdorur"
+
+msgid "Multi-format publications"
+msgstr "Botime me shumë formate"
+
+msgid "multiple choice"
+msgstr "me zgjedhje të shumëfishta"
+
+msgid "my-book-slug"
+msgstr "my-book-slug"
+
+msgid "N/A"
+msgstr "N/A"
+
+msgid "Natural, expressive voices. Best general-purpose default."
+msgstr "Zëra natyralë dhe shprehës. Parazgjedhja më e mirë për qëllime të përgjithshme."
+
+msgid "Nav"
+msgstr "Nav"
+
+msgid "Navigate within Preview to capture page-specific review notes"
+msgstr "Navigo brenda Paraparjes për të regjistruar shënimet e rishikimit specifike për faqen"
+
+msgid "Needs changes"
+msgstr "Kërkon ndryshime"
+
+msgid "Needs rebuild"
+msgstr "Kërkon rindërtim"
+
+msgid "Never"
+msgstr "Kurrë"
+
+msgid "New"
+msgstr "E re"
+
+msgid "New checklist item"
+msgstr "Element i ri i listës kontrolluese"
+
+msgid "New Entry"
+msgstr "Hyrje e re"
+
+msgid "New session"
+msgstr "Sesion i ri"
+
+msgid "New version"
+msgstr "Version i ri"
+
+msgid "new_type_key"
+msgstr "new_type_key"
+
+msgid "Newest first"
+msgstr "Më i riu i pari"
+
+msgid "Next"
+msgstr "Tjetër"
+
+msgid "Next image"
+msgstr "Imazhi tjetër"
+
+msgid "Next missing section"
+msgstr "Seksioni tjetër që mungon"
+
+msgid "Next page"
+msgstr "Faqja tjetër"
+
+msgid "Next slide"
+msgstr "Sllajdi tjetër"
+
+msgid "Next Step"
+msgstr "Hapi tjetër"
+
+msgid "No accessibility assessment has been generated yet. Package the ADT output to create one."
+msgstr "Nuk është gjeneruar ende vlerësimi i aksesueshmërisë. Pako rezultatin ADT për ta krijuar."
+
+msgid "No accessibility findings were reported for this page."
+msgstr "Nuk u raportuan gjetje aksesueshmërie për këtë faqe."
+
+msgid "No AI edits yet for this section."
+msgstr "Nuk ka redaktime të AI ende për këtë seksion."
+
+#. placeholder {0}: linguiI18n._(PROVIDER_LABELS[provider])
+msgid "No API key for {0} yet. Add one in Book settings to enable this provider."
+msgstr "Nuk ka ende çelës API për {0}. Shto një te cilësimet e Librit për të aktivizuar këtë ofrues."
+
+msgid "No assessment"
+msgstr "Pa vlerësim"
+
+msgid "No audio for this page"
+msgstr "Nuk ka audio për këtë faqe"
+
+msgid "No books match your search"
+msgstr "Asnjë libër nuk përputhet me kërkimin tuaj"
+
+msgid "No captioned images yet. Run the image-captioning step first."
+msgstr "Nuk ka ende imazhe me tituj. Ekzekuto fillimisht hapin e titullimit të imazheve."
+
+msgid "No captions for this page"
+msgstr "Nuk ka tituj për këtë faqe"
+
+msgid "No changes flagged on this page"
+msgstr "Nuk janë sinjalizuar ndryshime në këtë faqe"
+
+msgid "No colors found"
+msgstr "Nuk u gjetën ngjyra"
+
+msgid "No content processing needed"
+msgstr "Nuk nevojitet procesim i përmbajtjes"
+
+msgid "No cover available"
+msgstr "Nuk ka kopertinë të disponueshme"
+
+msgid "No data"
+msgstr "Nuk ka të dhëna"
+
+msgid "No disabled rules"
+msgstr "Nuk ka rregulla të çaktiviziuara"
+
+msgid "No Easy Read for this page"
+msgstr "Nuk ka Lexim të Lehtë për këtë faqe"
+
+msgid "No entries match your search"
+msgstr "Asnjë hyrje nuk përputhet me kërkimin tuaj"
+
+msgid "No entries yet"
+msgstr "Nuk ka hyrje ende"
+
+msgid "No extracted text yet. Run the pipeline first."
+msgstr "Nuk ka tekst të nxjerrë ende. Ekzekuto fillimisht zinxhirin e procesimit."
+
+msgid "No fields to add"
+msgstr "Nuk ka fusha për të shtuar"
+
+msgid "No finding categories reported."
+msgstr "Nuk u raportuan kategori gjetjesh."
+
+msgid "No findings"
+msgstr "Nuk ka gjetje"
+
+msgid "No findings this page"
+msgstr "Nuk ka gjetje në këtë faqe"
+
+msgid "No flagged findings in reviewed pages"
+msgstr "Nuk ka gjetje të sinjalizuara në faqet e rishikuara"
+
+msgid "No image"
+msgstr "Pa imazh"
+
+msgid "No image available"
+msgstr "Nuk ka imazh të disponueshëm"
+
+msgid "No images in this book"
+msgstr "Nuk ka imazhe në këtë libër"
+
+msgid "No images in this section"
+msgstr "Nuk ka imazhe në këtë seksion"
+
+msgid "No images match your filter"
+msgstr "Asnjë imazh nuk përputhet me filtrin tuaj"
+
+msgid "No images match your filter."
+msgstr "Asnjë imazh nuk përputhet me filtrin tuaj."
+
+msgid "No images on this page"
+msgstr "Nuk ka imazhe në këtë faqe"
+
+msgid "No issues or manual review items match the current filters."
+msgstr "Asnjë problem ose element rishikimi manual nuk përputhet me filtrat aktualë."
+
+msgid "No issues or manual review items were reported."
+msgstr "Nuk u raportuan probleme ose elemente rishikimi manual."
+
+msgid "No items are currently flagged as needing changes in this reviewer session."
+msgstr "Aktualisht nuk ka elemente të sinjalizuara si që kërkojnë ndryshime në këtë sesion rishikuesi."
+
+msgid "No language-specific prompts configured."
+msgstr "Nuk ka kërkesa specifike gjuhësore të konfiguruara."
+
+msgid "No languages configured. Add languages in the Language settings."
+msgstr "Nuk ka gjuhë të konfiguruara. Shto gjuhë te cilësimet e Gjuhës."
+
+msgid "No log entries found yet."
+msgstr "Nuk u gjetën ende hyrje regjistrimi."
+
+msgid "No manual terms yet"
+msgstr "Nuk ka terma manualë ende"
+
+msgid "No matches for \"{search}\""
+msgstr "Nuk ka përputhje për \"{search}\""
+
+msgid "No matching blocks"
+msgstr "Nuk ka blloqe përputhëse"
+
+msgid "No matching pages"
+msgstr "Nuk ka faqe përputhëse"
+
+msgid "No matching quizzes"
+msgstr "Nuk ka kuize përputhëse"
+
+msgid "No matching sections"
+msgstr "Nuk ka seksione përputhëse"
+
+msgid "No metadata yet — run the pipeline to extract book details"
+msgstr "Nuk ka metadatë ende — ekzekuto zinxhirin e procesimit për të nxjerrë detajet e librit"
+
+msgid "No other images in this book"
+msgstr "Nuk ka imazhe të tjera në këtë libër"
+
+msgid "No page linked"
+msgstr "Nuk ka faqe të lidhur"
+
+msgid "No pages extracted yet"
+msgstr "Nuk janë nxjerrë faqe ende"
+
+msgid "No pages extracted yet. Run the pipeline to extract content."
+msgstr "Nuk janë nxjerrë faqe ende. Ekzekuto zinxhirin e procesimit për të nxjerrë përmbajtjen."
+
+msgid "No pages found"
+msgstr "Nuk u gjetën faqe"
+
+msgid "No PDF"
+msgstr "Nuk ka PDF"
+
+msgid "No pipeline data yet. Run the pipeline to see stats."
+msgstr "Nuk ka ende të dhëna pipeline. Ekzekutoni pipeline-in për të parë statistikat."
+
+msgid "No preset defaults — all options start empty."
+msgstr "Nuk ka paracaktime — të gjitha opsionet fillojnë bosh."
+
+msgid "No preview available"
+msgstr "Nuk ka pamje paraprake"
+
+msgid "No preview available."
+msgstr "Nuk ka pamje paraprake."
+
+msgid "No pruned terms"
+msgstr "Nuk ka terma të hequr"
+
+msgid "No quizzes for this page"
+msgstr "Nuk ka kuize për këtë faqe"
+
+msgid "No quizzes match your search"
+msgstr "Asnjë kuiz nuk përputhet me kërkimin tuaj"
+
+msgid "No rendered content for this section"
+msgstr "Nuk ka përmbajtje të gjeneruar për këtë seksion"
+
+msgid "No rendered pages yet. Run Storyboard first."
+msgstr "Nuk ka ende faqe të gjeneruara. Ekzekutoni Storyboard-in fillimisht."
+
+msgid "No review areas are currently flagged in this reviewer session."
+msgstr "Nuk ka zona të shënuara aktualisht në këtë sesion rishikimi."
+
+msgid "No reviewer validation sessions have been started yet. Open Preview to create a reviewer session and begin recording page-level findings."
+msgstr "Nuk ka ende sesione vërtetimi rishikuesi të filluara. Hapni Pamjen Paraprake për të krijuar një sesion rishikuesi dhe filluar regjistrimin e gjetjeve në nivel faqeje."
+
+msgid "No sectioning data available."
+msgstr "Nuk ka të dhëna seksionimi të disponueshme."
+
+msgid "No sections"
+msgstr "Nuk ka seksione"
+
+msgid "No sections for this page"
+msgstr "Nuk ka seksione për këtë faqe"
+
+msgid "No sections on this page"
+msgstr "Nuk ka seksione në këtë faqe"
+
+msgid "No sections to show"
+msgstr "Nuk ka seksione për të shfaqur"
+
+msgid "No sections yet"
+msgstr "Nuk ka ende seksione"
+
+msgid "No sections yet — run the storyboard stage to generate pages."
+msgstr "Nuk ka ende seksione — ekzekutoni fazën storyboard për të gjeneruar faqet."
+
+msgid "No segmentation needed for this image"
+msgstr "Nuk nevojitet segmentim për këtë imazh"
+
+msgid "No source image"
+msgstr "Nuk ka imazh burimor"
+
+msgid "No storyboard sections found. Run Storyboard to generate sections you can match videos to."
+msgstr "Nuk u gjetën seksione storyboard. Ekzekutoni Storyboard-in për të gjeneruar seksione me të cilat mund të përputhni video."
+
+msgid "No terms match your search"
+msgstr "Asnjë term nuk përputhet me kërkimin tuaj"
+
+msgid "No terms to show"
+msgstr "Nuk ka terma për të shfaqur"
+
+msgid "No text"
+msgstr "Nuk ka tekst"
+
+msgid "No text extracted"
+msgstr "Nuk u ekstraktua tekst"
+
+msgid "No translations for this page"
+msgstr "Nuk ka përkthime për këtë faqe"
+
+msgid "No versions"
+msgstr "Nuk ka versione"
+
+msgid "No versions found for {node} / {itemId}"
+msgstr "Nuk u gjetën versione për {node} / {itemId}"
+
+msgid "No videos assigned yet"
+msgstr "Nuk ka ende video të caktuara"
+
+msgid "No voice mappings configured."
+msgstr "Nuk ka vendosje zëri të konfiguruara."
+
+msgid "Nodes"
+msgstr "Nyje"
+
+msgid "noise"
+msgstr "zhurmë"
+
+msgid "None"
+msgstr "Asnjë"
+
+msgid "Not detected"
+msgstr "Nuk u zbulua"
+
+msgid "Not found in the book text"
+msgstr "Nuk u gjet në tekstin e librit"
+
+msgid "Not generated"
+msgstr "Nuk u gjenerua"
+
+msgid "Not rendered yet"
+msgstr "Nuk u gjenerua ende"
+
+msgid "Not reviewed"
+msgstr "Nuk u rishikua"
+
+msgid "Not run during the last execution — likely because its inputs weren't ready or its stage's settings turned it off."
+msgstr "Nuk u ekzekutua gjatë ekzekutimit të fundit — me shumë gjasë sepse hyrjet e tij nuk ishin gati ose cilësimet e fazës e çaktivizuan."
+
+msgid "Not started yet"
+msgstr "Nuk ka filluar ende"
+
+msgid "Note"
+msgstr "Shënim"
+
+msgid "Nothing to show"
+msgstr "Nuk ka asgjë për të shfaqur"
+
+msgid "Number of pages of content to include per quiz question."
+msgstr "Numri i faqeve të përmbajtjes që do të përfshihen për çdo pyetje kuizi."
+
+msgid "Number of refinement iterations performed after the initial sectioning pass."
+msgstr "Numri i iteracioneve të rafinimit të kryera pas kalimit fillestar të seksionimit."
+
+msgid "O ciclo da água descreve o movimento contínuo da água."
+msgstr "O ciclo da água descreve o movimento contínuo da água."
+
+msgid "OAuth 2.0"
+msgstr "OAuth 2.0"
+
+msgid "OCR & cleanup"
+msgstr "OCR dhe pastrim"
+
+msgid "of"
+msgstr "nga"
+
+msgid "Off"
+msgstr "Joaktiv"
+
+msgid "On"
+msgstr "Aktiv"
+
+msgid "One Column"
+msgstr "Një kolonë"
+
+msgid "One column for every section. Clean and predictable."
+msgstr "Një kolonë për çdo seksion. E pastër dhe e parashikueshme."
+
+msgid "One tag per line or comma-separated. Leave as-is to keep the current package defaults."
+msgstr "Një etiketë për rresht ose të ndara me presje. Lërini siç janë për të mbajtur paracaktimet aktuale të paketës."
+
+msgid "Only images that appear in the storyboard (have captions) can be selected."
+msgstr "Mund të zgjidhen vetëm imazhet që shfaqen në storyboard (kanë tituj)."
+
+msgid "Only images that appear in the storyboard are listed. The selected images will be regenerated for each output language with their text translated."
+msgstr "Listohen vetëm imazhet që shfaqen në storyboard. Imazhet e zgjedhura do të rigjenerohen për çdo gjuhë dalje me tekstin e tyre të përkthyer."
+
+msgid "Only letters, numbers, dots, dashes, underscores. Must start with a letter or number."
+msgstr "Vetëm shkronja, numra, pika, viza, nënviza. Duhet të fillojë me një shkronjë ose numër."
+
+msgid "Only pages containing these section types are counted when grouping pages for quiz generation."
+msgstr "Numërohen vetëm faqet që përmbajnë këto lloje seksionesh kur grupohen faqet për gjenerimin e kuizit."
+
+msgid "Only PDF files are supported"
+msgstr "Mbështeten vetëm skedarë PDF"
+
+msgid "Only the most central vocabulary."
+msgstr "Vetëm fjalorin më qendror."
+
+msgid "Only ZIP files are supported"
+msgstr "Mbështeten vetëm skedarë ZIP"
+
+msgid "Opacity"
+msgstr "Transparenca"
+
+msgid "Open"
+msgstr "Hapni"
+
+msgid "Open a page in Preview to show its page-specific accessibility findings here."
+msgstr "Hapni një faqe në Pamjen Paraprake për të shfaqur këtu gjetjet e aksesueshmërisë specifike të faqes."
+
+msgid "Open a page in Preview to start recording reviewer validation findings."
+msgstr "Hapni një faqe në Pamjen Paraprake për të filluar regjistrimin e gjetjeve të vërtetimit të rishikuesit."
+
+msgid "Open a page to review"
+msgstr "Hapni një faqe për rishikim"
+
+msgid "Open a page to see page-level findings"
+msgstr "Hapni një faqe për të parë gjetjet në nivel faqeje"
+
+msgid "Open edit panel"
+msgstr "Hapni panelin e redaktimit"
+
+msgid "Open image preview"
+msgstr "Hapni pamjen paraprake të imazhit"
+
+msgid "Open in any EPUB 3 reader, e-reader, or accessibility tool."
+msgstr "Hapeni në çdo lexues EPUB 3, e-reader, ose mjet aksesueshmërie."
+
+msgid "Open page preview for {pageId}"
+msgstr "Hapni pamjen paraprake të faqes për {pageId}"
+
+msgid "Open Preview"
+msgstr "Hapni Pamjen Paraprake"
+
+msgid "Open source PDF in a new tab"
+msgstr "Hapni PDF-in burimor në një skedë të re"
+
+msgid "Open the Quizzes stage to edit this quiz"
+msgstr "Hapni fazën Kuizet për të redaktuar këtë kuiz"
+
+msgid "Open Validation"
+msgstr "Hapni Vërtetimin"
+
+msgid "OpenAI"
+msgstr "OpenAI"
+
+msgid "OpenAI API Key"
+msgstr "Çelësi API i OpenAI"
+
+msgid "OpenAI image-edit model used to regenerate each image with translated text."
+msgstr "Modeli image-edit i OpenAI i përdorur për të rigjeneruar çdo imazh me tekst të përkthyer."
+
+msgid "OpenAI key required"
+msgstr "Kërkohet çelësi i OpenAI"
+
+msgid "OpenAI Voice"
+msgstr "Zëri i OpenAI"
+
+msgid "Optional"
+msgstr "Opsionale"
+
+msgid "Optional Features"
+msgstr "Veçori opsionale"
+
+msgid "Optional instructions for the LLM..."
+msgstr "Udhëzime opsionale për LLM-in..."
+
+msgid "Optional notes about the review scope or assignments"
+msgstr "Shënime opsionale rreth fushës ose detyrave të rishikimit"
+
+msgid "Optional notes to steer how captions are generated. Use Auto-fill to start from the book's title, language, and summary."
+msgstr "Shënime opsionale për të udhëhequr mënyrën e gjenerimit të titujve. Përdorni Plotësim automatik për të filluar nga titulli, gjuha dhe përmbledhja e librit."
+
+msgid "Optional notes to steer how the glossary is generated. Use Auto-fill to start from the book's title, language, and summary."
+msgstr "Shënime opsionale për të udhëhequr mënyrën e gjenerimit të glosariumit. Përdorni Plotësim automatik për të filluar nga titulli, gjuha dhe përmbledhja e librit."
+
+msgid "Optional page-level summary or handoff note"
+msgstr "Përmbledhje opsionale në nivel faqeje ose shënim kalimi"
+
+msgid "Optional suggestion for fixing or improving this item"
+msgstr "Sugjerim opsional për rregullimin ose përmirësimin e këtij elementi"
+
+msgid "Optional. Add notes about tone, focus, or vocabulary. Use Auto-fill to start from the book's title, language, and summary."
+msgstr "Opsionale. Shtoni shënime rreth tonit, fokusit ose fjalorit. Përdorni Plotësim automatik për të filluar nga titulli, gjuha dhe përmbledhja e librit."
+
+msgid "Optional. Tell the model what kinds of terms to focus on or avoid (e.g. \"skip proper nouns\", \"include scientific names\")."
+msgstr "Opsionale. Tregojini modelit cilat lloje termash të fokusohet ose të shmangë (p.sh. \"anashkalo emrat e përveçëm\", \"përfshij emrat shkencorë\")."
+
+msgid "Optional. Terms added here are pinned to the glossary so they always appear, even after re-running AI generation."
+msgstr "Opsionale. Termat e shtuar këtu janë të ngjitur në glosarium, kështu që gjithmonë shfaqen, edhe pas rigjenerimit me AI."
+
+msgid "Optionally translate burned-in text inside images (signs, labels, callouts). Select the images to localize — leaving the list empty keeps images in the source language."
+msgstr "Opsionalisht, përktheni tekstin e integruar brenda imazheve (shenja, etiketa, thirrje). Zgjidhni imazhet për lokalizim — lënia e listës bosh i mban imazhet në gjuhën burimore."
+
+msgid "options are deterministic;"
+msgstr "opsionet janë deterministe;"
+
+msgid "options generate a fresh layout per page."
+msgstr "opsionet gjenerojnë një paraqitje të re për çdo faqe."
+
+msgid "Or"
+msgstr "Ose"
+
+msgid "Original"
+msgstr "Origjinal"
+
+msgid "Original language"
+msgstr "Gjuha origjinale"
+
+msgid "Original PDF"
+msgstr "PDF origjinal"
+
+#. placeholder {0}: i18n._(selectedBook.title)
+msgid "Original PDF - {0}"
+msgstr "PDF origjinal - {0}"
+
+msgid "osmosis"
+msgstr "osmozë"
+
+msgid "Other"
+msgstr "Tjetër"
+
+msgid "Other images"
+msgstr "Imazhe të tjera"
+
+msgid "Other options"
+msgstr "Opsione të tjera"
+
+msgid "Out of date"
+msgstr "I vjetëruar"
+
+msgid "Output languages"
+msgstr "Gjuhët e daljes"
+
+msgid "Output Languages"
+msgstr "Gjuhët e daljes"
+
+msgid "Output Tokens"
+msgstr "Tokena dalje"
+
+msgid "Overall page note"
+msgstr "Shënim i përgjithshëm i faqes"
+
+msgid "Overview"
+msgstr "Përmbledhje"
+
+msgid "p. 1"
+msgstr "f. 1"
+
+msgid "p. 12"
+msgstr "f. 12"
+
+msgid "p. 14"
+msgstr "f. 14"
+
+msgid "p. 15"
+msgstr "f. 15"
+
+msgid "p. 21"
+msgstr "f. 21"
+
+msgid "p. 28"
+msgstr "f. 28"
+
+msgid "p. 3"
+msgstr "f. 3"
+
+msgid "p. 41"
+msgstr "f. 41"
+
+msgid "p. 7"
+msgstr "f. 7"
+
+#. placeholder {0}: String(current.pageNumber)
+msgid "p{0}"
+msgstr "f{0}"
+
+msgid "Package and preview the final ADT web application."
+msgstr "Paketoni dhe shikoni paraprakisht aplikacionin web përfundimtar ADT."
+
+msgid "Package preview to generate results"
+msgstr "Pamje paraprake e paketës për gjenerimin e rezultateve"
+
+msgid "Package the book for distribution. Pick a format, choose what content goes in, and we'll bundle everything into a downloadable archive."
+msgstr "Paketoni librin për shpërndarje. Zgjidhni një format, vendosni çfarë përmbajtje do të përfshihet dhe ne do të grumbullojmë gjithçka në një arkiv të shkarkueshëm."
+
+msgid "Package the finished book with every accessibility feature baked in — ready for a kid to open, listen, and read along."
+msgstr "Paketoni librin e përfunduar me të gjitha veçoritë e aksesueshmërisë të integruara — gati për t'u hapur, dëgjuar dhe lexuar nga një fëmijë."
+
+msgid "Packaging"
+msgstr "Paketimi"
+
+msgid "Packaging failed"
+msgstr "Paketimi dështoi"
+
+msgid "Packaging preview..."
+msgstr "Pamje paraprake e paketimit..."
+
+msgid "Packaging validation results..."
+msgstr "Rezultatet e vërtetimit të paketimit..."
+
+msgid "Padding"
+msgstr "Mbushje"
+
+msgid "page"
+msgstr "faqe"
+
+msgid "Page"
+msgstr "Faqe"
+
+#. placeholder {0}: String(activePage.pageNumber)
+#. placeholder {0}: String(group.pageNumber)
+#. placeholder {0}: String(item.pageNumber)
+msgid "Page {0}"
+msgstr "Faqja {0}"
+
+#. placeholder {0}: page.pageNumber
+#. placeholder {1}: i + 1
+msgid "Page {0} — Section {1}"
+msgstr "Faqja {0} — Seksioni {1}"
+
+#. placeholder {0}: String(pageNumber)
+msgid "Page {0} captions"
+msgstr "Titujt e faqes {0}"
+
+#. placeholder {0}: current.pageNumber
+#. placeholder {1}: renderedPages.length
+msgid "Page {0} of {1}"
+msgstr "Faqja {0} nga {1}"
+
+msgid "Page {n}"
+msgstr "Faqja {n}"
+
+msgid "Page {pageId}"
+msgstr "Faqja {pageId}"
+
+msgid "page {shownStr}"
+msgstr "faqja {shownStr}"
+
+msgid "Page coverage"
+msgstr "Mbulimi i faqeve"
+
+msgid "Page Grouping"
+msgstr "Grupimi i faqeve"
+
+msgid "Page Grouping Mode"
+msgstr "Mënyra e grupimit të faqeve"
+
+msgid "Page image"
+msgstr "Imazhi i faqes"
+
+msgid "Page image as background with positioned text overlay. Preserves the original page composition; ideal for illustrated storybooks."
+msgstr "Imazhi i faqes si sfond me tekst të pozicionuar sipër. Ruan kompozimin origjinal të faqes; ideal për libra me ilustrime."
+
+msgid "Page Mode"
+msgstr "Modaliteti i Faqes"
+
+msgid "Page preview"
+msgstr "Pamja paraprake e faqes"
+
+msgid "Page Range"
+msgstr "Gama e Faqeve"
+
+msgid "Page range help"
+msgstr "Ndihmë për gamën e faqeve"
+
+msgid "Page Sectioning"
+msgstr "Ndarja e Faqeve në Seksione"
+
+msgid "Page Sectioning Prompt"
+msgstr "Prompt i Ndarjes së Faqeve"
+
+msgid "Page Sectioning Refinement Prompt"
+msgstr "Prompt i Rafinimit të Ndarjes së Faqeve"
+
+msgid "pages"
+msgstr "faqe"
+
+msgid "Pages"
+msgstr "Faqet"
+
+#. placeholder {0}: activeSession.session.start_page ?? "?"
+#. placeholder {1}: activeSession.session.end_page ?? "?"
+msgid "Pages {0}–{1}"
+msgstr "Faqet {0}–{1}"
+
+msgid "pages {shownStr}"
+msgstr "faqet {shownStr}"
+
+msgid "pages per quiz"
+msgstr "faqe për kuiz"
+
+msgid "Pages per Quiz"
+msgstr "Faqe për Kuiz"
+
+msgid "Pages reviewed"
+msgstr "Faqe të rishikuara"
+
+msgid "Paper Collage"
+msgstr "Kolazh Letre"
+
+msgid "paragraph"
+msgstr "paragraf"
+
+msgid "Paragraph"
+msgstr "Paragraf"
+
+msgid "Parsing pages"
+msgstr "Analizimi i faqeve"
+
+msgid "Parsing pages into text, figures, and layout boxes — cached by content hash."
+msgstr "Analizimi i faqeve në tekst, figura dhe kuti paraqitjeje — memorizuar sipas hash-it të përmbajtjes."
+
+msgid "Parts"
+msgstr "Pjesë"
+
+msgid "Pass"
+msgstr "Kalon"
+
+msgid "Passed"
+msgstr "Kaloi"
+
+msgid "Patterns in the noise"
+msgstr "Modele në zhurmë"
+
+msgid "Pause"
+msgstr "Pauzë"
+
+msgid "Payload"
+msgstr "Ngarkesa"
+
+msgid "PDF"
+msgstr "PDF"
+
+msgid "PDF accepted"
+msgstr "PDF pranuar"
+
+msgid "PDF Extraction"
+msgstr "Nxjerrja e PDF"
+
+msgid "PDF File"
+msgstr "Skedar PDF"
+
+msgid "PDF info"
+msgstr "Informacioni PDF"
+
+msgid "PDF page {pageLabel} preview"
+msgstr "Pamja paraprake e faqes PDF {pageLabel}"
+
+msgid "Pencil Sketch"
+msgstr "Skicë me Laps"
+
+msgid "Pending..."
+msgstr "Në pritje..."
+
+msgid "Per Page"
+msgstr "Për Faqe"
+
+msgid "Per-Sentence"
+msgstr "Për-Fjali"
+
+msgid "Per-Step Breakdown"
+msgstr "Ndarja Hap-pas-Hapi"
+
+msgid "Per-Word"
+msgstr "Për-Fjalë"
+
+msgid "Perfect for children's books, pairing large images with minimal text."
+msgstr "E përsosur për librat e fëmijëve, duke çiftëzuar imazhe të mëdha me tekst minimal."
+
+msgid "Phase {phaseNumber}"
+msgstr "Faza {phaseNumber}"
+
+msgid "Photograph"
+msgstr "Fotografi"
+
+msgid "photosynthesis"
+msgstr "fotosinteza"
+
+msgid "Photosynthesis"
+msgstr "Fotosinteza"
+
+msgid "photosynthetic, photosynthesizing"
+msgstr "fotosintetik, duke kryer fotosintezo"
+
+msgid "Pick a preset"
+msgstr "Zgjidhni një konfigurim paraprak"
+
+msgid "Pick from book"
+msgstr "Zgjidhni nga libri"
+
+msgid "Pick from Book"
+msgstr "Zgjidhni nga Libri"
+
+msgid "Pick one layout approach."
+msgstr "Zgjidhni një qasje paraqitjeje."
+
+msgid "Pick the languages you want to translate to. The book's original language stays as-is."
+msgstr "Zgjidhni gjuhët në të cilat dëshironi të përktheni. Gjuha origjinale e librit mbetet ashtu siç është."
+
+msgid "Pick which voice each language uses for narration, including regional accents."
+msgstr "Zgjidhni cilën zë përdor secila gjuhë për tregimin, duke përfshirë thekset rajonale."
+
+msgid "Picture books and early readers"
+msgstr "Libra me ilustrime dhe lexues fillestarë"
+
+msgid "Pipeline · extract"
+msgstr "Pipeline · nxjerrje"
+
+msgid "Pipeline · storyboard"
+msgstr "Pipeline · storyboard"
+
+msgid "Pipeline features"
+msgstr "Veçoritë e Pipeline"
+
+msgid "Pipeline Stages"
+msgstr "Fazat e Pipeline"
+
+msgid "Pixel Art"
+msgstr "Pixel Art"
+
+msgid "Plants create sugar via <0>photosynthesis</0>, divide by <1>mitosis</1>, and absorb water by <2>osmosis</2>."
+msgstr "Bimët krijojnë sheqer nëpërmjet <0>fotosintezës</0>, ndahen me <1>mitozë</1>, dhe thithin ujë me <2>osmozë</2>."
+
+msgid "Play"
+msgstr "Luaj"
+
+msgid "Play video"
+msgstr "Luaj videon"
+
+msgid "Polishing paragraphs to perfection..."
+msgstr "Polisim paragrafet deri në përsosmëri..."
+
+msgid "Portuguese (BR)"
+msgstr "Portugalisht (BR)"
+
+msgid "Position"
+msgstr "Pozicioni"
+
+#. placeholder {0}: Math.round(bounds.x)
+#. placeholder {1}: Math.round(bounds.y)
+#. placeholder {2}: Math.round(bounds.width)
+#. placeholder {3}: Math.round(bounds.height)
+msgid "Position {0}, {1} → {2}×{3} pt"
+msgstr "Pozicioni {0}, {1} → {2}×{3} pt"
+
+msgid "Práticas de Alfabetização e de Matemática"
+msgstr "Práticas de Alfabetização e de Matemática"
+
+msgid "Pre-defined Terms"
+msgstr "Terma të Parapërcaktuar"
+
+msgid "Precipitation"
+msgstr "Reshje"
+
+msgid "Prefer terms central to the book's subject matter. Skip generic vocabulary and proper nouns that don't carry meaning beyond the page."
+msgstr "Preferoni terma qendrore për lëndën e librit. Anashkaloni fjalor gjeneral dhe emra të përveçëm që nuk bartin kuptim përtej faqes."
+
+msgid "Preserves the source PDF's exact page layout"
+msgstr "Ruan paraqitjen e saktë të faqes nga PDF-ja burimore"
+
+msgid "Preserves the source PDF's exact page layout — images and positioned text rendered in place."
+msgstr "Ruan paraqitjen e saktë të faqes nga PDF-ja burimore — imazhet dhe teksti i vendosur renderuhen në vend."
+
+msgid "Preset"
+msgstr "Konfigurim paraprak"
+
+msgid "Presets add recommendations and specific settings for your use case. You still choose each option step by step, and you can go back to select a different preset at any time."
+msgstr "Konfigurimet paraprake shtojnë rekomandime dhe cilësime specifike për rastin tuaj të përdorimit. Ju ende zgjidhni çdo opsion hap pas hapi dhe mund të ktheheni për të zgjedhur një konfigurim tjetër në çdo kohë."
+
+msgid "Prev"
+msgstr "Para"
+
+msgid "Preview"
+msgstr "Pamje paraprake"
+
+msgid "Preview linked page"
+msgstr "Shiko faqen e lidhur"
+
+msgid "Preview of the HTML/CSS patterns used for LLM-generated pages."
+msgstr "Pamje paraprake e modeleve HTML/CSS të përdorura për faqet e gjeneruara nga LLM."
+
+msgid "Preview: per-sentence"
+msgstr "Pamje paraprake: për-fjali"
+
+msgid "Preview: Per-Sentence"
+msgstr "Pamje paraprake: Për-Fjali"
+
+msgid "Preview: Per-Word"
+msgstr "Pamje paraprake: Për-Fjalë"
+
+msgid "Preview: word-by-word"
+msgstr "Pamje paraprake: fjalë-pas-fjale"
+
+msgid "Previous image"
+msgstr "Imazhi i mëparshëm"
+
+msgid "Previous page"
+msgstr "Faqja e mëparshme"
+
+msgid "Previous slide"
+msgstr "Sllajdi i mëparshëm"
+
+msgid "Processing metadata…"
+msgstr "Po përpunohen metadatat…"
+
+msgid "Progress"
+msgstr "Progresi"
+
+msgid "Project Archive"
+msgstr "Arkiva e Projektit"
+
+msgid "Project Name"
+msgstr "Emri i Projektit"
+
+msgid "Prompt"
+msgstr "Prompt"
+
+msgid "Prompt template"
+msgstr "Shabllon prompt"
+
+msgid "Prompt template not found."
+msgstr "Shablloni i prompt-it nuk u gjet."
+
+msgid "Provider"
+msgstr "Ofruesi"
+
+msgid "Provides consistent HTML/CSS patterns for LLM-generated pages."
+msgstr "Siguron modele të qëndrueshme HTML/CSS për faqet e gjeneruara nga LLM."
+
+msgid "Prune"
+msgstr "Shkurto"
+
+msgid "Prune element"
+msgstr "Shkurto elementin"
+
+msgid "Prune image"
+msgstr "Shkurto imazhin"
+
+msgid "Prune section from flow"
+msgstr "Shkurto seksionin nga rrjedha"
+
+msgid "Prune this term — it will be hidden from output and excluded from future regenerations."
+msgstr "Shkurtoni këtë term — do të fshihet nga dalja dhe do të përjashtohet nga rigjenerimet e ardhshme."
+
+msgid "pruned"
+msgstr "shkurtuar"
+
+msgid "Pruned"
+msgstr "Shkurtuar"
+
+msgid "Pruned Images"
+msgstr "Imazhe të Shkurtuara"
+
+msgid "Pruned: {reason}"
+msgstr "Shkurtuar: {reason}"
+
+msgid "PT"
+msgstr "PT"
+
+msgid "published in"
+msgstr "botuar në"
+
+msgid "Publisher"
+msgstr "Botuesi"
+
+msgid "Pull structured content from the source PDF. Extraction identifies headings, paragraphs, lists, and images so downstream stages work with clean, typed content instead of raw PDF."
+msgstr "Nxirrni përmbajtje të strukturuar nga PDF-ja burimore. Nxjerrja identifikon titujt, paragrafet, listat dhe imazhet, kështu që fazat pasuese punojnë me përmbajtje të pastër dhe të tipizuar në vend të PDF-së bruto."
+
+msgid "Pulls the book's metadata — title, author, language — from the PDF."
+msgstr "Nxjerr metadatat e librit — titullin, autorin, gjuhën — nga PDF-ja."
+
+msgid "px"
+msgstr "px"
+
+msgid "Query param"
+msgstr "Parametri i pyetjes"
+
+msgid "question"
+msgstr "pyetje"
+
+msgid "Queued"
+msgstr "Në radhë"
+
+msgid "quiz"
+msgstr "kuiz"
+
+msgid "Quiz"
+msgstr "Kuiz"
+
+#. placeholder {0}: String(activeQuiz.index + 1)
+#. placeholder {0}: String(item.index + 1)
+msgid "Quiz {0}"
+msgstr "Kuiz {0}"
+
+#. placeholder {0}: page.pageNumber
+msgid "Quiz after page {0}"
+msgstr "Kuiz pas faqes {0}"
+
+msgid "Quiz frequency"
+msgstr "Frekuenca e kuizit"
+
+msgid "Quiz Generation"
+msgstr "Gjenerimi i Kuizit"
+
+msgid "Quiz Generation Prompt"
+msgstr "Prompt i Gjenerimit të Kuizit"
+
+msgid "Quiz not found. It may have been removed since you opened the storyboard."
+msgstr "Kuizi nuk u gjet. Mund të jetë hequr që kur hapët storyboard-in."
+
+msgid "Quiz preview"
+msgstr "Pamje paraprake e kuizit"
+
+msgid "Quiz Preview"
+msgstr "Pamje Paraprake e Kuizit"
+
+msgid "Quiz Prompt"
+msgstr "Prompt i Kuizit"
+
+msgid "Quiz Section Types"
+msgstr "Llojet e Seksioneve të Kuizit"
+
+msgid "quizzes"
+msgstr "kuize"
+
+msgid "Quizzes"
+msgstr "Kuizet"
+
+msgid "Quizzes are generating. Wait for the run to finish before adding a quiz."
+msgstr "Kuizet po gjenerohen. Prisni të përfundojë ekzekutimi para se të shtoni një kuiz."
+
+msgid "Quizzes are linked to other pages in this book"
+msgstr "Kuizet janë të lidhura me faqe të tjera në këtë libër"
+
+msgid "Quizzes are written from the content that Storyboard places into pages. Finish Storyboard before running this stage."
+msgstr "Kuizet shkruhen nga përmbajtja që Storyboard vendos në faqe. Përfundoni Storyboard-in para se të ekzekutoni këtë fazë."
+
+msgid "Quizzes were generated by AI from your book's pages. Click any question, option, or explanation to edit it, and delete any quiz you don't need. Click a source page to zoom. Changes are saved as a new version, so you can always roll back."
+msgstr "Kuizet u gjeneruan nga AI nga faqet e librit tuaj. Klikoni çdo pyetje, opsion ose shpjegim për ta redaktuar, dhe fshini çdo kuiz që nuk ju nevojitet. Klikoni një faqe burimore për ta zmadhuar. Ndryshimet ruhen si version i ri, kështu që gjithmonë mund të ktheheni."
+
+msgid "Quote"
+msgstr "Citat"
+
+msgid "Radius"
+msgstr "Rrezja"
+
+msgid "Re-enable type"
+msgstr "Ri-aktivizo tipin"
+
+msgid "Re-package ADT"
+msgstr "Ri-paketo ADT"
+
+msgid "Re-render"
+msgstr "Ri-renderizo"
+
+msgid "Re-render (your edits will be preserved)"
+msgstr "Ri-renderizo (redaktimet tuaja do të ruhen)"
+
+msgid "Re-render failed"
+msgstr "Ri-renderizimi dështoi"
+
+msgid "Re-render section"
+msgstr "Ri-renderizo seksionin"
+
+msgid "Re-render this section"
+msgstr "Ri-renderizo këtë seksion"
+
+msgid "Re-rendering..."
+msgstr "Po ri-renderizohet..."
+
+msgid "Re-run"
+msgstr "Ri-ekzekuto"
+
+msgid "Re-run {stageLabel}"
+msgstr "Ri-ekzekuto {stageLabel}"
+
+msgid "Re-run {stageLabel}?"
+msgstr "Ri-ekzekuto {stageLabel}?"
+
+msgid "Re-run speech"
+msgstr "Ri-ekzekuto fjalimin"
+
+msgid "Re-run translation"
+msgstr "Ri-ekzekuto përkthimin"
+
+msgid "Re-running clears later stages"
+msgstr "Ri-ekzekutimi fshin fazat e mëvonshme"
+
+msgid "Read the prompt aloud"
+msgstr "Lexo kërkesën me zë"
+
+msgid "Reader Highlighting"
+msgstr "Theksimi i Lexuesit"
+
+msgid "Reader View"
+msgstr "Pamja e Lexuesit"
+
+msgid "Reader will play the video matched to each section."
+msgstr "Lexuesi do të luajë videon që korrespondon me çdo seksion."
+
+msgid "Reader-controlled"
+msgstr "E kontrolluar nga lexuesi"
+
+msgid "Readers see"
+msgstr "Lexuesit shohin"
+
+msgid "Readers switch between the original and simplified text with the Easy Read toggle."
+msgstr "Lexuesit kalojnë midis tekstit origjinal dhe të thjeshtëzuar me butonin Easy Read."
+
+msgid "Reading archive..."
+msgstr "Duke lexuar arkivin..."
+
+msgid "Reading PDF..."
+msgstr "Duke lexuar PDF-in..."
+
+msgid "Readium Web"
+msgstr "Readium Web"
+
+msgid "Readium Web Publication"
+msgstr "Publikim Readium Web"
+
+msgid "Readium Web Publication format for standards-based digital distribution platforms."
+msgstr "Formati Readium Web Publication për platformat e shpërndarjes dixhitale të bazuara në standarde."
+
+msgid "Readium-compatible digital book"
+msgstr "Libër dixhital i pajtueshëm me Readium"
+
+msgid "Reads in"
+msgstr "Lexohet në"
+
+msgid "Real books processed with this preset — before and after."
+msgstr "Libra të vërtetë të procesuar me këtë paracaktim — para dhe pas."
+
+msgid "Realistic / Photo"
+msgstr "Realist / Foto"
+
+msgid "Rearranging atoms of HTML..."
+msgstr "Duke riorganizuar atomet e HTML-it..."
+
+msgid "Recommended"
+msgstr "I rekomanduar"
+
+msgid "Recommended for"
+msgstr "I rekomanduar për"
+
+#. placeholder {0}: i18n._(presetLabel)
+msgid "Recommended for {0}"
+msgstr "I rekomanduar për {0}"
+
+msgid "Record reviewer findings for the current page and save them to the active validation session."
+msgstr "Regjistroni gjetjet e rishikuesit për faqen aktuale dhe ruajini në sesionin aktiv të validimit."
+
+msgid "Recrop from page"
+msgstr "Rirritjo nga faqja"
+
+msgid "Recrop from Page"
+msgstr "Rirritjo nga Faqja"
+
+msgid "Reference"
+msgstr "Referencë"
+
+msgid "Refinement Prompt"
+msgstr "Kërkesa e Rafinimit"
+
+msgid "Refresh validation"
+msgstr "Rifresko validimin"
+
+msgid "Refreshing results for this packaged preview."
+msgstr "Duke rifreskuar rezultatet për këtë pamje paraprake të paketuar."
+
+msgid "Regenerate"
+msgstr "Rigenero"
+
+msgid "Regenerate definition, variations, and emoji"
+msgstr "Rigenero përkufizimin, variacionet dhe emoji"
+
+msgid "Regenerate Easy Read"
+msgstr "Rigenero Easy Read"
+
+msgid "Regenerate selected images for each output language so that any text burned into them is shown in the target language."
+msgstr "Rigenero imazhet e zgjedhura për çdo gjuhë dalëse, në mënyrë që çdo tekst i djegur mbi to të shfaqet në gjuhën e synuar."
+
+msgid "Region"
+msgstr "Rajon"
+
+msgid "Reject renderings that diverge stylistically from the original. More rejections and rerenders, closer match to the source."
+msgstr "Refuzo renderime që devijojnë stilistikisht nga origjinali. Sa më shumë refuzime dhe rirendime, aq më afër origjinalit."
+
+msgid "Relaxed"
+msgstr "I relaksuar"
+
+msgid "Release to upload"
+msgstr "Lëshoni për të ngarkuar"
+
+msgid "Reload app"
+msgstr "Rinis aplikacionin"
+
+msgid "Remove"
+msgstr "Hiq"
+
+#. placeholder {0}: displayLang(code)
+#. placeholder {0}: term.word
+msgid "Remove {0}"
+msgstr "Hiq {0}"
+
+msgid "Remove all"
+msgstr "Hiq të gjitha"
+
+msgid "Remove all sign-language videos?"
+msgstr "Hiqni të gjitha videot e gjuhës së shenjave?"
+
+msgid "Remove checklist item"
+msgstr "Hiq artikullin e listës kontrolluese"
+
+msgid "Remove entry"
+msgstr "Hiq hyrjen"
+
+msgid "Remove file"
+msgstr "Hiq skedarin"
+
+msgid "Remove from group"
+msgstr "Hiq nga grupi"
+
+msgid "Remove manual glossary term"
+msgstr "Hiq termin manual të glosariumit"
+
+#. placeholder {0}: page.pageNumber
+msgid "Remove page {0} from the quiz"
+msgstr "Hiq faqen {0} nga kuizi"
+
+msgid "Remove PDF"
+msgstr "Hiq PDF-in"
+
+msgid "Remove section"
+msgstr "Hiq seksionin"
+
+msgid "Remove term"
+msgstr "Hiq termin"
+
+msgid "Remove this block"
+msgstr "Hiq këtë bllok"
+
+msgid "Remove type"
+msgstr "Hiq tipin"
+
+msgid "removed"
+msgstr "hequr"
+
+msgid "Render each typed section into an interactive HTML page. Pick a layout strategy that matches the book and let storyboard handle the rest."
+msgstr "Renderoni çdo seksion të shtypur në një faqe HTML interaktive. Zgjidhni një strategji paraqitjeje që përshtatet me librin dhe lini storyboard-in të kujdeset për pjesën tjetër."
+
+msgid "Render Reasoning"
+msgstr "Arsyetimi i Renderimit"
+
+msgid "Render Strategy"
+msgstr "Strategjia e Renderimit"
+
+msgid "Rendering Prompt"
+msgstr "Kërkesa e Renderimit"
+
+msgid "Rendering this section..."
+msgstr "Duke renderuar këtë seksion..."
+
+msgid "Renders activities from a fixed template for consistent styling."
+msgstr "Renderimi i aktiviteteve nga një shabllon i fiksuar për stil të qëndrueshëm."
+
+msgid "Renders each page into the storyboard layout used by the web reader."
+msgstr "Renderimi i çdo faqeje në paraqitjen e storyboard-it të përdorur nga lexuesi web."
+
+msgid "Replace"
+msgstr "Zëvendëso"
+
+msgid "Replace from book"
+msgstr "Zëvendëso nga libri"
+
+msgid "Replace from Book"
+msgstr "Zëvendëso nga Libri"
+
+msgid "Replace PDF"
+msgstr "Zëvendëso PDF-in"
+
+msgid "Replace quiz"
+msgstr "Zëvendëso kuizin"
+
+msgid "Replace quizzes"
+msgstr "Zëvendëso kuizet"
+
+msgid "Replace this audio file"
+msgstr "Zëvendëso këtë skedar audio"
+
+msgid "Require comment on failure"
+msgstr "Kërko koment në rast dështimi"
+
+msgid "Require suggested modification"
+msgstr "Kërko modifikim të sugjeruar"
+
+msgid "Required"
+msgstr "E detyrueshme"
+
+msgid "Required Fields"
+msgstr "Fushat e Detyrueshme"
+
+msgid "Reset to defaults"
+msgstr "Rivendos në paracaktimet"
+
+msgid "Reset to inherited"
+msgstr "Rivendos në të trashëguarën"
+
+msgid "Reset to inherited defaults"
+msgstr "Rivendos në paracaktimet e trashëguara"
+
+msgid "Reset zoom"
+msgstr "Rivendos zmadhimin"
+
+msgid "Resolving source language..."
+msgstr "Duke zgjidhur gjuhën burimore..."
+
+msgid "Restart and install"
+msgstr "Rinis dhe instalo"
+
+msgid "Restore"
+msgstr "Rikthe"
+
+msgid "Restore element"
+msgstr "Rikthe elementin"
+
+msgid "Restore section to flow"
+msgstr "Rikthe seksionin në rrjedhë"
+
+msgid "Restore this term — it will be eligible again on the next regeneration."
+msgstr "Riktheje këtë term — do të jetë i pranueshëm përsëri në rigjenerimin tjetër."
+
+msgid "restored"
+msgstr "rikthyer"
+
+msgid "Resume target"
+msgstr "Rimerr synimin"
+
+#. placeholder {0}: resumeTarget.pageNumber ?? resumeTarget.pageId
+msgid "Resume target: page {0}"
+msgstr "Rimerr synimin: faqja {0}"
+
+msgid "Retries"
+msgstr "Riprovime"
+
+msgid "Retry"
+msgstr "Riprovo"
+
+msgid "Retry Export"
+msgstr "Riprovo Eksportimin"
+
+msgid "Review and refine each simplified block side-by-side with the original before packaging."
+msgstr "Rishikoni dhe rafinoni çdo bllok të thjeshtëzuar krahas origjinalit përpara paketimit."
+
+msgid "Review areas with the most items marked as needing changes in this session."
+msgstr "Rishikoni zonat me numrin më të madh të artikujve të shënuar si duke nevojitë ndryshime në këtë sesion."
+
+msgid "Review one session at a time to inspect page coverage and flagged findings."
+msgstr "Rishikoni një sesion në të njëjtën kohë për të inspektuar mbulimin e faqeve dhe gjetjet e shënuara."
+
+msgid "Review progress"
+msgstr "Progresi i rishikimit"
+
+msgid "Review pruned sections"
+msgstr "Rishiko seksionet e hequra"
+
+msgid "Review the project details below and confirm the import."
+msgstr "Rishikoni detajet e projektit më poshtë dhe konfirmoni importimin."
+
+msgid "Review the source PDF details below and continue to configure how your book will be converted into an Accessible Digital Textbook."
+msgstr "Rishikoni detajet e PDF-it burimor më poshtë dhe vazhdoni të konfiguroni se si libri juaj do të konvertohet në një Tekst Dixhital të Aksesueshëm."
+
+msgid "Reviewer checklist"
+msgstr "Lista kontrolluese e rishikuesit"
+
+msgid "Reviewer Checklist"
+msgstr "Lista Kontrolluese e Rishikuesit"
+
+msgid "Reviewer checklist reviews are currently disabled."
+msgstr "Rishikimet e listës kontrolluese të rishikuesit janë aktualisht të çaktivizuara."
+
+msgid "Reviewer checklist settings saved."
+msgstr "Cilësimet e listës kontrolluese të rishikuesit u ruajtën."
+
+msgid "Reviewer guidance"
+msgstr "Udhëzimi i rishikuesit"
+
+msgid "Reviewer name"
+msgstr "Emri i rishikuesit"
+
+msgid "Reviewer name is required."
+msgstr "Emri i rishikuesit është i detyrueshëm."
+
+msgid "Reviewer Validation"
+msgstr "Validimi i Rishikuesit"
+
+msgid "Reviewer validation checklist"
+msgstr "Lista kontrolluese e validimit të rishikuesit"
+
+msgid "Reviewer validation summary"
+msgstr "Përmbledhja e validimit të rishikuesit"
+
+msgid "Rewriting the story of this section..."
+msgstr "Duke rishkruar historinë e këtij seksioni..."
+
+msgid "Rising ocean temperatures cause coral bleaching - when stressed corals expel the colorful algae living inside them and turn white. Without these algae, corals slowly starve. Protecting reefs means reducing pollution, overfishing, and greenhouse gas emissions."
+msgstr "Rritja e temperaturave të oqeanit shkakton zbardhjen e koraleve - kur koralett e stresuar nxjerrin algat me ngjyra që jetojnë brenda tyre dhe bëhen të bardha. Pa këto alga, koralett ngadalë vdesin nga uria. Mbrojtja e rifeve nënkupton reduktimin e ndotjes, mbipeshkimit dhe emetimeve të gazeve serrë."
+
+msgid "Role"
+msgstr "Rol"
+
+msgid "Row"
+msgstr "Rresht"
+
+msgid "Row reverse"
+msgstr "Rresht i anasjelltë"
+
+#. placeholder {0}: getStageLabelI18n("storyboard")
+msgid "Run {0} first"
+msgstr "Ekzekuto {0} së pari"
+
+msgid "Run {stageLabel}"
+msgstr "Ekzekuto {stageLabel}"
+
+msgid "Run {upstreamLabel} first"
+msgstr "Ekzekuto {upstreamLabel} së pari"
+
+msgid "Run Captions"
+msgstr "Ekzekuto Titujt"
+
+msgid "Run Easy Read"
+msgstr "Ekzekuto Easy Read"
+
+msgid "Run Extract"
+msgstr "Ekzekuto Ekstraktimin"
+
+msgid "Run Glossary"
+msgstr "Ekzekuto Glosariumin"
+
+msgid "Run Image Captions first — only captioned images appear in this list."
+msgstr "Ekzekuto Titujt e Imazheve së pari — vetëm imazhet me tituj shfaqen në këtë listë."
+
+msgid "Run Language first — speech narrates the translated text."
+msgstr "Ekzekuto Gjuhën së pari — të folurit narraton tekstin e përkthyer."
+
+msgid "Run Quizzes"
+msgstr "Ekzekuto Kuizet"
+
+msgid "Run Sectioning"
+msgstr "Ekzekuto Seksionimin"
+
+msgid "Run Speech"
+msgstr "Ekzekuto të Folurit"
+
+msgid "Run Storyboard"
+msgstr "Ekzekuto Storyboard-in"
+
+msgid "Run Storyboard first — captions describe the images placed by Storyboard."
+msgstr "Ekzekuto Storyboard-in së pari — titujt përshkruajnë imazhet e vendosura nga Storyboard."
+
+msgid "Run Storyboard first — Easy Read simplifies the text it places on each page."
+msgstr "Ekzekuto Storyboard-in së pari — Easy Read thjeshtëzon tekstin që vendos në çdo faqe."
+
+msgid "Run Storyboard first — quizzes are written from the content placed into pages by Storyboard."
+msgstr "Ekzekuto Storyboard-in së pari — kuizet shkruhen nga përmbajtja e vendosur në faqe nga Storyboard."
+
+msgid "Run Storyboard first — the glossary is built from the typed sections placed by Storyboard."
+msgstr "Ekzekuto Storyboard-in së pari — glosariumi ndërtohet nga seksionet e shtypura të vendosura nga Storyboard."
+
+msgid "Run Storyboard first — the table of contents lists the typed sections it produces."
+msgstr "Ekzekuto Storyboard-in së pari — tabela e përmbajtjes liston seksionet e shtypura që prodhon."
+
+msgid "Run Storyboard first — translation needs the typed sections placed by Storyboard."
+msgstr "Ekzekuto Storyboard-in së pari — përkthimi ka nevojë për seksionet e shtypura të vendosura nga Storyboard."
+
+msgid "Run Storyboard to generate sections you can match sign-language videos to."
+msgstr "Ekzekuto Storyboard-in për të gjeneruar seksione me të cilat mund të lidhni video të gjuhës së shenjave."
+
+msgid "Run the pipeline"
+msgstr "Ekzekuto pipeline-in"
+
+msgid "Run the pipeline to extract content"
+msgstr "Ekzekuto pipeline-in për të ekstraktuar përmbajtjen"
+
+msgid "Run TOC"
+msgstr "Ekzekuto TOC-in"
+
+msgid "Run Translation"
+msgstr "Ekzekuto Përkthimin"
+
+msgid "Run whole-book validation checks and configure accessibility assessment settings."
+msgstr "Ekzekutoni kontrollet e validimit të librit të plotë dhe konfiguroni cilësimet e vlerësimit të aksesueshmërisë."
+
+msgid "Run-only tags"
+msgstr "Etiketa vetëm-ekzekutimi"
+
+msgid "Running"
+msgstr "Duke ekzekutuar"
+
+msgid "RUNNING"
+msgstr "NË EKZEKUTIM"
+
+msgid "Running Sectioning will run Extract first, then section the extracted pages."
+msgstr "Ekzekutimi i Seksionimit do të ekzekutojë Ekstraktimin së pari, pastaj do të seksionojë faqet e ekstraktuara."
+
+msgid "Running Storyboard will run the earlier core stages it depends on first, then render the typed sections."
+msgstr "Ekzekutimi i Storyboard-it do të ekzekutojë fazat kryesore të mëparshme nga të cilat varet së pari, pastaj do të renderojë seksionet e shtypura."
+
+msgid "Running Validation..."
+msgstr "Duke ekzekutuar Validimin..."
+
+msgid "Running..."
+msgstr "Duke ekzekutuar..."
+
+msgid "Runs accessibility checks against the packaged book."
+msgstr "Ekzekuton kontrolle aksesueshmërie kundrejt librit të paketuar."
+
+msgid "Runs in background — you can keep editing"
+msgstr "Ekzekutohet në sfond — mund të vazhdoni editimin"
+
+msgid "Sample"
+msgstr "Shembull"
+
+msgid "Sample Illustrated Story"
+msgstr "Histori e Ilustruar Shembull"
+
+msgid "Sample Rate"
+msgstr "Shkalla e Shembullit"
+
+msgid "Sample Reference Manual"
+msgstr "Manual Referues Shembull"
+
+msgid "Sample shown for illustration. The actual languages used come from your Output Languages list above."
+msgstr "Shembull për ilustrim. Gjuhët aktuale të përdorura vijnë nga lista juaj e Gjuhëve të Daljes më lart."
+
+msgid "Sans-serif"
+msgstr "Sans-serif"
+
+msgid "Save"
+msgstr "Ruaj"
+
+msgid "Save & Rerun"
+msgstr "Ruaj dhe Riekzekuto"
+
+msgid "Save & Rerun Captions"
+msgstr "Ruaj dhe Riekzekuto Titujt"
+
+msgid "Save & Rerun Easy Read"
+msgstr "Ruaj dhe Riekzekuto Leximin e Lehtë"
+
+msgid "Save & Rerun Extraction"
+msgstr "Ruaj dhe Riekzekuto Nxjerrjen"
+
+msgid "Save & Rerun Glossary"
+msgstr "Ruaj dhe Riekzekuto Glosarin"
+
+msgid "Save & Rerun Quizzes"
+msgstr "Ruaj dhe Riekzekuto Kuizet"
+
+msgid "Save & Rerun Sectioning"
+msgstr "Ruaj dhe Riekzekuto Seksionimin"
+
+msgid "Save & Rerun Speech"
+msgstr "Ruaj dhe Riekzekuto Fjalimin"
+
+msgid "Save & Rerun Storyboard"
+msgstr "Ruaj dhe Riekzekuto Storyboard"
+
+msgid "Save & Rerun TOC Generation"
+msgstr "Ruaj dhe Riekzekuto Gjenerimin e Përmbajtjes"
+
+msgid "Save & Rerun Translations"
+msgstr "Ruaj dhe Riekzekuto Përkthimet"
+
+msgid "Save changes"
+msgstr "Ruaj ndryshimet"
+
+msgid "Save changes before re-rendering"
+msgstr "Ruaj ndryshimet para ri-renderimit"
+
+msgid "Save changes first to preview the latest version"
+msgstr "Ruaj ndryshimet fillimisht për të parë paraprakisht versionin e fundit"
+
+msgid "Save checklist"
+msgstr "Ruaj listën e kontrollit"
+
+msgid "Save failed"
+msgstr "Ruajtja dështoi"
+
+msgid "Save page review"
+msgstr "Ruaj rishikimin e faqes"
+
+msgid "Save selection"
+msgstr "Ruaj zgjedhjen"
+
+msgid "Save settings"
+msgstr "Ruaj cilësimet"
+
+msgid "Saved. Re-package Preview to apply."
+msgstr "U ruajt. Ri-pako Parapamjen për ta aplikuar."
+
+msgid "Saving..."
+msgstr "Po ruhet..."
+
+msgid "Saving…"
+msgstr "Po ruhet…"
+
+msgid "Scene 04"
+msgstr "Skena 04"
+
+msgid "School textbooks and workbooks"
+msgstr "Tekste shkollore dhe fletore pune"
+
+msgid "Scientific papers and journals"
+msgstr "Punime shkencore dhe revista"
+
+msgid "Score 84%"
+msgstr "Rezultat 84%"
+
+msgid "Scores each image for how much it contributes to the book's meaning."
+msgstr "Vlerëson çdo imazh sipas kontributit të tij në kuptimin e librit."
+
+msgid "SCORM Export"
+msgstr "Eksportim SCORM"
+
+msgid "SCORM Package"
+msgstr "Paketë SCORM"
+
+msgid "Screen readers cannot interpret images without text alternatives. Adding captions ensures blind and low-vision readers understand every illustration."
+msgstr "Lexuesit e ekranit nuk mund të interpretojnë imazhet pa alternativa tekstuale. Shtimi i titujve siguron që lexuesit e verbër dhe me shikim të dobët të kuptojnë çdo ilustrim."
+
+msgid "Search books"
+msgstr "Kërko libra"
+
+msgid "Search books..."
+msgstr "Kërko libra..."
+
+msgid "Search captions or image IDs…"
+msgstr "Kërko tituj ose ID imazhesh…"
+
+msgid "Search colors"
+msgstr "Kërko ngjyra"
+
+msgid "Search entries…"
+msgstr "Kërko regjistrime…"
+
+msgid "Search languages..."
+msgstr "Kërko gjuhë..."
+
+msgid "Search original or Easy Read text…"
+msgstr "Kërko tekstin origjinal ose Leximin e Lehtë…"
+
+msgid "Search questions or options…"
+msgstr "Kërko pyetje ose opsione…"
+
+msgid "Search sections..."
+msgstr "Kërko seksione..."
+
+msgid "Search style guides..."
+msgstr "Kërko udhëzues stili..."
+
+msgid "Search terms or definitions…"
+msgstr "Kërko terma ose përkufizime…"
+
+msgid "Search..."
+msgstr "Kërko..."
+
+msgid "section"
+msgstr "seksion"
+
+msgid "Section"
+msgstr "Seksion"
+
+msgid "section › activity"
+msgstr "seksion › aktivitet"
+
+msgid "section › group"
+msgstr "seksion › grup"
+
+msgid "section › list"
+msgstr "seksion › listë"
+
+#. placeholder {0}: String(block.sectionIndex + 1)
+#. placeholder {0}: String(group.sectionIndex + 1)
+#. placeholder {0}: String(i + 1)
+msgid "Section {0}"
+msgstr "Seksioni {0}"
+
+#. placeholder {0}: String(group.sectionIndex + 1)
+#. placeholder {1}: group.sectionType
+msgid "Section {0} — {1}"
+msgstr "Seksioni {0} — {1}"
+
+#. placeholder {0}: section.sectionIndex + 1
+#. placeholder {1}: section.sectionType
+msgid "Section {0} · {1}"
+msgstr "Seksioni {0} · {1}"
+
+#. placeholder {0}: String(i + 1)
+#. placeholder {0}: i + 1
+#. placeholder {0}: section.sectionIndex + 1
+msgid "Section {0} (pruned)"
+msgstr "Seksioni {0} (i shkurtuar)"
+
+msgid "Section 3 · Overview"
+msgstr "Seksioni 3 · Përmbledhje"
+
+msgid "Section 3.2"
+msgstr "Seksioni 3.2"
+
+msgid "Section label"
+msgstr "Etiketë seksioni"
+
+msgid "Section Mode"
+msgstr "Modaliteti i Seksionit"
+
+msgid "Section not found."
+msgstr "Seksioni nuk u gjet."
+
+msgid "Section preview"
+msgstr "Parapamje seksioni"
+
+msgid "Section pruned from flow"
+msgstr "Seksion i hequr nga rrjedha"
+
+msgid "Section Types"
+msgstr "Llojet e Seksionit"
+
+msgid "Sectioning"
+msgstr "Seksionim"
+
+msgid "Sectioning mode"
+msgstr "Modaliteti i seksionimit"
+
+msgid "Sectioning Mode"
+msgstr "Modaliteti i Seksionimit"
+
+msgid "Sectioning Pages..."
+msgstr "Po seksionohen faqet..."
+
+msgid "Sectioning Preview"
+msgstr "Parapamje e Seksionimit"
+
+msgid "Sectioning Prompt"
+msgstr "Prompt i Seksionimit"
+
+msgid "Sectioning Reasoning"
+msgstr "Arsyetimi i Seksionimit"
+
+msgid "sections"
+msgstr "seksione"
+
+msgid "Sections"
+msgstr "Seksione"
+
+msgid "See examples"
+msgstr "Shiko shembuj"
+
+msgid "Segment"
+msgstr "Segment"
+
+msgid "Segment Preview"
+msgstr "Parapamje Segmenti"
+
+msgid "Segmentation apply failed"
+msgstr "Aplikimi i segmentimit dështoi"
+
+msgid "Segmentation failed"
+msgstr "Segmentimi dështoi"
+
+msgid "Segmentation preview"
+msgstr "Parapamje segmentimi"
+
+msgid "Segmentation produced no valid segments"
+msgstr "Segmentimi nuk prodhoi asnjë segment të vlefshëm"
+
+msgid "Segmentation Prompt"
+msgstr "Prompt i Segmentimit"
+
+msgid "Segmentation runs"
+msgstr "Ekzekutime segmentimi"
+
+msgid "Segmenting scenes"
+msgstr "Po segmentohen skenat"
+
+msgid "Segmenting..."
+msgstr "Po segmentohet..."
+
+msgid "Segmenting…"
+msgstr "Po segmentohet…"
+
+msgid "Select a node type and enter an item ID to view versions."
+msgstr "Zgjidhni një lloj nyje dhe shkruani një ID elementi për të parë versionet."
+
+msgid "Select a page grouping to continue"
+msgstr "Zgjidhni një grupim faqesh për të vazhduar"
+
+msgid "Select a render strategy to continue"
+msgstr "Zgjidhni një strategji renderimi për të vazhduar"
+
+msgid "Select a render strategy to preview how your book pages will be laid out."
+msgstr "Zgjidhni një strategji renderimi për të parë paraprakisht si do të vendosen faqet e librit tuaj."
+
+msgid "Select a reviewer session to inspect its progress and findings."
+msgstr "Zgjidhni një sesion rishikuesi për të inspektuar progresin dhe gjetjet e tij."
+
+msgid "Select a section mode to continue"
+msgstr "Zgjidhni një modalitet seksioni për të vazhduar"
+
+msgid "Select a style guide to preview how it styles the generated pages - typography, colors, and component layout."
+msgstr "Zgjidhni një udhëzues stili për të parë paraprakisht si stilon faqet e gjeneruara - tipografi, ngjyra dhe paraqitje komponentësh."
+
+msgid "Select activity mode..."
+msgstr "Zgjidhni modalitetin e aktivitetit..."
+
+msgid "Select activity type..."
+msgstr "Zgjidhni llojin e aktivitetit..."
+
+msgid "Select all"
+msgstr "Zgjidhni të gjitha"
+
+msgid "Select images to translate"
+msgstr "Zgjidhni imazhet për të përkthyer"
+
+msgid "Select node type..."
+msgstr "Zgjidhni llojin e nyjes..."
+
+msgid "Select reviewer session"
+msgstr "Zgjidhni sesionin e rishikuesit"
+
+msgid "Select section mode"
+msgstr "Zgjidhni modalitetin e seksionit"
+
+msgid "Select strategy..."
+msgstr "Zgjidhni strategjinë..."
+
+msgid "Select styleguide..."
+msgstr "Zgjidhni udhëzuesin e stilit..."
+
+msgid "Select template..."
+msgstr "Zgjidhni shabllonin..."
+
+msgid "Select the pages the quiz is written from, then choose where it appears using the buttons between pages."
+msgstr "Zgjidhni faqet nga të cilat është shkruar kuizi, pastaj zgjidhni ku shfaqet duke përdorur butonat ndërmjet faqeve."
+
+msgid "Select up to 5 pages to use as visual references. The LLM will analyze them and generate a styleguide."
+msgstr "Zgjidhni deri në 5 faqe për t'i përdorur si referenca vizuale. LLM do t'i analizojë dhe do të gjenerojë një udhëzues stili."
+
+msgid "Selected images"
+msgstr "Imazhe të zgjedhura"
+
+msgid "Selected: {styleImageId}"
+msgstr "Zgjedhur: {styleImageId}"
+
+msgid "Selecting \"None\" lets the LLM choose its own styling for each page."
+msgstr "Zgjedhja e \"Asnjë\" i lejon LLM-it të zgjedhë stilin e tij për çdo faqe."
+
+msgid "Self-contained ADT web app"
+msgstr "Aplikacion web ADT i pavarur"
+
+msgid "Separator"
+msgstr "Ndarës"
+
+msgid "Serif"
+msgstr "Serif"
+
+msgid "serious"
+msgstr "serioz"
+
+msgid "Serious"
+msgstr "Serioz"
+
+msgid "Session comments"
+msgstr "Komente sesioni"
+
+msgid "Sessions"
+msgstr "Sesione"
+
+msgid "Sessions let different reviewers capture findings independently, including language-specific reviews."
+msgstr "Sesionet u lejojnë rishikuesve të ndryshëm të regjistrojnë gjetjet në mënyrë të pavarur, duke përfshirë rishikimet specifike për gjuhë."
+
+msgid "Set a Gemini API key to generate audio"
+msgstr "Vendosni një çelës API Gemini për të gjeneruar audio"
+
+msgid "Set the editing language and choose output languages for the book."
+msgstr "Vendosni gjuhën e redaktimit dhe zgjidhni gjuhët e daljes për librin."
+
+msgid "Set your API key to auto-generate"
+msgstr "Vendosni çelësin tuaj API për gjenerim automatik"
+
+msgid "Sets the default layout used when a section has no specific strategy assigned."
+msgstr "Vendos paraqitjen e paracaktuar që përdoret kur një seksion nuk ka strategji specifike të caktuar."
+
+msgid "Settings"
+msgstr "Cilësime"
+
+msgid "Settings for this step are not yet available."
+msgstr "Cilësimet për këtë hap nuk janë ende të disponueshme."
+
+msgid "Shadow"
+msgstr "Hije"
+
+msgid "Ship"
+msgstr "Dërgo"
+
+msgid "Short, simple sentences for kindergarten through 5th grade."
+msgstr "Fjali të shkurtra dhe të thjeshta për klasën e parë deri në të pestën."
+
+msgid "Show accessibility summary"
+msgstr "Shfaq përmbledhjen e aksesueshmërisë"
+
+msgid "Show AI edit history"
+msgstr "Shfaq historikun e redaktimeve të AI"
+
+msgid "Show all"
+msgstr "Shfaq të gjitha"
+
+#. placeholder {0}: pages.length
+msgid "Show all {0}"
+msgstr "Shfaq të gjitha {0}"
+
+msgid "Show all pages"
+msgstr "Shfaq të gjitha faqet"
+
+msgid "Show all translations"
+msgstr "Shfaq të gjitha përkthimet"
+
+msgid "Show error details"
+msgstr "Shfaq detajet e gabimit"
+
+msgid "Show fewer"
+msgstr "Shfaq më pak"
+
+msgid "Show only the terms you added manually"
+msgstr "Shfaq vetëm termat që shtuat manualisht"
+
+msgid "Show reviewer validation"
+msgstr "Shfaq validimin e rishikuesit"
+
+msgid "Show:"
+msgstr "Shfaq:"
+
+msgid "Showing only terms you added — click to show all"
+msgstr "Po shfaqen vetëm termat që shtuat — klikoni për të shfaqur të gjitha"
+
+msgid "Shown after page {afterNumber}"
+msgstr "Shfaqur pas faqes {afterNumber}"
+
+msgid "Side-by-side image and narrative."
+msgstr "Imazh dhe narrativë krah për krah."
+
+msgid "Sign"
+msgstr "Shenjë"
+
+msgid "Sign language"
+msgstr "Gjuhë shenjash"
+
+msgid "Sign Language"
+msgstr "Gjuha e Shenjave"
+
+msgid "Sign Language assigns one video per Storyboard section. Finish Storyboard first so you have sections to match against."
+msgstr "Gjuha e Shenjave cakton një video për çdo seksion të Storyboard. Përfundo Storyboard-in fillimisht që të kesh seksione me të cilat të përputhësh."
+
+msgid "Sign Language Preview"
+msgstr "Parashikim i Gjuhës së Shenjave"
+
+msgid "Sign language video overlays for each page"
+msgstr "Mbivendosje videosh të gjuhës së shenjave për çdo faqe"
+
+msgid "Sign language videos provide access for deaf and hard of hearing readers who may not be fluent in written language."
+msgstr "Videot e gjuhës së shenjave ofrojnë qasje për lexuesit shurdhamutë dhe me dëgjim të kufizuar, të cilët mund të mos jenë të rrjedhshëm në gjuhën e shkruar."
+
+msgid "Single"
+msgstr "Të vetëm"
+
+msgid "Single Column"
+msgstr "Kolonë e Vetme"
+
+msgid "Single composited image"
+msgstr "Imazh i vetëm i kompozuar"
+
+msgid "Single Mode"
+msgstr "Modalitet i Vetëm"
+
+msgid "Single Page"
+msgstr "Faqe e Vetme"
+
+msgid "Single quiz"
+msgstr "Quiz i vetëm"
+
+msgid "Single value"
+msgstr "Vlerë e vetme"
+
+msgid "Size"
+msgstr "Madhësia"
+
+msgid "Sizing"
+msgstr "Dimensionimi"
+
+msgid "sk-..."
+msgstr "sk-..."
+
+msgid "sk-ant-..."
+msgstr "sk-ant-..."
+
+msgid "Skip for now"
+msgstr "Kalo tani"
+
+msgid "Skip intro"
+msgstr "Kalo hyrjen"
+
+msgid "Skip segmentation for images whose shortest side is below this threshold."
+msgstr "Kalo segmentimin për imazhet çdofaqja më e shkurtër e të cilave është nën këtë prag."
+
+msgid "Skipped"
+msgstr "Kaluar"
+
+msgid "Sky"
+msgstr "Qiell"
+
+msgid "slide"
+msgstr "rrëshqitëse"
+
+#. placeholder {0}: i + 1
+msgid "Slide {0}"
+msgstr "Rrëshqitëse {0}"
+
+msgid "Smart Cropping"
+msgstr "Prerje Inteligjente"
+
+msgid "Software update"
+msgstr "Përditësim softueri"
+
+msgid "Software Update"
+msgstr "Përditësim Softueri"
+
+msgid "Software update status"
+msgstr "Gjendja e përditësimit të softuerit"
+
+msgid "Something went wrong"
+msgstr "Diçka shkoi keq"
+
+msgid "Sort"
+msgstr "Rendit"
+
+msgid "Sort books"
+msgstr "Rendit librat"
+
+msgid "Source"
+msgstr "Burimi"
+
+msgid "Source PDF"
+msgstr "PDF Burim"
+
+msgid "Space around"
+msgstr "Hapësirë rreth"
+
+msgid "Space between"
+msgstr "Hapësirë midis"
+
+msgid "Space-separated. Saves on blur."
+msgstr "Të ndara me hapësirë. Ruhet me humbje fokusi."
+
+msgid "Spacing"
+msgstr "Hapësirëzimi"
+
+msgid "Spanish"
+msgstr "Spanjisht"
+
+msgid "Specialized workflows"
+msgstr "Flukse pune të specializuara"
+
+msgid "Specific pages"
+msgstr "Faqe specifike"
+
+msgid "Speech"
+msgstr "Të folurit"
+
+msgid "Speech Generation"
+msgstr "Gjenerimi i të Folurit"
+
+msgid "Speech narrates the translated text Language produces. Finish Language before running this stage."
+msgstr "Të folurit rrëfen tekstin e përkthyer që prodhon hapi Language. Përfundo Language para se të ekzekutosh këtë fazë."
+
+msgid "Speech Preview"
+msgstr "Parashikim i të Folurit"
+
+msgid "Speech Prompts"
+msgstr "Prompte të të Folurit"
+
+msgid "Speech Settings"
+msgstr "Cilësimet e të Folurit"
+
+msgid "Split segments"
+msgstr "Ndaj segmentet"
+
+msgid "Spread"
+msgstr "Shpërndarje"
+
+msgid "Spread Mode"
+msgstr "Modalitet Shpërndarjeje"
+
+msgid "Sprinkling some digital fairy dust..."
+msgstr "Duke spërkatur pak pluhur magjik dixhital..."
+
+msgid "Stages are rerunable and every result is versioned, so experimenting is safe — nothing is ever overwritten."
+msgstr "Fazat mund të ri-ekzekutohen dhe çdo rezultat versionohet, kështu që eksperimentimi është i sigurt — asgjë nuk mbishkruhet kurrë."
+
+msgid "Standard"
+msgstr "Standard"
+
+msgid "Standard e-book for readers & libraries"
+msgstr "E-book standard për lexues dhe biblioteka"
+
+msgid "Standard EPUB 3 file for e-readers, reading apps, and accessibility tools. Interactive features (quizzes, TTS) work in readers that support JavaScript."
+msgstr "Skedar standard EPUB 3 për lexues elektronikë, aplikacione leximi dhe mjete aksesueshmërie. Veçoritë interaktive (quiz-e, TTS) funksionojnë në lexues që mbështesin JavaScript."
+
+msgid "Start"
+msgstr "Fillo"
+
+msgid "Start a reviewer session"
+msgstr "Fillo një sesion rishikimi"
+
+msgid "Start from a PDF"
+msgstr "Fillo nga një PDF"
+
+msgid "Start page"
+msgstr "Faqja fillestare"
+
+msgid "Start reviewer validation"
+msgstr "Fillo validimin e rishikuesit"
+
+msgid "Start typing to see words from the book…"
+msgstr "Fillo të shkruash për të parë fjalë nga libri…"
+
+msgid "Start with a PDF"
+msgstr "Fillo me një PDF"
+
+msgid "Stats"
+msgstr "Statistika"
+
+msgid "Stay"
+msgstr "Qëndro"
+
+msgid "Step"
+msgstr "Hapi"
+
+#. placeholder {0}: STEPS.length
+msgid "Step {step} of {0}"
+msgstr "Hapi {step} nga {0}"
+
+msgid "Step failed"
+msgstr "Hapi dështoi"
+
+msgid "Step run failed"
+msgstr "Ekzekutimi i hapit dështoi"
+
+msgid "Storyboard"
+msgstr "Storyboard"
+
+msgid "Storyboard has already been run. Changes made here will not take effect until storyboard is re-run."
+msgstr "Storyboard-i është ekzekutuar tashmë. Ndryshimet e bëra këtu nuk do të hyjnë në fuqi derisa storyboard-i të ri-ekzekutohet."
+
+msgid "Storyboard not ready"
+msgstr "Storyboard-i nuk është gati"
+
+msgid "Storyboard Overview"
+msgstr "Pasqyrë e Storyboard-it"
+
+msgid "Storyboard Preview"
+msgstr "Parashikim i Storyboard-it"
+
+msgid "Storybook"
+msgstr "Storybook"
+
+msgid "Stretch"
+msgstr "Zgjerimi"
+
+msgid "Strict"
+msgstr "Rreptë"
+
+msgid "Strikethrough"
+msgstr "Goditje"
+
+msgid "Structure"
+msgstr "Struktura"
+
+msgid "Structure & semantics"
+msgstr "Struktura dhe semantika"
+
+msgid "Structure each page into a content tree of sections and nodes for downstream rendering."
+msgstr "Strukturo çdo faqe në një pemë përmbajtjeje me seksione dhe nyje për renderimin vijues."
+
+msgid "Structured chapters, exercises. Best for educational content with complex layouts."
+msgstr "Kapituj dhe ushtrime të strukturuara. Më i miri për përmbajtje edukative me paraqitje komplekse."
+
+msgid "Structured HTML"
+msgstr "HTML i Strukturuar"
+
+msgid "Structures each page into a tree of sections and nodes."
+msgstr "Strukturon çdo faqe në një pemë seksionesh dhe nyjesh."
+
+msgid "Style"
+msgstr "Stili"
+
+msgid "Style guide"
+msgstr "Udhëzues stili"
+
+msgid "Style Guide"
+msgstr "Udhëzues Stili"
+
+msgid "Style reference"
+msgstr "Referencë stili"
+
+msgid "Style reference image"
+msgstr "Imazh referencë stili"
+
+msgid "Styleguide"
+msgstr "Udhëzues Stili"
+
+msgid "Styleguide Preview"
+msgstr "Parashikim i Udhëzuesit të Stilit"
+
+msgid "Styleguide Preview — {styleguide}"
+msgstr "Parashikim i Udhëzuesit të Stilit — {styleguide}"
+
+msgid "Submit"
+msgstr "Dërgo"
+
+msgid "Success"
+msgstr "Sukses"
+
+msgid "Successfully uploaded"
+msgstr "Ngarkuar me sukses"
+
+msgid "Suggested modification"
+msgstr "Modifikim i sugjeruar"
+
+msgid "Suggested modification:"
+msgstr "Modifikim i sugjeruar:"
+
+msgid "Summary Prompt"
+msgstr "Prompt Përmbledhjeje"
+
+msgid "Sun"
+msgstr "Diell"
+
+msgid "SW"
+msgstr "JP"
+
+msgid "Symbiosis"
+msgstr "Simbiozë"
+
+msgid "Synthesizes narration audio for each page."
+msgstr "Sintetizon audion e rrëfimit për çdo faqe."
+
+msgid "System Prompt"
+msgstr "Prompt Sistemi"
+
+msgid "Table of contents"
+msgstr "Tabela e përmbajtjes"
+
+msgid "Table of Contents"
+msgstr "Tabela e Përmbajtjes"
+
+msgid "Tables"
+msgstr "Tabelat"
+
+msgid "Tablet"
+msgstr "Tabletë"
+
+msgid "Tailwind classes"
+msgstr "Klasa Tailwind"
+
+msgid "Takes liberties and produces something similar."
+msgstr "Merr liri dhe prodhon diçka të ngjashme."
+
+msgid "Task Running"
+msgstr "Detyra po Ekzekutohet"
+
+msgid "Task running..."
+msgstr "Detyra po ekzekutohet..."
+
+msgid "Tasks Running"
+msgstr "Detyrat po Ekzekutohen"
+
+msgid "Teaching the pixels new tricks..."
+msgstr "Duke i mësuar pikselëve truke të reja..."
+
+msgid "Technical documentation"
+msgstr "Dokumentacion teknik"
+
+msgid "Technical manuals with diagrams"
+msgstr "Manuale teknike me diagrama"
+
+msgid "Temperature"
+msgstr "Temperatura"
+
+msgid "Template"
+msgstr "Shablloni"
+
+msgid "Template not found."
+msgstr "Shablloni nuk u gjet."
+
+msgid "Template One Column"
+msgstr "Shabllon me Një Kolonë"
+
+msgid "Template Rendering"
+msgstr "Renderimi i Shabllonit"
+
+msgid "Template-based"
+msgstr "Bazuar në shabllon"
+
+msgid "term"
+msgstr "term"
+
+msgid "terms"
+msgstr "terme"
+
+msgid "Terms marked with an asterisk (*) are defined by the ISO standard and may differ from colloquial usage in other fields."
+msgstr "Termet e shënuara me asterisk (*) janë të përcaktuara nga standardi ISO dhe mund të ndryshojnë nga përdorimi i zakonshëm në fusha të tjera."
+
+msgid "Terms were picked by AI from the book. Edit a definition or its emojis, add your own terms, or prune the ones you don't want. Pruned terms stay out of the output and future regenerations. Changes are saved as a new version, so you can always roll back."
+msgstr "Termet u zgjodhën nga AI nga libri. Redakto një përkufizim ose emoji-t e tij, shto termet e tua, ose elimino ato që nuk dëshiron. Termet e eliminuara përjashtohen nga dalja dhe regjenerimet e ardhshme. Ndryshimet ruhen si version i ri, kështu që mund të kthehesh gjithmonë."
+
+msgid "Text"
+msgstr "Teksti"
+
+msgid "Text & Images"
+msgstr "Tekst dhe Imazhe"
+
+msgid "Text & Single Image"
+msgstr "Tekst dhe Imazh i Vetëm"
+
+msgid "Text alternatives"
+msgstr "Alternativa tekstuale"
+
+msgid "Text Catalog"
+msgstr "Katalog Teksti"
+
+msgid "Text color"
+msgstr "Ngjyra e tekstit"
+
+#. placeholder {0}: section.textColor
+msgid "Text color: {0}"
+msgstr "Ngjyra e tekstit: {0}"
+
+msgid "Text Only"
+msgstr "Vetëm Tekst"
+
+msgid "Text roles the LLM may assign to text in the content tree. Pruned roles are classified but excluded from rendering."
+msgstr "Rolet tekstuale që LLM mund t'u caktojë teksteve në pemën e përmbajtjes. Rolet e eliminuara klasifikohen por përjashtohen nga renderimi."
+
+msgid "Text Types"
+msgstr "Llojet e Tekstit"
+
+msgid "Textbooks & Activities"
+msgstr "Tekste Shkollore dhe Aktivitete"
+
+msgid "The AI is having a think..."
+msgstr "AI po mendon..."
+
+msgid "The AI will preserve the original style while applying your changes."
+msgstr "AI do të ruajë stilin origjinal ndërkohë që aplikon ndryshimet tuaja."
+
+msgid "The application ran into an unexpected error. You can try reloading — your work in progress is saved on disk."
+msgstr "Aplikacioni ndeshi një gabim të papritur. Mund të provosh të ringarkosh — puna juaj në vazhdim është ruajtur në disk."
+
+msgid "The back cover of the book."
+msgstr "Kapaku i pasëm i librit."
+
+msgid "The book is written in {langName}."
+msgstr "Libri është shkruar në {langName}."
+
+msgid "The community of living organisms in a place and the way they interact with each other and their environment."
+msgstr "Bashkësia e organizmave të gjallë në një vend dhe mënyra si ndërveprojnë me njëri-tjetrin dhe mjedisin e tyre."
+
+msgid "The completed stages below will be reset and need to run again before final outputs are available."
+msgstr "Fazat e përfunduara më poshtë do të resetohen dhe duhet të ekzekutohen sërish para se rezultatet përfundimtare të jenë të disponueshme."
+
+msgid "The credits page."
+msgstr "Faqja e krediteve."
+
+msgid "The data sent within the body of a request or response message."
+msgstr "Të dhënat e dërguara brenda trupit të një mesazhi kërkese ose përgjigjeje."
+
+msgid "The default TTS instruction sent to OpenAI for all languages unless overridden below."
+msgstr "Udhëzimi TTS i parazgjedhur i dërguar te OpenAI për të gjitha gjuhët, nëse nuk anashkalohet më poshtë."
+
+msgid "The entire page is treated as a single section - all text and images stay together as one unit. Best for storybooks, reference books, and any content where each page is self-contained."
+msgstr "I gjithë faqja trajtohet si një seksion i vetëm — i gjithë teksti dhe imazhet qëndrojnë bashkë si një njësi. Më e mirë për libra me tregime, libra referencë dhe çdo përmbajtje ku çdo faqe është e vetëmjaftueshme."
+
+msgid "The file may be damaged or incomplete. Try downloading it again from the source."
+msgstr "Skedari mund të jetë i dëmtuar ose i paplotë. Provo ta shkarkosh sërish nga burimi."
+
+msgid "The following terms are used throughout this manual. Familiarity with these definitions is required before proceeding to the implementation chapters."
+msgstr "Termat e mëposhtëm përdoren gjatë gjithë këtij manuali. Njohja me këto përkufizime kërkohet para se të vazhdohet me kapitujt e zbatimit."
+
+msgid "The foreword or introduction."
+msgstr "Parathënia ose hyrja."
+
+msgid "The front cover of the book."
+msgstr "Kapaku i përparmë i librit."
+
+msgid "The glossary scans the typed sections that Storyboard places into pages. Finish Storyboard before running this stage."
+msgstr "Fjalori skanon seksionet e shtypura që Storyboard vendos në faqe. Përfundo Storyboard para se të ekzekutosh këtë fazë."
+
+msgid "The ideal choice for novels, focused on a clean and continuous reading experience."
+msgstr "Zgjedhja ideale për romane, e fokusuar në një përvojë leximi të pastër dhe të vazhdueshme."
+
+msgid "The inside cover of the book."
+msgstr "Kapaku i brendshëm i librit."
+
+msgid "The Lost Forest"
+msgstr "Pylli i Humbur"
+
+msgid "The model detects bounding boxes so each visual element can be stored and laid out separately."
+msgstr "Modeli zbulон kufijtë e elementeve vizualë që çdo element mund të ruhet dhe të vendoset veçmas."
+
+msgid "The process plants use to turn sunlight, water, and carbon dioxide into food."
+msgstr "Procesi që bimët përdorin për të kthyer dritën e diellit, ujin dhe dioksidin e karbonit në ushqim."
+
+msgid "The prompt sent to the image model alongside each selected image."
+msgstr "Udhëzimi i dërguar modelit të imazhit bashkë me çdo imazh të zgjedhur."
+
+msgid "The prompt template used to extract book metadata (title, author, etc.) from the first few pages. This is a Liquid template processed with page context."
+msgstr "Modeli i udhëzimit i përdorur për të nxjerrë metadatat e librit (titulli, autori, etj.) nga faqet e para. Ky është një shabllon Liquid i përpunuar me kontekstin e faqes."
+
+msgid "The prompt template used to generate captions for images in the book."
+msgstr "Modeli i udhëzimit i përdorur për të gjeneruar titujt e imazheve në libër."
+
+msgid "The prompt template used to generate editable Easy Read text blocks."
+msgstr "Modeli i udhëzimit i përdorur për të gjeneruar blloqet e tekstit të redaktueshme Easy Read."
+
+msgid "The prompt template used to generate glossary terms from book content."
+msgstr "Modeli i udhëzimit i përdorur për të gjeneruar termat e fjalorit nga përmbajtja e librit."
+
+msgid "The prompt template used to generate HTML for each section. This is a Liquid template processed with section context."
+msgstr "Modeli i udhëzimit i përdorur për të gjeneruar HTML për çdo seksion. Ky është një shabllon Liquid i përpunuar me kontekstin e seksionit."
+
+msgid "The prompt template used to generate quiz questions from page content."
+msgstr "Modeli i udhëzimit i përdorur për të gjeneruar pyetjet e testit nga përmbajtja e faqes."
+
+msgid "The prompt template used to generate the table of contents from book headings."
+msgstr "Modeli i udhëzimit i përdorur për të gjeneruar tabelën e përmbajtjes nga titujt e librit."
+
+msgid "The prompt template used to split each page into logical sections. This is a Liquid template processed with page context."
+msgstr "Modeli i udhëzimit i përdorur për të ndarë çdo faqe në seksione logjike. Ky është një shabllon Liquid i përpunuar me kontekstin e faqes."
+
+msgid "The prompt template used to translate text catalog entries."
+msgstr "Modeli i udhëzimit i përdorur për të përkthyer hyrjet e katalogut të tekstit."
+
+msgid "The prompt used by the reviewer pass to inspect and correct a candidate sectioning tree. Shares the model and retry settings of the sectioning prompt."
+msgstr "Udhëzimi i përdorur nga kalimi i rishikuesit për të inspektuar dhe korrigjuar një pemë seksionimi kandidate. Ndan modelin dhe cilësimet e riprovimit të udhëzimit të seksionimit."
+
+msgid "The quick brown fox jumps over the lazy dog."
+msgstr "Dhelpra e shpejtë kafe kërcen mbi qenin dembel."
+
+msgid "The rendering strategy used for sections without an explicit mapping."
+msgstr "Strategjia e renderimit e përdorur për seksionet pa një hartëzim eksplicit."
+
+msgid "The river meets the sea"
+msgstr "Lumi takon detin"
+
+msgid "The storyboard must be completed before generating {stageName}. Run the Storyboard stage first."
+msgstr "Storyboard duhet të plotësohet para gjenerimit të {stageName}. Ekzekuto fazën Storyboard fillimisht."
+
+msgid "The sun heats water in oceans, lakes, and rivers, turning it into vapor that rises into the atmosphere. As the vapor cools at higher altitudes, it condenses into tiny droplets that form clouds."
+msgstr "Dielli ngroh ujin në oqeane, liqene dhe lumenj, duke e kthyer në avull që ngjitet në atmosferë. Ndërsa avulli ftohet në lartësi më të mëdha, kondensohet në pika të vogla që formojnë retë."
+
+msgid "The table of contents."
+msgstr "Tabela e përmbajtjes."
+
+msgid "The TOC lists the typed sections placed by Storyboard. Finish Storyboard before running this stage."
+msgstr "TOC liston seksionet e shtypura të vendosura nga Storyboard. Përfundo Storyboard para se të ekzekutosh këtë fazë."
+
+msgid "The Water Cycle"
+msgstr "Cikli i Ujit"
+
+msgid "The weather was very bad."
+msgstr "Moti ishte shumë i keq."
+
+msgid "The world before us"
+msgstr "Bota para nesh"
+
+msgid "Theme"
+msgstr "Tema"
+
+msgid "These features improve access for people with disabilities. Running them before exporting helps your book meet ADT accessibility standards."
+msgstr "Këto veçori përmirësojnë aksesin për personat me aftësi të kufizuara. Ekzekutimi i tyre para eksportimit ndihmon librin tuaj të përmbushë standardet e aksesibilitetit ADT."
+
+msgid "These stages are optional. They don't depend on each other — run any of them in any order once the core pipeline is complete."
+msgstr "Këto faza janë opsionale. Ato nuk varen nga njëra-tjetra — ekzekuto cilëndo prej tyre në çfarëdo rendi pasi të jetë plotësuar tubi kryesor."
+
+msgid "These values reflect either the saved book override or the latest packaged defaults."
+msgstr "Këto vlera pasqyrojnë ose anashkalimin e ruajtur të librit ose parazgjedhjeve më të fundit të paketuara."
+
+msgid "They absorb water and nutrients from the soil."
+msgstr "Ato thithin ujë dhe lëndë ushqyese nga toka."
+
+msgid "They did not give up."
+msgstr "Ata nuk u dorëzuan."
+
+msgid "They produce flowers to attract pollinators."
+msgstr "Ato prodhojnë lule për të tërhequr polenizuesit."
+
+msgid "They release oxygen directly into the air."
+msgstr "Ato lëshojnë oksigjen drejtpërdrejt në ajër."
+
+msgid "This book has no images to caption"
+msgstr "Ky libër nuk ka imazhe për t'i titulluar"
+
+msgid "This book has no pages. Make sure the extraction and storyboard stages produced content before generating {stageName}."
+msgstr "Ky libër nuk ka faqe. Sigurohu që fazat e nxjerrjes dhe storyboard kanë prodhuar përmbajtje para gjenerimit të {stageName}."
+
+#. placeholder {0}: book.title
+msgid "This book is titled \"{0}\"."
+msgstr "Ky libër ka titullin \"{0}\"."
+
+msgid "This file couldn't be read as a ZIP archive"
+msgstr "Ky skedar nuk mund të lexohej si arkiv ZIP"
+
+msgid "This image is decorative. Screen readers will skip it and no caption is needed."
+msgstr "Ky imazh është dekorativ. Lexuesit e ekranit do ta anashkalojnë dhe nuk nevojitet titull."
+
+msgid "This image is marked decorative — click to un-mark"
+msgstr "Ky imazh është shënuar si dekorativ — kliko për ta hequr shënimin"
+
+msgid "This is <0>ADT Studio</0>."
+msgstr "Ky është <0>ADT Studio</0>."
+
+msgid "This is a preview of the options you have selected for your book, each option affects the preview in a different way."
+msgstr "Ky është një paraparim i opsioneve të zgjedhura për librin tuaj, çdo opsion ndikon paraparimimin në mënyra të ndryshme."
+
+msgid "This is Pip! He has a wiggly tail."
+msgstr "Ky është Pip! Ai ka bisht që lëkundet."
+
+msgid "This is Pip! He is a happy caramel dog with a very wiggly tail. Pip loves the green grass, the bright yellow sun, and making new friends in his garden."
+msgstr "Ky është Pip! Ai është një qen i lumtur karamel me bisht shumë lëkundes. Pip i do barin e gjelbër, diellin e ndritshëm të verdhë dhe të bëjë miq të rinj në kopshtin e tij."
+
+msgid "This page has no captioned images"
+msgstr "Kjo faqe nuk ka imazhe me tituj"
+
+msgid "This page has no entries to synthesize"
+msgstr "Kjo faqe nuk ka hyrje për të sintetizuar"
+
+msgid "This page has no sectioning output"
+msgstr "Kjo faqe nuk ka dalje seksionimi"
+
+msgid "This page has no simplified text blocks"
+msgstr "Kjo faqe nuk ka blloqe teksti të thjeshtuara"
+
+msgid "This page has no storyboard sections"
+msgstr "Kjo faqe nuk ka seksione storyboard"
+
+msgid "This page has no translatable text entries"
+msgstr "Kjo faqe nuk ka hyrje teksti të përkthyeshme"
+
+msgid "This page has not been reviewed yet"
+msgstr "Kjo faqe nuk është rishikuar akoma"
+
+msgid "This permanently deletes every uploaded video and clears all section assignments. This can't be undone."
+msgstr "Kjo fshin përgjithmonë çdo video të ngarkuar dhe pastron të gjitha caktimet e seksioneve. Ky veprim nuk mund të zhbëhet."
+
+msgid "This position already has {occupiedCount} quizzes. Add another after them, or replace them."
+msgstr "Kjo pozicion tashmë ka {occupiedCount} teste. Shto një tjetër pas tyre ose zëvendëso ato."
+
+msgid "This position already has a quiz. Add another right after it, or replace it."
+msgstr "Kjo pozicion tashmë ka një test. Shto një tjetër menjëherë pas tij ose zëvendëso atë."
+
+msgid "This prompt instructs the LLM how to evaluate the rendered HTML against the original page. Selection above controls which template is used."
+msgstr "Ky udhëzim i tregon LLM-it si të vlerësojë HTML-in e renderuar kundrejt faqes origjinale. Zgjedhja më lart kontrollon cilin shabllon përdoret."
+
+msgid "This quiz will be removed from the book. You can still restore it from the version history."
+msgstr "Ky test do të hiqet nga libri. Mund ta rikthesh nga historia e versioneve."
+
+msgid "This screen couldn’t load"
+msgstr "Ky ekran nuk mund të ngarkohej"
+
+msgid "This section has no storyboard rendering yet"
+msgstr "Ky seksion nuk ka ende renderim storyboard"
+
+msgid "This section is pruned and isn't rendered."
+msgstr "Ky seksion është prerë dhe nuk renderizohet."
+
+msgid "This session is using an older reviewer checklist snapshot. Newer checklist settings will apply only to newly created reviewer sessions."
+msgstr "Kjo sesion po përdor një fotografi të vjetër të listës së kontrollit të rishikuesit. Cilësimet e reja të listës do të zbatohen vetëm për sesionet e rishikuesit të krijuara rishtazi."
+
+msgid "This text is only perceptible to assistive technologies."
+msgstr "Ky tekst perceptohet vetëm nga teknologjitë ndihmëse."
+
+msgid "This will save your Easy Read settings and generate a new editable Easy Read version."
+msgstr "Kjo do të ruajë cilësimet tuaja Easy Read dhe do të gjenerojë një version të ri të redaktueshëm Easy Read."
+
+msgid "This will save your settings and re-generate the table of contents."
+msgstr "Kjo do të ruajë cilësimet tuaja dhe do të rigjenerojë tabelën e përmbajtjes."
+
+msgid "This will save your settings and re-run glossary generation."
+msgstr "Kjo do të ruajë cilësimet tuaja dhe do të riekzekutojë gjenerimin e fjalorit."
+
+msgid "This will save your settings and re-run image captioning."
+msgstr "Kjo do të ruajë cilësimet tuaja dhe do të riekzekutojë titullimin e imazheve."
+
+msgid "This will save your settings and re-run quiz generation."
+msgstr "Kjo do të ruajë cilësimet tuaja dhe do të riekzekutojë gjenerimin e testeve."
+
+msgid "This will save your settings and re-run sectioning for all pages."
+msgstr "Kjo do të ruajë cilësimet tuaja dhe do të riekzekutojë seksionimin për të gjitha faqet."
+
+msgid "This will save your settings and re-run speech generation."
+msgstr "Kjo do të ruajë cilësimet tuaja dhe do të riekzekutojë gjenerimin e të folurit."
+
+msgid "This will save your settings and re-run the extraction pipeline. Any manual edits to extracted text will be overwritten for affected pages."
+msgstr "Kjo do të ruajë cilësimet tuaja dhe do të riekzekutojë tubin e nxjerrjes. Çdo redaktim manual i tekstit të nxjerrë do të mbishkruhet për faqet e prekura."
+
+msgid "This will save your settings and re-run the storyboard pipeline. Only rendering will be regenerated — your existing sections will be preserved."
+msgstr "Kjo do të ruajë cilësimet tuaja dhe do të riekzekutojë tubin storyboard. Vetëm renderimi do të rigjerohet — seksionet tuaja ekzistuese do të ruhen."
+
+msgid "This will save your settings and re-run the storyboard pipeline. Sectioning and rendering will be run for all pages."
+msgstr "Kjo do të ruajë cilësimet tuaja dhe do të riekzekutojë tubin storyboard. Seksionimi dhe renderimi do të ekzekutohen për të gjitha faqet."
+
+msgid "This will save your settings and re-run translations, rebuilding the text catalog and translating to output languages."
+msgstr "Kjo do të ruajë cilësimet tuaja dhe do të riekzekutojë përkthimet, duke rindërtuar katalogun e tekstit dhe duke përkthyer në gjuhët e daljes."
+
+msgid "Thorium Reader"
+msgstr "Thorium Reader"
+
+msgid "Time"
+msgstr "Koha"
+
+msgid "Timestamps"
+msgstr "Vula kohore"
+
+msgid "Tip: {MODIFIER_LABEL}+Click the label to reset."
+msgstr "Këshillë: {MODIFIER_LABEL}+Kliko etiketën për ta rivendosur."
+
+msgid "Title and image with text overlaid as a caption — AI matches the source book's visual style."
+msgstr "Titulli dhe imazhi me tekst të mbivendosur si titull — AI përputhet me stilin vizual të librit burim."
+
+msgid "Titles generated by the model from section content."
+msgstr "Titujt e gjeneruar nga modeli nga përmbajtja e seksionit."
+
+msgid "Titles taken verbatim from typed section headings."
+msgstr "Titujt marrë fjalë për fjalë nga titujt e seksioneve të shtypura."
+
+msgid "to"
+msgstr "te"
+
+msgid "to stream API logs here."
+msgstr "për të transmetuar regjistrat API këtu."
+
+msgid "TOC Generation Prompt"
+msgstr "Udhëzimi i Gjenerimit të TOC"
+
+msgid "TOC Mode"
+msgstr "Mënyra TOC"
+
+msgid "TOC Preview"
+msgstr "Paraparimimi TOC"
+
+msgid "Toggle model list"
+msgstr "Ndrysho listën e modeleve"
+
+msgid "Token"
+msgstr "Token"
+
+msgid "Tokens"
+msgstr "Tokenë"
+
+msgid "Tokens In"
+msgstr "Tokenë Hyrës"
+
+msgid "Tokens Out"
+msgstr "Tokenë Dalës"
+
+msgid "Too large"
+msgstr "Shumë i madh"
+
+msgid "Too small"
+msgstr "Shumë i vogël"
+
+msgid "Total Tokens"
+msgstr "Tokenë Gjithsej"
+
+msgid "Track reviewer progress and review findings captured from Preview."
+msgstr "Gjurmo progresin e rishikuesit dhe gjetjet e rishikimit të kaptura nga Paraparimimi."
+
+msgid "Translate"
+msgstr "Përkthe"
+
+msgid "Translate text in images"
+msgstr "Përkthe tekstin në imazhe"
+
+msgid "Translate the book content to output languages."
+msgstr "Përkthe përmbajtjen e librit në gjuhët e daljes."
+
+msgid "Translate the book into additional languages. Each language is generated alongside the original, ready for narration, captions, and on-page reading."
+msgstr "Përkthe librin në gjuhë shtesë. Çdo gjuhë gjenerohet bashkë me origjinalin, e gatshme për tregim, tituj dhe lexim në faqe."
+
+msgid "Translate the book into other languages and generate narration. These stages are optional — skip them if your book doesn't need multilingual or audio output."
+msgstr "Përkthe librin në gjuhë të tjera dhe gjenerо tregimin. Këto faza janë opsionale — anashkaloi nëse libri juaj nuk ka nevojë për dalje shumëgjuhëshe ose audio."
+
+msgid "Translates extracted page text into the target languages."
+msgstr "Përkthe tekstin e nxjerrë të faqes në gjuhët e synuara."
+
+msgid "Translates text embedded in images — labels, captions, signs."
+msgstr "Përkthe tekstin i ngulitur në imazhe — etiketa, tituj, shenja."
+
+msgid "Translates the catalog into each target language."
+msgstr "Përkthe katalogun në çdo gjuhë të synuar."
+
+msgid "Translating languages..."
+msgstr "Duke përkthyer gjuhët..."
+
+msgid "translation"
+msgstr "përkthim"
+
+msgid "Translation"
+msgstr "Përkthimi"
+
+msgid "Translation Plan"
+msgstr "Plani i Përkthimit"
+
+msgid "Translation Preview"
+msgstr "Paraparimimi i Përkthimit"
+
+msgid "Translation Prompt"
+msgstr "Udhëzimi i Përkthimit"
+
+msgid "Translation runs on the typed sections placed by Storyboard. Finish Storyboard before running this stage."
+msgstr "Përkthimi ekzekutohet mbi seksionet e shtypura të vendosura nga Storyboard. Përfundo Storyboard para se të ekzekutosh këtë fazë."
+
+msgid "translations"
+msgstr "përkthime"
+
+msgid "Translations"
+msgstr "Përkthimet"
+
+msgid "Transparent"
+msgstr "Transparent"
+
+msgid "Transport"
+msgstr "Transport"
+
+msgid "Treat each page as a single section. Best for storybooks and self-contained pages."
+msgstr "Trajto çdo faqe si një seksion të vetëm. Më e mirë për libra me tregime dhe faqe të vetëmjaftueshme."
+
+msgid "Treats each page as a single section."
+msgstr "Trajton çdo faqe si një seksion të vetëm."
+
+msgid "Tries hard to match the original book design."
+msgstr "Përpiqet fort të përputhet me dizajnin origjinal të librit."
+
+msgid "Try a different search or filter"
+msgstr "Provo një kërkim ose filtër tjetër"
+
+msgid "Try Activity"
+msgstr "Provo Aktivitetin"
+
+msgid "Try again"
+msgstr "Provo sërish"
+
+msgid "Try another file"
+msgstr "Provo një skedar tjetër"
+
+msgid "Try the practice problem"
+msgstr "Provo problemin praktik"
+
+msgid "Try this screen again"
+msgstr "Provo këtë ekran sërish"
+
+msgid "Tune how text is simplified in the Easy Read Prompt settings. After running, each block becomes editable here in the Easy Read step."
+msgstr "Rregullo se si thjeshtohet teksti në cilësimet e Udhëzimit Easy Read. Pas ekzekutimit, çdo bllok bëhet i redaktueshëm këtu në hapin Easy Read."
+
+msgid "Turn any PDF into a fully accessible book — audio, translations, structured HTML layouts — all generated from your source file, <0>all editable</0>, <1>all yours</1>."
+msgstr "Ktheje çdo PDF në një libër plotësisht të aksesueshëm — audio, përkthime, paraqitje HTML të strukturuara — të gjitha të gjeneruara nga skedari juaj burim, <0>të gjitha të redaktueshme</0>, <1>të gjitha tuajat</1>."
+
+msgid "Turn this on to show the Validation review card in Preview and the Reviewer Validation tab in the Validation step."
+msgstr "Aktivizo këtë për të shfaqur kartën e rishikimit të Validimit në Paraparimim dhe skedën e Validimit të Rishikuesit në hapin e Validimit."
+
+msgid "Two authentication methods are supported: Bearer tokens passed in the Authorization header, and API keys passed as a query parameter. Bearer tokens are preferred for server-to-server requests due to their short expiry window."
+msgstr "Mbështeten dy metoda autentikimi: tokenët Bearer të kaluar në kokën Authorization dhe çelësat API të kaluar si parametër pyetjeje. Tokenët Bearer preferohen për kërkesat server-te-server për shkak të dritares së tyre të shkurtër të skadimit."
+
+msgid "Two Column"
+msgstr "Dy Kolona"
+
+msgid "Two Column Story"
+msgstr "Tregim me Dy Kolona"
+
+msgid "Two Columns"
+msgstr "Dy Kolona"
+
+msgid "Two Columns Story"
+msgstr "Tregim me Dy Kolona"
+
+msgid "Two-column template for story content"
+msgstr "Shabllon me dy kolona për përmbajtje tregimesh"
+
+msgid "Type"
+msgstr "Lloji"
+
+msgid "Typed Sections"
+msgstr "Seksionet e Shtypura"
+
+msgid "Types used during page sectioning. Pruned types are classified but excluded from rendering. Disabled types are hidden from the LLM entirely."
+msgstr "Llojet e përdorura gjatë seksionimit të faqes. Llojet e prera klasifikohen por përjashtohen nga renderimi. Llojet e çaktivizuara janë fshehur plotësisht nga LLM."
+
+msgid "Typography"
+msgstr "Tipografia"
+
+msgid "Unable to load reviewer checklist settings."
+msgstr "Nuk mund të ngarkohen cilësimet e listës së kontrollit të rishikuesit."
+
+msgid "Unable to render PDF preview."
+msgstr "Pamja paraprake e PDF nuk mund të shfaqet."
+
+msgid "Unassign video"
+msgstr "Hiq caktimin e videos"
+
+msgid "Unassigned"
+msgstr "Pa caktim"
+
+msgid "Unavailable"
+msgstr "Nuk disponohet"
+
+msgid "Uncategorized"
+msgstr "Pa kategori"
+
+msgid "Underline"
+msgstr "Nënvizim"
+
+msgid "UNICEF"
+msgstr "UNICEF"
+
+msgid "University academic publications"
+msgstr "Botime akademike universitare"
+
+msgid "unknown"
+msgstr "i panjohur"
+
+msgid "Unknown"
+msgstr "I panjohur"
+
+msgid "Unknown criterion"
+msgstr "Kriter i panjohur"
+
+msgid "Unknown stage"
+msgstr "Fazë e panjohur"
+
+msgid "Unknown step slug: {step}"
+msgstr "Slug i hapit i panjohur: {step}"
+
+msgid "Unknown step: {step}"
+msgstr "Hap i panjohur: {step}"
+
+msgid "Unprune image"
+msgstr "Rikthe imazhin"
+
+msgid "Unsaved changes"
+msgstr "Ndryshime të paruajtura"
+
+msgid "Untangling nested divs with care..."
+msgstr "Po zgjidhen divët e mbivendosur me kujdes..."
+
+msgid "Untitled"
+msgstr "Pa titull"
+
+msgid "Untitled entry"
+msgstr "Hyrje pa titull"
+
+msgid "Untitled quiz"
+msgstr "Kuiz pa titull"
+
+msgid "Update available"
+msgstr "Përditësim i disponueshëm"
+
+msgid "Update downloaded. Restart to install."
+msgstr "Përditësimi u shkarkua. Rinisni për të instaluar."
+
+msgid "Upload"
+msgstr "Ngarko"
+
+msgid "Upload a new image file from your computer"
+msgstr "Ngarko një skedar imazhi të ri nga kompjuteri yt"
+
+msgid "Upload a PDF to continue"
+msgstr "Ngarko një PDF për të vazhduar"
+
+msgid "Upload a PDF to get started"
+msgstr "Ngarko një PDF për të filluar"
+
+msgid "Upload a PDF to preview its pages here."
+msgstr "Ngarko një PDF për të parë faqet e tij këtu."
+
+msgid "Upload a sign-language video for any section and it'll appear here. Switch to Missing to see what still needs one."
+msgstr "Ngarko një video të gjuhës së shenjave për çdo seksion dhe do të shfaqet këtu. Kalo te Mungojnë për të parë çfarë ka ende nevojë."
+
+msgid "Upload an ADT Studio project archive (.zip) exported by you or shared by a colleague."
+msgstr "Ngarko një arkiv projekti të ADT Studio (.zip) të eksportuar nga ti ose të ndarë nga një koleg."
+
+msgid "Upload and assign sign language videos to book pages."
+msgstr "Ngarko dhe cakto video të gjuhës së shenjave në faqet e librit."
+
+msgid "Upload at least one video to see it appear here."
+msgstr "Ngarko të paktën një video për ta parë këtu."
+
+msgid "Upload failed"
+msgstr "Ngarkimi dështoi"
+
+msgid "Upload from Disk"
+msgstr "Ngarko nga disku"
+
+msgid "Upload image"
+msgstr "Ngarko imazh"
+
+msgid "Upload Image"
+msgstr "Ngarko imazh"
+
+msgid "Upload PDF or drag and drop"
+msgstr "Ngarko PDF ose tërhiq dhe lësho"
+
+msgid "Upload sign-language videos for each section of the book. The reader shows the matching video in a small player as the user scrolls through the page."
+msgstr "Ngarko video të gjuhës së shenjave për çdo seksion të librit. Lexuesi shfaq videon përkatëse në një luajtës të vogël ndërkohë që përdoruesi lëviz nëpër faqe."
+
+msgid "Upload Style Guide"
+msgstr "Ngarko udhëzuesin e stilit"
+
+msgid "Upload the source PDF of your book and we'll turn it into an Accessible Digital Textbook with interactive activities and adaptive layouts."
+msgstr "Ngarko PDF-in burimor të librit tënd dhe ne do ta shndërrojmë në një Libër Dixhital të Aksesueshëm me aktivitete interaktive dhe paraqitje adaptive."
+
+msgid "Upload to an LMS as a SCORM 1.2 package with completion tracking and offline support."
+msgstr "Ngarko në një LMS si paketë SCORM 1.2 me gjurmim të përfundimit dhe mbështetje offline."
+
+msgid "Upload to an LMS to track progress, quiz results, and completion."
+msgstr "Ngarko në një LMS për të gjurmuar progresin, rezultatet e kuizeve dhe përfundimin."
+
+msgid "Upload your own audio file"
+msgstr "Ngarko skedarin tënd audio"
+
+msgid "Upload ZIP or drag and drop"
+msgstr "Ngarko ZIP ose tërhiq dhe lësho"
+
+msgid "Uploading..."
+msgstr "Po ngarkohet..."
+
+msgid "Use an LLM to crop away stray text, artifacts, and excessive whitespace from image edges."
+msgstr "Përdor një LLM për të prerë tekstin e rastësishëm, artefaktet dhe hapësirat e tepërta nga skajet e imazhit."
+
+msgid "Use an LLM to detect and split composited images (e.g., multiple photos in a single image layer) into individual segments. Requires GPT-5.2+."
+msgstr "Përdor një LLM për të zbuluar dhe ndarë imazhet e kompozuara (p.sh., foto të shumta në një shtresë të vetme imazhi) në segmente individuale. Kërkon GPT-5.2+."
+
+msgid "Use an LLM to filter out decorative or non-educational images."
+msgstr "Përdor një LLM për të filtruar imazhet dekorative ose jo-edukative."
+
+#. placeholder {0}: page.pageNumber
+msgid "Use page {0} for the quiz"
+msgstr "Përdor faqen {0} për kuizin"
+
+msgid "Use section headings verbatim. Fast, deterministic, and preserves the original wording from the book."
+msgstr "Përdor titujt e seksioneve fjalë për fjalë. I shpejtë, deterministik dhe ruan formulimin origjinal të librit."
+
+msgid "Use Spread for printed books with facing-page layouts (covers stay solo, then 2+3, 4+5, …). Use Single when each PDF page should be processed on its own."
+msgstr "Përdor Spread për libra të shtypur me paraqitje faqesh ballë për ballë (kopertina mbetet vetëm, pastaj 2+3, 4+5, …). Përdor Single kur çdo faqe PDF duhet të përpunohet veçmas."
+
+msgid "Use the + between pages to place the quiz"
+msgstr "Përdor + ndërmjet faqeve për të vendosur kuizin"
+
+msgid "Use the sidebar on the left to open any stage of the pipeline. Each stage has its own page where you can review its content, configure its settings, and start a run. The cards below mirror that navigation — click a card to jump straight to that stage's page."
+msgstr "Përdor shiritin anësor majtas për të hapur çdo fazë të linjës. Çdo fazë ka faqen e saj ku mund të shqyrtosh përmbajtjen, të konfigurosh cilësimet dhe të nisësh një ekzekutim. Kartat më poshtë pasqyrojnë atë navigim — kliko një kartë për të kaluar direkt te faqja e asaj faze."
+
+msgid "Use this for checks you intentionally want to suppress, such as known false positives."
+msgstr "Përdor këtë për kontrollet që dëshiron t'i fshehësh me qëllim, si p.sh. pozitivët e rremë të njohur."
+
+msgid "Use this format to back up the project or move it to another machine."
+msgstr "Përdor këtë format për të rezervuar projektin ose për ta zhvendosur në një makinë tjetër."
+
+msgid "Used for Azure Speech TTS provider."
+msgstr "Përdoret për ofruesin Azure Speech TTS."
+
+msgid "Used for Claude models (claude-opus-4-6, claude-sonnet-4-6, etc.)"
+msgstr "Përdoret për modelet Claude (claude-opus-4-6, claude-sonnet-4-6, etj.)"
+
+msgid "Used for Gemini models — both LLM (gemini-2.5-pro, etc.) and TTS (gemini-2.5-pro-preview-tts, etc.)"
+msgstr "Përdoret për modelet Gemini — si LLM (gemini-2.5-pro, etj.) ashtu edhe TTS (gemini-2.5-pro-preview-tts, etj.)"
+
+msgid "Used for this quiz"
+msgstr "Përdoret për këtë kuiz"
+
+msgid "Validation"
+msgstr "Vërtetim"
+
+#. placeholder {0}: data.validationErrors.length
+msgid "Validation Errors ({0})"
+msgstr "Gabime vërtetimi ({0})"
+
+msgid "Variables"
+msgstr "Variabla"
+
+msgid "Variations"
+msgstr "Variacione"
+
+msgid "Vector Extraction"
+msgstr "Nxjerrje vektori"
+
+msgid "Verified applied"
+msgstr "Vërtetimi u aplikua"
+
+#. placeholder {0}: String(version)
+msgid "Version {0}"
+msgstr "Versioni {0}"
+
+msgid "Version {targetVersion}"
+msgstr "Versioni {targetVersion}"
+
+msgid "Versioned"
+msgstr "Me version"
+
+msgid "Versions"
+msgstr "Versione"
+
+msgid "video"
+msgstr "video"
+
+msgid "videos"
+msgstr "video"
+
+msgid "Videos"
+msgstr "Video"
+
+msgid "View HTML source"
+msgstr "Shiko burimin HTML"
+
+msgid "View image"
+msgstr "Shiko imazhin"
+
+msgid "View page"
+msgstr "Shiko faqen"
+
+msgid "Visual & sensory cues"
+msgstr "Sinjale vizuale dhe shqisore"
+
+msgid "Visual Layout"
+msgstr "Paraqitje vizuale"
+
+msgid "Visual Review"
+msgstr "Rishikim vizual"
+
+msgid "Visual Review Prompt (read-only)"
+msgstr "Prompt i rishikimit vizual (vetëm lexim)"
+
+msgid "Voice"
+msgstr "Zë"
+
+msgid "Voice Mappings"
+msgstr "Hartëzime zërash"
+
+msgid "Voices"
+msgstr "Zëra"
+
+msgid "Voices & Accents"
+msgstr "Zëra dhe akcente"
+
+msgid "Volcanic Origins"
+msgstr "Origjina vullkanike"
+
+msgid "Wait for glossary generation to finish"
+msgstr "Prit të përfundojë gjenerimi i glosariumit"
+
+msgid "Wait for storyboard to complete"
+msgstr "Prit të përfundojë storyboard-i"
+
+msgid "WAITING"
+msgstr "DUKE PRITUR"
+
+msgid "Waiting for API output…"
+msgstr "Duke pritur daljen e API-t…"
+
+msgid "Waiting for page to be processed..."
+msgstr "Duke pritur të përpunohet faqja..."
+
+msgid "Wall Clock"
+msgstr "Orë muri"
+
+msgid "Warning: Image Captions are required for accessibility"
+msgstr "Paralajmërim: Titujt e imazheve kërkohen për aksesueshmëri"
+
+msgid "Water is always moving. It travels from the oceans into the sky, falls as rain or snow, flows through rivers, and eventually returns to the sea. This continuous journey is called the water cycle."
+msgstr "Uji është gjithmonë në lëvizje. Udhëton nga oqeanet në qiell, bie si shi ose borë, rrjedh nëpër lumenj dhe në fund kthehet në det. Ky udhëtim i vazhdueshëm quhet cikli i ujit."
+
+msgid "Water moves continuously through evaporation, condensation, and precipitation. Most vapor returns to the oceans, while some falls on land as rain or snow before flowing back to the sea."
+msgstr "Uji lëviz vazhdimisht nëpërmjet avullimit, kondensimit dhe reshjeve. Shumica e avullit kthehet në oqeane, ndërsa një pjesë bie në tokë si shi ose borë para se të kthehet në det."
+
+msgid "Water moving through a membrane."
+msgstr "Uji lëviz nëpër një membranë."
+
+msgid "Watercolor"
+msgstr "Akuarel"
+
+msgid ""
+"wcag2a\n"
+"wcag2aa\n"
+"best-practice"
+msgstr ""
+"wcag2a\n"
+"wcag2aa\n"
+"best-practice"
+
+msgid "We hit a snag while loading this view. You can try this screen again or reload the whole app."
+msgstr "Ndesh një problem gjatë ngarkimit të kësaj pamjeje. Mund të provosh këtë ekran sërish ose të ringarko të gjithë aplikacionin."
+
+msgid "Web Export"
+msgstr "Eksport web"
+
+msgid "Web Package"
+msgstr "Paketë web"
+
+msgid "Web Publication"
+msgstr "Publikim web"
+
+msgid "Web Rendering"
+msgstr "Renderim web"
+
+msgid "WebPub"
+msgstr "WebPub"
+
+msgid "WebPub Export"
+msgstr "Eksport WebPub"
+
+msgid "Weight"
+msgstr "Peshë"
+
+msgid "Welcome to ADT Studio"
+msgstr "Mirë se vini në ADT Studio"
+
+msgid "What is the main role of a plant's roots?"
+msgstr "Cili është roli kryesor i rrënjëve të një bime?"
+
+msgid "What it does"
+msgstr "Çfarë bën"
+
+msgid "What should the AI change?"
+msgstr "Çfarë duhet të ndryshojë AI-ja?"
+
+msgid "What we discovered"
+msgstr "Çfarë zbuluam"
+
+msgid "What's inside"
+msgstr "Çfarë ka brenda"
+
+msgid "What's new"
+msgstr "Çfarë është e re"
+
+msgid "When describing images, mention any culturally specific objects, locations, or recurring characters by name."
+msgstr "Kur përshkruan imazhet, përmend çdo objekt specifik kulturor, vendndodhje ose personazh të përsëritur me emër."
+
+msgid "When enabled, background colors from the styleguide are applied to the full page body."
+msgstr "Kur aktivizohet, ngjyrat e sfondit nga udhëzuesi i stilit aplikohen në të gjithë trupin e faqes."
+
+msgid "When enabled, text labels near vector images (e.g. chart dimensions, speech bubbles) are grouped together and extracted as raster crops. Disable to extract only the core vector shapes without text."
+msgstr "Kur aktivizohet, etiketat e tekstit pranë imazheve vektoriale (p.sh. dimensionet e grafikut, flluska dialogu) grupohen dhe nxirren si prerje raster. Çaktivizo për të nxjerrë vetëm format vektoriale kryesore pa tekst."
+
+msgid "When enabled, the selected images below are regenerated for every output language during the translate stage."
+msgstr "Kur aktivizohet, imazhet e zgjedhura më poshtë rigjenerohen për çdo gjuhë dalje gjatë fazës së përkthimit."
+
+msgid "When enabled, word-level timestamps are calculated automatically during speech generation so the reader can highlight words as they're spoken. When disabled, you can still calculate timestamps manually from the speech view."
+msgstr "Kur aktivizohet, afatet kohore në nivel fjale llogariten automatikisht gjatë gjenerimit të të folurit në mënyrë që lexuesi të mund të theksojë fjalët ndërkohë që thuhen. Kur çaktivizohet, mund të llogarisësh afatet kohore manualisht nga pamja e të folurit."
+
+msgid "When your PDF isn't built around facing pages, single mode keeps every page separate: nothing is merged across a spread. That matches how most textbooks, novels, and reference books are read - one page at a time."
+msgstr "Kur PDF-i yt nuk është ndërtuar rreth faqeve ballë për ballë, modaliteti single mban çdo faqe të ndarë: asgjë nuk bashkohet nëpër një spread. Kjo përkon me mënyrën se si lexohen shumica e librave shkollorë, romaneve dhe librave referuese — një faqe në një kohë."
+
+msgid "Where it all begins"
+msgstr "Ku fillon gjithçka"
+
+msgid "While editing"
+msgstr "Gjatë redaktimit"
+
+msgid "Whole-book checks for packaged ADT output, plus reviewer findings captured from Preview."
+msgstr "Kontrolle për të gjithë librin për dalje të paketuara ADT, plus gjetjet e rishikuesve të kaptura nga Parapamja."
+
+msgid "Wide multilingual coverage with neural voices for many locales."
+msgstr "Mbulim i gjerë shumëgjuhësh me zëra neural për shumë lokale."
+
+msgid "Width"
+msgstr "Gjerësi"
+
+msgid "Will be reset"
+msgstr "Do të rivendoset"
+
+msgid "Within range"
+msgstr "Brenda intervalit"
+
+msgid "Word"
+msgstr "Fjalë"
+
+msgid "Word and definition are required."
+msgstr "Fjala dhe përkufizimi kërkohen."
+
+msgid "Word Highlighting"
+msgstr "Theksim fjalësh"
+
+msgid "Word-level highlighting"
+msgstr "Theksim në nivel fjale"
+
+msgid "words"
+msgstr "fjalë"
+
+msgid "Wrap in group"
+msgstr "Mbështjell në grup"
+
+msgid "Wraps 'Edit this image' requests. The AI receives the original image alongside this prompt. Supports user_prompt and style variables."
+msgstr "Mbështjell kërkesat 'Redakto këtë imazh'. AI-ja merr imazhin origjinal bashkë me këtë prompt. Mbështet variablat user_prompt dhe style."
+
+msgid "Wraps 'Generate new' requests. Supports user_prompt, style, and image_type variables. Uses Liquid syntax for conditionals."
+msgstr "Mbështjell kërkesat 'Gjenero të re'. Mbështet variablat user_prompt, style dhe image_type. Përdor sintaksën Liquid për kushtet."
+
+msgid "You can export at this stage"
+msgstr "Mund të eksportosh në këtë fazë"
+
+msgid "You have unsaved changes. If you leave, they'll be lost."
+msgstr "Ke ndryshime të paruajtura. Nëse largohesh, ato do të humbasin."
+
+msgid "You haven't added any terms manually yet"
+msgstr "Nuk ke shtuar ende asnjë term manualisht"
+
+msgid "Young adult fiction"
+msgstr "Fiksion për të rinj"
+
+msgid "Your app is up to date. There's nothing to do."
+msgstr "Aplikacioni yt është i përditësuar. Nuk ka asgjë për të bërë."
+
+msgid "Your book"
+msgstr "Libri yt"
+
+msgid "Your Books"
+msgstr "Librat tuaj"
+
+msgid "Your first ADT <0>starts here.</0>"
+msgstr "ADT-ja juaj e parë <0>fillon këtu.</0>"
+
+msgid "Z → A"
+msgstr "Z → A"
+
+msgid "Zoom in"
+msgstr "Zmadhim"
+
+msgid "Zoom out"
+msgstr "Zvogëlim"

--- a/apps/studio/src/main.tsx
+++ b/apps/studio/src/main.tsx
@@ -10,6 +10,7 @@ import { messages as enMessages } from "./locales/en.po"
 import { messages as ptBRMessages } from "./locales/pt-BR.po"
 import { messages as esMessages } from "./locales/es.po"
 import { messages as frMessages } from "./locales/fr.po"
+import { messages as sqMessages } from "./locales/sq.po"
 import { routeTree } from "./routeTree.gen"
 import "./styles/globals.css"
 import { LOCALES } from "./i18n/locales"
@@ -22,7 +23,7 @@ function detectLocale(): AppLocale {
   return "en"
 }
 
-i18n.load({ en: enMessages, "pt-BR": ptBRMessages, es: esMessages, fr: frMessages })
+i18n.load({ en: enMessages, "pt-BR": ptBRMessages, es: esMessages, fr: frMessages, sq: sqMessages })
 i18n.activate(detectLocale())
 
 if (import.meta.env.VITE_WORKSPACE_NAME) {


### PR DESCRIPTION
## Summary

Adds **Albanian (Shqip)** — locale code `sq`, the primary language of Kosovo — as a fully translated UI language for ADT Studio. Shown in the language switcher with the 🇽🇰 flag and the label "Albanian".

## Changes

- **Register the locale** in the single source of truth and CLI config:
  - `apps/studio/src/i18n/locales.ts` — add `sq` to `LOCALES`, `LOCALE_FLAGS` (🇽🇰), `LOCALE_NAMES`
  - `apps/studio/lingui.config.ts` — add `sq` to `locales`
  - `apps/studio/src/components/LocaleSwitcher.tsx` — add the `Albanian` label
  - `apps/studio/src/main.tsx` — import and register `sq.po` in `i18n.load()`
- **`apps/studio/src/locales/sq.po`** (new) — all **2,271** message strings translated to Albanian
- **`en/es/fr/pt-BR.po`** — pick up the new "Albanian" label string (translated in es/fr/pt-BR)
- **`AGENTS.md`** — document `sq` in the supported-locale list

## Validation

| Check | Result |
|-------|--------|
| `lingui extract` | 0 missing across en/es/fr/pt-BR/sq |
| `lingui compile` | clean |
| `pnpm typecheck` | clean |
| `pnpm lint` | 0 errors (pre-existing warnings only) |

Placeholders (`{count}`), ICU plurals, and HTML tags (`<0>...</0>`) are preserved across all translated strings. WCAG tag identifiers are left untranslated by design.

## Test plan

- [ ] Run `pnpm dev` and open `http://localhost:5173?lang=sq` — confirm the UI renders in Albanian
- [ ] Verify the language switcher lists 🇽🇰 Albanian and switching works