### PR TITLE
Add i18n (Lingui) to the landing page (en, pt-BR, es, fr)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+    branches-ignore: [landing-page]
 
 permissions:
   contents: write

--- a/.github/workflows/landing-ci.yml
+++ b/.github/workflows/landing-ci.yml
@@ -1,0 +1,35 @@
+name: Landing CI
+
+on:
+  pull_request:
+    branches: [landing-page]
+  push:
+    branches: [landing-page]
+
+permissions:
+  contents: read
+
+jobs:
+  landing:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Lint
+        run: pnpm --filter @adt/landing lint
+      - name: Check for unextracted strings
+        run: |
+          pnpm --filter @adt/landing extract
+          NEW=$(git diff -- apps/landing/src/locales/ | grep '^+msgid "' | grep -v '^+msgid ""' || true)
+          if [ -n "$NEW" ]; then
+            echo "New unextracted strings found. Run 'pnpm --filter @adt/landing extract' and commit the updated .po files."
+            echo "$NEW"
+            exit 1
+          fi
+      - name: Build
+        run: pnpm --filter @adt/landing build

--- a/.github/workflows/landing.yml
+++ b/.github/workflows/landing.yml
@@ -2,7 +2,7 @@ name: Deploy landing page
 
 on:
   push:
-    branches: [main, landing-page]
+    branches: [landing-page]
     paths:
       - "apps/landing/**"
       - ".github/workflows/landing.yml"

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ package-lock.json
 # Build output
 dist/
 apps/studio/src/locales/*.js
+apps/landing/src/locales/*.js
 .output/
 *.tsbuildinfo
 /books/

--- a/apps/landing/eslint-suppressions.json
+++ b/apps/landing/eslint-suppressions.json
@@ -1,0 +1,30 @@
+{
+  "src/components/PdfToBookDiagram.tsx": {
+    "lingui/no-unlocalized-strings": {
+      "count": 5
+    }
+  },
+  "src/components/ReleaseMarkdown.tsx": {
+    "@next/next/no-img-element": {
+      "count": 1
+    },
+    "lingui/no-unlocalized-strings": {
+      "count": 1
+    }
+  },
+  "src/components/pages/download/shared.ts": {
+    "lingui/no-unlocalized-strings": {
+      "count": 11
+    }
+  },
+  "src/components/scenes/AnimEnrich.tsx": {
+    "lingui/no-unlocalized-strings": {
+      "count": 21
+    }
+  },
+  "src/components/scenes/AnimExport.tsx": {
+    "lingui/no-unlocalized-strings": {
+      "count": 27
+    }
+  }
+}

--- a/apps/landing/eslint.config.js
+++ b/apps/landing/eslint.config.js
@@ -1,0 +1,186 @@
+import tseslint from "typescript-eslint"
+import linguiPlugin from "eslint-plugin-lingui"
+
+export default [
+  { ignores: ["src/locales/**/*", "src/i18n/locales.ts", "dist/**", "src/**/*.test.*", "src/**/*.d.ts"] },
+  {
+    files: ["src/**/*.{ts,tsx}"],
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: { ecmaFeatures: { jsx: true } },
+    },
+    plugins: { lingui: linguiPlugin },
+    rules: {
+      "lingui/no-unlocalized-strings": [
+        "error",
+        {
+          ignoreNames: [
+            // --- HTML / JSX structural attributes ---
+            { regex: { pattern: "className", flags: "i" } },
+            "style",
+            "id",
+            "type",
+            "href",
+            "src",
+            "key",
+            "name",
+            "target",
+            "rel",
+            "role",
+            "loading",
+            "htmlFor",
+            { regex: { pattern: "^data-" } },
+            // Identifier-like prop/variable ending with "id" or "Id"
+            { regex: { pattern: "^[A-Za-z0-9_]*(id|Id)$" } },
+
+            // --- SVG attributes ---
+            "fill",
+            "d",
+            "viewBox",
+            "strokeLinecap",
+            "strokeLinejoin",
+            "strokeDasharray",
+            "stroke",
+            "points",
+            "transform",
+            "gradientUnits",
+            "offset",
+            "stopColor",
+
+            // --- Layout / variant props ---
+            "variant",
+            "size",
+            "align",
+            "side",
+            "top",
+            "bottom",
+            "left",
+            "right",
+
+            // --- CSS class & color props (never user-visible) ---
+            "color",
+            "hex",
+            "tint",
+            "fg",
+            "bg",
+            "textColor",
+            "borderColor",
+            "iconColor",
+            "colorClass",
+            "bgColor",
+            "accentBg",
+            "imageSrc",
+            { regex: { pattern: "Class$" } },
+            { regex: { pattern: "Color$" } },
+            { regex: { pattern: "Bg$" } },
+
+            // --- Data / config identifiers ---
+            "slug",
+            "num",
+            "category",
+            "mode",
+
+            // --- i18n locale metadata ---
+            "LOCALE_LABEL_MESSAGES",
+            "LOCALE_FLAGS",
+          ],
+          ignoreFunctions: [
+            // --- Console / logging ---
+            "console.*",
+            "*.log",
+            "*.warn",
+            "*.error",
+            "*.info",
+            "*.debug",
+
+            // --- Error constructors ---
+            "Error",
+            "TypeError",
+            "RangeError",
+
+            // --- API / fetch calls ---
+            "request",
+            "fetch",
+
+            // --- DOM manipulation / events ---
+            "document.createElement",
+            "*.setAttribute",
+            "*.getAttribute",
+            "*.querySelector",
+            "*.querySelectorAll",
+            "*.closest",
+            "*.setProperty",
+            "*.getContext",
+            "*.addEventListener",
+            "*.removeEventListener",
+            "*.scrollIntoView",
+            "*.scrollTo",
+
+            // --- String / array operations ---
+            "*.replace",
+            "*.startsWith",
+            "*.endsWith",
+            "*.includes",
+
+            // --- URL / search params ---
+            "*.set",
+            "*.get",
+            "*.delete",
+            "new URL",
+            "new URLSearchParams",
+
+            // --- Analytics (event/category identifiers + Matomo command strings, not UI copy) ---
+            "trackEvent",
+            "trackDownload",
+            "trackPageView",
+            "push",
+
+            // --- CSS class composition utilities ---
+            "cn",
+            "clsx",
+
+            // --- Math / formatting ---
+            "*.toFixed",
+          ],
+          ignore: [
+            // project brand name (intentional non-translatable literal)
+            "^ADT Studio$",
+            // npm package names and module paths
+            "^@?[a-zA-Z0-9_-]+(/[a-zA-Z0-9_.-]+)+",
+            // TypeScript path aliases (e.g. "@/lib/cn")
+            "^@/[a-zA-Z0-9_.-]+(/[a-zA-Z0-9_.-]+)*$",
+            // locale codes (e.g. "en", "pt-BR", "es")
+            "^[a-z]{2}(-[A-Z]{2})?$",
+            // absolute URLs
+            "^https?://",
+            // relative URL paths and hash routes (e.g. "/api", "#/download", "#/releases/")
+            "^#?/[a-zA-Z0-9_-]?",
+            // Tailwind CSS classes, internal identifiers, status values
+            "^[a-z][a-z0-9._:-]*$",
+            // Multi-class Tailwind strings
+            "^[a-z][a-z0-9._:/-]*( [a-z!][a-z0-9._:/-]*)+$",
+            // Tailwind classes with arbitrary-value syntax (e.g. "bg-[color:var(--x)] text-[7px] hover:brightness-110").
+            // Tokens are all-lowercase utilities so this never matches English prose (which has capitals/punctuation).
+            "^!?[a-z0-9][a-z0-9:/._\\[\\]()#%,-]*( !?[a-z0-9\\[][a-z0-9:/._\\[\\]()#%,-]*)*$",
+            // Hex color values
+            "^#[0-9a-fA-F]+$",
+            // CSS dimension / numeric-leading values
+            "^[0-9]",
+            // CSS transform function template literals
+            "^(translate[XYZ3d]*|rotate[XYZ3d]*|scale[XYZ]?|skew[XY]?|matrix3?d?|perspective)\\(",
+            // CSS transform function values
+            "^(translate|translate3d|rotate|rotate3d|scale|scale3d|skew|matrix)\\(",
+            // Byte-size literals
+            "^[0-9]+(?:\\.[0-9]+)?\\s?(?:B|KB|MB|GB|TB|b|kb|mb|gb|tb)$",
+            // Unit-suffix remnants from formatting template literals (lingui joins quasis
+            // around the numeric expression, e.g. `${mb} MB` → " MB", `${v}M` → "M")
+            "^\\s?(?:B|KB|MB|GB|TB|K|M|G)$",
+            // Data URIs
+            "^data:",
+          ],
+        },
+      ],
+      "lingui/t-call-in-function": "error",
+    },
+  },
+]

--- a/apps/landing/lingui.config.ts
+++ b/apps/landing/lingui.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "@lingui/conf";
+
+export default defineConfig({
+  locales: ["en", "pt-BR", "es", "fr"],
+  sourceLocale: "en",
+  catalogs: [
+    {
+      path: "<rootDir>/src/locales/{locale}",
+      include: ["src"],
+      exclude: ["src/locales/**", "**/*.d.ts"],
+    },
+  ],
+  format: "po",
+  formatOptions: {
+    origins: false,
+  },
+});

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -6,9 +6,15 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "extract": "lingui extract",
+    "compile": "lingui compile",
+    "lint": "eslint src --suppressions-location eslint-suppressions.json --pass-on-unpruned-suppressions",
+    "translate:missing": "tsx scripts/translate-missing.ts"
   },
   "dependencies": {
+    "@lingui/core": "^5.9.3",
+    "@lingui/react": "^5.9.3",
     "clsx": "^2.1.0",
     "lucide-react": "^0.469.0",
     "react": "^19.0.0",
@@ -20,12 +26,25 @@
     "tailwind-merge": "^3.0.0"
   },
   "devDependencies": {
+    "@ai-sdk/openai": "^1.0.0",
+    "@lingui/babel-plugin-lingui-macro": "^5.9.3",
+    "@lingui/cli": "^5.9.3",
+    "@lingui/conf": "^5.9.3",
+    "@lingui/macro": "^5.9.3",
+    "@lingui/vite-plugin": "^5.9.3",
     "@tailwindcss/vite": "^4.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.0",
+    "ai": "^4.0.0",
+    "babel-plugin-macros": "^3.1.0",
+    "eslint": "^9",
+    "eslint-plugin-lingui": "^0.11.0",
     "tailwindcss": "^4.0.0",
+    "tsx": "^4.21.0",
     "typescript": "^5",
-    "vite": "^6.0.0"
+    "typescript-eslint": "^8",
+    "vite": "^6.0.0",
+    "zod": "^3.24.0"
   }
 }

