### PR TITLE
fix(studio): bundle pdfjs WASM decoders so JPEG 2000 covers render

### DIFF
--- a/apps/studio/src/components/wizard/shared/pdfjsLoader.ts
+++ b/apps/studio/src/components/wizard/shared/pdfjsLoader.ts
@@ -3,6 +3,17 @@ import { installCollectionMethodPolyfills } from "@/lib/pdfjs-dist-polyfill"
 
 let pdfjsModule: Promise<typeof import("pdfjs-dist")> | null = null
 
+// pdfjs-dist 5.x loads its JPEG 2000 (OpenJPEG) and JBIG2 WASM decoders from
+// this directory at runtime. Without it, JPEG 2000 cover images fail to decode
+// and silently render blank. The files are served here by the `pdfjsWasmAssets`
+// Vite plugin (trailing slash is required by pdfjs).
+const PDF_WASM_BASE_URL = `${import.meta.env.BASE_URL}pdfjs-wasm/`
+
+/** WASM-decoder URL to spread into every `getDocument` call that renders pages. */
+export const PDF_WASM_OPTIONS = {
+  wasmUrl: PDF_WASM_BASE_URL,
+} as const
+
 /** Single dynamic import + worker setup so pdf work stays off the critical path until needed. */
 export function getPdfJs() {
   if (!pdfjsModule) {

--- a/apps/studio/src/components/wizard/shared/usePdfPreviewPages.ts
+++ b/apps/studio/src/components/wizard/shared/usePdfPreviewPages.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react"
-import { getPdfJs } from "@/components/wizard/shared/pdfjsLoader"
+import { getPdfJs, PDF_WASM_OPTIONS } from "@/components/wizard/shared/pdfjsLoader"
 
 const JPEG_QUALITY = 0.92
 const MAX_CACHE_ENTRIES = 12
@@ -72,8 +72,8 @@ export function usePdfPreviewPages(params: UsePdfPreviewPagesParams) {
     ;(async () => {
       try {
         const documentSource = file
-          ? { url: (objectUrl = URL.createObjectURL(file)) }
-          : { url: src as string }
+          ? { url: (objectUrl = URL.createObjectURL(file)), ...PDF_WASM_OPTIONS }
+          : { url: src as string, ...PDF_WASM_OPTIONS }
 
         const pdfjs = await getPdfJs()
         if (cancelled) return

--- a/apps/studio/vite.config.ts
+++ b/apps/studio/vite.config.ts
@@ -1,15 +1,58 @@
 import { lingui } from "@lingui/vite-plugin";
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import { tanstackRouter } from "@tanstack/router-plugin/vite";
 import { fileURLToPath, URL } from "node:url";
+import { createRequire } from "node:module";
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+// pdfjs-dist 5.x decodes JPEG 2000 (JPXDecode), JBIG2, and ICC color via WASM
+// modules shipped in `pdfjs-dist/wasm/`. They must be reachable at a stable URL
+// (with their original filenames) so pdfjs can fetch them at runtime; otherwise
+// JPEG 2000 images silently fail to decode. We expose them under `/pdfjs-wasm/`
+// in dev (middleware) and in builds (emitted unhashed assets).
+function pdfjsWasmAssets(): Plugin {
+  const require = createRequire(import.meta.url);
+  const wasmDir = join(dirname(require.resolve("pdfjs-dist/package.json")), "wasm");
+  const files = readdirSync(wasmDir).filter(
+    (f) => f.endsWith(".wasm") || f.endsWith(".js"),
+  );
+  const URL_PREFIX = "/pdfjs-wasm/";
+  return {
+    name: "pdfjs-wasm-assets",
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        const url = req.url?.split("?")[0] ?? "";
+        if (!url.startsWith(URL_PREFIX)) return next();
+        const name = url.slice(URL_PREFIX.length);
+        if (!files.includes(name)) return next();
+        res.setHeader(
+          "Content-Type",
+          name.endsWith(".wasm") ? "application/wasm" : "text/javascript",
+        );
+        res.end(readFileSync(join(wasmDir, name)));
+      });
+    },
+    generateBundle() {
+      for (const name of files) {
+        this.emitFile({
+          type: "asset",
+          fileName: `pdfjs-wasm/${name}`,
+          source: readFileSync(join(wasmDir, name)),
+        });
+      }
+    },
+  };
+}
 
 export default defineConfig(({ mode }) => {
   const isDesktop = mode === "desktop";
 
   return {
     plugins: [
+      pdfjsWasmAssets(),
       lingui(),
       tanstackRouter({
         quoteStyle: "double",


### PR DESCRIPTION
## Problem

PDF cover previews rendered **blank** for books whose cover is encoded as **JPEG 2000** (or JBIG2).

`pdfjs-dist` 5.x moved its JPEG 2000 / JBIG2 / ICC decoders out of the main bundle into separate **WASM modules** that it fetches at runtime from a `wasmUrl` option. In a plain Vite app that option is never set, so pdfjs has nowhere to load the decoders from — and it **fails silently**, leaving the image (and thus the whole cover preview) blank. Ordinary JPEG/PNG covers were unaffected because those decoders are still built in.

## Fix

1. **Serve the decoders** — a `pdfjsWasmAssets()` Vite plugin exposes `pdfjs-dist/wasm/*` under `/pdfjs-wasm/`, via dev middleware and as emitted (unhashed) build assets. Filenames are preserved because pdfjs builds the URLs itself.
2. **Point pdfjs at them** — `pdfjsLoader.ts` exports `PDF_WASM_OPTIONS = { wasmUrl }`, built from `import.meta.env.BASE_URL` (so it works under a sub-path and under the Electron `app://` protocol, with the trailing slash pdfjs requires). `usePdfPreviewPages.ts` spreads it into every rendering `getDocument` call.

The metadata-only path (`pdfMetadata.ts`) is untouched since it never renders images.

## Verification

- `pnpm --filter @adt/studio build` succeeds and emits `dist/pdfjs-wasm/{openjpeg,jbig2,qcms_bg}.wasm` + `openjpeg_nowasm_fallback.js`.
- `pnpm --filter @adt/studio lint` — 0 errors.