### PR TITLE
fix(api): rebuild text-catalog on every translate run

### DIFF
--- a/apps/api/src/routes/text-catalog.test.ts
+++ b/apps/api/src/routes/text-catalog.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { createBookStorage } from "@adt/storage"
+import { createTextCatalogRoutes } from "./text-catalog.js"
+
+let tmpDir: string
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "adt-text-catalog-route-"))
+})
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+})
+
+/** Book with an extracted page AND rendered HTML — buildTextCatalog yields entries. */
+function seedRenderedBook(label: string): void {
+  const storage = createBookStorage(label, tmpDir)
+  try {
+    storage.putExtractedPage({
+      pageId: "pg001",
+      pageNumber: 1,
+      text: "Page text",
+      pageImage: {
+        imageId: "pg001_page",
+        buffer: Buffer.from("fake-page-image"),
+        format: "png",
+        hash: "hash-page",
+        width: 800,
+        height: 600,
+      },
+      images: [],
+    })
+    storage.putNodeData("web-rendering", "pg001", {
+      sections: [
+        {
+          sectionIndex: 0,
+          sectionType: "content",
+          reasoning: "",
+          html: '<p data-id="pg001_t001">Hello world</p>',
+        },
+      ],
+    })
+  } finally {
+    storage.close()
+  }
+}
+
+/** Book extracted but not yet rendered (Storyboard not run) — buildTextCatalog yields nothing. */
+function seedUnrenderedBook(label: string): void {
+  const storage = createBookStorage(label, tmpDir)
+  try {
+    storage.putExtractedPage({
+      pageId: "pg001",
+      pageNumber: 1,
+      text: "Page text",
+      pageImage: {
+        imageId: "pg001_page",
+        buffer: Buffer.from("fake-page-image"),
+        format: "png",
+        hash: "hash-page",
+        width: 800,
+        height: 600,
+      },
+      images: [],
+    })
+  } finally {
+    storage.close()
+  }
+}
+
+describe("GET /books/:label/text-catalog lazy build", () => {
+  it("builds and persists a non-empty catalog on demand", async () => {
+    seedRenderedBook("rendered")
+    const app = createTextCatalogRoutes(tmpDir)
+    const res = await app.request("/books/rendered/text-catalog")
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.entries.length).toBeGreaterThan(0)
+
+    // Persisted so downstream consumers (translate, speech, packaging) can read it.
+    const verify = createBookStorage("rendered", tmpDir)
+    try {
+      expect(verify.getLatestNodeData("text-catalog", "book")).toBeTruthy()
+    } finally {
+      verify.close()
+    }
+  })
+
+  it("does not persist an empty catalog (book opened before Storyboard ran)", async () => {
+    seedUnrenderedBook("not-rendered")
+    const app = createTextCatalogRoutes(tmpDir)
+    const res = await app.request("/books/not-rendered/text-catalog")
+    expect(res.status).toBe(200)
+    expect(await res.json()).toBeNull()
+
+    // The empty catalog must NOT be written — a persisted empty node would
+    // poison Translate (it only rebuilds when the node is absent).
+    const verify = createBookStorage("not-rendered", tmpDir)
+    try {
+      expect(verify.getLatestNodeData("text-catalog", "book")).toBeFalsy()
+    } finally {
+      verify.close()
+    }
+  })
+
+  it("returns 404 for a missing book", async () => {
+    const app = createTextCatalogRoutes(tmpDir)
+    const res = await app.request("/books/ghost/text-catalog")
+    expect(res.status).toBe(404)
+  })
+})

