### PR TITLE
feat(epub): glossary support for EPUB 3 export

### DIFF
--- a/apps/studio/src/components/wizard/bookCreationConfig.ts
+++ b/apps/studio/src/components/wizard/bookCreationConfig.ts
@@ -1,5 +1,6 @@
 import type { WizardFormValues } from "./wizardForm"
 import { PRESETS } from "./constants"
+import { SECTION_TYPES } from "@/lib/section-constants"
 
 function parsePositiveInt(raw: string): number | undefined {
   const n = Number(raw.trim())
@@ -21,6 +22,25 @@ export function buildConfigOverrides(values: WizardFormValues): Record<string, u
     (name) => renderStrategies[name].render_type === "activity"
   )
 
+  // Section types to leave out of activity detection. Two independent reasons
+  // to seed an activity type as disabled (the Sectioning page reads/writes
+  // disabled_section_types and shows the toggle accordingly — still
+  // overridable there):
+  const disabledSectionTypes = new Set<string>()
+  // 1. Activities generator off → skip the activity render strategies the
+  //    preset defines.
+  if (!values.activitiesGenerator) {
+    for (const name of activityTypeNames) disabledSectionTypes.add(name)
+  }
+  // 2. Fixed layout bakes activities into the page image, so they shouldn't be
+  //    split into their own interactive sections — disable the activity
+  //    section types by default.
+  if (values.renderStrategy === "fixed_layout") {
+    for (const { value } of SECTION_TYPES) {
+      if (value.startsWith("activity_")) disabledSectionTypes.add(value)
+    }
+  }
+
   const config: Record<string, unknown> = {
     ...baseConfig,
     default_render_strategy: values.renderStrategy,
@@ -28,8 +48,8 @@ export function buildConfigOverrides(values: WizardFormValues): Record<string, u
     spread_mode: values.pageGrouping === "spread",
     vector_text_grouping: values.figureExtraction,
     apply_body_background: true,
-    ...(!values.activitiesGenerator && activityTypeNames.length > 0 && {
-      disabled_section_types: activityTypeNames,
+    ...(disabledSectionTypes.size > 0 && {
+      disabled_section_types: Array.from(disabledSectionTypes),
     }),
     image_filters: {
       ...baseImageFilters,

--- a/packages/pipeline/src/__tests__/epub-glossary.test.ts
+++ b/packages/pipeline/src/__tests__/epub-glossary.test.ts
@@ -1,0 +1,310 @@
+import { describe, it, expect } from "vitest"
+import { JSDOM } from "jsdom"
+import {
+  buildGlossaryDocument,
+  loadGlossaryEntries,
+  wrapGlossaryTerms,
+  type GlossaryBacklink,
+} from "../epub-glossary.js"
+
+// Minimal XHTML scaffold so JSDOM can parse with contentType:
+// application/xhtml+xml. Keep this tight — we only care about the body
+// payload in the assertions.
+function xhtml(body: string): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<head><meta charset="UTF-8"/><title>t</title></head>
+<body>
+${body}
+</body>
+</html>`
+}
+
+/**
+ * Parse a string as strict XML. Returns the `<parsererror>` text if the
+ * document is not well-formed, else null — mirroring how a strict EPUB
+ * reader (e.g. BookFusion) rejects a malformed page.
+ */
+function xmlParseError(src: string): string | null {
+  const win = new JSDOM("").window
+  const parsed = new win.DOMParser().parseFromString(src, "application/xml")
+  const err = parsed.querySelector("parsererror")
+  return err ? err.textContent : null
+}
+
+/** Build the backlinksByEntry map the document builder expects. */
+function backlinks(
+  pairs: Record<string, GlossaryBacklink[]>,
+): Map<string, GlossaryBacklink[]> {
+  return new Map(Object.entries(pairs))
+}
+
+const VOLCANO_JSON = {
+  volcano: {
+    word: "volcano",
+    definition: "A mountain that erupts molten rock.",
+    variations: ["volcanoes"],
+    emoji: "🌋",
+  },
+  lava: {
+    word: "lava",
+    definition: "Molten rock that has reached the surface.",
+    variations: [],
+    emoji: "",
+  },
+  "data set": {
+    word: "data set",
+    definition: "A collection of related data.",
+    variations: [],
+    emoji: "",
+  },
+  data: {
+    word: "data",
+    definition: "Facts and statistics.",
+    variations: [],
+    emoji: "",
+  },
+}
+
+describe("loadGlossaryEntries", () => {
+  it("assigns stable, padded ids in declaration order", () => {
+    const entries = loadGlossaryEntries(VOLCANO_JSON)
+    expect(entries.map((e) => e.id)).toEqual([
+      "gl_001",
+      "gl_002",
+      "gl_003",
+      "gl_004",
+    ])
+    expect(entries[0].word).toBe("volcano")
+  })
+
+  it("returns [] for undefined / empty input", () => {
+    expect(loadGlossaryEntries(undefined)).toEqual([])
+    expect(loadGlossaryEntries({})).toEqual([])
+  })
+})
+
+describe("wrapGlossaryTerms", () => {
+  it("wraps the first matching term in <a epub:type=\"glossref\">", () => {
+    const entries = loadGlossaryEntries(VOLCANO_JSON)
+    const input = xhtml(
+      `<p data-id="p1"><span id="p1_w001">A</span> <span id="p1_w002">volcano</span> <span id="p1_w003">erupts</span>.</p>`,
+    )
+    const { xhtml: out, occurrences } = wrapGlossaryTerms(input, entries)
+    expect(occurrences).toEqual([{ entryId: "gl_001", fragment: "p1_w002" }])
+    expect(out).toContain(`epub:type="glossref"`)
+    expect(out).toContain(`href="glossary.xhtml#gl_001"`)
+    // Styling hook for the dotted-underline affordance (CSS ships separately).
+    expect(out).toContain(`class="glossref"`)
+    // The word-span stays untouched inside the anchor so SMIL fragment refs
+    // (page.xhtml#p1_w002) still resolve.
+    expect(out).toMatch(
+      /<a[^>]*epub:type="glossref"[^>]*><span id="p1_w002">volcano<\/span><\/a>/,
+    )
+  })
+
+  it("reports the inner word-span id as the backlink fragment", () => {
+    const entries = loadGlossaryEntries(VOLCANO_JSON)
+    const input = xhtml(
+      `<p data-id="p1"><span id="p1_w001">A</span> <span id="p1_w002">volcano</span>.</p>`,
+    )
+    const { occurrences } = wrapGlossaryTerms(input, entries)
+    expect(occurrences[0].fragment).toBe("p1_w002")
+  })
+
+  it("stamps the anchor with a fallback id when no inner id exists", () => {
+    const entries = loadGlossaryEntries(VOLCANO_JSON)
+    const input = xhtml(`<p data-id="p1">a volcano erupts.</p>`)
+    const { xhtml: out, occurrences } = wrapGlossaryTerms(input, entries)
+    expect(occurrences[0].fragment).toBe("glref_gl_001")
+    expect(out).toContain(`id="glref_gl_001"`)
+  })
+
+  it("matches variations and resolves them to the parent entry", () => {
+    const entries = loadGlossaryEntries(VOLCANO_JSON)
+    const input = xhtml(
+      `<p data-id="p1"><span id="p1_w001">Two</span> <span id="p1_w002">volcanoes</span>.</p>`,
+    )
+    const { xhtml: out, occurrences } = wrapGlossaryTerms(input, entries)
+    expect(occurrences[0].entryId).toBe("gl_001")
+    expect(out).toContain(`href="glossary.xhtml#gl_001"`)
+    expect(out).toContain(`<span id="p1_w002">volcanoes</span>`)
+  })
+
+  it("emits only first occurrence per page across paragraphs", () => {
+    const entries = loadGlossaryEntries(VOLCANO_JSON)
+    const input = xhtml(
+      `<p data-id="p1"><span id="p1_w001">A</span> <span id="p1_w002">volcano</span>.</p>
+       <p data-id="p2"><span id="p2_w001">Another</span> <span id="p2_w002">volcano</span>.</p>`,
+    )
+    const { xhtml: out, occurrences } = wrapGlossaryTerms(input, entries)
+    expect(occurrences.filter((o) => o.entryId === "gl_001")).toHaveLength(1)
+    expect((out.match(/href="glossary\.xhtml#gl_001"/g) ?? []).length).toBe(1)
+  })
+
+  it("prefers the longer multi-word term over a substring match", () => {
+    const entries = loadGlossaryEntries(VOLCANO_JSON)
+    const input = xhtml(
+      `<p data-id="p1"><span id="p1_w001">The</span> <span id="p1_w002">data</span> <span id="p1_w003">set</span>.</p>`,
+    )
+    const { xhtml: out, occurrences } = wrapGlossaryTerms(input, entries)
+    const ids = occurrences.map((o) => o.entryId)
+    expect(ids).toContain("gl_003") // "data set"
+    expect(ids).not.toContain("gl_004") // "data"
+    expect(out).toContain(`href="glossary.xhtml#gl_003"`)
+    expect(out).not.toContain(`href="glossary.xhtml#gl_004"`)
+    expect(out).toMatch(
+      /<a[^>]*gl_003[^>]*><span id="p1_w002">data<\/span> <span id="p1_w003">set<\/span><\/a>/,
+    )
+  })
+
+  it("skips headings and activity items", () => {
+    const entries = loadGlossaryEntries(VOLCANO_JSON)
+    const input = xhtml(
+      `<h1 data-id="h1"><span id="h1_w001">volcano</span></h1>
+       <div class="activity-text" data-id="a1"><span id="a1_w001">volcano</span></div>
+       <p data-id="p1"><span id="p1_w001">volcano</span></p>`,
+    )
+    const { xhtml: out, occurrences } = wrapGlossaryTerms(input, entries)
+    expect(occurrences).toHaveLength(1)
+    expect(out).toMatch(/<h1[^>]*><span id="h1_w001">volcano<\/span><\/h1>/)
+    expect(out).toMatch(
+      /<div class="activity-text"[^>]*><span id="a1_w001">volcano<\/span><\/div>/,
+    )
+    expect(out).toMatch(
+      /<p[^>]*><a[^>]*gl_001[^>]*><span id="p1_w001">volcano<\/span><\/a><\/p>/,
+    )
+  })
+
+  it("returns input untouched when there are no entries", () => {
+    const input = xhtml(`<p data-id="p1"><span id="p1_w001">volcano</span></p>`)
+    const { xhtml: out, occurrences } = wrapGlossaryTerms(input, [])
+    expect(out).toBe(input)
+    expect(occurrences).toHaveLength(0)
+  })
+
+  it("declares xmlns:epub on <html> only when a glossref is emitted", () => {
+    const entries = loadGlossaryEntries(VOLCANO_JSON)
+    const matching = xhtml(`<p data-id="p1"><span id="p1_w001">volcano</span></p>`)
+    const empty = xhtml(`<p data-id="p1"><span id="p1_w001">unrelated</span></p>`)
+    expect(wrapGlossaryTerms(matching, entries).xhtml).toContain(
+      `xmlns:epub="http://www.idpf.org/2007/ops"`,
+    )
+    expect(wrapGlossaryTerms(empty, entries).xhtml).not.toContain(`xmlns:epub=`)
+  })
+
+  it("respects \\b — does not match a term inside a longer word", () => {
+    const entries = loadGlossaryEntries({
+      cat: { word: "cat", definition: "feline", variations: [], emoji: "" },
+    })
+    const input = xhtml(`<p data-id="p1"><span id="p1_w001">concatenate</span></p>`)
+    const { occurrences } = wrapGlossaryTerms(input, entries)
+    expect(occurrences).toHaveLength(0)
+  })
+
+  it("emits a single well-formed prologue (no duplicate DOCTYPE)", () => {
+    // Regression: JSDOM serialize() emits the DOCTYPE but not the XML
+    // declaration. A naive re-attach stacked a second <!DOCTYPE>, which is a
+    // fatal XML parse error and broke loading in strict EPUB readers.
+    const entries = loadGlossaryEntries(VOLCANO_JSON)
+    const input = xhtml(`<p data-id="p1"><span id="p1_w001">volcano</span></p>`)
+    const { xhtml: out } = wrapGlossaryTerms(input, entries)
+    expect(out.match(/<!DOCTYPE/gi)?.length).toBe(1)
+    expect(out.match(/<\?xml/gi)?.length).toBe(1)
+    expect(out.indexOf("<?xml")).toBe(0)
+    expect(xmlParseError(out)).toBeNull()
+  })
+
+  it("stays well-formed when no term matches (round-trip prologue)", () => {
+    const entries = loadGlossaryEntries(VOLCANO_JSON)
+    const input = xhtml(`<p data-id="p1"><span id="p1_w001">unrelated</span></p>`)
+    const { xhtml: out } = wrapGlossaryTerms(input, entries)
+    expect(out.match(/<!DOCTYPE/gi)?.length).toBe(1)
+    expect(xmlParseError(out)).toBeNull()
+  })
+})
+
+describe("buildGlossaryDocument", () => {
+  it("emits a doc-glossary dl with one dt/dd per referenced entry", () => {
+    const entries = loadGlossaryEntries(VOLCANO_JSON)
+    const xml = buildGlossaryDocument({
+      language: "en",
+      heading: "Glossary",
+      entries,
+      backlinksByEntry: backlinks({
+        gl_001: [{ href: "pg002_sec001.xhtml#pg002_p3_w006", label: "Page 3" }],
+        gl_002: [],
+      }),
+    })
+    expect(xml).toContain(`<title>Glossary</title>`)
+    expect(xml).toContain(`xmlns:epub="http://www.idpf.org/2007/ops"`)
+    expect(xml).toContain(`epub:type="glossary"`)
+    expect(xml).toContain(`role="doc-glossary"`)
+    expect(xml).toContain(`<dt id="gl_001"><dfn>volcano</dfn></dt>`)
+    expect(xml).toContain(`<dt id="gl_002"><dfn>lava</dfn></dt>`)
+    expect(xml).not.toContain(`id="gl_003"`)
+    // Backlink nav with epub:type="backlink" so the reader extracts "Used in".
+    expect(xml).toContain(
+      `<a epub:type="backlink" href="pg002_sec001.xhtml#pg002_p3_w006">Page 3</a>`,
+    )
+    // Alphabetised: "lava" before "volcano" regardless of declaration order.
+    expect(xml.indexOf(">lava<")).toBeLessThan(xml.indexOf(">volcano<"))
+  })
+
+  it("is parseable by the reader's glossary contract (dl/dt[id]/dfn/dd)", () => {
+    // Mirror app/services/glossary-parser.ts in the web-reader: find a
+    // glossary container, then dt(id)+dfn / dd pairs inside its <dl>.
+    const entries = loadGlossaryEntries(VOLCANO_JSON)
+    const xml = buildGlossaryDocument({
+      language: "en",
+      heading: "Glossary",
+      entries,
+      backlinksByEntry: backlinks({
+        gl_001: [{ href: "pg002_sec001.xhtml#x", label: "Page 3" }],
+      }),
+    })
+    const doc = new (new JSDOM("").window.DOMParser)().parseFromString(
+      xml,
+      "application/xml",
+    )
+    const container = doc.querySelector('[role="doc-glossary"]')
+    expect(container).not.toBeNull()
+    const dt = container!.querySelector("dl > dt")
+    expect(dt?.getAttribute("id")).toBe("gl_001")
+    expect(dt?.querySelector("dfn")?.textContent).toBe("volcano")
+    expect(container!.querySelector("dl > dd")).not.toBeNull()
+  })
+
+  it("escapes special characters in the heading + definition", () => {
+    const entries = loadGlossaryEntries({
+      ampersand: {
+        word: "&fun",
+        definition: `quotes "ok" & angles <>`,
+        variations: [],
+        emoji: "",
+      },
+    })
+    const xml = buildGlossaryDocument({
+      language: "en",
+      heading: "Glossary <test>",
+      entries,
+      backlinksByEntry: backlinks({ gl_001: [] }),
+    })
+    expect(xml).toContain(`<title>Glossary &lt;test&gt;</title>`)
+    expect(xml).toContain(`&amp;fun`)
+    expect(xml).toContain(`quotes &quot;ok&quot; &amp; angles &lt;&gt;`)
+    expect(xmlParseError(xml)).toBeNull()
+  })
+
+  it("omits entries that weren't referenced", () => {
+    const entries = loadGlossaryEntries(VOLCANO_JSON)
+    const xml = buildGlossaryDocument({
+      language: "en",
+      heading: "Glossary",
+      entries,
+      backlinksByEntry: backlinks({}),
+    })
+    expect(xml).not.toContain(`<dt`)
+  })
+})

--- a/packages/pipeline/src/__tests__/package-epub.test.ts
+++ b/packages/pipeline/src/__tests__/package-epub.test.ts
@@ -106,6 +106,31 @@ describe("wrapWordSpans", () => {
     )
   })
 
+  it("styles inter-word separators with the surrounding segment so spaces keep the display font-size", () => {
+    // Regression: in fixed-layout the font-size lives only on the per-segment
+    // span and the <p> has none, so a bare-text-node space inherits the page
+    // default (~16px) and a gap between two 48px words renders ~4px wide —
+    // the words look unspaced. The separator must be wrapped in a span
+    // carrying the segment style.
+    const segments = [
+      { text: "I am", style: { "font-size": "48px", color: "#000000" } },
+    ]
+    const dataSegments = JSON.stringify(segments).replace(/"/g, "&quot;")
+    const html =
+      `<html><body><p data-id="pg001_p000" data-segments="${dataSegments}">` +
+      `<span style="font-size:48px;color:#000000">I am</span>` +
+      `</p></body></html>`
+    const out = wrapWordSpans(html)
+    // The space between the two words is wrapped in a font-sized span, not a
+    // bare text node directly under <p>.
+    expect(out).toMatch(
+      /<span id="pg001_p000_w001"><span style="font-size:48px;color:#000000">I<\/span><\/span><span style="font-size:48px;color:#000000"> <\/span><span id="pg001_p000_w002">/,
+    )
+    // And no bare space sits directly between the closing word span and the
+    // next word span.
+    expect(out).not.toContain(`</span> <span id="pg001_p000_w002"`)
+  })
+
   it("applies the bundled font-family fallback to data-segments styles", () => {
     // wrapBySegments must use the same styleMapToInline as the renderer so
     // the exported EPUB renders fonts the same way the in-studio viewer

--- a/packages/pipeline/src/__tests__/package-web.test.ts
+++ b/packages/pipeline/src/__tests__/package-web.test.ts
@@ -6,6 +6,7 @@ import type { Storage, PageData } from "@adt/storage"
 import {
   computePackagingInputHash,
   buildGlossaryJson,
+  injectWebpubStyles,
   packageAdtWeb,
   packageWebpub,
   renderPageHtml,
@@ -1821,6 +1822,41 @@ describe("convertLatexToMathml (HTML)", () => {
   })
 })
 
+describe("injectWebpubStyles", () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "inject-styles-"))
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  function writePage(): string {
+    const p = path.join(tmpDir, "index.html")
+    fs.writeFileSync(p, "<html><head><title>t</title></head><body>x</body></html>")
+    return p
+  }
+
+  it("splices extraCss into the injected <style> block, before </style>", () => {
+    const p = writePage()
+    injectWebpubStyles(tmpDir, { fixedLayout: true, extraCss: ".glossref { color: red }" })
+    const html = fs.readFileSync(p, "utf-8")
+    expect(html).toContain(".glossref { color: red }")
+    // Inside the single injected style block, not after it.
+    const styleClose = html.indexOf("</style>")
+    expect(html.indexOf(".glossref")).toBeLessThan(styleClose)
+    expect(html.indexOf(".glossref")).toBeGreaterThan(html.indexOf("<style>"))
+  })
+
+  it("omits extraCss when not provided", () => {
+    const p = writePage()
+    injectWebpubStyles(tmpDir, { fixedLayout: true })
+    expect(fs.readFileSync(p, "utf-8")).not.toContain(".glossref")
+  })
+})
+
 describe("packageWebpub", () => {
   let tmpDir: string
 
@@ -1935,6 +1971,8 @@ describe("packageWebpub", () => {
     expect(html).toContain("columns: auto !important")
     expect(html).toContain("flex-direction: column !important")
     expect(html).toContain("max-width: 100% !important")
+    // The glossref affordance is EPUB-only; webpub must not carry it.
+    expect(html).not.toContain(".glossref")
   })
 
   it("writes a valid webpub manifest with scrolled presentation", async () => {

--- a/packages/pipeline/src/epub-glossary.ts
+++ b/packages/pipeline/src/epub-glossary.ts
@@ -1,0 +1,375 @@
+/**
+ * EPUB-native glossary surface, built to the EPUB 3 Dictionaries &
+ * Glossaries model that the BookFusion reader consumes:
+ *
+ *   - Each first occurrence of a term on a page becomes an
+ *     `<a epub:type="glossref" href="glossary.xhtml#gl_NNN">…</a>` wrapping
+ *     the existing word `<span id>` elements. The reader resolves the
+ *     fragment against the parsed glossary and shows a definition popover.
+ *   - `glossary.xhtml` is a `<section epub:type="glossary" role="doc-glossary">`
+ *     containing a `<dl>` of `<dt id="gl_NNN"><dfn>term</dfn></dt><dd>…</dd>`
+ *     entries. The reader's glossary parser keys off this exact shape; the
+ *     `<dd>` may carry a `<nav>` of `epub:type="backlink"` anchors pointing
+ *     back at the in-text occurrences ("Used in").
+ *   - A `<nav epub:type="landmarks">` entry of `epub:type="glossary"` in the
+ *     navigation document is what surfaces the reader's Glossary tab.
+ *
+ * Matching mirrors the web runtime (apps/adt-runtime/src/features/glossary/
+ * lib/highlight.ts): longest-first, case-insensitive, `\b…\b`, variations
+ * canonicalised to the parent word, first-occurrence per page.
+ *
+ * The footnote/`noteref` model (a different reader code path) is deliberately
+ * not used: it never registers as a glossary, so no tab would appear.
+ */
+import { JSDOM } from "jsdom"
+
+export interface GlossaryEntry {
+  /** Stable EPUB id used in href fragments + `<dt>` ids (`gl_001` …). */
+  id: string
+  /** Canonical (already translated) headword. */
+  word: string
+  definition: string
+  variations: string[]
+  emoji: string
+}
+
+/** A reference to one in-text occurrence, used to build backlinks. */
+export interface GlossaryBacklink {
+  /** Resolvable href to the occurrence, e.g. `pg002_sec001.xhtml#pg002_p0_w006`. */
+  href: string
+  /** Human label for the link, e.g. `Page 3`. */
+  label: string
+}
+
+/** Shape of `OEBPS/content/i18n/<lang>/glossary.json` (see buildGlossaryJson). */
+type GlossaryJson = Record<
+  string,
+  { word: string; definition: string; variations: string[]; emoji: string }
+>
+
+const XHTML_NS = "http://www.w3.org/1999/xhtml"
+const EPUB_NS = "http://www.idpf.org/2007/ops"
+
+/** Paragraphs we never turn into a glossref — same intent as the web SKIP list. */
+const SKIP_PARENT_SELECTOR =
+  "h1, h2, h3, h4, h5, h6, nav, .activity-text, [data-activity-item], .word-card"
+
+// ---------------------------------------------------------------------------
+// Loading
+// ---------------------------------------------------------------------------
+
+/**
+ * Read the glossary JSON for a language, assign stable EPUB ids, and return
+ * the list in declaration order. Returns an empty list if the file is
+ * missing or empty so callers can branch on `length === 0`.
+ */
+export function loadGlossaryEntries(json: GlossaryJson | undefined): GlossaryEntry[] {
+  if (!json) return []
+  const entries: GlossaryEntry[] = []
+  let i = 0
+  for (const [, raw] of Object.entries(json)) {
+    i += 1
+    entries.push({
+      id: `gl_${String(i).padStart(3, "0")}`,
+      word: raw.word,
+      definition: raw.definition,
+      variations: raw.variations ?? [],
+      emoji: raw.emoji ?? "",
+    })
+  }
+  return entries
+}
+
+// ---------------------------------------------------------------------------
+// Matcher (port of apps/adt-runtime/src/features/glossary/lib/highlight.ts)
+// ---------------------------------------------------------------------------
+
+interface TermDescriptor {
+  /** Text to match (variation or canonical). */
+  text: string
+  /** Entry id this match resolves to. */
+  entryId: string
+  /** Lowercase dedupe key — variations of the same word share it. */
+  baseForm: string
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
+
+function buildDescriptors(entries: GlossaryEntry[]): TermDescriptor[] {
+  const items: TermDescriptor[] = []
+  for (const e of entries) {
+    const baseForm = e.word.toLowerCase().replace(/[es]?s$/, "")
+    items.push({ text: e.word, entryId: e.id, baseForm })
+    for (const v of e.variations) {
+      items.push({
+        text: v,
+        entryId: e.id,
+        baseForm: v.toLowerCase().replace(/[es]?s$/, ""),
+      })
+    }
+  }
+  // Longest first so multi-word terms beat their substrings.
+  items.sort((a, b) => b.text.length - a.text.length)
+  return items
+}
+
+// ---------------------------------------------------------------------------
+// DOM wrapping
+// ---------------------------------------------------------------------------
+
+/** One in-text occurrence found while wrapping a page. */
+export interface GlossaryOccurrence {
+  entryId: string
+  /** Id of an element inside the glossref anchor, for backlink targeting. */
+  fragment: string
+}
+
+/**
+ * Wrap glossary terms in each `[data-id]` paragraph of an XHTML page.
+ * Returns the rewritten XHTML and the occurrences found on this page (one
+ * per first-matched term), so the caller can build per-entry backlinks.
+ */
+export function wrapGlossaryTerms(
+  xhtml: string,
+  entries: GlossaryEntry[],
+): { xhtml: string; occurrences: GlossaryOccurrence[] } {
+  if (entries.length === 0) return { xhtml, occurrences: [] }
+
+  const dom = new JSDOM(xhtml, { contentType: "application/xhtml+xml" })
+  const doc = dom.window.document
+
+  const descriptors = buildDescriptors(entries)
+  const occurrences: GlossaryOccurrence[] = []
+  // First-occurrence-per-page — reset between pages, matching the web
+  // runtime's per-section scope.
+  const seen = new Set<string>()
+
+  for (const para of Array.from(doc.querySelectorAll("[data-id]"))) {
+    if (para.tagName.toLowerCase() === "img") continue
+    if (para.closest(SKIP_PARENT_SELECTOR)) continue
+    wrapInParagraph(para, descriptors, seen, occurrences)
+  }
+
+  if (occurrences.length > 0) ensureEpubNamespace(doc)
+  return { xhtml: serializeXhtml(dom), occurrences }
+}
+
+interface Atom {
+  /** Inline node carrying its own text (word-span or bare text). */
+  node: Node
+  text: string
+  start: number
+  end: number
+}
+
+function wrapInParagraph(
+  para: Element,
+  descriptors: TermDescriptor[],
+  seen: Set<string>,
+  occurrences: GlossaryOccurrence[],
+): void {
+  const atoms = collectAtoms(para)
+  if (atoms.length === 0) return
+
+  const concat = atoms.map((a) => a.text).join("")
+  if (!concat.trim()) return
+
+  interface Wrapped {
+    start: number
+    end: number
+    entryId: string
+  }
+  const wrapped: Wrapped[] = []
+  const overlapsWrapped = (s: number, e: number): boolean =>
+    wrapped.some((w) => s < w.end && e > w.start)
+
+  for (const desc of descriptors) {
+    if (seen.has(desc.baseForm)) continue
+    const re = new RegExp(`\\b${escapeRegExp(desc.text)}\\b`, "i")
+    const m = re.exec(concat)
+    if (!m || m.index === undefined) continue
+    const start = m.index
+    const end = start + m[0].length
+    if (overlapsWrapped(start, end)) continue
+    seen.add(desc.baseForm)
+    wrapped.push({ start, end, entryId: desc.entryId })
+  }
+
+  if (wrapped.length === 0) return
+
+  // Apply in reverse document order so earlier mutations don't shift the
+  // atom node references we still need for later (earlier-positioned) wraps.
+  wrapped.sort((a, b) => b.start - a.start)
+  for (const w of wrapped) {
+    const range = atomsCovering(atoms, w.start, w.end)
+    if (range.length === 0) continue
+    const fragment = wrapAtomsWithGlossref(para.ownerDocument!, range, w.entryId)
+    occurrences.push({ entryId: w.entryId, fragment })
+  }
+}
+
+function collectAtoms(para: Element): Atom[] {
+  const atoms: Atom[] = []
+  let cursor = 0
+  for (const child of Array.from(para.childNodes)) {
+    if (child.nodeType === 3 /* TEXT_NODE */) {
+      const text = child.textContent ?? ""
+      if (text.length === 0) continue
+      atoms.push({ node: child, text, start: cursor, end: cursor + text.length })
+      cursor += text.length
+    } else if (child.nodeType === 1 /* ELEMENT_NODE */) {
+      // Each direct element child (word-span, inline <em>/<strong>, styled
+      // separator span) is one atom; its text is its textContent.
+      const text = child.textContent ?? ""
+      atoms.push({ node: child, text, start: cursor, end: cursor + text.length })
+      cursor += text.length
+    }
+  }
+  return atoms
+}
+
+function atomsCovering(atoms: Atom[], start: number, end: number): Atom[] {
+  const out: Atom[] = []
+  for (const a of atoms) {
+    if (a.end <= start) continue
+    if (a.start >= end) break
+    out.push(a)
+  }
+  return out
+}
+
+/**
+ * Wrap the given atoms in a glossref anchor and return a fragment id that
+ * resolves to a node inside it (for backlink targeting). Prefers an existing
+ * id on a wrapped element (the word-span id emitted by `wrapWordSpans`);
+ * falls back to stamping the anchor itself.
+ */
+function wrapAtomsWithGlossref(doc: Document, atoms: Atom[], entryId: string): string {
+  const first = atoms[0].node
+  const parent = first.parentNode
+  const anchor = doc.createElementNS(XHTML_NS, "a")
+  // Plain attribute (not setAttributeNS): JSDOM's serializer otherwise
+  // synthesises a fresh `xmlns:ns1=…` prefix on every element instead of
+  // reusing the `xmlns:epub` declaration on <html>. Readers resolve
+  // `epub:type` against the ancestor namespace either way.
+  anchor.setAttribute("epub:type", "glossref")
+  // The `glossref` class is the styling hook: a class selector dodges the
+  // XML-namespace pitfalls of an `[epub|type~=glossref]` attribute selector,
+  // and the reader keys its popover off `epub:type`, not the class. The CSS
+  // rule (dotted underline) ships via injectWebpubStyles.
+  anchor.setAttribute("class", "glossref")
+  anchor.setAttribute("href", `glossary.xhtml#${entryId}`)
+  if (parent) parent.insertBefore(anchor, first)
+  for (const a of atoms) anchor.appendChild(a.node)
+
+  const inner = anchor.querySelector("[id]")
+  if (inner?.id) return inner.id
+  const fallback = `glref_${entryId}`
+  anchor.setAttribute("id", fallback)
+  return fallback
+}
+
+function ensureEpubNamespace(doc: Document): void {
+  const html = doc.documentElement
+  if (!html) return
+  if (html.getAttribute("xmlns:epub") === EPUB_NS) return
+  html.setAttribute("xmlns:epub", EPUB_NS)
+}
+
+/**
+ * Re-attach a single canonical XHTML prologue. JSDOM's serializer emits the
+ * parsed DOCTYPE but never the XML declaration, so we strip whatever leading
+ * `<?xml?>` / `<!DOCTYPE>` it produced and prepend exactly one of each.
+ * Without the strip the DOCTYPE would be duplicated, which is a fatal XML
+ * parse error in strict EPUB readers.
+ */
+function serializeXhtml(dom: JSDOM): string {
+  const body = dom
+    .serialize()
+    .replace(/^\s*<\?xml[^>]*\?>\s*/i, "")
+    .replace(/^\s*<!DOCTYPE[^>]*>\s*/i, "")
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE html>\n${body}`
+}
+
+// ---------------------------------------------------------------------------
+// glossary.xhtml builder
+// ---------------------------------------------------------------------------
+
+export interface BuildGlossaryDocumentInput {
+  language: string
+  /** Localised page title (e.g. "Glossary" / "Glosario"). */
+  heading: string
+  entries: GlossaryEntry[]
+  /**
+   * Entry id → backlinks to its in-text occurrences. Only entries present
+   * as keys are emitted; an entry with an empty array still appears (it was
+   * referenced but we couldn't resolve a target).
+   */
+  backlinksByEntry: Map<string, GlossaryBacklink[]>
+}
+
+/**
+ * Build the glossary content document: an EPUB 3 doc-glossary `<dl>` the
+ * reader parses into entries, with each definition followed by a backlink
+ * `<nav>` ("Used in"). Entries are sorted alphabetically by headword.
+ */
+export function buildGlossaryDocument(input: BuildGlossaryDocumentInput): string {
+  const { language, heading, entries, backlinksByEntry } = input
+
+  const used = entries.filter((e) => backlinksByEntry.has(e.id))
+  used.sort((a, b) => a.word.localeCompare(b.word, language || undefined))
+
+  const rows = used
+    .map((e) => {
+      const emoji = e.emoji
+        ? `<span class="gl-emoji" aria-hidden="true">${escapeXml(e.emoji)} </span>`
+        : ""
+      const backlinks = backlinksByEntry.get(e.id) ?? []
+      const backlinkNav =
+        backlinks.length > 0
+          ? `
+      <nav class="gl-backlinks">
+        <ol>
+${backlinks
+  .map(
+    (bl) =>
+      `          <li><a epub:type="backlink" href="${escapeXml(bl.href)}">${escapeXml(bl.label)}</a></li>`,
+  )
+  .join("\n")}
+        </ol>
+      </nav>`
+          : ""
+      return `      <dt id="${escapeXml(e.id)}"><dfn>${escapeXml(e.word)}</dfn></dt>
+      <dd><p>${emoji}${escapeXml(e.definition)}</p>${backlinkNav}
+      </dd>`
+    })
+    .join("\n")
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html>
+<html xmlns="${XHTML_NS}" xmlns:epub="${EPUB_NS}" lang="${escapeXml(language)}">
+<head>
+  <meta charset="UTF-8"/>
+  <title>${escapeXml(heading)}</title>
+</head>
+<body>
+  <section epub:type="glossary" role="doc-glossary">
+    <h1>${escapeXml(heading)}</h1>
+    <dl class="gl-list">
+${rows}
+    </dl>
+  </section>
+</body>
+</html>`
+}
+
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;")
+}

--- a/packages/pipeline/src/package-epub.ts
+++ b/packages/pipeline/src/package-epub.ts
@@ -16,6 +16,13 @@ function wordIdFor(dataId: string, idx: number): string {
 import { buildSmil, formatMediaDuration, type SmilParagraph } from "./smil.js"
 import { tokenizeWords } from "./word-tokenize.js"
 import { styleMapToInline } from "./fixed-layout-rendering.js"
+import {
+  buildGlossaryDocument,
+  loadGlossaryEntries,
+  wrapGlossaryTerms,
+  type GlossaryBacklink,
+  type GlossaryEntry,
+} from "./epub-glossary.js"
 
 export type PackageEpubOptions = PackageAdtWebOptions
 
@@ -27,6 +34,25 @@ interface PageEntry {
 
 /** Files/dirs in adt/ root that are SCORM/offline-specific and not needed in EPUB. */
 const EPUB_SKIP = new Set(["imsmanifest.xml", "AGENTS.md"])
+
+/**
+ * Visual affordance for in-text glossary references (EPUB only). The web
+ * runtime marks terms at runtime with `.glossary-term`; the EPUB packager
+ * instead emits `<a epub:type="glossref" class="glossref">`, and the reader
+ * adds no styling of its own, so a dotted underline (the standard dictionary
+ * "tap for a definition" signal) is shipped here. `!important` + the
+ * `-webkit-` prefix defend against Tailwind Preflight's `a` reset and
+ * aggressive reader CSS / older e-reader WebKit. Injected via
+ * `injectWebpubStyles({ extraCss })` so it stays out of the web/webpub output.
+ */
+const GLOSSREF_CSS = `
+.glossref {
+  -webkit-text-decoration: underline dotted !important;
+  text-decoration: underline dotted !important;
+  text-underline-offset: 0.15em;
+  text-decoration-thickness: from-font;
+  cursor: pointer;
+}`
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -70,12 +96,33 @@ export function packageEpub(
   // Strip the web runtime bundle. EPUB readers provide TOC, page navigation,
   // settings, and read-aloud playback (the latter via the SMIL media overlays
   // generated below) natively, so the React dock chrome would just duplicate
-  // them. Audio + word highlighting comes from SMIL; glossary is planned as
-  // an EPUB dictionary in a follow-up.
+  // them. Audio + word highlighting comes from SMIL; the glossary is lowered
+  // to EPUB-native markup (glossref + doc-glossary + landmarks) below.
   stripRuntimeBundle(oebpsDir)
 
-  // Inject reader-override CSS
-  injectWebpubStyles(oebpsDir, { fixedLayout: options.fixedLayout })
+  // ------------------------------------------------------------------
+  // Glossary (load once before the page loop)
+  // ------------------------------------------------------------------
+  // EPUB-native glossary, built to the EPUB 3 Dictionaries & Glossaries
+  // model the BookFusion reader consumes: first occurrences of terms become
+  // `<a epub:type="glossref">` anchors pointing at `<dt id>` entries in
+  // glossary.xhtml, the reader resolves them into definition popovers, and a
+  // `<nav epub:type="landmarks">` glossary entry surfaces the Glossary tab.
+  // The web runtime is stripped (see stripRuntimeBundle), so this is the
+  // only glossary surface in an EPUB export.
+  const glossaryEntries = loadGlossaryEntriesForLang(oebpsDir, language)
+  // Entry id → backlinks to each in-text occurrence ("Used in").
+  const backlinksByEntry = new Map<string, GlossaryBacklink[]>()
+
+  // Inject reader-override CSS. The glossref affordance (dotted underline) is
+  // EPUB-only — passed as extraCss here rather than baked into the shared
+  // override blocks, so it never ships in the web/webpub output (which marks
+  // terms at runtime instead and emits no glossref anchors). Only injected
+  // when the book actually has glossary terms.
+  injectWebpubStyles(oebpsDir, {
+    fixedLayout: options.fixedLayout,
+    extraCss: glossaryEntries.length > 0 ? GLOSSREF_CSS : undefined,
+  })
 
   // ------------------------------------------------------------------
   // Convert content HTML pages to XHTML (required by EPUB 3 / Apple Books)
@@ -88,8 +135,19 @@ export function packageEpub(
     if (!fs.existsSync(htmlPath)) continue
 
     const html = fs.readFileSync(htmlPath, "utf-8")
-    const xhtml = convertPageToXhtml(html)
+    let xhtml = convertPageToXhtml(html)
     const xhtmlHref = page.href.replace(/\.html$/, ".xhtml")
+
+    if (glossaryEntries.length > 0) {
+      const result = wrapGlossaryTerms(xhtml, glossaryEntries)
+      xhtml = result.xhtml
+      const label = page.page_number != null ? `Page ${page.page_number}` : page.section_id
+      for (const occ of result.occurrences) {
+        const list = backlinksByEntry.get(occ.entryId) ?? []
+        list.push({ href: `${xhtmlHref}#${occ.fragment}`, label })
+        backlinksByEntry.set(occ.entryId, list)
+      }
+    }
 
     fs.writeFileSync(path.join(oebpsDir, xhtmlHref), xhtml)
     fs.unlinkSync(htmlPath)
@@ -97,6 +155,26 @@ export function packageEpub(
   }
   // Update pages.json with .xhtml hrefs
   fs.writeFileSync(pagesJsonPath, JSON.stringify(rawPages, null, 2))
+
+  // ------------------------------------------------------------------
+  // glossary.xhtml + dead-weight cleanup
+  // ------------------------------------------------------------------
+  let glossaryHref: string | undefined
+  let glossaryHeading: string | undefined
+  if (backlinksByEntry.size > 0) {
+    glossaryHref = "glossary.xhtml"
+    glossaryHeading = loadGlossaryHeading(oebpsDir, language)
+    const doc = buildGlossaryDocument({
+      language,
+      heading: glossaryHeading,
+      entries: glossaryEntries,
+      backlinksByEntry,
+    })
+    fs.writeFileSync(path.join(oebpsDir, glossaryHref), doc)
+  }
+  // The runtime is stripped; per-language glossary.json files are now
+  // orphaned. Drop them so the package isn't shipping dead weight.
+  stripOrphanGlossaryJson(oebpsDir)
 
   // ------------------------------------------------------------------
   // SMIL media overlays (fixed-layout only)
@@ -183,13 +261,14 @@ export function packageEpub(
       coverHref,
       fixedLayout: options.fixedLayout,
       smilEntries,
+      glossaryHref,
     }),
   )
 
   // OEBPS/toc.xhtml (EPUB 3 navigation document)
   fs.writeFileSync(
     path.join(oebpsDir, "toc.xhtml"),
-    buildNavDocument(language, title, pageList, llmToc),
+    buildNavDocument(language, title, pageList, llmToc, glossaryHref, glossaryHeading),
   )
 
   // OEBPS/toc.ncx (EPUB 2 fallback)
@@ -379,8 +458,9 @@ function buildOpf(opts: {
   coverHref?: string
   fixedLayout?: boolean
   smilEntries?: SmilEntry[]
+  glossaryHref?: string
 }): string {
-  const { title, authors, publisher, language, pageList, allFiles, coverHref, fixedLayout, smilEntries } = opts
+  const { title, authors, publisher, language, pageList, allFiles, coverHref, fixedLayout, smilEntries, glossaryHref } = opts
   const smilByPage = new Map<string, SmilEntry>()
   for (const e of smilEntries ?? []) smilByPage.set(e.pageHref, e)
   const now = new Date().toISOString().replace(/\.\d{3}Z$/, "Z")
@@ -481,6 +561,15 @@ function buildOpf(opts: {
     const itemId = hrefToItemId.get(page.href) ?? escapeXml(page.section_id)
     return `    <itemref idref="${escapeXml(itemId)}"/>`
   })
+  // Glossary is reachable from in-text glossrefs and the landmarks nav;
+  // `linear="no"` keeps it out of the linear reading flow but in-spine so
+  // those hrefs resolve.
+  if (glossaryHref) {
+    const itemId = hrefToItemId.get(glossaryHref)
+    if (itemId) {
+      spineLines.push(`    <itemref idref="${escapeXml(itemId)}" linear="no"/>`)
+    }
+  }
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="pub-id"${fixedLayout ? ` prefix="rendition: http://www.idpf.org/vocab/rendition/#"` : ""}>
@@ -501,6 +590,8 @@ function buildNavDocument(
   title: string,
   pageList: PageEntry[],
   llmToc?: TocGenerationOutput,
+  glossaryHref?: string,
+  glossaryHeading?: string,
 ): string {
   let tocItems: string
 
@@ -526,6 +617,19 @@ function buildNavDocument(
       .join("\n")
   }
 
+  // The glossary is not part of the linear reading order, so it lives in a
+  // `landmarks` nav (below) rather than the TOC list. The reader keys its
+  // Glossary tab off the `epub:type="glossary"` landmark.
+  const landmarksNav =
+    glossaryHref && glossaryHeading
+      ? `
+  <nav epub:type="landmarks" hidden="">
+    <ol>
+      <li><a epub:type="glossary" href="${escapeXml(glossaryHref)}">${escapeXml(glossaryHeading)}</a></li>
+    </ol>
+  </nav>`
+      : ""
+
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" lang="${escapeXml(language)}">
@@ -539,7 +643,7 @@ function buildNavDocument(
     <ol>
 ${tocItems}
     </ol>
-  </nav>
+  </nav>${landmarksNav}
 </body>
 </html>`
 }
@@ -606,6 +710,64 @@ function escapeXml(str: string): string {
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;")
     .replace(/'/g, "&apos;")
+}
+
+// ---------------------------------------------------------------------------
+// Glossary helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Read `content/i18n/<lang>/glossary.json` and assign stable EPUB ids.
+ * Empty list if the file is absent or empty — callers branch on length.
+ */
+function loadGlossaryEntriesForLang(oebpsDir: string, language: string): GlossaryEntry[] {
+  const p = path.join(oebpsDir, "content", "i18n", language, "glossary.json")
+  if (!fs.existsSync(p)) return []
+  try {
+    const raw = JSON.parse(fs.readFileSync(p, "utf-8"))
+    return loadGlossaryEntries(raw)
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Read the "Glossary" heading from interface_translations for the export
+ * language, falling back to "Glossary" if the catalog is missing or the
+ * key isn't translated.
+ */
+function loadGlossaryHeading(oebpsDir: string, language: string): string {
+  const fallback = "Glossary"
+  const p = path.join(
+    oebpsDir,
+    "assets",
+    "interface_translations",
+    language,
+    "interface_translations.json",
+  )
+  if (!fs.existsSync(p)) return fallback
+  try {
+    const raw = JSON.parse(fs.readFileSync(p, "utf-8")) as Record<string, string>
+    return raw["glossary-label"]?.trim() || fallback
+  } catch {
+    return fallback
+  }
+}
+
+/**
+ * Remove `content/i18n/<lang>/glossary.json` from every language directory.
+ * The runtime that consumed these is stripped from EPUB exports
+ * (stripRuntimeBundle); the EPUB-native glossary surface (glossary.xhtml +
+ * glossrefs) is generated above, so the JSON catalogs are dead weight.
+ */
+function stripOrphanGlossaryJson(oebpsDir: string): void {
+  const i18nDir = path.join(oebpsDir, "content", "i18n")
+  if (!fs.existsSync(i18nDir)) return
+  for (const entry of fs.readdirSync(i18nDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue
+    const gjson = path.join(i18nDir, entry.name, "glossary.json")
+    if (fs.existsSync(gjson)) fs.unlinkSync(gjson)
+  }
 }
 
 /**
@@ -749,10 +911,16 @@ function wrapBySegments(
   let wordIdx = 0
   for (const tok of tokenizeWords(concatText)) {
     if (tok.type === "separator") {
-      // Separators (whitespace, punctuation) emit bare so word boxes stay
-      // tight; surrounding glyphs don't inherit a segment's font metrics.
+      // Separators (whitespace, punctuation) stay OUTSIDE the word-index
+      // wrapper so word boxes remain tight for SMIL highlighting, but they
+      // must still carry the segment's style: in fixed-layout the font-size
+      // lives only on the per-segment span, and the paragraph itself has no
+      // font-size. A bare text node would inherit the page default (~16px),
+      // so a space between two 48px display words renders ~4px wide and the
+      // words look unspaced. Route the separator through buildPieces so each
+      // run of whitespace gets the surrounding segment's font metrics.
       if (tok.text.length > 0) {
-        parent.appendChild(doc.createTextNode(tok.text))
+        for (const piece of buildPieces(tok.start, tok.end)) parent.appendChild(piece)
       }
       continue
     }

--- a/packages/pipeline/src/package-web.ts
+++ b/packages/pipeline/src/package-web.ts
@@ -1007,6 +1007,12 @@ body {
 
 export interface InjectWebpubStylesOptions {
   fixedLayout?: boolean
+  /**
+   * Extra CSS rules appended inside the injected `<style>` block. Used by the
+   * EPUB packager to ship export-only affordances (e.g. the glossref dotted
+   * underline) without leaking them into the web/webpub output.
+   */
+  extraCss?: string
 }
 
 /**
@@ -1014,7 +1020,12 @@ export interface InjectWebpubStylesOptions {
  * `</head>` that overrides reader-injected column pagination CSS.
  */
 export function injectWebpubStyles(dir: string, options?: InjectWebpubStylesOptions): void {
-  const css = options?.fixedLayout ? FIXED_LAYOUT_OVERRIDE_CSS : REFLOWABLE_OVERRIDE_CSS
+  const base = options?.fixedLayout ? FIXED_LAYOUT_OVERRIDE_CSS : REFLOWABLE_OVERRIDE_CSS
+  // Splice any caller-supplied rules in before the closing tag so they share
+  // the single injected <style> block. Function replacer so `$` in the CSS
+  // isn't interpreted as a replacement pattern (`$&`, `$1`, …).
+  const extra = options?.extraCss
+  const css = extra ? base.replace("</style>", () => `${extra}\n</style>`) : base
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
     const fullPath = path.join(dir, entry.name)
     if (entry.isDirectory()) {


### PR DESCRIPTION
## Summary

Adds a native glossary to the EPUB 3 export and fixes a fixed-layout
word-spacing defect found while testing it. Also defaults Activity
Detection off for fixed-layout books in the creation wizard.

The EPUB export strips the web runtime (TOC, settings, read-aloud are all
native in the reader), so the React glossary popover doesn't exist there.
This lowers the glossary to EPUB 3 Dictionaries & Glossaries markup that
the BookFusion reader consumes directly.

<img width="1666" height="993" alt="Pasted Graphic 2" src="https://github.com/user-attachments/assets/365c5973-4a6d-4994-96c9-db2e7ac19d0f" />
<img width="1665" height="990" alt="There is a black chalkboard" src="https://github.com/user-attachments/assets/2402632b-1449-419d-b6ae-901d0e34eb28" />

## What's in here

### Glossary (EPUB 3)
- **In-text:** the first occurrence of each term per page becomes
  `<a epub:type="glossref" class="glossref" href="glossary.xhtml#gl_NNN">`,
  resolving to a `<dt id>` entry. Matching mirrors the web runtime
  (longest-first, case-insensitive, word-boundary, variations canonicalised,
  first-occurrence per page).
- **Glossary page:** a new `glossary.xhtml` as
  `<section role="doc-glossary"><dl><dt id><dfn>…</dfn></dt><dd>…</dd></dl>`,
  with per-entry "Used in" backlinks to each occurrence.
- **Tab:** a `<nav epub:type="landmarks">` glossary entry surfaces the
  reader's Glossary tab.
- **Affordance:** a dotted underline on glossary terms, injected EPUB-only
  via a new `injectWebpubStyles({ extraCss })` hook (never ships in
  web/webpub, which marks terms at runtime instead).
- **Cleanup:** orphan `content/i18n/*/glossary.json` (only the stripped
  runtime read these) is removed from the package.

### Fixed-layout word spacing (bug fix)
- `wrapBySegments` emitted inter-word separators as bare text nodes outside
  the styled span. In fixed layout the font-size lives only on the segment
  span, so spaces between large display words inherited the ~16px page
  default and collapsed ("Iamalittlegirl"). Separators now carry the
  surrounding segment's font metrics. **Affects all fixed-layout EPUB
  exports, not just glossary books.**

### Wizard
- New fixed-layout books seed the activity section types into
  `disabled_section_types`, so the Sectioning page shows Activity Detection
  **off** by default (still toggleable — activities are baked into the page
  image in fixed layout).

## Testing
- Unit: glossary matcher/markup, well-formedness, separator spacing,
  EPUB-only CSS scoping. Full pipeline suite passes; typecheck clean.
- Verified end-to-end against a real fixed-layout book by replicating the
  reader's `parseGlossary` + landmark detection: 35 entries parse, the
  landmark resolves, all in-text glossrefs and backlinks resolve, dotted
  underline renders, spacing renders correctly (headless, JS-off).
