### PR TITLE
fix(book-metadata): readable language warning, language revert, author guards

### DIFF
--- a/apps/studio/src/components/pipeline/stages/extract/BookHeader.tsx
+++ b/apps/studio/src/components/pipeline/stages/extract/BookHeader.tsx
@@ -10,6 +10,7 @@ import {
   Loader2,
   Pencil,
   Plus,
+  RotateCcw,
   Sparkles,
   User,
   X,
@@ -21,7 +22,7 @@ import { useBook, useUpdateBookMetadata, useRegenerateBookSummary } from "@/hook
 import { usePageImage } from "@/hooks/use-pages"
 import { useApiKey } from "@/hooks/use-api-key"
 import { LanguagePicker } from "@/components/LanguagePicker"
-import { getBaseLanguage, normalizeLocale } from "@/lib/languages"
+import { getBaseLanguage, getDisplayName, normalizeLocale } from "@/lib/languages"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Button } from "@/components/ui/button"
@@ -114,6 +115,7 @@ export function BookHeader({
       ? normalizeLocale(current.language_code) !== normalizeLocale(original.language_code)
       : false
   const needsConfirmation = languageChanged && affectedStages.length > 0
+  const originalLanguageName = getDisplayName(original?.language_code ?? "")
 
   const update = (patch: Partial<MetadataDraft>) => {
     if (current) setDraft({ ...current, ...patch })
@@ -121,10 +123,11 @@ export function BookHeader({
 
   const persist = () => {
     if (!metadata || !current || !original) return
+    const trimmedAuthors = current.authors.map((a) => a.trim()).filter(Boolean)
     const payload: BookMetadata = {
       ...metadata,
       title: current.title.trim() || null,
-      authors: current.authors.map((a) => a.trim()).filter(Boolean),
+      authors: trimmedAuthors.filter((a, i) => trimmedAuthors.indexOf(a) === i),
       publisher: current.publisher.trim() || null,
       language_code: current.language_code
         ? normalizeLocale(current.language_code)
@@ -333,6 +336,10 @@ export function BookHeader({
                   variant="ghost"
                   size="sm"
                   className="gap-1.5 text-muted-foreground hover:text-foreground"
+                  disabled={
+                    current.authors.length > 0 &&
+                    current.authors[current.authors.length - 1].trim() === ""
+                  }
                   onClick={() => update({ authors: [...current.authors, ""] })}
                 >
                   <Plus className="h-3.5 w-3.5" />
@@ -363,14 +370,36 @@ export function BookHeader({
                 hint={t`Add the region (e.g. Spanish — Uruguay) so downstream stages use the right localization.`}
                 size="default"
               />
+              {languageChanged && (
+                <button
+                  type="button"
+                  onClick={() => update({ language_code: original?.language_code ?? "" })}
+                  className="inline-flex items-center gap-1 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+                >
+                  <RotateCcw className="h-3 w-3" />
+                  {originalLanguageName ? (
+                    <Trans>Revert to {originalLanguageName}</Trans>
+                  ) : (
+                    <Trans>Revert language change</Trans>
+                  )}
+                </button>
+              )}
               {needsConfirmation && (
-                <p className="flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs leading-relaxed text-amber-900 animate-in fade-in slide-in-from-top-1 duration-200 dark:border-amber-900/60 dark:bg-amber-950/20 dark:text-amber-200">
-                  <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-                  <Trans>
-                    Changing the language resets the completed downstream stages
-                    that depend on it. You'll confirm before it happens.
-                  </Trans>
-                </p>
+                <div className="flex items-start gap-2.5 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2.5 animate-in fade-in slide-in-from-top-1 duration-200">
+                  <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+                  <p className="text-xs leading-relaxed text-foreground">
+                    <span className="font-semibold">
+                      <Trans>Changing the language resets downstream work.</Trans>
+                    </span>{" "}
+                    <span className="text-muted-foreground">
+                      <Trans>
+                        Completed language-based stages (quizzes, glossary,
+                        captions, audio) will be cleared and need to run again.
+                        You'll confirm first.
+                      </Trans>
+                    </span>
+                  </p>
+                </div>
               )}
             </div>
 

--- a/apps/studio/src/components/pipeline/stages/extract/BookHeader.tsx
+++ b/apps/studio/src/components/pipeline/stages/extract/BookHeader.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react"
+import { useMemo, useState } from "react"
 import {
   AlertTriangle,
   BookOpen,
@@ -15,6 +15,7 @@ import {
   User,
   X,
 } from "lucide-react"
+import { useForm, useStore } from "@tanstack/react-form"
 import { Trans, useLingui } from "@lingui/react/macro"
 import type { BookMetadata } from "@adt/types"
 import type { PageSummaryItem } from "@/api/client"
@@ -37,6 +38,13 @@ interface MetadataDraft {
   language_code: string
 }
 
+const EMPTY_DRAFT: MetadataDraft = {
+  title: "",
+  authors: [],
+  publisher: "",
+  language_code: "",
+}
+
 function toDraft(metadata: BookMetadata): MetadataDraft {
   return {
     title: metadata.title ?? "",
@@ -46,21 +54,11 @@ function toDraft(metadata: BookMetadata): MetadataDraft {
   }
 }
 
-function draftsEqual(a: MetadataDraft, b: MetadataDraft): boolean {
-  return (
-    a.title === b.title &&
-    a.publisher === b.publisher &&
-    normalizeLocale(a.language_code) === normalizeLocale(b.language_code) &&
-    a.authors.length === b.authors.length &&
-    a.authors.every((author, i) => author === b.authors[i])
-  )
-}
-
 /**
  * Book header for the Extract stage. Reads as a banner (cover + title +
- * metadata + summary) and flips in place into an editable form via the Edit
- * button, so users discover that title/authors/publisher/language are
- * correctable right where they read them. Cover, page count, and extraction
+ * metadata + summary) and flips in place into an editable form (TanStack Form)
+ * via the Edit button, so users discover that title/authors/publisher/language
+ * are correctable right where they read them. Cover, page count, and extraction
  * rationale stay read-only. Changing the language warns before saving because
  * it resets the language-dependent downstream stages.
  */
@@ -80,7 +78,6 @@ export function BookHeader({
   const regenerateSummary = useRegenerateBookSummary()
 
   const [editing, setEditing] = useState(false)
-  const [draft, setDraft] = useState<MetadataDraft | null>(null)
   const [confirmOpen, setConfirmOpen] = useState(false)
 
   const metadata = book?.metadata ?? null
@@ -94,12 +91,42 @@ export function BookHeader({
   const coverPage = pages?.find((p) => p.pageNumber === coverPageNumber)
   const { data: coverImage } = usePageImage(bookLabel, coverPage?.pageId ?? "")
 
-  const current = draft ?? original
+  const form = useForm({
+    defaultValues: original ?? EMPTY_DRAFT,
+    onSubmit: ({ value }) => {
+      if (!metadata || !original) return
+      const trimmedAuthors = value.authors.map((a) => a.trim()).filter(Boolean)
+      const payload: BookMetadata = {
+        ...metadata,
+        title: value.title.trim() || null,
+        authors: trimmedAuthors.filter((a, i) => trimmedAuthors.indexOf(a) === i),
+        publisher: value.publisher.trim() || null,
+        language_code: value.language_code
+          ? normalizeLocale(value.language_code)
+          : null,
+      }
+      // A base-language change (es -> fr) makes the book summary stale; regenerate
+      // just that step in the new language instead of re-running the whole stage.
+      const baseChanged =
+        getBaseLanguage(payload.language_code ?? "") !==
+        getBaseLanguage(original.language_code)
+      updateMetadata.mutate(
+        { label: bookLabel, metadata: payload },
+        {
+          onSuccess: () => {
+            setEditing(false)
+            if (baseChanged && apiKey) {
+              regenerateSummary.mutate({ label: bookLabel, apiKey })
+            }
+          },
+        },
+      )
+    },
+  })
 
-  // Leaving edit mode resets the draft so a reopen starts from the saved values.
-  useEffect(() => {
-    if (!editing) setDraft(null)
-  }, [editing])
+  const values = useStore(form.store, (s) => s.values)
+  const isDirty = useStore(form.store, (s) => s.isDirty)
+  const canSubmit = useStore(form.store, (s) => s.canSubmit)
 
   if (!book) return null
 
@@ -109,53 +136,25 @@ export function BookHeader({
   const displayLanguage = book.languageCode ?? metadata?.language_code
   const summary = book.bookSummary?.summary
 
-  const dirty = current && original ? !draftsEqual(current, original) : false
-  const languageChanged =
-    current && original
-      ? normalizeLocale(current.language_code) !== normalizeLocale(original.language_code)
-      : false
+  const languageChanged = original
+    ? normalizeLocale(values.language_code) !== normalizeLocale(original.language_code)
+    : false
   const needsConfirmation = languageChanged && affectedStages.length > 0
   const originalLanguageName = getDisplayName(original?.language_code ?? "")
 
-  const update = (patch: Partial<MetadataDraft>) => {
-    if (current) setDraft({ ...current, ...patch })
+  const openEditor = () => {
+    form.reset(metadata ? toDraft(metadata) : EMPTY_DRAFT)
+    setEditing(true)
   }
 
-  const persist = () => {
-    if (!metadata || !current || !original) return
-    const trimmedAuthors = current.authors.map((a) => a.trim()).filter(Boolean)
-    const payload: BookMetadata = {
-      ...metadata,
-      title: current.title.trim() || null,
-      authors: trimmedAuthors.filter((a, i) => trimmedAuthors.indexOf(a) === i),
-      publisher: current.publisher.trim() || null,
-      language_code: current.language_code
-        ? normalizeLocale(current.language_code)
-        : null,
-    }
-    // A base-language change (es -> fr) makes the book summary stale; regenerate
-    // just that step in the new language instead of re-running the whole stage.
-    const baseChanged =
-      getBaseLanguage(payload.language_code ?? "") !==
-      getBaseLanguage(original.language_code)
-    updateMetadata.mutate(
-      { label: bookLabel, metadata: payload },
-      {
-        onSuccess: () => {
-          setEditing(false)
-          if (baseChanged && apiKey) {
-            regenerateSummary.mutate({ label: bookLabel, apiKey })
-          }
-        },
-      },
-    )
-  }
-
+  // A language change resets language-dependent downstream stages, so route
+  // through the confirmation dialog first; otherwise submit straight away.
   const handleSave = () => {
+    if (!isDirty || !canSubmit || updateMetadata.isPending) return
     if (needsConfirmation) {
       setConfirmOpen(true)
     } else {
-      persist()
+      form.handleSubmit()
     }
   }
 
@@ -206,7 +205,7 @@ export function BookHeader({
                   variant="outline"
                   size="sm"
                   className="shrink-0 gap-1.5"
-                  onClick={() => setEditing(true)}
+                  onClick={openEditor}
                 >
                   <Pencil className="h-3.5 w-3.5" />
                   <Trans>Edit book metadata</Trans>
@@ -255,12 +254,12 @@ export function BookHeader({
       )}
 
       {/* Edit mode */}
-      {editing && current && metadata && (
+      {editing && metadata && (
         <form
           className="animate-in fade-in duration-200"
           onSubmit={(e) => {
             e.preventDefault()
-            if (dirty && !updateMetadata.isPending) handleSave()
+            handleSave()
           }}
         >
           {/* Header strip */}
@@ -276,132 +275,172 @@ export function BookHeader({
                 <Trans>Correct the metadata extracted from the document.</Trans>
               </p>
             </div>
-            {dirty && unsavedBadge}
+            {isDirty && unsavedBadge}
           </div>
 
           {/* Body */}
           <div className="space-y-5 p-4">
             {/* Title */}
-            <div className="space-y-1.5">
-              <Label className="text-sm font-medium">
-                <Trans>Title</Trans>
-              </Label>
-              <Input
-                autoFocus
-                value={current.title}
-                onChange={(e) => update({ title: e.target.value })}
-                placeholder={t`Book title`}
-                className="font-medium"
-              />
-            </div>
-
-            {/* Authors */}
-            <div className="space-y-1.5">
-              <Label className="flex items-center gap-1.5 text-sm font-medium">
-                <User className="h-3.5 w-3.5 text-muted-foreground" />
-                <Trans>Authors</Trans>
-              </Label>
-              <div className="space-y-2">
-                {current.authors.length > 0 && (
-                  <div className="space-y-2">
-                    {current.authors.map((author, i) => (
-                      <div key={i} className="flex items-center gap-2">
-                        <Input
-                          value={author}
-                          onChange={(e) => {
-                            const authors = [...current.authors]
-                            authors[i] = e.target.value
-                            update({ authors })
-                          }}
-                          placeholder={t`Author name`}
-                        />
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="icon"
-                          aria-label={t`Remove author`}
-                          className="shrink-0 text-muted-foreground hover:text-destructive"
-                          onClick={() =>
-                            update({ authors: current.authors.filter((_, j) => j !== i) })
-                          }
-                        >
-                          <X className="h-4 w-4" />
-                        </Button>
-                      </div>
-                    ))}
-                  </div>
-                )}
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  className="gap-1.5 text-muted-foreground hover:text-foreground"
-                  disabled={
-                    current.authors.length > 0 &&
-                    current.authors[current.authors.length - 1].trim() === ""
-                  }
-                  onClick={() => update({ authors: [...current.authors, ""] })}
-                >
-                  <Plus className="h-3.5 w-3.5" />
-                  <Trans>Add author</Trans>
-                </Button>
-              </div>
-            </div>
-
-            {/* Publisher */}
-            <div className="space-y-1.5">
-              <Label className="flex items-center gap-1.5 text-sm font-medium">
-                <Building2 className="h-3.5 w-3.5 text-muted-foreground" />
-                <Trans>Publisher</Trans>
-              </Label>
-              <Input
-                value={current.publisher}
-                onChange={(e) => update({ publisher: e.target.value })}
-                placeholder={t`Publisher`}
-              />
-            </div>
-
-            {/* Language */}
-            <div className="space-y-1.5">
-              <LanguagePicker
-                selected={current.language_code}
-                onSelect={(v) => update({ language_code: v })}
-                label={t`Original language`}
-                hint={t`Add the region (e.g. Spanish — Uruguay) so downstream stages use the right localization.`}
-                size="default"
-              />
-              {languageChanged && (
-                <button
-                  type="button"
-                  onClick={() => update({ language_code: original?.language_code ?? "" })}
-                  className="inline-flex items-center gap-1 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
-                >
-                  <RotateCcw className="h-3 w-3" />
-                  {originalLanguageName ? (
-                    <Trans>Revert to {originalLanguageName}</Trans>
-                  ) : (
-                    <Trans>Revert language change</Trans>
-                  )}
-                </button>
-              )}
-              {needsConfirmation && (
-                <div className="flex items-start gap-2.5 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2.5 animate-in fade-in slide-in-from-top-1 duration-200">
-                  <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
-                  <p className="text-xs leading-relaxed text-foreground">
-                    <span className="font-semibold">
-                      <Trans>Changing the language resets downstream work.</Trans>
-                    </span>{" "}
-                    <span className="text-muted-foreground">
-                      <Trans>
-                        Completed language-based stages (quizzes, glossary,
-                        captions, audio) will be cleared and need to run again.
-                        You'll confirm first.
-                      </Trans>
-                    </span>
-                  </p>
+            <form.Field name="title">
+              {(field) => (
+                <div className="space-y-1.5">
+                  <Label className="text-sm font-medium">
+                    <Trans>Title</Trans>
+                  </Label>
+                  <Input
+                    autoFocus
+                    value={field.state.value}
+                    onChange={(e) => field.handleChange(e.target.value)}
+                    onBlur={field.handleBlur}
+                    placeholder={t`Book title`}
+                    className="font-medium"
+                  />
                 </div>
               )}
-            </div>
+            </form.Field>
+
+            {/* Authors */}
+            <form.Field name="authors" mode="array">
+              {(arrayField) => {
+                const authors = arrayField.state.value
+                const lastEmpty =
+                  authors.length > 0 && authors[authors.length - 1].trim() === ""
+                return (
+                  <div className="space-y-1.5">
+                    <Label className="flex items-center gap-1.5 text-sm font-medium">
+                      <User className="h-3.5 w-3.5 text-muted-foreground" />
+                      <Trans>Authors</Trans>
+                    </Label>
+                    <div className="space-y-2">
+                      {authors.length > 0 && (
+                        <div className="space-y-2">
+                          {authors.map((_, i) => (
+                            <form.Field key={i} name={`authors[${i}]`}>
+                              {(subField) => (
+                                <div className="flex items-center gap-2">
+                                  <Input
+                                    value={subField.state.value}
+                                    onChange={(e) => subField.handleChange(e.target.value)}
+                                    onBlur={subField.handleBlur}
+                                    placeholder={t`Author name`}
+                                  />
+                                  <Button
+                                    type="button"
+                                    variant="ghost"
+                                    size="icon"
+                                    aria-label={t`Remove author`}
+                                    className="shrink-0 text-muted-foreground hover:text-destructive"
+                                    onClick={() => arrayField.removeValue(i)}
+                                  >
+                                    <X className="h-4 w-4" />
+                                  </Button>
+                                </div>
+                              )}
+                            </form.Field>
+                          ))}
+                        </div>
+                      )}
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="gap-1.5 text-muted-foreground hover:text-foreground"
+                        disabled={lastEmpty}
+                        onClick={() => arrayField.pushValue("")}
+                      >
+                        <Plus className="h-3.5 w-3.5" />
+                        <Trans>Add author</Trans>
+                      </Button>
+                    </div>
+                  </div>
+                )
+              }}
+            </form.Field>
+
+            {/* Publisher */}
+            <form.Field name="publisher">
+              {(field) => (
+                <div className="space-y-1.5">
+                  <Label className="flex items-center gap-1.5 text-sm font-medium">
+                    <Building2 className="h-3.5 w-3.5 text-muted-foreground" />
+                    <Trans>Publisher</Trans>
+                  </Label>
+                  <Input
+                    value={field.state.value}
+                    onChange={(e) => field.handleChange(e.target.value)}
+                    onBlur={field.handleBlur}
+                    placeholder={t`Publisher`}
+                  />
+                </div>
+              )}
+            </form.Field>
+
+            {/* Language */}
+            <form.Field
+              name="language_code"
+              validators={{
+                onChange: ({ value }) =>
+                  value.trim()
+                    ? undefined
+                    : t`A language is required so downstream stages can localize the book.`,
+                onMount: ({ value }) =>
+                  value.trim()
+                    ? undefined
+                    : t`A language is required so downstream stages can localize the book.`,
+              }}
+            >
+              {(field) => {
+                const error = field.state.meta.errors[0]
+                return (
+                  <div className="space-y-1.5">
+                    <LanguagePicker
+                      selected={field.state.value}
+                      onSelect={(v) => field.handleChange(v)}
+                      label={t`Original language`}
+                      hint={t`Add the region (e.g. Spanish — Uruguay) so downstream stages use the right localization.`}
+                      size="default"
+                    />
+                    {error && (
+                      <p className="flex items-center gap-1.5 text-xs font-medium text-destructive">
+                        <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+                        {error}
+                      </p>
+                    )}
+                    {languageChanged && (
+                      <button
+                        type="button"
+                        onClick={() => field.handleChange(original?.language_code ?? "")}
+                        className="inline-flex items-center gap-1 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+                      >
+                        <RotateCcw className="h-3 w-3" />
+                        {originalLanguageName ? (
+                          <Trans>Revert to {originalLanguageName}</Trans>
+                        ) : (
+                          <Trans>Revert language change</Trans>
+                        )}
+                      </button>
+                    )}
+                    {needsConfirmation && (
+                      <div className="flex items-start gap-2.5 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2.5 animate-in fade-in slide-in-from-top-1 duration-200">
+                        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+                        <p className="text-xs leading-relaxed text-foreground">
+                          <span className="font-semibold">
+                            <Trans>Changing the language resets downstream work.</Trans>
+                          </span>{" "}
+                          <span className="text-muted-foreground">
+                            <Trans>
+                              Completed language-based stages (quizzes, glossary,
+                              captions, audio) will be cleared and need to run again.
+                              You'll confirm first.
+                            </Trans>
+                          </span>
+                        </p>
+                      </div>
+                    )}
+                  </div>
+                )
+              }}
+            </form.Field>
 
             {/* Extracted info (read-only) */}
             <div className="space-y-3 rounded-lg border border-dashed bg-muted/30 p-3">
@@ -473,7 +512,7 @@ export function BookHeader({
               type="submit"
               size="sm"
               className="gap-1.5"
-              disabled={!dirty || updateMetadata.isPending}
+              disabled={!isDirty || !canSubmit || updateMetadata.isPending}
             >
               {updateMetadata.isPending ? (
                 <>
@@ -504,7 +543,7 @@ export function BookHeader({
         confirmColorClass="bg-blue-600 hover:bg-blue-700"
         onConfirm={() => {
           setConfirmOpen(false)
-          persist()
+          form.handleSubmit()
         }}
       />
     </div>

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -448,6 +448,9 @@ msgstr "A fill-in-the-blank activity."
 msgid "A glossary term with this word already exists."
 msgstr "A glossary term with this word already exists."
 
+msgid "A language is required so downstream stages can localize the book."
+msgstr "A language is required so downstream stages can localize the book."
+
 msgid "A long row of shelves filled with food in a big store."
 msgstr "A long row of shelves filled with food in a big store."
 

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -1444,8 +1444,11 @@ msgstr "Change Preset"
 msgid "Change the book language?"
 msgstr "Change the book language?"
 
-msgid "Changing the language resets the completed downstream stages that depend on it. You'll confirm before it happens."
-msgstr "Changing the language resets the completed downstream stages that depend on it. You'll confirm before it happens."
+msgid "Changing the language resets downstream work."
+msgstr "Changing the language resets downstream work."
+
+#~ msgid "Changing the language resets the completed downstream stages that depend on it. You'll confirm before it happens."
+#~ msgstr "Changing the language resets the completed downstream stages that depend on it. You'll confirm before it happens."
 
 #~ msgid "Changing the language resets the stages that depend on it."
 #~ msgstr "Changing the language resets the stages that depend on it."
@@ -1635,6 +1638,9 @@ msgstr "Comments"
 
 msgid "Completed"
 msgstr "Completed"
+
+msgid "Completed language-based stages (quizzes, glossary, captions, audio) will be cleared and need to run again. You'll confirm first."
+msgstr "Completed language-based stages (quizzes, glossary, captions, audio) will be cleared and need to run again. You'll confirm first."
 
 msgid "Completion"
 msgstr "Completion"
@@ -5149,6 +5155,12 @@ msgstr "Retry"
 
 msgid "Retry Export"
 msgstr "Retry Export"
+
+msgid "Revert language change"
+msgstr "Revert language change"
+
+msgid "Revert to {originalLanguageName}"
+msgstr "Revert to {originalLanguageName}"
 
 msgid "Review and refine each simplified block side-by-side with the original before packaging."
 msgstr "Review and refine each simplified block side-by-side with the original before packaging."

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -1444,8 +1444,11 @@ msgstr "Cambiar Preajuste"
 msgid "Change the book language?"
 msgstr "¿Cambiar el idioma del libro?"
 
-msgid "Changing the language resets the completed downstream stages that depend on it. You'll confirm before it happens."
-msgstr "Cambiar el idioma restablece las etapas posteriores completadas que dependen de él. Lo confirmarás antes de que suceda."
+msgid "Changing the language resets downstream work."
+msgstr "Cambiar el idioma restablece el trabajo posterior."
+
+#~ msgid "Changing the language resets the completed downstream stages that depend on it. You'll confirm before it happens."
+#~ msgstr "Cambiar el idioma restablece las etapas posteriores completadas que dependen de él. Lo confirmarás antes de que suceda."
 
 #~ msgid "Changing the language resets the stages that depend on it."
 #~ msgstr "Cambiar el idioma restablece las etapas que dependen de él."
@@ -1635,6 +1638,9 @@ msgstr "Comments"
 
 msgid "Completed"
 msgstr "Completado"
+
+msgid "Completed language-based stages (quizzes, glossary, captions, audio) will be cleared and need to run again. You'll confirm first."
+msgstr "Las etapas completadas basadas en el idioma (cuestionarios, glosario, leyendas, audio) se borrarán y deberán ejecutarse de nuevo. Lo confirmarás primero."
 
 msgid "Completion"
 msgstr "Finalización"
@@ -5149,6 +5155,12 @@ msgstr "Reintentar"
 
 msgid "Retry Export"
 msgstr "Reintentar exportación"
+
+msgid "Revert language change"
+msgstr "Revertir cambio de idioma"
+
+msgid "Revert to {originalLanguageName}"
+msgstr "Revertir a {originalLanguageName}"
 
 msgid "Review and refine each simplified block side-by-side with the original before packaging."
 msgstr "Revisa y refina cada bloque simplificado junto al original antes de empaquetar."

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -448,6 +448,9 @@ msgstr "Una actividad de completar espacios en blanco."
 msgid "A glossary term with this word already exists."
 msgstr "Ya existe un término del glosario con esta palabra."
 
+msgid "A language is required so downstream stages can localize the book."
+msgstr "Se requiere un idioma para que las etapas posteriores puedan localizar el libro."
+
 msgid "A long row of shelves filled with food in a big store."
 msgstr "Una larga fila de estantes llenos de comida en una gran tienda."
 

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -450,6 +450,9 @@ msgstr "Une activité à compléter."
 msgid "A glossary term with this word already exists."
 msgstr "Un terme du glossaire avec ce mot existe déjà."
 
+msgid "A language is required so downstream stages can localize the book."
+msgstr "Une langue est requise pour que les étapes en aval puissent localiser le livre."
+
 msgid "A long row of shelves filled with food in a big store."
 msgstr "Une longue rangée d'étagères remplies de nourriture dans un grand magasin."
 

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -1446,8 +1446,11 @@ msgstr "Changer de préréglage"
 msgid "Change the book language?"
 msgstr "Changer la langue du livre ?"
 
-msgid "Changing the language resets the completed downstream stages that depend on it. You'll confirm before it happens."
-msgstr "Changer la langue réinitialise les étapes terminées en aval qui en dépendent. Vous confirmerez avant que cela ne se produise."
+msgid "Changing the language resets downstream work."
+msgstr "Changer la langue réinitialise le travail en aval."
+
+#~ msgid "Changing the language resets the completed downstream stages that depend on it. You'll confirm before it happens."
+#~ msgstr "Changer la langue réinitialise les étapes terminées en aval qui en dépendent. Vous confirmerez avant que cela ne se produise."
 
 #~ msgid "Changing the language resets the stages that depend on it."
 #~ msgstr "Changer la langue réinitialise les étapes qui en dépendent."
@@ -1637,6 +1640,9 @@ msgstr "Commentaires"
 
 msgid "Completed"
 msgstr "Terminé"
+
+msgid "Completed language-based stages (quizzes, glossary, captions, audio) will be cleared and need to run again. You'll confirm first."
+msgstr "Les étapes terminées liées à la langue (quiz, glossaire, légendes, audio) seront effacées et devront être réexécutées. Vous confirmerez d'abord."
 
 msgid "Completion"
 msgstr "Achèvement"
@@ -5151,6 +5157,12 @@ msgstr "Réessayer"
 
 msgid "Retry Export"
 msgstr "Réessayer Exporter"
+
+msgid "Revert language change"
+msgstr "Annuler le changement de langue"
+
+msgid "Revert to {originalLanguageName}"
+msgstr "Revenir à {originalLanguageName}"
 
 msgid "Review and refine each simplified block side-by-side with the original before packaging."
 msgstr "Examinez et peaufinez chaque bloc simplifié côte à côte avec l'original avant l'emballage."

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -448,6 +448,9 @@ msgstr "Uma atividade de preencher lacunas."
 msgid "A glossary term with this word already exists."
 msgstr "Já existe um termo de glossário com esta palavra."
 
+msgid "A language is required so downstream stages can localize the book."
+msgstr "Um idioma é obrigatório para que as etapas posteriores possam localizar o livro."
+
 msgid "A long row of shelves filled with food in a big store."
 msgstr "Uma longa fileira de prateleiras cheias de alimentos em uma grande loja."
 

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -1444,8 +1444,11 @@ msgstr "Alterar Predefinição"
 msgid "Change the book language?"
 msgstr "Alterar o idioma do livro?"
 
-msgid "Changing the language resets the completed downstream stages that depend on it. You'll confirm before it happens."
-msgstr "Alterar o idioma redefine as etapas posteriores concluídas que dependem dele. Você confirmará antes que isso aconteça."
+msgid "Changing the language resets downstream work."
+msgstr "Alterar o idioma redefine o trabalho posterior."
+
+#~ msgid "Changing the language resets the completed downstream stages that depend on it. You'll confirm before it happens."
+#~ msgstr "Alterar o idioma redefine as etapas posteriores concluídas que dependem dele. Você confirmará antes que isso aconteça."
 
 #~ msgid "Changing the language resets the stages that depend on it."
 #~ msgstr "Alterar o idioma redefine as etapas que dependem dele."
@@ -1635,6 +1638,9 @@ msgstr "Comments"
 
 msgid "Completed"
 msgstr "Concluído"
+
+msgid "Completed language-based stages (quizzes, glossary, captions, audio) will be cleared and need to run again. You'll confirm first."
+msgstr "As etapas concluídas baseadas no idioma (questionários, glossário, legendas, áudio) serão apagadas e precisarão ser executadas novamente. Você confirmará primeiro."
 
 msgid "Completion"
 msgstr "Conclusão"
@@ -5149,6 +5155,12 @@ msgstr "Tentar novamente"
 
 msgid "Retry Export"
 msgstr "Tentar exportar novamente"
+
+msgid "Revert language change"
+msgstr "Reverter alteração de idioma"
+
+msgid "Revert to {originalLanguageName}"
+msgstr "Reverter para {originalLanguageName}"
 
 msgid "Review and refine each simplified block side-by-side with the original before packaging."
 msgstr "Revise e refine cada bloco simplificado lado a lado com o original antes de empacotar."

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -449,6 +449,9 @@ msgstr "Një aktivitet me plotësim boshllëqesh."
 msgid "A glossary term with this word already exists."
 msgstr "Një term glosari me këtë fjalë ekziston tashmë."
 
+msgid "A language is required so downstream stages can localize the book."
+msgstr "Kërkohet një gjuhë që fazat e mëvonshme të mund ta lokalizojnë librin."
+
 msgid "A long row of shelves filled with food in a big store."
 msgstr "Një rresht i gjatë rafte të mbushur me ushqim në një dyqan të madh."
 

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -1445,8 +1445,11 @@ msgstr "Ndrysho Presetin"
 msgid "Change the book language?"
 msgstr "Të ndryshohet gjuha e librit?"
 
-msgid "Changing the language resets the completed downstream stages that depend on it. You'll confirm before it happens."
-msgstr "Ndryshimi i gjuhës rivendos fazat e mëvonshme të përfunduara që varen prej saj. Do ta konfirmoni para se të ndodhë."
+msgid "Changing the language resets downstream work."
+msgstr "Ndryshimi i gjuhës rivendos punën e mëvonshme."
+
+#~ msgid "Changing the language resets the completed downstream stages that depend on it. You'll confirm before it happens."
+#~ msgstr "Ndryshimi i gjuhës rivendos fazat e mëvonshme të përfunduara që varen prej saj. Do ta konfirmoni para se të ndodhë."
 
 #~ msgid "Changing the language resets the stages that depend on it."
 #~ msgstr "Ndryshimi i gjuhës rivendos fazat që varen prej saj."
@@ -1636,6 +1639,9 @@ msgstr "Komente"
 
 msgid "Completed"
 msgstr "Përfunduar"
+
+msgid "Completed language-based stages (quizzes, glossary, captions, audio) will be cleared and need to run again. You'll confirm first."
+msgstr "Fazat e përfunduara të bazuara në gjuhë (kuize, glosar, titra, audio) do të fshihen dhe duhet të ekzekutohen sërish. Do ta konfirmoni më parë."
 
 msgid "Completion"
 msgstr "Përfundim"
@@ -5150,6 +5156,12 @@ msgstr "Riprovo"
 
 msgid "Retry Export"
 msgstr "Riprovo Eksportimin"
+
+msgid "Revert language change"
+msgstr "Kthe ndryshimin e gjuhës"
+
+msgid "Revert to {originalLanguageName}"
+msgstr "Kthehu te {originalLanguageName}"
 
 msgid "Review and refine each simplified block side-by-side with the original before packaging."
 msgstr "Rishikoni dhe rafinoni çdo bllok të thjeshtëzuar krahas origjinalit përpara paketimit."


### PR DESCRIPTION
Follow-ups to the book-metadata editor (#150).

**Language-change warning — contrast fix**
The inline warning was illegible: amber text shades (`amber-900/800/100`) were overridden by the dark theme and rendered near-white on a pale fill. Rebuilt as a high-contrast callout — the message text now uses the semantic `foreground` / `muted-foreground` tokens (always high-contrast in both themes), and amber is kept only for the tint, border, and icon. Also reworded to name what actually resets (quizzes, glossary, captions, audio) instead of self-referential copy.

**Revert language**
Added a "Revert to {original language}" action that appears only when the language differs from the pre-edit value. It restores just the language, keeping your other edits — unlike Cancel, which discards everything.

**Author field guards**
- "Add author" is disabled while the last row is still empty (no pile of blank rows).
- Identical authors are de-duplicated on save (in addition to the existing trim + drop-empty).

**i18n:** new strings extracted and translated for `es`, `pt-BR`, `fr`, `sq` (0 missing).
**Checks:** `tsc` ✅ · lint ✅ (0 errors).