--- a/apps/api/src/routes/text-catalog.ts
+++ b/apps/api/src/routes/text-catalog.ts
@@ -31,6 +31,13 @@ export function createTextCatalogRoutes(booksDir: string): Hono {
     // If no catalog exists yet (translate stage hasn't run), build one on demand
     // from existing pipeline outputs so consumers like the glossary autofill have
     // source-language text available before translation.
+    //
+    // Only persist a *non-empty* result. Opening the book before Storyboard has
+    // rendered any pages builds an empty catalog; persisting that empty node
+    // poisons every downstream reader (translate, speech, packaging) — translate
+    // historically only rebuilt when the node was absent, so an empty persisted
+    // catalog silently skipped all translation until the Easy Read stage
+    // rebuilt it. Leaving the node absent keeps the rebuild paths intact.
     {
       const storage = createBookStorage(safeLabel, booksDir)
       try {
@@ -38,7 +45,9 @@ export function createTextCatalogRoutes(booksDir: string): Hono {
         if (!existing) {
           const pages = storage.getPages()
           const catalog = await buildTextCatalog(storage, pages)
-          storage.putNodeData("text-catalog", "book", catalog)
+          if (catalog.entries.length > 0) {
+            storage.putNodeData("text-catalog", "book", catalog)
+          }
         }
       } finally {
         storage.close()

--- a/apps/api/src/services/stage-runner.test.ts
+++ b/apps/api/src/services/stage-runner.test.ts
@@ -740,6 +740,122 @@ output_languages:
       verify.close()
     }
   })
+
+  // Regression: a present-but-empty text-catalog node (e.g. persisted by
+  // GET /text-catalog when the book was opened before Storyboard rendered)
+  // previously stuck — Translate only rebuilt when the node was absent, so the
+  // empty catalog silently skipped all translation. Translate must rebuild it.
+  it("rebuilds a stale empty text-catalog instead of skipping translation", async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "stage-runner-translate-emptycatalog-"))
+    const booksDir = path.join(tmpDir, "books")
+    const promptsDir = path.join(tmpDir, "prompts")
+    const configPath = path.join(tmpDir, "config.yaml")
+    fs.mkdirSync(promptsDir, { recursive: true })
+    fs.writeFileSync(
+      configPath,
+      `role_types:
+  section_text: Main body text
+structure_types:
+  paragraph: Paragraph
+output_languages:
+  - fr
+`
+    )
+
+    // Seed a book with rendered text AND a stale, empty text-catalog node.
+    const seed = createBookStorage("translate-empty-catalog", booksDir)
+    try {
+      seed.putExtractedPage({
+        pageId: "pg001",
+        pageNumber: 1,
+        text: "Page text",
+        pageImage: {
+          imageId: "pg001_page",
+          buffer: Buffer.from("fake-page-image"),
+          format: "png",
+          hash: "hash-page",
+          width: 800,
+          height: 600,
+        },
+        images: [],
+      })
+      seed.putNodeData("web-rendering", "pg001", {
+        sections: [
+          {
+            sectionIndex: 0,
+            sectionType: "content",
+            reasoning: "",
+            html: '<p data-id="pg001_t001">Hello world</p>',
+          },
+        ],
+      })
+      // The poison: a persisted catalog with zero entries.
+      seed.putNodeData("text-catalog", "book", {
+        entries: [],
+        generatedAt: "2026-01-01T00:00:00.000Z",
+      })
+      const seeded = seed.getLatestNodeData("text-catalog", "book")?.data as
+        | { entries?: unknown[] }
+        | undefined
+      expect(seeded?.entries?.length).toBe(0)
+    } finally {
+      seed.close()
+    }
+
+    easyReadGenerateObjectMock.mockImplementation(async (options: {
+      context?: { texts?: Array<{ text: string }> }
+      validate?: (raw: unknown, context: unknown) => { valid: boolean; errors: string[] }
+    }) => {
+      const texts = options.context?.texts ?? []
+      const object = { translations: texts.map((t) => `FR: ${t.text}`) }
+      const validation = options.validate?.(object, options.context)
+      if (validation && !validation.valid) {
+        throw new Error(validation.errors.join("\n"))
+      }
+      return { object, usage: { inputTokens: 1, outputTokens: 1 } }
+    })
+
+    const events: ProgressEvent[] = []
+    const runner = createStageRunner()
+    await runner.run(
+      "translate-empty-catalog",
+      {
+        booksDir,
+        apiKey: "sk-test",
+        promptsDir,
+        configPath,
+        fromStage: "translate",
+        toStage: "translate",
+      },
+      { emit: (event) => events.push(event) }
+    )
+
+    // Translation must run, not skip on the stale empty catalog.
+    expect(
+      events.some(
+        (event) => event.type === "step-skip" && event.step === "catalog-translation"
+      )
+    ).toBe(false)
+    expect(
+      events.some(
+        (event) => event.type === "step-start" && event.step === "catalog-translation"
+      )
+    ).toBe(true)
+
+    const verify = createBookStorage("translate-empty-catalog", booksDir)
+    try {
+      const catalog = verify.getLatestNodeData("text-catalog", "book")?.data as
+        | { entries?: unknown[] }
+        | undefined
+      expect(catalog?.entries?.length).toBeGreaterThan(0)
+
+      const frTranslation = verify.getLatestNodeData("text-catalog-translation", "fr")
+        ?.data as { entries?: unknown[] } | undefined
+      expect(frTranslation?.entries?.length).toBeGreaterThan(0)
+    } finally {
+      verify.close()
+    }
+  })
 })
 
 describe("createStageRunner speech Gemini partial failures", () => {

--- a/apps/api/src/services/stage-runner.ts
+++ b/apps/api/src/services/stage-runner.ts
@@ -124,6 +124,24 @@ function toErrorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err)
 }
 
