### PR TITLE
feat(studio): centralize filtered empty state + add it to captions filters

### DIFF
--- a/apps/studio/src/components/pipeline/components/FilteredEmptyState.tsx
+++ b/apps/studio/src/components/pipeline/components/FilteredEmptyState.tsx
@@ -1,0 +1,51 @@
+import type { LucideIcon } from "lucide-react"
+import type { ReactNode } from "react"
+import { Trans } from "@lingui/react/macro"
+import { StageEmptyState, type EmptyStateColor } from "./StageEmptyState"
+
+interface FilteredEmptyStateProps {
+  icon: LucideIcon
+  color: EmptyStateColor
+  title: ReactNode
+  subtitle?: ReactNode
+  /**
+   * When provided, renders a reset link that clears the active search/filters.
+   * Omit it for the "nothing exists yet" case (no filters to clear).
+   */
+  onClear?: () => void
+  clearLabel?: ReactNode
+}
+
+/**
+ * Empty state for a filtered or searched list that matched nothing. Wraps
+ * {@link StageEmptyState} with the shared "clear" reset affordance so every
+ * stage's "no results" view looks and behaves identically.
+ */
+export function FilteredEmptyState({
+  icon,
+  color,
+  title,
+  subtitle,
+  onClear,
+  clearLabel,
+}: FilteredEmptyStateProps) {
+  return (
+    <StageEmptyState
+      icon={icon}
+      color={color}
+      title={title}
+      subtitle={subtitle}
+      cta={
+        onClear ? (
+          <button
+            type="button"
+            onClick={onClear}
+            className="text-xs font-medium text-muted-foreground hover:text-foreground hover:underline transition-colors cursor-pointer"
+          >
+            {clearLabel ?? <Trans>Clear filters</Trans>}
+          </button>
+        ) : undefined
+      }
+    />
+  )
+}

--- a/apps/studio/src/components/pipeline/stages/captions/CaptionsView.tsx
+++ b/apps/studio/src/components/pipeline/stages/captions/CaptionsView.tsx
@@ -9,11 +9,13 @@ import { useApiKey } from "@/hooks/use-api-key"
 import { StageRunCard } from "../../components/StageRunCard"
 import { StageContentGuard } from "../../components/StageContentGuard"
 import { StageEmptyState } from "../../components/StageEmptyState"
+import { FilteredEmptyState } from "../../components/FilteredEmptyState"
 import { useSectionNav } from "@/routes/books.$label"
 import { useLingui } from "@lingui/react/macro"
 import { CaptionsHintBanner } from "./components/CaptionsHintBanner"
 import { PageCaptions } from "./components/PageCaptions"
 import { PageJumper } from "./components/PageJumper"
+import { matchesDecorativeFilter, matchesSearch } from "./lib/utils"
 import type { DecorativeFilter, PageJumperEntry } from "./lib/types"
 
 const TOOLBAR_HEIGHT = 64
@@ -91,6 +93,23 @@ export function CaptionsView({ bookLabel, selectedPageId, onSelectPage }: { book
     }
     return { total, captioned, decorative }
   }, [pageDetailQueries])
