### PR TITLE
fix: MathML rendering, Albanian word timestamps, and Easy Read toggle

### DIFF
--- a/apps/adt-runtime/src/features/language/components/LanguageDockContent.tsx
+++ b/apps/adt-runtime/src/features/language/components/LanguageDockContent.tsx
@@ -1,4 +1,4 @@
-import { useAtom } from "jotai"
+import { useAtom, useAtomValue } from "jotai"
 import { useMemo, useState } from "react"
 import { currentLanguageAtom } from "@/features/language/state/language.atoms"
 import { useAvailableLanguages } from "@/features/language/hooks/useAvailableLanguages"
@@ -6,6 +6,10 @@ import { useTranslation } from "@/features/language/hooks/useTranslation"
 import { cn } from "@/shared/lib/utils"
 import { ScrollArea } from "@/shared/ui/scroll-area"
 import { DockContent } from "@/features/dock/components/DockLayout"
+import { ToggleRow } from "@/features/settings/components/ToggleRow"
+import { appConfigAtom } from "@/shared/state/config.atoms"
+import { easyReadModeAtom } from "@/shared/state/ui.atoms"
+import { trackToggleEvent } from "@/shared/lib/analytics"
 
 interface LanguageContentProps {
   onSelect?: () => void
@@ -16,6 +20,8 @@ export function LanguageContent({ onSelect }: LanguageContentProps) {
   const { languages, names } = useAvailableLanguages()
   const { t } = useTranslation()
   const [query, setQuery] = useState("")
+  const features = useAtomValue(appConfigAtom).features
+  const [easyRead, setEasyRead] = useAtom(easyReadModeAtom)
 
   const filtered = useMemo(() => {
     if (!query.trim()) return languages
@@ -68,6 +74,19 @@ export function LanguageContent({ onSelect }: LanguageContentProps) {
           ) : null}
         </ul>
       </ScrollArea>
+      {features.easyRead ? (
+        <div className="px-2.5">
+          <ToggleRow
+            label={t("easy-read-label") || "Easy Read"}
+            checked={easyRead}
+            onChange={(next) => {
+              trackToggleEvent("EasyRead", next)
+              setEasyRead(next)
+            }}
+            borderTop
+          />
+        </div>
+      ) : null}
     </DockContent>
   )
 }

--- a/apps/adt-runtime/src/features/language/runtime/text-formatting.test.ts
+++ b/apps/adt-runtime/src/features/language/runtime/text-formatting.test.ts
@@ -31,4 +31,22 @@ describe("Easy Read text formatting", () => {
     expect(element?.querySelector("strong")).toBeNull()
     expect(element?.innerHTML).toBe("Texto &lt;strong&gt;simple&lt;/strong&gt;")
   })
+
+  it("renders Temml-baked <math> while keeping surrounding prose plain", () => {
+    document.body.innerHTML = "<p></p>"
+    const element = document.querySelector("p")
+    expect(element).not.toBeNull()
+
+    applyPlainTextWithLineBreaks(
+      element as HTMLElement,
+      'Dong Xu<math xmlns="http://www.w3.org/1998/Math/MathML"><msup><mrow></mrow><mn>1,2</mn></msup></math> <strong>x</strong>',
+    )
+
+    // Math is rendered as a real element, not shown as literal tags.
+    expect(element?.querySelector("math")).not.toBeNull()
+    expect(element?.textContent).toContain("Dong Xu")
+    // Non-math markup is still escaped (LLM output can't inject elements).
+    expect(element?.querySelector("strong")).toBeNull()
+    expect(element?.innerHTML).toContain("&lt;strong&gt;x&lt;/strong&gt;")
+  })
 })