+/**
+ * Compare two text catalogs by content (entry id + text, in order). Used to
+ * skip writing a new node version when a rebuild produced identical output.
+ */
+function textCatalogsEqual(
+  a: TextCatalogOutput | undefined,
+  b: TextCatalogOutput
+): boolean {
+  if (!a) return false
+  if (a.entries.length !== b.entries.length) return false
+  for (let i = 0; i < a.entries.length; i++) {
+    if (a.entries[i].id !== b.entries[i].id || a.entries[i].text !== b.entries[i].text) {
+      return false
+    }
+  }
+  return true
+}
+
 function isGeminiTtsRateLimitMessage(message: string): boolean {
   return /\(429\)|quota exceeded|rate limit|too many requests/i.test(message)
 }
@@ -1736,24 +1754,33 @@ async function runTranslateStep(
       )
     )
 
-    const catalogRow = storage.getLatestNodeData("text-catalog", "book")
-    let catalog = catalogRow?.data as TextCatalogOutput | undefined
-    // The text-catalog is normally produced by the easy-read stage. A translate
-    // run can start here without it — a standalone translate run (fromStage
-    // "translate") never runs easy-read, and caption/page edits clear the
-    // catalog. Rebuild it so translation isn't silently skipped.
-    if (!catalog) {
-      const pages = storage.getPages()
-      catalog = await buildTextCatalog(storage, pages)
+    // The text-catalog is a derived artifact (a pure read of storyboard +
+    // captions + glossary + quizzes, no LLM). It's normally produced by the
+    // easy-read stage, but Translate must guarantee a *fresh* catalog rather
+    // than trust whatever node happens to exist:
+    //   - a standalone translate run (fromStage "translate") never runs
+    //     easy-read, and
+    //   - GET /text-catalog lazily persists a catalog the moment the book is
+    //     viewed; opened before Storyboard renders, that persisted catalog is
+    //     empty and previously stuck here (we only rebuilt when the node was
+    //     entirely absent), silently skipping all translation.
+    // Always rebuild from current data; persist a new version only when the
+    // content changed, to avoid version churn on repeated re-runs.
+    const pages = storage.getPages()
+    const catalog = await buildTextCatalog(storage, pages)
+    const existingCatalog = storage.getLatestNodeData("text-catalog", "book")?.data as
+      | TextCatalogOutput
+      | undefined
+    if (!textCatalogsEqual(existingCatalog, catalog)) {
       storage.putNodeData("text-catalog", "book", catalog)
       console.log(
-        `[stage-run] ${label}: rebuilt missing text catalog (${catalog.entries.length} entries)`
+        `[stage-run] ${label}: rebuilt text catalog (${catalog.entries.length} entries)`
       )
     }
     const easyReadRow = storage.getLatestNodeData("easy-read", "book")
     const easyRead = easyReadRow?.data as EasyReadOutput | undefined
     const easyReadEntries = easyRead ? flattenEasyReadEntries(easyRead) : []
-    const translationEntries = [...(catalog?.entries ?? []), ...easyReadEntries]
+    const translationEntries = [...catalog.entries, ...easyReadEntries]
 
     // ── Step 2: Translate catalog to target languages ────────────────
     const targetLanguages = getTargetLanguages(outputLanguages, language)


### PR DESCRIPTION
## Problem

Translating a book only worked *after* running Easy Read first. The Translate stage rebuilt the text-catalog only when the node was entirely absent (`if (!catalog)`), but `GET /text-catalog` lazily **persists** a catalog the moment a book is viewed (via the sidebar) — and if the book was opened before Storyboard rendered, that persisted catalog is empty. The empty-but-present node then stuck, so `catalog-translation` skipped (both steps showed as crossed-out) and translation only ran once the Easy Read stage rebuilt the catalog.

## Fix

`runTranslateStep` now always rebuilds the text-catalog from current data (a pure, no-LLM read), writing a new version only when the content changed to avoid version churn. `GET /text-catalog` no longer persists an empty catalog, removing the root poison that also affected speech and packaging. Added regression tests for the present-but-empty Translate path and the GET route's lazy-build behaviour; the full `@adt/api` suite (283 tests) passes.