### PR TITLE
fix(config): restore generic default Speech prompt

### DIFF
--- a/config/speech_instructions.yaml
+++ b/config/speech_instructions.yaml
@@ -1,4 +1,4 @@
-default: Speak in natural Albanian as spoken in Kosovo. Use a clear, authentic Kosovo Albanian pronunciation with a warm, conversational tone. Sound like an educated native speaker from Kosovo. Maintain natural rhythm, intonation, and vocabulary commonly heard in everyday speech in Kosovo. Avoid sounding overly formal, theatrical, or robotic. Speak at a moderate pace with excellent clarity.
+default: Speak in a cheerful and positive tone.
 en: Speak in a cheerful and positive tone.
 sq: |
   Style: Warm, natural, child-friendly conversational cadence at a calm, measured pace.


### PR DESCRIPTION
## Problem

The **default** TTS/Speech accent prompt was hardcoded to a Kosovo Albanian instruction, so every book whose language had no specific entry was given an Albanian accent. See #481.

## Root cause

Commit 8902c37b changed the `default:` entry in `config/speech_instructions.yaml` from the generic prompt to a Kosovo Albanian instruction:

```diff
-default: Speak in a cheerful and positive tone.
+default: Speak in natural Albanian as spoken in Kosovo. ...
```

Speech instructions resolve as **exact language match → base language → `default`** (`packages/pipeline/src/speech.ts:102-115`). That makes `default` the catch-all fallback for *every* language without its own entry — so all non-Albanian books inherited the Albanian accent.

## Fix

Revert the `default:` entry back to the generic prompt:

```yaml
default: Speak in a cheerful and positive tone.
```

The Albanian-specific behavior is fully preserved:
- The `sq:` entry still resolves the Kosovo accent via exact match.
- The Whisper 400-retry logic added in the same commit (`packages/llm/src/speech.ts`) is untouched.

## Testing

- `vitest run packages/pipeline/src/__tests__/speech.test.ts` — 48 tests pass.
- Albanian (`sq`) books still resolve to the Kosovo accent prompt; other languages fall back to the generic default.

Fixes #481