--- a/apps/landing/scripts/translate-missing.ts
+++ b/apps/landing/scripts/translate-missing.ts
@@ -1,0 +1,203 @@
+#!/usr/bin/env tsx
+/**
+ * Automatically translates missing msgstr entries in non-source .po locale files.
+ * Reads the English source strings from en.po and translates them in batches for
+ * each locale that has empty msgstr entries.
+ *
+ * Usage:
+ *   OPENAI_API_KEY=<key> pnpm --filter @adt/landing translate:missing
+ *
+ * Environment variables:
+ *   OPENAI_API_KEY   (required) OpenAI API key
+ *   TRANSLATE_MODEL  (optional) Model in "provider:model" format. Default: "openai:gpt-4o"
+ *                    Examples: "openai:gpt-4o-mini", "openai:gpt-4-turbo"
+ */
+import { generateObject, type LanguageModel } from "ai"
+import { openai } from "@ai-sdk/openai"
+import { z } from "zod"
+import { readFileSync, writeFileSync, readdirSync } from "fs"
+import { join, basename, dirname } from "path"
+import { fileURLToPath } from "url"
+import { LOCALE_NAMES } from "../src/i18n/locales.js"
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const LOCALES_DIR = join(__dirname, "../src/locales")
+const SOURCE_LOCALE = "en"
+
+function resolveModel(modelId: string): LanguageModel {
+  const [provider, model] = modelId.includes(":")
+    ? modelId.split(":", 2)
+    : ["openai", modelId]
+
+  switch (provider) {
+    case "openai":
+      return openai(model)
+    default:
+      throw new Error(
+        `Unsupported provider: "${provider}". Currently supported: "openai"`,
+      )
+  }
+}
+
+const TranslationSchema = z.object({
+  translations: z.array(z.object({ msgid: z.string(), msgstr: z.string() })),
+})
+
+interface PoEntry {
+  msgid: string
+  msgstrLineIndex: number
+}
+
+/**
+ * Parses a .po file and returns all entries that have an empty msgstr,
+ * along with the line index of the msgstr so we can patch it in place.
+ */
+function findMissingEntries(filePath: string): PoEntry[] {
+  const lines = readFileSync(filePath, "utf-8").split("\n")
+  const missing: PoEntry[] = []
+
+  for (let i = 0; i < lines.length - 1; i++) {
+    const line = lines[i]
+    const next = lines[i + 1]
+
+    // Skip obsolete entries
+    if (line.startsWith("#~")) continue
+
+    // Single-line msgid (non-empty) followed immediately by empty msgstr
+    if (
+      line.startsWith('msgid "') &&
+      line !== 'msgid ""' &&
+      next === 'msgstr ""'
+    ) {
+      missing.push({
+        msgid: line.slice(7, -1), // strip msgid " and trailing "
+        msgstrLineIndex: i + 1,
+      })
+    }
+  }
+
+  return missing
+}
+
+/**
+ * Patches a .po file in-place, writing translations at the given line indices.
+ */
+function applyTranslations(
+  filePath: string,
+  patches: Map<number, string>,
+): void {
+  const lines = readFileSync(filePath, "utf-8").split("\n")
+
+  for (const [lineIndex, translation] of patches) {
+    // Escape backslashes and double quotes for .po string format
+    const escaped = translation.replace(/\\/g, "\\\\").replace(/"/g, '\\"')
+    lines[lineIndex] = `msgstr "${escaped}"`
+  }
+
+  writeFileSync(filePath, lines.join("\n"), "utf-8")
+}
+
+/**
+ * Calls the configured LLM to translate a batch of English strings to the target locale.
+ * Returns a map of msgid -> translated string.
+ */
+async function translateBatch(
+  model: LanguageModel,
+  locale: string,
+  entries: PoEntry[],
+): Promise<Map<string, string>> {
+  const localeName = LOCALE_NAMES[locale] ?? locale
+
+  const stringsJson = JSON.stringify(
+    entries.map((e) => e.msgid),
+    null,
+    2,
+  )
+
+  const { object } = await generateObject({
+    model,
+    schema: TranslationSchema,
+    system: `You are a professional UI translator. Translate English UI strings to ${localeName}.
+Rules:
+- Preserve all {variable} placeholders exactly as-is (e.g. {0}, {name}, {stepLabel})
+- Preserve all HTML tags exactly as-is
+- Be concise — these are short UI labels and messages, not prose
+- Match the tone of the original (formal/informal)
+- Include ALL strings from the input — do not skip any`,
+    messages: [
+      {
+        role: "user",
+        content: `Translate these ${entries.length} UI strings to ${localeName}:\n\n${stringsJson}`,
+      },
+    ],
+  })
+
+  const result = new Map<string, string>()
+  for (const item of object.translations) {
+    if (item.msgid && item.msgstr) {
+      result.set(item.msgid, item.msgstr)
+    }
+  }
+  return result
+}
+
+async function main() {
+  if (!process.env.OPENAI_API_KEY) {
+    console.error("Error: OPENAI_API_KEY is not set")
+    process.exit(1)
+  }
+
+  const modelId = process.env.TRANSLATE_MODEL || "openai:gpt-4o"
+  const model = resolveModel(modelId)
+  console.log(`Using model: ${modelId}`)
+
+  const poFiles = readdirSync(LOCALES_DIR).filter(
+    (f) => f.endsWith(".po") && basename(f, ".po") !== SOURCE_LOCALE,
+  )
+
+  if (poFiles.length === 0) {
+    console.log("No non-source locale files found.")
+    return
+  }
+
+  let totalTranslated = 0
+
+  for (const file of poFiles) {
+    const locale = basename(file, ".po")
+    const filePath = join(LOCALES_DIR, file)
+    const missing = findMissingEntries(filePath)
+
+    if (missing.length === 0) {
+      console.log(`✓ ${locale}: no missing translations`)
+      continue
+    }
+
+    console.log(`→ ${locale}: translating ${missing.length} missing string(s)...`)
+
+    const translations = await translateBatch(model, locale, missing)
+
+    const patches = new Map<number, string>()
+    let matched = 0
+
+    for (const entry of missing) {
+      const translation = translations.get(entry.msgid)
+      if (translation) {
+        patches.set(entry.msgstrLineIndex, translation)
+        matched++
+      } else {
+        console.warn(`  ⚠ No translation returned for: "${entry.msgid}"`)
+      }
+    }
+
+    applyTranslations(filePath, patches)
+    totalTranslated += matched
+    console.log(`✓ ${locale}: applied ${matched}/${missing.length} translations`)
+  }
+
+  console.log(`\nDone. Total strings translated: ${totalTranslated}`)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/apps/landing/src/App.tsx
+++ b/apps/landing/src/App.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useMemo } from "react";
+import { i18n } from "@lingui/core";
+import { msg } from "@lingui/core/macro";
 import { DownloadPage } from "@/components/pages/DownloadPage";
 import { ReleasesPage } from "@/components/pages/ReleasesPage";
 import { CarouselScene } from "@/components/sections/CarouselScene";
@@ -38,13 +40,13 @@ function resolveRoute(hashRoute: string): Route {
 function getRouteTitle(route: Route): string {
   switch (route.kind) {
     case "home":
-      return "ADT Studio — Turn any PDF into an accessible book";
+      return i18n._(msg`ADT Studio — Turn any PDF into an accessible book`);
     case "download":
-      return "Download — ADT Studio";
+      return i18n._(msg`Download — ADT Studio`);
     case "releases":
       return route.focusTag
-        ? `Release ${route.focusTag} — ADT Studio`
-        : "Changelog — ADT Studio";
+        ? i18n._(msg`Release ${route.focusTag} — ADT Studio`)
+        : i18n._(msg`Changelog — ADT Studio`);
   }
 }
 

--- a/apps/landing/src/components/LocaleSwitcher.tsx
+++ b/apps/landing/src/components/LocaleSwitcher.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useRef, useState } from "react";
+import { Check, Globe } from "lucide-react";
+import { msg } from "@lingui/core/macro";
+import { useLingui } from "@lingui/react";
+import type { MessageDescriptor } from "@lingui/core";
+import { cn } from "@/lib/cn";
+import { setLocale } from "@/i18n/setup";
+import { LOCALES, LOCALE_FLAGS, type AppLocale } from "@/i18n/locales";
+
+const LOCALE_LABEL_MESSAGES: Record<AppLocale, MessageDescriptor> = {
+  en: msg`English`,
+  "pt-BR": msg`Portuguese (BR)`,
+  es: msg`Spanish`,
+  fr: msg`French`,
+};
+
+export function LocaleSwitcher({ className }: { className?: string }) {
+  const { i18n } = useLingui();
+  const currentLocale = (
+    LOCALES.includes(i18n.locale as AppLocale) ? i18n.locale : "en"
+  ) as AppLocale;
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    window.addEventListener("mousedown", onClick);
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("mousedown", onClick);
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  const handleSelect = (loc: AppLocale) => {
+    setOpen(false);
+    if (loc !== currentLocale) setLocale(loc);
+  };
+
+  return (
+    <div ref={ref} className={cn("relative", className)}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-label={i18n._(msg`Change language`)}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        className="grid h-9 w-9 cursor-pointer place-items-center rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-card)] text-[color:var(--color-muted-foreground)] transition-colors duration-200 hover:bg-[color:var(--color-accent)] hover:text-[color:var(--color-foreground)]"
+      >
+        <Globe className="h-4 w-4" />
+      </button>
+      <div
+        role="listbox"
+        className={cn(
+          "absolute right-0 top-full z-50 mt-2 min-w-[176px] origin-top-right overflow-hidden rounded-xl border border-[color:var(--color-border)] bg-[color:var(--color-card)] p-1 shadow-[0_20px_40px_-24px_rgba(0,0,0,0.45)] transition-all duration-200 ease-[cubic-bezier(0.22,1,0.36,1)]",
+          open
+            ? "translate-y-0 opacity-100"
+            : "pointer-events-none -translate-y-1 opacity-0",
+        )}
+      >
+        {LOCALES.map((loc) => {
+          const active = loc === currentLocale;
+          return (
+            <button
+              key={loc}
+              type="button"
+              role="option"
+              aria-selected={active}
+              onClick={() => handleSelect(loc)}
+              className={cn(
+                "flex w-full cursor-pointer items-center gap-2.5 rounded-lg px-2.5 py-2 text-left text-[13px] font-medium transition-colors duration-150",
+                active
+                  ? "bg-[color:var(--color-accent)] text-[color:var(--color-foreground)]"
+                  : "text-[color:var(--color-muted-foreground)] hover:bg-[color:var(--color-accent)]/60 hover:text-[color:var(--color-foreground)]",
+              )}
+            >
+              <span className="text-base leading-none">{LOCALE_FLAGS[loc]}</span>
+              <span className="flex-1">{i18n._(LOCALE_LABEL_MESSAGES[loc])}</span>
+              {active ? <Check className="h-3.5 w-3.5" /> : null}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/landing/src/components/PdfToBookDiagram.tsx
+++ b/apps/landing/src/components/PdfToBookDiagram.tsx
@@ -7,6 +7,7 @@ import {
   Volume2,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
+import { Trans, useLingui } from "@lingui/react/macro";
 import { cn } from "@/lib/cn";
 
 export function PdfToBookDiagram({ mounted }: { mounted: boolean }) {
@@ -141,6 +142,7 @@ function PDFCard({ mounted }: { mounted: boolean }) {
 }
 
 function BookCard({ mounted }: { mounted: boolean }) {
+  const { t } = useLingui();
   return (
     <div
       className={cn(
@@ -156,7 +158,7 @@ function BookCard({ mounted }: { mounted: boolean }) {
       <div className="flex h-[30px] items-center gap-1.5 bg-blue-500 px-3">
         <Check className="h-3 w-3 text-white" />
         <span className="text-[9px] font-extrabold uppercase tracking-[0.1em] text-white">
-          Accessible book
+          <Trans>Accessible book</Trans>
         </span>
         <span aria-hidden className="ml-auto flex gap-[3px]">
           <span className="h-1 w-1 rounded-full bg-white/60" />
@@ -166,7 +168,7 @@ function BookCard({ mounted }: { mounted: boolean }) {
       </div>
       <div className="px-4 pb-3.5 pt-4">
         <div className="mb-1.5 text-[9px] font-bold uppercase tracking-wide text-[color:var(--color-muted-foreground)]">
-          Chapter 3
+          <Trans>Chapter 3</Trans>
         </div>
         <div className="mb-2.5 h-3 w-3/4 rounded-sm bg-[color:var(--color-foreground)]" />
         <div className="mb-1.5 h-1 w-[92%] rounded-sm bg-[color:var(--color-muted)]" />
@@ -185,7 +187,10 @@ function BookCard({ mounted }: { mounted: boolean }) {
           </span>
         </div>
         <div className="mb-3 text-[8px] italic leading-relaxed text-[color:var(--color-muted-foreground)]">
-          Fig 3.1 — The water cycle: evaporation, condensation, precipitation.
+          <Trans>
+            Fig 3.1 — The water cycle: evaporation, condensation,
+            precipitation.
+          </Trans>
         </div>
 
         <div className="flex flex-wrap gap-1">
@@ -209,7 +214,7 @@ function BookCard({ mounted }: { mounted: boolean }) {
             color="text-lime-700"
             bg="bg-lime-50"
             Icon={BookMarked}
-            label="Glossary"
+            label={t`Glossary`}
             delay={1400}
             mounted={mounted}
           />

--- a/apps/landing/src/components/ReleaseMarkdown.tsx
+++ b/apps/landing/src/components/ReleaseMarkdown.tsx
@@ -1,4 +1,5 @@
 import { ChevronRight } from "lucide-react";
+import { Trans } from "@lingui/react/macro";
 import { type ComponentProps } from "react";
 import ReactMarkdown, { type Components } from "react-markdown";
 import rehypeRaw from "rehype-raw";
@@ -357,9 +358,11 @@ function BetaBanner() {
   return (
     <div className="-mx-1 mb-2 flex items-center gap-2 rounded-lg border border-amber-200/70 bg-amber-100/40 px-3 py-2 text-[12px] font-semibold text-amber-800">
       <span className="inline-flex items-center rounded-md bg-amber-200/60 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider">
-        Beta
+        <Trans>Beta</Trans>
       </span>
-      Pre-release — APIs and behavior may still change before the stable cut.
+      <Trans>
+        Pre-release — APIs and behavior may still change before the stable cut.
+      </Trans>
     </div>
   );
 }

--- a/apps/landing/src/components/pages/DownloadPage.tsx
+++ b/apps/landing/src/components/pages/DownloadPage.tsx
@@ -1,4 +1,5 @@
 import { AlertTriangle, ArrowUpRight, Construction, Monitor } from "lucide-react";
+import { Trans, useLingui } from "@lingui/react/macro";
 import { useEffect, useMemo, useState } from "react";
 import { Button } from "@/components/Button";
 import { cn } from "@/lib/cn";
@@ -22,6 +23,7 @@ import {
 } from "./download/shared";
 
 export function DownloadPage() {
+  const { t } = useLingui();
   const { releases, loading, error } = useStableReleases();
   const latest: GithubRelease | undefined = releases?.[0];
   const [userPlatform, setUserPlatform] = useState<DetectedPlatform | null>(
@@ -84,7 +86,7 @@ export function DownloadPage() {
       <div className="relative mx-auto flex w-full max-w-2xl flex-1 flex-col items-center justify-center px-4 py-16 text-center">
         <a
           href="#top"
-          aria-label="ADT Studio home"
+          aria-label={t`ADT Studio home`}
           className={cn(
             "group relative inline-flex transition-all duration-700",
             mounted ? "translate-y-0 opacity-100" : "translate-y-1 opacity-0",
@@ -110,7 +112,7 @@ export function DownloadPage() {
           )}
           style={{ transitionDelay: "120ms" }}
         >
-          Start building accessible books.
+          <Trans>Start building accessible books.</Trans>
         </h1>
 
         <p
@@ -120,8 +122,10 @@ export function DownloadPage() {
           )}
           style={{ transitionDelay: "240ms" }}
         >
-          Free, open-source, and runs on your machine. Available for macOS,
-          Windows, and Linux.
+          <Trans>
+            Free, open-source, and runs on your machine. Available for macOS,
+            Windows, and Linux.
+          </Trans>
         </p>
 
         <div
@@ -142,7 +146,7 @@ export function DownloadPage() {
               onClick={() => trackDownload(detected.key, detectedAsset.name)}
             >
               <PrimaryIcon className="h-4 w-4" strokeWidth={1.8} />
-              Download for {detected.label}
+              <Trans>Download for {detected.label}</Trans>
             </Button>
           ) : (
             <EmptyPlatformState
@@ -163,7 +167,7 @@ export function DownloadPage() {
             style={{ transitionDelay: "440ms" }}
           >
             {loading
-              ? "Resolving latest release…"
+              ? t`Resolving latest release…`
               : `${detectedAsset.name} · ${formatSize(detectedAsset.size)} · ${detectedResolution.release.tag_name}`}
           </div>
         )}
@@ -185,7 +189,7 @@ export function DownloadPage() {
           style={{ transitionDelay: "540ms" }}
         >
           <div className="text-[10px] font-bold uppercase tracking-[0.18em] text-[color:var(--color-muted-foreground)]">
-            {hasDetectedBuild ? "Also available on" : "Available for"}
+            {hasDetectedBuild ? t`Also available on` : t`Available for`}
           </div>
           <div className="flex flex-wrap items-center justify-center gap-2">
             {chipPlatforms.map((p) => (
@@ -211,7 +215,9 @@ export function DownloadPage() {
             <span className="font-semibold text-[color:var(--color-foreground)]">
               {formatDownloads(totalDownloads)}
             </span>
-            <span>downloads to date</span>
+            <span>
+              <Trans>downloads to date</Trans>
+            </span>
           </div>
         )}
 
@@ -224,36 +230,40 @@ export function DownloadPage() {
         >
           {latest?.prerelease && (
             <div className="inline-flex items-center gap-2">
-              <span>ADT Studio is currently in</span>
+              <span>
+                <Trans>ADT Studio is currently in</Trans>
+              </span>
               <span className="rounded-md border border-[color:var(--color-border)] px-1.5 py-0.5 font-mono text-[10px] font-bold uppercase tracking-wider text-[color:var(--color-foreground)]">
-                Beta
+                <Trans>Beta</Trans>
               </span>
             </div>
           )}
           <div className="max-w-md text-balance">
-            If your device has been wrongly detected,{" "}
-            <a
-              href="https://github.com/unicef/adt-studio/releases/latest"
-              target="_blank"
-              rel="noreferrer noopener"
-              className="font-medium text-[color:var(--color-primary)] underline-offset-2 hover:underline"
-            >
-              see all downloads
-            </a>
-            . Please report any issues you encounter on{" "}
-            <a
-              href="https://github.com/unicef/adt-studio/issues"
-              target="_blank"
-              rel="noreferrer noopener"
-              className="font-medium text-[color:var(--color-primary)] underline-offset-2 hover:underline"
-            >
-              GitHub
-            </a>
-            .
+            <Trans>
+              If your device has been wrongly detected,{" "}
+              <a
+                href="https://github.com/unicef/adt-studio/releases/latest"
+                target="_blank"
+                rel="noreferrer noopener"
+                className="font-medium text-[color:var(--color-primary)] underline-offset-2 hover:underline"
+              >
+                see all downloads
+              </a>
+              . Please report any issues you encounter on{" "}
+              <a
+                href="https://github.com/unicef/adt-studio/issues"
+                target="_blank"
+                rel="noreferrer noopener"
+                className="font-medium text-[color:var(--color-primary)] underline-offset-2 hover:underline"
+              >
+                GitHub
+              </a>
+              .
+            </Trans>
           </div>
           {latest && (
             <div className="font-mono text-[10px] text-[color:var(--color-muted-foreground)]/70">
-              Released {formatRelativeDate(latest.published_at)}
+              <Trans>Released {formatRelativeDate(latest.published_at)}</Trans>
             </div>
           )}
         </div>
@@ -271,15 +281,17 @@ function MobileNotice({ fallbackHref }: { fallbackHref: string }) {
         </span>
         <div className="flex-1">
           <div className="text-[10px] font-bold uppercase tracking-[0.18em] text-[color:var(--color-muted-foreground)]">
-            Desktop only
+            <Trans>Desktop only</Trans>
           </div>
           <div className="mt-0.5 text-base font-semibold tracking-tight text-[color:var(--color-foreground)]">
-            ADT Studio is a desktop app
+            <Trans>ADT Studio is a desktop app</Trans>
           </div>
           <p className="mt-2 text-sm leading-relaxed text-[color:var(--color-muted-foreground)]">
-            We don&rsquo;t ship a mobile version. To install ADT Studio, open
-            this page on macOS, Windows, or Linux — or send the link to your
-            computer.
+            <Trans>
+              We don&rsquo;t ship a mobile version. To install ADT Studio, open
+              this page on macOS, Windows, or Linux — or send the link to your
+              computer.
+            </Trans>
           </p>
         </div>
       </div>
@@ -292,7 +304,7 @@ function MobileNotice({ fallbackHref }: { fallbackHref: string }) {
         size="md"
         className="mt-4 w-full justify-center"
       >
-        View release on GitHub
+        <Trans>View release on GitHub</Trans>
         <ArrowUpRight className="h-4 w-4" />
       </Button>
     </div>
@@ -310,11 +322,12 @@ function EmptyPlatformState({
   loading: boolean;
   failed: boolean;
 }) {
+  const { t } = useLingui();
   if (loading) {
     return (
       <div className="mx-auto max-w-md rounded-2xl border border-dashed border-[color:var(--color-border)] bg-[color:var(--color-card)]/40 p-6 text-center">
         <div className="text-[10px] font-bold uppercase tracking-[0.18em] text-[color:var(--color-muted-foreground)]">
-          Resolving latest release…
+          <Trans>Resolving latest release…</Trans>
         </div>
       </div>
     );
@@ -327,15 +340,15 @@ function EmptyPlatformState({
         </span>
         <div className="flex-1">
           <div className="text-[10px] font-bold uppercase tracking-[0.18em] text-[color:var(--color-muted-foreground)]">
-            {failed ? "Couldn't reach GitHub" : "Coming soon"}
+            {failed ? t`Couldn't reach GitHub` : t`Coming soon`}
           </div>
           <div className="mt-0.5 text-base font-semibold tracking-tight text-[color:var(--color-foreground)]">
-            No {meta.label} build yet
+            <Trans>No {meta.label} build yet</Trans>
           </div>
           <p className="mt-2 text-sm leading-relaxed text-[color:var(--color-muted-foreground)]">
             {failed
-              ? "We couldn't fetch the latest release. Try the release page directly, or pick another platform below."
-              : `We don't ship a prebuilt installer for ${meta.label} in this release. Pick another platform below or follow progress on GitHub.`}
+              ? t`We couldn't fetch the latest release. Try the release page directly, or pick another platform below.`
+              : t`We don't ship a prebuilt installer for ${meta.label} in this release. Pick another platform below or follow progress on GitHub.`}
           </p>
         </div>
       </div>
@@ -348,7 +361,7 @@ function EmptyPlatformState({
         size="md"
         className="mt-4 w-full justify-center"
       >
-        View release on GitHub
+        <Trans>View release on GitHub</Trans>
         <ArrowUpRight className="h-4 w-4" />
       </Button>
     </div>
@@ -364,6 +377,7 @@ function PlatformChip({
   resolution: PlatformResolution | null;
   fallbackRelease: GithubRelease | undefined;
 }) {
+  const { t } = useLingui();
   const Icon = meta.icon;
   const fallbackHref =
     fallbackRelease?.html_url ??
@@ -374,9 +388,9 @@ function PlatformChip({
 
   const title = hasBuild
     ? isOutdated
-      ? `Download for ${meta.label} — ${resolution.release.tag_name} (a newer release exists for other platforms)`
-      : `Download for ${meta.label} ${resolution.release.tag_name}`
-    : `${meta.label} build is coming — track on GitHub`;
+      ? t`Download for ${meta.label} — ${resolution.release.tag_name} (a newer release exists for other platforms)`
+      : t`Download for ${meta.label} ${resolution.release.tag_name}`
+    : t`${meta.label} build is coming — track on GitHub`;
 
   return (
     <a
@@ -408,7 +422,7 @@ function PlatformChip({
       )}
       {!hasBuild && (
         <span className="ml-0.5 rounded-full bg-[color:var(--color-muted)] px-1.5 py-0.5 font-mono text-[9px] font-bold uppercase tracking-wider text-[color:var(--color-muted-foreground)]">
-          Soon
+          <Trans>Soon</Trans>
         </span>
       )}
     </a>
@@ -437,20 +451,23 @@ function OutdatedNotice({
     >
       <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" strokeWidth={2} />
       <span>
-        {platform.label} latest is{" "}
-        <span className="font-mono font-semibold">
-          {platformResolution.release.tag_name}
-        </span>{" "}
-        — the project is on{" "}
-        <a
-          href={overallLatest.html_url}
-          target="_blank"
-          rel="noreferrer noopener"
-          className="font-mono font-semibold underline-offset-2 hover:underline"
-        >
-          {overallLatest.tag_name}
-        </a>
-        . A {platform.label} build for the newer tag isn&rsquo;t available yet.
+        <Trans>
+          {platform.label} latest is{" "}
+          <span className="font-mono font-semibold">
+            {platformResolution.release.tag_name}
+          </span>{" "}
+          — the project is on{" "}
+          <a
+            href={overallLatest.html_url}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="font-mono font-semibold underline-offset-2 hover:underline"
+          >
+            {overallLatest.tag_name}
+          </a>
+          . A {platform.label} build for the newer tag isn&rsquo;t available
+          yet.
+        </Trans>
       </span>
     </div>
   );

--- a/apps/landing/src/components/pages/ReleasesPage.tsx
+++ b/apps/landing/src/components/pages/ReleasesPage.tsx
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/react/macro";
 import { ArrowLeft, ArrowUpRight, Github } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { Button } from "@/components/Button";
@@ -59,7 +60,7 @@ export function ReleasesPage({ focusTag }: { focusTag?: string }) {
             className="group inline-flex items-center gap-1.5 rounded-full border border-[color:var(--color-border)] bg-[color:var(--color-card)]/70 px-3 py-1 text-xs font-semibold text-[color:var(--color-muted-foreground)] shadow-sm backdrop-blur-sm transition-all hover:border-[color:var(--color-primary)]/30 hover:text-[color:var(--color-foreground)]"
           >
             <ArrowLeft className="h-3.5 w-3.5 transition-transform duration-200 group-hover:-translate-x-0.5" />
-            Back to home
+            <Trans>Back to home</Trans>
           </a>
         </div>
 
@@ -71,7 +72,7 @@ export function ReleasesPage({ focusTag }: { focusTag?: string }) {
             )}
             style={{ transitionDelay: "80ms" }}
           >
-            Changelog
+            <Trans>Changelog</Trans>
           </div>
           <h1
             className={cn(
@@ -80,7 +81,7 @@ export function ReleasesPage({ focusTag }: { focusTag?: string }) {
             )}
             style={{ transitionDelay: "140ms" }}
           >
-            Every ship of ADT Studio.
+            <Trans>Every ship of ADT Studio.</Trans>
           </h1>
           <p
             className={cn(
@@ -89,8 +90,10 @@ export function ReleasesPage({ focusTag }: { focusTag?: string }) {
             )}
             style={{ transitionDelay: "240ms" }}
           >
-            Newest first, with the full notes inline — what changed, why it
-            matters, and the screenshots to back it up.
+            <Trans>
+              Newest first, with the full notes inline — what changed, why it
+              matters, and the screenshots to back it up.
+            </Trans>
           </p>
         </header>
 
@@ -133,7 +136,7 @@ export function ReleasesPage({ focusTag }: { focusTag?: string }) {
               variant="secondary"
               size="md"
             >
-              See all releases on GitHub
+              <Trans>See all releases on GitHub</Trans>
               <ArrowUpRight className="h-4 w-4" />
             </Button>
           </div>
@@ -193,7 +196,7 @@ function ReleaseEntry({
         <div className="mt-2 flex flex-wrap items-center gap-1.5">
           {isLatest && (
             <span className="rounded-md bg-emerald-50 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-emerald-700">
-              Latest
+              <Trans>Latest</Trans>
             </span>
           )}
           <span className="font-mono text-[10px] text-[color:var(--color-muted-foreground)]/80">
@@ -222,7 +225,7 @@ function ReleaseEntry({
             />
           ) : (
             <p className="text-sm text-[color:var(--color-muted-foreground)]">
-              No release notes were provided for this version.
+              <Trans>No release notes were provided for this version.</Trans>
             </p>
           )}
         </div>
@@ -314,11 +317,13 @@ function ErrorCard() {
   return (
     <div className="rounded-2xl border border-[color:var(--color-border)] bg-[color:var(--color-card)] p-6">
       <div className="text-base font-semibold text-[color:var(--color-foreground)]">
-        Couldn&rsquo;t load the changelog
+        <Trans>Couldn&rsquo;t load the changelog</Trans>
       </div>
       <p className="mt-1 text-sm text-[color:var(--color-muted-foreground)]">
-        We couldn&rsquo;t reach GitHub. The full list is always available on
-        the upstream repo.
+        <Trans>
+          We couldn&rsquo;t reach GitHub. The full list is always available on
+          the upstream repo.
+        </Trans>
       </p>
       <div className="mt-4">
         <Button
@@ -329,7 +334,7 @@ function ErrorCard() {
           size="md"
         >
           <Github className="h-4 w-4" />
-          Open on GitHub
+          <Trans>Open on GitHub</Trans>
           <ArrowUpRight className="h-4 w-4" />
         </Button>
       </div>
@@ -340,7 +345,9 @@ function ErrorCard() {
 function EmptyCard() {
   return (
     <div className="rounded-2xl border border-dashed border-[color:var(--color-border)] bg-[color:var(--color-card)]/60 p-6 text-sm text-[color:var(--color-muted-foreground)]">
-      No releases published yet — check back once the first build ships.
+      <Trans>
+        No releases published yet — check back once the first build ships.
+      </Trans>
     </div>
   );
 }

--- a/apps/landing/src/components/scenes/AnimEnrich.tsx
+++ b/apps/landing/src/components/scenes/AnimEnrich.tsx
@@ -1,9 +1,11 @@
 import { BookMarked, Globe, Languages, Volume2 } from "lucide-react";
+import { Trans, useLingui } from "@lingui/react/macro";
 import { cn } from "@/lib/cn";
 import { lerp, seg } from "@/lib/seg";
 import { Cursor } from "@/components/Cursor";
 
 export function AnimEnrich({ progress }: { progress: number }) {
+  const { t } = useLingui();
   const p = progress;
   const enriching = p >= 0.45;
 
@@ -27,7 +29,7 @@ export function AnimEnrich({ progress }: { progress: number }) {
         }}
       >
         <div className="text-[11px] font-bold uppercase tracking-wider text-[color:var(--color-muted-foreground)]">
-          Edit & enrich
+          <Trans>Edit & enrich</Trans>
         </div>
         <div className="grid flex-1 grid-cols-2 grid-rows-2 gap-2.5">
           <EnrichPane
@@ -36,7 +38,7 @@ export function AnimEnrich({ progress }: { progress: number }) {
             bg="bg-pink-50"
             iconColor="text-pink-600"
             Icon={Languages}
-            label="Translate"
+            label={t`Translate`}
           >
             <TranslatePane t={p} />
           </EnrichPane>
@@ -46,7 +48,7 @@ export function AnimEnrich({ progress }: { progress: number }) {
             bg="bg-blue-50"
             iconColor="text-blue-600"
             Icon={Globe}
-            label="Languages"
+            label={t`Languages`}
           >
             <GlobePane t={p} />
           </EnrichPane>
@@ -56,7 +58,7 @@ export function AnimEnrich({ progress }: { progress: number }) {
             bg="bg-rose-50"
             iconColor="text-rose-600"
             Icon={Volume2}
-            label="Speech"
+            label={t`Speech`}
           >
             <WaveformPane t={p} />
           </EnrichPane>
@@ -66,7 +68,7 @@ export function AnimEnrich({ progress }: { progress: number }) {
             bg="bg-lime-50"
             iconColor="text-lime-600"
             Icon={BookMarked}
-            label="Glossary"
+            label={t`Glossary`}
           >
             <GlossaryPane t={p} />
           </EnrichPane>
@@ -248,7 +250,7 @@ function EnrichPane({
             className="ml-auto font-mono text-[9px] font-bold"
             style={{ color }}
           >
-            ● LIVE
+            ● <Trans>LIVE</Trans>
           </span>
         )}
       </div>

--- a/apps/landing/src/components/scenes/AnimExport.tsx
+++ b/apps/landing/src/components/scenes/AnimExport.tsx
@@ -6,6 +6,7 @@ import {
   Sparkles,
   Volume2,
 } from "lucide-react";
+import { Trans, useLingui } from "@lingui/react/macro";
 import { lerp, seg } from "@/lib/seg";
 
 const BOOK_COPY = {
@@ -40,6 +41,7 @@ const BOOK_COPY = {
 } as const;
 
 export function AnimExport({ progress }: { progress: number }) {
+  const { t } = useLingui();
   const p = progress;
 
   const tabletT = seg(p, 0, 0.05);
@@ -98,7 +100,7 @@ export function AnimExport({ progress }: { progress: number }) {
       >
         <Check className="h-3 w-3" strokeWidth={3} />
         <span className="font-mono text-[9px] font-bold uppercase tracking-wider">
-          Delivered
+          <Trans>Delivered</Trans>
         </span>
       </div>
 
@@ -173,25 +175,25 @@ export function AnimExport({ progress }: { progress: number }) {
                 active={audioActive}
                 color="#e11d48"
                 Icon={Volume2}
-                label="Audio"
+                label={t`Audio`}
               />
               <FeatureIcon
                 active={translateActive}
                 color="#db2777"
                 Icon={Languages}
-                label="Translate"
+                label={t`Translate`}
               />
               <FeatureIcon
                 active={signActive}
                 color="#2563eb"
                 Icon={Hand}
-                label="Sign"
+                label={t`Sign`}
               />
               <FeatureIcon
                 active={glossaryActive}
                 color="#65a30d"
                 Icon={Sparkles}
-                label="Glossary"
+                label={t`Glossary`}
               />
             </div>
           </div>
@@ -212,7 +214,10 @@ export function AnimExport({ progress }: { progress: number }) {
           className="text-[10.5px] font-medium leading-snug"
           style={{ color: "#2563eb" }}
         >
-          Every reader opens the same book, with the features they need on tap.
+          <Trans>
+            Every reader opens the same book, with the features they need on
+            tap.
+          </Trans>
         </span>
       </div>
     </div>
@@ -275,7 +280,7 @@ function LanguagePicker({
       <div className="flex items-center gap-1 px-1.5 pb-1 pt-0.5">
         <Languages className="h-2.5 w-2.5 text-pink-600" />
         <span className="font-mono text-[8px] font-bold uppercase tracking-wider text-pink-600">
-          Language
+          <Trans>Language</Trans>
         </span>
       </div>
       {langs.map((l) => {

--- a/apps/landing/src/components/scenes/AnimPdfPreset.tsx
+++ b/apps/landing/src/components/scenes/AnimPdfPreset.tsx
@@ -1,4 +1,5 @@
 import { Check, FileText } from "lucide-react";
+import { Trans } from "@lingui/react/macro";
 import { cn } from "@/lib/cn";
 import { lerp, seg } from "@/lib/seg";
 import { Cursor } from "@/components/Cursor";
@@ -45,7 +46,7 @@ export function AnimPdfPreset({ progress }: { progress: number }) {
         >
           <FileText className="h-10 w-10 text-[color:var(--color-muted-foreground)]" />
           <span className="text-sm text-[color:var(--color-muted-foreground)]">
-            Drop a PDF to get started
+            <Trans>Drop a PDF to get started</Trans>
           </span>
         </div>
 
@@ -55,7 +56,7 @@ export function AnimPdfPreset({ progress }: { progress: number }) {
             dragging && !dropped ? "opacity-100" : "pointer-events-none opacity-0",
           )}
         >
-          Release to upload
+          <Trans>Release to upload</Trans>
         </span>
 
         <div
@@ -112,7 +113,7 @@ export function AnimPdfPreset({ progress }: { progress: number }) {
             )}
           >
             <Check className="h-3 w-3" />
-            Successfully uploaded
+            <Trans>Successfully uploaded</Trans>
           </div>
         </div>
       </div>

--- a/apps/landing/src/components/scenes/AnimPipeline.tsx
+++ b/apps/landing/src/components/scenes/AnimPipeline.tsx
@@ -6,19 +6,21 @@ import {
   LayoutGrid,
   Sparkles,
 } from "lucide-react";
+import { useLingui } from "@lingui/react/macro";
 
 export function AnimPipeline({ progress }: { progress: number }) {
+  const { t } = useLingui();
   const p = progress;
 
   const extractSubs = [
-    { label: "Parsing pages", detail: "238 pp" },
-    { label: "Detecting figures", detail: "42 figs" },
-    { label: "OCR & cleanup", detail: "14.2 kB" },
+    { label: t`Parsing pages`, detail: "238 pp" },
+    { label: t`Detecting figures`, detail: "42 figs" },
+    { label: t`OCR & cleanup`, detail: "14.2 kB" },
   ];
   const storySubs = [
-    { label: "Segmenting scenes", detail: "18 scenes" },
-    { label: "Generating panels", detail: "72 panels" },
-    { label: "Laying out spreads", detail: "36 spreads" },
+    { label: t`Segmenting scenes`, detail: "18 scenes" },
+    { label: t`Generating panels`, detail: "72 panels" },
+    { label: t`Laying out spreads`, detail: "36 spreads" },
   ];
 
   const extractT = Math.max(0, Math.min(1, (p - 0.03) / 0.35));
@@ -41,7 +43,7 @@ export function AnimPipeline({ progress }: { progress: number }) {
     <div className="absolute inset-0 flex flex-col gap-3.5 overflow-hidden p-7">
       <div className="flex items-center gap-2.5">
         <div className="text-[11px] font-bold uppercase tracking-wider text-[color:var(--color-muted-foreground)]">
-          {storyActive ? "Pipeline · storyboard" : "Pipeline · extract"}
+          {storyActive ? t`Pipeline · storyboard` : t`Pipeline · extract`}
         </div>
         <div className="h-[3px] max-w-[180px] flex-1 overflow-hidden rounded-full bg-[color:var(--color-muted)]">
           <div
@@ -61,7 +63,7 @@ export function AnimPipeline({ progress }: { progress: number }) {
 
       <div className="grid flex-1 grid-cols-[1fr_24px_1fr] items-stretch gap-2.5">
         <PipelineStage
-          title="Extract"
+          title={t`Extract`}
           Icon={FileText}
           color="#2563eb"
           subs={extractSubs}
@@ -70,7 +72,7 @@ export function AnimPipeline({ progress }: { progress: number }) {
           active={!extractDone}
           dimmed={false}
           NoteIcon={Sparkles}
-          note="Parsing pages into text, figures, and layout boxes — cached by content hash."
+          note={t`Parsing pages into text, figures, and layout boxes — cached by content hash.`}
         />
         <div
           className="flex items-center justify-center transition-colors duration-300"
@@ -79,7 +81,7 @@ export function AnimPipeline({ progress }: { progress: number }) {
           <ArrowRight className="h-4 w-4" />
         </div>
         <PipelineStage
-          title="Storyboard"
+          title={t`Storyboard`}
           Icon={LayoutGrid}
           color="#7c3aed"
           subs={storySubs}
@@ -88,7 +90,7 @@ export function AnimPipeline({ progress }: { progress: number }) {
           active={storyActive && !storyDone}
           dimmed={!storyActive}
           NoteIcon={Layers}
-          note="Grouping content by purpose, then laying out every section as reviewable HTML."
+          note={t`Grouping content by purpose, then laying out every section as reviewable HTML.`}
         />
       </div>
     </div>
@@ -118,6 +120,7 @@ function PipelineStage({
   note: string;
   NoteIcon: typeof FileText;
 }) {
+  const { t } = useLingui();
   const n = subs.length;
   return (
     <div
@@ -154,7 +157,7 @@ function PipelineStage({
           {done ? (
             <>
               <Check className="h-2.5 w-2.5" />
-              DONE
+              {t`DONE`}
             </>
           ) : active ? (
             <>
@@ -165,10 +168,10 @@ function PipelineStage({
                   animation: "onboarding-blink-dot 1s infinite",
                 }}
               />
-              RUNNING
+              {t`RUNNING`}
             </>
           ) : (
-            "WAITING"
+            t`WAITING`
           )}
         </span>
       </div>

--- a/apps/landing/src/components/scenes/PresetCard.tsx
+++ b/apps/landing/src/components/scenes/PresetCard.tsx
@@ -1,3 +1,4 @@
+import { Trans, useLingui } from "@lingui/react/macro";
 import { Info, Settings } from "lucide-react";
 import type { Preset } from "@/data/presets";
 import { cn } from "@/lib/cn";
@@ -9,6 +10,7 @@ export function PresetCard({
   preset: Preset;
   selected: boolean;
 }) {
+  const { i18n } = useLingui();
   const { Icon } = preset;
   return (
     <div
@@ -39,10 +41,10 @@ export function PresetCard({
       </div>
       <div className="flex flex-col gap-2 px-4 pt-4 pb-3">
         <span className="text-sm font-bold text-black leading-5">
-          {preset.title}
+          {i18n._(preset.title)}
         </span>
         <span className="line-clamp-3 text-[10px] leading-[14px] text-[#737373]">
-          {preset.description}
+          {i18n._(preset.description)}
         </span>
         <div
           className="mt-1 flex items-center justify-between"
@@ -50,7 +52,7 @@ export function PresetCard({
         >
           <span className="flex items-center gap-1.5 text-xs font-medium text-[#2b7fff]">
             <Info className="h-3.5 w-3.5 shrink-0" />
-            See examples
+            <Trans>See examples</Trans>
           </span>
           <span className="flex items-center gap-1 rounded-full border border-[#e5e5e5] px-2 py-0.5">
             <Settings className="h-3.5 w-3.5 text-[#0a0a0a]" />

--- a/apps/landing/src/components/sections/CarouselScene.tsx
+++ b/apps/landing/src/components/sections/CarouselScene.tsx
@@ -1,3 +1,6 @@
+import { msg } from "@lingui/core/macro";
+import type { MessageDescriptor } from "@lingui/core";
+import { Trans, useLingui } from "@lingui/react/macro";
 import { Check, Pause, Play } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { AnimEnrich } from "@/components/scenes/AnimEnrich";
@@ -11,40 +14,40 @@ import { useInViewLive } from "@/lib/useScrollProgress";
 
 type Feature = {
   num: string;
-  title: string;
-  body: string;
+  title: MessageDescriptor;
+  body: MessageDescriptor;
   Anim: (props: { progress: number }) => React.ReactElement;
 };
 
 const FEATURES: Feature[] = [
   {
     num: "01",
-    title: "Start from a PDF",
-    body: "Drop in a PDF to kick things off. ADT Studio organizes it into a new book project so you don't start from zero.",
+    title: msg`Start from a PDF`,
+    body: msg`Drop in a PDF to kick things off. ADT Studio organizes it into a new book project so you don't start from zero.`,
     Anim: AnimPdfPreset,
   },
   {
     num: "02",
-    title: "Pick a preset",
-    body: "Choose a preset that matches your content — textbook, storyboard, reference, or custom — and ADT Studio tailors the pipeline accordingly.",
+    title: msg`Pick a preset`,
+    body: msg`Choose a preset that matches your content — textbook, storyboard, reference, or custom — and ADT Studio tailors the pipeline accordingly.`,
     Anim: AnimPresetPicker,
   },
   {
     num: "03",
-    title: "Run the pipeline",
-    body: "Configure each stage — extract, storyboard, layout — then let ADT Studio build the book. Review the output, correct anything that needs a human touch.",
+    title: msg`Run the pipeline`,
+    body: msg`Configure each stage — extract, storyboard, layout — then let ADT Studio build the book. Review the output, correct anything that needs a human touch.`,
     Anim: AnimPipeline,
   },
   {
     num: "04",
-    title: "Edit & enrich",
-    body: "Layer on translations, text-to-speech, and a glossary — all inspectable, cacheable, reversible.",
+    title: msg`Edit & enrich`,
+    body: msg`Layer on translations, text-to-speech, and a glossary — all inspectable, cacheable, reversible.`,
     Anim: AnimEnrich,
   },
   {
     num: "05",
-    title: "Export to a reader",
-    body: "Package the finished book with every accessibility feature baked in — ready for a kid to open, listen, and read along.",
+    title: msg`Export to a reader`,
+    body: msg`Package the finished book with every accessibility feature baked in — ready for a kid to open, listen, and read along.`,
     Anim: AnimExport,
   },
 ];
@@ -54,6 +57,7 @@ const HOLD_AFTER_MS = [1600, 1600, 500, 1600, 1600];
 const FEATURE_COUNT = FEATURES.length;
 
 export function CarouselScene() {
+  const { i18n } = useLingui();
   const { ref, inView } = useInViewLive<HTMLElement>({ threshold: 0.35 });
   const [idx, setIdx] = useState(0);
   const [progress, setProgress] = useState(0);
@@ -116,7 +120,7 @@ export function CarouselScene() {
     >
       <div className="mx-auto grid w-full max-w-6xl grid-cols-1 items-center gap-14 px-4 md:grid-cols-[1fr_1.35fr]">
         <div className="flex flex-col">
-          <SectionEyebrow label="How it works" className="mb-5" />
+          <SectionEyebrow label={i18n._(msg`How it works`)} className="mb-5" />
 
           <div className="relative min-h-[170px]">
             {FEATURES.map((f, i) => (
@@ -133,10 +137,10 @@ export function CarouselScene() {
                   {f.num} / {String(FEATURE_COUNT).padStart(2, "0")}
                 </div>
                 <h2 className="mb-3.5 text-3xl font-semibold leading-tight tracking-tight text-[color:var(--color-foreground)]">
-                  {f.title}
+                  {i18n._(f.title)}
                 </h2>
                 <p className="max-w-md text-sm leading-relaxed text-[color:var(--color-muted-foreground)]">
-                  {f.body}
+                  {i18n._(f.body)}
                 </p>
               </div>
             ))}
@@ -186,7 +190,7 @@ export function CarouselScene() {
                         : "font-medium text-[color:var(--color-muted-foreground)]",
                     )}
                   >
-                    {f.title}
+                    {i18n._(f.title)}
                   </span>
                   {active && (
                     <span className="h-[3px] w-14 overflow-hidden rounded bg-[color:var(--color-muted)]">
@@ -207,7 +211,7 @@ export function CarouselScene() {
             className="mt-3 inline-flex w-fit cursor-pointer items-center gap-1.5 rounded-md px-2 py-1.5 text-xs text-[color:var(--color-muted-foreground)] transition-colors hover:bg-[color:var(--color-accent)]/60 hover:text-[color:var(--color-foreground)]"
           >
             {playing ? <Pause className="h-3 w-3" /> : <Play className="h-3 w-3" />}
-            {playing ? "Pause" : "Play"}
+            {playing ? <Trans>Pause</Trans> : <Trans>Play</Trans>}
           </button>
         </div>
 

--- a/apps/landing/src/components/sections/FeaturesScene.tsx
+++ b/apps/landing/src/components/sections/FeaturesScene.tsx
@@ -5,13 +5,16 @@ import {
   Volume2,
   type LucideIcon,
 } from "lucide-react";
+import { msg } from "@lingui/core/macro";
+import { type MessageDescriptor } from "@lingui/core";
+import { Trans, useLingui } from "@lingui/react/macro";
 import { SectionEyebrow } from "@/components/SectionEyebrow";
 import { cn } from "@/lib/cn";
 import { useInView } from "@/lib/useScrollProgress";
 
 type Feature = {
-  title: string;
-  body: string;
+  title: MessageDescriptor;
+  body: MessageDescriptor;
   Icon: LucideIcon;
   tint: string;
   fg: string;
@@ -19,33 +22,29 @@ type Feature = {
 
 const FEATURES: Feature[] = [
   {
-    title: "Audio narration",
-    body:
-      "Generate studio-quality text-to-speech for every page, with speaker control and per-language voices — no recording needed.",
+    title: msg`Audio narration`,
+    body: msg`Generate studio-quality text-to-speech for every page, with speaker control and per-language voices — no recording needed.`,
     Icon: Volume2,
     tint: "bg-rose-50",
     fg: "text-rose-600",
   },
   {
-    title: "Translations",
-    body:
-      "Ship the same book in every language you need. Translate text, captions and alt-text in one pass — review, edit, re-run.",
+    title: msg`Translations`,
+    body: msg`Ship the same book in every language you need. Translate text, captions and alt-text in one pass — review, edit, re-run.`,
     Icon: Languages,
     tint: "bg-pink-50",
     fg: "text-pink-600",
   },
   {
-    title: "Structured layouts",
-    body:
-      "Recover headings, paragraphs, figures, tables and alt-text from the source PDF as real semantic HTML — built for screen readers.",
+    title: msg`Structured layouts`,
+    body: msg`Recover headings, paragraphs, figures, tables and alt-text from the source PDF as real semantic HTML — built for screen readers.`,
     Icon: LayoutGrid,
     tint: "bg-blue-50",
     fg: "text-blue-600",
   },
   {
-    title: "Sign language",
-    body:
-      "Attach sign-language video for ASL, LIBRAS and beyond — aligned to chapters and inspectable alongside the text.",
+    title: msg`Sign language`,
+    body: msg`Attach sign-language video for ASL, LIBRAS and beyond — aligned to chapters and inspectable alongside the text.`,
     Icon: Hand,
     tint: "bg-cyan-50",
     fg: "text-cyan-600",
@@ -53,6 +52,7 @@ const FEATURES: Feature[] = [
 ];
 
 export function FeaturesScene() {
+  const { i18n } = useLingui();
   const { ref, inView: mounted } = useInView<HTMLDivElement>({ threshold: 0.2 });
 
   return (
@@ -65,7 +65,7 @@ export function FeaturesScene() {
         className="mx-auto w-full max-w-6xl px-4"
       >
         <div className="mx-auto max-w-2xl text-center">
-          <SectionEyebrow label="What it does" />
+          <SectionEyebrow label={i18n._(msg`What it does`)} />
           <h2
             className={cn(
               "mt-5 text-balance text-4xl font-semibold leading-[1.08] tracking-tight md:text-5xl",
@@ -74,11 +74,13 @@ export function FeaturesScene() {
             )}
             style={{ transitionDelay: "80ms" }}
           >
-            Every accessibility feature,{" "}
-            <span className="text-[color:var(--color-primary)]">
-              built in from page one
-            </span>
-            .
+            <Trans>
+              Every accessibility feature,{" "}
+              <span className="text-[color:var(--color-primary)]">
+                built in from page one
+              </span>
+              .
+            </Trans>
           </h2>
           <p
             className={cn(
@@ -88,16 +90,18 @@ export function FeaturesScene() {
             )}
             style={{ transitionDelay: "220ms" }}
           >
-            ADT Studio takes one PDF and rebuilds it as a fully-editable,
-            fully-yours accessible book — with the pieces that used to take
-            a team of specialists.
+            <Trans>
+              ADT Studio takes one PDF and rebuilds it as a fully-editable,
+              fully-yours accessible book — with the pieces that used to take
+              a team of specialists.
+            </Trans>
           </p>
         </div>
 
         <div className="mt-14 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
           {FEATURES.map((f, i) => (
             <div
-              key={f.title}
+              key={f.title.id}
               className={cn(
                 "group relative flex flex-col gap-4 rounded-2xl border border-[color:var(--color-border)] bg-[color:var(--color-card)] p-6 transition-all duration-[700ms] ease-[cubic-bezier(0.22,1,0.36,1)] hover:-translate-y-0.5 hover:border-[color:var(--color-primary)]/30 hover:shadow-[0_10px_30px_-12px_rgba(0,0,0,0.12)]",
                 mounted ? "translate-y-0 opacity-100" : "translate-y-4 opacity-0",
@@ -115,10 +119,10 @@ export function FeaturesScene() {
               </span>
               <div>
                 <h3 className="mb-1.5 text-base font-semibold tracking-tight text-[color:var(--color-foreground)]">
-                  {f.title}
+                  {i18n._(f.title)}
                 </h3>
                 <p className="text-sm leading-relaxed text-[color:var(--color-muted-foreground)]">
-                  {f.body}
+                  {i18n._(f.body)}
                 </p>
               </div>
             </div>

--- a/apps/landing/src/components/sections/FinaleScene.tsx
+++ b/apps/landing/src/components/sections/FinaleScene.tsx
@@ -1,4 +1,5 @@
 import { ArrowRight, Github } from "lucide-react";
+import { Trans, useLingui } from "@lingui/react/macro";
 import { Button } from "@/components/Button";
 import { SectionEyebrow } from "@/components/SectionEyebrow";
 import { trackEvent } from "@/lib/matomo";
@@ -7,6 +8,7 @@ import { cn } from "@/lib/cn";
 import { useInView } from "@/lib/useScrollProgress";
 
 export function FinaleScene() {
+  const { t } = useLingui();
   const { ref, inView: mounted } = useInView<HTMLDivElement>({ threshold: 0.2 });
 
   return (
@@ -29,7 +31,7 @@ export function FinaleScene() {
       >
         <div className="flex flex-col items-center gap-5">
           <SectionEyebrow
-            label="Get started"
+            label={t`Get started`}
             className={cn(
               "transition-opacity duration-500",
               mounted ? "opacity-100" : "opacity-0",
@@ -44,10 +46,12 @@ export function FinaleScene() {
             )}
             style={{ transitionDelay: "120ms" }}
           >
-            Your first accessible book{" "}
-            <span className="bg-gradient-to-r from-[color:var(--color-primary)] to-violet-500 bg-clip-text text-transparent">
-              starts here.
-            </span>
+            <Trans>
+              Your first accessible book{" "}
+              <span className="bg-gradient-to-r from-[color:var(--color-primary)] to-violet-500 bg-clip-text text-transparent">
+                starts here.
+              </span>
+            </Trans>
           </h2>
           <p
             className={cn(
@@ -56,9 +60,11 @@ export function FinaleScene() {
             )}
             style={{ transitionDelay: "280ms" }}
           >
-            Drop in a PDF and watch it flow through every stage — from raw
-            pages to an accessible reader. Free, open-source, runs on your
-            machine.
+            <Trans>
+              Drop in a PDF and watch it flow through every stage — from raw
+              pages to an accessible reader. Free, open-source, runs on your
+              machine.
+            </Trans>
           </p>
         </div>
 
@@ -75,7 +81,7 @@ export function FinaleScene() {
             variant="primary"
             onClick={() => trackEvent("cta", "download_click", "finale")}
           >
-            Download ADT Studio
+            <Trans>Download ADT Studio</Trans>
             <ArrowRight className="h-4 w-4" />
           </Button>
           <Button
@@ -87,7 +93,7 @@ export function FinaleScene() {
             onClick={() => trackEvent("outbound", "github_source", "finale")}
           >
             <Github className="h-4 w-4" />
-            View source
+            <Trans>View source</Trans>
           </Button>
         </div>
 
@@ -98,16 +104,22 @@ export function FinaleScene() {
           )}
           style={{ transitionDelay: "540ms" }}
         >
-          <span className="font-mono">Free forever</span>
+          <span className="font-mono">
+            <Trans>Free forever</Trans>
+          </span>
           <span className="h-1 w-1 rounded-full bg-[color:var(--color-border)]" />
-          <span className="font-mono">No account needed</span>
+          <span className="font-mono">
+            <Trans>No account needed</Trans>
+          </span>
           <span className="h-1 w-1 rounded-full bg-[color:var(--color-border)]" />
-          <span className="font-mono">MIT licensed</span>
+          <span className="font-mono">
+            <Trans>MIT licensed</Trans>
+          </span>
         </div>
 
         <div className="mt-6 w-full">
           <div className="mb-4 text-[10px] font-bold uppercase tracking-[0.18em] text-[color:var(--color-muted-foreground)]">
-            What happens when you drop in a PDF
+            <Trans>What happens when you drop in a PDF</Trans>
           </div>
           <StageTimeline mounted={mounted} />
         </div>
@@ -117,9 +129,10 @@ export function FinaleScene() {
 }
 
 function StageTimeline({ mounted }: { mounted: boolean }) {
+  const { t } = useLingui();
   return (
     <ol
-      aria-label="Book creation stages"
+      aria-label={t`Book creation stages`}
       className="relative flex w-full items-start justify-between"
     >
       <span
@@ -146,6 +159,7 @@ function StageNode({
   index: number;
   mounted: boolean;
 }) {
+  const { i18n } = useLingui();
   const Icon = stage.icon;
   return (
     <li className="relative flex flex-col items-center gap-2.5">
@@ -170,7 +184,7 @@ function StageNode({
         )}
         style={{ transitionDelay: `${900 + index * 60}ms` }}
       >
-        {stage.label}
+        {i18n._(stage.label)}
       </span>
     </li>
   );

--- a/apps/landing/src/components/sections/Footer.tsx
+++ b/apps/landing/src/components/sections/Footer.tsx
@@ -1,63 +1,67 @@
 import { Github } from "lucide-react";
+import { msg } from "@lingui/core/macro";
+import { Trans, useLingui } from "@lingui/react/macro";
+import type { MessageDescriptor } from "@lingui/core";
 
 type LinkCol = {
-  title: string;
-  links: { label: string; href: string; external?: boolean }[];
+  title: MessageDescriptor;
+  links: { label: MessageDescriptor; href: string; external?: boolean }[];
 };
 
 const COLUMNS: LinkCol[] = [
   {
-    title: "Product",
+    title: msg`Product`,
     links: [
       {
-        label: "Download",
+        label: msg`Download`,
         href: "https://github.com/unicef/adt-studio/releases/latest",
         external: true,
       },
-      { label: "What it does", href: "#pitch" },
-      { label: "How it works", href: "#carousel" },
-      { label: "Get started", href: "#finale" },
+      { label: msg`What it does`, href: "#pitch" },
+      { label: msg`How it works`, href: "#carousel" },
+      { label: msg`Get started`, href: "#finale" },
     ],
   },
   {
-    title: "Project",
+    title: msg`Project`,
     links: [
       {
-        label: "GitHub",
+        label: msg`GitHub`,
         href: "https://github.com/unicef/adt-studio",
         external: true,
       },
       {
-        label: "Issues",
+        label: msg`Issues`,
         href: "https://github.com/unicef/adt-studio/issues",
         external: true,
       },
       {
-        label: "Releases",
+        label: msg`Releases`,
         href: "https://github.com/unicef/adt-studio/releases",
         external: true,
       },
     ],
   },
   {
-    title: "Docs",
+    title: msg`Docs`,
     links: [
       {
-        label: "Guidelines",
+        label: msg`Guidelines`,
         href: "https://github.com/unicef/adt-studio/blob/main/docs/GUIDELINES.md",
         external: true,
       },
       {
-        label: "Architecture",
+        label: msg`Architecture`,
         href: "https://github.com/unicef/adt-studio/blob/main/docs/DECISIONS.md",
         external: true,
       },
-      { label: "License", href: "https://opensource.org/licenses/MIT", external: true },
+      { label: msg`License`, href: "https://opensource.org/licenses/MIT", external: true },
     ],
   },
 ];
 
 export function Footer() {
+  const { i18n } = useLingui();
   return (
     <footer className="border-t border-[color:var(--color-border)] bg-[color:var(--color-muted)]/40">
       <div className="mx-auto w-full max-w-6xl px-6 pb-10 pt-16">
@@ -76,8 +80,10 @@ export function Footer() {
               </span>
             </a>
             <p className="max-w-xs text-sm leading-relaxed text-[color:var(--color-muted-foreground)]">
-              Open-source desktop pipeline for turning PDFs into accessible
-              books — built with UNICEF.
+              <Trans>
+                Open-source desktop pipeline for turning PDFs into accessible
+                books — built with UNICEF.
+              </Trans>
             </p>
             <a
               href="https://github.com/unicef/adt-studio"
@@ -86,25 +92,25 @@ export function Footer() {
               className="inline-flex w-fit items-center gap-2 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-card)] px-3 py-2 text-xs font-semibold text-[color:var(--color-foreground)] transition-colors hover:bg-[color:var(--color-accent)]"
             >
               <Github className="h-3.5 w-3.5" />
-              Star on GitHub
+              <Trans>Star on GitHub</Trans>
             </a>
           </div>
 
           {COLUMNS.map((col) => (
-            <div key={col.title} className="flex flex-col gap-3">
+            <div key={col.title.id} className="flex flex-col gap-3">
               <div className="text-[11px] font-bold uppercase tracking-[0.14em] text-[color:var(--color-foreground)]">
-                {col.title}
+                {i18n._(col.title)}
               </div>
               <ul className="flex flex-col gap-2">
                 {col.links.map((l) => (
-                  <li key={l.label}>
+                  <li key={l.href}>
                     <a
                       href={l.href}
                       target={l.external ? "_blank" : undefined}
                       rel={l.external ? "noreferrer noopener" : undefined}
                       className="text-sm text-[color:var(--color-muted-foreground)] transition-colors hover:text-[color:var(--color-foreground)]"
                     >
-                      {l.label}
+                      {i18n._(l.label)}
                     </a>
                   </li>
                 ))}
@@ -115,11 +121,13 @@ export function Footer() {
 
         <div className="mt-12 flex flex-col items-start justify-between gap-4 border-t border-[color:var(--color-border)] pt-6 text-xs text-[color:var(--color-muted-foreground)] sm:flex-row sm:items-center">
           <div>
-            &copy; {new Date().getFullYear()} ADT Studio — MIT licensed.
+            <Trans>
+              &copy; {new Date().getFullYear()} ADT Studio — MIT licensed.
+            </Trans>
           </div>
           <div className="flex items-center gap-2 font-mono">
             <span className="inline-block h-1.5 w-1.5 rounded-full bg-[color:var(--color-primary)]" />
-            Every book, every learner.
+            <Trans>Every book, every learner.</Trans>
           </div>
         </div>
       </div>

--- a/apps/landing/src/components/sections/Nav.tsx
+++ b/apps/landing/src/components/sections/Nav.tsx
@@ -1,25 +1,30 @@
 import { useEffect, useMemo, useState } from "react";
 import { Github, Menu, X } from "lucide-react";
+import { msg } from "@lingui/core/macro";
+import { Trans, useLingui } from "@lingui/react/macro";
+import type { MessageDescriptor } from "@lingui/core";
 import { Button } from "@/components/Button";
+import { LocaleSwitcher } from "@/components/LocaleSwitcher";
 import { cn } from "@/lib/cn";
 import { useHashRoute } from "@/lib/useHashRoute";
 import { useScrolled } from "@/lib/useScrolled";
 import { useSectionNav } from "@/lib/useSectionNav";
 import { trackEvent } from "@/lib/matomo";
 
-const LINKS = [
-  { href: "#top", id: "top", label: "Home" },
-  { href: "#features", id: "features", label: "Features" },
-  { href: "#carousel", id: "carousel", label: "How it works" },
-  { href: "#showcase", id: "showcase", label: "Output" },
-  { href: "#releases", id: "releases", label: "Releases" },
-  { href: "#finale", id: "finale", label: "Get started" },
+const LINKS: { href: string; id: string; label: MessageDescriptor }[] = [
+  { href: "#top", id: "top", label: msg`Home` },
+  { href: "#features", id: "features", label: msg`Features` },
+  { href: "#carousel", id: "carousel", label: msg`How it works` },
+  { href: "#showcase", id: "showcase", label: msg`Output` },
+  { href: "#releases", id: "releases", label: msg`Releases` },
+  { href: "#finale", id: "finale", label: msg`Get started` },
 ];
 
 const HOME_IDS = LINKS.map((l) => l.id);
 const EMPTY_IDS: readonly string[] = [];
 
 export function Nav() {
+  const { t, i18n } = useLingui();
   const scrolled = useScrolled(8);
   const hashRoute = useHashRoute();
   const isHome = !hashRoute.startsWith("/");
@@ -54,7 +59,7 @@ export function Nav() {
         <a
           href="#top"
           className="group flex items-center gap-2.5"
-          aria-label="ADT Studio home"
+          aria-label={t`ADT Studio home`}
         >
           <span className="relative inline-flex">
             <span
@@ -75,7 +80,7 @@ export function Nav() {
         </a>
 
         <nav
-          aria-label="Primary"
+          aria-label={t`Primary`}
           className="ml-auto hidden items-center gap-0.5 md:flex"
         >
           {LINKS.filter((l) => l.id !== "top").map((l) => {
@@ -92,7 +97,7 @@ export function Nav() {
                     : "text-[color:var(--color-muted-foreground)] hover:bg-[color:var(--color-accent)]/60 hover:text-[color:var(--color-foreground)]",
                 )}
               >
-                {l.label}
+                {i18n._(l.label)}
                 <span
                   aria-hidden
                   className={cn(
@@ -115,7 +120,7 @@ export function Nav() {
             className="hidden h-9 gap-1.5 px-3 text-[13px] sm:inline-flex"
           >
             <Github className="h-3.5 w-3.5" />
-            Star
+            <Trans>Star</Trans>
           </Button>
           <Button
             href="#/download"
@@ -124,13 +129,14 @@ export function Nav() {
             className="hidden h-9 px-4 text-[13px] sm:inline-flex"
             onClick={() => trackEvent("cta", "download_click", "nav")}
           >
-            Download
+            <Trans>Download</Trans>
           </Button>
+          <LocaleSwitcher />
           <button
             type="button"
             className="grid h-9 w-9 cursor-pointer place-items-center rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-card)] text-[color:var(--color-foreground)] transition-colors hover:bg-[color:var(--color-accent)] md:hidden"
             onClick={() => setOpen((v) => !v)}
-            aria-label={open ? "Close menu" : "Open menu"}
+            aria-label={open ? t`Close menu` : t`Open menu`}
             aria-expanded={open}
           >
             {open ? <X className="h-4 w-4" /> : <Menu className="h-4 w-4" />}
@@ -162,7 +168,7 @@ export function Nav() {
                     : "text-[color:var(--color-muted-foreground)] hover:bg-[color:var(--color-accent)]/60 hover:text-[color:var(--color-foreground)]",
                 )}
               >
-                {l.label}
+                {i18n._(l.label)}
               </a>
             );
           })}
@@ -177,7 +183,7 @@ export function Nav() {
               onClick={() => setOpen(false)}
             >
               <Github className="h-4 w-4" />
-              Star
+              <Trans>Star</Trans>
             </Button>
             <Button
               href="#/download"
@@ -186,7 +192,7 @@ export function Nav() {
               className="flex-1"
               onClick={() => { setOpen(false); trackEvent("cta", "download_click", "nav"); }}
             >
-              Download
+              <Trans>Download</Trans>
             </Button>
           </div>
         </div>

--- a/apps/landing/src/components/sections/PrinciplesScene.tsx
+++ b/apps/landing/src/components/sections/PrinciplesScene.tsx
@@ -5,45 +5,45 @@ import {
   ShieldCheck,
   type LucideIcon,
 } from "lucide-react";
+import { msg } from "@lingui/core/macro";
+import { type MessageDescriptor } from "@lingui/core";
+import { Trans, useLingui } from "@lingui/react/macro";
 import { SectionEyebrow } from "@/components/SectionEyebrow";
 import { cn } from "@/lib/cn";
 import { useInView } from "@/lib/useScrollProgress";
 
 type Principle = {
-  title: string;
-  body: string;
+  title: MessageDescriptor;
+  body: MessageDescriptor;
   Icon: LucideIcon;
 };
 
 const PRINCIPLES: Principle[] = [
   {
-    title: "One folder per book",
-    body:
-      "Everything about a book — sources, prompts, outputs, history — lives in a single directory. Zip it, share it, back it up.",
+    title: msg`One folder per book`,
+    body: msg`Everything about a book — sources, prompts, outputs, history — lives in a single directory. Zip it, share it, back it up.`,
     Icon: FolderArchive,
   },
   {
-    title: "Nothing is overwritten",
-    body:
-      "Every edit creates a new version. Roll back any stage, compare outputs, keep a full trail of what changed and why.",
+    title: msg`Nothing is overwritten`,
+    body: msg`Every edit creates a new version. Roll back any stage, compare outputs, keep a full trail of what changed and why.`,
     Icon: GitBranch,
   },
   {
-    title: "Rerun what matters",
-    body:
-      "Results are cached at the LLM call level. Tweak a prompt and only the affected steps re-run — fast, deterministic, inspectable.",
+    title: msg`Rerun what matters`,
+    body: msg`Results are cached at the LLM call level. Tweak a prompt and only the affected steps re-run — fast, deterministic, inspectable.`,
     Icon: Rewind,
   },
   {
-    title: "No black boxes",
-    body:
-      "Every prompt, every LLM call, every cost is visible. Audit the whole pipeline or hand it off to the next person with confidence.",
+    title: msg`No black boxes`,
+    body: msg`Every prompt, every LLM call, every cost is visible. Audit the whole pipeline or hand it off to the next person with confidence.`,
     Icon: ShieldCheck,
   },
 ];
 
 export function PrinciplesScene() {
   const { ref, inView: mounted } = useInView<HTMLDivElement>({ threshold: 0.2 });
+  const { t, i18n } = useLingui();
 
   return (
     <section
@@ -53,7 +53,7 @@ export function PrinciplesScene() {
       <div ref={ref} className="mx-auto w-full max-w-6xl px-4">
         <div className="grid grid-cols-1 items-start gap-14 lg:grid-cols-[1fr_1.3fr] lg:gap-20">
           <div className="lg:sticky lg:top-28">
-            <SectionEyebrow label="How we build it" />
+            <SectionEyebrow label={t`How we build it`} />
             <h2
               className={cn(
                 "mt-5 text-balance text-4xl font-semibold leading-[1.08] tracking-tight md:text-[44px]",
@@ -62,11 +62,13 @@ export function PrinciplesScene() {
               )}
               style={{ transitionDelay: "80ms" }}
             >
-              Designed for the people who{" "}
-              <span className="text-[color:var(--color-primary)]">
-                do the work
-              </span>
-              .
+              <Trans>
+                Designed for the people who{" "}
+                <span className="text-[color:var(--color-primary)]">
+                  do the work
+                </span>
+                .
+              </Trans>
             </h2>
             <p
               className={cn(
@@ -76,17 +78,19 @@ export function PrinciplesScene() {
               )}
               style={{ transitionDelay: "220ms" }}
             >
-              ADT Studio is built for teachers, editors and accessibility
-              specialists — not engineers. Every choice in the app follows four
-              principles so your work is always safe, transparent and under
-              your control.
+              <Trans>
+                ADT Studio is built for teachers, editors and accessibility
+                specialists — not engineers. Every choice in the app follows
+                four principles so your work is always safe, transparent and
+                under your control.
+              </Trans>
             </p>
           </div>
 
           <ol className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             {PRINCIPLES.map((p, i) => (
               <li
-                key={p.title}
+                key={i}
                 className={cn(
                   "group flex flex-col gap-3 rounded-2xl border border-[color:var(--color-border)] bg-[color:var(--color-card)] p-6 transition-all duration-[700ms] ease-[cubic-bezier(0.22,1,0.36,1)] hover:-translate-y-0.5 hover:border-[color:var(--color-primary)]/30 hover:shadow-[0_10px_30px_-12px_rgba(0,0,0,0.12)]",
                   mounted ? "translate-y-0 opacity-100" : "translate-y-4 opacity-0",
@@ -103,10 +107,10 @@ export function PrinciplesScene() {
                 </div>
                 <div>
                   <h3 className="mb-1.5 text-base font-semibold tracking-tight text-[color:var(--color-foreground)]">
-                    {p.title}
+                    {i18n._(p.title)}
                   </h3>
                   <p className="text-sm leading-relaxed text-[color:var(--color-muted-foreground)]">
-                    {p.body}
+                    {i18n._(p.body)}
                   </p>
                 </div>
               </li>

--- a/apps/landing/src/components/sections/ReleasesScene.tsx
+++ b/apps/landing/src/components/sections/ReleasesScene.tsx
@@ -1,3 +1,4 @@
+import { Trans, useLingui } from "@lingui/react/macro";
 import { ArrowRight, ArrowUpRight, Sparkles, Tag } from "lucide-react";
 import { SectionEyebrow } from "@/components/SectionEyebrow";
 import { cn } from "@/lib/cn";
@@ -17,6 +18,7 @@ import {
 import { useInView } from "@/lib/useScrollProgress";
 
 export function ReleasesScene() {
+  const { t } = useLingui();
   const { releases, loading } = useStableReleases();
   const { ref, inView: mounted } = useInView<HTMLDivElement>({ threshold: 0.2 });
   const latest = releases?.[0];
@@ -28,7 +30,7 @@ export function ReleasesScene() {
     >
       <div ref={ref} className="mx-auto w-full max-w-5xl px-6 md:px-10">
         <div className="mx-auto max-w-2xl text-center">
-          <SectionEyebrow label="Changelog" />
+          <SectionEyebrow label={t`Changelog`} />
           <h2
             className={cn(
               "mt-5 text-balance text-4xl font-semibold leading-[1.08] tracking-tight md:text-5xl",
@@ -37,8 +39,10 @@ export function ReleasesScene() {
             )}
             style={{ transitionDelay: "80ms" }}
           >
-            Fresh off the{" "}
-            <span className="text-[color:var(--color-primary)]">press</span>.
+            <Trans>
+              Fresh off the{" "}
+              <span className="text-[color:var(--color-primary)]">press</span>.
+            </Trans>
           </h2>
           <p
             className={cn(
@@ -48,8 +52,10 @@ export function ReleasesScene() {
             )}
             style={{ transitionDelay: "220ms" }}
           >
-            Here's what shipped in the latest version — and there are plenty
-            more where this came from.
+            <Trans>
+              Here's what shipped in the latest version — and there are plenty
+              more where this came from.
+            </Trans>
           </p>
         </div>
 
@@ -82,7 +88,7 @@ export function ReleasesScene() {
             rel="noreferrer noopener"
             className="group/gh inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-semibold text-[color:var(--color-muted-foreground)] transition-colors hover:text-[color:var(--color-foreground)]"
           >
-            Raw notes on GitHub
+            <Trans>Raw notes on GitHub</Trans>
             <ArrowUpRight className="h-3 w-3 transition-transform duration-200 group-hover/gh:translate-x-0.5 group-hover/gh:-translate-y-0.5" />
           </a>
         </div>
@@ -92,6 +98,7 @@ export function ReleasesScene() {
 }
 
 function HeroSpotlight({ release }: { release: GithubRelease }) {
+  const { t } = useLingui();
   const title = release.name?.trim() || release.tag_name;
   const cover = firstImageFromBody(release.body);
   const excerpt = firstParagraphFromBody(release.body, 240);
@@ -107,7 +114,7 @@ function HeroSpotlight({ release }: { release: GithubRelease }) {
       {/* Whole-card link — sits beneath the content, above the background. */}
       <a
         href={detailHref}
-        aria-label={`Read release ${release.tag_name}`}
+        aria-label={t`Read release ${release.tag_name}`}
         className="absolute inset-0 z-0 rounded-3xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-ring)]"
       />
 
@@ -120,7 +127,7 @@ function HeroSpotlight({ release }: { release: GithubRelease }) {
             {release.tag_name}
           </span>
           <span className="rounded-md bg-emerald-50 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-emerald-700">
-            Latest
+            <Trans>Latest</Trans>
           </span>
           <span aria-hidden className="opacity-50">·</span>
           <span>{formatAbsoluteDate(release.published_at)}</span>
@@ -156,7 +163,7 @@ function HeroSpotlight({ release }: { release: GithubRelease }) {
         <div className="mt-auto flex flex-wrap items-center gap-3 pt-2">
           <span className="group/cta relative inline-flex items-center gap-2 overflow-hidden rounded-full bg-[color:var(--color-primary)] px-5 py-2.5 text-sm font-semibold text-white shadow-[0_10px_24px_-10px_color-mix(in_oklch,var(--color-primary)_60%,transparent)] transition-all duration-300 group-hover/hero:shadow-[0_18px_36px_-14px_color-mix(in_oklch,var(--color-primary)_70%,transparent)]">
             <Sparkles className="h-4 w-4" />
-            Read this release
+            <Trans>Read this release</Trans>
             <ArrowRight className="h-4 w-4 transition-transform duration-200 group-hover/hero:translate-x-0.5" />
           </span>
           <a
@@ -165,7 +172,7 @@ function HeroSpotlight({ release }: { release: GithubRelease }) {
             rel="noreferrer noopener"
             className="group/raw pointer-events-auto relative z-[2] inline-flex items-center gap-1 rounded-full px-3 py-1.5 text-xs font-semibold text-[color:var(--color-muted-foreground)] transition-colors hover:text-[color:var(--color-foreground)]"
           >
-            On GitHub
+            <Trans>On GitHub</Trans>
             <ArrowUpRight className="h-3 w-3 transition-transform duration-200 group-hover/raw:translate-x-0.5 group-hover/raw:-translate-y-0.5" />
           </a>
         </div>
@@ -287,7 +294,9 @@ function HeroSkeleton() {
 function EmptyHero() {
   return (
     <div className="rounded-3xl border border-dashed border-[color:var(--color-border)] bg-[color:var(--color-card)]/60 p-10 text-center text-sm text-[color:var(--color-muted-foreground)]">
-      No releases yet — once the first build ships, it'll show up here.
+      <Trans>
+        No releases yet — once the first build ships, it'll show up here.
+      </Trans>
     </div>
   );
 }

--- a/apps/landing/src/components/sections/ShowcaseScene.tsx
+++ b/apps/landing/src/components/sections/ShowcaseScene.tsx
@@ -6,27 +6,31 @@ import {
   Languages,
   Volume2,
 } from "lucide-react";
+import { msg } from "@lingui/core/macro";
+import { type MessageDescriptor } from "@lingui/core";
+import { Trans, useLingui } from "@lingui/react/macro";
 import { SectionEyebrow } from "@/components/SectionEyebrow";
 import { cn } from "@/lib/cn";
 import { useInView } from "@/lib/useScrollProgress";
 
-const HIGHLIGHTS = [
+const HIGHLIGHTS: { title: MessageDescriptor; body: MessageDescriptor }[] = [
   {
-    title: "One book, every format",
-    body: "HTML, audio, translations and sign-language — exported together as a single package.",
+    title: msg`One book, every format`,
+    body: msg`HTML, audio, translations and sign-language — exported together as a single package.`,
   },
   {
-    title: "Read on any device",
-    body: "Open in the reader, on the web, or hand the bundle off to an existing LMS.",
+    title: msg`Read on any device`,
+    body: msg`Open in the reader, on the web, or hand the bundle off to an existing LMS.`,
   },
   {
-    title: "Always editable",
-    body: "Your team stays in control. Every asset is a file you can re-run, replace or roll back.",
+    title: msg`Always editable`,
+    body: msg`Your team stays in control. Every asset is a file you can re-run, replace or roll back.`,
   },
 ];
 
 export function ShowcaseScene() {
   const { ref, inView: mounted } = useInView<HTMLDivElement>({ threshold: 0.2 });
+  const { t, i18n } = useLingui();
 
   return (
     <section
@@ -36,7 +40,7 @@ export function ShowcaseScene() {
       <div ref={ref} className="mx-auto w-full max-w-6xl px-6 md:px-10">
         <div className="grid grid-cols-1 items-center gap-16 lg:grid-cols-[1fr_1.1fr] lg:gap-14">
           <div>
-            <SectionEyebrow label="The output" />
+            <SectionEyebrow label={t`The output`} />
             <h2
               className={cn(
                 "mt-5 text-balance text-4xl font-semibold leading-[1.08] tracking-tight md:text-[44px]",
@@ -45,11 +49,13 @@ export function ShowcaseScene() {
               )}
               style={{ transitionDelay: "80ms" }}
             >
-              An accessible book,{" "}
-              <span className="text-[color:var(--color-primary)]">
-                ready to ship
-              </span>
-              .
+              <Trans>
+                An accessible book,{" "}
+                <span className="text-[color:var(--color-primary)]">
+                  ready to ship
+                </span>
+                .
+              </Trans>
             </h2>
             <p
               className={cn(
@@ -59,15 +65,17 @@ export function ShowcaseScene() {
               )}
               style={{ transitionDelay: "220ms" }}
             >
-              When the pipeline finishes, you get a clean bundle with every
-              accessibility feature baked in — ready for a classroom, a
-              publisher, or a kid on the couch.
+              <Trans>
+                When the pipeline finishes, you get a clean bundle with every
+                accessibility feature baked in — ready for a classroom, a
+                publisher, or a kid on the couch.
+              </Trans>
             </p>
 
             <ul className="mt-8 flex flex-col gap-4">
               {HIGHLIGHTS.map((h, i) => (
                 <li
-                  key={h.title}
+                  key={i}
                   className={cn(
                     "flex items-start gap-3 transition-all duration-[600ms] ease-[cubic-bezier(0.22,1,0.36,1)]",
                     mounted
@@ -81,10 +89,10 @@ export function ShowcaseScene() {
                   </span>
                   <div>
                     <div className="text-sm font-semibold text-[color:var(--color-foreground)]">
-                      {h.title}
+                      {i18n._(h.title)}
                     </div>
                     <div className="text-sm leading-relaxed text-[color:var(--color-muted-foreground)]">
-                      {h.body}
+                      {i18n._(h.body)}
                     </div>
                   </div>
                 </li>
@@ -126,13 +134,13 @@ function BookMockup({ mounted }: { mounted: boolean }) {
         <div className="flex h-[30px] items-center gap-1.5 bg-blue-500 px-3">
           <Check className="h-3 w-3 text-white" />
           <span className="text-[9px] font-extrabold uppercase tracking-[0.1em] text-white">
-            Cover · Chapter 1
+            <Trans>Cover · Chapter 1</Trans>
           </span>
         </div>
         <div className="flex h-[calc(100%-30px)] flex-col justify-between p-5">
           <div>
             <div className="mb-1.5 text-[9px] font-bold uppercase tracking-wide text-[color:var(--color-muted-foreground)]">
-              Science Textbook
+              <Trans>Science Textbook</Trans>
             </div>
             <div className="mb-3 h-4 w-4/5 rounded-sm bg-[color:var(--color-foreground)]" />
             <div
@@ -143,7 +151,7 @@ function BookMockup({ mounted }: { mounted: boolean }) {
             >
               <ImageIcon className="h-8 w-8 text-blue-500" />
               <span className="absolute bottom-1 right-1 rounded-sm bg-teal-50 px-1 py-0.5 text-[7px] font-bold uppercase tracking-wide text-teal-600">
-                Alt
+                <Trans>Alt</Trans>
               </span>
             </div>
             <div className="mb-1.5 h-1 w-[92%] rounded-sm bg-[color:var(--color-muted)]" />
@@ -153,10 +161,10 @@ function BookMockup({ mounted }: { mounted: boolean }) {
           </div>
           <div className="flex flex-wrap gap-1">
             <Pill tint="bg-rose-50" fg="text-rose-600" Icon={Volume2}>
-              EN · PT
+              <Trans>EN · PT</Trans>
             </Pill>
             <Pill tint="bg-lime-50" fg="text-lime-700" Icon={BookMarked}>
-              Glossary
+              <Trans>Glossary</Trans>
             </Pill>
           </div>
         </div>
@@ -180,13 +188,13 @@ function BookMockup({ mounted }: { mounted: boolean }) {
             <span className="h-2 w-2 rounded-full bg-[#28c840]" />
           </div>
           <span className="font-mono text-[9px] text-[color:var(--color-muted-foreground)]">
-            science · chapter 3
+            <Trans>science · chapter 3</Trans>
           </span>
           <span className="h-2 w-4 rounded-full bg-[color:var(--color-border)]" />
         </div>
         <div className="px-5 pb-5 pt-4">
           <div className="mb-1.5 text-[9px] font-bold uppercase tracking-wide text-[color:var(--color-primary)]">
-            Chapter 3
+            <Trans>Chapter 3</Trans>
           </div>
           <div className="mb-3 h-4 w-5/6 rounded-sm bg-[color:var(--color-foreground)]" />
           <div className="mb-1.5 h-1 w-[94%] rounded-sm bg-[color:var(--color-muted)]" />
@@ -201,7 +209,7 @@ function BookMockup({ mounted }: { mounted: boolean }) {
           >
             <ImageIcon className="h-7 w-7 text-blue-500" />
             <span className="absolute bottom-1.5 right-1.5 rounded-sm bg-teal-50 px-1.5 py-0.5 text-[8px] font-bold uppercase tracking-wide text-teal-600">
-              Alt described
+              <Trans>Alt described</Trans>
             </span>
           </div>
 
@@ -209,7 +217,7 @@ function BookMockup({ mounted }: { mounted: boolean }) {
             <div className="mb-1.5 flex items-center gap-1.5">
               <Volume2 className="h-3 w-3 text-rose-600" />
               <span className="text-[9px] font-bold uppercase tracking-wide text-[color:var(--color-muted-foreground)]">
-                Narration · 0:42
+                <Trans>Narration · 0:42</Trans>
               </span>
             </div>
             <div className="flex items-center gap-1.5">
@@ -224,16 +232,16 @@ function BookMockup({ mounted }: { mounted: boolean }) {
 
           <div className="flex flex-wrap gap-1">
             <Pill tint="bg-rose-50" fg="text-rose-600" Icon={Volume2}>
-              EN · PT · ES
+              <Trans>EN · PT · ES</Trans>
             </Pill>
             <Pill tint="bg-cyan-50" fg="text-cyan-600" Icon={Hand}>
-              ASL · LIBRAS
+              <Trans>ASL · LIBRAS</Trans>
             </Pill>
             <Pill tint="bg-pink-50" fg="text-pink-600" Icon={Languages}>
-              4 languages
+              <Trans>4 languages</Trans>
             </Pill>
             <Pill tint="bg-lime-50" fg="text-lime-700" Icon={BookMarked}>
-              Glossary
+              <Trans>Glossary</Trans>
             </Pill>
           </div>
         </div>

--- a/apps/landing/src/components/sections/TrustStrip.tsx
+++ b/apps/landing/src/components/sections/TrustStrip.tsx
@@ -1,32 +1,35 @@
 import { Apple, Github, Laptop, Lock, MonitorPlay, ShieldCheck } from "lucide-react";
+import { msg } from "@lingui/core/macro";
+import { Trans, useLingui } from "@lingui/react/macro";
 
 const ITEMS = [
-  { Icon: ShieldCheck, label: "MIT licensed" },
-  { Icon: Lock, label: "Runs locally" },
-  { Icon: Github, label: "Open source" },
-  { Icon: Apple, label: "macOS" },
-  { Icon: MonitorPlay, label: "Windows" },
-  { Icon: Laptop, label: "Linux" },
+  { Icon: ShieldCheck, label: msg`MIT licensed` },
+  { Icon: Lock, label: msg`Runs locally` },
+  { Icon: Github, label: msg`Open source` },
+  { Icon: Apple, label: msg`macOS` },
+  { Icon: MonitorPlay, label: msg`Windows` },
+  { Icon: Laptop, label: msg`Linux` },
 ];
 
 export function TrustStrip() {
+  const { t, i18n } = useLingui();
   return (
     <section
-      aria-label="Trust"
+      aria-label={t`Trust`}
       className="relative border-y border-[color:var(--color-border)] bg-[color:var(--color-muted)]/40"
     >
       <div className="mx-auto flex w-full max-w-6xl flex-wrap items-center justify-center gap-x-10 gap-y-3 px-4 py-5">
         <span className="text-[10px] font-bold uppercase tracking-[0.18em] text-[color:var(--color-muted-foreground)]">
-          Built with UNICEF
+          <Trans>Built with UNICEF</Trans>
         </span>
         <span aria-hidden className="hidden h-3 w-px bg-[color:var(--color-border)] sm:block" />
         {ITEMS.map(({ Icon, label }) => (
           <span
-            key={label}
+            key={label.id}
             className="inline-flex items-center gap-1.5 text-xs font-medium text-[color:var(--color-muted-foreground)]"
           >
             <Icon className="h-3.5 w-3.5" />
-            {label}
+            {i18n._(label)}
           </span>
         ))}
       </div>

--- a/apps/landing/src/components/sections/WelcomeScene.tsx
+++ b/apps/landing/src/components/sections/WelcomeScene.tsx
@@ -1,4 +1,5 @@
 import { ArrowRight, ChevronDown, Github, Sparkles } from "lucide-react";
+import { Trans, useLingui } from "@lingui/react/macro";
 import { useEffect, useState } from "react";
 import { Button } from "@/components/Button";
 import { PdfToBookDiagram } from "@/components/PdfToBookDiagram";
@@ -10,6 +11,7 @@ import {
 import { trackEvent } from "@/lib/matomo";
 
 export function WelcomeScene() {
+  const { t } = useLingui();
   const [mounted, setMounted] = useState(false);
   const { releases } = useStableReleases();
   const latest = releases?.[0];
@@ -51,7 +53,7 @@ export function WelcomeScene() {
           >
             <span className="inline-flex shrink-0 items-center gap-1.5 rounded-full bg-[color:var(--color-primary)]/10 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-[color:var(--color-primary)]">
               <Sparkles className="h-3 w-3" />
-              New
+              <Trans>New</Trans>
             </span>
             {latest ? (
               <span className="min-w-0 truncate">
@@ -60,13 +62,18 @@ export function WelcomeScene() {
                   {" · "}
                   {formatRelativeDate(latest.published_at)}
                 </span>
-                <span className="hidden sm:inline">{" · ADT Studio"}</span>
+                <span className="hidden sm:inline">
+                  {" · "}
+                  <Trans>ADT Studio</Trans>
+                </span>
               </span>
             ) : (
               <span className="min-w-0 truncate">
-                <span className="sm:hidden">Now on macOS, Windows, Linux</span>
+                <span className="sm:hidden">
+                  <Trans>Now on macOS, Windows, Linux</Trans>
+                </span>
                 <span className="hidden sm:inline">
-                  ADT Studio — now on macOS, Windows, Linux
+                  <Trans>ADT Studio — now on macOS, Windows, Linux</Trans>
                 </span>
               </span>
             )}
@@ -80,9 +87,11 @@ export function WelcomeScene() {
             )}
             style={{ transitionDelay: "150ms" }}
           >
-            <span className="block">From PDF to</span>
+            <span className="block">
+              <Trans>From PDF to</Trans>
+            </span>
             <span className="block bg-gradient-to-r from-[color:var(--color-primary)] to-violet-500 bg-clip-text text-transparent">
-              accessible books.
+              <Trans>accessible books.</Trans>
             </span>
           </h1>
 
@@ -93,9 +102,11 @@ export function WelcomeScene() {
             )}
             style={{ transitionDelay: "350ms" }}
           >
-            Turn any textbook into something every student can read, hear,
-            see, and understand — audio, structured layouts, translations, and
-            sign language, all built in.
+            <Trans>
+              Turn any textbook into something every student can read, hear,
+              see, and understand — audio, structured layouts, translations, and
+              sign language, all built in.
+            </Trans>
           </p>
 
           <div
@@ -111,7 +122,7 @@ export function WelcomeScene() {
               variant="primary"
               onClick={() => trackEvent("cta", "download_click", "hero")}
             >
-              Download for free
+              <Trans>Download for free</Trans>
               <ArrowRight className="h-4 w-4" />
             </Button>
             <Button
@@ -123,7 +134,7 @@ export function WelcomeScene() {
               onClick={() => trackEvent("outbound", "github_star", "hero")}
             >
               <Github className="h-4 w-4" />
-              Star on GitHub
+              <Trans>Star on GitHub</Trans>
             </Button>
           </div>
 
@@ -134,11 +145,17 @@ export function WelcomeScene() {
             )}
             style={{ transitionDelay: "650ms" }}
           >
-            <span className="font-mono">MIT licensed</span>
+            <span className="font-mono">
+              <Trans>MIT licensed</Trans>
+            </span>
             <span className="h-1 w-1 rounded-full bg-[color:var(--color-border)]" />
-            <span className="font-mono">Runs locally</span>
+            <span className="font-mono">
+              <Trans>Runs locally</Trans>
+            </span>
             <span className="h-1 w-1 rounded-full bg-[color:var(--color-border)]" />
-            <span className="font-mono">Windows · macOS · Linux</span>
+            <span className="font-mono">
+              <Trans>Windows · macOS · Linux</Trans>
+            </span>
           </div>
         </div>
 
@@ -159,7 +176,7 @@ export function WelcomeScene() {
 
       <a
         href="#features"
-        aria-label="Scroll to next section"
+        aria-label={t`Scroll to next section`}
         className={cn(
           "absolute bottom-6 left-1/2 grid h-10 w-10 -translate-x-1/2 cursor-pointer place-items-center rounded-full border border-[color:var(--color-border)] bg-[color:var(--color-card)]/70 text-[color:var(--color-muted-foreground)] backdrop-blur-sm transition-all duration-500 hover:border-[color:var(--color-primary)]/40 hover:text-[color:var(--color-foreground)]",
           mounted ? "opacity-100" : "opacity-0",

--- a/apps/landing/src/data/presets.ts
+++ b/apps/landing/src/data/presets.ts
@@ -1,3 +1,5 @@
+import { msg } from "@lingui/core/macro";
+import type { MessageDescriptor } from "@lingui/core";
 import {
   BookOpen,
   FileText,
@@ -8,8 +10,8 @@ import {
 
 export type Preset = {
   id: "textbook" | "storybook" | "reference" | "custom";
-  title: string;
-  description: string;
+  title: MessageDescriptor;
+  description: MessageDescriptor;
   Icon: LucideIcon;
   iconColor: string;
   bgColor: string;
@@ -19,9 +21,8 @@ export type Preset = {
 export const PRESETS: Preset[] = [
   {
     id: "textbook",
-    title: "Textbooks & Activities",
-    description:
-      "Structured chapters and exercises. Best for educational content with complex layouts.",
+    title: msg`Textbooks & Activities`,
+    description: msg`Structured chapters and exercises. Best for educational content with complex layouts.`,
     Icon: FileText,
     iconColor: "text-blue-500",
     bgColor: "bg-blue-500/5",
@@ -29,9 +30,8 @@ export const PRESETS: Preset[] = [
   },
   {
     id: "storybook",
-    title: "Storybook",
-    description:
-      "Large images with narrative flow. Ideal for illustrated books with rich TTS voices.",
+    title: msg`Storybook`,
+    description: msg`Large images with narrative flow. Ideal for illustrated books with rich TTS voices.`,
     Icon: BookOpen,
     iconColor: "text-amber-500",
     bgColor: "bg-amber-500/5",
@@ -39,9 +39,8 @@ export const PRESETS: Preset[] = [
   },
   {
     id: "reference",
-    title: "Reference",
-    description:
-      "Dense text, tables, glossaries. Best for technical material and documentation.",
+    title: msg`Reference`,
+    description: msg`Dense text, tables, glossaries. Best for technical material and documentation.`,
     Icon: Library,
     iconColor: "text-emerald-500",
     bgColor: "bg-emerald-500/5",
@@ -49,9 +48,8 @@ export const PRESETS: Preset[] = [
   },
   {
     id: "custom",
-    title: "Custom",
-    description:
-      "Full control over render strategies, pruning, and filters.",
+    title: msg`Custom`,
+    description: msg`Full control over render strategies, pruning, and filters.`,
     Icon: SlidersHorizontal,
     iconColor: "text-violet-500",
     bgColor: "bg-violet-500/5",

--- a/apps/landing/src/data/stages.ts
+++ b/apps/landing/src/data/stages.ts
@@ -1,3 +1,5 @@
+import { msg } from "@lingui/core/macro";
+import type { MessageDescriptor } from "@lingui/core";
 import {
   AudioLines,
   BookOpen,
@@ -13,19 +15,19 @@ import {
 
 export type Stage = {
   slug: string;
-  label: string;
+  label: MessageDescriptor;
   icon: LucideIcon;
   hex: string;
 };
 
 export const STAGES: Stage[] = [
-  { slug: "extract", label: "Extract", icon: FileText, hex: "#2563eb" },
-  { slug: "storyboard", label: "Storyboard", icon: LayoutGrid, hex: "#7c3aed" },
-  { slug: "quizzes", label: "Quizzes", icon: HelpCircle, hex: "#ea580c" },
-  { slug: "captions", label: "Captions", icon: Image, hex: "#0d9488" },
-  { slug: "glossary", label: "Glossary", icon: BookOpen, hex: "#65a30d" },
-  { slug: "toc", label: "Contents", icon: List, hex: "#d97706" },
-  { slug: "translate", label: "Language", icon: Languages, hex: "#db2777" },
-  { slug: "speech", label: "Speech", icon: AudioLines, hex: "#e11d48" },
-  { slug: "preview", label: "Preview", icon: Eye, hex: "#4b5563" },
+  { slug: "extract", label: msg`Extract`, icon: FileText, hex: "#2563eb" },
+  { slug: "storyboard", label: msg`Storyboard`, icon: LayoutGrid, hex: "#7c3aed" },
+  { slug: "quizzes", label: msg`Quizzes`, icon: HelpCircle, hex: "#ea580c" },
+  { slug: "captions", label: msg`Captions`, icon: Image, hex: "#0d9488" },
+  { slug: "glossary", label: msg`Glossary`, icon: BookOpen, hex: "#65a30d" },
+  { slug: "toc", label: msg`Contents`, icon: List, hex: "#d97706" },
+  { slug: "translate", label: msg`Language`, icon: Languages, hex: "#db2777" },
+  { slug: "speech", label: msg`Speech`, icon: AudioLines, hex: "#e11d48" },
+  { slug: "preview", label: msg`Preview`, icon: Eye, hex: "#4b5563" },
 ];

--- a/apps/landing/src/i18n/locales.ts
+++ b/apps/landing/src/i18n/locales.ts
@@ -1,0 +1,36 @@
+/**
+ * Single source of truth for supported locales on the landing site.
+ *
+ * When adding a new language:
+ * 1. Add its BCP-47 code to LOCALES
+ * 2. Add its flag emoji to LOCALE_FLAGS
+ * 3. Add its full English name to LOCALE_NAMES (used by auto-translate tooling)
+ * 4. Add its display label to LOCALE_LABEL_MESSAGES in LocaleSwitcher.tsx
+ * 5. Also update lingui.config.ts (cannot import from src/)
+ */
+export const LOCALES = ["en", "pt-BR", "es", "fr"] as const;
+export type AppLocale = (typeof LOCALES)[number];
+
+export const DEFAULT_LOCALE: AppLocale = "en";
+
+/** Flag emoji for each locale, shown in the language switcher UI. */
+export const LOCALE_FLAGS: Record<AppLocale, string> = {
+  en: "🇺🇸",
+  "pt-BR": "🇧🇷",
+  es: "🇪🇸",
+  fr: "🇫🇷",
+};
+
+/**
+ * Full English language names used by auto-translate tooling.
+ * Add an entry here when adding a new locale.
+ */
+export const LOCALE_NAMES: Record<string, string> = {
+  "pt-BR": "Brazilian Portuguese",
+  es: "Spanish",
+  fr: "French",
+};
+
+export function isAppLocale(value: string): value is AppLocale {
+  return (LOCALES as readonly string[]).includes(value);
+}

--- a/apps/landing/src/i18n/setup.ts
+++ b/apps/landing/src/i18n/setup.ts
@@ -1,0 +1,68 @@
+import { i18n } from "@lingui/core";
+import { messages as enMessages } from "@/locales/en.po";
+import { messages as ptBRMessages } from "@/locales/pt-BR.po";
+import { messages as esMessages } from "@/locales/es.po";
+import { messages as frMessages } from "@/locales/fr.po";
+import {
+  DEFAULT_LOCALE,
+  isAppLocale,
+  LOCALES,
+  type AppLocale,
+} from "./locales";
+
+const STORAGE_KEY = "adt:landing:locale";
+
+i18n.load({
+  en: enMessages,
+  "pt-BR": ptBRMessages,
+  es: esMessages,
+  fr: frMessages,
+});
+
+/** Resolve a browser language tag (e.g. "pt", "pt-PT", "es-419") to a supported locale. */
+function matchBrowserLocale(tag: string): AppLocale | null {
+  const lower = tag.toLowerCase();
+  for (const loc of LOCALES) {
+    if (loc.toLowerCase() === lower) return loc;
+  }
+  const base = lower.split("-")[0];
+  for (const loc of LOCALES) {
+    if (loc.toLowerCase().split("-")[0] === base) return loc;
+  }
+  return null;
+}
+
+function detectLocale(): AppLocale {
+  const urlLang = new URLSearchParams(window.location.search).get("lang");
+  if (urlLang && isAppLocale(urlLang)) return urlLang;
+
+  const stored = window.localStorage.getItem(STORAGE_KEY);
+  if (stored && isAppLocale(stored)) return stored;
+
+  for (const tag of navigator.languages ?? [navigator.language]) {
+    const matched = matchBrowserLocale(tag);
+    if (matched) return matched;
+  }
+
+  return DEFAULT_LOCALE;
+}
+
+/** Activate a locale and persist the choice to localStorage + the URL. */
+export function setLocale(next: AppLocale): void {
+  i18n.activate(next);
+  try {
+    window.localStorage.setItem(STORAGE_KEY, next);
+  } catch {
+    // Ignore storage errors (private mode, etc.) — the URL still carries the choice.
+  }
+  const url = new URL(window.location.href);
+  url.searchParams.set("lang", next);
+  window.history.replaceState(null, "", url.toString());
+  document.documentElement.lang = next;
+}
+
+export function initI18n(): void {
+  const locale = detectLocale();
+  i18n.activate(locale);
+  document.documentElement.lang = locale;
+}

--- a/apps/landing/src/locales/en.po
+++ b/apps/landing/src/locales/en.po
@@ -1,0 +1,630 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2026-06-11 13:49-0300\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: en\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#. placeholder {0}: meta.label
+msgid "{0} build is coming — track on GitHub"
+msgstr "{0} build is coming — track on GitHub"
+
+#. placeholder {0}: platform.label
+#. placeholder {1}: platformResolution.release.tag_name
+#. placeholder {2}: overallLatest.tag_name
+#. placeholder {3}: platform.label
+msgid "{0} latest is <0>{1}</0> — the project is on <1>{2}</1>. A {3} build for the newer tag isn’t available yet."
+msgstr "{0} latest is <0>{1}</0> — the project is on <1>{2}</1>. A {3} build for the newer tag isn’t available yet."
+
+#. placeholder {0}: new Date().getFullYear()
+msgid "© {0} ADT Studio — MIT licensed."
+msgstr "© {0} ADT Studio — MIT licensed."
+
+msgid "4 languages"
+msgstr "4 languages"
+
+msgid "Accessible book"
+msgstr "Accessible book"
+
+msgid "accessible books."
+msgstr "accessible books."
+
+msgid "ADT Studio"
+msgstr "ADT Studio"
+
+msgid "ADT Studio — now on macOS, Windows, Linux"
+msgstr "ADT Studio — now on macOS, Windows, Linux"
+
+msgid "ADT Studio — Turn any PDF into an accessible book"
+msgstr "ADT Studio — Turn any PDF into an accessible book"
+
+msgid "ADT Studio home"
+msgstr "ADT Studio home"
+
+msgid "ADT Studio is a desktop app"
+msgstr "ADT Studio is a desktop app"
+
+msgid "ADT Studio is built for teachers, editors and accessibility specialists — not engineers. Every choice in the app follows four principles so your work is always safe, transparent and under your control."
+msgstr "ADT Studio is built for teachers, editors and accessibility specialists — not engineers. Every choice in the app follows four principles so your work is always safe, transparent and under your control."
+
+msgid "ADT Studio is currently in"
+msgstr "ADT Studio is currently in"
+
+msgid "ADT Studio takes one PDF and rebuilds it as a fully-editable, fully-yours accessible book — with the pieces that used to take a team of specialists."
+msgstr "ADT Studio takes one PDF and rebuilds it as a fully-editable, fully-yours accessible book — with the pieces that used to take a team of specialists."
+
+msgid "Also available on"
+msgstr "Also available on"
+
+msgid "Alt"
+msgstr "Alt"
+
+msgid "Alt described"
+msgstr "Alt described"
+
+msgid "Always editable"
+msgstr "Always editable"
+
+msgid "An accessible book, <0>ready to ship</0>."
+msgstr "An accessible book, <0>ready to ship</0>."
+
+msgid "Architecture"
+msgstr "Architecture"
+
+msgid "ASL · LIBRAS"
+msgstr "ASL · LIBRAS"
+
+msgid "Attach sign-language video for ASL, LIBRAS and beyond — aligned to chapters and inspectable alongside the text."
+msgstr "Attach sign-language video for ASL, LIBRAS and beyond — aligned to chapters and inspectable alongside the text."
+
+msgid "Audio"
+msgstr "Audio"
+
+msgid "Audio narration"
+msgstr "Audio narration"
+
+msgid "Available for"
+msgstr "Available for"
+
+msgid "Back to home"
+msgstr "Back to home"
+
+msgid "Beta"
+msgstr "Beta"
+
+msgid "Book creation stages"
+msgstr "Book creation stages"
+
+msgid "Built with UNICEF"
+msgstr "Built with UNICEF"
+
+msgid "Captions"
+msgstr "Captions"
+
+msgid "Change language"
+msgstr "Change language"
+
+msgid "Changelog"
+msgstr "Changelog"
+
+msgid "Changelog — ADT Studio"
+msgstr "Changelog — ADT Studio"
+
+msgid "Chapter 3"
+msgstr "Chapter 3"
+
+msgid "Choose a preset that matches your content — textbook, storyboard, reference, or custom — and ADT Studio tailors the pipeline accordingly."
+msgstr "Choose a preset that matches your content — textbook, storyboard, reference, or custom — and ADT Studio tailors the pipeline accordingly."
+
+msgid "Close menu"
+msgstr "Close menu"
+
+msgid "Coming soon"
+msgstr "Coming soon"
+
+msgid "Configure each stage — extract, storyboard, layout — then let ADT Studio build the book. Review the output, correct anything that needs a human touch."
+msgstr "Configure each stage — extract, storyboard, layout — then let ADT Studio build the book. Review the output, correct anything that needs a human touch."
+
+msgid "Contents"
+msgstr "Contents"
+
+msgid "Couldn’t load the changelog"
+msgstr "Couldn’t load the changelog"
+
+msgid "Couldn't reach GitHub"
+msgstr "Couldn't reach GitHub"
+
+msgid "Cover · Chapter 1"
+msgstr "Cover · Chapter 1"
+
+msgid "Custom"
+msgstr "Custom"
+
+msgid "Delivered"
+msgstr "Delivered"
+
+msgid "Dense text, tables, glossaries. Best for technical material and documentation."
+msgstr "Dense text, tables, glossaries. Best for technical material and documentation."
+
+msgid "Designed for the people who <0>do the work</0>."
+msgstr "Designed for the people who <0>do the work</0>."
+
+msgid "Desktop only"
+msgstr "Desktop only"
+
+msgid "Detecting figures"
+msgstr "Detecting figures"
+
+msgid "Docs"
+msgstr "Docs"
+
+msgid "DONE"
+msgstr "DONE"
+
+msgid "Download"
+msgstr "Download"
+
+msgid "Download — ADT Studio"
+msgstr "Download — ADT Studio"
+
+msgid "Download ADT Studio"
+msgstr "Download ADT Studio"
+
+#. placeholder {0}: detected.label
+msgid "Download for {0}"
+msgstr "Download for {0}"
+
+#. placeholder {0}: meta.label
+#. placeholder {1}: resolution.release.tag_name
+msgid "Download for {0} — {1} (a newer release exists for other platforms)"
+msgstr "Download for {0} — {1} (a newer release exists for other platforms)"
+
+#. placeholder {0}: meta.label
+#. placeholder {1}: resolution.release.tag_name
+msgid "Download for {0} {1}"
+msgstr "Download for {0} {1}"
+
+msgid "Download for free"
+msgstr "Download for free"
+
+msgid "downloads to date"
+msgstr "downloads to date"
+
+msgid "Drop a PDF to get started"
+msgstr "Drop a PDF to get started"
+
+msgid "Drop in a PDF and watch it flow through every stage — from raw pages to an accessible reader. Free, open-source, runs on your machine."
+msgstr "Drop in a PDF and watch it flow through every stage — from raw pages to an accessible reader. Free, open-source, runs on your machine."
+
+msgid "Drop in a PDF to kick things off. ADT Studio organizes it into a new book project so you don't start from zero."
+msgstr "Drop in a PDF to kick things off. ADT Studio organizes it into a new book project so you don't start from zero."
+
+msgid "Edit & enrich"
+msgstr "Edit & enrich"
+
+msgid "EN · PT"
+msgstr "EN · PT"
+
+msgid "EN · PT · ES"
+msgstr "EN · PT · ES"
+
+msgid "English"
+msgstr "English"
+
+msgid "Every accessibility feature, <0>built in from page one</0>."
+msgstr "Every accessibility feature, <0>built in from page one</0>."
+
+msgid "Every book, every learner."
+msgstr "Every book, every learner."
+
+msgid "Every edit creates a new version. Roll back any stage, compare outputs, keep a full trail of what changed and why."
+msgstr "Every edit creates a new version. Roll back any stage, compare outputs, keep a full trail of what changed and why."
+
+msgid "Every prompt, every LLM call, every cost is visible. Audit the whole pipeline or hand it off to the next person with confidence."
+msgstr "Every prompt, every LLM call, every cost is visible. Audit the whole pipeline or hand it off to the next person with confidence."
+
+msgid "Every reader opens the same book, with the features they need on tap."
+msgstr "Every reader opens the same book, with the features they need on tap."
+
+msgid "Every ship of ADT Studio."
+msgstr "Every ship of ADT Studio."
+
+msgid "Everything about a book — sources, prompts, outputs, history — lives in a single directory. Zip it, share it, back it up."
+msgstr "Everything about a book — sources, prompts, outputs, history — lives in a single directory. Zip it, share it, back it up."
+
+msgid "Export to a reader"
+msgstr "Export to a reader"
+
+msgid "Extract"
+msgstr "Extract"
+
+msgid "Features"
+msgstr "Features"
+
+msgid "Fig 3.1 — The water cycle: evaporation, condensation, precipitation."
+msgstr "Fig 3.1 — The water cycle: evaporation, condensation, precipitation."
+
+msgid "Free forever"
+msgstr "Free forever"
+
+msgid "Free, open-source, and runs on your machine. Available for macOS, Windows, and Linux."
+msgstr "Free, open-source, and runs on your machine. Available for macOS, Windows, and Linux."
+
+msgid "French"
+msgstr "French"
+
+msgid "Fresh off the <0>press</0>."
+msgstr "Fresh off the <0>press</0>."
+
+msgid "From PDF to"
+msgstr "From PDF to"
+
+msgid "Full control over render strategies, pruning, and filters."
+msgstr "Full control over render strategies, pruning, and filters."
+
+msgid "Generate studio-quality text-to-speech for every page, with speaker control and per-language voices — no recording needed."
+msgstr "Generate studio-quality text-to-speech for every page, with speaker control and per-language voices — no recording needed."
+
+msgid "Generating panels"
+msgstr "Generating panels"
+
+msgid "Get started"
+msgstr "Get started"
+
+msgid "GitHub"
+msgstr "GitHub"
+
+msgid "Glossary"
+msgstr "Glossary"
+
+msgid "Grouping content by purpose, then laying out every section as reviewable HTML."
+msgstr "Grouping content by purpose, then laying out every section as reviewable HTML."
+
+msgid "Guidelines"
+msgstr "Guidelines"
+
+msgid "Here's what shipped in the latest version — and there are plenty more where this came from."
+msgstr "Here's what shipped in the latest version — and there are plenty more where this came from."
+
+msgid "Home"
+msgstr "Home"
+
+msgid "How it works"
+msgstr "How it works"
+
+msgid "How we build it"
+msgstr "How we build it"
+
+msgid "HTML, audio, translations and sign-language — exported together as a single package."
+msgstr "HTML, audio, translations and sign-language — exported together as a single package."
+
+msgid "If your device has been wrongly detected, <0>see all downloads</0>. Please report any issues you encounter on <1>GitHub</1>."
+msgstr "If your device has been wrongly detected, <0>see all downloads</0>. Please report any issues you encounter on <1>GitHub</1>."
+
+msgid "Issues"
+msgstr "Issues"
+
+msgid "Language"
+msgstr "Language"
+
+msgid "Languages"
+msgstr "Languages"
+
+msgid "Large images with narrative flow. Ideal for illustrated books with rich TTS voices."
+msgstr "Large images with narrative flow. Ideal for illustrated books with rich TTS voices."
+
+msgid "Latest"
+msgstr "Latest"
+
+msgid "Layer on translations, text-to-speech, and a glossary — all inspectable, cacheable, reversible."
+msgstr "Layer on translations, text-to-speech, and a glossary — all inspectable, cacheable, reversible."
+
+msgid "Laying out spreads"
+msgstr "Laying out spreads"
+
+msgid "License"
+msgstr "License"
+
+msgid "Linux"
+msgstr "Linux"
+
+msgid "LIVE"
+msgstr "LIVE"
+
+msgid "macOS"
+msgstr "macOS"
+
+msgid "MIT licensed"
+msgstr "MIT licensed"
+
+msgid "Narration · 0:42"
+msgstr "Narration · 0:42"
+
+msgid "New"
+msgstr "New"
+
+msgid "Newest first, with the full notes inline — what changed, why it matters, and the screenshots to back it up."
+msgstr "Newest first, with the full notes inline — what changed, why it matters, and the screenshots to back it up."
+
+#. placeholder {0}: meta.label
+msgid "No {0} build yet"
+msgstr "No {0} build yet"
+
+msgid "No account needed"
+msgstr "No account needed"
+
+msgid "No black boxes"
+msgstr "No black boxes"
+
+msgid "No release notes were provided for this version."
+msgstr "No release notes were provided for this version."
+
+msgid "No releases published yet — check back once the first build ships."
+msgstr "No releases published yet — check back once the first build ships."
+
+msgid "No releases yet — once the first build ships, it'll show up here."
+msgstr "No releases yet — once the first build ships, it'll show up here."
+
+msgid "Nothing is overwritten"
+msgstr "Nothing is overwritten"
+
+msgid "Now on macOS, Windows, Linux"
+msgstr "Now on macOS, Windows, Linux"
+
+msgid "OCR & cleanup"
+msgstr "OCR & cleanup"
+
+msgid "On GitHub"
+msgstr "On GitHub"
+
+msgid "One book, every format"
+msgstr "One book, every format"
+
+msgid "One folder per book"
+msgstr "One folder per book"
+
+msgid "Open in the reader, on the web, or hand the bundle off to an existing LMS."
+msgstr "Open in the reader, on the web, or hand the bundle off to an existing LMS."
+
+msgid "Open menu"
+msgstr "Open menu"
+
+msgid "Open on GitHub"
+msgstr "Open on GitHub"
+
+msgid "Open source"
+msgstr "Open source"
+
+msgid "Open-source desktop pipeline for turning PDFs into accessible books — built with UNICEF."
+msgstr "Open-source desktop pipeline for turning PDFs into accessible books — built with UNICEF."
+
+msgid "Output"
+msgstr "Output"
+
+msgid "Package the finished book with every accessibility feature baked in — ready for a kid to open, listen, and read along."
+msgstr "Package the finished book with every accessibility feature baked in — ready for a kid to open, listen, and read along."
+
+msgid "Parsing pages"
+msgstr "Parsing pages"
+
+msgid "Parsing pages into text, figures, and layout boxes — cached by content hash."
+msgstr "Parsing pages into text, figures, and layout boxes — cached by content hash."
+
+msgid "Pause"
+msgstr "Pause"
+
+msgid "Pick a preset"
+msgstr "Pick a preset"
+
+msgid "Pipeline · extract"
+msgstr "Pipeline · extract"
+
+msgid "Pipeline · storyboard"
+msgstr "Pipeline · storyboard"
+
+msgid "Play"
+msgstr "Play"
+
+msgid "Portuguese (BR)"
+msgstr "Portuguese (BR)"
+
+msgid "Pre-release — APIs and behavior may still change before the stable cut."
+msgstr "Pre-release — APIs and behavior may still change before the stable cut."
+
+msgid "Preview"
+msgstr "Preview"
+
+msgid "Primary"
+msgstr "Primary"
+
+msgid "Product"
+msgstr "Product"
+
+msgid "Project"
+msgstr "Project"
+
+msgid "Quizzes"
+msgstr "Quizzes"
+
+msgid "Raw notes on GitHub"
+msgstr "Raw notes on GitHub"
+
+msgid "Read on any device"
+msgstr "Read on any device"
+
+#. placeholder {0}: release.tag_name
+msgid "Read release {0}"
+msgstr "Read release {0}"
+
+msgid "Read this release"
+msgstr "Read this release"
+
+msgid "Recover headings, paragraphs, figures, tables and alt-text from the source PDF as real semantic HTML — built for screen readers."
+msgstr "Recover headings, paragraphs, figures, tables and alt-text from the source PDF as real semantic HTML — built for screen readers."
+
+msgid "Reference"
+msgstr "Reference"
+
+#. placeholder {0}: route.focusTag
+msgid "Release {0} — ADT Studio"
+msgstr "Release {0} — ADT Studio"
+
+msgid "Release to upload"
+msgstr "Release to upload"
+
+#. placeholder {0}: formatRelativeDate(latest.published_at)
+msgid "Released {0}"
+msgstr "Released {0}"
+
+msgid "Releases"
+msgstr "Releases"
+
+msgid "Rerun what matters"
+msgstr "Rerun what matters"
+
+msgid "Resolving latest release…"
+msgstr "Resolving latest release…"
+
+msgid "Results are cached at the LLM call level. Tweak a prompt and only the affected steps re-run — fast, deterministic, inspectable."
+msgstr "Results are cached at the LLM call level. Tweak a prompt and only the affected steps re-run — fast, deterministic, inspectable."
+
+msgid "Run the pipeline"
+msgstr "Run the pipeline"
+
+msgid "RUNNING"
+msgstr "RUNNING"
+
+msgid "Runs locally"
+msgstr "Runs locally"
+
+msgid "science · chapter 3"
+msgstr "science · chapter 3"
+
+msgid "Science Textbook"
+msgstr "Science Textbook"
+
+msgid "Scroll to next section"
+msgstr "Scroll to next section"
+
+msgid "See all releases on GitHub"
+msgstr "See all releases on GitHub"
+
+msgid "See examples"
+msgstr "See examples"
+
+msgid "Segmenting scenes"
+msgstr "Segmenting scenes"
+
+msgid "Ship the same book in every language you need. Translate text, captions and alt-text in one pass — review, edit, re-run."
+msgstr "Ship the same book in every language you need. Translate text, captions and alt-text in one pass — review, edit, re-run."
+
+msgid "Sign"
+msgstr "Sign"
+
+msgid "Sign language"
+msgstr "Sign language"
+
+msgid "Soon"
+msgstr "Soon"
+
+msgid "Spanish"
+msgstr "Spanish"
+
+msgid "Speech"
+msgstr "Speech"
+
+msgid "Star"
+msgstr "Star"
+
+msgid "Star on GitHub"
+msgstr "Star on GitHub"
+
+msgid "Start building accessible books."
+msgstr "Start building accessible books."
+
+msgid "Start from a PDF"
+msgstr "Start from a PDF"
+
+msgid "Storyboard"
+msgstr "Storyboard"
+
+msgid "Storybook"
+msgstr "Storybook"
+
+msgid "Structured chapters and exercises. Best for educational content with complex layouts."
+msgstr "Structured chapters and exercises. Best for educational content with complex layouts."
+
+msgid "Structured layouts"
+msgstr "Structured layouts"
+
+msgid "Successfully uploaded"
+msgstr "Successfully uploaded"
+
+msgid "Textbooks & Activities"
+msgstr "Textbooks & Activities"
+
+msgid "The output"
+msgstr "The output"
+
+msgid "Translate"
+msgstr "Translate"
+
+msgid "Translations"
+msgstr "Translations"
+
+msgid "Trust"
+msgstr "Trust"
+
+msgid "Turn any textbook into something every student can read, hear, see, and understand — audio, structured layouts, translations, and sign language, all built in."
+msgstr "Turn any textbook into something every student can read, hear, see, and understand — audio, structured layouts, translations, and sign language, all built in."
+
+msgid "View release on GitHub"
+msgstr "View release on GitHub"
+
+msgid "View source"
+msgstr "View source"
+
+msgid "WAITING"
+msgstr "WAITING"
+
+msgid "We couldn't fetch the latest release. Try the release page directly, or pick another platform below."
+msgstr "We couldn't fetch the latest release. Try the release page directly, or pick another platform below."
+
+msgid "We couldn’t reach GitHub. The full list is always available on the upstream repo."
+msgstr "We couldn’t reach GitHub. The full list is always available on the upstream repo."
+
+msgid "We don’t ship a mobile version. To install ADT Studio, open this page on macOS, Windows, or Linux — or send the link to your computer."
+msgstr "We don’t ship a mobile version. To install ADT Studio, open this page on macOS, Windows, or Linux — or send the link to your computer."
+
+#. placeholder {0}: meta.label
+msgid "We don't ship a prebuilt installer for {0} in this release. Pick another platform below or follow progress on GitHub."
+msgstr "We don't ship a prebuilt installer for {0} in this release. Pick another platform below or follow progress on GitHub."
+
+msgid "What happens when you drop in a PDF"
+msgstr "What happens when you drop in a PDF"
+
+msgid "What it does"
+msgstr "What it does"
+
+msgid "When the pipeline finishes, you get a clean bundle with every accessibility feature baked in — ready for a classroom, a publisher, or a kid on the couch."
+msgstr "When the pipeline finishes, you get a clean bundle with every accessibility feature baked in — ready for a classroom, a publisher, or a kid on the couch."
+
+msgid "Windows"
+msgstr "Windows"
+
+msgid "Windows · macOS · Linux"
+msgstr "Windows · macOS · Linux"
+
+msgid "Your first accessible book <0>starts here.</0>"
+msgstr "Your first accessible book <0>starts here.</0>"
+
+msgid "Your team stays in control. Every asset is a file you can re-run, replace or roll back."
+msgstr "Your team stays in control. Every asset is a file you can re-run, replace or roll back."

--- a/apps/landing/src/locales/es.po
+++ b/apps/landing/src/locales/es.po
@@ -1,0 +1,630 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2026-06-11 13:49-0300\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: es\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#. placeholder {0}: meta.label
+msgid "{0} build is coming — track on GitHub"
+msgstr "El build de {0} está en camino — sigue en GitHub"
+
+#. placeholder {0}: platform.label
+#. placeholder {1}: platformResolution.release.tag_name
+#. placeholder {2}: overallLatest.tag_name
+#. placeholder {3}: platform.label
+msgid "{0} latest is <0>{1}</0> — the project is on <1>{2}</1>. A {3} build for the newer tag isn’t available yet."
+msgstr "La última versión de {0} es <0>{1}</0> — el proyecto está en <1>{2}</1>. Aún no hay un build de {3} para la nueva etiqueta."
+
+#. placeholder {0}: new Date().getFullYear()
+msgid "© {0} ADT Studio — MIT licensed."
+msgstr "© {0} ADT Studio — Licencia MIT."
+
+msgid "4 languages"
+msgstr "4 idiomas"
+
+msgid "Accessible book"
+msgstr "Libro accesible"
+
+msgid "accessible books."
+msgstr "libros accesibles."
+
+msgid "ADT Studio"
+msgstr "ADT Studio"
+
+msgid "ADT Studio — now on macOS, Windows, Linux"
+msgstr "ADT Studio — ahora en macOS, Windows, Linux"
+
+msgid "ADT Studio — Turn any PDF into an accessible book"
+msgstr "ADT Studio — Convierte cualquier PDF en un libro accesible"
+
+msgid "ADT Studio home"
+msgstr "Inicio de ADT Studio"
+
+msgid "ADT Studio is a desktop app"
+msgstr "ADT Studio es una aplicación de escritorio"
+
+msgid "ADT Studio is built for teachers, editors and accessibility specialists — not engineers. Every choice in the app follows four principles so your work is always safe, transparent and under your control."
+msgstr "ADT Studio está diseñado para profesores, editores y especialistas en accesibilidad — no para ingenieros. Cada elección en la aplicación sigue cuatro principios para que tu trabajo sea siempre seguro, transparente y bajo tu control."
+
+msgid "ADT Studio is currently in"
+msgstr "ADT Studio está actualmente en"
+
+msgid "ADT Studio takes one PDF and rebuilds it as a fully-editable, fully-yours accessible book — with the pieces that used to take a team of specialists."
+msgstr "ADT Studio toma un PDF y lo reconstruye como un libro accesible completamente editable y tuyo — con las piezas que solían requerir un equipo de especialistas."
+
+msgid "Also available on"
+msgstr "También disponible en"
+
+msgid "Alt"
+msgstr "Alt"
+
+msgid "Alt described"
+msgstr "Alt descrito"
+
+msgid "Always editable"
+msgstr "Siempre editable"
+
+msgid "An accessible book, <0>ready to ship</0>."
+msgstr "Un libro accesible, <0>listo para publicar</0>."
+
+msgid "Architecture"
+msgstr "Arquitectura"
+
+msgid "ASL · LIBRAS"
+msgstr "ASL · LIBRAS"
+
+msgid "Attach sign-language video for ASL, LIBRAS and beyond — aligned to chapters and inspectable alongside the text."
+msgstr "Adjunta video en lengua de señas para ASL, LIBRAS y más — alineado a capítulos e inspeccionable junto al texto."
+
+msgid "Audio"
+msgstr "Audio"
+
+msgid "Audio narration"
+msgstr "Narración de audio"
+
+msgid "Available for"
+msgstr "Disponible para"
+
+msgid "Back to home"
+msgstr "Volver al inicio"
+
+msgid "Beta"
+msgstr "Beta"
+
+msgid "Book creation stages"
+msgstr "Etapas de creación del libro"
+
+msgid "Built with UNICEF"
+msgstr "Construido con UNICEF"
+
+msgid "Captions"
+msgstr "Subtítulos"
+
+msgid "Change language"
+msgstr "Cambiar idioma"
+
+msgid "Changelog"
+msgstr "Registro de cambios"
+
+msgid "Changelog — ADT Studio"
+msgstr "Registro de cambios — ADT Studio"
+
+msgid "Chapter 3"
+msgstr "Capítulo 3"
+
+msgid "Choose a preset that matches your content — textbook, storyboard, reference, or custom — and ADT Studio tailors the pipeline accordingly."
+msgstr "Elige un preset que coincida con tu contenido — libro de texto, storyboard, referencia o personalizado — y ADT Studio adapta el pipeline en consecuencia."
+
+msgid "Close menu"
+msgstr "Cerrar menú"
+
+msgid "Coming soon"
+msgstr "Próximamente"
+
+msgid "Configure each stage — extract, storyboard, layout — then let ADT Studio build the book. Review the output, correct anything that needs a human touch."
+msgstr "Configura cada etapa — extracción, storyboard, diseño — luego deja que ADT Studio construya el libro. Revisa el resultado, corrige cualquier cosa que necesite un toque humano."
+
+msgid "Contents"
+msgstr "Índice"
+
+msgid "Couldn’t load the changelog"
+msgstr "No se pudo cargar el registro de cambios"
+
+msgid "Couldn't reach GitHub"
+msgstr "No se pudo acceder a GitHub"
+
+msgid "Cover · Chapter 1"
+msgstr "Portada · Capítulo 1"
+
+msgid "Custom"
+msgstr "Personalizado"
+
+msgid "Delivered"
+msgstr "Entregado"
+
+msgid "Dense text, tables, glossaries. Best for technical material and documentation."
+msgstr "Texto denso, tablas, glosarios. Ideal para material técnico y documentación."
+
+msgid "Designed for the people who <0>do the work</0>."
+msgstr "Diseñado para las personas que <0>hacen el trabajo</0>."
+
+msgid "Desktop only"
+msgstr "Solo para escritorio"
+
+msgid "Detecting figures"
+msgstr "Detectando figuras"
+
+msgid "Docs"
+msgstr "Documentación"
+
+msgid "DONE"
+msgstr "HECHO"
+
+msgid "Download"
+msgstr "Descargar"
+
+msgid "Download — ADT Studio"
+msgstr "Descargar — ADT Studio"
+
+msgid "Download ADT Studio"
+msgstr "Descargar ADT Studio"
+
+#. placeholder {0}: detected.label
+msgid "Download for {0}"
+msgstr "Descargar para {0}"
+
+#. placeholder {0}: meta.label
+#. placeholder {1}: resolution.release.tag_name
+msgid "Download for {0} — {1} (a newer release exists for other platforms)"
+msgstr "Descargar para {0} — {1} (existe una versión más reciente para otras plataformas)"
+
+#. placeholder {0}: meta.label
+#. placeholder {1}: resolution.release.tag_name
+msgid "Download for {0} {1}"
+msgstr "Descargar para {0} {1}"
+
+msgid "Download for free"
+msgstr "Descargar gratis"
+
+msgid "downloads to date"
+msgstr "descargas hasta la fecha"
+
+msgid "Drop a PDF to get started"
+msgstr "Suelta un PDF para comenzar"
+
+msgid "Drop in a PDF and watch it flow through every stage — from raw pages to an accessible reader. Free, open-source, runs on your machine."
+msgstr "Suelta un PDF y observa cómo fluye por cada etapa — desde páginas en bruto hasta un lector accesible. Gratis, de código abierto, se ejecuta en tu máquina."
+
+msgid "Drop in a PDF to kick things off. ADT Studio organizes it into a new book project so you don't start from zero."
+msgstr "Suelta un PDF para comenzar. ADT Studio lo organiza en un nuevo proyecto de libro para que no empieces desde cero."
+
+msgid "Edit & enrich"
+msgstr "Editar y enriquecer"
+
+msgid "EN · PT"
+msgstr "EN · PT"
+
+msgid "EN · PT · ES"
+msgstr "EN · PT · ES"
+
+msgid "English"
+msgstr "Inglés"
+
+msgid "Every accessibility feature, <0>built in from page one</0>."
+msgstr "Cada característica de accesibilidad, <0>integrada desde la primera página</0>."
+
+msgid "Every book, every learner."
+msgstr "Cada libro, cada estudiante."
+
+msgid "Every edit creates a new version. Roll back any stage, compare outputs, keep a full trail of what changed and why."
+msgstr "Cada edición crea una nueva versión. Revierte cualquier etapa, compara resultados, mantén un registro completo de lo que cambió y por qué."
+
+msgid "Every prompt, every LLM call, every cost is visible. Audit the whole pipeline or hand it off to the next person with confidence."
+msgstr "Cada prompt, cada llamada LLM, cada costo es visible. Audita todo el pipeline o pásalo a la siguiente persona con confianza."
+
+msgid "Every reader opens the same book, with the features they need on tap."
+msgstr "Cada lector abre el mismo libro, con las características que necesita al alcance."
+
+msgid "Every ship of ADT Studio."
+msgstr "Cada versión de ADT Studio."
+
+msgid "Everything about a book — sources, prompts, outputs, history — lives in a single directory. Zip it, share it, back it up."
+msgstr "Todo sobre un libro — fuentes, prompts, resultados, historial — vive en un solo directorio. Comprímelo, compártelo, haz una copia de seguridad."
+
+msgid "Export to a reader"
+msgstr "Exportar a un lector"
+
+msgid "Extract"
+msgstr "Extraer"
+
+msgid "Features"
+msgstr "Características"
+
+msgid "Fig 3.1 — The water cycle: evaporation, condensation, precipitation."
+msgstr "Fig 3.1 — El ciclo del agua: evaporación, condensación, precipitación."
+
+msgid "Free forever"
+msgstr "Gratis para siempre"
+
+msgid "Free, open-source, and runs on your machine. Available for macOS, Windows, and Linux."
+msgstr "Gratis, de código abierto y se ejecuta en tu máquina. Disponible para macOS, Windows y Linux."
+
+msgid "French"
+msgstr "Francés"
+
+msgid "Fresh off the <0>press</0>."
+msgstr "Recién salido de la <0>prensa</0>."
+
+msgid "From PDF to"
+msgstr "De PDF a"
+
+msgid "Full control over render strategies, pruning, and filters."
+msgstr "Control total sobre estrategias de renderizado, poda y filtros."
+
+msgid "Generate studio-quality text-to-speech for every page, with speaker control and per-language voices — no recording needed."
+msgstr "Genera texto a voz de calidad de estudio para cada página, con control de locutor y voces por idioma — no se necesita grabación."
+
+msgid "Generating panels"
+msgstr "Generando paneles"
+
+msgid "Get started"
+msgstr "Comenzar"
+
+msgid "GitHub"
+msgstr "GitHub"
+
+msgid "Glossary"
+msgstr "Glosario"
+
+msgid "Grouping content by purpose, then laying out every section as reviewable HTML."
+msgstr "Agrupando contenido por propósito, luego diseñando cada sección como HTML revisable."
+
+msgid "Guidelines"
+msgstr "Directrices"
+
+msgid "Here's what shipped in the latest version — and there are plenty more where this came from."
+msgstr "Esto es lo que llegó en la última versión — y hay mucho más de donde vino esto."
+
+msgid "Home"
+msgstr "Inicio"
+
+msgid "How it works"
+msgstr "Cómo funciona"
+
+msgid "How we build it"
+msgstr "Cómo lo construimos"
+
+msgid "HTML, audio, translations and sign-language — exported together as a single package."
+msgstr "HTML, audio, traducciones y lengua de señas — exportados juntos como un solo paquete."
+
+msgid "If your device has been wrongly detected, <0>see all downloads</0>. Please report any issues you encounter on <1>GitHub</1>."
+msgstr "Si tu dispositivo ha sido detectado incorrectamente, <0>ver todas las descargas</0>. Por favor, reporta cualquier problema que encuentres en <1>GitHub</1>."
+
+msgid "Issues"
+msgstr "Problemas"
+
+msgid "Language"
+msgstr "Idioma"
+
+msgid "Languages"
+msgstr "Idiomas"
+
+msgid "Large images with narrative flow. Ideal for illustrated books with rich TTS voices."
+msgstr "Imágenes grandes con flujo narrativo. Ideal para libros ilustrados con voces TTS ricas."
+
+msgid "Latest"
+msgstr "Más reciente"
+
+msgid "Layer on translations, text-to-speech, and a glossary — all inspectable, cacheable, reversible."
+msgstr "Suma traducciones, texto a voz y un glosario — todo inspeccionable, almacenable en caché, reversible."
+
+msgid "Laying out spreads"
+msgstr "Diseñando pliegos"
+
+msgid "License"
+msgstr "Licencia"
+
+msgid "Linux"
+msgstr "Linux"
+
+msgid "LIVE"
+msgstr "EN VIVO"
+
+msgid "macOS"
+msgstr "macOS"
+
+msgid "MIT licensed"
+msgstr "Licencia MIT"
+
+msgid "Narration · 0:42"
+msgstr "Narración · 0:42"
+
+msgid "New"
+msgstr "Nuevo"
+
+msgid "Newest first, with the full notes inline — what changed, why it matters, and the screenshots to back it up."
+msgstr "Lo más nuevo primero, con las notas completas en línea — qué cambió, por qué importa y las capturas de pantalla para respaldarlo."
+
+#. placeholder {0}: meta.label
+msgid "No {0} build yet"
+msgstr "Aún no hay build para {0}"
+
+msgid "No account needed"
+msgstr "No se necesita cuenta"
+
+msgid "No black boxes"
+msgstr "Sin cajas negras"
+
+msgid "No release notes were provided for this version."
+msgstr "No se proporcionaron notas de lanzamiento para esta versión."
+
+msgid "No releases published yet — check back once the first build ships."
+msgstr "Aún no se han publicado versiones — vuelve a consultar cuando salga el primer build."
+
+msgid "No releases yet — once the first build ships, it'll show up here."
+msgstr "Aún no hay versiones — cuando salga el primer build, aparecerá aquí."
+
+msgid "Nothing is overwritten"
+msgstr "Nada se sobrescribe"
+
+msgid "Now on macOS, Windows, Linux"
+msgstr "Ahora en macOS, Windows, Linux"
+
+msgid "OCR & cleanup"
+msgstr "OCR y limpieza"
+
+msgid "On GitHub"
+msgstr "En GitHub"
+
+msgid "One book, every format"
+msgstr "Un libro, cada formato"
+
+msgid "One folder per book"
+msgstr "Una carpeta por libro"
+
+msgid "Open in the reader, on the web, or hand the bundle off to an existing LMS."
+msgstr "Abrir en el lector, en la web, o pasar el paquete a un LMS existente."
+
+msgid "Open menu"
+msgstr "Abrir menú"
+
+msgid "Open on GitHub"
+msgstr "Abrir en GitHub"
+
+msgid "Open source"
+msgstr "Código abierto"
+
+msgid "Open-source desktop pipeline for turning PDFs into accessible books — built with UNICEF."
+msgstr "Pipeline de escritorio de código abierto para convertir PDFs en libros accesibles — construido con UNICEF."
+
+msgid "Output"
+msgstr "Salida"
+
+msgid "Package the finished book with every accessibility feature baked in — ready for a kid to open, listen, and read along."
+msgstr "Empaqueta el libro terminado con todas las características de accesibilidad integradas — listo para que un niño lo abra, escuche y lea."
+
+msgid "Parsing pages"
+msgstr "Analizando páginas"
+
+msgid "Parsing pages into text, figures, and layout boxes — cached by content hash."
+msgstr "Analizando páginas en texto, figuras y cajas de diseño — almacenado en caché por hash de contenido."
+
+msgid "Pause"
+msgstr "Pausa"
+
+msgid "Pick a preset"
+msgstr "Elige un preset"
+
+msgid "Pipeline · extract"
+msgstr "Pipeline · extracción"
+
+msgid "Pipeline · storyboard"
+msgstr "Pipeline · storyboard"
+
+msgid "Play"
+msgstr "Reproducir"
+
+msgid "Portuguese (BR)"
+msgstr "Portugués (BR)"
+
+msgid "Pre-release — APIs and behavior may still change before the stable cut."
+msgstr "Pre-lanzamiento — las APIs y el comportamiento aún pueden cambiar antes de la versión estable."
+
+msgid "Preview"
+msgstr "Vista previa"
+
+msgid "Primary"
+msgstr "Principal"
+
+msgid "Product"
+msgstr "Producto"
+
+msgid "Project"
+msgstr "Proyecto"
+
+msgid "Quizzes"
+msgstr "Cuestionarios"
+
+msgid "Raw notes on GitHub"
+msgstr "Notas sin formato en GitHub"
+
+msgid "Read on any device"
+msgstr "Leer en cualquier dispositivo"
+
+#. placeholder {0}: release.tag_name
+msgid "Read release {0}"
+msgstr "Leer versión {0}"
+
+msgid "Read this release"
+msgstr "Leer esta versión"
+
+msgid "Recover headings, paragraphs, figures, tables and alt-text from the source PDF as real semantic HTML — built for screen readers."
+msgstr "Recupera encabezados, párrafos, figuras, tablas y texto alternativo del PDF original como HTML semántico real — diseñado para lectores de pantalla."
+
+msgid "Reference"
+msgstr "Referencia"
+
+#. placeholder {0}: route.focusTag
+msgid "Release {0} — ADT Studio"
+msgstr "Versión {0} — ADT Studio"
+
+msgid "Release to upload"
+msgstr "Suelta para subir"
+
+#. placeholder {0}: formatRelativeDate(latest.published_at)
+msgid "Released {0}"
+msgstr "Publicado {0}"
+
+msgid "Releases"
+msgstr "Versiones"
+
+msgid "Rerun what matters"
+msgstr "Reejecutar lo que importa"
+
+msgid "Resolving latest release…"
+msgstr "Resolviendo la última versión…"
+
+msgid "Results are cached at the LLM call level. Tweak a prompt and only the affected steps re-run — fast, deterministic, inspectable."
+msgstr "Los resultados se almacenan en caché a nivel de llamada LLM. Ajusta un prompt y solo se reejecutan los pasos afectados — rápido, determinista, inspeccionable."
+
+msgid "Run the pipeline"
+msgstr "Ejecutar el pipeline"
+
+msgid "RUNNING"
+msgstr "EJECUTANDO"
+
+msgid "Runs locally"
+msgstr "Se ejecuta localmente"
+
+msgid "science · chapter 3"
+msgstr "ciencia · capítulo 3"
+
+msgid "Science Textbook"
+msgstr "Libro de texto de ciencia"
+
+msgid "Scroll to next section"
+msgstr "Desplazar a la siguiente sección"
+
+msgid "See all releases on GitHub"
+msgstr "Ver todas las versiones en GitHub"
+
+msgid "See examples"
+msgstr "Ver ejemplos"
+
+msgid "Segmenting scenes"
+msgstr "Segmentando escenas"
+
+msgid "Ship the same book in every language you need. Translate text, captions and alt-text in one pass — review, edit, re-run."
+msgstr "Publica el mismo libro en cada idioma que necesites. Traduce texto, subtítulos y texto alternativo en una sola pasada — revisa, edita, reejecuta."
+
+msgid "Sign"
+msgstr "Señas"
+
+msgid "Sign language"
+msgstr "Lengua de señas"
+
+msgid "Soon"
+msgstr "Pronto"
+
+msgid "Spanish"
+msgstr "Español"
+
+msgid "Speech"
+msgstr "Voz"
+
+msgid "Star"
+msgstr "Star"
+
+msgid "Star on GitHub"
+msgstr "Star en GitHub"
+
+msgid "Start building accessible books."
+msgstr "Comienza a crear libros accesibles."
+
+msgid "Start from a PDF"
+msgstr "Comienza desde un PDF"
+
+msgid "Storyboard"
+msgstr "Storyboard"
+
+msgid "Storybook"
+msgstr "Libro de cuentos"
+
+msgid "Structured chapters and exercises. Best for educational content with complex layouts."
+msgstr "Capítulos y ejercicios estructurados. Ideal para contenido educativo con diseños complejos."
+
+msgid "Structured layouts"
+msgstr "Diseños estructurados"
+
+msgid "Successfully uploaded"
+msgstr "Subido con éxito"
+
+msgid "Textbooks & Activities"
+msgstr "Libros de texto y actividades"
+
+msgid "The output"
+msgstr "La salida"
+
+msgid "Translate"
+msgstr "Traducir"
+
+msgid "Translations"
+msgstr "Traducciones"
+
+msgid "Trust"
+msgstr "Confianza"
+
+msgid "Turn any textbook into something every student can read, hear, see, and understand — audio, structured layouts, translations, and sign language, all built in."
+msgstr "Convierte cualquier libro de texto en algo que cada estudiante pueda leer, escuchar, ver y entender — audio, diseños estructurados, traducciones y lengua de señas, todo integrado."
+
+msgid "View release on GitHub"
+msgstr "Ver versión en GitHub"
+
+msgid "View source"
+msgstr "Ver código fuente"
+
+msgid "WAITING"
+msgstr "ESPERANDO"
+
+msgid "We couldn't fetch the latest release. Try the release page directly, or pick another platform below."
+msgstr "No pudimos obtener la última versión. Intenta la página de versiones directamente, o elige otra plataforma abajo."
+
+msgid "We couldn’t reach GitHub. The full list is always available on the upstream repo."
+msgstr "No pudimos acceder a GitHub. La lista completa siempre está disponible en el repositorio principal."
+
+msgid "We don’t ship a mobile version. To install ADT Studio, open this page on macOS, Windows, or Linux — or send the link to your computer."
+msgstr "No ofrecemos una versión móvil. Para instalar ADT Studio, abre esta página en macOS, Windows o Linux — o envía el enlace a tu computadora."
+
+#. placeholder {0}: meta.label
+msgid "We don't ship a prebuilt installer for {0} in this release. Pick another platform below or follow progress on GitHub."
+msgstr "No ofrecemos un instalador preconstruido para {0} en esta versión. Elige otra plataforma abajo o sigue el progreso en GitHub."
+
+msgid "What happens when you drop in a PDF"
+msgstr "Qué sucede cuando sueltas un PDF"
+
+msgid "What it does"
+msgstr "Qué hace"
+
+msgid "When the pipeline finishes, you get a clean bundle with every accessibility feature baked in — ready for a classroom, a publisher, or a kid on the couch."
+msgstr "Cuando el pipeline termina, obtienes un paquete limpio con todas las características de accesibilidad integradas — listo para un aula, un editor o un niño en el sofá."
+
+msgid "Windows"
+msgstr "Windows"
+
+msgid "Windows · macOS · Linux"
+msgstr "Windows · macOS · Linux"
+
+msgid "Your first accessible book <0>starts here.</0>"
+msgstr "Tu primer libro accesible <0>comienza aquí.</0>"
+
+msgid "Your team stays in control. Every asset is a file you can re-run, replace or roll back."
+msgstr "Tu equipo mantiene el control. Cada recurso es un archivo que puedes reejecutar, reemplazar o revertir."

--- a/apps/landing/src/locales/fr.po
+++ b/apps/landing/src/locales/fr.po
@@ -1,0 +1,630 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2026-06-11 13:49-0300\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: fr\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#. placeholder {0}: meta.label
+msgid "{0} build is coming — track on GitHub"
+msgstr "Le build {0} arrive — suivez-le sur GitHub"
+
+#. placeholder {0}: platform.label
+#. placeholder {1}: platformResolution.release.tag_name
+#. placeholder {2}: overallLatest.tag_name
+#. placeholder {3}: platform.label
+msgid "{0} latest is <0>{1}</0> — the project is on <1>{2}</1>. A {3} build for the newer tag isn’t available yet."
+msgstr "La dernière version de {0} est <0>{1}</0> — le projet est sur <1>{2}</1>. Un build {3} pour le nouveau tag n'est pas encore disponible."
+
+#. placeholder {0}: new Date().getFullYear()
+msgid "© {0} ADT Studio — MIT licensed."
+msgstr "© {0} ADT Studio — sous licence MIT."
+
+msgid "4 languages"
+msgstr "4 langues"
+
+msgid "Accessible book"
+msgstr "Livre accessible"
+
+msgid "accessible books."
+msgstr "livres accessibles."
+
+msgid "ADT Studio"
+msgstr "ADT Studio"
+
+msgid "ADT Studio — now on macOS, Windows, Linux"
+msgstr "ADT Studio — maintenant sur macOS, Windows, Linux"
+
+msgid "ADT Studio — Turn any PDF into an accessible book"
+msgstr "ADT Studio — Transformez n'importe quel PDF en livre accessible"
+
+msgid "ADT Studio home"
+msgstr "Accueil ADT Studio"
+
+msgid "ADT Studio is a desktop app"
+msgstr "ADT Studio est une application de bureau"
+
+msgid "ADT Studio is built for teachers, editors and accessibility specialists — not engineers. Every choice in the app follows four principles so your work is always safe, transparent and under your control."
+msgstr "ADT Studio est conçu pour les enseignants, éditeurs et spécialistes de l'accessibilité — pas pour les ingénieurs. Chaque choix dans l'application suit quatre principes pour que votre travail soit toujours sûr, transparent et sous votre contrôle."
+
+msgid "ADT Studio is currently in"
+msgstr "ADT Studio est actuellement en"
+
+msgid "ADT Studio takes one PDF and rebuilds it as a fully-editable, fully-yours accessible book — with the pieces that used to take a team of specialists."
+msgstr "ADT Studio prend un PDF et le reconstruit en un livre accessible entièrement éditable, entièrement à vous — avec les éléments qui nécessitaient auparavant une équipe de spécialistes."
+
+msgid "Also available on"
+msgstr "Également disponible sur"
+
+msgid "Alt"
+msgstr "Alt"
+
+msgid "Alt described"
+msgstr "Alt décrit"
+
+msgid "Always editable"
+msgstr "Toujours éditable"
+
+msgid "An accessible book, <0>ready to ship</0>."
+msgstr "Un livre accessible, <0>prêt à être publié</0>."
+
+msgid "Architecture"
+msgstr "Architecture"
+
+msgid "ASL · LIBRAS"
+msgstr "ASL · LIBRAS"
+
+msgid "Attach sign-language video for ASL, LIBRAS and beyond — aligned to chapters and inspectable alongside the text."
+msgstr "Joignez une vidéo en langue des signes pour ASL, LIBRAS et au-delà — alignée sur les chapitres et inspectable avec le texte."
+
+msgid "Audio"
+msgstr "Audio"
+
+msgid "Audio narration"
+msgstr "Narration audio"
+
+msgid "Available for"
+msgstr "Disponible pour"
+
+msgid "Back to home"
+msgstr "Retour à l'accueil"
+
+msgid "Beta"
+msgstr "Bêta"
+
+msgid "Book creation stages"
+msgstr "Étapes de création du livre"
+
+msgid "Built with UNICEF"
+msgstr "Développé avec l'UNICEF"
+
+msgid "Captions"
+msgstr "Sous-titres"
+
+msgid "Change language"
+msgstr "Changer de langue"
+
+msgid "Changelog"
+msgstr "Journal des modifications"
+
+msgid "Changelog — ADT Studio"
+msgstr "Journal des modifications — ADT Studio"
+
+msgid "Chapter 3"
+msgstr "Chapitre 3"
+
+msgid "Choose a preset that matches your content — textbook, storyboard, reference, or custom — and ADT Studio tailors the pipeline accordingly."
+msgstr "Choisissez un préréglage qui correspond à votre contenu — manuel, storyboard, référence ou personnalisé — et ADT Studio adapte le pipeline en conséquence."
+
+msgid "Close menu"
+msgstr "Fermer le menu"
+
+msgid "Coming soon"
+msgstr "Bientôt disponible"
+
+msgid "Configure each stage — extract, storyboard, layout — then let ADT Studio build the book. Review the output, correct anything that needs a human touch."
+msgstr "Configurez chaque étape — extraction, storyboard, mise en page — puis laissez ADT Studio construire le livre. Vérifiez le résultat, corrigez tout ce qui nécessite une intervention humaine."
+
+msgid "Contents"
+msgstr "Sommaire"
+
+msgid "Couldn’t load the changelog"
+msgstr "Impossible de charger le journal des modifications"
+
+msgid "Couldn't reach GitHub"
+msgstr "Impossible d'atteindre GitHub"
+
+msgid "Cover · Chapter 1"
+msgstr "Couverture · Chapitre 1"
+
+msgid "Custom"
+msgstr "Personnalisé"
+
+msgid "Delivered"
+msgstr "Livré"
+
+msgid "Dense text, tables, glossaries. Best for technical material and documentation."
+msgstr "Texte dense, tableaux, glossaires. Idéal pour le matériel technique et la documentation."
+
+msgid "Designed for the people who <0>do the work</0>."
+msgstr "Conçu pour les personnes qui <0>font le travail</0>."
+
+msgid "Desktop only"
+msgstr "Bureau uniquement"
+
+msgid "Detecting figures"
+msgstr "Détection des figures"
+
+msgid "Docs"
+msgstr "Docs"
+
+msgid "DONE"
+msgstr "TERMINÉ"
+
+msgid "Download"
+msgstr "Télécharger"
+
+msgid "Download — ADT Studio"
+msgstr "Télécharger — ADT Studio"
+
+msgid "Download ADT Studio"
+msgstr "Télécharger ADT Studio"
+
+#. placeholder {0}: detected.label
+msgid "Download for {0}"
+msgstr "Télécharger pour {0}"
+
+#. placeholder {0}: meta.label
+#. placeholder {1}: resolution.release.tag_name
+msgid "Download for {0} — {1} (a newer release exists for other platforms)"
+msgstr "Télécharger pour {0} — {1} (une version plus récente existe pour d'autres plateformes)"
+
+#. placeholder {0}: meta.label
+#. placeholder {1}: resolution.release.tag_name
+msgid "Download for {0} {1}"
+msgstr "Télécharger pour {0} {1}"
+
+msgid "Download for free"
+msgstr "Télécharger gratuitement"
+
+msgid "downloads to date"
+msgstr "téléchargements à ce jour"
+
+msgid "Drop a PDF to get started"
+msgstr "Déposez un PDF pour commencer"
+
+msgid "Drop in a PDF and watch it flow through every stage — from raw pages to an accessible reader. Free, open-source, runs on your machine."
+msgstr "Déposez un PDF et regardez-le passer par chaque étape — des pages brutes à un lecteur accessible. Gratuit, open-source, fonctionne sur votre machine."
+
+msgid "Drop in a PDF to kick things off. ADT Studio organizes it into a new book project so you don't start from zero."
+msgstr "Déposez un PDF pour démarrer. ADT Studio l'organise en un nouveau projet de livre pour que vous ne commenciez pas de zéro."
+
+msgid "Edit & enrich"
+msgstr "Éditer & enrichir"
+
+msgid "EN · PT"
+msgstr "EN · PT"
+
+msgid "EN · PT · ES"
+msgstr "EN · PT · ES"
+
+msgid "English"
+msgstr "Anglais"
+
+msgid "Every accessibility feature, <0>built in from page one</0>."
+msgstr "Chaque fonctionnalité d'accessibilité, <0>intégrée dès la première page</0>."
+
+msgid "Every book, every learner."
+msgstr "Chaque livre, chaque apprenant."
+
+msgid "Every edit creates a new version. Roll back any stage, compare outputs, keep a full trail of what changed and why."
+msgstr "Chaque modification crée une nouvelle version. Revenez à n'importe quelle étape, comparez les résultats, gardez une trace complète de ce qui a changé et pourquoi."
+
+msgid "Every prompt, every LLM call, every cost is visible. Audit the whole pipeline or hand it off to the next person with confidence."
+msgstr "Chaque invite, chaque appel LLM, chaque coût est visible. Auditez l'ensemble du pipeline ou transmettez-le à la personne suivante en toute confiance."
+
+msgid "Every reader opens the same book, with the features they need on tap."
+msgstr "Chaque lecteur ouvre le même livre, avec les fonctionnalités dont il a besoin à portée de main."
+
+msgid "Every ship of ADT Studio."
+msgstr "Chaque version d'ADT Studio."
+
+msgid "Everything about a book — sources, prompts, outputs, history — lives in a single directory. Zip it, share it, back it up."
+msgstr "Tout ce qui concerne un livre — sources, invites, résultats, historique — se trouve dans un seul répertoire. Compressez-le, partagez-le, sauvegardez-le."
+
+msgid "Export to a reader"
+msgstr "Exporter vers un lecteur"
+
+msgid "Extract"
+msgstr "Extraire"
+
+msgid "Features"
+msgstr "Fonctionnalités"
+
+msgid "Fig 3.1 — The water cycle: evaporation, condensation, precipitation."
+msgstr "Fig 3.1 — Le cycle de l'eau : évaporation, condensation, précipitation."
+
+msgid "Free forever"
+msgstr "Gratuit pour toujours"
+
+msgid "Free, open-source, and runs on your machine. Available for macOS, Windows, and Linux."
+msgstr "Gratuit, open-source, et fonctionne sur votre machine. Disponible pour macOS, Windows et Linux."
+
+msgid "French"
+msgstr "Français"
+
+msgid "Fresh off the <0>press</0>."
+msgstr "Tout juste sorti de <0>l'imprimerie</0>."
+
+msgid "From PDF to"
+msgstr "De PDF à"
+
+msgid "Full control over render strategies, pruning, and filters."
+msgstr "Contrôle total sur les stratégies de rendu, l'élagage et les filtres."
+
+msgid "Generate studio-quality text-to-speech for every page, with speaker control and per-language voices — no recording needed."
+msgstr "Générez une synthèse vocale de qualité studio pour chaque page, avec contrôle du locuteur et voix par langue — aucun enregistrement nécessaire."
+
+msgid "Generating panels"
+msgstr "Génération des cases"
+
+msgid "Get started"
+msgstr "Commencer"
+
+msgid "GitHub"
+msgstr "GitHub"
+
+msgid "Glossary"
+msgstr "Glossaire"
+
+msgid "Grouping content by purpose, then laying out every section as reviewable HTML."
+msgstr "Regrouper le contenu par objectif, puis disposer chaque section en HTML révisable."
+
+msgid "Guidelines"
+msgstr "Directives"
+
+msgid "Here's what shipped in the latest version — and there are plenty more where this came from."
+msgstr "Voici ce qui a été livré dans la dernière version — et ce n'est qu'un début."
+
+msgid "Home"
+msgstr "Accueil"
+
+msgid "How it works"
+msgstr "Comment ça marche"
+
+msgid "How we build it"
+msgstr "Comment nous le construisons"
+
+msgid "HTML, audio, translations and sign-language — exported together as a single package."
+msgstr "HTML, audio, traductions et langue des signes — exportés ensemble en un seul package."
+
+msgid "If your device has been wrongly detected, <0>see all downloads</0>. Please report any issues you encounter on <1>GitHub</1>."
+msgstr "Si votre appareil a été mal détecté, <0>voir tous les téléchargements</0>. Veuillez signaler tout problème rencontré sur <1>GitHub</1>."
+
+msgid "Issues"
+msgstr "Problèmes"
+
+msgid "Language"
+msgstr "Langue"
+
+msgid "Languages"
+msgstr "Langues"
+
+msgid "Large images with narrative flow. Ideal for illustrated books with rich TTS voices."
+msgstr "Grandes images avec flux narratif. Idéal pour les livres illustrés avec des voix TTS riches."
+
+msgid "Latest"
+msgstr "Plus récent"
+
+msgid "Layer on translations, text-to-speech, and a glossary — all inspectable, cacheable, reversible."
+msgstr "Ajoutez des traductions, de la synthèse vocale et un glossaire — tous inspectables, mis en cache, réversibles."
+
+msgid "Laying out spreads"
+msgstr "Mise en page des doubles pages"
+
+msgid "License"
+msgstr "Licence"
+
+msgid "Linux"
+msgstr "Linux"
+
+msgid "LIVE"
+msgstr "EN DIRECT"
+
+msgid "macOS"
+msgstr "macOS"
+
+msgid "MIT licensed"
+msgstr "Sous licence MIT"
+
+msgid "Narration · 0:42"
+msgstr "Narration · 0:42"
+
+msgid "New"
+msgstr "Nouveau"
+
+msgid "Newest first, with the full notes inline — what changed, why it matters, and the screenshots to back it up."
+msgstr "Les plus récents d'abord, avec les notes complètes en ligne — ce qui a changé, pourquoi c'est important, et les captures d'écran pour le prouver."
+
+#. placeholder {0}: meta.label
+msgid "No {0} build yet"
+msgstr "Pas encore de build {0}"
+
+msgid "No account needed"
+msgstr "Pas de compte nécessaire"
+
+msgid "No black boxes"
+msgstr "Pas de boîtes noires"
+
+msgid "No release notes were provided for this version."
+msgstr "Aucune note de version n'a été fournie pour cette version."
+
+msgid "No releases published yet — check back once the first build ships."
+msgstr "Aucune version publiée pour le moment — revenez une fois que le premier build sera disponible."
+
+msgid "No releases yet — once the first build ships, it'll show up here."
+msgstr "Aucune version pour le moment — une fois que le premier build sera disponible, il apparaîtra ici."
+
+msgid "Nothing is overwritten"
+msgstr "Rien n'est écrasé"
+
+msgid "Now on macOS, Windows, Linux"
+msgstr "Maintenant sur macOS, Windows, Linux"
+
+msgid "OCR & cleanup"
+msgstr "OCR & nettoyage"
+
+msgid "On GitHub"
+msgstr "Sur GitHub"
+
+msgid "One book, every format"
+msgstr "Un livre, chaque format"
+
+msgid "One folder per book"
+msgstr "Un dossier par livre"
+
+msgid "Open in the reader, on the web, or hand the bundle off to an existing LMS."
+msgstr "Ouvrez dans le lecteur, sur le web, ou transmettez le package à un LMS existant."
+
+msgid "Open menu"
+msgstr "Ouvrir le menu"
+
+msgid "Open on GitHub"
+msgstr "Ouvrir sur GitHub"
+
+msgid "Open source"
+msgstr "Open source"
+
+msgid "Open-source desktop pipeline for turning PDFs into accessible books — built with UNICEF."
+msgstr "Pipeline de bureau open-source pour transformer les PDF en livres accessibles — développé avec l'UNICEF."
+
+msgid "Output"
+msgstr "Sortie"
+
+msgid "Package the finished book with every accessibility feature baked in — ready for a kid to open, listen, and read along."
+msgstr "Regroupez le livre fini avec toutes les fonctionnalités d'accessibilité intégrées — prêt pour qu'un enfant l'ouvre, l'écoute et le lise."
+
+msgid "Parsing pages"
+msgstr "Analyse des pages"
+
+msgid "Parsing pages into text, figures, and layout boxes — cached by content hash."
+msgstr "Analyse des pages en texte, figures et boîtes de mise en page — mis en cache par hachage de contenu."
+
+msgid "Pause"
+msgstr "Pause"
+
+msgid "Pick a preset"
+msgstr "Choisir un préréglage"
+
+msgid "Pipeline · extract"
+msgstr "Pipeline · extraction"
+
+msgid "Pipeline · storyboard"
+msgstr "Pipeline · storyboard"
+
+msgid "Play"
+msgstr "Lire"
+
+msgid "Portuguese (BR)"
+msgstr "Portugais (BR)"
+
+msgid "Pre-release — APIs and behavior may still change before the stable cut."
+msgstr "Pré-version — Les API et le comportement peuvent encore changer avant la version stable."
+
+msgid "Preview"
+msgstr "Aperçu"
+
+msgid "Primary"
+msgstr "Principal"
+
+msgid "Product"
+msgstr "Produit"
+
+msgid "Project"
+msgstr "Projet"
+
+msgid "Quizzes"
+msgstr "Quiz"
+
+msgid "Raw notes on GitHub"
+msgstr "Notes brutes sur GitHub"
+
+msgid "Read on any device"
+msgstr "Lire sur n'importe quel appareil"
+
+#. placeholder {0}: release.tag_name
+msgid "Read release {0}"
+msgstr "Lire la version {0}"
+
+msgid "Read this release"
+msgstr "Lire cette version"
+
+msgid "Recover headings, paragraphs, figures, tables and alt-text from the source PDF as real semantic HTML — built for screen readers."
+msgstr "Récupérez les titres, paragraphes, figures, tableaux et textes alternatifs du PDF source en tant que véritable HTML sémantique — conçu pour les lecteurs d'écran."
+
+msgid "Reference"
+msgstr "Référence"
+
+#. placeholder {0}: route.focusTag
+msgid "Release {0} — ADT Studio"
+msgstr "Version {0} — ADT Studio"
+
+msgid "Release to upload"
+msgstr "Relâchez pour téléverser"
+
+#. placeholder {0}: formatRelativeDate(latest.published_at)
+msgid "Released {0}"
+msgstr "Publié {0}"
+
+msgid "Releases"
+msgstr "Versions"
+
+msgid "Rerun what matters"
+msgstr "Relancer ce qui compte"
+
+msgid "Resolving latest release…"
+msgstr "Résolution de la dernière version…"
+
+msgid "Results are cached at the LLM call level. Tweak a prompt and only the affected steps re-run — fast, deterministic, inspectable."
+msgstr "Les résultats sont mis en cache au niveau de l'appel LLM. Ajustez une invite et seules les étapes affectées sont relancées — rapide, déterministe, inspectable."
+
+msgid "Run the pipeline"
+msgstr "Exécuter le pipeline"
+
+msgid "RUNNING"
+msgstr "EN COURS"
+
+msgid "Runs locally"
+msgstr "Fonctionne localement"
+
+msgid "science · chapter 3"
+msgstr "science · chapitre 3"
+
+msgid "Science Textbook"
+msgstr "Manuel de science"
+
+msgid "Scroll to next section"
+msgstr "Faire défiler vers la section suivante"
+
+msgid "See all releases on GitHub"
+msgstr "Voir toutes les versions sur GitHub"
+
+msgid "See examples"
+msgstr "Voir des exemples"
+
+msgid "Segmenting scenes"
+msgstr "Segmentation des scènes"
+
+msgid "Ship the same book in every language you need. Translate text, captions and alt-text in one pass — review, edit, re-run."
+msgstr "Publiez le même livre dans chaque langue dont vous avez besoin. Traduisez le texte, les sous-titres et les textes alternatifs en une seule fois — révisez, éditez, relancez."
+
+msgid "Sign"
+msgstr "Signes"
+
+msgid "Sign language"
+msgstr "Langue des signes"
+
+msgid "Soon"
+msgstr "Bientôt"
+
+msgid "Spanish"
+msgstr "Espagnol"
+
+msgid "Speech"
+msgstr "Parole"
+
+msgid "Star"
+msgstr "Star"
+
+msgid "Star on GitHub"
+msgstr "Star sur GitHub"
+
+msgid "Start building accessible books."
+msgstr "Commencez à créer des livres accessibles."
+
+msgid "Start from a PDF"
+msgstr "Commencer à partir d'un PDF"
+
+msgid "Storyboard"
+msgstr "Storyboard"
+
+msgid "Storybook"
+msgstr "Livre d'histoires"
+
+msgid "Structured chapters and exercises. Best for educational content with complex layouts."
+msgstr "Chapitres et exercices structurés. Idéal pour le contenu éducatif avec des mises en page complexes."
+
+msgid "Structured layouts"
+msgstr "Mises en page structurées"
+
+msgid "Successfully uploaded"
+msgstr "Téléversé avec succès"
+
+msgid "Textbooks & Activities"
+msgstr "Manuels & Activités"
+
+msgid "The output"
+msgstr "La sortie"
+
+msgid "Translate"
+msgstr "Traduire"
+
+msgid "Translations"
+msgstr "Traductions"
+
+msgid "Trust"
+msgstr "Confiance"
+
+msgid "Turn any textbook into something every student can read, hear, see, and understand — audio, structured layouts, translations, and sign language, all built in."
+msgstr "Transformez n'importe quel manuel en quelque chose que chaque élève peut lire, entendre, voir et comprendre — audio, mises en page structurées, traductions et langue des signes, tout est intégré."
+
+msgid "View release on GitHub"
+msgstr "Voir la version sur GitHub"
+
+msgid "View source"
+msgstr "Voir le code source"
+
+msgid "WAITING"
+msgstr "EN ATTENTE"
+
+msgid "We couldn't fetch the latest release. Try the release page directly, or pick another platform below."
+msgstr "Nous n'avons pas pu récupérer la dernière version. Essayez directement la page de version, ou choisissez une autre plateforme ci-dessous."
+
+msgid "We couldn’t reach GitHub. The full list is always available on the upstream repo."
+msgstr "Nous n'avons pas pu atteindre GitHub. La liste complète est toujours disponible sur le dépôt en amont."
+
+msgid "We don’t ship a mobile version. To install ADT Studio, open this page on macOS, Windows, or Linux — or send the link to your computer."
+msgstr "Nous ne proposons pas de version mobile. Pour installer ADT Studio, ouvrez cette page sur macOS, Windows ou Linux — ou envoyez le lien à votre ordinateur."
+
+#. placeholder {0}: meta.label
+msgid "We don't ship a prebuilt installer for {0} in this release. Pick another platform below or follow progress on GitHub."
+msgstr "Nous ne proposons pas d'installateur préconstruit pour {0} dans cette version. Choisissez une autre plateforme ci-dessous ou suivez les progrès sur GitHub."
+
+msgid "What happens when you drop in a PDF"
+msgstr "Que se passe-t-il lorsque vous déposez un PDF"
+
+msgid "What it does"
+msgstr "Ce que ça fait"
+
+msgid "When the pipeline finishes, you get a clean bundle with every accessibility feature baked in — ready for a classroom, a publisher, or a kid on the couch."
+msgstr "Lorsque le pipeline se termine, vous obtenez un package propre avec toutes les fonctionnalités d'accessibilité intégrées — prêt pour une salle de classe, un éditeur ou un enfant sur le canapé."
+
+msgid "Windows"
+msgstr "Windows"
+
+msgid "Windows · macOS · Linux"
+msgstr "Windows · macOS · Linux"
+
+msgid "Your first accessible book <0>starts here.</0>"
+msgstr "Votre premier livre accessible <0>commence ici.</0>"
+
+msgid "Your team stays in control. Every asset is a file you can re-run, replace or roll back."
+msgstr "Votre équipe garde le contrôle. Chaque ressource est un fichier que vous pouvez relancer, remplacer ou restaurer."

--- a/apps/landing/src/locales/pt-BR.po
+++ b/apps/landing/src/locales/pt-BR.po
@@ -1,0 +1,630 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2026-06-11 13:49-0300\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: pt-BR\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#. placeholder {0}: meta.label
+msgid "{0} build is coming — track on GitHub"
+msgstr "Build para {0} está chegando — acompanhe no GitHub"
+
+#. placeholder {0}: platform.label
+#. placeholder {1}: platformResolution.release.tag_name
+#. placeholder {2}: overallLatest.tag_name
+#. placeholder {3}: platform.label
+msgid "{0} latest is <0>{1}</0> — the project is on <1>{2}</1>. A {3} build for the newer tag isn’t available yet."
+msgstr "A versão mais recente de {0} é <0>{1}</0> — o projeto está em <1>{2}</1>. Ainda não há uma build de {3} para a tag mais nova."
+
+#. placeholder {0}: new Date().getFullYear()
+msgid "© {0} ADT Studio — MIT licensed."
+msgstr "© {0} ADT Studio — Licença MIT."
+
+msgid "4 languages"
+msgstr "4 idiomas"
+
+msgid "Accessible book"
+msgstr "Livro acessível"
+
+msgid "accessible books."
+msgstr "livros acessíveis."
+
+msgid "ADT Studio"
+msgstr "ADT Studio"
+
+msgid "ADT Studio — now on macOS, Windows, Linux"
+msgstr "ADT Studio — agora no macOS, Windows, Linux"
+
+msgid "ADT Studio — Turn any PDF into an accessible book"
+msgstr "ADT Studio — Transforme qualquer PDF em um livro acessível"
+
+msgid "ADT Studio home"
+msgstr "Início do ADT Studio"
+
+msgid "ADT Studio is a desktop app"
+msgstr "ADT Studio é um aplicativo de desktop"
+
+msgid "ADT Studio is built for teachers, editors and accessibility specialists — not engineers. Every choice in the app follows four principles so your work is always safe, transparent and under your control."
+msgstr "ADT Studio é feito para professores, editores e especialistas em acessibilidade — não engenheiros. Cada escolha no aplicativo segue quatro princípios para que seu trabalho esteja sempre seguro, transparente e sob seu controle."
+
+msgid "ADT Studio is currently in"
+msgstr "ADT Studio está atualmente em"
+
+msgid "ADT Studio takes one PDF and rebuilds it as a fully-editable, fully-yours accessible book — with the pieces that used to take a team of specialists."
+msgstr "ADT Studio pega um PDF e o reconstrói como um livro acessível totalmente editável e seu — com as partes que costumavam exigir uma equipe de especialistas."
+
+msgid "Also available on"
+msgstr "Também disponível em"
+
+msgid "Alt"
+msgstr "Alt"
+
+msgid "Alt described"
+msgstr "Alt descrito"
+
+msgid "Always editable"
+msgstr "Sempre editável"
+
+msgid "An accessible book, <0>ready to ship</0>."
+msgstr "Um livro acessível, <0>pronto para enviar</0>."
+
+msgid "Architecture"
+msgstr "Arquitetura"
+
+msgid "ASL · LIBRAS"
+msgstr "ASL · LIBRAS"
+
+msgid "Attach sign-language video for ASL, LIBRAS and beyond — aligned to chapters and inspectable alongside the text."
+msgstr "Anexe vídeo em língua de sinais para ASL, LIBRAS e além — alinhado aos capítulos e inspecionável junto ao texto."
+
+msgid "Audio"
+msgstr "Áudio"
+
+msgid "Audio narration"
+msgstr "Narração em áudio"
+
+msgid "Available for"
+msgstr "Disponível para"
+
+msgid "Back to home"
+msgstr "Voltar ao início"
+
+msgid "Beta"
+msgstr "Beta"
+
+msgid "Book creation stages"
+msgstr "Etapas de criação do livro"
+
+msgid "Built with UNICEF"
+msgstr "Feito com a UNICEF"
+
+msgid "Captions"
+msgstr "Legendas"
+
+msgid "Change language"
+msgstr "Mudar idioma"
+
+msgid "Changelog"
+msgstr "Registro de alterações"
+
+msgid "Changelog — ADT Studio"
+msgstr "Registro de alterações — ADT Studio"
+
+msgid "Chapter 3"
+msgstr "Capítulo 3"
+
+msgid "Choose a preset that matches your content — textbook, storyboard, reference, or custom — and ADT Studio tailors the pipeline accordingly."
+msgstr "Escolha um preset que corresponda ao seu conteúdo — livro didático, storyboard, referência ou personalizado — e o ADT Studio ajusta o pipeline de acordo."
+
+msgid "Close menu"
+msgstr "Fechar menu"
+
+msgid "Coming soon"
+msgstr "Em breve"
+
+msgid "Configure each stage — extract, storyboard, layout — then let ADT Studio build the book. Review the output, correct anything that needs a human touch."
+msgstr "Configure cada etapa — extração, storyboard, layout — e deixe o ADT Studio construir o livro. Revise o resultado, corrija qualquer coisa que precise de um toque humano."
+
+msgid "Contents"
+msgstr "Sumário"
+
+msgid "Couldn’t load the changelog"
+msgstr "Não foi possível carregar o registro de alterações"
+
+msgid "Couldn't reach GitHub"
+msgstr "Não foi possível acessar o GitHub"
+
+msgid "Cover · Chapter 1"
+msgstr "Capa · Capítulo 1"
+
+msgid "Custom"
+msgstr "Personalizado"
+
+msgid "Delivered"
+msgstr "Entregue"
+
+msgid "Dense text, tables, glossaries. Best for technical material and documentation."
+msgstr "Texto denso, tabelas, glossários. Melhor para material técnico e documentação."
+
+msgid "Designed for the people who <0>do the work</0>."
+msgstr "Projetado para as pessoas que <0>fazem o trabalho</0>."
+
+msgid "Desktop only"
+msgstr "Apenas para desktop"
+
+msgid "Detecting figures"
+msgstr "Detectando figuras"
+
+msgid "Docs"
+msgstr "Documentação"
+
+msgid "DONE"
+msgstr "CONCLUÍDO"
+
+msgid "Download"
+msgstr "Baixar"
+
+msgid "Download — ADT Studio"
+msgstr "Baixar — ADT Studio"
+
+msgid "Download ADT Studio"
+msgstr "Baixar ADT Studio"
+
+#. placeholder {0}: detected.label
+msgid "Download for {0}"
+msgstr "Baixar para {0}"
+
+#. placeholder {0}: meta.label
+#. placeholder {1}: resolution.release.tag_name
+msgid "Download for {0} — {1} (a newer release exists for other platforms)"
+msgstr "Baixar para {0} — {1} (uma versão mais recente existe para outras plataformas)"
+
+#. placeholder {0}: meta.label
+#. placeholder {1}: resolution.release.tag_name
+msgid "Download for {0} {1}"
+msgstr "Baixar para {0} {1}"
+
+msgid "Download for free"
+msgstr "Baixar gratuitamente"
+
+msgid "downloads to date"
+msgstr "downloads até o momento"
+
+msgid "Drop a PDF to get started"
+msgstr "Solte um PDF para começar"
+
+msgid "Drop in a PDF and watch it flow through every stage — from raw pages to an accessible reader. Free, open-source, runs on your machine."
+msgstr "Solte um PDF e veja-o fluir por todas as etapas — de páginas brutas a um leitor acessível. Gratuito, código aberto, roda na sua máquina."
+
+msgid "Drop in a PDF to kick things off. ADT Studio organizes it into a new book project so you don't start from zero."
+msgstr "Solte um PDF para começar. O ADT Studio o organiza em um novo projeto de livro para que você não comece do zero."
+
+msgid "Edit & enrich"
+msgstr "Editar e enriquecer"
+
+msgid "EN · PT"
+msgstr "EN · PT"
+
+msgid "EN · PT · ES"
+msgstr "EN · PT · ES"
+
+msgid "English"
+msgstr "Inglês"
+
+msgid "Every accessibility feature, <0>built in from page one</0>."
+msgstr "Cada recurso de acessibilidade, <0>embutido desde a primeira página</0>."
+
+msgid "Every book, every learner."
+msgstr "Todo livro, todo estudante."
+
+msgid "Every edit creates a new version. Roll back any stage, compare outputs, keep a full trail of what changed and why."
+msgstr "Cada edição cria uma nova versão. Reverta qualquer etapa, compare saídas, mantenha um registro completo do que mudou e por quê."
+
+msgid "Every prompt, every LLM call, every cost is visible. Audit the whole pipeline or hand it off to the next person with confidence."
+msgstr "Cada prompt, cada chamada LLM, cada custo é visível. Audite todo o pipeline ou passe para a próxima pessoa com confiança."
+
+msgid "Every reader opens the same book, with the features they need on tap."
+msgstr "Todo leitor abre o mesmo livro, com os recursos que precisam à disposição."
+
+msgid "Every ship of ADT Studio."
+msgstr "Cada envio do ADT Studio."
+
+msgid "Everything about a book — sources, prompts, outputs, history — lives in a single directory. Zip it, share it, back it up."
+msgstr "Tudo sobre um livro — fontes, prompts, saídas, histórico — vive em um único diretório. Compacte, compartilhe, faça backup."
+
+msgid "Export to a reader"
+msgstr "Exportar para um leitor"
+
+msgid "Extract"
+msgstr "Extrair"
+
+msgid "Features"
+msgstr "Recursos"
+
+msgid "Fig 3.1 — The water cycle: evaporation, condensation, precipitation."
+msgstr "Fig 3.1 — O ciclo da água: evaporação, condensação, precipitação."
+
+msgid "Free forever"
+msgstr "Gratuito para sempre"
+
+msgid "Free, open-source, and runs on your machine. Available for macOS, Windows, and Linux."
+msgstr "Gratuito, código aberto e roda na sua máquina. Disponível para macOS, Windows e Linux."
+
+msgid "French"
+msgstr "Francês"
+
+msgid "Fresh off the <0>press</0>."
+msgstr "Quentinho do <0>forno</0>."
+
+msgid "From PDF to"
+msgstr "De PDF para"
+
+msgid "Full control over render strategies, pruning, and filters."
+msgstr "Controle total sobre estratégias de renderização, poda e filtros."
+
+msgid "Generate studio-quality text-to-speech for every page, with speaker control and per-language voices — no recording needed."
+msgstr "Gere texto-para-fala de qualidade de estúdio para cada página, com controle de locutor e vozes por idioma — sem necessidade de gravação."
+
+msgid "Generating panels"
+msgstr "Gerando painéis"
+
+msgid "Get started"
+msgstr "Começar"
+
+msgid "GitHub"
+msgstr "GitHub"
+
+msgid "Glossary"
+msgstr "Glossário"
+
+msgid "Grouping content by purpose, then laying out every section as reviewable HTML."
+msgstr "Agrupando conteúdo por propósito, depois organizando cada seção como HTML revisável."
+
+msgid "Guidelines"
+msgstr "Diretrizes"
+
+msgid "Here's what shipped in the latest version — and there are plenty more where this came from."
+msgstr "Aqui está o que foi enviado na última versão — e há muito mais de onde isso veio."
+
+msgid "Home"
+msgstr "Início"
+
+msgid "How it works"
+msgstr "Como funciona"
+
+msgid "How we build it"
+msgstr "Como construímos"
+
+msgid "HTML, audio, translations and sign-language — exported together as a single package."
+msgstr "HTML, áudio, traduções e língua de sinais — exportados juntos como um único pacote."
+
+msgid "If your device has been wrongly detected, <0>see all downloads</0>. Please report any issues you encounter on <1>GitHub</1>."
+msgstr "Se o seu dispositivo foi detectado incorretamente, <0>veja todos os downloads</0>. Por favor, relate quaisquer problemas que encontrar no <1>GitHub</1>."
+
+msgid "Issues"
+msgstr "Problemas"
+
+msgid "Language"
+msgstr "Idioma"
+
+msgid "Languages"
+msgstr "Idiomas"
+
+msgid "Large images with narrative flow. Ideal for illustrated books with rich TTS voices."
+msgstr "Imagens grandes com fluxo narrativo. Ideal para livros ilustrados com vozes TTS ricas."
+
+msgid "Latest"
+msgstr "Mais recente"
+
+msgid "Layer on translations, text-to-speech, and a glossary — all inspectable, cacheable, reversible."
+msgstr "Camada de traduções, texto-para-fala e um glossário — tudo inspecionável, armazenável em cache, reversível."
+
+msgid "Laying out spreads"
+msgstr "Diagramando spreads"
+
+msgid "License"
+msgstr "Licença"
+
+msgid "Linux"
+msgstr "Linux"
+
+msgid "LIVE"
+msgstr "AO VIVO"
+
+msgid "macOS"
+msgstr "macOS"
+
+msgid "MIT licensed"
+msgstr "Licença MIT"
+
+msgid "Narration · 0:42"
+msgstr "Narração · 0:42"
+
+msgid "New"
+msgstr "Novo"
+
+msgid "Newest first, with the full notes inline — what changed, why it matters, and the screenshots to back it up."
+msgstr "Mais recentes primeiro, com as notas completas em linha — o que mudou, por que é importante e as capturas de tela para apoiar."
+
+#. placeholder {0}: meta.label
+msgid "No {0} build yet"
+msgstr "Ainda não há build para {0}"
+
+msgid "No account needed"
+msgstr "Nenhuma conta necessária"
+
+msgid "No black boxes"
+msgstr "Sem caixas pretas"
+
+msgid "No release notes were provided for this version."
+msgstr "Nenhuma nota de lançamento foi fornecida para esta versão."
+
+msgid "No releases published yet — check back once the first build ships."
+msgstr "Nenhum lançamento publicado ainda — volte quando a primeira build for publicada."
+
+msgid "No releases yet — once the first build ships, it'll show up here."
+msgstr "Nenhum lançamento ainda — assim que a primeira build for publicada, aparecerá aqui."
+
+msgid "Nothing is overwritten"
+msgstr "Nada é sobrescrito"
+
+msgid "Now on macOS, Windows, Linux"
+msgstr "Agora no macOS, Windows, Linux"
+
+msgid "OCR & cleanup"
+msgstr "OCR e limpeza"
+
+msgid "On GitHub"
+msgstr "No GitHub"
+
+msgid "One book, every format"
+msgstr "Um livro, todos os formatos"
+
+msgid "One folder per book"
+msgstr "Uma pasta por livro"
+
+msgid "Open in the reader, on the web, or hand the bundle off to an existing LMS."
+msgstr "Abra no leitor, na web, ou entregue o pacote a um LMS existente."
+
+msgid "Open menu"
+msgstr "Abrir menu"
+
+msgid "Open on GitHub"
+msgstr "Abrir no GitHub"
+
+msgid "Open source"
+msgstr "Código aberto"
+
+msgid "Open-source desktop pipeline for turning PDFs into accessible books — built with UNICEF."
+msgstr "Pipeline de desktop de código aberto para transformar PDFs em livros acessíveis — feito com a UNICEF."
+
+msgid "Output"
+msgstr "Saída"
+
+msgid "Package the finished book with every accessibility feature baked in — ready for a kid to open, listen, and read along."
+msgstr "Empacote o livro finalizado com todos os recursos de acessibilidade embutidos — pronto para uma criança abrir, ouvir e ler junto."
+
+msgid "Parsing pages"
+msgstr "Analisando páginas"
+
+msgid "Parsing pages into text, figures, and layout boxes — cached by content hash."
+msgstr "Analisando páginas em texto, figuras e caixas de layout — armazenado em cache por hash de conteúdo."
+
+msgid "Pause"
+msgstr "Pausar"
+
+msgid "Pick a preset"
+msgstr "Escolha um preset"
+
+msgid "Pipeline · extract"
+msgstr "Pipeline · extrair"
+
+msgid "Pipeline · storyboard"
+msgstr "Pipeline · storyboard"
+
+msgid "Play"
+msgstr "Reproduzir"
+
+msgid "Portuguese (BR)"
+msgstr "Português (BR)"
+
+msgid "Pre-release — APIs and behavior may still change before the stable cut."
+msgstr "Pré-lançamento — APIs e comportamento ainda podem mudar antes da versão estável."
+
+msgid "Preview"
+msgstr "Pré-visualização"
+
+msgid "Primary"
+msgstr "Principal"
+
+msgid "Product"
+msgstr "Produto"
+
+msgid "Project"
+msgstr "Projeto"
+
+msgid "Quizzes"
+msgstr "Questionários"
+
+msgid "Raw notes on GitHub"
+msgstr "Notas originais no GitHub"
+
+msgid "Read on any device"
+msgstr "Leia em qualquer dispositivo"
+
+#. placeholder {0}: release.tag_name
+msgid "Read release {0}"
+msgstr "Leia o lançamento {0}"
+
+msgid "Read this release"
+msgstr "Leia este lançamento"
+
+msgid "Recover headings, paragraphs, figures, tables and alt-text from the source PDF as real semantic HTML — built for screen readers."
+msgstr "Recupere cabeçalhos, parágrafos, figuras, tabelas e texto alternativo do PDF de origem como HTML semântico real — feito para leitores de tela."
+
+msgid "Reference"
+msgstr "Referência"
+
+#. placeholder {0}: route.focusTag
+msgid "Release {0} — ADT Studio"
+msgstr "Lançamento {0} — ADT Studio"
+
+msgid "Release to upload"
+msgstr "Solte para enviar"
+
+#. placeholder {0}: formatRelativeDate(latest.published_at)
+msgid "Released {0}"
+msgstr "Lançado {0}"
+
+msgid "Releases"
+msgstr "Lançamentos"
+
+msgid "Rerun what matters"
+msgstr "Reexecutar o que importa"
+
+msgid "Resolving latest release…"
+msgstr "Resolvendo o último lançamento..."
+
+msgid "Results are cached at the LLM call level. Tweak a prompt and only the affected steps re-run — fast, deterministic, inspectable."
+msgstr "Os resultados são armazenados em cache no nível da chamada LLM. Ajuste um prompt e apenas as etapas afetadas serão reexecutadas — rápido, determinístico, inspecionável."
+
+msgid "Run the pipeline"
+msgstr "Executar o pipeline"
+
+msgid "RUNNING"
+msgstr "EXECUTANDO"
+
+msgid "Runs locally"
+msgstr "Roda localmente"
+
+msgid "science · chapter 3"
+msgstr "ciência · capítulo 3"
+
+msgid "Science Textbook"
+msgstr "Livro Didático de Ciências"
+
+msgid "Scroll to next section"
+msgstr "Rolar para a próxima seção"
+
+msgid "See all releases on GitHub"
+msgstr "Veja todos os lançamentos no GitHub"
+
+msgid "See examples"
+msgstr "Veja exemplos"
+
+msgid "Segmenting scenes"
+msgstr "Segmentando cenas"
+
+msgid "Ship the same book in every language you need. Translate text, captions and alt-text in one pass — review, edit, re-run."
+msgstr "Envie o mesmo livro em todos os idiomas que você precisa. Traduza texto, legendas e texto alternativo em uma única passagem — revise, edite, reexecute."
+
+msgid "Sign"
+msgstr "Sinais"
+
+msgid "Sign language"
+msgstr "Língua de sinais"
+
+msgid "Soon"
+msgstr "Em breve"
+
+msgid "Spanish"
+msgstr "Espanhol"
+
+msgid "Speech"
+msgstr "Fala"
+
+msgid "Star"
+msgstr "Star"
+
+msgid "Star on GitHub"
+msgstr "Star no GitHub"
+
+msgid "Start building accessible books."
+msgstr "Comece a construir livros acessíveis."
+
+msgid "Start from a PDF"
+msgstr "Comece de um PDF"
+
+msgid "Storyboard"
+msgstr "Storyboard"
+
+msgid "Storybook"
+msgstr "Livro de histórias"
+
+msgid "Structured chapters and exercises. Best for educational content with complex layouts."
+msgstr "Capítulos e exercícios estruturados. Melhor para conteúdo educacional com layouts complexos."
+
+msgid "Structured layouts"
+msgstr "Layouts estruturados"
+
+msgid "Successfully uploaded"
+msgstr "Enviado com sucesso"
+
+msgid "Textbooks & Activities"
+msgstr "Livros Didáticos e Atividades"
+
+msgid "The output"
+msgstr "A saída"
+
+msgid "Translate"
+msgstr "Traduzir"
+
+msgid "Translations"
+msgstr "Traduções"
+
+msgid "Trust"
+msgstr "Confiança"
+
+msgid "Turn any textbook into something every student can read, hear, see, and understand — audio, structured layouts, translations, and sign language, all built in."
+msgstr "Transforme qualquer livro didático em algo que todo aluno possa ler, ouvir, ver e entender — áudio, layouts estruturados, traduções e língua de sinais, tudo embutido."
+
+msgid "View release on GitHub"
+msgstr "Ver lançamento no GitHub"
+
+msgid "View source"
+msgstr "Ver código-fonte"
+
+msgid "WAITING"
+msgstr "AGUARDANDO"
+
+msgid "We couldn't fetch the latest release. Try the release page directly, or pick another platform below."
+msgstr "Não conseguimos buscar o último lançamento. Tente a página de lançamento diretamente ou escolha outra plataforma abaixo."
+
+msgid "We couldn’t reach GitHub. The full list is always available on the upstream repo."
+msgstr "Não conseguimos acessar o GitHub. A lista completa está sempre disponível no repositório upstream."
+
+msgid "We don’t ship a mobile version. To install ADT Studio, open this page on macOS, Windows, or Linux — or send the link to your computer."
+msgstr "Não fornecemos uma versão móvel. Para instalar o ADT Studio, abra esta página no macOS, Windows ou Linux — ou envie o link para o seu computador."
+
+#. placeholder {0}: meta.label
+msgid "We don't ship a prebuilt installer for {0} in this release. Pick another platform below or follow progress on GitHub."
+msgstr "Não fornecemos um instalador pré-construído para {0} nesta versão. Escolha outra plataforma abaixo ou acompanhe o progresso no GitHub."
+
+msgid "What happens when you drop in a PDF"
+msgstr "O que acontece quando você solta um PDF"
+
+msgid "What it does"
+msgstr "O que faz"
+
+msgid "When the pipeline finishes, you get a clean bundle with every accessibility feature baked in — ready for a classroom, a publisher, or a kid on the couch."
+msgstr "Quando o pipeline termina, você obtém um pacote limpo com todos os recursos de acessibilidade embutidos — pronto para uma sala de aula, um editor ou uma criança no sofá."
+
+msgid "Windows"
+msgstr "Windows"
+
+msgid "Windows · macOS · Linux"
+msgstr "Windows · macOS · Linux"
+
+msgid "Your first accessible book <0>starts here.</0>"
+msgstr "Seu primeiro livro acessível <0>começa aqui.</0>"
+
+msgid "Your team stays in control. Every asset is a file you can re-run, replace or roll back."
+msgstr "Sua equipe permanece no controle. Cada recurso é um arquivo que você pode reexecutar, substituir ou reverter."

--- a/apps/landing/src/main.tsx
+++ b/apps/landing/src/main.tsx
@@ -1,10 +1,17 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import { I18nProvider } from "@lingui/react";
+import { i18n } from "@lingui/core";
 import "./globals.css";
 import { App } from "./App";
+import { initI18n } from "./i18n/setup";
+
+initI18n();
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <App />
+    <I18nProvider i18n={i18n}>
+      <App />
+    </I18nProvider>
   </StrictMode>,
 );

--- a/apps/landing/src/vite-env.d.ts
+++ b/apps/landing/src/vite-env.d.ts
@@ -1,1 +1,7 @@
 /// <reference types="vite/client" />
+
+declare module "*.po" {
+  import type { Messages } from "@lingui/core";
+  const messages: Messages;
+  export { messages };
+}

--- a/apps/landing/vite.config.ts
+++ b/apps/landing/vite.config.ts
@@ -1,10 +1,19 @@
+import { lingui } from "@lingui/vite-plugin";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import { fileURLToPath, URL } from "node:url";
 
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [
+    lingui(),
+    react({
+      babel: {
+        plugins: ["@lingui/babel-plugin-lingui-macro"],
+      },
+    }),
+    tailwindcss(),
+  ],
   base: process.env.LANDING_BASE ?? "/",
   resolve: {
     alias: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,6 +94,12 @@ importers:
 
   apps/landing:
     dependencies:
+      '@lingui/core':
+        specifier: ^5.9.3
+        version: 5.9.3(@lingui/babel-plugin-lingui-macro@5.9.3(babel-plugin-macros@3.1.0)(typescript@5.9.3))(babel-plugin-macros@3.1.0)
+      '@lingui/react':
+        specifier: ^5.9.3
+        version: 5.9.3(@lingui/babel-plugin-lingui-macro@5.9.3(babel-plugin-macros@3.1.0)(typescript@5.9.3))(babel-plugin-macros@3.1.0)(react@19.2.4)
       clsx:
         specifier: ^2.1.0
         version: 2.1.1
@@ -122,6 +128,24 @@ importers:
         specifier: ^3.0.0
         version: 3.4.0
     devDependencies:
+      '@ai-sdk/openai':
+        specifier: ^1.0.0
+        version: 1.3.24(zod@3.25.76)
+      '@lingui/babel-plugin-lingui-macro':
+        specifier: ^5.9.3
+        version: 5.9.3(babel-plugin-macros@3.1.0)(typescript@5.9.3)
+      '@lingui/cli':
+        specifier: ^5.9.3
+        version: 5.9.3(babel-plugin-macros@3.1.0)(typescript@5.9.3)
+      '@lingui/conf':
+        specifier: ^5.9.3
+        version: 5.9.3(typescript@5.9.3)
+      '@lingui/macro':
+        specifier: ^5.9.3
+        version: 5.9.3(@lingui/babel-plugin-lingui-macro@5.9.3(babel-plugin-macros@3.1.0)(typescript@5.9.3))(babel-plugin-macros@3.1.0)(react@19.2.4)
+      '@lingui/vite-plugin':
+        specifier: ^5.9.3
+        version: 5.9.3(babel-plugin-macros@3.1.0)(typescript@5.9.3)(vite@6.4.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
       '@tailwindcss/vite':
         specifier: ^4.0.0
         version: 4.1.18(vite@6.4.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
@@ -134,15 +158,36 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.3.0
         version: 4.7.0(vite@6.4.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
+      ai:
+        specifier: ^4.0.0
+        version: 4.3.19(react@19.2.4)(zod@3.25.76)
+      babel-plugin-macros:
+        specifier: ^3.1.0
+        version: 3.1.0
+      eslint:
+        specifier: ^9
+        version: 9.39.4(jiti@2.6.1)
+      eslint-plugin-lingui:
+        specifier: ^0.11.0
+        version: 0.11.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       tailwindcss:
         specifier: ^4.0.0
         version: 4.1.18
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       typescript:
         specifier: ^5
         version: 5.9.3
+      typescript-eslint:
+        specifier: ^8
+        version: 8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       vite:
         specifier: ^6.0.0
         version: 6.4.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+      zod:
+        specifier: ^3.24.0
+        version: 3.25.76
 
   apps/studio:
     dependencies:


### PR DESCRIPTION
## Summary

Adds full internationalization to the landing site (`apps/landing`), mirroring the mechanism already used in `apps/studio` (Lingui v5).

- **Setup:** `lingui.config.ts`, Vite plugin + babel macro, `<I18nProvider>` in `main.tsx`, and locale detection (`?lang` → `localStorage` → browser language → `en`).
- **Locale switcher:** self-contained `LocaleSwitcher` in the nav (no shadcn dependency), persists choice to URL + `localStorage`.
- **String wrapping:** every user-visible string wrapped with `<Trans>` / `t\`\`` / `msg\`\`` across sections, pages, and data files (stage/preset/nav labels as message descriptors). Mock/demo content in the animation scenes, brand/format codes, and OS names left untranslated.
- **Catalogs:** `en`, `pt-BR`, `es`, `fr` `.po` files. Machine-translated, then **reviewed** for too-literal phrasing and for terms that should stay in English/are context-sensitive (e.g. `build`, `preset`, `storyboard`, `pipeline`, `Star`; fixed mistranslations like "Sign"→sign-language, "View source"→source code).
- **Tooling (parity with studio):** ESLint flat config with `lingui/no-unlocalized-strings` + a suppressions baseline; `extract` / `compile` scripts; and an OpenAI-backed `translate:missing` script.

Compiled `.js` catalogs are gitignored (only `.po` is committed), matching `apps/studio`.

## Validation
- `tsc -b` ✅
- `pnpm --filter @adt/landing lint` ✅
- `pnpm --filter @adt/landing compile --strict` ✅

## Issue
Implements #368 — `[Landing Page] Add i18n to the landing page (en, pt-BR, es, fr)`.

> Note: this PR targets `landing-page`, so merging it will not auto-close #368 (GitHub only auto-closes on merge to the default branch). The issue will close when `landing-page` reaches `main`, or can be closed manually.