### PR TITLE
Storyboard thumbnail loading: skeletons, empty states, and cache warming

### DIFF
--- a/apps/api/src/routes/pages.ts
+++ b/apps/api/src/routes/pages.ts
@@ -952,7 +952,7 @@ export function createPageRoutes(
       }
 
       const buffer = fs.readFileSync(cachePath)
-      c.header("Cache-Control", "private, max-age=300")
+      c.header("Cache-Control", "private, max-age=31536000, immutable")
       c.header("Content-Type", "image/png")
       return c.body(buffer)
     }

--- a/apps/api/src/routes/pages.ts
+++ b/apps/api/src/routes/pages.ts
@@ -18,12 +18,12 @@ import {
   applyCrop,
   generateStyleguide,
   buildStyleguideGenerationConfig,
-  buildScreenshotHtml,
   createScreenshotRenderer,
   SCREENSHOT_VIEWPORTS,
   isFixedLayoutBook,
   type ScreenshotRenderer,
 } from "@adt/pipeline"
+import { prepareSectionScreenshot, writeSectionScreenshot } from "../services/section-screenshot.js"
 import { createLLMModel, createPromptEngine, renderLiquidTemplate, generateImageWithCache } from "@adt/llm"
 
 /**
@@ -903,55 +903,32 @@ export function createPageRoutes(
         db.close()
       }
 
-      // Resolve images referenced by the section HTML so screenshots show real pixels.
-      const referencedImageIds = new Set<string>()
-      const imgDataIdRegex = /<img\s[^>]*data-id="([^"]+)"/g
-      let m: RegExpExecArray | null
-      while ((m = imgDataIdRegex.exec(sectionHtml)) !== null) {
-        referencedImageIds.add(m[1])
-      }
       const storage = createBookStorage(safeLabel, booksDir)
-      const images = new Map<string, { base64: string }>()
+      let prepared: { screenshotHtml: string; cachePath: string }
       try {
-        for (const id of referencedImageIds) {
-          try {
-            images.set(id, { base64: storage.getImageBase64(id) })
-          } catch {
-            // Image missing — screenshot will show a broken image.
-          }
-        }
+        prepared = await prepareSectionScreenshot({
+          bookDir,
+          label: safeLabel,
+          sectionHtml,
+          viewport,
+          images: storage,
+          webAssetsDir,
+        })
       } finally {
         storage.close()
       }
 
-      const screenshotHtml = await buildScreenshotHtml({
-        sectionHtml,
-        label: safeLabel,
-        images,
-        webAssetsDir,
-      })
-
-      // Cache key incorporates HTML + viewport so cache invalidates whenever
-      // either changes. Stored under .section-renders/ inside the book dir.
-      const cacheDir = path.join(bookDir, ".section-renders")
-      fs.mkdirSync(cacheDir, { recursive: true })
-      const hash = crypto
-        .createHash("sha256")
-        .update(`${viewport.label}:${viewport.width}x${viewport.height}\n${screenshotHtml}`)
-        .digest("hex")
-        .slice(0, 16)
-      const cachePath = path.join(cacheDir, `${hash}.png`)
-
-      if (!fs.existsSync(cachePath)) {
+      if (!fs.existsSync(prepared.cachePath)) {
         const renderer = await getSharedScreenshotRenderer()
-        const base64 = await renderer.screenshot(screenshotHtml, {
-          width: viewport.width,
-          height: viewport.height,
+        await writeSectionScreenshot({
+          renderer,
+          screenshotHtml: prepared.screenshotHtml,
+          viewport,
+          cachePath: prepared.cachePath,
         })
-        fs.writeFileSync(cachePath, Buffer.from(base64, "base64"))
       }
 
-      const buffer = fs.readFileSync(cachePath)
+      const buffer = fs.readFileSync(prepared.cachePath)
       c.header("Cache-Control", "private, max-age=31536000, immutable")
       c.header("Content-Type", "image/png")
       return c.body(buffer)

--- a/apps/api/src/services/section-screenshot.ts
+++ b/apps/api/src/services/section-screenshot.ts
@@ -1,0 +1,89 @@
+import crypto from "node:crypto"
+import fs from "node:fs"
+import path from "node:path"
+import { buildScreenshotHtml, type ScreenshotRenderer } from "@adt/pipeline"
+
+export interface SectionScreenshotViewport {
+  label: string
+  width: number
+  height: number
+}
+
+export interface SectionImageSource {
+  getImageBase64(imageId: string): string
+}
+
+const IMG_DATA_ID_RE = /<img\s[^>]*data-id="([^"]+)"/g
+
+export function resolveSectionImages(
+  sectionHtml: string,
+  source: SectionImageSource
+): Map<string, { base64: string }> {
+  const ids = new Set<string>()
+  let m: RegExpExecArray | null
+  IMG_DATA_ID_RE.lastIndex = 0
+  while ((m = IMG_DATA_ID_RE.exec(sectionHtml)) !== null) {
+    ids.add(m[1])
+  }
+  const images = new Map<string, { base64: string }>()
+  for (const id of ids) {
+    let base64: string | null = null
+    try {
+      base64 = source.getImageBase64(id)
+    } catch {
+      base64 = null
+    }
+    if (base64 != null) {
+      images.set(id, { base64 })
+    }
+  }
+  return images
+}
+
+export function sectionRenderCacheDir(bookDir: string): string {
+  return path.join(bookDir, ".section-renders")
+}
+
+export function sectionScreenshotHash(
+  viewport: SectionScreenshotViewport,
+  screenshotHtml: string
+): string {
+  return crypto
+    .createHash("sha256")
+    .update(`${viewport.label}:${viewport.width}x${viewport.height}\n${screenshotHtml}`)
+    .digest("hex")
+    .slice(0, 16)
+}
+
+export async function prepareSectionScreenshot(opts: {
+  bookDir: string
+  label: string
+  sectionHtml: string
+  viewport: SectionScreenshotViewport
+  images: SectionImageSource
+  webAssetsDir: string
+}): Promise<{ screenshotHtml: string; cachePath: string }> {
+  const screenshotHtml = await buildScreenshotHtml({
+    sectionHtml: opts.sectionHtml,
+    label: opts.label,
+    images: resolveSectionImages(opts.sectionHtml, opts.images),
+    webAssetsDir: opts.webAssetsDir,
+  })
+  const hash = sectionScreenshotHash(opts.viewport, screenshotHtml)
+  const cachePath = path.join(sectionRenderCacheDir(opts.bookDir), `${hash}.png`)
+  return { screenshotHtml, cachePath }
+}
+
+export async function writeSectionScreenshot(opts: {
+  renderer: ScreenshotRenderer
+  screenshotHtml: string
+  viewport: SectionScreenshotViewport
+  cachePath: string
+}): Promise<void> {
+  fs.mkdirSync(path.dirname(opts.cachePath), { recursive: true })
+  const base64 = await opts.renderer.screenshot(opts.screenshotHtml, {
+    width: opts.viewport.width,
+    height: opts.viewport.height,
+  })
+  fs.writeFileSync(opts.cachePath, Buffer.from(base64, "base64"))
+}

--- a/apps/api/src/services/stage-runner.ts
+++ b/apps/api/src/services/stage-runner.ts
@@ -72,9 +72,11 @@ import {
   createScreenshotRenderer,
   DEFAULT_VISUAL_REVIEW_MODEL_ID,
   isFixedLayoutBook,
+  SCREENSHOT_VIEWPORTS,
 } from "@adt/pipeline"
 import type { PageSectioningConfig, TranslationConfig, QuizPageInput, ProviderRouting, MeaningfulnessConfig, CroppingConfig, SegmentationConfig, VisualRefinementDeps } from "@adt/pipeline"
 import { loadStyleguideContent } from "./styleguide.js"
+import { prepareSectionScreenshot, writeSectionScreenshot } from "./section-screenshot.js"
 import { createTTSSynthesizer, createAzureTTSSynthesizer, createGeminiTTSSynthesizer } from "@adt/llm"
 import type { TTSSynthesizer } from "@adt/llm"
 import { STAGE_ORDER } from "@adt/types"
@@ -1081,6 +1083,62 @@ async function runStoryboardStep(
 
     progress.emit({ type: "step-complete", step: "web-rendering" })
     console.log(`[stage-run] ${label}: storyboard complete`)
+
+    if (webAssetsDir) {
+      const desktopViewport = SCREENSHOT_VIEWPORTS.find((v) => v.label === "desktop")
+      if (desktopViewport) {
+        const bookDir = path.join(path.resolve(booksDir), label)
+        const warmRenderer =
+          visualRefinement?.screenshotRenderer ?? (await createScreenshotRenderer())
+        const ownsWarmRenderer = !visualRefinement
+        let warmed = 0
+        try {
+          await processWithConcurrency(
+            pages,
+            Math.min(4, effectiveConcurrency),
+            async (page: PageData) => {
+              const row = storage.getLatestNodeData("web-rendering", page.pageId)
+              if (!row) return
+              const rendering = row.data as WebRenderingOutput
+              for (const section of rendering.sections) {
+                try {
+                  const prepared = await prepareSectionScreenshot({
+                    bookDir,
+                    label,
+                    sectionHtml: section.html,
+                    viewport: desktopViewport,
+                    images: storage,
+                    webAssetsDir,
+                  })
+                  if (!fs.existsSync(prepared.cachePath)) {
+                    await writeSectionScreenshot({
+                      renderer: warmRenderer,
+                      screenshotHtml: prepared.screenshotHtml,
+                      viewport: desktopViewport,
+                      cachePath: prepared.cachePath,
+                    })
+                    warmed++
+                  }
+                } catch (err) {
+                  console.warn(
+                    `[stage-run] ${label}: warm ${page.pageId}#${section.sectionIndex} failed: ${toErrorMessage(err)}`
+                  )
+                }
+              }
+            }
+          )
+          console.log(`[stage-run] ${label}: warmed ${warmed} section screenshot(s)`)
+        } catch (err) {
+          console.warn(
+            `[stage-run] ${label}: thumbnail warming skipped: ${toErrorMessage(err)}`
+          )
+        } finally {
+          if (ownsWarmRenderer) {
+            await warmRenderer.close()
+          }
+        }
+      }
+    }
   } finally {
     if (visualRefinement) {
       await visualRefinement.screenshotRenderer.close()

--- a/apps/studio/src/components/pipeline/components/StoryboardIndex.tsx
+++ b/apps/studio/src/components/pipeline/components/StoryboardIndex.tsx
@@ -7,6 +7,7 @@ import { msg } from "@lingui/core/macro"
 import { AlertTriangle, ArrowLeftRight, CheckCircle2, EyeOff, FileText, HelpCircle, Loader2, Monitor, Puzzle } from "lucide-react"
 import { useVirtualizer } from "@tanstack/react-virtual"
 import { cn } from "@/lib/utils"
+import { Skeleton } from "@/components/ui/skeleton"
 import { usePages, usePageImage } from "@/hooks/use-pages"
 import { useQuizzes } from "@/hooks/use-quizzes"
 import { getSectionScreenshotUrl, type PageSummaryItem, type PageSummarySection } from "@/api/client"
@@ -19,6 +20,23 @@ import type { Quiz } from "@adt/types"
  * section of their `afterPageId`. Hovering a row shows a side-by-side
  * comparison of the original PDF page and the rendered section screenshot.
  */
