### PR TITLE
feat(tts): steer Gemini accents via in-prompt instructions

### DIFF
--- a/apps/api/src/routes/tts.ts
+++ b/apps/api/src/routes/tts.ts
@@ -24,8 +24,10 @@ import {
 import {
   getBaseLanguage,
   loadBookConfig,
+  loadSpeechInstructions,
   loadVoicesConfig,
   normalizeLocale,
+  resolveInstructions,
   resolveProviderForLanguage,
   resolveSpeechFormat,
   resolveSpeechModel,
@@ -684,6 +686,7 @@ export function createTTSRoutes(booksDir: string, configPath?: string, taskServi
 
       const configDir = getConfigDir(configPath)
       const voiceMaps = loadVoicesConfig(configDir)
+      const instructionsMap = loadSpeechInstructions(configDir)
       const model = resolveSpeechModel(provider, providerConfigs, config.speech?.model)
       const format = resolveSpeechFormat(provider, config.speech?.format)
       const voice = resolveVoice(
@@ -715,7 +718,14 @@ export function createTTSRoutes(booksDir: string, configPath?: string, taskServi
           language: normalizedLanguage,
           model: options.targetModel,
           voice: options.targetVoice,
-          instructions: "",
+          // Gemini embeds these in the prompt text; OpenAI uses its instructions
+          // field. Azure has no instruction channel. Mirrors stage-runner.ts so the
+          // single-item cache key matches the batch path.
+          instructions:
+            options.targetProvider === "openai" ||
+            options.targetProvider === "gemini"
+              ? resolveInstructions(normalizedLanguage, instructionsMap)
+              : "",
           format,
           bookDir,
           cacheDir,

--- a/apps/api/src/services/stage-runner.ts
+++ b/apps/api/src/services/stage-runner.ts
@@ -2151,9 +2151,14 @@ async function runSpeechStep(
         const providerModel = resolveSpeechModel(provider, providerConfigs, speechModel)
         const outputFormat = resolveSpeechFormat(provider, config.speech?.format)
         const voice = resolveVoice(provider, lang, voiceMaps, config.speech?.voice)
-        const instructions = provider === "openai"
-          ? resolveInstructions(lang, instructionsMap)
-          : ""
+        // OpenAI consumes instructions via its `instructions` field; Gemini embeds
+        // them in the prompt text (it rejects systemInstruction). Both paths must
+        // resolve identically here and in the generation loop below so the cache key
+        // (computeSpeechCacheKey) stays in sync with canReuseSpeechEntry.
+        const instructions =
+          provider === "openai" || provider === "gemini"
+            ? resolveInstructions(lang, instructionsMap)
+            : ""
         const existingEntry = existingSpeechEntries.get(entry.id)
 
         if (
@@ -2216,9 +2221,12 @@ async function runSpeechStep(
         const providerModel = resolveSpeechModel(provider, providerConfigs, speechModel)
         const outputFormat = resolveSpeechFormat(provider, config.speech?.format)
         const voice = resolveVoice(provider, item.language, voiceMaps, config.speech?.voice)
-        const instructions = provider === "openai"
-          ? resolveInstructions(item.language, instructionsMap)
-          : ""
+        // Must mirror the reuse-check above: OpenAI + Gemini both receive resolved
+        // instructions (Gemini embeds them in the prompt text), Azure does not.
+        const instructions =
+          provider === "openai" || provider === "gemini"
+            ? resolveInstructions(item.language, instructionsMap)
+            : ""
         let attemptCount = 0
 
         console.log(`[stage-run] ${label}: TTS ${item.textId} → provider=${provider} voice=${voice} model=${providerModel} format=${outputFormat}`)

--- a/apps/studio/src/components/pipeline/components/ModelSelect.tsx
+++ b/apps/studio/src/components/pipeline/components/ModelSelect.tsx
@@ -288,6 +288,7 @@ export const GEMINI_TTS_MODELS: ModelGroup[] = [
   {
     provider: "gemini",
     models: [
+      "gemini-3.1-flash-tts-preview",
       "gemini-2.5-flash-preview-tts",
       "gemini-2.5-pro-preview-tts",
     ],

--- a/apps/studio/src/components/pipeline/stages/languages/LanguageView.tsx
+++ b/apps/studio/src/components/pipeline/stages/languages/LanguageView.tsx
@@ -40,6 +40,14 @@ import { usePendingChanges } from "../../components/change-summary"
 import { msg } from "@lingui/core/macro"
 import { useLingui } from "@lingui/react/macro"
 
+// Per-provider default TTS voice/model shown in the speech summary when the book hasn't
+// pinned one. Mirrors resolveVoice()/resolveSpeechModel() in @adt/pipeline (and
+// config/voices.yaml) so we never show an OpenAI voice/model for a Gemini/Azure provider.
+// Values are voice/model identifiers, not user-facing copy — display only.
+// eslint-disable-next-line lingui/no-unlocalized-strings -- voice identifiers
+const DEFAULT_TTS_VOICE: Record<string, string> = { openai: "alloy", azure: "en-US-JennyNeural", gemini: "Kore" }
+const DEFAULT_TTS_MODEL: Record<string, string> = { openai: "gpt-4o-mini-tts", azure: "azure-tts", gemini: "gemini-2.5-pro-preview-tts" }
+
 export function LanguageView({ bookLabel, stageSlug = "translate", selectedPageId, onSelectPage }: { bookLabel: string; stageSlug?: string; selectedPageId?: string; onSelectPage?: (pageId: string | null) => void }) {
   const isSpeechStage = stageSlug === "speech"
   const { t, i18n } = useLingui()
@@ -540,24 +548,21 @@ export function LanguageView({ bookLabel, stageSlug = "translate", selectedPageI
 
   // Resolve speech config summary for display
   const speechSummary = useMemo(() => {
-    // Per-provider defaults shown when the book hasn't pinned a voice/model. Mirror the
-    // resolveVoice()/resolveSpeechModel() defaults in @adt/pipeline (and config/voices.yaml)
-    // so we never show an OpenAI voice (alloy) or model for a Gemini/Azure provider.
-    // Display only — actual generation resolves these server-side.
-    const defaultVoiceFor = (p: string): string =>
-      ({ openai: "alloy", azure: "en-US-JennyNeural", gemini: "Kore" })[p] ?? "alloy"
-    const defaultModelFor = (p: string): string =>
-      ({ openai: "gpt-4o-mini-tts", azure: "azure-tts", gemini: "gemini-2.5-pro-preview-tts" })[p] ?? "gpt-4o-mini-tts"
+    const provider =
+      (speechConfig && typeof speechConfig === "object"
+        ? ((speechConfig as Record<string, unknown>).default_provider as string)
+        : undefined) ?? "openai"
+    const defaultVoice = DEFAULT_TTS_VOICE[provider] ?? DEFAULT_TTS_VOICE.openai
+    const defaultModel = DEFAULT_TTS_MODEL[provider] ?? DEFAULT_TTS_MODEL.openai
     if (!speechConfig || typeof speechConfig !== "object") {
-      return { provider: "openai", voice: defaultVoiceFor("openai"), model: defaultModelFor("openai") }
+      return { provider, voice: defaultVoice, model: defaultModel }
     }
     const sc = speechConfig as Record<string, unknown>
-    const provider = (sc.default_provider as string) ?? "openai"
-    const voice = (sc.voice as string) ?? defaultVoiceFor(provider)
+    const voice = (sc.voice as string) ?? defaultVoice
     const model = (sc.model as string) ?? undefined
     const providers = sc.providers as Record<string, Record<string, unknown>> | undefined
     const providerModel = providers?.[provider]?.model as string | undefined
-    return { provider, voice, model: providerModel ?? model ?? defaultModelFor(provider) }
+    return { provider, voice, model: providerModel ?? model ?? defaultModel }
   }, [speechConfig])
 
   if (showRunCard || !catalog || entries.length === 0) {

--- a/apps/studio/src/components/pipeline/stages/languages/LanguageView.tsx
+++ b/apps/studio/src/components/pipeline/stages/languages/LanguageView.tsx
@@ -540,16 +540,24 @@ export function LanguageView({ bookLabel, stageSlug = "translate", selectedPageI
 
   // Resolve speech config summary for display
   const speechSummary = useMemo(() => {
+    // Per-provider defaults shown when the book hasn't pinned a voice/model. Mirror the
+    // resolveVoice()/resolveSpeechModel() defaults in @adt/pipeline (and config/voices.yaml)
+    // so we never show an OpenAI voice (alloy) or model for a Gemini/Azure provider.
+    // Display only — actual generation resolves these server-side.
+    const defaultVoiceFor = (p: string): string =>
+      ({ openai: "alloy", azure: "en-US-JennyNeural", gemini: "Kore" })[p] ?? "alloy"
+    const defaultModelFor = (p: string): string =>
+      ({ openai: "gpt-4o-mini-tts", azure: "azure-tts", gemini: "gemini-2.5-pro-preview-tts" })[p] ?? "gpt-4o-mini-tts"
     if (!speechConfig || typeof speechConfig !== "object") {
-      return { provider: "openai", voice: "alloy", model: "gpt-4o-mini-tts" }
+      return { provider: "openai", voice: defaultVoiceFor("openai"), model: defaultModelFor("openai") }
     }
     const sc = speechConfig as Record<string, unknown>
     const provider = (sc.default_provider as string) ?? "openai"
-    const voice = (sc.voice as string) ?? "alloy"
+    const voice = (sc.voice as string) ?? defaultVoiceFor(provider)
     const model = (sc.model as string) ?? undefined
     const providers = sc.providers as Record<string, Record<string, unknown>> | undefined
     const providerModel = providers?.[provider]?.model as string | undefined
-    return { provider, voice, model: providerModel ?? model ?? "gpt-4o-mini-tts" }
+    return { provider, voice, model: providerModel ?? model ?? defaultModelFor(provider) }
   }, [speechConfig])
 
   if (showRunCard || !catalog || entries.length === 0) {

--- a/apps/studio/src/components/pipeline/stages/languages/components/SpeechPromptsEditor.tsx
+++ b/apps/studio/src/components/pipeline/stages/languages/components/SpeechPromptsEditor.tsx
@@ -93,7 +93,7 @@ export function SpeechPromptsEditor({ bookLabel, headerTarget }: SpeechPromptsEd
           {t`Default Prompt`}
         </Label>
         <p className="text-xs text-muted-foreground">
-          {t`The default TTS instruction sent to OpenAI for all languages unless overridden below.`}
+          {t`The default TTS instruction applied to every language unless overridden below. OpenAI uses it as a voice instruction and Gemini as in-prompt accent steering; Azure ignores it.`}
         </p>
         <textarea
           value={defaultEntry}
@@ -119,6 +119,9 @@ export function SpeechPromptsEditor({ bookLabel, headerTarget }: SpeechPromptsEd
             {t`Add Language`}
           </Button>
         </div>
+        <p className="text-xs text-muted-foreground">
+          {t`Each prompt is applied to whichever provider its language is routed to — for example, Albanian (sq) routed to Gemini receives this as its accent steering.`}
+        </p>
 
         {showAddLang && (
           <div className="flex items-center gap-2">

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -2186,6 +2186,9 @@ msgstr "Each iteration is one LLM call. Lower values are faster and cheaper; hig
 msgid "Each polyp secretes a hard calcium carbonate skeleton. Over hundreds of years, millions of these skeletons build up into the massive reef structures we see today."
 msgstr "Each polyp secretes a hard calcium carbonate skeleton. Over hundreds of years, millions of these skeletons build up into the massive reef structures we see today."
 
+msgid "Each prompt is applied to whichever provider its language is routed to — for example, Albanian (sq) routed to Gemini receives this as its accent steering."
+msgstr "Each prompt is applied to whichever provider its language is routed to — for example, Albanian (sq) routed to Gemini receives this as its accent steering."
+
 msgid "Each section introduces a new theme with worked examples, followed by short practice activities at the end of the page."
 msgstr "Each section introduces a new theme with worked examples, followed by short practice activities at the end of the page."
 
@@ -6111,8 +6114,11 @@ msgstr "The credits page."
 msgid "The data sent within the body of a request or response message."
 msgstr "The data sent within the body of a request or response message."
 
-msgid "The default TTS instruction sent to OpenAI for all languages unless overridden below."
-msgstr "The default TTS instruction sent to OpenAI for all languages unless overridden below."
+msgid "The default TTS instruction applied to every language unless overridden below. OpenAI uses it as a voice instruction and Gemini as in-prompt accent steering; Azure ignores it."
+msgstr "The default TTS instruction applied to every language unless overridden below. OpenAI uses it as a voice instruction and Gemini as in-prompt accent steering; Azure ignores it."
+
+#~ msgid "The default TTS instruction sent to OpenAI for all languages unless overridden below."
+#~ msgstr "The default TTS instruction sent to OpenAI for all languages unless overridden below."
 
 msgid "The entire page is treated as a single section - all text and images stay together as one unit. Best for storybooks, reference books, and any content where each page is self-contained."
 msgstr "The entire page is treated as a single section - all text and images stay together as one unit. Best for storybooks, reference books, and any content where each page is self-contained."

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -6117,9 +6117,6 @@ msgstr "The data sent within the body of a request or response message."
 msgid "The default TTS instruction applied to every language unless overridden below. OpenAI uses it as a voice instruction and Gemini as in-prompt accent steering; Azure ignores it."
 msgstr "The default TTS instruction applied to every language unless overridden below. OpenAI uses it as a voice instruction and Gemini as in-prompt accent steering; Azure ignores it."
 
-#~ msgid "The default TTS instruction sent to OpenAI for all languages unless overridden below."
-#~ msgstr "The default TTS instruction sent to OpenAI for all languages unless overridden below."
-
 msgid "The entire page is treated as a single section - all text and images stay together as one unit. Best for storybooks, reference books, and any content where each page is self-contained."
 msgstr "The entire page is treated as a single section - all text and images stay together as one unit. Best for storybooks, reference books, and any content where each page is self-contained."
 

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -6117,9 +6117,6 @@ msgstr "Los datos enviados en el cuerpo de un mensaje de solicitud o respuesta."
 msgid "The default TTS instruction applied to every language unless overridden below. OpenAI uses it as a voice instruction and Gemini as in-prompt accent steering; Azure ignores it."
 msgstr "La instrucción de TTS predeterminada que se aplica a todos los idiomas, salvo que se anule a continuación. OpenAI la usa como instrucción de voz y Gemini como guía de acento dentro del mensaje; Azure la ignora."
 
-#~ msgid "The default TTS instruction sent to OpenAI for all languages unless overridden below."
-#~ msgstr "La instrucción predeterminada de TTS enviada a OpenAI para todos los idiomas, a menos que se anule a continuación."
-
 msgid "The entire page is treated as a single section - all text and images stay together as one unit. Best for storybooks, reference books, and any content where each page is self-contained."
 msgstr "Toda la página se trata como una sola sección - todo el texto e imágenes permanecen juntos como una unidad. Mejor para libros de cuentos, libros de referencia y cualquier contenido donde cada página sea autónoma."
 

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -2186,6 +2186,9 @@ msgstr "Cada iteración es una llamada LLM. Valores más bajos son más rápidos
 msgid "Each polyp secretes a hard calcium carbonate skeleton. Over hundreds of years, millions of these skeletons build up into the massive reef structures we see today."
 msgstr "Cada pólipo secreta un esqueleto duro de carbonato de calcio. Durante cientos de años, millones de estos esqueletos se acumulan en las estructuras masivas de arrecifes que vemos hoy."
 
+msgid "Each prompt is applied to whichever provider its language is routed to — for example, Albanian (sq) routed to Gemini receives this as its accent steering."
+msgstr "Cada instrucción se aplica al proveedor al que se enruta su idioma; por ejemplo, el albanés (sq) enrutado a Gemini recibe esto como su guía de acento."
+
 msgid "Each section introduces a new theme with worked examples, followed by short practice activities at the end of the page."
 msgstr "Cada sección introduce un nuevo tema con ejemplos trabajados, seguido de actividades prácticas cortas al final de la página."
 
@@ -6111,8 +6114,11 @@ msgstr "La página de créditos."
 msgid "The data sent within the body of a request or response message."
 msgstr "Los datos enviados en el cuerpo de un mensaje de solicitud o respuesta."
 
-msgid "The default TTS instruction sent to OpenAI for all languages unless overridden below."
-msgstr "La instrucción predeterminada de TTS enviada a OpenAI para todos los idiomas, a menos que se anule a continuación."
+msgid "The default TTS instruction applied to every language unless overridden below. OpenAI uses it as a voice instruction and Gemini as in-prompt accent steering; Azure ignores it."
+msgstr "La instrucción de TTS predeterminada que se aplica a todos los idiomas, salvo que se anule a continuación. OpenAI la usa como instrucción de voz y Gemini como guía de acento dentro del mensaje; Azure la ignora."
+
+#~ msgid "The default TTS instruction sent to OpenAI for all languages unless overridden below."
+#~ msgstr "La instrucción predeterminada de TTS enviada a OpenAI para todos los idiomas, a menos que se anule a continuación."
 
 msgid "The entire page is treated as a single section - all text and images stay together as one unit. Best for storybooks, reference books, and any content where each page is self-contained."
 msgstr "Toda la página se trata como una sola sección - todo el texto e imágenes permanecen juntos como una unidad. Mejor para libros de cuentos, libros de referencia y cualquier contenido donde cada página sea autónoma."

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -2188,6 +2188,9 @@ msgstr "Chaque itération est un appel LLM. Des valeurs plus basses sont plus ra
 msgid "Each polyp secretes a hard calcium carbonate skeleton. Over hundreds of years, millions of these skeletons build up into the massive reef structures we see today."
 msgstr "Chaque polype sécrète un squelette rigide de carbonate de calcium. Au fil de centaines d'années, des millions de ces squelettes s'accumulent pour former les immenses structures récifales que nous voyons aujourd'hui."
 
+msgid "Each prompt is applied to whichever provider its language is routed to — for example, Albanian (sq) routed to Gemini receives this as its accent steering."
+msgstr "Chaque instruction est appliquée au fournisseur vers lequel sa langue est dirigée — par exemple, l'albanais (sq) dirigé vers Gemini la reçoit comme orientation d'accent."
+
 msgid "Each section introduces a new theme with worked examples, followed by short practice activities at the end of the page."
 msgstr "Chaque section introduit un nouveau thème avec des exemples travaillés, suivis de courtes activités pratiques à la fin de la page."
 
@@ -6113,8 +6116,11 @@ msgstr "La page de crédits."
 msgid "The data sent within the body of a request or response message."
 msgstr "Les données envoyées dans le corps d'un message de requête ou de réponse."
 
-msgid "The default TTS instruction sent to OpenAI for all languages unless overridden below."
-msgstr "L'instruction TTS par défaut envoyée à OpenAI pour toutes les langues, sauf remplacement ci-dessous."
+msgid "The default TTS instruction applied to every language unless overridden below. OpenAI uses it as a voice instruction and Gemini as in-prompt accent steering; Azure ignores it."
+msgstr "L'instruction TTS par défaut appliquée à toutes les langues, sauf si elle est remplacée ci-dessous. OpenAI l'utilise comme instruction de voix et Gemini comme orientation d'accent intégrée à l'invite ; Azure l'ignore."
+
+#~ msgid "The default TTS instruction sent to OpenAI for all languages unless overridden below."
+#~ msgstr "L'instruction TTS par défaut envoyée à OpenAI pour toutes les langues, sauf remplacement ci-dessous."
 
 msgid "The entire page is treated as a single section - all text and images stay together as one unit. Best for storybooks, reference books, and any content where each page is self-contained."
 msgstr "La page entière est traitée comme une seule section — tout le texte et les images restent ensemble en une seule unité. Idéal pour les livres d'histoires, les ouvrages de référence et tout contenu où chaque page est autonome."

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -6119,9 +6119,6 @@ msgstr "Les données envoyées dans le corps d'un message de requête ou de rép
 msgid "The default TTS instruction applied to every language unless overridden below. OpenAI uses it as a voice instruction and Gemini as in-prompt accent steering; Azure ignores it."
 msgstr "L'instruction TTS par défaut appliquée à toutes les langues, sauf si elle est remplacée ci-dessous. OpenAI l'utilise comme instruction de voix et Gemini comme orientation d'accent intégrée à l'invite ; Azure l'ignore."
 
-#~ msgid "The default TTS instruction sent to OpenAI for all languages unless overridden below."
-#~ msgstr "L'instruction TTS par défaut envoyée à OpenAI pour toutes les langues, sauf remplacement ci-dessous."
-
 msgid "The entire page is treated as a single section - all text and images stay together as one unit. Best for storybooks, reference books, and any content where each page is self-contained."
 msgstr "La page entière est traitée comme une seule section — tout le texte et les images restent ensemble en une seule unité. Idéal pour les livres d'histoires, les ouvrages de référence et tout contenu où chaque page est autonome."
 

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -2186,6 +2186,9 @@ msgstr "Cada iteração é uma chamada LLM. Valores menores são mais rápidos e
 msgid "Each polyp secretes a hard calcium carbonate skeleton. Over hundreds of years, millions of these skeletons build up into the massive reef structures we see today."
 msgstr "Cada pólipo secreta um esqueleto duro de carbonato de cálcio. Ao longo de centenas de anos, milhões desses esqueletos formam as enormes estruturas de recifes que vemos hoje."
 
+msgid "Each prompt is applied to whichever provider its language is routed to — for example, Albanian (sq) routed to Gemini receives this as its accent steering."
+msgstr "Cada instrução é aplicada ao provedor para o qual seu idioma é roteado — por exemplo, o albanês (sq) roteado para o Gemini recebe isto como seu direcionamento de sotaque."
+
 msgid "Each section introduces a new theme with worked examples, followed by short practice activities at the end of the page."
 msgstr "Cada seção introduz um novo tema com exemplos trabalhados, seguidos por atividades práticas curtas no final da página."
 
@@ -6111,8 +6114,11 @@ msgstr "A página de créditos."
 msgid "The data sent within the body of a request or response message."
 msgstr "Os dados enviados no corpo de uma mensagem de requisição ou resposta."
 
-msgid "The default TTS instruction sent to OpenAI for all languages unless overridden below."
-msgstr "A instrução padrão de TTS enviada ao OpenAI para todos os idiomas, a menos que seja substituída abaixo."
+msgid "The default TTS instruction applied to every language unless overridden below. OpenAI uses it as a voice instruction and Gemini as in-prompt accent steering; Azure ignores it."
+msgstr "A instrução de TTS padrão aplicada a todos os idiomas, a menos que seja substituída abaixo. A OpenAI a usa como instrução de voz e o Gemini como direcionamento de sotaque no prompt; o Azure a ignora."
+
+#~ msgid "The default TTS instruction sent to OpenAI for all languages unless overridden below."
+#~ msgstr "A instrução padrão de TTS enviada ao OpenAI para todos os idiomas, a menos que seja substituída abaixo."
 
 msgid "The entire page is treated as a single section - all text and images stay together as one unit. Best for storybooks, reference books, and any content where each page is self-contained."
 msgstr "A página inteira é tratada como uma única seção - todo o texto e imagens permanecem juntos como uma unidade. Melhor para livros de histórias, livros de referência e qualquer conteúdo onde cada página é autossuficiente."

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -6117,9 +6117,6 @@ msgstr "Os dados enviados no corpo de uma mensagem de requisição ou resposta."
 msgid "The default TTS instruction applied to every language unless overridden below. OpenAI uses it as a voice instruction and Gemini as in-prompt accent steering; Azure ignores it."
 msgstr "A instrução de TTS padrão aplicada a todos os idiomas, a menos que seja substituída abaixo. A OpenAI a usa como instrução de voz e o Gemini como direcionamento de sotaque no prompt; o Azure a ignora."
 
-#~ msgid "The default TTS instruction sent to OpenAI for all languages unless overridden below."
-#~ msgstr "A instrução padrão de TTS enviada ao OpenAI para todos os idiomas, a menos que seja substituída abaixo."
-
 msgid "The entire page is treated as a single section - all text and images stay together as one unit. Best for storybooks, reference books, and any content where each page is self-contained."
 msgstr "A página inteira é tratada como uma única seção - todo o texto e imagens permanecem juntos como uma unidade. Melhor para livros de histórias, livros de referência e qualquer conteúdo onde cada página é autossuficiente."
 

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -6118,9 +6118,6 @@ msgstr "Të dhënat e dërguara brenda trupit të një mesazhi kërkese ose për
 msgid "The default TTS instruction applied to every language unless overridden below. OpenAI uses it as a voice instruction and Gemini as in-prompt accent steering; Azure ignores it."
 msgstr "Udhëzimi i parazgjedhur i TTS që zbatohet për çdo gjuhë, përveçse kur anashkalohet më poshtë. OpenAI e përdor si udhëzim zëri dhe Gemini si drejtim theksi brenda kërkesës; Azure e shpërfill."
 
-#~ msgid "The default TTS instruction sent to OpenAI for all languages unless overridden below."
-#~ msgstr "Udhëzimi TTS i parazgjedhur i dërguar te OpenAI për të gjitha gjuhët, nëse nuk anashkalohet më poshtë."
-
 msgid "The entire page is treated as a single section - all text and images stay together as one unit. Best for storybooks, reference books, and any content where each page is self-contained."
 msgstr "I gjithë faqja trajtohet si një seksion i vetëm — i gjithë teksti dhe imazhet qëndrojnë bashkë si një njësi. Më e mirë për libra me tregime, libra referencë dhe çdo përmbajtje ku çdo faqe është e vetëmjaftueshme."
 

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -2187,6 +2187,9 @@ msgstr "Çdo iteracion është një thirrje LLM. Vlerat e ulëta janë më të s
 msgid "Each polyp secretes a hard calcium carbonate skeleton. Over hundreds of years, millions of these skeletons build up into the massive reef structures we see today."
 msgstr "Çdo polip sekreton një skelet të fortë karbonati kalciumi. Gjatë qindra viteve, miliona prej këtyre skeletve grumbullohen duke formuar strukturat masive të rifeve që shohim sot."
 
+msgid "Each prompt is applied to whichever provider its language is routed to — for example, Albanian (sq) routed to Gemini receives this as its accent steering."
+msgstr "Çdo udhëzim zbatohet te ofruesi te i cili drejtohet gjuha e tij — për shembull, shqipja (sq) e drejtuar te Gemini e merr këtë si drejtimin e theksit."
+
 msgid "Each section introduces a new theme with worked examples, followed by short practice activities at the end of the page."
 msgstr "Çdo seksion prezanton një temë të re me shembuj të zgjidhur, të ndjekur nga aktivitete të shkurtra praktike në fund të faqes."
 
@@ -6112,8 +6115,11 @@ msgstr "Faqja e krediteve."
 msgid "The data sent within the body of a request or response message."
 msgstr "Të dhënat e dërguara brenda trupit të një mesazhi kërkese ose përgjigjeje."
 
-msgid "The default TTS instruction sent to OpenAI for all languages unless overridden below."
-msgstr "Udhëzimi TTS i parazgjedhur i dërguar te OpenAI për të gjitha gjuhët, nëse nuk anashkalohet më poshtë."
+msgid "The default TTS instruction applied to every language unless overridden below. OpenAI uses it as a voice instruction and Gemini as in-prompt accent steering; Azure ignores it."
+msgstr "Udhëzimi i parazgjedhur i TTS që zbatohet për çdo gjuhë, përveçse kur anashkalohet më poshtë. OpenAI e përdor si udhëzim zëri dhe Gemini si drejtim theksi brenda kërkesës; Azure e shpërfill."
+
+#~ msgid "The default TTS instruction sent to OpenAI for all languages unless overridden below."
+#~ msgstr "Udhëzimi TTS i parazgjedhur i dërguar te OpenAI për të gjitha gjuhët, nëse nuk anashkalohet më poshtë."
 
 msgid "The entire page is treated as a single section - all text and images stay together as one unit. Best for storybooks, reference books, and any content where each page is self-contained."
 msgstr "I gjithë faqja trajtohet si një seksion i vetëm — i gjithë teksti dhe imazhet qëndrojnë bashkë si një njësi. Më e mirë për libra me tregime, libra referencë dhe çdo përmbajtje ku çdo faqe është e vetëmjaftueshme."

--- a/config/speech_instructions.yaml
+++ b/config/speech_instructions.yaml
@@ -1,5 +1,14 @@
 default: Speak in a cheerful and positive tone.
 en: Speak in a cheerful and positive tone.
+sq: |
+  Style: Warm, natural, child-friendly conversational cadence at a calm, measured pace.
+  Accent: Speak in an authentic Albanian accent native to Pristina, Kosovo. Use Gheg
+  dialect pacing, local regional vowel drops, and the distinct inflections typical of
+  Kosovo. Do not use a standard Tirana accent.
+
+  DO NOT CHANGE THE TEXT ITSELF. Read exactly what is written in Albanian. Do not
+  translate, paraphrase, or swap words. Use pronunciation influence only — never change
+  the vocabulary or grammar. Speak in a cheerful and positive tone.
 en-tz: |
   Speak it in a Tanzanian English accent. Use the pronunciation and
   intonation typical of Tanzania. Maintain a calm, conversational tone.

--- a/config/voices.yaml
+++ b/config/voices.yaml
@@ -105,4 +105,5 @@ azure:
 gemini:
   ne: Kore
   si: Aoede
+  sq: Kore
   ur: Kore

--- a/packages/llm/src/__tests__/speech.test.ts
+++ b/packages/llm/src/__tests__/speech.test.ts
@@ -228,4 +228,113 @@ describe("createGeminiTTSSynthesizer", () => {
       /response did not include audio data\. Response summary: text="The selected voice is unavailable for this request\."/
     )
   })
+
+  it("embeds instructions as a Director's Chair prompt when provided", async () => {
+    const pcmBytes = new Uint8Array([1, 2, 3, 4])
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    inlineData: {
+                      data: Buffer.from(pcmBytes).toString("base64"),
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
+    )
+
+    const synth = createGeminiTTSSynthesizer({ apiKey: "gm-test" })
+    await synth.synthesize({
+      model: "gemini-3.1-flash-tts-preview",
+      voice: "Kore",
+      input: "Përshëndetje!",
+      responseFormat: "wav",
+      instructions: "Speak with a Pristina, Kosovo accent.",
+    })
+
+    const sentText = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body))
+      .contents[0].parts[0].text as string
+    // Instructions go above the transcript delimiter, transcript below it.
+    expect(sentText).toBe(
+      "### PERFORMANCE\nSpeak with a Pristina, Kosovo accent.\n\n#### TRANSCRIPT\nPërshëndetje!"
+    )
+    // The model must never receive a systemInstruction (rejected by the TTS models).
+    expect(JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body))).not.toHaveProperty(
+      "systemInstruction"
+    )
+  })
+
+  it("sends the bare transcript when instructions are empty or absent", async () => {
+    const pcmBytes = new Uint8Array([1, 2, 3, 4])
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          candidates: [
+            { content: { parts: [{ inlineData: { data: Buffer.from(pcmBytes).toString("base64") } } ] } },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
+    )
+
+    const synth = createGeminiTTSSynthesizer({ apiKey: "gm-test" })
+    await synth.synthesize({
+      model: "gemini-3.1-flash-tts-preview",
+      voice: "Kore",
+      input: "Hello world",
+      responseFormat: "wav",
+      instructions: "   ",
+    })
+
+    expect(
+      JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body)).contents[0].parts[0].text
+    ).toBe("Hello world")
+  })
+
+  it("re-wraps the short-text punctuation retry with instructions", async () => {
+    const pcmBytes = new Uint8Array([9, 10, 11, 12])
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            candidates: [{ content: { parts: [{ text: "No audio returned." }] } }],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            candidates: [
+              { content: { parts: [{ inlineData: { data: Buffer.from(pcmBytes).toString("base64") } } ] } },
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        )
+      )
+
+    const synth = createGeminiTTSSynthesizer({ apiKey: "gm-test" })
+    await synth.synthesize({
+      model: "gemini-3.1-flash-tts-preview",
+      voice: "Kore",
+      input: "Po",
+      responseFormat: "wav",
+      instructions: "Kosovo accent.",
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    // Retry appends terminal punctuation to the transcript, still inside the wrapper.
+    expect(
+      JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body)).contents[0].parts[0].text
+    ).toBe("### PERFORMANCE\nKosovo accent.\n\n#### TRANSCRIPT\nPo.")
+  })
 })

--- a/packages/llm/src/speech.ts
+++ b/packages/llm/src/speech.ts
@@ -240,6 +240,23 @@ function buildGeminiShortTextRetryInput(input: string): string | null {
 }
 
 /**
+ * Wrap transcript text in the structured "performance + transcript" layout the
+ * native Gemini TTS models use for accent/style steering.
+ *
+ * The newer native speech models (e.g. gemini-*-tts-preview) reject the
+ * `systemInstruction` field at the API schema level ("Developer instruction is
+ * not enabled for this model"), so steering must live inside the prompt text.
+ * The `#### TRANSCRIPT` delimiter keeps the performance notes from being spoken
+ * aloud — only the text below it is read. Returns the transcript unchanged when
+ * there are no instructions, preserving the bare-text behaviour.
+ */
+function buildGeminiSpeechPrompt(transcript: string, instructions?: string): string {
+  const performance = instructions?.trim()
+  if (!performance) return transcript
+  return `### PERFORMANCE\n${performance}\n\n#### TRANSCRIPT\n${transcript}`
+}
+
+/**
  * Create a TTS client using Azure Speech Services REST API.
  */
 export function createAzureTTSSynthesizer(
@@ -342,7 +359,7 @@ export function createGeminiTTSSynthesizer(
       }
 
       const url = `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(options.model)}:generateContent`
-      const synthesizeInput = async (inputText: string): Promise<GeminiGenerateContentPayload> => {
+      const synthesizeInput = async (transcript: string): Promise<GeminiGenerateContentPayload> => {
         const response = await fetch(url, {
           method: "POST",
           headers: {
@@ -354,7 +371,7 @@ export function createGeminiTTSSynthesizer(
               {
                 parts: [
                   {
-                    text: inputText,
+                    text: buildGeminiSpeechPrompt(transcript, options.instructions),
                   },
                 ],
               },

--- a/packages/pipeline/src/pipeline-dag.ts
+++ b/packages/pipeline/src/pipeline-dag.ts
@@ -869,7 +869,13 @@ export async function runFullPipeline(
         const providerModel = resolveSpeechModel(provider, providerConfigs, speechModel)
         const outputFormat = resolveSpeechFormat(provider, config.speech?.format)
         const voice = resolveVoice(provider, item.language, voiceMaps, config.speech?.voice)
-        const instructions = provider === "openai" ? resolveInstructions(item.language, instructionsMap) : ""
+        // OpenAI + Gemini both receive resolved instructions (Gemini embeds them in
+        // the prompt text); Azure has no instruction channel. Must match stage-runner.ts
+        // and tts.ts so the shared TTS cache key (computeSpeechCacheKey) stays consistent.
+        const instructions =
+          provider === "openai" || provider === "gemini"
+            ? resolveInstructions(item.language, instructionsMap)
+            : ""
         const ttsSynthesizer = getSynthesizer(provider)
         const entry = await generateSpeechFile({
           textId: item.textId,


### PR DESCRIPTION
The native Gemini TTS models (e.g. `gemini-3.1-flash-tts-preview`) reject the `systemInstruction` field, so per-language accent instructions are now embedded directly in the prompt text via a `### PERFORMANCE / #### TRANSCRIPT` wrapper that keeps the steering notes from being spoken aloud (verified live: preamble adds ~1.0–1.1× duration, not 2×+). Instructions are now resolved for Gemini at all four TTS call sites — the stage-runner reuse-check and generation loop, the single-item `generate-one` route, and the DAG pipeline — so the shared `computeSpeechCacheKey` value stays consistent and cache hits don't break. An editable Albanian/Kosovo `sq` accent entry is added to `speech_instructions.yaml` and a default Gemini voice to `voices.yaml`, both surfacing automatically in the existing Languages settings editors. New unit tests cover the wrapper output, the bare-transcript fallback when instructions are empty, and the short-text punctuation-retry path.

Note: because of the global `default` instruction, Gemini now wraps every language (incl. existing ne/si/ur), which invalidates their TTS cache once and regenerates on next run — verified safe even for long instructions.