### PR TITLE
feat(storyboard): disable Tailwind style editor on fixed-layout pages

### DIFF
--- a/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
@@ -627,6 +627,12 @@ export function StoryboardSectionDetail({
   const section = sectioningData?.sections[sectionIndex]
   const renderingData = pendingRendering ?? page.rendering
   const renderedSection = getRenderedSectionByIndex(renderingData, sectionIndex)
+  // Fixed-layout pages style every element via inline CSS (the `<p>`'s own
+  // `style` + per-run `data-segments`), not Tailwind classes — so the class
+  // editor's changes are always overridden and never apply. Disable the
+  // class-based style controls for these pages until inline-style editing
+  // lands; image actions, prune/delete, and inline text edits still work.
+  const isFixedLayout = renderedSection?.sectionType === "fixed-layout-page"
   const renderingDirty = pendingRendering != null || hasUnflushedEdits
 
   // When server-delivered HTML for the current section changes to something we
@@ -2360,6 +2366,7 @@ export function StoryboardSectionDetail({
         }
         onClassesChange={handleClassesChange}
         deviceView={deviceView}
+        isFixedLayout={isFixedLayout}
       />
     </div>
 

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/style-editor/StyleEditorPanel.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/style-editor/StyleEditorPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState, type ReactNode } from "react"
 import {
   Box,
+  Construction,
   Eye,
   EyeOff,
   Film,
@@ -45,6 +46,10 @@ interface StyleEditorPanelProps {
    *  typography properties — used as inspector defaults so the fields show
    *  the actually-rendered value when no explicit class is set. */
   computedTypography?: ComputedTypographyStyles | null
+  /** Fixed-layout pages style elements via inline CSS, not Tailwind classes,
+   *  so the class-based controls have no effect. When true, the class sections
+   *  (and Advanced) are hidden; image actions and prune/delete remain. */
+  isFixedLayout?: boolean
 }
 
 export function StyleEditorPanel({
@@ -57,6 +62,7 @@ export function StyleEditorPanel({
   onClassesChange,
   deviceView,
   computedTypography,
+  isFixedLayout = false,
 }: StyleEditorPanelProps) {
   const { t } = useLingui()
 
@@ -179,6 +185,7 @@ export function StyleEditorPanel({
             onClassesChange={onClassesChange}
             deviceView={deviceView}
             computedTypography={computedTypography ?? null}
+            isFixedLayout={isFixedLayout}
           />
         ) : null}
       </div>
@@ -246,6 +253,7 @@ interface StyleEditorBodyProps {
   onClassesChange: (dataId: string, classes: string[]) => void
   deviceView: DeviceView
   computedTypography: ComputedTypographyStyles | null
+  isFixedLayout: boolean
 }
 
 function StyleEditorBody({
@@ -256,6 +264,7 @@ function StyleEditorBody({
   onClassesChange,
   deviceView,
   computedTypography,
+  isFixedLayout,
 }: StyleEditorBodyProps) {
   const visibleSections = useMemo(
     () => (elementType ? getVisibleSections(elementType) : []),
@@ -272,20 +281,56 @@ function StyleEditorBody({
         computedStyles: computedTypography ?? undefined,
       }}
     >
-      <div className="flex flex-col">
+      <div className="flex flex-col min-h-full">
         {elementProps?.isImage ? (
           <ImageActionsSection dataId={dataId} elementProps={elementProps} />
         ) : null}
         {elementType === "text" ? (
           <TextRoleSection dataId={dataId} elementProps={elementProps} />
         ) : null}
-        {visibleSections.map((key) => {
-          const SectionComponent = SECTION_COMPONENTS[key]
-          return <SectionComponent key={key} />
-        })}
-        <AdvancedSection />
+        {isFixedLayout ? (
+          <div className="flex flex-1 items-center justify-center">
+            <FixedLayoutNotice />
+          </div>
+        ) : (
+          <>
+            {visibleSections.map((key) => {
+              const SectionComponent = SECTION_COMPONENTS[key]
+              return <SectionComponent key={key} />
+            })}
+            <AdvancedSection />
+          </>
+        )}
       </div>
     </ElementProvider>
+  )
+}
+
+/** Centered placeholder shown in place of the class-based style controls on
+ *  fixed-layout pages, where styling is driven by inline CSS rather than
+ *  Tailwind classes. Signals the feature is in development. */
+function FixedLayoutNotice() {
+  return (
+    <div className="flex flex-col items-center gap-3 px-2 py-4 text-center animate-in fade-in slide-in-from-bottom-1 duration-300">
+      <div className="relative flex h-12 w-12 items-center justify-center rounded-full bg-violet-50">
+        <Construction className="h-6 w-6 text-violet-500" />
+        <span className="absolute inset-0 rounded-full ring-1 ring-inset ring-violet-200/70" />
+      </div>
+      <div className="flex flex-col gap-1.5">
+        <p className="text-xs font-semibold text-foreground">
+          <Trans>Style editing coming soon</Trans>
+        </p>
+        <p className="text-[11px] leading-relaxed text-muted-foreground">
+          <Trans>
+            Visual style editing isn't available for fixed-layout pages yet. You
+            can still edit text inline, swap or crop images, and prune elements.
+          </Trans>
+        </p>
+      </div>
+      <span className="inline-flex items-center gap-1 rounded-full bg-amber-50 px-2 py-0.5 text-[10px] font-medium text-amber-700">
+        <Trans>In development</Trans>
+      </span>
+    </div>
   )
 }
 

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -3116,6 +3116,9 @@ msgstr "In book:"
 msgid "In case you don't want to convert the whole book, adjust the sliders to define which pages will be digitized."
 msgstr "In case you don't want to convert the whole book, adjust the sliders to define which pages will be digitized."
 
+msgid "In development"
+msgstr "In development"
+
 msgid "in the book"
 msgstr "in the book"
 
@@ -5939,6 +5942,9 @@ msgstr "Structures each page into a tree of sections and nodes."
 msgid "Style"
 msgstr "Style"
 
+msgid "Style editing coming soon"
+msgstr "Style editing coming soon"
+
 msgid "Style guide"
 msgstr "Style guide"
 
@@ -6783,6 +6789,9 @@ msgstr "Visual Review"
 
 msgid "Visual Review Prompt (read-only)"
 msgstr "Visual Review Prompt (read-only)"
+
+msgid "Visual style editing isn't available for fixed-layout pages yet. You can still edit text inline, swap or crop images, and prune elements."
+msgstr "Visual style editing isn't available for fixed-layout pages yet. You can still edit text inline, swap or crop images, and prune elements."
 
 msgid "Voice"
 msgstr "Voice"

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -3116,6 +3116,9 @@ msgstr "En el libro:"
 msgid "In case you don't want to convert the whole book, adjust the sliders to define which pages will be digitized."
 msgstr "En caso de que no quieras convertir todo el libro, ajusta los controles deslizantes para definir qué páginas se digitalizarán."
 
+msgid "In development"
+msgstr "En desarrollo"
+
 msgid "in the book"
 msgstr "en el libro"
 
@@ -5939,6 +5942,9 @@ msgstr "Estructura cada página en un árbol de secciones y nodos."
 msgid "Style"
 msgstr "Estilo"
 
+msgid "Style editing coming soon"
+msgstr "Edición de estilos próximamente"
+
 msgid "Style guide"
 msgstr "Guía de estilo"
 
@@ -6783,6 +6789,9 @@ msgstr "Revisión Visual"
 
 msgid "Visual Review Prompt (read-only)"
 msgstr "Aviso de Revisión Visual (solo lectura)"
+
+msgid "Visual style editing isn't available for fixed-layout pages yet. You can still edit text inline, swap or crop images, and prune elements."
+msgstr "La edición visual de estilos aún no está disponible para páginas de maquetación fija. Aún puedes editar texto en línea, reemplazar o recortar imágenes y eliminar elementos."
 
 msgid "Voice"
 msgstr "Voz"

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -3118,6 +3118,9 @@ msgstr "Dans le livre :"
 msgid "In case you don't want to convert the whole book, adjust the sliders to define which pages will be digitized."
 msgstr "Si vous ne souhaitez pas convertir le livre entier, ajustez les curseurs pour définir quelles pages seront numérisées."
 
+msgid "In development"
+msgstr "En développement"
+
 msgid "in the book"
 msgstr "dans le livre"
 
@@ -5941,6 +5944,9 @@ msgstr "Structure chaque page en un arbre de sections et de nœuds."
 msgid "Style"
 msgstr "Style"
 
+msgid "Style editing coming soon"
+msgstr "Édition de style bientôt disponible"
+
 msgid "Style guide"
 msgstr "Guide de style"
 
@@ -6785,6 +6791,9 @@ msgstr "Révision visuelle"
 
 msgid "Visual Review Prompt (read-only)"
 msgstr "Invite de révision visuelle (lecture seule)"
+
+msgid "Visual style editing isn't available for fixed-layout pages yet. You can still edit text inline, swap or crop images, and prune elements."
+msgstr "L'édition visuelle des styles n'est pas encore disponible pour les pages à mise en page fixe. Vous pouvez toujours modifier le texte en ligne, remplacer ou recadrer des images et élaguer des éléments."
 
 msgid "Voice"
 msgstr "Voix"

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -3116,6 +3116,9 @@ msgstr "No livro:"
 msgid "In case you don't want to convert the whole book, adjust the sliders to define which pages will be digitized."
 msgstr "Caso não queira converter o livro inteiro, ajuste os controles deslizantes para definir quais páginas serão digitalizadas."
 
+msgid "In development"
+msgstr "Em desenvolvimento"
+
 msgid "in the book"
 msgstr "no livro"
 
@@ -5939,6 +5942,9 @@ msgstr "Estrutura cada página em uma árvore de seções e nós."
 msgid "Style"
 msgstr "Estilo"
 
+msgid "Style editing coming soon"
+msgstr "Edição de estilo em breve"
+
 msgid "Style guide"
 msgstr "Guia de estilo"
 
@@ -6783,6 +6789,9 @@ msgstr "Revisão Visual"
 
 msgid "Visual Review Prompt (read-only)"
 msgstr "Prompt de Revisão Visual (somente leitura)"
+
+msgid "Visual style editing isn't available for fixed-layout pages yet. You can still edit text inline, swap or crop images, and prune elements."
+msgstr "A edição visual de estilos ainda não está disponível para páginas de layout fixo. Você ainda pode editar texto inline, substituir ou recortar imagens e remover elementos."
 
 msgid "Voice"
 msgstr "Voz"

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -3117,6 +3117,9 @@ msgstr "Në libër:"
 msgid "In case you don't want to convert the whole book, adjust the sliders to define which pages will be digitized."
 msgstr "Nëse nuk doni të konvertoni të gjithë librin, rregulloni rrëshqitësit për të përcaktuar cilat faqe do të digjitalizohen."
 
+msgid "In development"
+msgstr "Në zhvillim"
+
 msgid "in the book"
 msgstr "në libër"
 
@@ -5940,6 +5943,9 @@ msgstr "Strukturon çdo faqe në një pemë seksionesh dhe nyjesh."
 msgid "Style"
 msgstr "Stili"
 
+msgid "Style editing coming soon"
+msgstr "Redaktimi i stilit së shpejti"
+
 msgid "Style guide"
 msgstr "Udhëzues stili"
 
@@ -6784,6 +6790,9 @@ msgstr "Rishikim vizual"
 
 msgid "Visual Review Prompt (read-only)"
 msgstr "Prompt i rishikimit vizual (vetëm lexim)"
+
+msgid "Visual style editing isn't available for fixed-layout pages yet. You can still edit text inline, swap or crop images, and prune elements."
+msgstr "Redaktimi vizual i stileve nuk është ende i disponueshëm për faqet me strukturë fikse. Ende mund të redaktoni tekstin në linjë, të zëvendësoni ose prisni imazhe dhe të shkurtoni elemente."
 
 msgid "Voice"
 msgstr "Zë"


### PR DESCRIPTION
## Problem
On fixed-layout pages, the left-sidebar Tailwind class editor was silently overridden: FL styling lives in **inline CSS** (the `<p>`'s own `style` + per-run `data-segments`), not Tailwind classes, so any edit was lost behind the inline styles (and auto-fit) and never applied to the rendered output. Users saw controls that did nothing.

## Change
- Hide the class-based sections (Typography / Sizing / Spacing / Layout / Appearance / Borders / ImageFit) **and** the Advanced raw-class textarea for fixed-layout pages.
- Show a centered, animated "in development" placeholder (`Construction` icon + "Style editing coming soon" + an "In development" badge) in their place.
- **Kept available** (these don't depend on classes): image actions (replace / crop / AI / segment), prune & delete, and inline text editing.
- Detection: `renderedSection.sectionType === "fixed-layout-page"`.

## Scope
Temporary UX gate until real inline-style / `data-segments` editing lands. Minimal, self-contained change — no other modifications.

## i18n
3 new strings, translated for `es` / `fr` / `pt-BR` / `sq`; `lingui compile --strict` passes. `.po` diff is additions only (no obsolete-key churn).

## Verification
- `tsc --noEmit` — no errors in changed files (a pre-existing, unrelated `easy-read/EasyReadLandingPage.tsx` error already exists on `develop`).
- `eslint` (changed files) ✓
- `lingui compile --strict` ✓
- Repro book available locally: `LP-4-Volcanoes` (fixed-layout, spread mode).