+function StoryboardIndexSkeleton() {
+  return (
+    <div className="flex-1 overflow-y-auto" aria-hidden>
+      {Array.from({ length: 8 }).map((_, i) => (
+        <div key={i} className="flex items-start gap-2 px-2 py-1.5">
+          <Skeleton className="shrink-0 w-24 aspect-[4/3] ring-1 ring-border" />
+          <div className="flex flex-col gap-1.5 min-w-0 flex-1 pt-1">
+            <Skeleton className="h-2.5 w-full" />
+            <Skeleton className="h-2.5 w-2/3" />
+            <Skeleton className="mt-1 h-2 w-1/3" />
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
 export function StoryboardIndex({
   bookLabel,
   selectedPageId,
@@ -32,7 +50,7 @@ export function StoryboardIndex({
   onSelectSection?: (pageId: string, sectionIndex: number) => void
   stageRunning?: boolean
 }) {
-  const { data: pages } = usePages(bookLabel)
+  const { data: pages, isLoading } = usePages(bookLabel)
   const { data: quizzesData } = useQuizzes(bookLabel)
   const navigate = useNavigate()
   const parentRef = useRef<HTMLDivElement>(null)
@@ -108,6 +126,10 @@ export function StoryboardIndex({
     },
     [navigate, bookLabel],
   )
+
+  if (isLoading) {
+    return <StoryboardIndexSkeleton />
+  }
 
   if (!pages?.length) {
     return (
@@ -194,6 +216,32 @@ type StoryboardListItem =
 
 /* ---------- SectionRow ---------- */
 
+function RenderedThumb({ src, grayscale }: { src: string; grayscale?: boolean }) {
+  const imgRef = useRef<HTMLImageElement>(null)
+  const [loaded, setLoaded] = useState(false)
+  useEffect(() => {
+    const img = imgRef.current
+    setLoaded(!!img?.complete && img.naturalWidth > 0)
+  }, [src])
+  return (
+    <>
+      {!loaded && <Skeleton className="absolute inset-0 ring-1 ring-border" />}
+      <img
+        ref={imgRef}
+        src={src}
+        alt=""
+        loading="lazy"
+        onLoad={() => setLoaded(true)}
+        className={cn(
+          "w-full h-full rounded-md object-cover object-top ring-1 ring-border bg-white shadow-sm transition-opacity duration-300",
+          loaded ? "opacity-100" : "opacity-0",
+          grayscale && "grayscale",
+        )}
+      />
+    </>
+  )
+}
+
 function SectionRow({
   bookLabel,
   page,
@@ -262,14 +310,7 @@ function SectionRow({
     >
       <div className="relative shrink-0 w-24 aspect-[4/3]">
         {renderedThumb ? (
-          <img
-            src={renderedThumb}
-            alt=""
-            className={cn(
-              "w-full h-full rounded-md object-cover object-top ring-1 ring-border bg-white shadow-sm transition-opacity",
-              section.isPruned && "grayscale",
-            )}
-          />
+          <RenderedThumb src={renderedThumb} grayscale={section.isPruned} />
         ) : pageImageLoading || !pdfThumb ? (
           <div className="w-full h-full bg-muted rounded-md ring-1 ring-border" />
         ) : (
@@ -599,14 +640,20 @@ function ComparisonPreview({
             </div>
           </div>
           <PreviewPanel
-            src={renderedThumb}
+            src={isPruned ? null : renderedThumb}
             icon={<Monitor className="w-3 h-3" />}
             label={<Trans>Generated section</Trans>}
             fallback={
               isPruned ? (
-                <Trans>This section is pruned and isn't rendered.</Trans>
+                <>
+                  <EyeOff className="w-6 h-6 text-muted-foreground/40" />
+                  <Trans>This section is pruned and isn't rendered.</Trans>
+                </>
               ) : (
-                <Trans>Not rendered yet</Trans>
+                <>
+                  <Monitor className="w-6 h-6 text-muted-foreground/40" />
+                  <Trans>Not rendered yet</Trans>
+                </>
               )
             }
             tint={isStale ? "amber" : isPruned ? "zinc" : undefined}
@@ -643,12 +690,12 @@ function PreviewPanel({
           tint === "zinc" && "ring-zinc-200 bg-zinc-100/60",
         )}
       >
-        {src ? (
+        {src != null ? (
           <img src={src} alt="" className="max-h-full max-w-full object-contain" />
         ) : (
-          <span className="text-xs text-muted-foreground px-3 text-center">
+          <div className="flex flex-col items-center gap-2 px-3 text-center text-xs text-muted-foreground">
             {fallback ?? <Trans>No preview available</Trans>}
-          </span>
+          </div>
         )}
       </div>
     </div>

--- a/apps/studio/src/components/ui/skeleton.tsx
+++ b/apps/studio/src/components/ui/skeleton.tsx
@@ -1,0 +1,15 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("skeleton-shimmer rounded-md bg-foreground/8", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/apps/studio/src/styles/globals.css
+++ b/apps/studio/src/styles/globals.css
@@ -441,3 +441,34 @@
 .drag-region * {
   -webkit-app-region: no-drag;
 }
+
+@keyframes skeleton-shimmer {
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+.skeleton-shimmer {
+  position: relative;
+  overflow: hidden;
+}
+
+.skeleton-shimmer::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background: linear-gradient(
+    90deg,
+    transparent,
+    color-mix(in oklch, var(--foreground) 18%, transparent),
+    transparent
+  );
+  animation: skeleton-shimmer 1.6s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton-shimmer::after {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary

Improves the storyboard thumbnail experience on two fronts: **perceived speed** (skeletons + clean empty states) and **actual cold-load speed** (pre-warming the section-screenshot cache during the render stage).

## Changes

### Studio — skeleton & empty states (`feat(studio)`)
- Add a shadcn `Skeleton` component with a glow shimmer sweep (`skeleton-shimmer` keyframe, respects `prefers-reduced-motion`).
- Show a glowing skeleton list in the storyboard sidebar while pages load (previously fell through to the "No pages extracted yet" text).
- Per-thumbnail skeleton while a section screenshot loads, with a guard against already-cached images that never fire `onLoad` (which would leave the thumb blank).
- Comparison popover: icon-based empty states for **not-rendered** and **pruned** sections; shows image-or-empty-state only (no loader — the popover only appears once we already have the image or know its empty state).
- Serve section screenshots with an immutable `Cache-Control` so re-opens are instant from browser cache (the URL is already version- and content-hash-keyed).

### API — cold-load cache warming (`perf(api)`)
- Cold opens previously generated every section screenshot lazily via Playwright on first view (~1–3s each, largely serialized) → slow first load.
- Extract the section-screenshot HTML build + hash + cache-path into a shared helper (`section-screenshot.ts`) used by **both** the on-demand endpoint and the warmer, so their cache keys can't drift.
- After the storyboard render step completes, pre-render each section's **desktop** screenshot into `.section-renders/` (bounded concurrency, best-effort: failures are logged and fall back to lazy generation).
- Refactor the screenshot endpoint onto the shared helper (no behavior change).

**Result:** the storyboard opens against a warm disk cache and the endpoint just serves files, independent of platform or HTTP connection limits.

## Verification
- `tsc` clean for `@adt/studio` and `@adt/api`.
- Tests pass: stage-runner (13), debug (17), screenshot-html (3).
- No new user-visible strings (reused existing `<Trans>`), so no i18n re-extract needed.

## Follow-up (not in this PR)
- Thumbnail-size variant: the sidebar displays at ~96px but the endpoint renders/serves a full desktop-width PNG; a `?size=thumb` variant would cut payload/decode for the many sidebar thumbs.