### PR TITLE
fix(books): keep "Last modified" / "Created" sort stable across launches

### DIFF
--- a/apps/api/src/services/book-service.test.ts
+++ b/apps/api/src/services/book-service.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
 import fs from "node:fs"
 import os from "node:os"
 import path from "node:path"
@@ -196,6 +196,59 @@ describe("listBooks", () => {
     expect(() => new Date(books[0].modifiedAt).toISOString()).not.toThrow()
     expect(Date.parse(books[0].createdAt)).not.toBeNaN()
     expect(Date.parse(books[0].modifiedAt)).not.toBeNaN()
+  })
+
+  it("derives modifiedAt from content files, not the bumped directory mtime", () => {
+    // Reproduces the "Last modified resets on every launch" bug: opening a book DB
+    // creates/removes a .lock dir inside the book folder, bumping the folder mtime
+    // to "now" on POSIX filesystems. modifiedAt must reflect the real .db edit time,
+    // not the freshly-bumped directory mtime.
+    createTestDb("stale")
+    const bookDir = path.join(tmpDir, "stale")
+    const dbPath = path.join(bookDir, "stale.db")
+
+    const oldDate = new Date("2020-01-02T03:04:05.000Z")
+    fs.utimesSync(dbPath, oldDate, oldDate)
+    // Simulate the launch-time directory mtime bump.
+    const now = new Date()
+    fs.utimesSync(bookDir, now, now)
+
+    const books = listBooks(tmpDir)
+    expect(books).toHaveLength(1)
+    expect(books[0].modifiedAt).toBe(oldDate.toISOString())
+  })
+
+  it("derives createdAt from content files (not ctime) when birthtime is unavailable", () => {
+    // On filesystems that don't report a birth time (birthtimeMs === 0), createdAt
+    // must fall back to the earliest content mtime, NOT the directory's ctime — which,
+    // like its mtime, is bumped to "now" on every launch by the .lock-dir churn.
+    createTestDb("nobirth")
+    const bookDir = path.join(tmpDir, "nobirth")
+    const dbPath = path.join(bookDir, "nobirth.db")
+
+    const oldDate = new Date("2019-05-06T07:08:09.000Z")
+    fs.utimesSync(dbPath, oldDate, oldDate)
+    // Simulate the launch-time directory mtime bump (ctime moves with it).
+    const now = new Date()
+    fs.utimesSync(bookDir, now, now)
+
+    // Simulate a filesystem that doesn't expose birthtime for the book directory.
+    const realStatSync = fs.statSync.bind(fs)
+    const spy = vi
+      .spyOn(fs, "statSync")
+      .mockImplementation(((p: fs.PathLike, opts?: fs.StatSyncOptions) => {
+        const stat = realStatSync(p, opts) as fs.Stats
+        if (p === bookDir) stat.birthtimeMs = 0
+        return stat
+      }) as typeof fs.statSync)
+
+    try {
+      const books = listBooks(tmpDir)
+      expect(books).toHaveLength(1)
+      expect(books[0].createdAt).toBe(oldDate.toISOString())
+    } finally {
+      spy.mockRestore()
+    }
   })
 
   it("lists multiple books sorted by label", () => {

--- a/apps/api/src/services/book-service.ts
+++ b/apps/api/src/services/book-service.ts
@@ -51,28 +51,16 @@ function resolveTimestamps(
 ): { createdAt: string; modifiedAt: string } {
   const dirStat = fs.statSync(bookDir)
 
-  // Base both timestamps on the real content/config files, never on the directory's
-  // mtime/ctime. node-sqlite3-wasm creates and removes a `<label>.db.lock` directory
-  // (plus -journal/-wal/-shm files) inside the book folder on every DB open/close,
-  // which bumps the folder's mtime AND ctime to "now" on every launch (POSIX). Since
-  // both startup cleanup and listBooks open every DB, trusting the directory's
-  // mtime/ctime would collapse these timestamps to the last-launch time for all
-  // books, breaking the "Last modified" / "Created" sorts. The .db/.pdf/config.yaml
-  // mtimes only advance on real edits.
+  // Derive timestamps from content files, never the directory's mtime/ctime:
+  // node-sqlite3-wasm's `.db.lock` churn on every DB open bumps both to "now" on
+  // each launch (POSIX), which would collapse the sort to last-launch time.
   const configPath = path.join(bookDir, "config.yaml")
   const mtimes: number[] = []
   if (fs.existsSync(dbPath)) mtimes.push(fs.statSync(dbPath).mtimeMs)
   if (fs.existsSync(pdfPath)) mtimes.push(fs.statSync(pdfPath).mtimeMs)
   if (fs.existsSync(configPath)) mtimes.push(fs.statSync(configPath).mtimeMs)
 
-  // modifiedAt: most recent edit to any content file (fall back to the dir mtime
-  // only for an empty/new book dir with no content files yet).
   const modifiedMs = mtimes.length > 0 ? Math.max(...mtimes) : dirStat.mtimeMs
-
-  // createdAt: the directory's true birth time when the filesystem reports it;
-  // otherwise the earliest content mtime — NOT ctime, which is bumped on every
-  // launch by the .lock churn described above (some filesystems report birthtimeMs
-  // as 0, e.g. certain Docker volume drivers / network mounts).
   const createdMs =
     dirStat.birthtimeMs || (mtimes.length > 0 ? Math.min(...mtimes) : dirStat.mtimeMs)
 

--- a/apps/api/src/services/book-service.ts
+++ b/apps/api/src/services/book-service.ts
@@ -50,13 +50,32 @@ function resolveTimestamps(
   pdfPath: string
 ): { createdAt: string; modifiedAt: string } {
   const dirStat = fs.statSync(bookDir)
-  const createdMs = dirStat.birthtimeMs || dirStat.ctimeMs
 
-  const candidates: number[] = [dirStat.mtimeMs]
-  if (fs.existsSync(dbPath)) candidates.push(fs.statSync(dbPath).mtimeMs)
-  if (fs.existsSync(pdfPath)) candidates.push(fs.statSync(pdfPath).mtimeMs)
+  // Base both timestamps on the real content/config files, never on the directory's
+  // mtime/ctime. node-sqlite3-wasm creates and removes a `<label>.db.lock` directory
+  // (plus -journal/-wal/-shm files) inside the book folder on every DB open/close,
+  // which bumps the folder's mtime AND ctime to "now" on every launch (POSIX). Since
+  // both startup cleanup and listBooks open every DB, trusting the directory's
+  // mtime/ctime would collapse these timestamps to the last-launch time for all
+  // books, breaking the "Last modified" / "Created" sorts. The .db/.pdf/config.yaml
+  // mtimes only advance on real edits.
+  const configPath = path.join(bookDir, "config.yaml")
+  const mtimes: number[] = []
+  if (fs.existsSync(dbPath)) mtimes.push(fs.statSync(dbPath).mtimeMs)
+  if (fs.existsSync(pdfPath)) mtimes.push(fs.statSync(pdfPath).mtimeMs)
+  if (fs.existsSync(configPath)) mtimes.push(fs.statSync(configPath).mtimeMs)
 
-  const modifiedMs = Math.max(...candidates)
+  // modifiedAt: most recent edit to any content file (fall back to the dir mtime
+  // only for an empty/new book dir with no content files yet).
+  const modifiedMs = mtimes.length > 0 ? Math.max(...mtimes) : dirStat.mtimeMs
+
+  // createdAt: the directory's true birth time when the filesystem reports it;
+  // otherwise the earliest content mtime — NOT ctime, which is bumped on every
+  // launch by the .lock churn described above (some filesystems report birthtimeMs
+  // as 0, e.g. certain Docker volume drivers / network mounts).
+  const createdMs =
+    dirStat.birthtimeMs || (mtimes.length > 0 ? Math.min(...mtimes) : dirStat.mtimeMs)
+
   return { createdAt: toIsoDate(createdMs), modifiedAt: toIsoDate(modifiedMs) }
 }
 


### PR DESCRIPTION
## Problem

On the ADT Studio start screen, sorting the book list by **Last modified** was useless: **every launch stamped every book with the same recent time**, so the order never reflected which book you actually worked on last. (The "Created" sort had the same latent weakness.)

## Root cause

`resolveTimestamps()` in `apps/api/src/services/book-service.ts` derived `modifiedAt` — and `createdAt`'s fallback — from the book **directory's** `mtime`/`ctime`.

`node-sqlite3-wasm` creates and removes a `<label>.db.lock` directory (plus `-journal`/`-wal`/`-shm` files) **inside the book folder on every DB open/close**. On POSIX filesystems, creating/removing that entry bumps the folder's `mtime` **and** `ctime` to "now". Because **both** the startup `cleanupInterruptedSteps()` scan **and** `listBooks()` itself open every book's DB, the directory timestamps collapsed to the last-launch time for all books — and `resolveTimestamps` took `max(dirMtime, …)`, so that noise dominated.

### Why it looked fine on Windows

This is a **POSIX filesystem manifestation**:

- **Affected:** Linux (local dev + the `ghcr.io/unicef/adt-studio` Docker deployment) and the macOS desktop build (APFS).
- **Not observed on the Windows desktop app** — NTFS doesn't surface that transient child create/delete as a change to the parent folder's modified time the same way, which is why the Windows app looked correct.

### Evidence (local Linux `./books`, app last launched ~09:02)

| Book | Dir mtime | `.db` mtime | `.pdf` mtime |
|---|---|---|---|
| raven | **09:02 today** | 06-05 12:37 | 06-03 16:12 |
| LP-4-Volcanoes | **09:02 today** | 06-03 17:30 | 06-03 16:50 |
| cuaderno5 | **09:02 today** | 06-03 15:48 | 05-11 10:42 |

Only the directory mtime was bumped to launch time; the `.db`/`.pdf` mtimes correctly retained their real last-edit times.

## Fix

Derive **both** timestamps from the real content/config files only — never from the directory `mtime`/`ctime`:

- **`modifiedAt`** = newest `mtime` among `{.db, .pdf, config.yaml}`; falls back to the directory mtime only for an empty/new book dir with no files yet.
- **`createdAt`** = the directory's birth time when the filesystem reports it, otherwise the **earliest content mtime** — no longer `ctime`, which carries the same launch-bump instability (some filesystems, e.g. certain Docker volume drivers / network mounts, report `birthtimeMs` as `0`).

These mtimes only advance on **real** edits (pipeline writes, page edits, image/video additions, metadata/config edits), so the sort is now stable across launches on every platform.

**Bonus:** the cover-image cache-buster (`getBookCoverUrl(book.label, book.modifiedAt)`) stops invalidating on every launch, so book covers stop re-fetching needlessly.

### Known, accepted tradeoff

A book change that only adds a top-level folder *without* writing the DB (e.g. book-level `prompts/` or `audio/` override dirs) no longer counts as "modified". The `.db` covers the overwhelming majority of real edits, so this narrowing is intentional.

## Tests

Two regression tests added in `book-service.test.ts`:
1. A launch-time directory mtime bump no longer affects `modifiedAt` (it tracks the real `.db` edit time).
2. `createdAt` falls back to the earliest content mtime — not `ctime` — when `birthtimeMs` is unavailable (simulated via a `fs.statSync` spy).

The first test also empirically confirms the load-bearing assumption: opening a book DB during `listBooks` does **not** rewrite the `.db` file mtime.

## Verification

- ✅ `book-service` suite: **38/38 pass** (incl. both new regression tests)
- ✅ `pnpm typecheck` clean
- Manual: launch twice without editing — each book's "Modified" date stays at its real last-edit time and the sort is stable across launches.

## Scope

Single production change to `resolveTimestamps()` + tests. No frontend change (the start-screen sort already keys off `modifiedAt`; it just needed trustworthy values). The startup `cleanupInterruptedSteps()` scan is intentionally left as-is — it still touches directory mtimes via the `.lock` churn, but that no longer affects the reported timestamps.