--- a/apps/adt-runtime/src/features/language/runtime/text-formatting.ts
+++ b/apps/adt-runtime/src/features/language/runtime/text-formatting.ts
@@ -1,11 +1,38 @@
+const MATH_BLOCK_RE = /<math[\s\S]*?<\/math>/gi
+
 export function applyPlainTextWithLineBreaks(element: HTMLElement, text: string): void {
   const fragment = document.createDocumentFragment()
   const lines = String(text ?? "").split(/\r?\n/)
 
   lines.forEach((line, index) => {
     if (index > 0) fragment.appendChild(document.createElement("br"))
-    fragment.appendChild(document.createTextNode(line))
+    appendLineWithMath(fragment, line)
   })
 
   element.replaceChildren(fragment)
+}
+
+/**
+ * Append one line of Easy Read text. The text is rendered as plain text so
+ * LLM-generated content can't inject arbitrary markup (e.g. a stray
+ * `<strong>` stays literal). The one exception is Temml-rendered
+ * `<math>…</math>` that the packaging step bakes into the catalog entry via
+ * `convertLatexString` — that must render, so math blocks are parsed into real
+ * MathML nodes while everything around them stays escaped text nodes.
+ */
+function appendLineWithMath(parent: DocumentFragment, line: string): void {
+  let lastIndex = 0
+  for (const match of line.matchAll(MATH_BLOCK_RE)) {
+    const start = match.index ?? 0
+    if (start > lastIndex) {
+      parent.appendChild(document.createTextNode(line.slice(lastIndex, start)))
+    }
+    const template = document.createElement("template")
+    template.innerHTML = match[0]
+    parent.appendChild(template.content)
+    lastIndex = start + match[0].length
+  }
+  if (lastIndex < line.length) {
+    parent.appendChild(document.createTextNode(line.slice(lastIndex)))
+  }
 }

