### PR TITLE
feat(storyboard): disable Tailwind style editor on fixed-layout pages

### DIFF
--- a/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
@@ -763,6 +763,12 @@ export function StoryboardSectionDetail({
   const section = sectioningData?.sections[sectionIndex]
   const renderingData = pendingRendering ?? page.rendering
   const renderedSection = getRenderedSectionByIndex(renderingData, sectionIndex)
+  // Fixed-layout pages style every element via inline CSS (the `<p>`'s own
+  // `style` + per-run `data-segments`), not Tailwind classes — so the class
+  // editor's changes are always overridden and never apply. Disable the
+  // class-based style controls for these pages until inline-style editing
+  // lands; image actions, prune/delete, and inline text edits still work.
+  const isFixedLayout = renderedSection?.sectionType === "fixed-layout-page"
   const renderingDirty = pendingRendering != null || hasUnflushedEdits
 
   // When server-delivered HTML for the current section changes to something we
@@ -2532,6 +2538,7 @@ export function StoryboardSectionDetail({
         }
         onClassesChange={handleClassesChange}
         deviceView={deviceView}
+        isFixedLayout={isFixedLayout}
       />
     </div>
 

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/style-editor/StyleEditorPanel.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/style-editor/StyleEditorPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState, type ReactNode } from "react"
 import {
   Box,
+  Construction,
   Eye,
   EyeOff,
   Film,
@@ -45,6 +46,10 @@ interface StyleEditorPanelProps {
    *  typography properties — used as inspector defaults so the fields show
    *  the actually-rendered value when no explicit class is set. */
   computedTypography?: ComputedTypographyStyles | null
+  /** Fixed-layout pages style elements via inline CSS, not Tailwind classes,
+   *  so the class-based controls have no effect. When true, the class sections
+   *  (and Advanced) are hidden; image actions and prune/delete remain. */
+  isFixedLayout?: boolean
 }
 
 export function StyleEditorPanel({
@@ -57,6 +62,7 @@ export function StyleEditorPanel({
   onClassesChange,
   deviceView,
   computedTypography,
+  isFixedLayout = false,
 }: StyleEditorPanelProps) {
   const { t } = useLingui()
 
@@ -179,6 +185,7 @@ export function StyleEditorPanel({
             onClassesChange={onClassesChange}
             deviceView={deviceView}
             computedTypography={computedTypography ?? null}
+            isFixedLayout={isFixedLayout}
           />
         ) : null}
       </div>
@@ -246,6 +253,7 @@ interface StyleEditorBodyProps {
   onClassesChange: (dataId: string, classes: string[]) => void
   deviceView: DeviceView
   computedTypography: ComputedTypographyStyles | null
+  isFixedLayout: boolean
 }
 
 function StyleEditorBody({
@@ -256,6 +264,7 @@ function StyleEditorBody({
   onClassesChange,
   deviceView,
   computedTypography,
+  isFixedLayout,
 }: StyleEditorBodyProps) {
   const visibleSections = useMemo(
     () => (elementType ? getVisibleSections(elementType) : []),
@@ -272,20 +281,56 @@ function StyleEditorBody({
         computedStyles: computedTypography ?? undefined,
       }}
     >
-      <div className="flex flex-col">
+      <div className="flex flex-col min-h-full">
         {elementProps?.isImage ? (
           <ImageActionsSection dataId={dataId} elementProps={elementProps} />
         ) : null}
         {elementType === "text" ? (
           <TextRoleSection dataId={dataId} elementProps={elementProps} />
         ) : null}
-        {visibleSections.map((key) => {
-          const SectionComponent = SECTION_COMPONENTS[key]
-          return <SectionComponent key={key} />
-        })}
-        <AdvancedSection />
+        {isFixedLayout ? (
+          <div className="flex flex-1 items-center justify-center">
+            <FixedLayoutNotice />
+          </div>
+        ) : (
+          <>
+            {visibleSections.map((key) => {
+              const SectionComponent = SECTION_COMPONENTS[key]
+              return <SectionComponent key={key} />
+            })}
+            <AdvancedSection />
+          </>
+        )}
       </div>
     </ElementProvider>
+  )
+}
+
+/** Centered placeholder shown in place of the class-based style controls on
+ *  fixed-layout pages, where styling is driven by inline CSS rather than
+ *  Tailwind classes. Signals the feature is in development. */
+function FixedLayoutNotice() {
+  return (
+    <div className="flex flex-col items-center gap-3 px-2 py-4 text-center animate-in fade-in slide-in-from-bottom-1 duration-300">
+      <div className="relative flex h-12 w-12 items-center justify-center rounded-full bg-violet-50">
+        <Construction className="h-6 w-6 text-violet-500" />
+        <span className="absolute inset-0 rounded-full ring-1 ring-inset ring-violet-200/70" />
+      </div>
+      <div className="flex flex-col gap-1.5">
+        <p className="text-xs font-semibold text-foreground">
+          <Trans>Style editing coming soon</Trans>
+        </p>
+        <p className="text-[11px] leading-relaxed text-muted-foreground">
+          <Trans>
+            Visual style editing isn't available for fixed-layout pages yet. You
+            can still edit text inline, swap or crop images, and prune elements.
+          </Trans>
+        </p>
+      </div>
+      <span className="inline-flex items-center gap-1 rounded-full bg-amber-50 px-2 py-0.5 text-[10px] font-medium text-amber-700">
+        <Trans>In development</Trans>
+      </span>
+    </div>
   )
 }
 

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -451,14 +451,8 @@ msgstr "A new version is available for download."
 msgid "A question worth asking"
 msgstr "A question worth asking"
 
-#~ msgid "A quiz already exists at this position. Generating will replace the current quiz here."
-#~ msgstr "A quiz already exists at this position. Generating will replace the current quiz here."
-
 msgid "A quiz already sits here — add another after it or replace it"
 msgstr "A quiz already sits here — add another after it or replace it"
-
-#~ msgid "A quiz already sits here — generating will replace it"
-#~ msgstr "A quiz already sits here — generating will replace it"
 
 msgid "A scenic view at dusk."
 msgstr "A scenic view at dusk."
@@ -616,9 +610,6 @@ msgstr "Activity section types are hidden from the classifier and skipped during
 msgid "Activity Types"
 msgstr "Activity Types"
 
-#~ msgid "Activity: {activityTypeLabel}"
-#~ msgstr "Activity: {activityTypeLabel}"
-
 msgid "Activity: Fill in a Table"
 msgstr "Activity: Fill in a Table"
 
@@ -715,9 +706,6 @@ msgstr "Add checklist item to this section"
 
 msgid "Add custom instructions"
 msgstr "Add custom instructions"
-
-#~ msgid "Add emojis"
-#~ msgstr "Add emojis"
 
 msgid "Add entry"
 msgstr "Add entry"
@@ -973,9 +961,6 @@ msgstr "and more sections across the page"
 msgid "Answer"
 msgstr "Answer"
 
-#~ msgid "Answer options"
-#~ msgstr "Answer options"
-
 msgid "Answer Prompt"
 msgstr "Answer Prompt"
 
@@ -1115,9 +1100,6 @@ msgstr "Audio Player"
 
 msgid "Author"
 msgstr "Author"
-
-#~ msgid "Author's reasoning"
-#~ msgstr "Author's reasoning"
 
 msgid "Authored by {authorsList}."
 msgstr "Authored by {authorsList}."
@@ -1414,9 +1396,6 @@ msgstr "Change language"
 msgid "Change Preset"
 msgstr "Change Preset"
 
-#~ msgid "Changes save automatically when you save on the page card."
-#~ msgstr "Changes save automatically when you save on the page card."
-
 msgid "Chapter 1: Introduction"
 msgstr "Chapter 1: Introduction"
 
@@ -1443,9 +1422,6 @@ msgstr "Chapter One"
 
 msgid "Chart / Graph"
 msgstr "Chart / Graph"
-
-#~ msgid "Check answer"
-#~ msgstr "Check answer"
 
 msgid "Check for updates"
 msgstr "Check for updates"
@@ -1489,9 +1465,6 @@ msgstr "Choose Provider"
 msgid "Choose the source pages and where the quiz lands in the page editor."
 msgstr "Choose the source pages and where the quiz lands in the page editor."
 
-#~ msgid "Choose up to {MAX_SOURCE_PAGES} pages whose content the quiz question is based on."
-#~ msgstr "Choose up to {MAX_SOURCE_PAGES} pages whose content the quiz question is based on."
-
 msgid "Choose which per-page validation items reviewers must check, customize the wording and guidance, and add your own checklist items for this document."
 msgstr "Choose which per-page validation items reviewers must check, customize the wording and guidance, and add your own checklist items for this document."
 
@@ -1527,12 +1500,6 @@ msgstr "Clear, descriptive captions for middle and high school readers."
 
 msgid "Click an image to select"
 msgstr "Click an image to select"
-
-#~ msgid "Click any caption to edit it, or mark an image as decorative to hide it from screen readers when it doesn't need a caption. Changes are saved as a new version, so you can always roll back."
-#~ msgstr "Click any caption to edit it, or mark an image as decorative to hide it from screen readers when it doesn't need a caption. Changes are saved as a new version, so you can always roll back."
-
-#~ msgid "Click any caption to edit it. Your changes are saved as a new version, so you can always roll back to an earlier one."
-#~ msgstr "Click any caption to edit it. Your changes are saved as a new version, so you can always roll back to an earlier one."
 
 msgid "Click images to select"
 msgstr "Click images to select"
@@ -1744,9 +1711,6 @@ msgstr "Core Pipeline"
 msgid "Correct answer"
 msgstr "Correct answer"
 
-#~ msgid "Correct!"
-#~ msgstr "Correct!"
-
 msgid "Could not read this PDF. The file may be corrupted or password-protected."
 msgstr "Could not read this PDF. The file may be corrupted or password-protected."
 
@@ -1866,9 +1830,6 @@ msgstr "Debug mode is not enabled."
 
 msgid "Decorative"
 msgstr "Decorative"
-
-#~ msgid "Decorative images are hidden from screen readers and don't need a caption"
-#~ msgstr "Decorative images are hidden from screen readers and don't need a caption"
 
 msgid "Decrease indent"
 msgstr "Decrease indent"
@@ -2071,9 +2032,6 @@ msgstr "Disabled rules"
 msgid "Discard"
 msgstr "Discard"
 
-#~ msgid "Dismiss"
-#~ msgstr "Dismiss"
-
 msgid "Display"
 msgstr "Display"
 
@@ -2225,9 +2183,6 @@ msgstr "Edit this image"
 
 msgid "Edit this section"
 msgstr "Edit this section"
-
-#~ msgid "Editable"
-#~ msgstr "Editable"
 
 msgid "edited"
 msgstr "edited"
@@ -2565,9 +2520,6 @@ msgstr "Filter pages…"
 msgid "Filter quizzes…"
 msgstr "Filter quizzes…"
 
-#~ msgid "Filter terms…"
-#~ msgstr "Filter terms…"
-
 msgid "Filtered by:"
 msgstr "Filtered by:"
 
@@ -2712,9 +2664,6 @@ msgstr "Generate missing Gemini audio"
 msgid "Generate multiple-choice comprehension quizzes from the book's content. Create them automatically across the whole book, or add a single quiz from specific pages."
 msgstr "Generate multiple-choice comprehension quizzes from the book's content. Create them automatically across the whole book, or add a single quiz from specific pages."
 
-#~ msgid "Generate multiple-choice comprehension quizzes from the book's content. Set how often a quiz appears, then run the stage to create them across the whole book."
-#~ msgstr "Generate multiple-choice comprehension quizzes from the book's content. Set how often a quiz appears, then run the stage to create them across the whole book."
-
 msgid "Generate new"
 msgstr "Generate new"
 
@@ -2741,9 +2690,6 @@ msgstr "Generated from pages {fromLabel}"
 
 msgid "Generated from these pages"
 msgstr "Generated from these pages"
-
-#~ msgid "Generated page"
-#~ msgstr "Generated page"
 
 msgid "Generated section"
 msgstr "Generated section"
@@ -2870,9 +2816,6 @@ msgstr "Hide AI edit history"
 
 msgid "Hide error details"
 msgstr "Hide error details"
-
-#~ msgid "Hide pruned terms"
-#~ msgstr "Hide pruned terms"
 
 msgid "High"
 msgstr "High"
@@ -3086,6 +3029,9 @@ msgstr "In book:"
 
 msgid "In case you don't want to convert the whole book, adjust the sliders to define which pages will be digitized."
 msgstr "In case you don't want to convert the whole book, adjust the sliders to define which pages will be digitized."
+
+msgid "In development"
+msgstr "In development"
 
 msgid "in the book"
 msgstr "in the book"
@@ -3471,9 +3417,6 @@ msgstr "Manage all sections"
 msgid "Manage sign-language videos"
 msgstr "Manage sign-language videos"
 
-#~ msgid "manual"
-#~ msgstr "manual"
-
 msgid "Manual only"
 msgstr "Manual only"
 
@@ -3500,12 +3443,6 @@ msgstr "Mark as decorative"
 
 msgid "Mark as decorative (hidden from screen readers)"
 msgstr "Mark as decorative (hidden from screen readers)"
-
-#~ msgid "Marked as decorative — hidden from screen readers, no caption needed."
-#~ msgstr "Marked as decorative — hidden from screen readers, no caption needed."
-
-#~ msgid "Marked decorative"
-#~ msgstr "Marked decorative"
 
 msgid "Match Design"
 msgstr "Match Design"
@@ -3874,9 +3811,6 @@ msgstr "No language-specific prompts configured."
 msgid "No languages configured. Add languages in the Language settings."
 msgstr "No languages configured. Add languages in the Language settings."
 
-#~ msgid "No link"
-#~ msgstr "No link"
-
 msgid "No log entries found yet."
 msgstr "No log entries found yet."
 
@@ -3937,9 +3871,6 @@ msgstr "No quizzes for this page"
 msgid "No quizzes match your search"
 msgstr "No quizzes match your search"
 
-#~ msgid "No quizzes yet"
-#~ msgstr "No quizzes yet"
-
 msgid "No rendered content for this section"
 msgstr "No rendered content for this section"
 
@@ -3982,17 +3913,11 @@ msgstr "No source image"
 msgid "No storyboard sections found. Run Storyboard to generate sections you can match videos to."
 msgstr "No storyboard sections found. Run Storyboard to generate sections you can match videos to."
 
-#~ msgid "No terms match your filter."
-#~ msgstr "No terms match your filter."
-
 msgid "No terms match your search"
 msgstr "No terms match your search"
 
 msgid "No terms to show"
 msgstr "No terms to show"
-
-#~ msgid "No terms to show."
-#~ msgstr "No terms to show."
 
 msgid "No text extracted"
 msgstr "No text extracted"
@@ -4030,9 +3955,6 @@ msgstr "Not found in the book text"
 msgid "Not generated"
 msgstr "Not generated"
 
-#~ msgid "Not quite"
-#~ msgstr "Not quite"
-
 msgid "Not rendered yet"
 msgstr "Not rendered yet"
 
@@ -4068,9 +3990,6 @@ msgstr "OCR & cleanup"
 
 msgid "of"
 msgstr "of"
-
-#~ msgid "of {0}"
-#~ msgstr "of {0}"
 
 msgid "Off"
 msgstr "Off"
@@ -4200,9 +4119,6 @@ msgstr "Optional. Terms added here are pinned to the glossary so they always app
 
 msgid "Optionally translate burned-in text inside images (signs, labels, callouts). Select the images to localize — leaving the list empty keeps images in the source language."
 msgstr "Optionally translate burned-in text inside images (signs, labels, callouts). Select the images to localize — leaving the list empty keeps images in the source language."
-
-#~ msgid "Options"
-#~ msgstr "Options"
 
 msgid "options are deterministic;"
 msgstr "options are deterministic;"
@@ -4363,9 +4279,6 @@ msgstr "Page Mode"
 msgid "Page preview"
 msgstr "Page preview"
 
-#~ msgid "Page preview {pageId}"
-#~ msgstr "Page preview {pageId}"
-
 msgid "Page Range"
 msgstr "Page Range"
 
@@ -4476,9 +4389,6 @@ msgstr "Per-Word"
 msgid "Perfect for children's books, pairing large images with minimal text."
 msgstr "Perfect for children's books, pairing large images with minimal text."
 
-#~ msgid "pg {0} · s{1}"
-#~ msgstr "pg {0} · s{1}"
-
 msgid "Phase {phaseNumber}"
 msgstr "Phase {phaseNumber}"
 
@@ -4508,9 +4418,6 @@ msgstr "Pick one layout approach."
 
 msgid "Pick the languages you want to translate to. The book's original language stays as-is."
 msgstr "Pick the languages you want to translate to. The book's original language stays as-is."
-
-#~ msgid "Pick the pages the quiz is written from and choose where it appears in the book."
-#~ msgstr "Pick the pages the quiz is written from and choose where it appears in the book."
 
 msgid "Pick which voice each language uses for narration, including regional accents."
 msgstr "Pick which voice each language uses for narration, including regional accents."
@@ -4660,9 +4567,6 @@ msgstr "pruned"
 msgid "Pruned"
 msgstr "Pruned"
 
-#~ msgid "Pruned ({0})"
-#~ msgstr "Pruned ({0})"
-
 msgid "Pruned Images"
 msgstr "Pruned Images"
 
@@ -4692,9 +4596,6 @@ msgstr "Query param"
 
 msgid "question"
 msgstr "question"
-
-#~ msgid "Question"
-#~ msgstr "Question"
 
 msgid "Queued"
 msgstr "Queued"
@@ -4749,9 +4650,6 @@ msgstr "Quizzes are written from the content that Storyboard places into pages. 
 
 msgid "Quizzes were generated by AI from your book's pages. Click any question, option, or explanation to edit it, and delete any quiz you don't need. Click a source page to zoom. Changes are saved as a new version, so you can always roll back."
 msgstr "Quizzes were generated by AI from your book's pages. Click any question, option, or explanation to edit it, and delete any quiz you don't need. Click a source page to zoom. Changes are saved as a new version, so you can always roll back."
-
-#~ msgid "Quizzes you generate will show up here."
-#~ msgstr "Quizzes you generate will show up here."
 
 msgid "Quote"
 msgstr "Quote"
@@ -5125,9 +5023,6 @@ msgstr "Run Captions"
 msgid "Run Extract"
 msgstr "Run Extract"
 
-#~ msgid "Run Extract first — sectioning needs extracted page text and images."
-#~ msgstr "Run Extract first — sectioning needs extracted page text and images."
-
 msgid "Run Glossary"
 msgstr "Run Glossary"
 
@@ -5142,9 +5037,6 @@ msgstr "Run Quizzes"
 
 msgid "Run Sectioning"
 msgstr "Run Sectioning"
-
-#~ msgid "Run Sectioning first — storyboard needs typed sections to render."
-#~ msgstr "Run Sectioning first — storyboard needs typed sections to render."
 
 msgid "Run Speech"
 msgstr "Run Speech"
@@ -5423,9 +5315,6 @@ msgstr "Sectioning mode"
 msgid "Sectioning Mode"
 msgstr "Sectioning Mode"
 
-#~ msgid "Sectioning needs the page text and images that Extract produces. Finish Extract before running this stage."
-#~ msgstr "Sectioning needs the page text and images that Extract produces. Finish Extract before running this stage."
-
 msgid "Sectioning Pages..."
 msgstr "Sectioning Pages..."
 
@@ -5485,9 +5374,6 @@ msgstr "Select a node type and enter an item ID to view versions."
 
 msgid "Select a page grouping to continue"
 msgstr "Select a page grouping to continue"
-
-#~ msgid "Select a page…"
-#~ msgstr "Select a page…"
 
 msgid "Select a render strategy to continue"
 msgstr "Select a render strategy to continue"
@@ -5600,9 +5486,6 @@ msgstr "Ship"
 msgid "Short, simple sentences for kindergarten through 5th grade."
 msgstr "Short, simple sentences for kindergarten through 5th grade."
 
-#~ msgid "Show"
-#~ msgstr "Show"
-
 msgid "Show accessibility summary"
 msgstr "Show accessibility summary"
 
@@ -5630,12 +5513,6 @@ msgstr "Show fewer"
 
 msgid "Show only the terms you added manually"
 msgstr "Show only the terms you added manually"
-
-#~ msgid "Show pruned terms"
-#~ msgstr "Show pruned terms"
-
-#~ msgid "Show quiz after"
-#~ msgstr "Show quiz after"
 
 msgid "Show reviewer validation"
 msgstr "Show reviewer validation"
@@ -5751,9 +5628,6 @@ msgstr "Sort books"
 
 msgid "Source"
 msgstr "Source"
-
-#~ msgid "Source pages"
-#~ msgstr "Source pages"
 
 msgid "Source PDF"
 msgstr "Source PDF"
@@ -5873,9 +5747,6 @@ msgstr "Storyboard Overview"
 msgid "Storyboard Preview"
 msgstr "Storyboard Preview"
 
-#~ msgid "Storyboard renders the typed sections produced by Sectioning. Finish Sectioning before running this stage."
-#~ msgstr "Storyboard renders the typed sections produced by Sectioning. Finish Sectioning before running this stage."
-
 msgid "Storybook"
 msgstr "Storybook"
 
@@ -5884,9 +5755,6 @@ msgstr "Stretch"
 
 msgid "Strict"
 msgstr "Strict"
-
-#~ msgid "Strict grid template that repeats across pages."
-#~ msgstr "Strict grid template that repeats across pages."
 
 msgid "Strikethrough"
 msgstr "Strikethrough"
@@ -5911,6 +5779,9 @@ msgstr "Structures each page into a tree of sections and nodes."
 
 msgid "Style"
 msgstr "Style"
+
+msgid "Style editing coming soon"
+msgstr "Style editing coming soon"
 
 msgid "Style guide"
 msgstr "Style guide"
@@ -6153,9 +6024,6 @@ msgstr "The prompt used by the reviewer pass to inspect and correct a candidate 
 msgid "The quick brown fox jumps over the lazy dog."
 msgstr "The quick brown fox jumps over the lazy dog."
 
-#~ msgid "The quiz is inserted into the book right after this page."
-#~ msgstr "The quiz is inserted into the book right after this page."
-
 msgid "The rendering strategy used for sections without an explicit mapping."
 msgstr "The rendering strategy used for sections without an explicit mapping."
 
@@ -6182,9 +6050,6 @@ msgstr "The world before us"
 
 msgid "Theme"
 msgstr "Theme"
-
-#~ msgid "These captions were generated automatically"
-#~ msgstr "These captions were generated automatically"
 
 msgid "These features improve access for people with disabilities. Running them before exporting helps your book meet ADT accessibility standards."
 msgstr "These features improve access for people with disabilities. Running them before exporting helps your book meet ADT accessibility standards."
@@ -6720,6 +6585,9 @@ msgstr "Visual Review"
 
 msgid "Visual Review Prompt (read-only)"
 msgstr "Visual Review Prompt (read-only)"
+
+msgid "Visual style editing isn't available for fixed-layout pages yet. You can still edit text inline, swap or crop images, and prune elements."
+msgstr "Visual style editing isn't available for fixed-layout pages yet. You can still edit text inline, swap or crop images, and prune elements."
 
 msgid "Voice"
 msgstr "Voice"

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -451,14 +451,8 @@ msgstr "Una nueva versión está disponible para descargar."
 msgid "A question worth asking"
 msgstr "Una pregunta que vale la pena hacer"
 
-#~ msgid "A quiz already exists at this position. Generating will replace the current quiz here."
-#~ msgstr "Ya existe un cuestionario en esta posición. Al generarlo se reemplazará el cuestionario actual."
-
 msgid "A quiz already sits here — add another after it or replace it"
 msgstr "Aquí ya hay un cuestionario; añade otro después o reemplázalo"
-
-#~ msgid "A quiz already sits here — generating will replace it"
-#~ msgstr "Aquí ya hay un cuestionario; al generarlo se reemplazará"
 
 msgid "A scenic view at dusk."
 msgstr "Una vista panorámica al anochecer."
@@ -616,9 +610,6 @@ msgstr "Los tipos de sección de actividad están ocultos del clasificador y se 
 msgid "Activity Types"
 msgstr "Tipos de Actividad"
 
-#~ msgid "Activity: {activityTypeLabel}"
-#~ msgstr "Actividad: {activityTypeLabel}"
-
 msgid "Activity: Fill in a Table"
 msgstr "Actividad: Completar una tabla"
 
@@ -715,9 +706,6 @@ msgstr "Añadir elemento de la lista a esta sección"
 
 msgid "Add custom instructions"
 msgstr "Añadir instrucciones personalizadas"
-
-#~ msgid "Add emojis"
-#~ msgstr "Añadir emojis"
 
 msgid "Add entry"
 msgstr "Agregar entrada"
@@ -973,9 +961,6 @@ msgstr "y más secciones a lo largo de la página"
 msgid "Answer"
 msgstr "Respuesta"
 
-#~ msgid "Answer options"
-#~ msgstr "Opciones de respuesta"
-
 msgid "Answer Prompt"
 msgstr "Prompt de respuesta"
 
@@ -1115,9 +1100,6 @@ msgstr "Reproductor de Audio"
 
 msgid "Author"
 msgstr "Autor"
-
-#~ msgid "Author's reasoning"
-#~ msgstr "Razonamiento del autor"
 
 msgid "Authored by {authorsList}."
 msgstr "Escrito por {authorsList}."
@@ -1414,9 +1396,6 @@ msgstr "Cambiar idioma"
 msgid "Change Preset"
 msgstr "Cambiar Preajuste"
 
-#~ msgid "Changes save automatically when you save on the page card."
-#~ msgstr "Los cambios se guardan automáticamente cuando guardas en la tarjeta de la página."
-
 msgid "Chapter 1: Introduction"
 msgstr "Capítulo 1: Introducción"
 
@@ -1443,9 +1422,6 @@ msgstr "Capítulo Uno"
 
 msgid "Chart / Graph"
 msgstr "Gráfico / Tabla"
-
-#~ msgid "Check answer"
-#~ msgstr "Comprobar respuesta"
 
 msgid "Check for updates"
 msgstr "Buscar actualizaciones"
@@ -1489,9 +1465,6 @@ msgstr "Elegir proveedor"
 msgid "Choose the source pages and where the quiz lands in the page editor."
 msgstr "Elige las páginas de origen y dónde se ubica el cuestionario en el editor de páginas."
 
-#~ msgid "Choose up to {MAX_SOURCE_PAGES} pages whose content the quiz question is based on."
-#~ msgstr "Elige hasta {MAX_SOURCE_PAGES} páginas en cuyo contenido se basará la pregunta del cuestionario."
-
 msgid "Choose which per-page validation items reviewers must check, customize the wording and guidance, and add your own checklist items for this document."
 msgstr "Elige qué elementos de validación por página deben verificar los revisores, personaliza la redacción y la orientación, y añade tus propios elementos de la lista para este documento."
 
@@ -1527,12 +1500,6 @@ msgstr "Subtítulos claros y descriptivos para lectores de secundaria y preparat
 
 msgid "Click an image to select"
 msgstr "Haz clic en una imagen para seleccionar"
-
-#~ msgid "Click any caption to edit it, or mark an image as decorative to hide it from screen readers when it doesn't need a caption. Changes are saved as a new version, so you can always roll back."
-#~ msgstr "Haz clic en cualquier subtítulo para editarlo, o marca una imagen como decorativa para ocultarla de los lectores de pantalla cuando no necesite subtítulo. Los cambios se guardan como una nueva versión, por lo que siempre puedes volver atrás."
-
-#~ msgid "Click any caption to edit it. Your changes are saved as a new version, so you can always roll back to an earlier one."
-#~ msgstr "Haz clic en cualquier subtítulo para editarlo. Tus cambios se guardan como una nueva versión, por lo que siempre puedes volver a una anterior."
 
 msgid "Click images to select"
 msgstr "Haz clic en las imágenes para seleccionar"
@@ -1744,9 +1711,6 @@ msgstr "Tubería Principal"
 msgid "Correct answer"
 msgstr "Respuesta correcta"
 
-#~ msgid "Correct!"
-#~ msgstr "¡Correcto!"
-
 msgid "Could not read this PDF. The file may be corrupted or password-protected."
 msgstr "No se pudo leer este PDF. El archivo puede estar dañado o protegido con contraseña."
 
@@ -1866,9 +1830,6 @@ msgstr "El modo de depuración no está habilitado."
 
 msgid "Decorative"
 msgstr "Decorativa"
-
-#~ msgid "Decorative images are hidden from screen readers and don't need a caption"
-#~ msgstr "Las imágenes decorativas se ocultan de los lectores de pantalla y no necesitan subtítulo"
 
 msgid "Decrease indent"
 msgstr "Disminuir sangría"
@@ -2071,9 +2032,6 @@ msgstr "Reglas desactivadas"
 msgid "Discard"
 msgstr "Descartar"
 
-#~ msgid "Dismiss"
-#~ msgstr "Cerrar"
-
 msgid "Display"
 msgstr "Visualización"
 
@@ -2225,9 +2183,6 @@ msgstr "Editar esta imagen"
 
 msgid "Edit this section"
 msgstr "Editar esta sección"
-
-#~ msgid "Editable"
-#~ msgstr "Editable"
 
 msgid "edited"
 msgstr "editado"
@@ -2565,9 +2520,6 @@ msgstr "Filtrar páginas…"
 msgid "Filter quizzes…"
 msgstr "Filtrar cuestionarios…"
 
-#~ msgid "Filter terms…"
-#~ msgstr "Filtrar términos…"
-
 msgid "Filtered by:"
 msgstr "Filtrado por:"
 
@@ -2712,9 +2664,6 @@ msgstr "Generar audio de Gemini faltante"
 msgid "Generate multiple-choice comprehension quizzes from the book's content. Create them automatically across the whole book, or add a single quiz from specific pages."
 msgstr "Genera cuestionarios de comprensión de opción múltiple a partir del contenido del libro. Créalos automáticamente en todo el libro o añade un único cuestionario a partir de páginas específicas."
 
-#~ msgid "Generate multiple-choice comprehension quizzes from the book's content. Set how often a quiz appears, then run the stage to create them across the whole book."
-#~ msgstr "Genera cuestionarios de comprensión de opción múltiple a partir del contenido del libro. Define con qué frecuencia aparece un cuestionario y luego ejecuta la etapa para crearlos en todo el libro."
-
 msgid "Generate new"
 msgstr "Generar nueva"
 
@@ -2741,9 +2690,6 @@ msgstr "Generado a partir de las páginas {fromLabel}"
 
 msgid "Generated from these pages"
 msgstr "Generado a partir de estas páginas"
-
-#~ msgid "Generated page"
-#~ msgstr "Página generada"
 
 msgid "Generated section"
 msgstr "Sección generada"
@@ -2870,9 +2816,6 @@ msgstr "Ocultar historial de edición con IA"
 
 msgid "Hide error details"
 msgstr "Ocultar detalles del error"
-
-#~ msgid "Hide pruned terms"
-#~ msgstr "Ocultar términos podados"
 
 msgid "High"
 msgstr "Alto"
@@ -3086,6 +3029,9 @@ msgstr "En el libro:"
 
 msgid "In case you don't want to convert the whole book, adjust the sliders to define which pages will be digitized."
 msgstr "En caso de que no quieras convertir todo el libro, ajusta los controles deslizantes para definir qué páginas se digitalizarán."
+
+msgid "In development"
+msgstr "En desarrollo"
 
 msgid "in the book"
 msgstr "en el libro"
@@ -3471,9 +3417,6 @@ msgstr "Gestionar todas las secciones"
 msgid "Manage sign-language videos"
 msgstr "Gestionar videos de lenguaje de señas"
 
-#~ msgid "manual"
-#~ msgstr "manual"
-
 msgid "Manual only"
 msgstr "Solo manual"
 
@@ -3500,12 +3443,6 @@ msgstr "Marcar como decorativo"
 
 msgid "Mark as decorative (hidden from screen readers)"
 msgstr "Marcar como decorativo (oculto para lectores de pantalla)"
-
-#~ msgid "Marked as decorative — hidden from screen readers, no caption needed."
-#~ msgstr "Marcada como decorativa: oculta para los lectores de pantalla, no necesita subtítulo."
-
-#~ msgid "Marked decorative"
-#~ msgstr "Marcado como decorativo"
 
 msgid "Match Design"
 msgstr "Coincidir con el diseño"
@@ -3874,9 +3811,6 @@ msgstr "No hay prompts por idioma configurados."
 msgid "No languages configured. Add languages in the Language settings."
 msgstr "No hay idiomas configurados. Agrega idiomas en la configuración de Idioma."
 
-#~ msgid "No link"
-#~ msgstr "Sin enlace"
-
 msgid "No log entries found yet."
 msgstr "Aún no hay entradas de registro."
 
@@ -3937,9 +3871,6 @@ msgstr "No hay quizzes para esta página"
 msgid "No quizzes match your search"
 msgstr "Ningún cuestionario coincide con tu búsqueda"
 
-#~ msgid "No quizzes yet"
-#~ msgstr "Aún no hay cuestionarios"
-
 msgid "No rendered content for this section"
 msgstr "Sin contenido renderizado para esta sección"
 
@@ -3982,17 +3913,11 @@ msgstr "No hay imagen de origen"
 msgid "No storyboard sections found. Run Storyboard to generate sections you can match videos to."
 msgstr "No se encontraron secciones de storyboard. Ejecuta Storyboard para generar secciones a las que puedas asignar videos."
 
-#~ msgid "No terms match your filter."
-#~ msgstr "Ningún término coincide con tu filtro."
-
 msgid "No terms match your search"
 msgstr "No hay términos que coincidan con tu búsqueda"
 
 msgid "No terms to show"
 msgstr "No hay términos para mostrar"
-
-#~ msgid "No terms to show."
-#~ msgstr "No hay términos para mostrar."
 
 msgid "No text extracted"
 msgstr "No se extrajo texto"
@@ -4030,9 +3955,6 @@ msgstr "No encontrado en el texto del libro"
 msgid "Not generated"
 msgstr "No generado"
 
-#~ msgid "Not quite"
-#~ msgstr "Casi"
-
 msgid "Not rendered yet"
 msgstr "Aún no renderizado"
 
@@ -4068,9 +3990,6 @@ msgstr "OCR y limpieza"
 
 msgid "of"
 msgstr "de"
-
-#~ msgid "of {0}"
-#~ msgstr "de {0}"
 
 msgid "Off"
 msgstr "Apagado"
@@ -4200,9 +4119,6 @@ msgstr "Opcional. Los términos añadidos aquí se fijan al glosario para que si
 
 msgid "Optionally translate burned-in text inside images (signs, labels, callouts). Select the images to localize — leaving the list empty keeps images in the source language."
 msgstr "Opcionalmente traduce texto incrustado dentro de imágenes (señales, etiquetas, llamadas). Selecciona las imágenes para localizar — dejar la lista vacía mantiene las imágenes en el idioma original."
-
-#~ msgid "Options"
-#~ msgstr "Opciones"
 
 msgid "options are deterministic;"
 msgstr "las opciones son deterministas;"
@@ -4363,9 +4279,6 @@ msgstr "Modo de Página"
 msgid "Page preview"
 msgstr "Vista previa de la página"
 
-#~ msgid "Page preview {pageId}"
-#~ msgstr "Vista previa de la página {pageId}"
-
 msgid "Page Range"
 msgstr "Rango de páginas"
 
@@ -4476,9 +4389,6 @@ msgstr "Por-Palabra"
 msgid "Perfect for children's books, pairing large images with minimal text."
 msgstr "Perfecto para libros infantiles, combinando imágenes grandes con texto mínimo."
 
-#~ msgid "pg {0} · s{1}"
-#~ msgstr "pág. {0} · s{1}"
-
 msgid "Phase {phaseNumber}"
 msgstr "Fase {phaseNumber}"
 
@@ -4508,9 +4418,6 @@ msgstr "Elige un enfoque de diseño."
 
 msgid "Pick the languages you want to translate to. The book's original language stays as-is."
 msgstr "Elige los idiomas a los que deseas traducir. El idioma original del libro permanece igual."
-
-#~ msgid "Pick the pages the quiz is written from and choose where it appears in the book."
-#~ msgstr "Elige las páginas en las que se basa el cuestionario y dónde aparece en el libro."
 
 msgid "Pick which voice each language uses for narration, including regional accents."
 msgstr "Elige qué voz usa cada idioma para la narración, incluidos los acentos regionales."
@@ -4660,9 +4567,6 @@ msgstr "eliminado"
 msgid "Pruned"
 msgstr "Eliminado"
 
-#~ msgid "Pruned ({0})"
-#~ msgstr "Podado ({0})"
-
 msgid "Pruned Images"
 msgstr "Imágenes eliminadas"
 
@@ -4692,9 +4596,6 @@ msgstr "Parámetro de consulta"
 
 msgid "question"
 msgstr "pregunta"
-
-#~ msgid "Question"
-#~ msgstr "Pregunta"
 
 msgid "Queued"
 msgstr "En cola"
@@ -4749,9 +4650,6 @@ msgstr "Los cuestionarios se redactan a partir del contenido que Storyboard colo
 
 msgid "Quizzes were generated by AI from your book's pages. Click any question, option, or explanation to edit it, and delete any quiz you don't need. Click a source page to zoom. Changes are saved as a new version, so you can always roll back."
 msgstr "Los cuestionarios fueron generados por IA a partir de las páginas de tu libro. Haz clic en cualquier pregunta, opción o explicación para editarla, y elimina cualquier cuestionario que no necesites. Haz clic en una página fuente para ampliar. Los cambios se guardan como una nueva versión, por lo que siempre puedes revertir."
-
-#~ msgid "Quizzes you generate will show up here."
-#~ msgstr "Los cuestionarios que generes aparecerán aquí."
 
 msgid "Quote"
 msgstr "Cita"
@@ -5125,9 +5023,6 @@ msgstr "Ejecutar Subtítulos"
 msgid "Run Extract"
 msgstr "Ejecutar Extracción"
 
-#~ msgid "Run Extract first — sectioning needs extracted page text and images."
-#~ msgstr "Ejecuta Extracción primero — el seccionamiento necesita texto e imágenes extraídas de la página."
-
 msgid "Run Glossary"
 msgstr "Ejecutar Glosario"
 
@@ -5142,9 +5037,6 @@ msgstr "Ejecutar Cuestionarios"
 
 msgid "Run Sectioning"
 msgstr "Ejecutar Seccionamiento"
-
-#~ msgid "Run Sectioning first — storyboard needs typed sections to render."
-#~ msgstr "Ejecuta Seccionamiento primero — el storyboard necesita secciones escritas para renderizar."
 
 msgid "Run Speech"
 msgstr "Ejecutar Voz"
@@ -5423,9 +5315,6 @@ msgstr "Modo de sección"
 msgid "Sectioning Mode"
 msgstr "Modo de sección"
 
-#~ msgid "Sectioning needs the page text and images that Extract produces. Finish Extract before running this stage."
-#~ msgstr "El seccionamiento necesita el texto e imágenes de la página que produce Extracción. Termina Extracción antes de ejecutar esta etapa."
-
 msgid "Sectioning Pages..."
 msgstr "Seccionando páginas..."
 
@@ -5485,9 +5374,6 @@ msgstr "Selecciona un tipo de nodo e ingresa un ID de elemento para ver las vers
 
 msgid "Select a page grouping to continue"
 msgstr "Selecciona un grupo de páginas para continuar"
-
-#~ msgid "Select a page…"
-#~ msgstr "Selecciona una página…"
 
 msgid "Select a render strategy to continue"
 msgstr "Selecciona una estrategia de renderizado para continuar"
@@ -5600,9 +5486,6 @@ msgstr "Enviar"
 msgid "Short, simple sentences for kindergarten through 5th grade."
 msgstr "Oraciones cortas y simples para jardín de infancia hasta 5º grado."
 
-#~ msgid "Show"
-#~ msgstr "Mostrar"
-
 msgid "Show accessibility summary"
 msgstr "Mostrar resumen de accesibilidad"
 
@@ -5630,12 +5513,6 @@ msgstr "Mostrar menos"
 
 msgid "Show only the terms you added manually"
 msgstr "Mostrar solo los términos que agregaste manualmente"
-
-#~ msgid "Show pruned terms"
-#~ msgstr "Mostrar términos podados"
-
-#~ msgid "Show quiz after"
-#~ msgstr "Mostrar cuestionario después de"
 
 msgid "Show reviewer validation"
 msgstr "Mostrar validación del revisor"
@@ -5751,9 +5628,6 @@ msgstr "Ordenar libros"
 
 msgid "Source"
 msgstr "Fuente"
-
-#~ msgid "Source pages"
-#~ msgstr "Páginas de origen"
 
 msgid "Source PDF"
 msgstr "PDF Fuente"
@@ -5873,9 +5747,6 @@ msgstr "Vista general del Storyboard"
 msgid "Storyboard Preview"
 msgstr "Vista previa del Storyboard"
 
-#~ msgid "Storyboard renders the typed sections produced by Sectioning. Finish Sectioning before running this stage."
-#~ msgstr "El Storyboard renderiza las secciones escritas producidas por el Seccionamiento. Termina el Seccionamiento antes de ejecutar esta etapa."
-
 msgid "Storybook"
 msgstr "Libro de cuentos"
 
@@ -5884,9 +5755,6 @@ msgstr "Estirar"
 
 msgid "Strict"
 msgstr "Estricto"
-
-#~ msgid "Strict grid template that repeats across pages."
-#~ msgstr "Plantilla de cuadrícula estricta que se repite a través de las páginas."
 
 msgid "Strikethrough"
 msgstr "Tachado"
@@ -5911,6 +5779,9 @@ msgstr "Estructura cada página en un árbol de secciones y nodos."
 
 msgid "Style"
 msgstr "Estilo"
+
+msgid "Style editing coming soon"
+msgstr "Edición de estilos próximamente"
 
 msgid "Style guide"
 msgstr "Guía de estilo"
@@ -6153,9 +6024,6 @@ msgstr "El prompt utilizado por la pasada de revisión para inspeccionar y corre
 msgid "The quick brown fox jumps over the lazy dog."
 msgstr "El veloz zorro marrón salta sobre el perro perezoso."
 
-#~ msgid "The quiz is inserted into the book right after this page."
-#~ msgstr "El cuestionario se inserta en el libro justo después de esta página."
-
 msgid "The rendering strategy used for sections without an explicit mapping."
 msgstr "La estrategia de renderización usada para secciones sin un mapeo explícito."
 
@@ -6182,9 +6050,6 @@ msgstr "El mundo ante nosotros"
 
 msgid "Theme"
 msgstr "Tema"
-
-#~ msgid "These captions were generated automatically"
-#~ msgstr "Estos subtítulos se generaron automáticamente"
 
 msgid "These features improve access for people with disabilities. Running them before exporting helps your book meet ADT accessibility standards."
 msgstr "Estas funciones mejoran el acceso para personas con discapacidades. Ejecutarlas antes de exportar ayuda a que su libro cumpla con los estándares de accesibilidad ADT."
@@ -6720,6 +6585,9 @@ msgstr "Revisión Visual"
 
 msgid "Visual Review Prompt (read-only)"
 msgstr "Aviso de Revisión Visual (solo lectura)"
+
+msgid "Visual style editing isn't available for fixed-layout pages yet. You can still edit text inline, swap or crop images, and prune elements."
+msgstr "La edición visual de estilos aún no está disponible para páginas de maquetación fija. Aún puedes editar texto en línea, reemplazar o recortar imágenes y eliminar elementos."
 
 msgid "Voice"
 msgstr "Voz"

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -453,14 +453,8 @@ msgstr "Une nouvelle version est disponible au téléchargement."
 msgid "A question worth asking"
 msgstr "Une question qui mérite d'être posée"
 
-#~ msgid "A quiz already exists at this position. Generating will replace the current quiz here."
-#~ msgstr "Un quiz existe déjà à cette position. Le générer remplacera le quiz actuel."
-
 msgid "A quiz already sits here — add another after it or replace it"
 msgstr "Un quiz se trouve déjà ici — ajoutez-en un autre à la suite ou remplacez-le"
-
-#~ msgid "A quiz already sits here — generating will replace it"
-#~ msgstr "Un quiz se trouve déjà ici — le générer le remplacera"
 
 msgid "A scenic view at dusk."
 msgstr "Un panorama au crépuscule."
@@ -618,9 +612,6 @@ msgstr "Les types de section d'activité sont masqués du classifieur et ignoré
 msgid "Activity Types"
 msgstr "Types d'activité"
 
-#~ msgid "Activity: {activityTypeLabel}"
-#~ msgstr "Activité : {activityTypeLabel}"
-
 msgid "Activity: Fill in a Table"
 msgstr "Activité : Remplir un tableau"
 
@@ -717,9 +708,6 @@ msgstr "Ajouter un élément de liste de contrôle à cette section"
 
 msgid "Add custom instructions"
 msgstr "Ajouter des instructions personnalisées"
-
-#~ msgid "Add emojis"
-#~ msgstr "Ajouter des emojis"
 
 msgid "Add entry"
 msgstr "Ajouter une entrée"
@@ -975,9 +963,6 @@ msgstr "et plus de sections sur la page"
 msgid "Answer"
 msgstr "Réponse"
 
-#~ msgid "Answer options"
-#~ msgstr "Options de réponse"
-
 msgid "Answer Prompt"
 msgstr "Réponse Invite"
 
@@ -1117,9 +1102,6 @@ msgstr "Lecteur audio"
 
 msgid "Author"
 msgstr "Auteur"
-
-#~ msgid "Author's reasoning"
-#~ msgstr "Raisonnement de l'auteur"
 
 msgid "Authored by {authorsList}."
 msgstr "Écrit par {authorsList}."
@@ -1416,9 +1398,6 @@ msgstr "Changer de langue"
 msgid "Change Preset"
 msgstr "Changer de préréglage"
 
-#~ msgid "Changes save automatically when you save on the page card."
-#~ msgstr "Les modifications sont enregistrées automatiquement lorsque vous enregistrez sur la carte de la page."
-
 msgid "Chapter 1: Introduction"
 msgstr "Chapitre 1 : Introduction"
 
@@ -1445,9 +1424,6 @@ msgstr "Chapitre un"
 
 msgid "Chart / Graph"
 msgstr "Graphique / Diagramme"
-
-#~ msgid "Check answer"
-#~ msgstr "Vérifier la réponse"
 
 msgid "Check for updates"
 msgstr "Vérifier les mises à jour"
@@ -1491,9 +1467,6 @@ msgstr "Choisir le fournisseur"
 msgid "Choose the source pages and where the quiz lands in the page editor."
 msgstr "Choisissez les pages sources et l'emplacement du quiz dans l'éditeur de pages."
 
-#~ msgid "Choose up to {MAX_SOURCE_PAGES} pages whose content the quiz question is based on."
-#~ msgstr "Choisissez jusqu'à {MAX_SOURCE_PAGES} pages dont le contenu servira de base à la question du quiz."
-
 msgid "Choose which per-page validation items reviewers must check, customize the wording and guidance, and add your own checklist items for this document."
 msgstr "Choisissez quels éléments de validation par page les réviseurs doivent vérifier, personnalisez la formulation et les consignes, et ajoutez vos propres éléments de liste de contrôle pour ce document."
 
@@ -1529,12 +1502,6 @@ msgstr "Des sous-titres clairs et descriptifs pour les lecteurs de collège et d
 
 msgid "Click an image to select"
 msgstr "Cliquez sur une image pour la sélectionner"
-
-#~ msgid "Click any caption to edit it, or mark an image as decorative to hide it from screen readers when it doesn't need a caption. Changes are saved as a new version, so you can always roll back."
-#~ msgstr "Cliquez sur n'importe quelle légende pour la modifier, ou marquez une image comme décorative pour la masquer aux lecteurs d'écran lorsqu'elle n'a pas besoin de légende. Les modifications sont enregistrées comme une nouvelle version, vous pouvez donc toujours revenir en arrière."
-
-#~ msgid "Click any caption to edit it. Your changes are saved as a new version, so you can always roll back to an earlier one."
-#~ msgstr "Cliquez sur n'importe quelle légende pour la modifier. Vos modifications sont enregistrées comme une nouvelle version, vous pouvez donc toujours revenir à une version antérieure."
 
 msgid "Click images to select"
 msgstr "Cliquez sur les images pour les sélectionner"
@@ -1746,9 +1713,6 @@ msgstr "Pipeline principal"
 msgid "Correct answer"
 msgstr "Bonne réponse"
 
-#~ msgid "Correct!"
-#~ msgstr "Correct !"
-
 msgid "Could not read this PDF. The file may be corrupted or password-protected."
 msgstr "Impossible de lire ce PDF. Le fichier est peut-être corrompu ou protégé par un mot de passe."
 
@@ -1868,9 +1832,6 @@ msgstr "Le mode débogage n'est pas activé."
 
 msgid "Decorative"
 msgstr "Décorative"
-
-#~ msgid "Decorative images are hidden from screen readers and don't need a caption"
-#~ msgstr "Les images décoratives sont masquées aux lecteurs d'écran et n'ont pas besoin de légende"
 
 msgid "Decrease indent"
 msgstr "Diminuer l'indentation"
@@ -2073,9 +2034,6 @@ msgstr "Règles désactivées"
 msgid "Discard"
 msgstr "Abandonner"
 
-#~ msgid "Dismiss"
-#~ msgstr "Fermer"
-
 msgid "Display"
 msgstr "Affichage"
 
@@ -2227,9 +2185,6 @@ msgstr "Modifier cette image"
 
 msgid "Edit this section"
 msgstr "Modifier cette section"
-
-#~ msgid "Editable"
-#~ msgstr "Modifiable"
 
 msgid "edited"
 msgstr "modifié"
@@ -2567,9 +2522,6 @@ msgstr "Filtrer les pages…"
 msgid "Filter quizzes…"
 msgstr "Filtrer les quiz…"
 
-#~ msgid "Filter terms…"
-#~ msgstr "Filtrer les termes…"
-
 msgid "Filtered by:"
 msgstr "Filtré par :"
 
@@ -2714,9 +2666,6 @@ msgstr "Générer l'audio Gemini manquant"
 msgid "Generate multiple-choice comprehension quizzes from the book's content. Create them automatically across the whole book, or add a single quiz from specific pages."
 msgstr "Générez des quiz de compréhension à choix multiples à partir du contenu du livre. Créez-les automatiquement dans tout le livre ou ajoutez un seul quiz à partir de pages spécifiques."
 
-#~ msgid "Generate multiple-choice comprehension quizzes from the book's content. Set how often a quiz appears, then run the stage to create them across the whole book."
-#~ msgstr "Générez des quiz de compréhension à choix multiples à partir du contenu du livre. Définissez la fréquence d'apparition d'un quiz, puis exécutez l'étape pour les créer dans tout le livre."
-
 msgid "Generate new"
 msgstr "Générer nouveau"
 
@@ -2743,9 +2692,6 @@ msgstr "Généré à partir des pages {fromLabel}"
 
 msgid "Generated from these pages"
 msgstr "Généré à partir de ces pages"
-
-#~ msgid "Generated page"
-#~ msgstr "Page générée"
 
 msgid "Generated section"
 msgstr "Section générée"
@@ -2872,9 +2818,6 @@ msgstr "Masquer l'historique des modifications IA"
 
 msgid "Hide error details"
 msgstr "Masquer les détails de l'erreur"
-
-#~ msgid "Hide pruned terms"
-#~ msgstr "Masquer les termes élagués"
 
 msgid "High"
 msgstr "Élevé"
@@ -3088,6 +3031,9 @@ msgstr "Dans le livre :"
 
 msgid "In case you don't want to convert the whole book, adjust the sliders to define which pages will be digitized."
 msgstr "Si vous ne souhaitez pas convertir le livre entier, ajustez les curseurs pour définir quelles pages seront numérisées."
+
+msgid "In development"
+msgstr "En développement"
 
 msgid "in the book"
 msgstr "dans le livre"
@@ -3473,9 +3419,6 @@ msgstr "Gérer toutes les sections"
 msgid "Manage sign-language videos"
 msgstr "Gérer les vidéos en langue des signes"
 
-#~ msgid "manual"
-#~ msgstr "manuel"
-
 msgid "Manual only"
 msgstr "Manuel uniquement"
 
@@ -3502,12 +3445,6 @@ msgstr "Marquer comme décoratif"
 
 msgid "Mark as decorative (hidden from screen readers)"
 msgstr "Marquer comme décoratif (caché des lecteurs d'écran)"
-
-#~ msgid "Marked as decorative — hidden from screen readers, no caption needed."
-#~ msgstr "Marquée comme décorative — masquée aux lecteurs d'écran, aucune légende nécessaire."
-
-#~ msgid "Marked decorative"
-#~ msgstr "Marqué comme décoratif"
 
 msgid "Match Design"
 msgstr "Correspondre au design"
@@ -3876,9 +3813,6 @@ msgstr "Aucune invite spécifique à la langue configurée."
 msgid "No languages configured. Add languages in the Language settings."
 msgstr "Aucune langue configurée. Ajoutez des langues dans les paramètres de langue."
 
-#~ msgid "No link"
-#~ msgstr "Aucun lien"
-
 msgid "No log entries found yet."
 msgstr "Aucune entrée de journal trouvée."
 
@@ -3939,9 +3873,6 @@ msgstr "Aucun quiz pour cette page"
 msgid "No quizzes match your search"
 msgstr "Aucun quiz ne correspond à votre recherche"
 
-#~ msgid "No quizzes yet"
-#~ msgstr "Aucun quiz pour l'instant"
-
 msgid "No rendered content for this section"
 msgstr "Aucun contenu rendu pour cette section"
 
@@ -3984,17 +3915,11 @@ msgstr "Aucune image source"
 msgid "No storyboard sections found. Run Storyboard to generate sections you can match videos to."
 msgstr "Aucune section de storyboard trouvée. Exécutez le Storyboard pour générer des sections auxquelles vous pouvez associer des vidéos."
 
-#~ msgid "No terms match your filter."
-#~ msgstr "Aucun terme ne correspond à votre filtre."
-
 msgid "No terms match your search"
 msgstr "Aucun terme ne correspond à votre recherche"
 
 msgid "No terms to show"
 msgstr "Aucun terme à afficher"
-
-#~ msgid "No terms to show."
-#~ msgstr "Aucun terme à afficher."
 
 msgid "No text extracted"
 msgstr "Aucun texte extrait"
@@ -4032,9 +3957,6 @@ msgstr "Non trouvé dans le texte du livre"
 msgid "Not generated"
 msgstr "Non généré"
 
-#~ msgid "Not quite"
-#~ msgstr "Pas tout à fait"
-
 msgid "Not rendered yet"
 msgstr "Pas encore rendu"
 
@@ -4070,9 +3992,6 @@ msgstr "OCR et nettoyage"
 
 msgid "of"
 msgstr "sur"
-
-#~ msgid "of {0}"
-#~ msgstr "sur {0}"
 
 msgid "Off"
 msgstr "Désactivé"
@@ -4202,9 +4121,6 @@ msgstr "Facultatif. Les termes ajoutés ici sont épinglés au glossaire pour qu
 
 msgid "Optionally translate burned-in text inside images (signs, labels, callouts). Select the images to localize — leaving the list empty keeps images in the source language."
 msgstr "Traduisez éventuellement le texte incrusté dans les images (panneaux, étiquettes, légendes). Sélectionnez les images à localiser — laisser la liste vide garde les images dans la langue source."
-
-#~ msgid "Options"
-#~ msgstr "Options"
 
 msgid "options are deterministic;"
 msgstr "les options sont déterministes ;"
@@ -4365,9 +4281,6 @@ msgstr "Mode de page"
 msgid "Page preview"
 msgstr "Aperçu de la page"
 
-#~ msgid "Page preview {pageId}"
-#~ msgstr "Page aperçu {pageId}"
-
 msgid "Page Range"
 msgstr "Plage de pages"
 
@@ -4478,9 +4391,6 @@ msgstr "Par mot"
 msgid "Perfect for children's books, pairing large images with minimal text."
 msgstr "Parfait pour les livres pour enfants, associant de grandes images avec un minimum de texte."
 
-#~ msgid "pg {0} · s{1}"
-#~ msgstr "p. {0} · s{1}"
-
 msgid "Phase {phaseNumber}"
 msgstr "Phase {phaseNumber}"
 
@@ -4510,9 +4420,6 @@ msgstr "Choisissez une approche de mise en page."
 
 msgid "Pick the languages you want to translate to. The book's original language stays as-is."
 msgstr "Choisissez les langues vers lesquelles vous souhaitez traduire. La langue originale du livre reste inchangée."
-
-#~ msgid "Pick the pages the quiz is written from and choose where it appears in the book."
-#~ msgstr "Choisissez les pages à partir desquelles le quiz est rédigé et où il apparaît dans le livre."
 
 msgid "Pick which voice each language uses for narration, including regional accents."
 msgstr "Choisissez quelle voix chaque langue utilise pour la narration, y compris les accents régionaux."
@@ -4662,9 +4569,6 @@ msgstr "élagué"
 msgid "Pruned"
 msgstr "Élagué"
 
-#~ msgid "Pruned ({0})"
-#~ msgstr "Élagué ({0})"
-
 msgid "Pruned Images"
 msgstr "Images élaguées"
 
@@ -4694,9 +4598,6 @@ msgstr "Paramètre de requête"
 
 msgid "question"
 msgstr "question"
-
-#~ msgid "Question"
-#~ msgstr "Question"
 
 msgid "Queued"
 msgstr "En file d'attente"
@@ -4751,9 +4652,6 @@ msgstr "Les quiz sont rédigés à partir du contenu que Scénarimage place dans
 
 msgid "Quizzes were generated by AI from your book's pages. Click any question, option, or explanation to edit it, and delete any quiz you don't need. Click a source page to zoom. Changes are saved as a new version, so you can always roll back."
 msgstr "Les quiz ont été générés par l'IA à partir des pages de votre livre. Cliquez sur une question, une option ou une explication pour la modifier, et supprimez tout quiz dont vous n'avez pas besoin. Cliquez sur une page source pour zoomer. Les modifications sont enregistrées comme une nouvelle version, vous pouvez donc toujours revenir en arrière."
-
-#~ msgid "Quizzes you generate will show up here."
-#~ msgstr "Les quiz que vous générez apparaîtront ici."
 
 msgid "Quote"
 msgstr "Citation"
@@ -5127,9 +5025,6 @@ msgstr "Exécuter les sous-titres"
 msgid "Run Extract"
 msgstr "Exécuter l'extraction"
 
-#~ msgid "Run Extract first — sectioning needs extracted page text and images."
-#~ msgstr "Exécutez d'abord l'extraction — le découpage a besoin du texte et des images extraits des pages."
-
 msgid "Run Glossary"
 msgstr "Exécuter le glossaire"
 
@@ -5144,9 +5039,6 @@ msgstr "Exécuter les quiz"
 
 msgid "Run Sectioning"
 msgstr "Exécuter le découpage"
-
-#~ msgid "Run Sectioning first — storyboard needs typed sections to render."
-#~ msgstr "Exécutez d'abord le découpage — le storyboard a besoin de sections tapées pour rendre."
 
 msgid "Run Speech"
 msgstr "Exécuter la parole"
@@ -5425,9 +5317,6 @@ msgstr "Mode de sectionnement"
 msgid "Sectioning Mode"
 msgstr "Mode de sectionnement"
 
-#~ msgid "Sectioning needs the page text and images that Extract produces. Finish Extract before running this stage."
-#~ msgstr "Le découpage a besoin du texte et des images des pages produits par l'extraction. Terminez l'extraction avant d'exécuter cette étape."
-
 msgid "Sectioning Pages..."
 msgstr "Sectionnement des pages..."
 
@@ -5487,9 +5376,6 @@ msgstr "Sélectionnez un type de nœud et saisissez un ID d'élément pour voir 
 
 msgid "Select a page grouping to continue"
 msgstr "Sélectionnez un regroupement de pages pour continuer"
-
-#~ msgid "Select a page…"
-#~ msgstr "Sélectionnez une page…"
 
 msgid "Select a render strategy to continue"
 msgstr "Sélectionnez une stratégie de rendu pour continuer"
@@ -5602,9 +5488,6 @@ msgstr "Livrer"
 msgid "Short, simple sentences for kindergarten through 5th grade."
 msgstr "Phrases courtes et simples pour la maternelle jusqu'à la 5e année."
 
-#~ msgid "Show"
-#~ msgstr "Afficher"
-
 msgid "Show accessibility summary"
 msgstr "Afficher le résumé d'accessibilité"
 
@@ -5632,12 +5515,6 @@ msgstr "Afficher moins"
 
 msgid "Show only the terms you added manually"
 msgstr "Afficher uniquement les termes que vous avez ajoutés manuellement"
-
-#~ msgid "Show pruned terms"
-#~ msgstr "Afficher les termes élagués"
-
-#~ msgid "Show quiz after"
-#~ msgstr "Afficher le quiz après"
 
 msgid "Show reviewer validation"
 msgstr "Afficher la validation du réviseur"
@@ -5753,9 +5630,6 @@ msgstr "Trier les livres"
 
 msgid "Source"
 msgstr "Source"
-
-#~ msgid "Source pages"
-#~ msgstr "Pages sources"
 
 msgid "Source PDF"
 msgstr "PDF source"
@@ -5875,9 +5749,6 @@ msgstr "Aperçu du storyboard"
 msgid "Storyboard Preview"
 msgstr "Aperçu du storyboard"
 
-#~ msgid "Storyboard renders the typed sections produced by Sectioning. Finish Sectioning before running this stage."
-#~ msgstr "Le storyboard rend les sections tapées produites par le découpage. Terminez le découpage avant d'exécuter cette étape."
-
 msgid "Storybook"
 msgstr "Livre d'histoires"
 
@@ -5886,9 +5757,6 @@ msgstr "Étirer"
 
 msgid "Strict"
 msgstr "Strict"
-
-#~ msgid "Strict grid template that repeats across pages."
-#~ msgstr "Modèle de grille strict qui se répète sur les pages."
 
 msgid "Strikethrough"
 msgstr "Barré"
@@ -5913,6 +5781,9 @@ msgstr "Structure chaque page en un arbre de sections et de nœuds."
 
 msgid "Style"
 msgstr "Style"
+
+msgid "Style editing coming soon"
+msgstr "Édition de style bientôt disponible"
 
 msgid "Style guide"
 msgstr "Guide de style"
@@ -6155,9 +6026,6 @@ msgstr "Le prompt utilisé par la passe de revue pour inspecter et corriger un a
 msgid "The quick brown fox jumps over the lazy dog."
 msgstr "Le vif renard brun saute par-dessus le chien paresseux."
 
-#~ msgid "The quiz is inserted into the book right after this page."
-#~ msgstr "Le quiz est inséré dans le livre juste après cette page."
-
 msgid "The rendering strategy used for sections without an explicit mapping."
 msgstr "La stratégie de rendu utilisée pour les sections sans correspondance explicite."
 
@@ -6184,9 +6052,6 @@ msgstr "Le monde devant nous"
 
 msgid "Theme"
 msgstr "Thème"
-
-#~ msgid "These captions were generated automatically"
-#~ msgstr "Ces légendes ont été générées automatiquement"
 
 msgid "These features improve access for people with disabilities. Running them before exporting helps your book meet ADT accessibility standards."
 msgstr "Ces fonctionnalités améliorent l'accès pour les personnes handicapées. Les exécuter avant l'exportation aide votre livre à respecter les normes d'accessibilité ADT."
@@ -6722,6 +6587,9 @@ msgstr "Révision visuelle"
 
 msgid "Visual Review Prompt (read-only)"
 msgstr "Invite de révision visuelle (lecture seule)"
+
+msgid "Visual style editing isn't available for fixed-layout pages yet. You can still edit text inline, swap or crop images, and prune elements."
+msgstr "L'édition visuelle des styles n'est pas encore disponible pour les pages à mise en page fixe. Vous pouvez toujours modifier le texte en ligne, remplacer ou recadrer des images et élaguer des éléments."
 
 msgid "Voice"
 msgstr "Voix"

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -451,14 +451,8 @@ msgstr "Uma nova versão está disponível para download."
 msgid "A question worth asking"
 msgstr "Uma pergunta que vale a pena fazer"
 
-#~ msgid "A quiz already exists at this position. Generating will replace the current quiz here."
-#~ msgstr "Já existe um questionário nesta posição. Gerar irá substituir o questionário atual."
-
 msgid "A quiz already sits here — add another after it or replace it"
 msgstr "Já existe um questionário aqui — adicione outro depois ou substitua-o"
-
-#~ msgid "A quiz already sits here — generating will replace it"
-#~ msgstr "Já existe um questionário aqui — gerar irá substituí-lo"
 
 msgid "A scenic view at dusk."
 msgstr "Uma vista cênica ao entardecer."
@@ -616,9 +610,6 @@ msgstr "Os tipos de seção de atividade estão ocultos do classificador e ignor
 msgid "Activity Types"
 msgstr "Tipos de Atividade"
 
-#~ msgid "Activity: {activityTypeLabel}"
-#~ msgstr "Atividade: {activityTypeLabel}"
-
 msgid "Activity: Fill in a Table"
 msgstr "Atividade: Preencher uma tabela"
 
@@ -715,9 +706,6 @@ msgstr "Adicionar item da lista de verificação a esta seção"
 
 msgid "Add custom instructions"
 msgstr "Adicionar instruções personalizadas"
-
-#~ msgid "Add emojis"
-#~ msgstr "Adicionar emojis"
 
 msgid "Add entry"
 msgstr "Adicionar entrada"
@@ -973,9 +961,6 @@ msgstr "e mais seções na página"
 msgid "Answer"
 msgstr "Resposta"
 
-#~ msgid "Answer options"
-#~ msgstr "Opções de resposta"
-
 msgid "Answer Prompt"
 msgstr "Prompt de resposta"
 
@@ -1115,9 +1100,6 @@ msgstr "Reprodutor de Áudio"
 
 msgid "Author"
 msgstr "Autor"
-
-#~ msgid "Author's reasoning"
-#~ msgstr "Raciocínio do autor"
 
 msgid "Authored by {authorsList}."
 msgstr "Autoria de {authorsList}."
@@ -1414,9 +1396,6 @@ msgstr "Mudar idioma"
 msgid "Change Preset"
 msgstr "Alterar Predefinição"
 
-#~ msgid "Changes save automatically when you save on the page card."
-#~ msgstr "As alterações são salvas automaticamente quando você salva no cartão da página."
-
 msgid "Chapter 1: Introduction"
 msgstr "Capítulo 1: Introdução"
 
@@ -1443,9 +1422,6 @@ msgstr "Capítulo Um"
 
 msgid "Chart / Graph"
 msgstr "Gráfico / Tabela"
-
-#~ msgid "Check answer"
-#~ msgstr "Verificar resposta"
 
 msgid "Check for updates"
 msgstr "Verificar atualizações"
@@ -1489,9 +1465,6 @@ msgstr "Escolher provedor"
 msgid "Choose the source pages and where the quiz lands in the page editor."
 msgstr "Escolha as páginas de origem e onde o questionário será inserido no editor de páginas."
 
-#~ msgid "Choose up to {MAX_SOURCE_PAGES} pages whose content the quiz question is based on."
-#~ msgstr "Escolha até {MAX_SOURCE_PAGES} páginas cujo conteúdo servirá de base para a pergunta do questionário."
-
 msgid "Choose which per-page validation items reviewers must check, customize the wording and guidance, and add your own checklist items for this document."
 msgstr "Escolha quais itens de validação por página os revisores devem verificar, personalize o texto e a orientação e adicione seus próprios itens da lista de verificação para este documento."
 
@@ -1527,12 +1500,6 @@ msgstr "Legendas claras e descritivas para leitores do ensino fundamental e méd
 
 msgid "Click an image to select"
 msgstr "Clique em uma imagem para selecionar"
-
-#~ msgid "Click any caption to edit it, or mark an image as decorative to hide it from screen readers when it doesn't need a caption. Changes are saved as a new version, so you can always roll back."
-#~ msgstr "Clique em qualquer legenda para editá-la ou marque uma imagem como decorativa para ocultá-la dos leitores de tela quando não precisar de legenda. As alterações são salvas como uma nova versão, então você sempre pode reverter."
-
-#~ msgid "Click any caption to edit it. Your changes are saved as a new version, so you can always roll back to an earlier one."
-#~ msgstr "Clique em qualquer legenda para editá-la. Suas alterações são salvas como uma nova versão, então você sempre pode reverter para uma anterior."
 
 msgid "Click images to select"
 msgstr "Clique nas imagens para selecionar"
@@ -1744,9 +1711,6 @@ msgstr "Pipeline Principal"
 msgid "Correct answer"
 msgstr "Resposta correta"
 
-#~ msgid "Correct!"
-#~ msgstr "Correto!"
-
 msgid "Could not read this PDF. The file may be corrupted or password-protected."
 msgstr "Não foi possível ler este PDF. O arquivo pode estar corrompido ou protegido por senha."
 
@@ -1866,9 +1830,6 @@ msgstr "Modo de depuração não está ativado."
 
 msgid "Decorative"
 msgstr "Decorativa"
-
-#~ msgid "Decorative images are hidden from screen readers and don't need a caption"
-#~ msgstr "Imagens decorativas são ocultadas dos leitores de tela e não precisam de legenda"
 
 msgid "Decrease indent"
 msgstr "Diminuir recuo"
@@ -2071,9 +2032,6 @@ msgstr "Regras desativadas"
 msgid "Discard"
 msgstr "Descartar"
 
-#~ msgid "Dismiss"
-#~ msgstr "Fechar"
-
 msgid "Display"
 msgstr "Exibição"
 
@@ -2225,9 +2183,6 @@ msgstr "Editar esta imagem"
 
 msgid "Edit this section"
 msgstr "Editar esta seção"
-
-#~ msgid "Editable"
-#~ msgstr "Editável"
 
 msgid "edited"
 msgstr "editado"
@@ -2565,9 +2520,6 @@ msgstr "Filtrar páginas…"
 msgid "Filter quizzes…"
 msgstr "Filtrar questionários…"
 
-#~ msgid "Filter terms…"
-#~ msgstr "Filtrar termos…"
-
 msgid "Filtered by:"
 msgstr "Filtrado por:"
 
@@ -2712,9 +2664,6 @@ msgstr "Gerar áudio faltante do Gemini"
 msgid "Generate multiple-choice comprehension quizzes from the book's content. Create them automatically across the whole book, or add a single quiz from specific pages."
 msgstr "Gere questionários de compreensão de múltipla escolha a partir do conteúdo do livro. Crie-os automaticamente em todo o livro ou adicione um único questionário a partir de páginas específicas."
 
-#~ msgid "Generate multiple-choice comprehension quizzes from the book's content. Set how often a quiz appears, then run the stage to create them across the whole book."
-#~ msgstr "Gere questionários de compreensão de múltipla escolha a partir do conteúdo do livro. Defina com que frequência um questionário aparece e execute a etapa para criá-los em todo o livro."
-
 msgid "Generate new"
 msgstr "Gerar nova"
 
@@ -2741,9 +2690,6 @@ msgstr "Gerado a partir das páginas {fromLabel}"
 
 msgid "Generated from these pages"
 msgstr "Gerado a partir destas páginas"
-
-#~ msgid "Generated page"
-#~ msgstr "Página gerada"
 
 msgid "Generated section"
 msgstr "Seção gerada"
@@ -2870,9 +2816,6 @@ msgstr "Ocultar histórico de edições com IA"
 
 msgid "Hide error details"
 msgstr "Ocultar detalhes do erro"
-
-#~ msgid "Hide pruned terms"
-#~ msgstr "Ocultar termos podados"
 
 msgid "High"
 msgstr "Alto"
@@ -3086,6 +3029,9 @@ msgstr "No livro:"
 
 msgid "In case you don't want to convert the whole book, adjust the sliders to define which pages will be digitized."
 msgstr "Caso não queira converter o livro inteiro, ajuste os controles deslizantes para definir quais páginas serão digitalizadas."
+
+msgid "In development"
+msgstr "Em desenvolvimento"
 
 msgid "in the book"
 msgstr "no livro"
@@ -3471,9 +3417,6 @@ msgstr "Gerenciar todas as seções"
 msgid "Manage sign-language videos"
 msgstr "Gerenciar vídeos em linguagem de sinais"
 
-#~ msgid "manual"
-#~ msgstr "manual"
-
 msgid "Manual only"
 msgstr "Somente manual"
 
@@ -3500,12 +3443,6 @@ msgstr "Marcar como decorativo"
 
 msgid "Mark as decorative (hidden from screen readers)"
 msgstr "Marcar como decorativo (oculto para leitores de tela)"
-
-#~ msgid "Marked as decorative — hidden from screen readers, no caption needed."
-#~ msgstr "Marcada como decorativa — oculta dos leitores de tela, nenhuma legenda necessária."
-
-#~ msgid "Marked decorative"
-#~ msgstr "Marcado como decorativo"
 
 msgid "Match Design"
 msgstr "Corresponder ao Design"
@@ -3874,9 +3811,6 @@ msgstr "Nenhum prompt por idioma configurado."
 msgid "No languages configured. Add languages in the Language settings."
 msgstr "Nenhum idioma configurado. Adicione idiomas nas configurações de Idioma."
 
-#~ msgid "No link"
-#~ msgstr "Sem link"
-
 msgid "No log entries found yet."
 msgstr "Nenhuma entrada de registro encontrada ainda."
 
@@ -3937,9 +3871,6 @@ msgstr "Nenhum quiz para esta página"
 msgid "No quizzes match your search"
 msgstr "Nenhum questionário corresponde à sua pesquisa"
 
-#~ msgid "No quizzes yet"
-#~ msgstr "Nenhum questionário ainda"
-
 msgid "No rendered content for this section"
 msgstr "Sem conteúdo renderizado para esta seção"
 
@@ -3982,17 +3913,11 @@ msgstr "Nenhuma imagem de origem"
 msgid "No storyboard sections found. Run Storyboard to generate sections you can match videos to."
 msgstr "Nenhuma seção de storyboard encontrada. Execute o Storyboard para gerar seções que você pode associar a vídeos."
 
-#~ msgid "No terms match your filter."
-#~ msgstr "Nenhum termo corresponde ao seu filtro."
-
 msgid "No terms match your search"
 msgstr "Nenhum termo corresponde à sua pesquisa"
 
 msgid "No terms to show"
 msgstr "Nenhum termo para mostrar"
-
-#~ msgid "No terms to show."
-#~ msgstr "Nenhum termo para mostrar."
 
 msgid "No text extracted"
 msgstr "Nenhum texto extraído"
@@ -4030,9 +3955,6 @@ msgstr "Não encontrado no texto do livro"
 msgid "Not generated"
 msgstr "Não gerado"
 
-#~ msgid "Not quite"
-#~ msgstr "Quase lá"
-
 msgid "Not rendered yet"
 msgstr "Ainda não renderizado"
 
@@ -4068,9 +3990,6 @@ msgstr "OCR e limpeza"
 
 msgid "of"
 msgstr "de"
-
-#~ msgid "of {0}"
-#~ msgstr "de {0}"
 
 msgid "Off"
 msgstr "Desligado"
@@ -4200,9 +4119,6 @@ msgstr "Opcional. Termos adicionados aqui são fixados no glossário para que se
 
 msgid "Optionally translate burned-in text inside images (signs, labels, callouts). Select the images to localize — leaving the list empty keeps images in the source language."
 msgstr "Opcionalmente, traduza texto embutido dentro de imagens (sinais, rótulos, legendas). Selecione as imagens para localizar — deixar a lista vazia mantém as imagens no idioma original."
-
-#~ msgid "Options"
-#~ msgstr "Opções"
 
 msgid "options are deterministic;"
 msgstr "entrega resultados previsíveis;"
@@ -4363,9 +4279,6 @@ msgstr "Modo de Página"
 msgid "Page preview"
 msgstr "Pré-visualização da página"
 
-#~ msgid "Page preview {pageId}"
-#~ msgstr "Pré-visualização da página {pageId}"
-
 msgid "Page Range"
 msgstr "Intervalo de páginas"
 
@@ -4476,9 +4389,6 @@ msgstr "Por Palavra"
 msgid "Perfect for children's books, pairing large images with minimal text."
 msgstr "Perfeito para livros infantis, combinando imagens grandes com texto mínimo."
 
-#~ msgid "pg {0} · s{1}"
-#~ msgstr "pág. {0} · s{1}"
-
 msgid "Phase {phaseNumber}"
 msgstr "Fase {phaseNumber}"
 
@@ -4508,9 +4418,6 @@ msgstr "Escolha uma abordagem de layout."
 
 msgid "Pick the languages you want to translate to. The book's original language stays as-is."
 msgstr "Escolha os idiomas para os quais deseja traduzir. O idioma original do livro permanece como está."
-
-#~ msgid "Pick the pages the quiz is written from and choose where it appears in the book."
-#~ msgstr "Escolha as páginas em que o questionário se baseia e onde ele aparece no livro."
 
 msgid "Pick which voice each language uses for narration, including regional accents."
 msgstr "Escolha qual voz cada idioma usa para narração, incluindo sotaques regionais."
@@ -4660,9 +4567,6 @@ msgstr "removido"
 msgid "Pruned"
 msgstr "Removido"
 
-#~ msgid "Pruned ({0})"
-#~ msgstr "Podado ({0})"
-
 msgid "Pruned Images"
 msgstr "Imagens removidas"
 
@@ -4692,9 +4596,6 @@ msgstr "Parâmetro de consulta"
 
 msgid "question"
 msgstr "pergunta"
-
-#~ msgid "Question"
-#~ msgstr "Pergunta"
 
 msgid "Queued"
 msgstr "Na fila"
@@ -4749,9 +4650,6 @@ msgstr "Os questionários são escritos a partir do conteúdo que o Storyboard c
 
 msgid "Quizzes were generated by AI from your book's pages. Click any question, option, or explanation to edit it, and delete any quiz you don't need. Click a source page to zoom. Changes are saved as a new version, so you can always roll back."
 msgstr "Os questionários foram gerados por IA a partir das páginas do seu livro. Clique em qualquer pergunta, opção ou explicação para editá-la e exclua qualquer questionário que você não precise. Clique em uma página de origem para ampliar. As alterações são salvas como uma nova versão, para que você sempre possa reverter."
-
-#~ msgid "Quizzes you generate will show up here."
-#~ msgstr "Os questionários que você gerar aparecerão aqui."
 
 msgid "Quote"
 msgstr "Citação"
@@ -5125,9 +5023,6 @@ msgstr "Executar Legendas"
 msgid "Run Extract"
 msgstr "Executar Extração"
 
-#~ msgid "Run Extract first — sectioning needs extracted page text and images."
-#~ msgstr "Execute Extração primeiro — o seccionamento precisa do texto e das imagens extraídas da página."
-
 msgid "Run Glossary"
 msgstr "Executar Glossário"
 
@@ -5142,9 +5037,6 @@ msgstr "Executar Questionários"
 
 msgid "Run Sectioning"
 msgstr "Executar Seccionamento"
-
-#~ msgid "Run Sectioning first — storyboard needs typed sections to render."
-#~ msgstr "Execute Seccionamento primeiro — o storyboard precisa de seções classificadas para renderizar."
 
 msgid "Run Speech"
 msgstr "Executar Fala"
@@ -5423,9 +5315,6 @@ msgstr "Modo de seção"
 msgid "Sectioning Mode"
 msgstr "Modo de seção"
 
-#~ msgid "Sectioning needs the page text and images that Extract produces. Finish Extract before running this stage."
-#~ msgstr "O seccionamento precisa do texto e das imagens da página que a Extração produz. Termine a Extração antes de executar esta etapa."
-
 msgid "Sectioning Pages..."
 msgstr "Seccionando páginas..."
 
@@ -5485,9 +5374,6 @@ msgstr "Selecione um tipo de nó e insira um ID de item para ver as versões."
 
 msgid "Select a page grouping to continue"
 msgstr "Selecione um agrupamento de páginas para continuar"
-
-#~ msgid "Select a page…"
-#~ msgstr "Selecione uma página…"
 
 msgid "Select a render strategy to continue"
 msgstr "Selecione uma estratégia de renderização para continuar"
@@ -5600,9 +5486,6 @@ msgstr "Entregar"
 msgid "Short, simple sentences for kindergarten through 5th grade."
 msgstr "Frases curtas e simples para jardim de infância até o 5º ano."
 
-#~ msgid "Show"
-#~ msgstr "Mostrar"
-
 msgid "Show accessibility summary"
 msgstr "Mostrar resumo de acessibilidade"
 
@@ -5630,12 +5513,6 @@ msgstr "Mostrar menos"
 
 msgid "Show only the terms you added manually"
 msgstr "Mostrar apenas os termos que você adicionou manualmente"
-
-#~ msgid "Show pruned terms"
-#~ msgstr "Mostrar termos podados"
-
-#~ msgid "Show quiz after"
-#~ msgstr "Mostrar questionário após"
 
 msgid "Show reviewer validation"
 msgstr "Mostrar validação do revisor"
@@ -5751,9 +5628,6 @@ msgstr "Ordenar livros"
 
 msgid "Source"
 msgstr "Fonte"
-
-#~ msgid "Source pages"
-#~ msgstr "Páginas de origem"
 
 msgid "Source PDF"
 msgstr "PDF de Origem"
@@ -5873,9 +5747,6 @@ msgstr "Visão Geral do Storyboard"
 msgid "Storyboard Preview"
 msgstr "Pré-visualização do Storyboard"
 
-#~ msgid "Storyboard renders the typed sections produced by Sectioning. Finish Sectioning before running this stage."
-#~ msgstr "O Storyboard renderiza as seções classificadas produzidas pelo Seccionamento. Termine o Seccionamento antes de executar esta etapa."
-
 msgid "Storybook"
 msgstr "Livro de Histórias"
 
@@ -5884,9 +5755,6 @@ msgstr "Esticar"
 
 msgid "Strict"
 msgstr "Rigoroso"
-
-#~ msgid "Strict grid template that repeats across pages."
-#~ msgstr "Modelo de grade estrito que se repete nas páginas."
 
 msgid "Strikethrough"
 msgstr "Tachado"
@@ -5911,6 +5779,9 @@ msgstr "Estrutura cada página em uma árvore de seções e nós."
 
 msgid "Style"
 msgstr "Estilo"
+
+msgid "Style editing coming soon"
+msgstr "Edição de estilo em breve"
 
 msgid "Style guide"
 msgstr "Guia de estilo"
@@ -6153,9 +6024,6 @@ msgstr "O prompt usado pela passagem de revisão para inspecionar e corrigir uma
 msgid "The quick brown fox jumps over the lazy dog."
 msgstr "A rápida raposa marrom salta sobre o cão preguiçoso."
 
-#~ msgid "The quiz is inserted into the book right after this page."
-#~ msgstr "O questionário é inserido no livro logo após esta página."
-
 msgid "The rendering strategy used for sections without an explicit mapping."
 msgstr "A estratégia de renderização usada para seções sem um mapeamento explícito."
 
@@ -6182,9 +6050,6 @@ msgstr "O mundo diante de nós"
 
 msgid "Theme"
 msgstr "Tema"
-
-#~ msgid "These captions were generated automatically"
-#~ msgstr "Estas legendas foram geradas automaticamente"
 
 msgid "These features improve access for people with disabilities. Running them before exporting helps your book meet ADT accessibility standards."
 msgstr "Esses recursos melhoram o acesso para pessoas com deficiência. Executá-los antes de exportar ajuda seu livro a atender aos padrões de acessibilidade ADT."
@@ -6720,6 +6585,9 @@ msgstr "Revisão Visual"
 
 msgid "Visual Review Prompt (read-only)"
 msgstr "Prompt de Revisão Visual (somente leitura)"
+
+msgid "Visual style editing isn't available for fixed-layout pages yet. You can still edit text inline, swap or crop images, and prune elements."
+msgstr "A edição visual de estilos ainda não está disponível para páginas de layout fixo. Você ainda pode editar texto inline, substituir ou recortar imagens e remover elementos."
 
 msgid "Voice"
 msgstr "Voz"


### PR DESCRIPTION
## Problem
On fixed-layout pages, the left-sidebar Tailwind class editor was silently overridden: FL styling lives in **inline CSS** (the `<p>`'s own `style` + per-run `data-segments`), not Tailwind classes, so any edit was lost behind the inline styles (and auto-fit) and never applied to the rendered output. Users saw controls that did nothing.

## Change
- Hide the class-based sections (Typography / Sizing / Spacing / Layout / Appearance / Borders / ImageFit) **and** the Advanced raw-class textarea for fixed-layout pages.
- Show a centered, animated "in development" placeholder (`Construction` icon + "Style editing coming soon" + an "In development" badge) in their place.
- **Kept available** (these don't depend on classes): image actions (replace / crop / AI / segment), prune & delete, and inline text editing.
- Detection: `renderedSection.sectionType === "fixed-layout-page"`.

## Scope
Temporary UX gate until real inline-style / `data-segments` editing lands. **Not** a substitute for #473 — that fix is still required for FL inline text editing (which routes through `serializeContentWrapper`).

## i18n
3 new strings, translated for `es` / `fr` / `pt-BR`; `lingui compile --strict` passes. The `.po` diff also reflects `extract`'s pruning of pre-existing obsolete keys.

## Verification
- `tsc --noEmit` (@adt/studio) ✓
- `eslint` (changed files) ✓
- `lingui compile --strict` ✓
- Repro book available locally: `LP-4-Volcanoes` (fixed-layout, spread mode).