### PR TITLE
feat(extract): warn when a page has no text layer but vision recovered text

### DIFF
--- a/apps/api/src/routes/pages.ts
+++ b/apps/api/src/routes/pages.ts
@@ -67,8 +67,9 @@ interface PageSummary {
   renderingVersion: number | null
   sectioningVersion: number | null
   sections: PageSummarySection[]
-  /** Extraction-quality warning for this page (no readable text when there
-   *  should be), or null when the page extracted cleanly / is blank. */
+  /** `text-layer-missing` when the page's embedded text layer was empty but the
+   *  Sectioning step (vision) recovered text from the page image (a scanned /
+   *  image-only page); null otherwise. */
   extractionWarning: ExtractionWarning | null
 }
 
@@ -101,8 +102,9 @@ interface PageDetail {
    *  fixed-layout books and for the Merriweather default (no override needed).
    *  Mirrors what packaging/preview inject, so the storyboard preview can match. */
   reflowableFontFamily: string | null
-  /** Extraction-quality warning for this page (no readable text when there
-   *  should be), or null when the page extracted cleanly / is blank. */
+  /** `text-layer-missing` when the page's embedded text layer was empty but the
+   *  Sectioning step (vision) recovered text from the page image (a scanned /
+   *  image-only page); null otherwise. */
   extractionWarning: ExtractionWarning | null
   versions: {
     sectioning: number | null

--- a/apps/api/src/routes/pages.ts
+++ b/apps/api/src/routes/pages.ts
@@ -5,7 +5,8 @@ import { z } from "zod"
 import { Hono } from "hono"
 import { HTTPException } from "hono/http-exception"
 import { parseBookLabel, ImageClassificationOutput, PageSectioningOutput, WebRenderingOutput, ImageCaptioningOutput, ImageSegmentRegion, DEFAULT_LLM_MAX_RETRIES, primaryFontFamily, reflowableFontChain } from "@adt/types"
-import type { ContentNodeData } from "@adt/types"
+import type { ContentNodeData, ExtractionWarning } from "@adt/types"
+import { classifyExtractionWarning, flattenVisibleSectioningText } from "../services/extraction-warning.js"
 import { openBookDb } from "@adt/storage"
 import { createBookStorage } from "@adt/storage"
 import type { Storage } from "@adt/storage"
@@ -66,6 +67,9 @@ interface PageSummary {
   renderingVersion: number | null
   sectioningVersion: number | null
   sections: PageSummarySection[]
+  /** Extraction-quality warning for this page (no readable text when there
+   *  should be), or null when the page extracted cleanly / is blank. */
+  extractionWarning: ExtractionWarning | null
 }
 
 interface PageDetail {
@@ -97,6 +101,9 @@ interface PageDetail {
    *  fixed-layout books and for the Merriweather default (no override needed).
    *  Mirrors what packaging/preview inject, so the storyboard preview can match. */
   reflowableFontFamily: string | null
+  /** Extraction-quality warning for this page (no readable text when there
+   *  should be), or null when the page extracted cleanly / is blank. */
+  extractionWarning: ExtractionWarning | null
   versions: {
     sectioning: number | null
     imageClassification: number | null
@@ -671,6 +678,10 @@ export function createPageRoutes(
         renderingVersion: renderingByPage.get(p.page_id)?.version ?? null,
         sectioningVersion: sectioningVersions.get(p.page_id) ?? null,
         sections: sectionsByPage.get(p.page_id) ?? [],
+        // Cross-check: empty extracted text layer, but the Sectioning step
+        // recovered text from the page image → the PDF isn't exposing this
+        // page's text directly (scanned/image-only page).
+        extractionWarning: classifyExtractionWarning(p.text, structuredText.get(p.page_id)),
       }))
 
       return c.json(result)
@@ -757,6 +768,14 @@ export function createPageRoutes(
         if (parsed.success) sectioningTreeForUI = parsed.data
       }
 
+      // Cross-check the empty text layer against vision-recovered text (see
+      // classifyExtractionWarning). Uses the validated tree so we don't read
+      // text from a malformed blob.
+      const recoveredSectioningText = flattenVisibleSectioningText(
+        (sectioningTreeForUI as { sections?: Array<{ isPruned?: boolean; nodes?: unknown[] }> } | null)
+          ?.sections
+      )
+
       // Per-image meta (width/height/bounds) — sourced directly from the
       // images table rather than node_data so it reflects the latest state.
       const imageMetaRows = db.all(
@@ -796,6 +815,7 @@ export function createPageRoutes(
         fonts: derivePageFonts(positionedTextNode?.data),
         fontProfile,
         reflowableFontFamily,
+        extractionWarning: classifyExtractionWarning(page.text, recoveredSectioningText),
         versions: {
           sectioning: sectioningNode?.version ?? null,
           imageClassification: imageClassNode?.version ?? null,

--- a/apps/api/src/routes/pages.ts
+++ b/apps/api/src/routes/pages.ts
@@ -768,13 +768,20 @@ export function createPageRoutes(
         if (parsed.success) sectioningTreeForUI = parsed.data
       }
 
-      // Cross-check the empty text layer against vision-recovered text (see
-      // classifyExtractionWarning). Uses the validated tree so we don't read
-      // text from a malformed blob.
-      const recoveredSectioningText = flattenVisibleSectioningText(
-        (sectioningTreeForUI as { sections?: Array<{ isPruned?: boolean; nodes?: unknown[] }> } | null)
-          ?.sections
-      )
+      // Cross-check the empty text layer against the Sectioning step's
+      // vision-recovered text (see classifyExtractionWarning). Read from the raw
+      // stored blob — the SAME source the pages-summary route uses — so the
+      // warning stays consistent across the grid badge, banners, sidebar, and
+      // this detail view even when the blob doesn't fully validate against the
+      // canonical schema. Only walked when the text layer is empty, since
+      // classifyExtractionWarning short-circuits on non-empty text.
+      const recoveredSectioningText =
+        page.text.trim().length === 0
+          ? flattenVisibleSectioningText(
+              (sectioningNode?.data as { sections?: Array<{ isPruned?: boolean; nodes?: unknown[] }> } | null)
+                ?.sections
+            )
+          : ""
 
       // Per-image meta (width/height/bounds) — sourced directly from the
       // images table rather than node_data so it reflects the latest state.

--- a/apps/api/src/services/extraction-warning.test.ts
+++ b/apps/api/src/services/extraction-warning.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest"
+import {
+  classifyExtractionWarning,
+  flattenVisibleSectioningText,
+  MIN_RECOVERED_TEXT_CHARS,
+} from "./extraction-warning.js"
+
+const longText = "x".repeat(MIN_RECOVERED_TEXT_CHARS)
+
+describe("classifyExtractionWarning", () => {
+  it("flags empty extract text when Sectioning recovered enough text", () => {
+    expect(classifyExtractionWarning("", longText)).toBe("text-layer-missing")
+  })
+
+  it("treats whitespace-only extract text as empty", () => {
+    expect(classifyExtractionWarning("  \n\t ", longText)).toBe("text-layer-missing")
+  })
+
+  it("does not flag when the extract text layer has content", () => {
+    expect(classifyExtractionWarning("Real extracted text", longText)).toBeNull()
+  })
+
+  it("does not flag when Sectioning recovered too little text (blank/illustration page)", () => {
+    expect(classifyExtractionWarning("", "hi")).toBeNull()
+  })
+
+  it("counts only non-whitespace recovered characters against the threshold", () => {
+    const padded = "a b c\n".repeat(10) // many chars, but whitespace-heavy
+    const nonWs = padded.replace(/\s+/g, "").length
+    expect(nonWs).toBeGreaterThanOrEqual(MIN_RECOVERED_TEXT_CHARS)
+    expect(classifyExtractionWarning("", padded)).toBe("text-layer-missing")
+  })
+
+  it("does not flag when Sectioning has not run (no recovered text)", () => {
+    expect(classifyExtractionWarning("", null)).toBeNull()
+    expect(classifyExtractionWarning("", undefined)).toBeNull()
+  })
+})
+
+describe("flattenVisibleSectioningText", () => {
+  it("returns empty string for missing sections", () => {
+    expect(flattenVisibleSectioningText(undefined)).toBe("")
+    expect(flattenVisibleSectioningText(null)).toBe("")
+  })
+
+  it("collects text from nested nodes, skipping pruned sections and leaves", () => {
+    const sections = [
+      {
+        isPruned: false,
+        nodes: [
+          { text: "Title" },
+          { children: [{ text: "Body" }, { isPruned: true, text: "hidden leaf" }] },
+        ],
+      },
+      { isPruned: true, nodes: [{ text: "pruned section" }] },
+    ]
+    expect(flattenVisibleSectioningText(sections)).toBe("Title\nBody")
+  })
+})

--- a/apps/api/src/services/extraction-warning.ts
+++ b/apps/api/src/services/extraction-warning.ts
@@ -1,0 +1,54 @@
+import type { ExtractionWarning } from "@adt/types"
+
+/**
+ * Minimum amount of vision-recovered text (non-whitespace characters) before we
+ * treat an empty-text-layer page as one that "should have had text". Keeps blank
+ * or illustration-only pages — where the Sectioning step also finds little or
+ * nothing — from being flagged.
+ */
+export const MIN_RECOVERED_TEXT_CHARS = 24
+
+type SectioningNode = { isPruned?: boolean; text?: string; children?: unknown[] }
+type SectioningSection = { isPruned?: boolean; nodes?: unknown[] }
+
+/**
+ * Collect the visible text from a page-sectioning tree, skipping pruned sections
+ * and pruned leaves. Mirrors the page-level preview walk in the pages route.
+ */
+export function flattenVisibleSectioningText(
+  sections: SectioningSection[] | undefined | null
+): string {
+  if (!sections) return ""
+  const parts: string[] = []
+  const walk = (node: SectioningNode): void => {
+    if (node.isPruned) return
+    if (typeof node.text === "string" && node.text.length > 0) parts.push(node.text)
+    if (Array.isArray(node.children)) {
+      for (const child of node.children) walk(child as SectioningNode)
+    }
+  }
+  for (const section of sections) {
+    if (section.isPruned) continue
+    for (const node of section.nodes ?? []) walk(node as SectioningNode)
+  }
+  return parts.join("\n")
+}
+
+/**
+ * Cross-check the embedded text layer against the Sectioning step's
+ * vision-recovered text. When the extracted text is empty but the Sectioning
+ * step recovered a meaningful amount of text from the page image, the PDF's text
+ * isn't being extracted directly (a scanned/image-only page) — flag it.
+ *
+ * Returns null when there's nothing to flag, or when Sectioning hasn't run yet
+ * (no recovered text to compare against).
+ */
+export function classifyExtractionWarning(
+  extractText: string,
+  sectioningText: string | null | undefined
+): ExtractionWarning | null {
+  const extractEmpty = extractText.trim().length === 0
+  if (!extractEmpty) return null
+  const recoveredChars = (sectioningText ?? "").replace(/\s+/g, "").length
+  return recoveredChars >= MIN_RECOVERED_TEXT_CHARS ? "text-layer-missing" : null
+}

--- a/apps/studio/src/api/client.ts
+++ b/apps/studio/src/api/client.ts
@@ -199,8 +199,9 @@ export interface PageSummaryItem {
   renderingVersion: number | null
   sectioningVersion: number | null
   sections: PageSummarySection[]
-  /** Warning when the page extracted no readable text but evidently should
-   *  have (undecodable fonts or an image-only/scanned page); null otherwise. */
+  /** `text-layer-missing` when the page's embedded text layer was empty but the
+   *  Sectioning step (vision) recovered text from the page image (a scanned /
+   *  image-only page); null otherwise. */
   extractionWarning: ExtractionWarning | null
 }
 
@@ -286,8 +287,9 @@ export interface PageDetail {
    *  the Merriweather default). The storyboard preview injects it to match the
    *  packaged output. */
   reflowableFontFamily: string | null
-  /** Warning when the page extracted no readable text but evidently should
-   *  have (undecodable fonts or an image-only/scanned page); null otherwise. */
+  /** `text-layer-missing` when the page's embedded text layer was empty but the
+   *  Sectioning step (vision) recovered text from the page image (a scanned /
+   *  image-only page); null otherwise. */
   extractionWarning: ExtractionWarning | null
   versions: {
     imageClassification: number | null

--- a/apps/studio/src/api/client.ts
+++ b/apps/studio/src/api/client.ts
@@ -4,6 +4,7 @@ import type {
   BookDetail,
   BookMetadata,
   BookSummary,
+  ExtractionWarning,
   ReviewerPageValidationRecord,
   ReviewerValidationIdentificationField,
   ReviewerValidationInstruction,
@@ -198,6 +199,9 @@ export interface PageSummaryItem {
   renderingVersion: number | null
   sectioningVersion: number | null
   sections: PageSummarySection[]
+  /** Warning when the page extracted no readable text but evidently should
+   *  have (undecodable fonts or an image-only/scanned page); null otherwise. */
+  extractionWarning: ExtractionWarning | null
 }
 
 export interface SectionRendering {
@@ -282,6 +286,9 @@ export interface PageDetail {
    *  the Merriweather default). The storyboard preview injects it to match the
    *  packaged output. */
   reflowableFontFamily: string | null
+  /** Warning when the page extracted no readable text but evidently should
+   *  have (undecodable fonts or an image-only/scanned page); null otherwise. */
+  extractionWarning: ExtractionWarning | null
   versions: {
     imageClassification: number | null
     imageCropping: number | null

--- a/apps/studio/src/components/pipeline/components/StageSidebar.tsx
+++ b/apps/studio/src/components/pipeline/components/StageSidebar.tsx
@@ -6,6 +6,7 @@ import {
   Loader2,
   RotateCcw,
   Settings,
+  TriangleAlert,
 } from "lucide-react"
 import { useVirtualizer } from "@tanstack/react-virtual"
 import { cn } from "@/lib/utils"
@@ -179,6 +180,11 @@ export function StageSidebar({
   const stageMissing = useStageMissingCounts(bookLabel)
   const translateNeedsRerun = stageMissing.translate > 0
   const speechNeedsRerun = stageMissing.speech > 0
+  // At least one page had an empty embedded text layer but vision recovered its
+  // text (scanned/image-only). Surfaced as an advisory badge on the Extract
+  // entry. Reuses the cached `pages` query the Extract/Sectioning views populate.
+  const { data: sidebarPages } = usePages(bookLabel)
+  const hasNoTextLayer = (sidebarPages ?? []).some((p) => p.extractionWarning)
 
   const currentState = stageState(activeStep)
   const stageHasContent =
@@ -317,6 +323,16 @@ export function StageSidebar({
                 <Icon className="w-3.5 h-3.5" />
               </div>
               <StepProgressRing size={28} state={ringState} colorClass={isActive ? "bg-white" : step.color} />
+              {step.slug === "extract" && hasNoTextLayer && (
+                <span
+                  className="absolute -top-1 -right-1 z-20 flex items-center justify-center w-3.5 h-3.5 rounded-full bg-amber-500 ring-2 ring-background"
+                  title={i18n._(
+                    msg`Some pages have no embedded text layer — text was recovered from the page image. Prefer a text-based PDF.`
+                  )}
+                >
+                  <TriangleAlert className="w-2 h-2 text-white" />
+                </span>
+              )}
             </div>
             <span className={cn("truncate hidden", x.showLabel)}>
               {stepLabel}

--- a/apps/studio/src/components/pipeline/components/StageSidebar.tsx
+++ b/apps/studio/src/components/pipeline/components/StageSidebar.tsx
@@ -182,9 +182,14 @@ export function StageSidebar({
   const speechNeedsRerun = stageMissing.speech > 0
   // At least one page had an empty embedded text layer but vision recovered its
   // text (scanned/image-only). Surfaced as an advisory badge on the Extract
-  // entry. Reuses the cached `pages` query the Extract/Sectioning views populate.
-  const { data: sidebarPages } = usePages(bookLabel)
+  // entry. `enabled: false` reads the `pages` query the Extract/Sectioning views
+  // populate without triggering its own fetch, so opening the sidebar (e.g. on a
+  // freshly imported book or the settings view) adds no background /pages load.
+  const { data: sidebarPages } = usePages(bookLabel, { enabled: false })
   const hasNoTextLayer = (sidebarPages ?? []).some((p) => p.extractionWarning)
+  const noTextLayerLabel = i18n._(
+    msg`Some pages have no embedded text layer — text was recovered from the page image. Prefer a text-based PDF.`
+  )
 
   const currentState = stageState(activeStep)
   const stageHasContent =
@@ -325,12 +330,12 @@ export function StageSidebar({
               <StepProgressRing size={28} state={ringState} colorClass={isActive ? "bg-white" : step.color} />
               {step.slug === "extract" && hasNoTextLayer && (
                 <span
+                  role="img"
+                  aria-label={noTextLayerLabel}
+                  title={noTextLayerLabel}
                   className="absolute -top-1 -right-1 z-20 flex items-center justify-center w-3.5 h-3.5 rounded-full bg-amber-500 ring-2 ring-background"
-                  title={i18n._(
-                    msg`Some pages have no embedded text layer — text was recovered from the page image. Prefer a text-based PDF.`
-                  )}
                 >
-                  <TriangleAlert className="w-2 h-2 text-white" />
+                  <TriangleAlert className="w-2 h-2 text-white" aria-hidden="true" />
                 </span>
               )}
             </div>

--- a/apps/studio/src/components/pipeline/stages/extract/ExtractView.tsx
+++ b/apps/studio/src/components/pipeline/stages/extract/ExtractView.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react"
-import { AlignLeft, ArrowLeft, ArrowRight, FileText, Image } from "lucide-react"
+import { AlignLeft, ArrowLeft, ArrowRight, FileText, Image, TriangleAlert } from "lucide-react"
 import { Trans } from "@lingui/react/macro"
 import { useLingui } from "@lingui/react/macro"
 import { usePages, usePageImage } from "@/hooks/use-pages"
@@ -11,6 +11,7 @@ import { LoadingState } from "../../components/LoadingState"
 import { useStepHeader } from "../../components/StepViewRouter"
 import { StageRunCard } from "../../components/StageRunCard"
 import { StageEmptyState } from "../../components/StageEmptyState"
+import { LandingPageWarning } from "../../components/LandingPageWarning"
 import type { PageSummaryItem } from "@/api/client"
 
 /** Returns true once the element has scrolled into view. */
@@ -83,6 +84,14 @@ function PageCard({
         <div className="flex items-center justify-between mb-0.5">
           <span className="text-xs font-medium"><Trans>Page {String(page.pageNumber)}</Trans></span>
           <div className="flex items-center gap-2">
+            {page.extractionWarning && (
+              <span
+                className="flex items-center text-amber-600"
+                title={t`No readable text extracted from this page`}
+              >
+                <TriangleAlert className="h-2.5 w-2.5" />
+              </span>
+            )}
             {page.wordCount > 0 && (
               <span className="flex items-center gap-0.5 text-[10px] text-muted-foreground">
                 <AlignLeft className="h-2.5 w-2.5" />
@@ -133,6 +142,7 @@ export function ExtractView({ bookLabel, selectedPageId: selectedPageIdProp, onS
   }, [hasApiKey, extractRunning, apiKey, queueRun])
 
   const pageList = pages ?? []
+  const warnPages = pageList.filter((p) => p.extractionWarning)
   const currentIndex = selectedPageId ? pageList.findIndex((p) => p.pageId === selectedPageId) : -1
   const selectedPage = currentIndex >= 0 ? pageList[currentIndex] : null
   const prevPageId = currentIndex > 0 ? pageList[currentIndex - 1].pageId : null
@@ -243,16 +253,36 @@ export function ExtractView({ bookLabel, selectedPageId: selectedPageIdProp, onS
           subtitle={t`Run the pipeline to extract content`}
         />
       ) : (
-        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
-          {pageList.map((page) => (
-            <PageCard
-              key={page.pageId}
-              bookLabel={bookLabel}
-              page={page}
-              onClick={() => setSelectedPageId(page.pageId)}
-            />
-          ))}
-        </div>
+        <>
+          {warnPages.length > 0 && (
+            <div className="mb-4">
+              <LandingPageWarning
+                variant="prereq"
+                title={t`${warnPages.length} of ${pageList.length} pages had no extracted text`}
+                description={
+                  <Trans>
+                    These pages have no embedded text layer, but the Sectioning
+                    step recovered text from the page images — so this PDF looks
+                    scanned or image-based. The pipeline can still work from the
+                    recovered text, but for better summaries, metadata, and
+                    translations, try to obtain a text-based version of this PDF
+                    (one with a real text layer) rather than a scanned copy.
+                  </Trans>
+                }
+              />
+            </div>
+          )}
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
+            {pageList.map((page) => (
+              <PageCard
+                key={page.pageId}
+                bookLabel={bookLabel}
+                page={page}
+                onClick={() => setSelectedPageId(page.pageId)}
+              />
+            ))}
+          </div>
+        </>
       )}
       </div>
     </div>

--- a/apps/studio/src/components/pipeline/stages/extract/ExtractView.tsx
+++ b/apps/studio/src/components/pipeline/stages/extract/ExtractView.tsx
@@ -86,10 +86,12 @@ function PageCard({
           <div className="flex items-center gap-2">
             {page.extractionWarning && (
               <span
-                className="flex items-center text-amber-600"
+                role="img"
+                aria-label={t`No embedded text layer — text was recovered from the page image`}
                 title={t`No embedded text layer — text was recovered from the page image`}
+                className="flex items-center text-amber-600"
               >
-                <TriangleAlert className="h-2.5 w-2.5" />
+                <TriangleAlert className="h-2.5 w-2.5" aria-hidden="true" />
               </span>
             )}
             {page.wordCount > 0 && (

--- a/apps/studio/src/components/pipeline/stages/extract/ExtractView.tsx
+++ b/apps/studio/src/components/pipeline/stages/extract/ExtractView.tsx
@@ -87,7 +87,7 @@ function PageCard({
             {page.extractionWarning && (
               <span
                 className="flex items-center text-amber-600"
-                title={t`No readable text extracted from this page`}
+                title={t`No embedded text layer — text was recovered from the page image`}
               >
                 <TriangleAlert className="h-2.5 w-2.5" />
               </span>

--- a/apps/studio/src/components/pipeline/stages/extract/components/ExtractPageDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/extract/components/ExtractPageDetail.tsx
@@ -406,6 +406,23 @@ export function ExtractPageDetail({
               {page.text}
             </div>
           </div>
+        ) : page.extractionWarning ? (
+          <div className="rounded border border-amber-200 bg-amber-50 p-3">
+            <div className="flex items-center gap-1.5 text-xs font-medium text-amber-800 uppercase tracking-wider mb-1">
+              <AlertTriangle className="h-3 w-3" />
+              <Trans>No text extracted</Trans>
+            </div>
+            <p className="text-xs text-amber-700 leading-relaxed">
+              <Trans>
+                This page's embedded text layer is empty, but the Sectioning step
+                recovered text from the page image — so it looks like a scanned or
+                image-only page. The pipeline can still work from the recovered
+                text, but for better summaries, metadata, and translations, try to
+                obtain a text-based version of this PDF (one with a real text
+                layer) rather than a scanned copy.
+              </Trans>
+            </p>
+          </div>
         ) : (
           <div className="text-sm text-muted-foreground py-8 text-center">
             <Trans>No extracted text yet. Run the pipeline first.</Trans>

--- a/apps/studio/src/components/pipeline/stages/sectioning/SectioningPageDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/sectioning/SectioningPageDetail.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react"
 import { createPortal } from "react-dom"
+import { Eye } from "lucide-react"
 import { Trans, useLingui } from "@lingui/react/macro"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import type { PageSectioningOutput, PageSectioningSection } from "@adt/types"
@@ -190,6 +191,19 @@ export function SectioningPageDetail({
         )}
       </div>
       <div className="w-1/2 min-w-0 overflow-auto p-4 space-y-4">
+        {page.extractionWarning && (
+          <div className="flex gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2">
+            <Eye className="w-3.5 h-3.5 text-amber-600 shrink-0 mt-0.5" />
+            <span className="text-[12px] text-amber-700 leading-relaxed">
+              <Trans>
+                This page has no embedded text layer — the text below was
+                recovered from the page image (vision). For better summaries,
+                metadata, and translations, prefer a text-based version of this
+                PDF.
+              </Trans>
+            </span>
+          </div>
+        )}
         {mergedSections.length === 0 ? (
           <div className="text-sm text-muted-foreground italic">
             <Trans>No sections on this page</Trans>

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/SectioningOverview.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/SectioningOverview.tsx
@@ -12,6 +12,7 @@ import {
   FileText,
   Loader2,
   SlidersHorizontal,
+  Eye,
 } from "lucide-react"
 import { SectionActionsDropdown } from "./SectionActionsDropdown"
 import { SectionEditToolbar } from "./SectionEditToolbar"
@@ -412,6 +413,15 @@ function PageSectionRows({
             <span className="text-muted-foreground text-[10px] ml-1">
               — {sections.length} {sections.length === 1 ? t`section` : t`sections`}
             </span>
+            {page.extractionWarning && (
+              <span
+                className="inline-flex items-center gap-0.5 text-[10px] bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400 px-1 rounded"
+                title={t`Text recovered from the page image — this page has no embedded text layer`}
+              >
+                <Eye className="h-3 w-3" />
+                <Trans>vision</Trans>
+              </span>
+            )}
             {reasoning && reasoning !== "No content to section" && (
               <>
                 {reasoningOpen ? (

--- a/apps/studio/src/hooks/use-pages.ts
+++ b/apps/studio/src/hooks/use-pages.ts
@@ -3,12 +3,14 @@ import { api } from "@/api/client"
 
 export function usePages(
   label: string,
-  options?: { refetchInterval?: number | false; refetchOnMount?: boolean | "always" }
+  options?: { refetchInterval?: number | false; refetchOnMount?: boolean | "always"; enabled?: boolean }
 ) {
   return useQuery({
     queryKey: ["books", label, "pages"],
     queryFn: () => api.getPages(label),
-    enabled: !!label,
+    // `enabled: false` still subscribes to (and re-renders on) the cached query
+    // populated by other observers — it just won't trigger its own fetch.
+    enabled: !!label && (options?.enabled ?? true),
     refetchOnMount: options?.refetchOnMount,
     refetchInterval: options?.refetchInterval ?? false,
   })

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -3925,6 +3925,9 @@ msgstr "No disabled rules"
 msgid "No Easy Read for this page"
 msgstr "No Easy Read for this page"
 
+msgid "No embedded text layer — text was recovered from the page image"
+msgstr "No embedded text layer — text was recovered from the page image"
+
 msgid "No entries match your search"
 msgstr "No entries match your search"
 
@@ -4048,8 +4051,8 @@ msgstr "No quizzes for this page"
 msgid "No quizzes match your search"
 msgstr "No quizzes match your search"
 
-msgid "No readable text extracted from this page"
-msgstr "No readable text extracted from this page"
+#~ msgid "No readable text extracted from this page"
+#~ msgstr "No readable text extracted from this page"
 
 msgid "No rendered content for this section"
 msgstr "No rendered content for this section"

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -161,6 +161,14 @@ msgstr "{0} of {1} images"
 msgid "{0} of {1} items"
 msgstr "{0} of {1} items"
 
+#. placeholder {0}: warnPages.length
+#. placeholder {1}: pageList.length
+msgid "{0} of {1} pages had no extracted text"
+msgstr "{0} of {1} pages had no extracted text"
+
+#~ msgid "{0} of {1} pages had no readable text"
+#~ msgstr "{0} of {1} pages had no readable text"
+
 #. placeholder {0}: String(displayPages.length)
 #. placeholder {0}: book.pageCount
 msgid "{0} pages"
@@ -4040,6 +4048,9 @@ msgstr "No quizzes for this page"
 msgid "No quizzes match your search"
 msgstr "No quizzes match your search"
 
+msgid "No readable text extracted from this page"
+msgstr "No readable text extracted from this page"
+
 msgid "No rendered content for this section"
 msgstr "No rendered content for this section"
 
@@ -6170,6 +6181,9 @@ msgstr "Text color: {0}"
 msgid "Text Only"
 msgstr "Text Only"
 
+msgid "Text recovered from the page image — this page has no embedded text layer"
+msgstr "Text recovered from the page image — this page has no embedded text layer"
+
 msgid "Text roles the LLM may assign to text in the content tree. Pruned roles are classified but excluded from rendering."
 msgstr "Text roles the LLM may assign to text in the content tree. Pruned roles are classified but excluded from rendering."
 
@@ -6314,6 +6328,9 @@ msgstr "Theme"
 msgid "These features improve access for people with disabilities. Running them before exporting helps your book meet ADT accessibility standards."
 msgstr "These features improve access for people with disabilities. Running them before exporting helps your book meet ADT accessibility standards."
 
+msgid "These pages have no embedded text layer, but the Sectioning step recovered text from the page images — so this PDF looks scanned or image-based. The pipeline can still work from the recovered text, but for better summaries, metadata, and translations, try to obtain a text-based version of this PDF (one with a real text layer) rather than a scanned copy."
+msgstr "These pages have no embedded text layer, but the Sectioning step recovered text from the page images — so this PDF looks scanned or image-based. The pipeline can still work from the recovered text, but for better summaries, metadata, and translations, try to obtain a text-based version of this PDF (one with a real text layer) rather than a scanned copy."
+
 msgid "These stages are optional. They don't depend on each other — run any of them in any order once the core pipeline is complete."
 msgstr "These stages are optional. They don't depend on each other — run any of them in any order once the core pipeline is complete."
 
@@ -6366,6 +6383,9 @@ msgstr "This is Pip! He is a happy caramel dog with a very wiggly tail. Pip love
 msgid "This page has no captioned images"
 msgstr "This page has no captioned images"
 
+msgid "This page has no embedded text layer — the text below was recovered from the page image (vision). For better summaries, metadata, and translations, prefer a text-based version of this PDF."
+msgstr "This page has no embedded text layer — the text below was recovered from the page image (vision). For better summaries, metadata, and translations, prefer a text-based version of this PDF."
+
 msgid "This page has no entries to synthesize"
 msgstr "This page has no entries to synthesize"
 
@@ -6378,11 +6398,32 @@ msgstr "This page has no simplified text blocks"
 msgid "This page has no storyboard sections"
 msgstr "This page has no storyboard sections"
 
+#~ msgid "This page has no text layer — it appears to be a scanned or image-only page. The Sectioning step may still recover text from the page image. For reliable text, first try to obtain a better-quality, text-based version of this PDF; only if none is available, run OCR on the file before importing."
+#~ msgstr "This page has no text layer — it appears to be a scanned or image-only page. The Sectioning step may still recover text from the page image. For reliable text, first try to obtain a better-quality, text-based version of this PDF; only if none is available, run OCR on the file before importing."
+
+#~ msgid "This page has no text layer — it appears to be a scanned or image-only page. The Sectioning step may still recover text from the page image. For reliable text, run OCR on this PDF before importing."
+#~ msgstr "This page has no text layer — it appears to be a scanned or image-only page. The Sectioning step may still recover text from the page image. For reliable text, run OCR on this PDF before importing."
+
 msgid "This page has no translatable text entries"
 msgstr "This page has no translatable text entries"
 
 msgid "This page has not been reviewed yet"
 msgstr "This page has not been reviewed yet"
+
+#~ msgid "This page renders text, but its fonts could not be decoded (a font/encoding issue in the PDF). The Sectioning step may still recover the text from the page image. For reliable text, first try to obtain a cleaner, text-based version of this PDF; only if none is available, run OCR on the file before importing."
+#~ msgstr "This page renders text, but its fonts could not be decoded (a font/encoding issue in the PDF). The Sectioning step may still recover the text from the page image. For reliable text, first try to obtain a cleaner, text-based version of this PDF; only if none is available, run OCR on the file before importing."
+
+#~ msgid "This page renders text, but its fonts could not be decoded (a font/encoding issue in the PDF). The Sectioning step may still recover the text from the page image. For reliable text, supply a text-based PDF or run OCR on this file before importing."
+#~ msgstr "This page renders text, but its fonts could not be decoded (a font/encoding issue in the PDF). The Sectioning step may still recover the text from the page image. For reliable text, supply a text-based PDF or run OCR on this file before importing."
+
+msgid "This page's embedded text layer is empty, but the Sectioning step recovered text from the page image — so it looks like a scanned or image-only page. The pipeline can still work from the recovered text, but for better summaries, metadata, and translations, try to obtain a text-based version of this PDF (one with a real text layer) rather than a scanned copy."
+msgstr "This page's embedded text layer is empty, but the Sectioning step recovered text from the page image — so it looks like a scanned or image-only page. The pipeline can still work from the recovered text, but for better summaries, metadata, and translations, try to obtain a text-based version of this PDF (one with a real text layer) rather than a scanned copy."
+
+#~ msgid "This PDF appears to be image-based or uses fonts we can't read as text, so the extracted text may be incomplete. The Sectioning step can still recover some text from the page image, but for better summaries, metadata, and translations, first try to obtain a better-quality, text-based version of this PDF — and only run OCR on it if no such version is available."
+#~ msgstr "This PDF appears to be image-based or uses fonts we can't read as text, so the extracted text may be incomplete. The Sectioning step can still recover some text from the page image, but for better summaries, metadata, and translations, first try to obtain a better-quality, text-based version of this PDF — and only run OCR on it if no such version is available."
+
+#~ msgid "This PDF appears to be image-based or uses fonts we can't read as text, so the extracted text may be incomplete. The Sectioning step can still recover some text from the page image, but for better summaries, metadata, and translations, supply a text-based PDF or run OCR on this file before importing."
+#~ msgstr "This PDF appears to be image-based or uses fonts we can't read as text, so the extracted text may be incomplete. The Sectioning step can still recover some text from the page image, but for better summaries, metadata, and translations, supply a text-based PDF or run OCR on this file before importing."
 
 msgid "This permanently deletes every uploaded video and clears all section assignments. This can't be undone."
 msgstr "This permanently deletes every uploaded video and clears all section assignments. This can't be undone."
@@ -6869,6 +6910,9 @@ msgstr "View image"
 
 msgid "View page"
 msgstr "View page"
+
+msgid "vision"
+msgstr "vision"
 
 msgid "Visual & sensory cues"
 msgstr "Visual & sensory cues"

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -5864,6 +5864,9 @@ msgstr "Software Update"
 msgid "Software update status"
 msgstr "Software update status"
 
+msgid "Some pages have no embedded text layer — text was recovered from the page image. Prefer a text-based PDF."
+msgstr "Some pages have no embedded text layer — text was recovered from the page image. Prefer a text-based PDF."
+
 msgid "Something went wrong"
 msgstr "Something went wrong"
 

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -3925,6 +3925,9 @@ msgstr "No disabled rules"
 msgid "No Easy Read for this page"
 msgstr "No hay Lectura Fácil para esta página"
 
+msgid "No embedded text layer — text was recovered from the page image"
+msgstr "Sin capa de texto incrustado — el texto se recuperó a partir de la imagen de la página"
+
 msgid "No entries match your search"
 msgstr "No hay entradas que coincidan con tu búsqueda"
 
@@ -4048,8 +4051,8 @@ msgstr "No hay quizzes para esta página"
 msgid "No quizzes match your search"
 msgstr "Ningún cuestionario coincide con tu búsqueda"
 
-msgid "No readable text extracted from this page"
-msgstr "No se extrajo texto legible de esta página"
+#~ msgid "No readable text extracted from this page"
+#~ msgstr "No se extrajo texto legible de esta página"
 
 msgid "No rendered content for this section"
 msgstr "Sin contenido renderizado para esta sección"

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -161,6 +161,14 @@ msgstr "{0} de {1} imágenes"
 msgid "{0} of {1} items"
 msgstr "{0} de {1} elementos"
 
+#. placeholder {0}: warnPages.length
+#. placeholder {1}: pageList.length
+msgid "{0} of {1} pages had no extracted text"
+msgstr "{0} de {1} páginas no tienen texto extraído"
+
+#~ msgid "{0} of {1} pages had no readable text"
+#~ msgstr "{0} de {1} páginas no tienen texto legible"
+
 #. placeholder {0}: String(displayPages.length)
 #. placeholder {0}: book.pageCount
 msgid "{0} pages"
@@ -4040,6 +4048,9 @@ msgstr "No hay quizzes para esta página"
 msgid "No quizzes match your search"
 msgstr "Ningún cuestionario coincide con tu búsqueda"
 
+msgid "No readable text extracted from this page"
+msgstr "No se extrajo texto legible de esta página"
+
 msgid "No rendered content for this section"
 msgstr "Sin contenido renderizado para esta sección"
 
@@ -6170,6 +6181,9 @@ msgstr "Color del texto: {0}"
 msgid "Text Only"
 msgstr "Solo texto"
 
+msgid "Text recovered from the page image — this page has no embedded text layer"
+msgstr "Texto recuperado a partir de la imagen de la página — esta página no tiene capa de texto incrustado"
+
 msgid "Text roles the LLM may assign to text in the content tree. Pruned roles are classified but excluded from rendering."
 msgstr "Roles de texto que el LLM puede asignar al texto en el árbol de contenido. Los roles podados se clasifican pero se excluyen del renderizado."
 
@@ -6314,6 +6328,9 @@ msgstr "Tema"
 msgid "These features improve access for people with disabilities. Running them before exporting helps your book meet ADT accessibility standards."
 msgstr "Estas funciones mejoran el acceso para personas con discapacidades. Ejecutarlas antes de exportar ayuda a que su libro cumpla con los estándares de accesibilidad ADT."
 
+msgid "These pages have no embedded text layer, but the Sectioning step recovered text from the page images — so this PDF looks scanned or image-based. The pipeline can still work from the recovered text, but for better summaries, metadata, and translations, try to obtain a text-based version of this PDF (one with a real text layer) rather than a scanned copy."
+msgstr "Estas páginas no tienen capa de texto incrustado, pero el paso de Seccionamiento recuperó texto a partir de las imágenes de las páginas, por lo que este PDF parece escaneado o basado en imágenes. La canalización aún puede funcionar con el texto recuperado, pero para obtener mejores resúmenes, metadatos y traducciones, intenta conseguir una versión de este PDF basada en texto (con una capa de texto real) en lugar de una copia escaneada."
+
 msgid "These stages are optional. They don't depend on each other — run any of them in any order once the core pipeline is complete."
 msgstr "Estas etapas son opcionales. No dependen unas de otras: ejecuta cualquiera en cualquier orden una vez completado el flujo principal."
 
@@ -6366,6 +6383,9 @@ msgstr "¡Este es Pip! Es un perro caramelo feliz con una cola muy movida. A Pip
 msgid "This page has no captioned images"
 msgstr "Esta página no tiene imágenes con leyendas"
 
+msgid "This page has no embedded text layer — the text below was recovered from the page image (vision). For better summaries, metadata, and translations, prefer a text-based version of this PDF."
+msgstr "Esta página no tiene capa de texto incrustado — el texto de abajo se recuperó a partir de la imagen de la página (visión). Para obtener mejores resúmenes, metadatos y traducciones, usa una versión de este PDF basada en texto."
+
 msgid "This page has no entries to synthesize"
 msgstr "Esta página no tiene entradas para sintetizar"
 
@@ -6378,11 +6398,32 @@ msgstr "Esta página no tiene bloques de texto simplificados"
 msgid "This page has no storyboard sections"
 msgstr "Esta página no tiene secciones de storyboard"
 
+#~ msgid "This page has no text layer — it appears to be a scanned or image-only page. The Sectioning step may still recover text from the page image. For reliable text, first try to obtain a better-quality, text-based version of this PDF; only if none is available, run OCR on the file before importing."
+#~ msgstr "Esta página no tiene capa de texto: parece ser una página escaneada o solo de imagen. El paso de Seccionamiento aún puede recuperar algo de texto a partir de la imagen de la página. Para obtener texto fiable, primero intenta conseguir una versión de este PDF de mejor calidad y basada en texto; solo si no hay ninguna disponible, aplica OCR al archivo antes de importarlo."
+
+#~ msgid "This page has no text layer — it appears to be a scanned or image-only page. The Sectioning step may still recover text from the page image. For reliable text, run OCR on this PDF before importing."
+#~ msgstr "Esta página no tiene capa de texto: parece ser una página escaneada o solo de imagen. El paso de Seccionamiento aún puede recuperar algo de texto a partir de la imagen de la página. Para obtener texto fiable, aplica OCR a este PDF antes de importarlo."
+
 msgid "This page has no translatable text entries"
 msgstr "Esta página no tiene entradas de texto traducibles"
 
 msgid "This page has not been reviewed yet"
 msgstr "This page has not been reviewed yet"
+
+#~ msgid "This page renders text, but its fonts could not be decoded (a font/encoding issue in the PDF). The Sectioning step may still recover the text from the page image. For reliable text, first try to obtain a cleaner, text-based version of this PDF; only if none is available, run OCR on the file before importing."
+#~ msgstr "Esta página muestra texto, pero no se pudieron decodificar sus fuentes (un problema de fuente/codificación en el PDF). El paso de Seccionamiento aún puede recuperar el texto a partir de la imagen de la página. Para obtener texto fiable, primero intenta conseguir una versión más limpia de este PDF basada en texto; solo si no hay ninguna disponible, aplica OCR al archivo antes de importarlo."
+
+#~ msgid "This page renders text, but its fonts could not be decoded (a font/encoding issue in the PDF). The Sectioning step may still recover the text from the page image. For reliable text, supply a text-based PDF or run OCR on this file before importing."
+#~ msgstr "Esta página muestra texto, pero no se pudieron decodificar sus fuentes (un problema de fuente/codificación en el PDF). El paso de Seccionamiento aún puede recuperar el texto a partir de la imagen de la página. Para obtener texto fiable, usa un PDF basado en texto o aplica OCR a este archivo antes de importarlo."
+
+msgid "This page's embedded text layer is empty, but the Sectioning step recovered text from the page image — so it looks like a scanned or image-only page. The pipeline can still work from the recovered text, but for better summaries, metadata, and translations, try to obtain a text-based version of this PDF (one with a real text layer) rather than a scanned copy."
+msgstr "La capa de texto incrustado de esta página está vacía, pero el paso de Seccionamiento recuperó texto a partir de la imagen de la página, por lo que parece una página escaneada o solo de imagen. La canalización aún puede funcionar con el texto recuperado, pero para obtener mejores resúmenes, metadatos y traducciones, intenta conseguir una versión de este PDF basada en texto (con una capa de texto real) en lugar de una copia escaneada."
+
+#~ msgid "This PDF appears to be image-based or uses fonts we can't read as text, so the extracted text may be incomplete. The Sectioning step can still recover some text from the page image, but for better summaries, metadata, and translations, first try to obtain a better-quality, text-based version of this PDF — and only run OCR on it if no such version is available."
+#~ msgstr "Este PDF parece estar basado en imágenes o usa fuentes que no podemos leer como texto, por lo que el texto extraído puede estar incompleto. El paso de Seccionamiento aún puede recuperar parte del texto a partir de la imagen de la página, pero para obtener mejores resúmenes, metadatos y traducciones, primero intenta conseguir una versión de este PDF de mejor calidad y basada en texto, y aplica OCR solo si no hay ninguna disponible."
+
+#~ msgid "This PDF appears to be image-based or uses fonts we can't read as text, so the extracted text may be incomplete. The Sectioning step can still recover some text from the page image, but for better summaries, metadata, and translations, supply a text-based PDF or run OCR on this file before importing."
+#~ msgstr "Este PDF parece estar basado en imágenes o usa fuentes que no podemos leer como texto, por lo que el texto extraído puede estar incompleto. El paso de Seccionamiento aún puede recuperar parte del texto a partir de la imagen de la página, pero para obtener mejores resúmenes, metadatos y traducciones, usa un PDF basado en texto o aplica OCR a este archivo antes de importarlo."
 
 msgid "This permanently deletes every uploaded video and clears all section assignments. This can't be undone."
 msgstr "Esto elimina permanentemente cada video subido y borra todas las asignaciones de secciones. Esto no se puede deshacer."
@@ -6869,6 +6910,9 @@ msgstr "Ver imagen"
 
 msgid "View page"
 msgstr "Ver página"
+
+msgid "vision"
+msgstr "visión"
 
 msgid "Visual & sensory cues"
 msgstr "Visual & sensory cues"

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -5864,6 +5864,9 @@ msgstr "Actualización de Software"
 msgid "Software update status"
 msgstr "Estado de la actualización de software"
 
+msgid "Some pages have no embedded text layer — text was recovered from the page image. Prefer a text-based PDF."
+msgstr "Algunas páginas no tienen capa de texto incrustado — el texto se recuperó a partir de la imagen de la página. Usa preferentemente un PDF basado en texto."
+
 msgid "Something went wrong"
 msgstr "Algo salió mal"
 

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -163,6 +163,14 @@ msgstr "{0} sur {1} images"
 msgid "{0} of {1} items"
 msgstr "{0} sur {1} éléments"
 
+#. placeholder {0}: warnPages.length
+#. placeholder {1}: pageList.length
+msgid "{0} of {1} pages had no extracted text"
+msgstr "{0} pages sur {1} n'ont aucun texte extrait"
+
+#~ msgid "{0} of {1} pages had no readable text"
+#~ msgstr "{0} pages sur {1} n'ont aucun texte lisible"
+
 #. placeholder {0}: String(displayPages.length)
 #. placeholder {0}: book.pageCount
 msgid "{0} pages"
@@ -4042,6 +4050,9 @@ msgstr "Aucun quiz pour cette page"
 msgid "No quizzes match your search"
 msgstr "Aucun quiz ne correspond à votre recherche"
 
+msgid "No readable text extracted from this page"
+msgstr "Aucun texte lisible extrait de cette page"
+
 msgid "No rendered content for this section"
 msgstr "Aucun contenu rendu pour cette section"
 
@@ -6172,6 +6183,9 @@ msgstr "Texte couleur: {0}"
 msgid "Text Only"
 msgstr "Texte uniquement"
 
+msgid "Text recovered from the page image — this page has no embedded text layer"
+msgstr "Texte récupéré à partir de l'image de la page — cette page n'a pas de couche de texte intégrée"
+
 msgid "Text roles the LLM may assign to text in the content tree. Pruned roles are classified but excluded from rendering."
 msgstr "Rôles de texte que le LLM peut attribuer au texte dans l'arbre de contenu. Les rôles élagués sont classés mais exclus du rendu."
 
@@ -6316,6 +6330,9 @@ msgstr "Thème"
 msgid "These features improve access for people with disabilities. Running them before exporting helps your book meet ADT accessibility standards."
 msgstr "Ces fonctionnalités améliorent l'accès pour les personnes handicapées. Les exécuter avant l'exportation aide votre livre à respecter les normes d'accessibilité ADT."
 
+msgid "These pages have no embedded text layer, but the Sectioning step recovered text from the page images — so this PDF looks scanned or image-based. The pipeline can still work from the recovered text, but for better summaries, metadata, and translations, try to obtain a text-based version of this PDF (one with a real text layer) rather than a scanned copy."
+msgstr "Ces pages n'ont pas de couche de texte intégrée, mais l'étape de Sectionnement a récupéré du texte à partir des images des pages — ce PDF semble donc numérisé ou basé sur des images. Le pipeline peut toujours fonctionner à partir du texte récupéré, mais pour de meilleurs résumés, métadonnées et traductions, essayez d'obtenir une version de ce PDF basée sur du texte (avec une vraie couche de texte) plutôt qu'une copie numérisée."
+
 msgid "These stages are optional. They don't depend on each other — run any of them in any order once the core pipeline is complete."
 msgstr "Ces étapes sont facultatives. Elles ne dépendent pas les unes des autres — exécutez-les dans n'importe quel ordre une fois le pipeline principal terminé."
 
@@ -6368,6 +6385,9 @@ msgstr "Voici Pip ! C'est un joyeux chien caramel avec une queue très remuante.
 msgid "This page has no captioned images"
 msgstr "Cette page n'a pas d'images légendées"
 
+msgid "This page has no embedded text layer — the text below was recovered from the page image (vision). For better summaries, metadata, and translations, prefer a text-based version of this PDF."
+msgstr "Cette page n'a pas de couche de texte intégrée — le texte ci-dessous a été récupéré à partir de l'image de la page (vision). Pour de meilleurs résumés, métadonnées et traductions, utilisez une version de ce PDF basée sur du texte."
+
 msgid "This page has no entries to synthesize"
 msgstr "Cette page n'a pas d'entrées à synthétiser"
 
@@ -6380,11 +6400,32 @@ msgstr "Cette page n'a pas de blocs de texte simplifiés"
 msgid "This page has no storyboard sections"
 msgstr "Cette page n'a pas de sections de scénarimage"
 
+#~ msgid "This page has no text layer — it appears to be a scanned or image-only page. The Sectioning step may still recover text from the page image. For reliable text, first try to obtain a better-quality, text-based version of this PDF; only if none is available, run OCR on the file before importing."
+#~ msgstr "Cette page n'a pas de couche de texte : il s'agit apparemment d'une page numérisée ou uniquement composée d'images. L'étape de Sectionnement peut encore récupérer du texte à partir de l'image de la page. Pour un texte fiable, essayez d'abord d'obtenir une version de ce PDF de meilleure qualité et basée sur du texte ; n'appliquez l'OCR au fichier avant de l'importer que si aucune n'est disponible."
+
+#~ msgid "This page has no text layer — it appears to be a scanned or image-only page. The Sectioning step may still recover text from the page image. For reliable text, run OCR on this PDF before importing."
+#~ msgstr "Cette page n'a pas de couche de texte : il s'agit apparemment d'une page numérisée ou uniquement composée d'images. L'étape de Sectionnement peut encore récupérer du texte à partir de l'image de la page. Pour un texte fiable, appliquez l'OCR à ce PDF avant de l'importer."
+
 msgid "This page has no translatable text entries"
 msgstr "Cette page n'a pas d'entrées de texte traduisibles"
 
 msgid "This page has not been reviewed yet"
 msgstr "Cette page n'a pas encore été révisée"
+
+#~ msgid "This page renders text, but its fonts could not be decoded (a font/encoding issue in the PDF). The Sectioning step may still recover the text from the page image. For reliable text, first try to obtain a cleaner, text-based version of this PDF; only if none is available, run OCR on the file before importing."
+#~ msgstr "Cette page affiche du texte, mais ses polices n'ont pas pu être décodées (un problème de police ou d'encodage dans le PDF). L'étape de Sectionnement peut encore récupérer le texte à partir de l'image de la page. Pour un texte fiable, essayez d'abord d'obtenir une version plus propre de ce PDF basée sur du texte ; n'appliquez l'OCR au fichier avant de l'importer que si aucune n'est disponible."
+
+#~ msgid "This page renders text, but its fonts could not be decoded (a font/encoding issue in the PDF). The Sectioning step may still recover the text from the page image. For reliable text, supply a text-based PDF or run OCR on this file before importing."
+#~ msgstr "Cette page affiche du texte, mais ses polices n'ont pas pu être décodées (un problème de police ou d'encodage dans le PDF). L'étape de Sectionnement peut encore récupérer le texte à partir de l'image de la page. Pour un texte fiable, fournissez un PDF basé sur du texte ou appliquez l'OCR à ce fichier avant de l'importer."
+
+msgid "This page's embedded text layer is empty, but the Sectioning step recovered text from the page image — so it looks like a scanned or image-only page. The pipeline can still work from the recovered text, but for better summaries, metadata, and translations, try to obtain a text-based version of this PDF (one with a real text layer) rather than a scanned copy."
+msgstr "La couche de texte intégrée de cette page est vide, mais l'étape de Sectionnement a récupéré du texte à partir de l'image de la page — elle semble donc numérisée ou uniquement composée d'images. Le pipeline peut toujours fonctionner à partir du texte récupéré, mais pour de meilleurs résumés, métadonnées et traductions, essayez d'obtenir une version de ce PDF basée sur du texte (avec une vraie couche de texte) plutôt qu'une copie numérisée."
+
+#~ msgid "This PDF appears to be image-based or uses fonts we can't read as text, so the extracted text may be incomplete. The Sectioning step can still recover some text from the page image, but for better summaries, metadata, and translations, first try to obtain a better-quality, text-based version of this PDF — and only run OCR on it if no such version is available."
+#~ msgstr "Ce PDF semble être basé sur des images ou utilise des polices que nous ne pouvons pas lire comme du texte ; le texte extrait peut donc être incomplet. L'étape de Sectionnement peut encore récupérer une partie du texte à partir de l'image de la page, mais pour de meilleurs résumés, métadonnées et traductions, essayez d'abord d'obtenir une version de ce PDF de meilleure qualité et basée sur du texte, et n'appliquez l'OCR que si aucune n'est disponible."
+
+#~ msgid "This PDF appears to be image-based or uses fonts we can't read as text, so the extracted text may be incomplete. The Sectioning step can still recover some text from the page image, but for better summaries, metadata, and translations, supply a text-based PDF or run OCR on this file before importing."
+#~ msgstr "Ce PDF semble être basé sur des images ou utilise des polices que nous ne pouvons pas lire comme du texte ; le texte extrait peut donc être incomplet. L'étape de Sectionnement peut encore récupérer une partie du texte à partir de l'image de la page, mais pour de meilleurs résumés, métadonnées et traductions, fournissez un PDF basé sur du texte ou appliquez l'OCR à ce fichier avant de l'importer."
 
 msgid "This permanently deletes every uploaded video and clears all section assignments. This can't be undone."
 msgstr "Cela supprime définitivement chaque vidéo téléchargée et efface toutes les affectations de sections. Cela ne peut pas être annulé."
@@ -6871,6 +6912,9 @@ msgstr "Voir l'image"
 
 msgid "View page"
 msgstr "Voir la page"
+
+msgid "vision"
+msgstr "vision"
 
 msgid "Visual & sensory cues"
 msgstr "Indices visuels et sensoriels"

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -5866,6 +5866,9 @@ msgstr "Mise à jour logicielle"
 msgid "Software update status"
 msgstr "Statut de la mise à jour logicielle"
 
+msgid "Some pages have no embedded text layer — text was recovered from the page image. Prefer a text-based PDF."
+msgstr "Certaines pages n'ont pas de couche de texte intégrée — le texte a été récupéré à partir de l'image de la page. Préférez un PDF basé sur du texte."
+
 msgid "Something went wrong"
 msgstr "Quelque chose s'est mal passé"
 

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -3927,6 +3927,9 @@ msgstr "Aucune règle désactivée"
 msgid "No Easy Read for this page"
 msgstr "Pas de lecture facile pour cette page"
 
+msgid "No embedded text layer — text was recovered from the page image"
+msgstr "Pas de couche de texte intégrée — le texte a été récupéré à partir de l'image de la page"
+
 msgid "No entries match your search"
 msgstr "Aucune entrée ne correspond à votre recherche"
 
@@ -4050,8 +4053,8 @@ msgstr "Aucun quiz pour cette page"
 msgid "No quizzes match your search"
 msgstr "Aucun quiz ne correspond à votre recherche"
 
-msgid "No readable text extracted from this page"
-msgstr "Aucun texte lisible extrait de cette page"
+#~ msgid "No readable text extracted from this page"
+#~ msgstr "Aucun texte lisible extrait de cette page"
 
 msgid "No rendered content for this section"
 msgstr "Aucun contenu rendu pour cette section"

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -161,6 +161,14 @@ msgstr "{0} de {1} imagens"
 msgid "{0} of {1} items"
 msgstr "{0} de {1} itens"
 
+#. placeholder {0}: warnPages.length
+#. placeholder {1}: pageList.length
+msgid "{0} of {1} pages had no extracted text"
+msgstr "{0} de {1} páginas não têm texto extraído"
+
+#~ msgid "{0} of {1} pages had no readable text"
+#~ msgstr "{0} de {1} páginas não têm texto legível"
+
 #. placeholder {0}: String(displayPages.length)
 #. placeholder {0}: book.pageCount
 msgid "{0} pages"
@@ -4040,6 +4048,9 @@ msgstr "Nenhum quiz para esta página"
 msgid "No quizzes match your search"
 msgstr "Nenhum questionário corresponde à sua pesquisa"
 
+msgid "No readable text extracted from this page"
+msgstr "Nenhum texto legível extraído desta página"
+
 msgid "No rendered content for this section"
 msgstr "Sem conteúdo renderizado para esta seção"
 
@@ -6170,6 +6181,9 @@ msgstr "Cor do texto: {0}"
 msgid "Text Only"
 msgstr "Só texto"
 
+msgid "Text recovered from the page image — this page has no embedded text layer"
+msgstr "Texto recuperado a partir da imagem da página — esta página não tem camada de texto incorporada"
+
 msgid "Text roles the LLM may assign to text in the content tree. Pruned roles are classified but excluded from rendering."
 msgstr "Papéis de texto que o LLM pode atribuir ao texto na árvore de conteúdo. Papéis podados são classificados, mas excluídos da renderização."
 
@@ -6314,6 +6328,9 @@ msgstr "Tema"
 msgid "These features improve access for people with disabilities. Running them before exporting helps your book meet ADT accessibility standards."
 msgstr "Esses recursos melhoram o acesso para pessoas com deficiência. Executá-los antes de exportar ajuda seu livro a atender aos padrões de acessibilidade ADT."
 
+msgid "These pages have no embedded text layer, but the Sectioning step recovered text from the page images — so this PDF looks scanned or image-based. The pipeline can still work from the recovered text, but for better summaries, metadata, and translations, try to obtain a text-based version of this PDF (one with a real text layer) rather than a scanned copy."
+msgstr "Estas páginas não têm camada de texto incorporada, mas a etapa de Seccionamento recuperou texto a partir das imagens das páginas — portanto este PDF parece digitalizado ou baseado em imagens. O pipeline ainda pode funcionar com o texto recuperado, mas para melhores resumos, metadados e traduções, tente obter uma versão deste PDF baseada em texto (com uma camada de texto real) em vez de uma cópia digitalizada."
+
 msgid "These stages are optional. They don't depend on each other — run any of them in any order once the core pipeline is complete."
 msgstr "Essas etapas são opcionais. Elas não dependem umas das outras — execute qualquer uma em qualquer ordem após a conclusão do pipeline principal."
 
@@ -6366,6 +6383,9 @@ msgstr "Este é o Pip! Ele é um cachorro caramelo feliz com um rabo muito agita
 msgid "This page has no captioned images"
 msgstr "Esta página não tem imagens legendadas"
 
+msgid "This page has no embedded text layer — the text below was recovered from the page image (vision). For better summaries, metadata, and translations, prefer a text-based version of this PDF."
+msgstr "Esta página não tem camada de texto incorporada — o texto abaixo foi recuperado a partir da imagem da página (visão). Para melhores resumos, metadados e traduções, use uma versão deste PDF baseada em texto."
+
 msgid "This page has no entries to synthesize"
 msgstr "Esta página não tem entradas para sintetizar"
 
@@ -6378,11 +6398,32 @@ msgstr "Esta página não tem blocos de texto simplificados"
 msgid "This page has no storyboard sections"
 msgstr "Esta página não tem seções de storyboard"
 
+#~ msgid "This page has no text layer — it appears to be a scanned or image-only page. The Sectioning step may still recover text from the page image. For reliable text, first try to obtain a better-quality, text-based version of this PDF; only if none is available, run OCR on the file before importing."
+#~ msgstr "Esta página não tem camada de texto: parece ser uma página digitalizada ou apenas de imagem. A etapa de Seccionamento ainda pode recuperar algum texto a partir da imagem da página. Para um texto confiável, primeiro tente obter uma versão deste PDF de melhor qualidade e baseada em texto; somente se nenhuma estiver disponível, aplique OCR ao arquivo antes de importá-lo."
+
+#~ msgid "This page has no text layer — it appears to be a scanned or image-only page. The Sectioning step may still recover text from the page image. For reliable text, run OCR on this PDF before importing."
+#~ msgstr "Esta página não tem camada de texto: parece ser uma página digitalizada ou apenas de imagem. A etapa de Seccionamento ainda pode recuperar algum texto a partir da imagem da página. Para um texto confiável, aplique OCR a este PDF antes de importá-lo."
+
 msgid "This page has no translatable text entries"
 msgstr "Esta página não tem entradas de texto traduzíveis"
 
 msgid "This page has not been reviewed yet"
 msgstr "This page has not been reviewed yet"
+
+#~ msgid "This page renders text, but its fonts could not be decoded (a font/encoding issue in the PDF). The Sectioning step may still recover the text from the page image. For reliable text, first try to obtain a cleaner, text-based version of this PDF; only if none is available, run OCR on the file before importing."
+#~ msgstr "Esta página exibe texto, mas suas fontes não puderam ser decodificadas (um problema de fonte/codificação no PDF). A etapa de Seccionamento ainda pode recuperar o texto a partir da imagem da página. Para um texto confiável, primeiro tente obter uma versão mais limpa deste PDF baseada em texto; somente se nenhuma estiver disponível, aplique OCR ao arquivo antes de importá-lo."
+
+#~ msgid "This page renders text, but its fonts could not be decoded (a font/encoding issue in the PDF). The Sectioning step may still recover the text from the page image. For reliable text, supply a text-based PDF or run OCR on this file before importing."
+#~ msgstr "Esta página exibe texto, mas suas fontes não puderam ser decodificadas (um problema de fonte/codificação no PDF). A etapa de Seccionamento ainda pode recuperar o texto a partir da imagem da página. Para um texto confiável, forneça um PDF baseado em texto ou aplique OCR a este arquivo antes de importá-lo."
+
+msgid "This page's embedded text layer is empty, but the Sectioning step recovered text from the page image — so it looks like a scanned or image-only page. The pipeline can still work from the recovered text, but for better summaries, metadata, and translations, try to obtain a text-based version of this PDF (one with a real text layer) rather than a scanned copy."
+msgstr "A camada de texto incorporada desta página está vazia, mas a etapa de Seccionamento recuperou texto a partir da imagem da página — portanto ela parece uma página digitalizada ou apenas de imagem. O pipeline ainda pode funcionar com o texto recuperado, mas para melhores resumos, metadados e traduções, tente obter uma versão deste PDF baseada em texto (com uma camada de texto real) em vez de uma cópia digitalizada."
+
+#~ msgid "This PDF appears to be image-based or uses fonts we can't read as text, so the extracted text may be incomplete. The Sectioning step can still recover some text from the page image, but for better summaries, metadata, and translations, first try to obtain a better-quality, text-based version of this PDF — and only run OCR on it if no such version is available."
+#~ msgstr "Este PDF parece ser baseado em imagens ou usa fontes que não conseguimos ler como texto, portanto o texto extraído pode estar incompleto. A etapa de Seccionamento ainda pode recuperar parte do texto a partir da imagem da página, mas para melhores resumos, metadados e traduções, primeiro tente obter uma versão deste PDF de melhor qualidade e baseada em texto — e aplique OCR somente se nenhuma estiver disponível."
+
+#~ msgid "This PDF appears to be image-based or uses fonts we can't read as text, so the extracted text may be incomplete. The Sectioning step can still recover some text from the page image, but for better summaries, metadata, and translations, supply a text-based PDF or run OCR on this file before importing."
+#~ msgstr "Este PDF parece ser baseado em imagens ou usa fontes que não conseguimos ler como texto, portanto o texto extraído pode estar incompleto. A etapa de Seccionamento ainda pode recuperar parte do texto a partir da imagem da página, mas para melhores resumos, metadados e traduções, forneça um PDF baseado em texto ou aplique OCR a este arquivo antes de importá-lo."
 
 msgid "This permanently deletes every uploaded video and clears all section assignments. This can't be undone."
 msgstr "Isso exclui permanentemente todos os vídeos enviados e limpa todas as atribuições de seção. Isso não pode ser desfeito."
@@ -6869,6 +6910,9 @@ msgstr "Ver imagem"
 
 msgid "View page"
 msgstr "Ver página"
+
+msgid "vision"
+msgstr "visão"
 
 msgid "Visual & sensory cues"
 msgstr "Visual & sensory cues"

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -3925,6 +3925,9 @@ msgstr "No disabled rules"
 msgid "No Easy Read for this page"
 msgstr "Sem Leitura Fácil para esta página"
 
+msgid "No embedded text layer — text was recovered from the page image"
+msgstr "Sem camada de texto incorporada — o texto foi recuperado a partir da imagem da página"
+
 msgid "No entries match your search"
 msgstr "Nenhuma entrada corresponde à sua pesquisa"
 
@@ -4048,8 +4051,8 @@ msgstr "Nenhum quiz para esta página"
 msgid "No quizzes match your search"
 msgstr "Nenhum questionário corresponde à sua pesquisa"
 
-msgid "No readable text extracted from this page"
-msgstr "Nenhum texto legível extraído desta página"
+#~ msgid "No readable text extracted from this page"
+#~ msgstr "Nenhum texto legível extraído desta página"
 
 msgid "No rendered content for this section"
 msgstr "Sem conteúdo renderizado para esta seção"

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -5864,6 +5864,9 @@ msgstr "Atualização de Software"
 msgid "Software update status"
 msgstr "Status da atualização de software"
 
+msgid "Some pages have no embedded text layer — text was recovered from the page image. Prefer a text-based PDF."
+msgstr "Algumas páginas não têm camada de texto incorporada — o texto foi recuperado a partir da imagem da página. Prefira um PDF baseado em texto."
+
 msgid "Something went wrong"
 msgstr "Algo deu errado"
 

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -5865,6 +5865,9 @@ msgstr "Përditësim Softueri"
 msgid "Software update status"
 msgstr "Gjendja e përditësimit të softuerit"
 
+msgid "Some pages have no embedded text layer — text was recovered from the page image. Prefer a text-based PDF."
+msgstr "Disa faqe nuk kanë shtresë teksti të integruar — teksti u rikuperua nga imazhi i faqes. Preferoni një PDF të bazuar në tekst."
+
 msgid "Something went wrong"
 msgstr "Diçka shkoi keq"
 

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -162,6 +162,14 @@ msgstr "{0} nga {1} imazhe"
 msgid "{0} of {1} items"
 msgstr "{0} nga {1} elemente"
 
+#. placeholder {0}: warnPages.length
+#. placeholder {1}: pageList.length
+msgid "{0} of {1} pages had no extracted text"
+msgstr "{0} nga {1} faqe nuk kanë tekst të nxjerrë"
+
+#~ msgid "{0} of {1} pages had no readable text"
+#~ msgstr "{0} nga {1} faqe nuk kanë tekst të lexueshëm"
+
 #. placeholder {0}: String(displayPages.length)
 #. placeholder {0}: book.pageCount
 msgid "{0} pages"
@@ -4041,6 +4049,9 @@ msgstr "Nuk ka kuize për këtë faqe"
 msgid "No quizzes match your search"
 msgstr "Asnjë kuiz nuk përputhet me kërkimin tuaj"
 
+msgid "No readable text extracted from this page"
+msgstr "Nuk u nxor tekst i lexueshëm nga kjo faqe"
+
 msgid "No rendered content for this section"
 msgstr "Nuk ka përmbajtje të gjeneruar për këtë seksion"
 
@@ -6171,6 +6182,9 @@ msgstr "Ngjyra e tekstit: {0}"
 msgid "Text Only"
 msgstr "Vetëm Tekst"
 
+msgid "Text recovered from the page image — this page has no embedded text layer"
+msgstr "Teksti u rikuperua nga imazhi i faqes — kjo faqe nuk ka shtresë teksti të integruar"
+
 msgid "Text roles the LLM may assign to text in the content tree. Pruned roles are classified but excluded from rendering."
 msgstr "Rolet tekstuale që LLM mund t'u caktojë teksteve në pemën e përmbajtjes. Rolet e eliminuara klasifikohen por përjashtohen nga renderimi."
 
@@ -6315,6 +6329,9 @@ msgstr "Tema"
 msgid "These features improve access for people with disabilities. Running them before exporting helps your book meet ADT accessibility standards."
 msgstr "Këto veçori përmirësojnë aksesin për personat me aftësi të kufizuara. Ekzekutimi i tyre para eksportimit ndihmon librin tuaj të përmbushë standardet e aksesibilitetit ADT."
 
+msgid "These pages have no embedded text layer, but the Sectioning step recovered text from the page images — so this PDF looks scanned or image-based. The pipeline can still work from the recovered text, but for better summaries, metadata, and translations, try to obtain a text-based version of this PDF (one with a real text layer) rather than a scanned copy."
+msgstr "Këto faqe nuk kanë shtresë teksti të integruar, por hapi i Seksionimit rikuperoi tekst nga imazhet e faqeve — pra ky PDF duket i skanuar ose i bazuar në imazhe. Procesi ende mund të punojë me tekstin e rikuperuar, por për përmbledhje, metadata dhe përkthime më të mira, provoni të siguroni një version të këtij PDF-je të bazuar në tekst (me një shtresë teksti reale) në vend të një kopjeje të skanuar."
+
 msgid "These stages are optional. They don't depend on each other — run any of them in any order once the core pipeline is complete."
 msgstr "Këto faza janë opsionale. Ato nuk varen nga njëra-tjetra — ekzekuto cilëndo prej tyre në çfarëdo rendi pasi të jetë plotësuar tubi kryesor."
 
@@ -6367,6 +6384,9 @@ msgstr "Ky është Pip! Ai është një qen i lumtur karamel me bisht shumë lë
 msgid "This page has no captioned images"
 msgstr "Kjo faqe nuk ka imazhe me tituj"
 
+msgid "This page has no embedded text layer — the text below was recovered from the page image (vision). For better summaries, metadata, and translations, prefer a text-based version of this PDF."
+msgstr "Kjo faqe nuk ka shtresë teksti të integruar — teksti më poshtë u rikuperua nga imazhi i faqes (vegim). Për përmbledhje, metadata dhe përkthime më të mira, përdorni një version të këtij PDF-je të bazuar në tekst."
+
 msgid "This page has no entries to synthesize"
 msgstr "Kjo faqe nuk ka hyrje për të sintetizuar"
 
@@ -6379,11 +6399,32 @@ msgstr "Kjo faqe nuk ka blloqe teksti të thjeshtuara"
 msgid "This page has no storyboard sections"
 msgstr "Kjo faqe nuk ka seksione storyboard"
 
+#~ msgid "This page has no text layer — it appears to be a scanned or image-only page. The Sectioning step may still recover text from the page image. For reliable text, first try to obtain a better-quality, text-based version of this PDF; only if none is available, run OCR on the file before importing."
+#~ msgstr "Kjo faqe nuk ka shtresë teksti: duket se është një faqe e skanuar ose vetëm me imazhe. Hapi i Seksionimit mund të rikuperojë ende njëfarë teksti nga imazhi i faqes. Për tekst të besueshëm, fillimisht provoni të siguroni një version më cilësor të këtij PDF-je të bazuar në tekst; vetëm nëse asnjë nuk është i disponueshëm, aplikoni OCR në skedar para se ta importoni."
+
+#~ msgid "This page has no text layer — it appears to be a scanned or image-only page. The Sectioning step may still recover text from the page image. For reliable text, run OCR on this PDF before importing."
+#~ msgstr "Kjo faqe nuk ka shtresë teksti: duket se është një faqe e skanuar ose vetëm me imazhe. Hapi i Seksionimit mund të rikuperojë ende njëfarë teksti nga imazhi i faqes. Për tekst të besueshëm, aplikoni OCR në këtë PDF para se ta importoni."
+
 msgid "This page has no translatable text entries"
 msgstr "Kjo faqe nuk ka hyrje teksti të përkthyeshme"
 
 msgid "This page has not been reviewed yet"
 msgstr "Kjo faqe nuk është rishikuar akoma"
+
+#~ msgid "This page renders text, but its fonts could not be decoded (a font/encoding issue in the PDF). The Sectioning step may still recover the text from the page image. For reliable text, first try to obtain a cleaner, text-based version of this PDF; only if none is available, run OCR on the file before importing."
+#~ msgstr "Kjo faqe shfaq tekst, por fontet e saj nuk mund të dekodoheshin (një problem fonti ose kodimi në PDF). Hapi i Seksionimit mund të rikuperojë ende tekstin nga imazhi i faqes. Për tekst të besueshëm, fillimisht provoni të siguroni një version më të pastër të këtij PDF-je të bazuar në tekst; vetëm nëse asnjë nuk është i disponueshëm, aplikoni OCR në skedar para se ta importoni."
+
+#~ msgid "This page renders text, but its fonts could not be decoded (a font/encoding issue in the PDF). The Sectioning step may still recover the text from the page image. For reliable text, supply a text-based PDF or run OCR on this file before importing."
+#~ msgstr "Kjo faqe shfaq tekst, por fontet e saj nuk mund të dekodoheshin (një problem fonti ose kodimi në PDF). Hapi i Seksionimit mund të rikuperojë ende tekstin nga imazhi i faqes. Për tekst të besueshëm, jepni një PDF të bazuar në tekst ose aplikoni OCR në këtë skedar para se ta importoni."
+
+msgid "This page's embedded text layer is empty, but the Sectioning step recovered text from the page image — so it looks like a scanned or image-only page. The pipeline can still work from the recovered text, but for better summaries, metadata, and translations, try to obtain a text-based version of this PDF (one with a real text layer) rather than a scanned copy."
+msgstr "Shtresa e tekstit të integruar e kësaj faqeje është bosh, por hapi i Seksionimit rikuperoi tekst nga imazhi i faqes — pra duket si një faqe e skanuar ose vetëm me imazhe. Procesi ende mund të punojë me tekstin e rikuperuar, por për përmbledhje, metadata dhe përkthime më të mira, provoni të siguroni një version të këtij PDF-je të bazuar në tekst (me një shtresë teksti reale) në vend të një kopjeje të skanuar."
+
+#~ msgid "This PDF appears to be image-based or uses fonts we can't read as text, so the extracted text may be incomplete. The Sectioning step can still recover some text from the page image, but for better summaries, metadata, and translations, first try to obtain a better-quality, text-based version of this PDF — and only run OCR on it if no such version is available."
+#~ msgstr "Ky PDF duket se është i bazuar në imazhe ose përdor fonte që nuk mund t'i lexojmë si tekst, prandaj teksti i nxjerrë mund të jetë i paplotë. Hapi i Seksionimit mund të rikuperojë ende një pjesë të tekstit nga imazhi i faqes, por për përmbledhje, metadata dhe përkthime më të mira, fillimisht provoni të siguroni një version më cilësor të këtij PDF-je të bazuar në tekst — dhe aplikoni OCR vetëm nëse asnjë version i tillë nuk është i disponueshëm."
+
+#~ msgid "This PDF appears to be image-based or uses fonts we can't read as text, so the extracted text may be incomplete. The Sectioning step can still recover some text from the page image, but for better summaries, metadata, and translations, supply a text-based PDF or run OCR on this file before importing."
+#~ msgstr "Ky PDF duket se është i bazuar në imazhe ose përdor fonte që nuk mund t'i lexojmë si tekst, prandaj teksti i nxjerrë mund të jetë i paplotë. Hapi i Seksionimit mund të rikuperojë ende një pjesë të tekstit nga imazhi i faqes, por për përmbledhje, metadata dhe përkthime më të mira, jepni një PDF të bazuar në tekst ose aplikoni OCR në këtë skedar para se ta importoni."
 
 msgid "This permanently deletes every uploaded video and clears all section assignments. This can't be undone."
 msgstr "Kjo fshin përgjithmonë çdo video të ngarkuar dhe pastron të gjitha caktimet e seksioneve. Ky veprim nuk mund të zhbëhet."
@@ -6870,6 +6911,9 @@ msgstr "Shiko imazhin"
 
 msgid "View page"
 msgstr "Shiko faqen"
+
+msgid "vision"
+msgstr "vegim"
 
 msgid "Visual & sensory cues"
 msgstr "Sinjale vizuale dhe shqisore"

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -3926,6 +3926,9 @@ msgstr "Nuk ka rregulla të çaktiviziuara"
 msgid "No Easy Read for this page"
 msgstr "Nuk ka Lexim të Lehtë për këtë faqe"
 
+msgid "No embedded text layer — text was recovered from the page image"
+msgstr "Pa shtresë teksti të integruar — teksti u rikuperua nga imazhi i faqes"
+
 msgid "No entries match your search"
 msgstr "Asnjë hyrje nuk përputhet me kërkimin tuaj"
 
@@ -4049,8 +4052,8 @@ msgstr "Nuk ka kuize për këtë faqe"
 msgid "No quizzes match your search"
 msgstr "Asnjë kuiz nuk përputhet me kërkimin tuaj"
 
-msgid "No readable text extracted from this page"
-msgstr "Nuk u nxor tekst i lexueshëm nga kjo faqe"
+#~ msgid "No readable text extracted from this page"
+#~ msgstr "Nuk u nxor tekst i lexueshëm nga kjo faqe"
 
 msgid "No rendered content for this section"
 msgstr "Nuk ka përmbajtje të gjeneruar për këtë seksion"

--- a/packages/types/src/extraction-warning.ts
+++ b/packages/types/src/extraction-warning.ts
@@ -1,0 +1,16 @@
+import { z } from "zod"
+
+/**
+ * Per-page extraction warning surfaced in the Extract UI.
+ *
+ * - `text-layer-missing` — the page's embedded text layer produced no text, yet
+ *   the Sectioning step (vision) recovered text from the page image. This means
+ *   the page genuinely has text the PDF isn't exposing directly (a scanned or
+ *   image-only page), so downstream quality suffers and the user should prefer a
+ *   text-based PDF.
+ *
+ * Modeled as an enum (rather than a boolean) so additional categories can be
+ * added later without changing the field shape.
+ */
+export const ExtractionWarning = z.enum(["text-layer-missing"])
+export type ExtractionWarning = z.infer<typeof ExtractionWarning>

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -153,6 +153,8 @@ export { BookMetadata } from "./metadata.js"
 
 export { BookSummaryOutput } from "./book-summary.js"
 
+export { ExtractionWarning } from "./extraction-warning.js"
+
 export {
   SectionRendering,
   WebRenderingOutput,


### PR DESCRIPTION
## Summary

Surfaces a per-page warning when a PDF's **embedded text layer produced no text** for a page, yet the **Sectioning step (vision) recovered text** from the page image. This identifies scanned / image-only pages where the PDF isn't exposing its text directly — so the user can supply a text-based PDF for better downstream quality (book summary, metadata, sectioning accuracy, translation).

### Background — why two steps disagreed
The Extract step and the Sectioning step read text from **different sources**:
- **Extract** → the PDF's embedded text layer (mupdf `toStructuredText().asText()`), stored in `pages.text`. Empty for scanned/image-only pages.
- **Sectioning** → the **rendered page image via vision**, so it recovers text even when the text layer is empty.

That's why a page could show *"No extracted text yet"* in Extract but a populated logical tree in Sectioning. Empty extracted text also degrades steps that consume `pages.text` directly (notably `book-summary`, which has no vision fallback).

## Approach
Detection is a **pure cross-check computed in the API** from data it already reads (`pages.text` vs. the `page-sectioning` flattened text) — **no pipeline, extractor, or stored-node changes**:

- `classifyExtractionWarning(extractText, sectioningText)` flags `text-layer-missing` when the extracted text is empty **and** vision recovered ≥ `MIN_RECOVERED_TEXT_CHARS` non-whitespace chars.
- Blank / illustration-only pages (where vision also finds little/nothing) are **not** flagged, avoiding false positives common in picture-heavy children's books.

> Note: an earlier extract-time heuristic (glyph-count / image-count) was dropped after review — it had a dead `text-undecodable` branch (glyph count and text derive from the same decode pass) and false-positived on legitimate illustrations. See review notes below.

## Where it shows
Both ends of the cause→effect chain:
- **Extract**: aggregate banner + per-page badge + detail-view note.
- **Sectioning**: per-page *"text came from vision"* note in the page detail, and a `vision` badge per page in the Sectioning Overview table (so the user doesn't have to navigate back to Extract).

## Changes
- `packages/types` — new `ExtractionWarning` Zod enum (`text-layer-missing`).
- `apps/api` — `services/extraction-warning.ts` (`classifyExtractionWarning` + `flattenVisibleSectioningText`) wired into the pages summary & detail routes; unit test.
- `apps/studio` — `extractionWarning` on the page summary/detail client types; UI in Extract + Sectioning; all strings localized (en/es/fr/pt-BR/sq).

## Trade-offs (intentional)
- The warning depends on Sectioning output, so it appears **after Sectioning runs**, not immediately after Extract.
- It deliberately does **not** flag undecodable-font / garbage-text PDFs (a different, rarer failure mode).

## Verification
- `pnpm typecheck` ✓
- studio lint — 0 errors ✓
- `vitest` packages + api — **1250 passed** (incl. new `extraction-warning` tests) ✓
- i18n — 0 missing across all 5 catalogs ✓

## Test plan
- [ ] Run Extract then Sectioning on a scanned/image-only PDF → expect the banner, per-page badges, and the Sectioning "vision" note/badge.
- [ ] Run on a normal text-based PDF → expect no warnings anywhere.
- [ ] Confirm picture pages with legitimately no text are **not** flagged.