### PR TITLE
fix(api): defer stage job execution so run kickoff returns immediately

### DIFF
--- a/apps/api/src/services/stage-service.ts
+++ b/apps/api/src/services/stage-service.ts
@@ -211,7 +211,17 @@ export function createStageService(
       }
       state.active = job
 
-      executeJob(label, job, options).catch(() => {})
+      // Defer execution to the next macrotask so this call — and the HTTP
+      // response that triggered it — returns before the job's synchronous
+      // startup runs. A stage's setup (e.g. extract: reading the PDF off disk,
+      // parsing it via WASM, extracting the first page) runs synchronously up
+      // to its first await and would otherwise block the response for several
+      // seconds, stalling the client that just kicked off the run. `state.active`
+      // is already set, so getStatus() reflects "running" right away; the step
+      // run record is written once the deferred job actually starts.
+      setImmediate(() => {
+        executeJob(label, job, options).catch(() => {})
+      })
 
       return { status: "started", id }
     },


### PR DESCRIPTION
## Problem
When a book is created, the wizard auto-starts extraction and awaits `POST /books/:label/stages/run` before navigating to the book page — but `startStageRun` ran the job's synchronous startup (reading the PDF off disk, parsing it via WASM, extracting the first page) inline, blocking that response and the event loop for up to ~10s, so the landing page stalled before extraction appeared to start.

## Fix
Defer `executeJob` to the next macrotask with `setImmediate` so the kickoff response returns immediately; `state.active` is already set, so status reflects "running" right away and the step run record is written once the deferred job starts.

Verified: `apps/api` typecheck clean and all 89 stage/route tests pass.