### PR TITLE
feat(easy-read): run sections concurrently and report X/Y progress

### DIFF
--- a/apps/api/src/routes/easy-read.ts
+++ b/apps/api/src/routes/easy-read.ts
@@ -229,7 +229,9 @@ export function createEasyReadRoutes(
           rateLimiter,
           onLog: (entry) => storage.appendLlmLog(entry),
         })
-        const output: EasyReadOutputType = await generateEasyRead(blocks, easyReadConfig, model)
+        const output: EasyReadOutputType = await generateEasyRead(blocks, easyReadConfig, model, {
+          concurrency: config.concurrency ?? 32,
+        })
         const previousRow = storage.getLatestNodeData("easy-read", "book")
         const previousEasyRead = parseStoredEasyRead(previousRow?.data)
         const version = storage.putNodeData("easy-read", "book", output)

--- a/apps/api/src/services/stage-runner.ts
+++ b/apps/api/src/services/stage-runner.ts
@@ -1684,7 +1684,26 @@ async function runEasyReadStep(
           onLog: onLlmLog,
           credentials: llmCredentials,
         })
-        const easyRead = await generateEasyRead(blocks, easyReadConfig, easyReadModel)
+        const totalEntries = blocks.reduce((sum, block) => sum + block.entries.length, 0)
+        progress.emit({
+          type: "step-progress",
+          step: "easy-read",
+          message: `0/${totalEntries}`,
+          page: 0,
+          totalPages: totalEntries,
+        })
+        const easyRead = await generateEasyRead(blocks, easyReadConfig, easyReadModel, {
+          concurrency: effectiveConcurrency,
+          onProgress: (completed, total) => {
+            progress.emit({
+              type: "step-progress",
+              step: "easy-read",
+              message: `${completed}/${total}`,
+              page: completed,
+              totalPages: total,
+            })
+          },
+        })
         storage.putNodeData("easy-read", "book", easyRead)
         easyReadEntries = flattenEasyReadEntries(easyRead)
         progress.emit({

--- a/packages/pipeline/src/__tests__/easy-read.test.ts
+++ b/packages/pipeline/src/__tests__/easy-read.test.ts
@@ -9,10 +9,12 @@ import {
   buildPageEasyReadBlocks,
   createEmptyEasyReadOutput,
   generateEasyRead,
+  rewriteBlockEasyRead,
   flattenEasyReadEntries,
   getEasyReadElementEligibility,
   isDeterministicEmptyEasyReadOutput,
 } from "../easy-read.js"
+import type { EasyReadOutput } from "@adt/types"
 
 function makeFakeModel(
   fn: (texts: Array<{ index: number; text: string }>) => string[],
@@ -33,6 +35,35 @@ function makeFakeModel(
 }
 
 const page: PageData = { pageId: "pg001", pageNumber: 1, text: "" }
+
+/** Build an Easy Read source block with `count` simple entries. */
+function makeBlock(
+  pageId: string,
+  sectionIndex: number,
+  count: number,
+): EasyReadOutput["blocks"][number] {
+  const sectionId = `${pageId}_sec${String(sectionIndex).padStart(3, "0")}`
+  return {
+    pageId,
+    pageNumber: sectionIndex + 1,
+    sectionId,
+    sectionIndex,
+    sectionType: "text_only",
+    entries: Array.from({ length: count }, (_, i) => {
+      const sourceId = `${pageId}_tx${sectionIndex}${String(i).padStart(3, "0")}`
+      const originalText = `${pageId} s${sectionIndex} text ${i}`
+      return {
+        sourceId,
+        easyReadId: `${sourceId}_easy_read`,
+        originalText,
+        text: originalText,
+        pageId,
+        sectionId,
+        sectionIndex,
+      }
+    }),
+  }
+}
 
 describe("buildPageEasyReadBlocks", () => {
   it("selects non-interactive body text and excludes headings, images, and activity controls", () => {
@@ -476,6 +507,85 @@ describe("generateEasyRead", () => {
       { id: "pg001_tx003_easy_read", text: outputs[2] },
       { id: "pg001_tx004_easy_read", text: outputs[3] },
     ])
+  })
+
+  it("reports cumulative progress that reaches total/total", async () => {
+    const config = buildEasyReadConfig(
+      {
+        role_types: { text: "Text" },
+        structure_types: { paragraph: "Paragraph" },
+        easy_read: { enabled: true, batch_size: 10 },
+      },
+      "en",
+    )
+    const model = makeFakeModel((texts) => texts.map((t) => `Easy: ${t.text}`))
+    const blocks = [makeBlock("pg001", 0, 2), makeBlock("pg002", 1, 3), makeBlock("pg003", 2, 1)]
+    const totalEntries = 6
+
+    const progress: Array<[number, number]> = []
+    await generateEasyRead(blocks, config, model, {
+      concurrency: 4,
+      onProgress: (completed, total) => progress.push([completed, total]),
+    })
+
+    // One callback per block (3 blocks), totals always equal the entry count.
+    expect(progress).toHaveLength(3)
+    expect(progress.every(([, total]) => total === totalEntries)).toBe(true)
+    // Cumulative completed counts are monotonically increasing and end at total.
+    const completedCounts = progress.map(([completed]) => completed)
+    expect(completedCounts).toEqual([...completedCounts].sort((a, b) => a - b))
+    expect(completedCounts.at(-1)).toBe(totalEntries)
+  })
+
+  it("produces identical output regardless of concurrency", async () => {
+    const config = buildEasyReadConfig(
+      {
+        role_types: { text: "Text" },
+        structure_types: { paragraph: "Paragraph" },
+        easy_read: { enabled: true, batch_size: 2 },
+      },
+      "en",
+    )
+    const blocks = [makeBlock("pg001", 0, 3), makeBlock("pg002", 1, 2), makeBlock("pg003", 2, 4)]
+    const buildModel = () => makeFakeModel((texts) => texts.map((t) => `Easy: ${t.text}`))
+
+    const sequential = await generateEasyRead(blocks, config, buildModel(), { concurrency: 1 })
+    const concurrent = await generateEasyRead(blocks, config, buildModel(), { concurrency: 8 })
+
+    expect(flattenEasyReadEntries(concurrent)).toEqual(flattenEasyReadEntries(sequential))
+  })
+})
+
+describe("rewriteBlockEasyRead", () => {
+  it("adapts a single section's entries and keys them by sourceId", async () => {
+    const config = buildEasyReadConfig(
+      {
+        role_types: { text: "Text" },
+        structure_types: { paragraph: "Paragraph" },
+        easy_read: { enabled: true, batch_size: 2 },
+      },
+      "en",
+    )
+    let sectionText = ""
+    let callCount = 0
+    const model = makeFakeModel(
+      (texts) => texts.map((t) => `Easy: ${t.text}`),
+      (options) => {
+        callCount += 1
+        const context = options.context as { section_text?: string }
+        sectionText = context.section_text ?? ""
+      },
+    )
+
+    const block = makeBlock("pg001", 0, 3)
+    const result = await rewriteBlockEasyRead(block, config, model)
+
+    // batch_size 2 over 3 entries → 2 LLM calls, each seeing the full section text.
+    expect(callCount).toBe(2)
+    expect(sectionText).toBe("pg001 s0 text 0\npg001 s0 text 1\npg001 s0 text 2")
+    expect(result.get("pg001_tx0000")).toBe("Easy: pg001 s0 text 0")
+    expect(result.get("pg001_tx0002")).toBe("Easy: pg001 s0 text 2")
+    expect(result.size).toBe(3)
   })
 })
 

--- a/packages/pipeline/src/easy-read.ts
+++ b/packages/pipeline/src/easy-read.ts
@@ -5,6 +5,7 @@ import { DEFAULT_LLM_MAX_RETRIES, EasyReadOutput as EasyReadOutputSchema, WebRen
 import type { LLMModel, ValidationResult } from "@adt/llm"
 import type { Storage, PageData } from "@adt/storage"
 import { buildLanguageContext, normalizeLocale } from "./language-context.js"
+import { processWithConcurrency } from "./concurrency.js"
 
 export const DEFAULT_EASY_READ_MODEL_ID = "openai:gpt-4.1"
 
@@ -196,57 +197,95 @@ export function buildPageEasyReadBlocks(
   return blocks
 }
 
+/**
+ * Adapt the texts of ONE section (block) into Easy Read.
+ *
+ * Pure with respect to shared state — it owns no caller state and returns its
+ * results keyed by `sourceId`, so many blocks can be processed concurrently.
+ * The section's full text is passed as `section_text` context on every call;
+ * `batchSize` only caps the per-call size for unusually large sections (the
+ * common case is a single call per section).
+ */
+export async function rewriteBlockEasyRead(
+  block: EasyReadOutput["blocks"][number],
+  config: EasyReadConfig,
+  llmModel: LLMModel,
+): Promise<Map<string, string>> {
+  const rewrittenBySourceId = new Map<string, string>()
+  const sectionText = block.entries.map((entry) => entry.originalText).join("\n")
+
+  for (let i = 0; i < block.entries.length; i += config.batchSize) {
+    const batch = block.entries.slice(i, i + config.batchSize)
+    const texts = batch.map((entry, index) => ({ index, text: entry.originalText }))
+    const result = await llmModel.generateObject<{ texts: string[] }>({
+      schema: easyReadSchema,
+      prompt: config.promptName,
+      context: {
+        ...buildLanguageContext(config.language),
+        section_text: sectionText,
+        section_type: block.sectionType,
+        texts,
+      },
+      validate: (raw: unknown): ValidationResult => {
+        const r = raw as { texts?: string[] }
+        if (!Array.isArray(r.texts) || r.texts.length !== batch.length) {
+          return {
+            valid: false,
+            errors: [
+              `Expected ${batch.length} Easy Read texts but got ${Array.isArray(r.texts) ? r.texts.length : "none"}.`,
+            ],
+          }
+        }
+        return { valid: true, errors: [] }
+      },
+      maxRetries: config.maxRetries,
+      maxTokens: 16384,
+      log: {
+        taskType: "easy-read",
+        promptName: config.promptName,
+        pageId: block.pageId,
+      },
+    })
+
+    batch.forEach((entry, index) => {
+      rewrittenBySourceId.set(entry.sourceId, result.object.texts[index] ?? entry.originalText)
+    })
+  }
+
+  return rewrittenBySourceId
+}
+
+export interface GenerateEasyReadOptions {
+  /** Maximum number of sections processed in parallel. Defaults to 1 (sequential). */
+  concurrency?: number
+  /** Called after each section finishes, with the cumulative entry counts. */
+  onProgress?: (completed: number, total: number) => void
+}
+
 export async function generateEasyRead(
   blocks: EasyReadOutput["blocks"],
   config: EasyReadConfig,
   llmModel: LLMModel,
+  options?: GenerateEasyReadOptions,
 ): Promise<EasyReadOutput> {
   if (!config.enabled || blocks.length === 0) {
     return createEmptyEasyReadOutput()
   }
 
+  const totalEntries = blocks.reduce((sum, block) => sum + block.entries.length, 0)
   const rewrittenBySourceId = new Map<string, string>()
+  let completed = 0
 
-  for (const block of blocks) {
-    const sectionText = block.entries.map((entry) => entry.originalText).join("\n")
-    for (let i = 0; i < block.entries.length; i += config.batchSize) {
-      const batch = block.entries.slice(i, i + config.batchSize)
-      const texts = batch.map((entry, index) => ({ index, text: entry.originalText }))
-      const result = await llmModel.generateObject<{ texts: string[] }>({
-        schema: easyReadSchema,
-        prompt: config.promptName,
-        context: {
-          ...buildLanguageContext(config.language),
-          section_text: sectionText,
-          section_type: block.sectionType,
-          texts,
-        },
-        validate: (raw: unknown): ValidationResult => {
-          const r = raw as { texts?: string[] }
-          if (!Array.isArray(r.texts) || r.texts.length !== batch.length) {
-            return {
-              valid: false,
-              errors: [
-                `Expected ${batch.length} Easy Read texts but got ${Array.isArray(r.texts) ? r.texts.length : "none"}.`,
-              ],
-            }
-          }
-          return { valid: true, errors: [] }
-        },
-        maxRetries: config.maxRetries,
-        maxTokens: 16384,
-        log: {
-          taskType: "easy-read",
-          promptName: config.promptName,
-          pageId: block.pageId,
-        },
-      })
-
-      batch.forEach((entry, index) => {
-        rewrittenBySourceId.set(entry.sourceId, result.object.texts[index] ?? entry.originalText)
-      })
+  // Each block writes a disjoint set of sourceIds, so concurrent writes to the
+  // shared map never collide.
+  await processWithConcurrency(blocks, options?.concurrency ?? 1, async (block) => {
+    const rewritten = await rewriteBlockEasyRead(block, config, llmModel)
+    for (const [sourceId, text] of rewritten) {
+      rewrittenBySourceId.set(sourceId, text)
     }
-  }
+    completed += block.entries.length
+    options?.onProgress?.(completed, totalEntries)
+  })
 
   const rewrittenBlocks = blocks.map((block) => ({
     ...block,

--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -155,11 +155,13 @@ export {
   buildPageEasyReadBlocks,
   createEmptyEasyReadOutput,
   generateEasyRead,
+  rewriteBlockEasyRead,
   flattenEasyReadEntries,
   DEFAULT_EASY_READ_MODEL_ID,
   EMPTY_EASY_READ_GENERATED_AT,
   isDeterministicEmptyEasyReadOutput,
   type EasyReadConfig,
+  type GenerateEasyReadOptions,
 } from "./easy-read.js"
 export {
   resolveVoice,

--- a/packages/pipeline/src/pipeline-dag.ts
+++ b/packages/pipeline/src/pipeline-dag.ts
@@ -729,12 +729,24 @@ export async function runFullPipeline(
         return
       }
       const model = getModel(easyReadConfig.modelId)
-      const output = await generateEasyRead(blocks, easyReadConfig, model)
+      const totalEntries = blocks.reduce((sum, block) => sum + block.entries.length, 0)
+      const output = await generateEasyRead(blocks, easyReadConfig, model, {
+        concurrency: effectiveConcurrency,
+        onProgress: (completed, total) => {
+          p.emit({
+            type: "step-progress",
+            step: "easy-read",
+            message: `${completed}/${total}`,
+            page: completed,
+            totalPages: total,
+          })
+        },
+      })
       storage.putNodeData("easy-read", "book", output)
       p.emit({
         type: "step-progress",
         step: "easy-read",
-        message: `${output.blocks.reduce((sum, block) => sum + block.entries.length, 0)} entries`,
+        message: `${totalEntries} entries`,
       })
     })
 


### PR DESCRIPTION
## Context

When a user runs the pipeline, the **Easy Read** step gave no feedback: it emitted one `step-start`, ran silently, then emitted a single `"<N> entries"` message and completed. The user couldn't tell how many Easy Read texts remained — every other LLM-driven step shows a live `X/Y` counter (e.g. Image Captioning `1/12 … 12/12`).

Investigating *why* surfaced a deeper issue than the missing counter: **Easy Read was the only book-level, multi-item LLM step that ran strictly sequentially.** `generateEasyRead` owned a nested `for block → for batch → await` loop with no concurrency and no progress hook, while Image Captioning (per-page) and Glossary/Quiz (per-batch) all parallelize via the shared `processWithConcurrency` helper. On a book with many sections this was far slower than necessary, with zero visibility while it ran.

The Easy Read prompt (`prompts/easy_read.liquid`) is already **section-oriented** — each LLM call adapts the texts of one section, passing that section's full text as context. So the natural, separable unit of work is a **section** (one "block"), mirroring how Image Captioning's unit is a page.

## What changed

- **Extract a pure per-section unit** — `rewriteBlockEasyRead(block, config, llmModel)` adapts one section's texts and returns them keyed by `sourceId`. It owns no shared state, so many sections can run in parallel. Independently unit-testable, analogous to `captionPageImages`.
- **Concurrent orchestration + progress** — `generateEasyRead` now drives those units through `processWithConcurrency`, with a new **optional** 4th param `options?: { concurrency?, onProgress?: (completed, total) => void }`. Output ordering still derives from the input `blocks`, so results are identical regardless of concurrency and LLM cache keys are unchanged.
- **Wire all three call sites** to pass concurrency + emit `step-progress` events (`page`/`totalPages`): the stage runner (`runEasyReadStep`), the headless DAG (`pipeline-dag.ts`), and the manual regenerate route (`routes/easy-read.ts`).
- The counter counts **Easy Read texts (entries)** — `X/Y` where `Y` is the total to create — advancing by each section's entry count and reaching `total/total`.

**No frontend / i18n / prompt changes:** `StageRunCard` already renders any step's `page`/`totalPages` as `X/Y`, the counter is purely numeric, and the prompt was already section-oriented (the restructure just makes the code honor that boundary).

## Net effect

- **Faster runs** — sections now process up to `concurrency` (default 32) at a time, throttled by the existing rate limiter — with identical output.
- **Visible progress** — a live `0/Y → … → Y/Y` counter in the stage card.
- **Consistent structure** — Easy Read now matches the rest of the pipeline's concurrent-batch steps.

## Testing

- `pnpm typecheck` — clean.
- Full pipeline + api suites pass (957 tests).
- New tests in `easy-read.test.ts`: the pure `rewriteBlockEasyRead` single-section unit, cumulative progress reaching `total/total`, and concurrency-invariant output.
- Independent regression review confirmed: behavioral equivalence, no data races, unchanged cache keys, conformant progress-event shape, all edge cases and call sites correct.

## Out of scope

- No change to the prompt text, the `EasyReadOutput` schema, storage/versioning, or `buildEasyReadSourceBlocks`.
- Finer-grained parallelism within a single huge section (sub-batch fan-out) — sections are the natural unit and `batchSize` already caps oversized calls.