--- a/apps/adt-runtime/src/features/settings/components/SettingsTab.tsx
+++ b/apps/adt-runtime/src/features/settings/components/SettingsTab.tsx
@@ -32,7 +32,7 @@ export function SettingsTab() {
   const iconSizeLocked = isSettingLocked(config, "iconSize");
   const reduceMotionLocked = isSettingLocked(config, "reduceMotion");
   const showAccessibilitySection =
-    !themeLocked || !iconSizeLocked || !reduceMotionLocked || !!features.easyRead;
+    !themeLocked || !iconSizeLocked || !reduceMotionLocked;
   const [easyRead, setEasyRead] = useAtom(easyReadModeAtom);
   const [stateMode, setStateMode] = useAtom(stateModeAtom);
   const [readAloud, setReadAloud] = useAtom(readAloudModeAtom);
@@ -49,50 +49,61 @@ export function SettingsTab() {
       setter(next);
     };
 
-  const showReadingSection = features.readAloud;
+  const showReadingSection = features.readAloud || !!features.easyRead;
   const showTtsSubsettings = readAloud;
 
   return (
     <div className="flex flex-col gap-1 px-4 pb-6">
       {showReadingSection ? (
         <SettingsSection title={t("settings-section-reading") || "Reading"}>
-          <ToggleRow
-            label={t("tts-label") || "Text to speech"}
-            checked={readAloud}
-            onChange={wrap("ReadAloud", setReadAloud)}
-          />
-          {showTtsSubsettings ? (
+          {features.easyRead ? (
+            <ToggleRow
+              label={t("easy-read-label") || "Easy Read"}
+              checked={easyRead}
+              onChange={wrap("EasyRead", setEasyRead)}
+            />
+          ) : null}
+          {features.readAloud ? (
             <>
-              {features.autoplay ? (
-                <ToggleRow
-                  label={t("autoplay-label") || "Autoplay"}
-                  checked={autoplay}
-                  onChange={wrap("Autoplay", setAutoplay)}
-                />
-              ) : null}
-              {features.describeImages ? (
-                <ToggleRow
-                  label={t("describe-images-label") || "Describe images"}
-                  checked={describeImages}
-                  onChange={wrap("DescribeImages", setDescribeImages)}
-                />
-              ) : null}
-              <SegmentedRow<"word" | "sentence">
-                label={t("highlight-mode-label") || "Highlight"}
-                value={wordHighlight ? "word" : "sentence"}
-                onChange={(v) => {
-                  const next = v === "word";
-                  trackToggleEvent("WordHighlight", next);
-                  setWordHighlight(next);
-                }}
-                options={[
-                  { value: "word", label: t("highlight-word") || "Word" },
-                  {
-                    value: "sentence",
-                    label: t("highlight-sentence") || "Sentence",
-                  },
-                ]}
+              <ToggleRow
+                label={t("tts-label") || "Text to speech"}
+                checked={readAloud}
+                onChange={wrap("ReadAloud", setReadAloud)}
               />
+              {showTtsSubsettings ? (
+                <>
+                  {features.autoplay ? (
+                    <ToggleRow
+                      label={t("autoplay-label") || "Autoplay"}
+                      checked={autoplay}
+                      onChange={wrap("Autoplay", setAutoplay)}
+                    />
+                  ) : null}
+                  {features.describeImages ? (
+                    <ToggleRow
+                      label={t("describe-images-label") || "Describe images"}
+                      checked={describeImages}
+                      onChange={wrap("DescribeImages", setDescribeImages)}
+                    />
+                  ) : null}
+                  <SegmentedRow<"word" | "sentence">
+                    label={t("highlight-mode-label") || "Highlight"}
+                    value={wordHighlight ? "word" : "sentence"}
+                    onChange={(v) => {
+                      const next = v === "word";
+                      trackToggleEvent("WordHighlight", next);
+                      setWordHighlight(next);
+                    }}
+                    options={[
+                      { value: "word", label: t("highlight-word") || "Word" },
+                      {
+                        value: "sentence",
+                        label: t("highlight-sentence") || "Sentence",
+                      },
+                    ]}
+                  />
+                </>
+              ) : null}
             </>
           ) : null}
         </SettingsSection>
@@ -108,13 +119,6 @@ export function SettingsTab() {
         <SettingsSection
           title={t("settings-section-accessibility") || "Accessibility"}
         >
-          {features.easyRead ? (
-            <ToggleRow
-              label={t("easy-read-label") || "Easy Read"}
-              checked={easyRead}
-              onChange={wrap("EasyRead", setEasyRead)}
-            />
-          ) : null}
           {!themeLocked ? (
             <SegmentedRow<Theme>
               label={t("theme-label") || "Theme"}

--- a/apps/adt-runtime/src/shared/lib/fl-segments.test.ts
+++ b/apps/adt-runtime/src/shared/lib/fl-segments.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest"
+
+import { rebuildSegmentedInnerHtml } from "./fl-segments"
+
+const MATH =
+  '<math xmlns="http://www.w3.org/1998/Math/MathML"><msup><mrow></mrow><mn>1,2</mn></msup></math>'
+
+describe("rebuildSegmentedInnerHtml", () => {
+  it("escapes prose so swapped text cannot inject markup", () => {
+    const segments = JSON.stringify([{ text: "a < b & c" }])
+    expect(rebuildSegmentedInnerHtml(segments, "x <strong>y</strong>")).toBe(
+      "x &lt;strong&gt;y&lt;/strong&gt;",
+    )
+  })
+
+  it("passes <br> through unescaped", () => {
+    // A non-matching source forces the single-run fallback, where the swapped
+    // text (carrying the <br>) is rendered directly.
+    const segments = JSON.stringify([{ text: "source" }])
+    expect(rebuildSegmentedInnerHtml(segments, "line one<br>line two")).toBe(
+      "line one<br>line two",
+    )
+  })
+
+  it("passes Temml <math> blocks through unescaped while escaping prose", () => {
+    // sourceConcat won't match the math-bearing translatedHtml, so this hits
+    // the single-run fallback — the exact path that surfaced literal MathML
+    // tags on fixed-layout title pages.
+    const segments = JSON.stringify([{ text: "Dong Xu1,2" }])
+    const result = rebuildSegmentedInnerHtml(segments, `Dong Xu${MATH}`)
+
+    expect(result).toContain(MATH)
+    expect(result).not.toContain("&lt;math&gt;")
+    expect(result.startsWith("Dong Xu<math")).toBe(true)
+  })
+
+  it("preserves per-segment styling around the math run", () => {
+    const segments = JSON.stringify([
+      { text: "Dong Xu1,2", style: { color: "rgb(0, 0, 0)" } },
+    ])
+    const result = rebuildSegmentedInnerHtml(segments, `Dong Xu${MATH}`)
+
+    expect(result).toBe(`<span style="color:rgb(0, 0, 0)">Dong Xu${MATH}</span>`)
+  })
+})

--- a/apps/adt-runtime/src/shared/lib/fl-segments.ts
+++ b/apps/adt-runtime/src/shared/lib/fl-segments.ts
@@ -59,8 +59,11 @@ function escapeHtml(s: string): string {
  * back to a single run carrying the first segment's style — full per-run
  * styling preservation across translation is a known follow-up.
  *
- * `<br>` tags inside the swapped text are passed through unescaped so
- * line breaks survive; everything else is HTML-escaped.
+ * `<br>` tags and Temml-rendered `<math>…</math>` blocks inside the swapped
+ * text are passed through unescaped (line breaks survive and math renders);
+ * everything else is HTML-escaped. The catalog bakes math into these entries
+ * via `convertLatexString`, so without the `<math>` pass-through the tags
+ * would surface as literal text in fixed-layout pages.
  */
 export function rebuildSegmentedInnerHtml(
   segmentsAttr: string | null,
@@ -80,8 +83,12 @@ export function rebuildSegmentedInnerHtml(
   return runs
     .map((seg) => {
       const html = seg.text
-        .split(/(<br\s*\/?>)/i)
-        .map((part) => (/^<br\s*\/?>$/i.test(part) ? part : escapeHtml(part)))
+        .split(/(<br\s*\/?>|<math[\s\S]*?<\/math>)/i)
+        .map((part) =>
+          /^<br\s*\/?>$/i.test(part) || /^<math[\s\S]*?<\/math>$/i.test(part)
+            ? part
+            : escapeHtml(part),
+        )
         .join("")
       const styleStr = styleToInline(seg.style)
       return styleStr ? `<span style="${styleStr}">${html}</span>` : html

--- a/config/speech_instructions.yaml
+++ b/config/speech_instructions.yaml
@@ -1,4 +1,4 @@
-default: Speak in a cheerful and positive tone.
+default: Speak in natural Albanian as spoken in Kosovo. Use a clear, authentic Kosovo Albanian pronunciation with a warm, conversational tone. Sound like an educated native speaker from Kosovo. Maintain natural rhythm, intonation, and vocabulary commonly heard in everyday speech in Kosovo. Avoid sounding overly formal, theatrical, or robotic. Speak at a moderate pace with excellent clarity.
 en: Speak in a cheerful and positive tone.
 en-tz: |
   Speak it in a Tanzanian English accent. Use the pronunciation and

--- a/packages/llm/src/__tests__/speech.test.ts
+++ b/packages/llm/src/__tests__/speech.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { createGeminiTTSSynthesizer } from "../speech.js"
+import { createGeminiTTSSynthesizer, transcribeWithWhisper } from "../speech.js"
 
 describe("createGeminiTTSSynthesizer", () => {
   const fetchMock = vi.fn<typeof fetch>()
@@ -227,5 +227,82 @@ describe("createGeminiTTSSynthesizer", () => {
     ).rejects.toThrow(
       /response did not include audio data\. Response summary: text="The selected voice is unavailable for this request\."/
     )
+  })
+})
+
+describe("transcribeWithWhisper", () => {
+  const fetchMock = vi.fn<typeof fetch>()
+
+  beforeEach(() => {
+    fetchMock.mockReset()
+    vi.stubGlobal("fetch", fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  const transcriptionResponse = () =>
+    new Response(
+      JSON.stringify({
+        text: "vera",
+        duration: 0.9,
+        words: [{ word: "vera", start: 0, end: 0.9 }],
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    )
+
+  it("retries without the language hint when the API rejects it with a 400", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response("Invalid language 'sq'. Supported languages are: ...", {
+          status: 400,
+        }),
+      )
+      .mockResolvedValueOnce(transcriptionResponse())
+
+    const result = await transcribeWithWhisper(
+      Buffer.from([1, 2, 3, 4]),
+      "pg016017_p007.mp3",
+      "sk-test",
+      "sq",
+      "VERA",
+    )
+
+    expect(result.words).toEqual([{ word: "vera", start: 0, end: 0.9 }])
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+
+    // First attempt carries the language hint; the retry drops it.
+    const firstBody = fetchMock.mock.calls[0]?.[1]?.body as FormData
+    const retryBody = fetchMock.mock.calls[1]?.[1]?.body as FormData
+    expect(firstBody.get("language")).toBe("sq")
+    expect(retryBody.has("language")).toBe(false)
+    // The prompt is preserved across the retry.
+    expect(retryBody.get("prompt")).toBe("VERA")
+  })
+
+  it("does not retry (and surfaces the error) on a non-language failure", async () => {
+    fetchMock.mockResolvedValue(
+      new Response("incorrect api key provided", { status: 401 }),
+    )
+
+    await expect(
+      transcribeWithWhisper(Buffer.from([1]), "x.mp3", "sk-bad", "sq"),
+    ).rejects.toThrow(/Whisper transcription failed \(401\)/)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("succeeds on the first call without retrying when the language is accepted", async () => {
+    fetchMock.mockResolvedValue(transcriptionResponse())
+
+    const result = await transcribeWithWhisper(
+      Buffer.from([1, 2]),
+      "y.mp3",
+      "sk-test",
+      "en",
+    )
+
+    expect(result.duration).toBe(0.9)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/llm/src/speech.ts
+++ b/packages/llm/src/speech.ts
@@ -24,6 +24,12 @@ export interface WhisperTranscriptionResult {
 
 /**
  * Transcribe an audio file using OpenAI Whisper with word-level timestamps.
+ *
+ * The `language` parameter is only an accuracy hint, but OpenAI's hosted
+ * transcription API rejects ISO codes outside its supported set with a 400
+ * (e.g. Albanian "sq") even though the underlying model can transcribe them.
+ * When that happens we retry once without the hint so auto-detection takes
+ * over, rather than hard-failing every item in that language.
  */
 export async function transcribeWithWhisper(
   audioBuffer: Buffer,
@@ -38,24 +44,41 @@ export async function transcribeWithWhisper(
       : ext === "ogg" ? "audio/ogg"
         : "audio/mpeg"
 
-  const blob = new Blob([audioBuffer], { type: mimeType })
-  const form = new FormData()
-  form.append("file", blob, fileName)
-  form.append("model", "whisper-1")
-  form.append("response_format", "verbose_json")
-  form.append("timestamp_granularities[]", "word")
-  if (language) form.append("language", language)
-  if (prompt) form.append("prompt", prompt)
+  const postTranscription = (withLanguage: boolean): Promise<Response> => {
+    const blob = new Blob([audioBuffer], { type: mimeType })
+    const form = new FormData()
+    form.append("file", blob, fileName)
+    form.append("model", "whisper-1")
+    form.append("response_format", "verbose_json")
+    form.append("timestamp_granularities[]", "word")
+    if (withLanguage && language) form.append("language", language)
+    if (prompt) form.append("prompt", prompt)
 
-  const response = await fetch("https://api.openai.com/v1/audio/transcriptions", {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-    },
-    body: form,
-  })
+    return fetch("https://api.openai.com/v1/audio/transcriptions", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: form,
+    })
+  }
 
-  if (!response.ok) {
+  let response = await postTranscription(Boolean(language))
+
+  // A 400 while a language hint is set is almost always the hint being
+  // rejected (unsupported ISO code). Retry once without it before giving up;
+  // a genuine non-language 400 (e.g. bad audio) simply fails again and the
+  // real message is surfaced below.
+  if (!response.ok && response.status === 400 && language) {
+    const firstError = await response.text()
+    response = await postTranscription(false)
+    if (!response.ok) {
+      const message = await response.text()
+      throw new Error(
+        `Whisper transcription failed (${response.status}): ${message || firstError || response.statusText}`
+      )
+    }
+  } else if (!response.ok) {
     const message = await response.text()
     throw new Error(
       `Whisper transcription failed (${response.status}): ${message || response.statusText}`


### PR DESCRIPTION
Reader equations were showing literal `<math>` tags in fixed-layout pages and Easy Read mode because the runtime HTML-escaped Temml-rendered MathML when rebuilding `data-segments` paragraphs (`fl-segments.ts`) and Easy Read text (`text-formatting.ts`); both paths now pass `<math>…</math>` through unescaped while still escaping other markup. Word-by-word highlighting failed for every item in languages OpenAI's transcription API won't accept as a `language` hint (e.g. Albanian `sq`, which 400s), so `transcribeWithWhisper` now retries once without the hint and lets Whisper auto-detect. The Easy Read toggle moved from the Accessibility section to the Reading section of Settings and is now also surfaced in the language menu. The default TTS speech instruction is set to Kosovo Albanian. Added unit tests for the MathML pass-through (both paths) and the Whisper retry/no-retry behavior.