+
+  // Total captions surviving the active decorative filter + search across every
+  // displayed page. Drives the gallery-level "no results" state so filtering
+  // down to nothing shows a single empty state instead of a blank gallery.
+  const visibleCaptionTotal = useMemo(() => {
+    let n = 0
+    for (const q of pageDetailQueries) {
+      for (const c of q.data?.imageCaptioning?.captions ?? []) {
+        if (matchesDecorativeFilter(c, decorativeFilter) && matchesSearch(c, searchQuery)) n += 1
+      }
+    }
+    return n
+  }, [pageDetailQueries, decorativeFilter, searchQuery])
+  const captionDetailsLoading = pageDetailQueries.some((q) => q.isLoading)
+  const filtersActive = decorativeFilter !== "all" || searchQuery.trim().length > 0
+  const showFilterEmpty =
+    hasCaptionData && filtersActive && !captionDetailsLoading && visibleCaptionTotal === 0
 
   const pageJumperEntries: PageJumperEntry[] = useMemo(
     () =>
@@ -262,7 +281,7 @@ export function CaptionsView({ bookLabel, selectedPageId, onSelectPage }: { book
           }
         />
       ) : (
-    <div ref={scrollContainerRef} className="flex flex-1 flex-col overflow-y-auto">
+    <div ref={scrollContainerRef} className="flex flex-1 flex-col overflow-y-auto [scrollbar-gutter:stable]">
       <CaptionsHintBanner />
       <div
         className="sticky top-0 z-20 flex items-center gap-3 px-6 py-3 bg-background/95 backdrop-blur-md border-b border-border/60"
@@ -345,21 +364,38 @@ export function CaptionsView({ bookLabel, selectedPageId, onSelectPage }: { book
         </div>
       </div>
 
-      <div className="flex flex-col gap-8 px-4 pb-12 pt-3">
-        {displayPages.map((page) => (
-          <PageCaptions
-            key={page.pageId}
-            bookLabel={bookLabel}
-            pageId={page.pageId}
-            pageNumber={page.pageNumber}
-            textPreview={page.textPreview}
-            emptyState={singlePageEmptyState}
-            filterSectionIndex={page.pageId === selectedPageId ? filterSectionIndex : undefined}
-            decorativeFilter={decorativeFilter}
-            searchQuery={searchQuery}
-            toolbarHeight={TOOLBAR_HEIGHT}
+      <div className="flex flex-1 flex-col gap-8 px-4 pb-12 pt-3">
+        {showFilterEmpty ? (
+          <FilteredEmptyState
+            icon={ImageIcon}
+            color="teal"
+            title={
+              searchQuery.trim()
+                ? t`No captions match your search`
+                : t`No captions match these filters`
+            }
+            onClear={() => {
+              setDecorativeFilter("all")
+              setSearchQuery("")
+            }}
+            clearLabel={searchQuery.trim() ? t`Clear search` : t`Clear filters`}
           />
-        ))}
+        ) : (
+          displayPages.map((page) => (
+            <PageCaptions
+              key={page.pageId}
+              bookLabel={bookLabel}
+              pageId={page.pageId}
+              pageNumber={page.pageNumber}
+              textPreview={page.textPreview}
+              emptyState={singlePageEmptyState}
+              filterSectionIndex={page.pageId === selectedPageId ? filterSectionIndex : undefined}
+              decorativeFilter={decorativeFilter}
+              searchQuery={searchQuery}
+              toolbarHeight={TOOLBAR_HEIGHT}
+            />
+          ))
+        )}
       </div>
     </div>
       )}

--- a/apps/studio/src/components/pipeline/stages/glossary/GlossaryView.tsx
+++ b/apps/studio/src/components/pipeline/stages/glossary/GlossaryView.tsx
@@ -31,7 +31,7 @@ import { useBookRun } from "@/hooks/use-book-run"
 import { useApiKey } from "@/hooks/use-api-key"
 import { StageRunCard } from "../../components/StageRunCard"
 import { StageContentGuard } from "../../components/StageContentGuard"
-import { StageEmptyState } from "../../components/StageEmptyState"
+import { FilteredEmptyState } from "../../components/FilteredEmptyState"
 import { VersionPicker } from "../../components/VersionPicker"
 import { usePendingChanges } from "../../components/change-summary"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
@@ -279,7 +279,7 @@ export function GlossaryView({ bookLabel }: { bookLabel: string }) {
         </>
       }
     >
-      <div className="flex flex-1 flex-col overflow-y-auto">
+      <div className="flex flex-1 flex-col overflow-y-auto [scrollbar-gutter:stable]">
         <GlossaryHintBanner />
         <div
           className="sticky top-0 z-20 flex items-center gap-3 px-6 py-3 bg-background/95 backdrop-blur-md border-b border-border/60"
@@ -396,9 +396,9 @@ export function GlossaryView({ bookLabel }: { bookLabel: string }) {
           </div>
         </div>
 
-        <div className="flex flex-col gap-2.5 px-4 pb-12 pt-4">
+        <div className="flex flex-1 flex-col gap-2.5 px-4 pb-12 pt-4">
           {displayItems.length === 0 ? (
-            <StageEmptyState
+            <FilteredEmptyState
               icon={BookOpen}
               color="lime"
               title={
@@ -410,6 +410,16 @@ export function GlossaryView({ bookLabel }: { bookLabel: string }) {
                       ? t`No pruned terms`
                       : t`No terms to show`
               }
+              onClear={
+                searchQuery || manualOnly || filter !== "active"
+                  ? () => {
+                      setSearchQuery("")
+                      setManualOnly(false)
+                      setFilter("active")
+                    }
+                  : undefined
+              }
+              clearLabel={searchQuery ? t`Clear search` : t`Clear filters`}
             />
           ) : (
             displayItems.map((item) => (

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -3822,6 +3822,12 @@ msgstr "No captioned images yet. Run the image-captioning step first."
 msgid "No captions for this page"
 msgstr "No captions for this page"
 
+msgid "No captions match these filters"
+msgstr "No captions match these filters"
+
+msgid "No captions match your search"
+msgstr "No captions match your search"
+
 msgid "No changes flagged on this page"
 msgstr "No changes flagged on this page"
 

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -3822,6 +3822,12 @@ msgstr "Aún no hay imágenes con subtítulo. Ejecuta primero el paso de generac
 msgid "No captions for this page"
 msgstr "Sin leyendas para esta página"
 
+msgid "No captions match these filters"
+msgstr "No hay leyendas que coincidan con estos filtros"
+
+msgid "No captions match your search"
+msgstr "No hay leyendas que coincidan con tu búsqueda"
+
 msgid "No changes flagged on this page"
 msgstr "No changes flagged on this page"
 

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -3824,6 +3824,12 @@ msgstr "Aucune image légendée pour le moment. Exécutez d'abord l'étape de l�
 msgid "No captions for this page"
 msgstr "Aucune légende pour cette page"
 
+msgid "No captions match these filters"
+msgstr "Aucune légende ne correspond à ces filtres"
+
+msgid "No captions match your search"
+msgstr "Aucune légende ne correspond à votre recherche"
+
 msgid "No changes flagged on this page"
 msgstr "Aucune modification signalée sur cette page"
 

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -3822,6 +3822,12 @@ msgstr "Ainda não há imagens com legenda. Execute primeiro a etapa de geraçã
 msgid "No captions for this page"
 msgstr "Sem legendas para esta página"
 
+msgid "No captions match these filters"
+msgstr "Nenhuma legenda corresponde a esses filtros"
+
+msgid "No captions match your search"
+msgstr "Nenhuma legenda corresponde à sua pesquisa"
+
 msgid "No changes flagged on this page"
 msgstr "No changes flagged on this page"
 

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -3823,6 +3823,12 @@ msgstr "Nuk ka ende imazhe me tituj. Ekzekuto fillimisht hapin e titullimit të 
 msgid "No captions for this page"
 msgstr "Nuk ka tituj për këtë faqe"
 
+msgid "No captions match these filters"
+msgstr "Asnjë titull nuk përputhet me këta filtra"
+
+msgid "No captions match your search"
+msgstr "Asnjë titull nuk përputhet me kërkimin tuaj"
+
 msgid "No changes flagged on this page"
 msgstr "Nuk janë sinjalizuar ndryshime në këtë faqe"
 


### PR DESCRIPTION
## Summary

Adds a shared **\`FilteredEmptyState\`** component and fixes the missing/awkward "no results" view on the captions and glossary stages.

## Changes

- **New shared component** \`FilteredEmptyState\` — wraps \`StageEmptyState\` with a consistent **Clear search / Clear filters** reset CTA, so every stage's "no results" view looks and behaves the same.
- **Glossary** — swapped its inline empty state for \`FilteredEmptyState\`; same search/manual-only/pruned/default titles, now with a clear action (shown only when a filter is actually active).
- **Captions** — previously, filtering (Decorative/Captioned + search) down to zero matches left the gallery **blank**. Now it computes the total captions surviving the active filter + search across all displayed pages and shows a single gallery-level empty state with a clear action. The toolbar stays visible so filters remain adjustable.
- **Layout** — made the list content containers \`flex-1\` so the empty state **centers** in the space below the toolbar instead of hugging the top, and added \`scrollbar-gutter: stable\` so toggling between a scrollable list and the empty state no longer shifts the layout sideways.

## Verification

- \`pnpm typecheck\` → clean (against current \`develop\`)
- \`pnpm --filter @adt/studio lint\` → 0 errors

## Note

New user-visible strings are wrapped in Lingui macros but **not yet extracted/translated** — \`pnpm --filter @adt/studio extract\` + filling the \`.po\` catalogs is still needed before merge (CI i18n job will flag it).