### PR TITLE
feat(extract): add Segment image tool to the Extract image viewer

### DIFF
--- a/apps/api/src/routes/pages.ts
+++ b/apps/api/src/routes/pages.ts
@@ -2262,7 +2262,13 @@ export function createPageRoutes(
 
       const imgResult = segResult.results[0]
       if (!imgResult || !imgResult.needsSegmentation || !imgResult.segments || imgResult.segments.length === 0) {
-        return c.json({ segmented: false })
+        // Still return dimensions so callers can offer a manual single-region
+        // fallback (open the segment editor with one full-image box).
+        return c.json({
+          segmented: false,
+          imageWidth: imageMeta.width,
+          imageHeight: imageMeta.height,
+        })
       }
 
       return c.json({

--- a/apps/studio/src/components/pipeline/stages/extract/components/ExtractPageDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/extract/components/ExtractPageDetail.tsx
@@ -228,12 +228,11 @@ export function ExtractPageDetail({
   const handleSegmentApply = useCallback(async (confirmedRegions: SegmentRegion[]) => {
     if (!segmentPreview) return
     const { imageId } = segmentPreview
-    setSegmentPreview(null)
+    setSegmentError(null)
     try {
       const result = await api.applySegmentation(bookLabel, imageId, pageId, confirmedRegions)
       if (!result.segments || result.segments.length === 0) {
-        setSegmentError(t`Segmentation produced no valid segments`)
-        return
+        throw new Error(t`Segmentation produced no valid segments`)
       }
       const base = pendingImageData ?? page?.imageClassification
       if (base) {
@@ -253,8 +252,15 @@ export function ExtractPageDetail({
       await queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "pages", pageId] })
       setPendingImageData(null)
       setCacheBust((n) => n + 1)
+      // Close only after success — keeps the dialog (and the user's adjusted
+      // regions) up while applying, so it can show its spinner and stay open
+      // for retry if the apply fails.
+      setSegmentPreview(null)
     } catch (err) {
       setSegmentError(err instanceof Error ? err.message : t`Segmentation apply failed`)
+      // Rethrow so SegmentPreviewDialog resets its applying state and the user
+      // can retry without re-running the (paid) LLM analysis.
+      throw err
     }
   }, [segmentPreview, bookLabel, pageId, queryClient, pendingImageData, page?.imageClassification, t])
 

--- a/apps/studio/src/components/pipeline/stages/extract/components/ExtractPageDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/extract/components/ExtractPageDetail.tsx
@@ -1,18 +1,20 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from "react"
-import { AlertTriangle, Check, Crop, Eye, EyeOff, FileText, Image, ImageOff, Layers, Loader2, ChevronDown, Square, Type, X } from "lucide-react"
+import { AlertTriangle, Check, Crop, Eye, EyeOff, FileText, Image, ImageOff, Layers, Loader2, ChevronDown, Scissors, Square, Type, X } from "lucide-react"
 import { useQueryClient } from "@tanstack/react-query"
 import { usePage, usePageImage } from "@/hooks/use-pages"
 import { api, BASE_URL } from "@/api/client"
 import { useActiveConfig } from "@/hooks/use-debug"
+import { useApiKey } from "@/hooks/use-api-key"
 import { useBookRun } from "@/hooks/use-book-run"
 import { Trans } from "@lingui/react/macro"
 import { useLingui } from "@lingui/react/macro"
 import { ImageCropDialog } from "@/components/pipeline/stages/storyboard/components/ImageCropDialog"
+import { SegmentPreviewDialog, type SegmentRegion } from "@/components/pipeline/stages/storyboard/components/SegmentPreviewDialog"
 import { VersionPicker } from "@/components/pipeline/components/VersionPicker"
 import { usePendingChanges } from "@/components/pipeline/components/change-summary"
 import { resolveReflowableFont } from "@adt/types"
 
-function ImageCard({ imageId, bookLabel, isPruned, reason, bounds, onTogglePrune, onRecrop, cacheBust }: { imageId: string; bookLabel: string; isPruned?: boolean; reason?: string; bounds?: { x: number; y: number; width: number; height: number }; onTogglePrune?: () => void; onRecrop?: () => void; cacheBust?: number }) {
+function ImageCard({ imageId, bookLabel, isPruned, reason, bounds, onTogglePrune, onRecrop, onSegment, segmenting, cacheBust }: { imageId: string; bookLabel: string; isPruned?: boolean; reason?: string; bounds?: { x: number; y: number; width: number; height: number }; onTogglePrune?: () => void; onRecrop?: () => void; onSegment?: () => void; segmenting?: boolean; cacheBust?: number }) {
   const { t } = useLingui()
   const [dimensions, setDimensions] = useState<{ w: number; h: number } | null>(null)
   // eslint-disable-next-line lingui/no-unlocalized-strings
@@ -40,6 +42,24 @@ function ImageCard({ imageId, bookLabel, isPruned, reason, bounds, onTogglePrune
             title={t`Recrop from page`}
           >
             <Crop className="h-3 w-3 text-white" />
+          </button>
+        )}
+        {onSegment && (
+          <button
+            type="button"
+            onClick={onSegment}
+            disabled={segmenting}
+            className={`flex items-center justify-center w-5 h-5 rounded-full cursor-pointer transition-colors disabled:cursor-default ${
+              segmenting
+                ? "bg-orange-500"
+                : "bg-black/30 opacity-0 group-hover:opacity-100 hover:bg-black/50"
+            }`}
+            title={segmenting ? t`Segmenting…` : t`Segment image`}
+          >
+            {segmenting
+              ? <Loader2 className="h-3 w-3 text-white animate-spin" />
+              : <Scissors className="h-3 w-3 text-white" />
+            }
           </button>
         )}
         <button
@@ -101,6 +121,7 @@ export function ExtractPageDetail({
   const { data: page, isLoading } = usePage(bookLabel, pageId)
   const { data: imageData } = usePageImage(bookLabel, pageId)
   const { data: activeConfigData } = useActiveConfig(bookLabel)
+  const { apiKey, hasApiKey } = useApiKey()
   const [pageImageDims, setPageImageDims] = useState<{ w: number; h: number } | null>(null)
   const { stageState, stepState } = useBookRun()
   const storyboardRunning = stageState("storyboard") === "running" || stageState("storyboard") === "queued"
@@ -112,6 +133,16 @@ export function ExtractPageDetail({
   const [cropTarget, setCropTarget] = useState<string | null>(null)
   const [cropPageSrc, setCropPageSrc] = useState<string | null>(null)
   const [cacheBust, setCacheBust] = useState(0)
+  // Image segmentation state
+  const [segmentingId, setSegmentingId] = useState<string | null>(null)
+  const [segmentPreview, setSegmentPreview] = useState<{
+    imageId: string
+    imageSrc: string
+    imageWidth: number
+    imageHeight: number
+    regions: SegmentRegion[]
+  } | null>(null)
+  const [segmentError, setSegmentError] = useState<string | null>(null)
   const queryClient = useQueryClient()
 
   // Clear pending state when page changes
@@ -119,6 +150,9 @@ export function ExtractPageDetail({
     setPendingImageData(null)
     setCropTarget(null)
     setCropPageSrc(null)
+    setSegmentingId(null)
+    setSegmentPreview(null)
+    setSegmentError(null)
   }, [pageId])
 
   const handleRecropFromPage = useCallback(async (imageId: string) => {
@@ -154,6 +188,75 @@ export function ExtractPageDetail({
       setCropPageSrc(null)
     }
   }, [cropTarget, bookLabel, pageId, queryClient, pendingImageData, page?.imageClassification])
+
+  // Run LLM segmentation analysis on an extracted image (phase 1: get bounding
+  // boxes). The editor always opens: if the LLM detects a composite we seed its
+  // boxes, otherwise we seed a single full-image box the user can adjust to crop.
+  const handleSegment = useCallback(async (imageId: string) => {
+    if (!hasApiKey || segmentingId) return
+    setSegmentError(null)
+    setSegmentingId(imageId)
+    try {
+      const result = await api.segmentImage(bookLabel, imageId, pageId, apiKey)
+      const width = result.imageWidth
+      const height = result.imageHeight
+      if (!width || !height) {
+        setSegmentError(t`Could not read image dimensions`)
+        return
+      }
+      const regions: SegmentRegion[] =
+        result.regions && result.regions.length > 0
+          ? result.regions
+          : [{ label: t`Region`, cropLeft: 0, cropTop: 0, cropRight: width, cropBottom: height }]
+      setSegmentPreview({
+        imageId,
+        imageSrc: `${BASE_URL}/books/${bookLabel}/images/${imageId}`,
+        imageWidth: width,
+        imageHeight: height,
+        regions,
+      })
+    } catch (err) {
+      setSegmentError(err instanceof Error ? err.message : t`Segmentation failed`)
+    } finally {
+      setSegmentingId(null)
+    }
+  }, [bookLabel, pageId, apiKey, hasApiKey, segmentingId, t])
+
+  // Apply confirmed segmentation (phase 2: crop, save, and add the new segment
+  // images to the image-filtering classification. The original is kept but
+  // pruned so it stays inspectable/restorable rather than disappearing).
+  const handleSegmentApply = useCallback(async (confirmedRegions: SegmentRegion[]) => {
+    if (!segmentPreview) return
+    const { imageId } = segmentPreview
+    setSegmentPreview(null)
+    try {
+      const result = await api.applySegmentation(bookLabel, imageId, pageId, confirmedRegions)
+      if (!result.segments || result.segments.length === 0) {
+        setSegmentError(t`Segmentation produced no valid segments`)
+        return
+      }
+      const base = pendingImageData ?? page?.imageClassification
+      if (base) {
+        const updated = {
+          ...base,
+          images: base.images.flatMap((img) =>
+            img.imageId === imageId
+              ? [
+                  { ...img, isPruned: true, reason: "segmented" },
+                  ...result.segments.map((seg) => ({ imageId: seg.imageId, isPruned: false })),
+                ]
+              : [img]
+          ),
+        }
+        await api.updateImageClassification(bookLabel, pageId, updated)
+      }
+      await queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "pages", pageId] })
+      setPendingImageData(null)
+      setCacheBust((n) => n + 1)
+    } catch (err) {
+      setSegmentError(err instanceof Error ? err.message : t`Segmentation apply failed`)
+    }
+  }, [segmentPreview, bookLabel, pageId, queryClient, pendingImageData, page?.imageClassification, t])
 
   // Effective data: pending if dirty, otherwise server
   const imageClassData = pendingImageData ?? page?.imageClassification ?? null
@@ -262,6 +365,22 @@ export function ExtractPageDetail({
           )
         })()}
 
+        {/* Segmentation error notice */}
+        {segmentError && (
+          <div className="flex items-center gap-2 rounded border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+            <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+            <span className="flex-1">{segmentError}</span>
+            <button
+              type="button"
+              onClick={() => setSegmentError(null)}
+              className="shrink-0 rounded p-0.5 cursor-pointer hover:bg-black/5 dark:hover:bg-white/10"
+              title={t`Close`}
+            >
+              <X className="h-3 w-3" />
+            </button>
+          </div>
+        )}
+
         {/* Page image */}
         {imageData ? (
           <div className="rounded border overflow-hidden shadow-sm">
@@ -324,6 +443,8 @@ export function ExtractPageDetail({
                     bounds={boundsByImageId.get(img.imageId)}
                     onTogglePrune={() => toggleImagePrune(img.imageId)}
                     onRecrop={!storyboardRunning ? () => handleRecropFromPage(img.imageId) : undefined}
+                    onSegment={hasApiKey && !storyboardRunning ? () => handleSegment(img.imageId) : undefined}
+                    segmenting={segmentingId === img.imageId}
                     cacheBust={cacheBust}
                   />
                 </div>
@@ -436,6 +557,16 @@ export function ExtractPageDetail({
           imageSrc={cropPageSrc}
           onApply={handleCropApply}
           onClose={() => { setCropTarget(null); setCropPageSrc(null) }}
+        />
+      )}
+      {segmentPreview && (
+        <SegmentPreviewDialog
+          imageSrc={segmentPreview.imageSrc}
+          imageWidth={segmentPreview.imageWidth}
+          imageHeight={segmentPreview.imageHeight}
+          regions={segmentPreview.regions}
+          onApply={handleSegmentApply}
+          onClose={() => setSegmentPreview(null)}
         />
       )}
     </div>

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -1816,6 +1816,9 @@ msgstr "Correct answer"
 msgid "Correct the metadata extracted from the document."
 msgstr "Correct the metadata extracted from the document."
 
+msgid "Could not read image dimensions"
+msgstr "Could not read image dimensions"
+
 msgid "Could not read this PDF. The file may be corrupted or password-protected."
 msgstr "Could not read this PDF. The file may be corrupted or password-protected."
 
@@ -5681,6 +5684,9 @@ msgstr "See examples"
 
 msgid "Segment"
 msgstr "Segment"
+
+msgid "Segment image"
+msgstr "Segment image"
 
 msgid "Segment Preview"
 msgstr "Segment Preview"

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -1816,6 +1816,9 @@ msgstr "Respuesta correcta"
 msgid "Correct the metadata extracted from the document."
 msgstr "Corrige los metadatos extraídos del documento."
 
+msgid "Could not read image dimensions"
+msgstr "No se pudieron leer las dimensiones de la imagen"
+
 msgid "Could not read this PDF. The file may be corrupted or password-protected."
 msgstr "No se pudo leer este PDF. El archivo puede estar dañado o protegido con contraseña."
 
@@ -5681,6 +5684,9 @@ msgstr "Ver ejemplos"
 
 msgid "Segment"
 msgstr "Segmentar"
+
+msgid "Segment image"
+msgstr "Segmentar imagen"
 
 msgid "Segment Preview"
 msgstr "Segment Preview"

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -1818,6 +1818,9 @@ msgstr "Bonne réponse"
 msgid "Correct the metadata extracted from the document."
 msgstr "Corrigez les métadonnées extraites du document."
 
+msgid "Could not read image dimensions"
+msgstr "Impossible de lire les dimensions de l'image"
+
 msgid "Could not read this PDF. The file may be corrupted or password-protected."
 msgstr "Impossible de lire ce PDF. Le fichier est peut-être corrompu ou protégé par un mot de passe."
 
@@ -5683,6 +5686,9 @@ msgstr "Voir les exemples"
 
 msgid "Segment"
 msgstr "Segment"
+
+msgid "Segment image"
+msgstr "Segmenter l'image"
 
 msgid "Segment Preview"
 msgstr "Aperçu du segment"

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -1816,6 +1816,9 @@ msgstr "Resposta correta"
 msgid "Correct the metadata extracted from the document."
 msgstr "Corrija os metadados extraídos do documento."
 
+msgid "Could not read image dimensions"
+msgstr "Não foi possível ler as dimensões da imagem"
+
 msgid "Could not read this PDF. The file may be corrupted or password-protected."
 msgstr "Não foi possível ler este PDF. O arquivo pode estar corrompido ou protegido por senha."
 
@@ -5681,6 +5684,9 @@ msgstr "Ver exemplos"
 
 msgid "Segment"
 msgstr "Segmentar"
+
+msgid "Segment image"
+msgstr "Segmentar imagem"
 
 msgid "Segment Preview"
 msgstr "Segment Preview"

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -1817,6 +1817,9 @@ msgstr "Përgjigje e saktë"
 msgid "Correct the metadata extracted from the document."
 msgstr "Korrigjoni meta të dhënat e nxjerra nga dokumenti."
 
+msgid "Could not read image dimensions"
+msgstr "Nuk u lexuan dot përmasat e imazhit"
+
 msgid "Could not read this PDF. The file may be corrupted or password-protected."
 msgstr "Nuk u mund të lexohet ky PDF. Skedari mund të jetë i dëmtuar ose i mbrojtur me fjalëkalim."
 
@@ -5682,6 +5685,9 @@ msgstr "Shiko shembuj"
 
 msgid "Segment"
 msgstr "Segment"
+
+msgid "Segment image"
+msgstr "Segmento imazhin"
 
 msgid "Segment Preview"
 msgstr "Parapamje Segmenti"


### PR DESCRIPTION
Brings the existing LLM image-segmentation tool — previously only available in Storyboard — into the Extract view's image viewer, reusing the shared `SegmentPreviewDialog`. Each extracted image card gets a Scissors button that runs segmentation and always opens the box editor: when the LLM detects a composite it seeds the detected boxes, otherwise it seeds a single full-image box the user can resize to crop/clean up the image. On apply, the original image is kept but marked pruned (reason `"segmented"`) and the new segment images are added to the classification, so nothing is lost and the original stays restorable. The backend's "no segmentation needed" response now also returns image dimensions so the manual single-region fallback can be seeded, and failures surface via a dismissible notice next to the images. Includes full translations (en/es/fr/pt-BR/sq).