### PR TITLE
feat(studio): crop modes + recrop-from-page overlay & native crop res

### DIFF
--- a/apps/api/src/routes/pages.ts
+++ b/apps/api/src/routes/pages.ts
@@ -15,6 +15,7 @@ import type { TaskService } from "../services/task-service.js"
 import {
   segmentPageImages,
   getSegmentedImageId,
+  segmentBoundsOnPage,
   loadBookConfig,
   applyCrop,
   generateStyleguide,
@@ -2315,6 +2316,10 @@ export function createPageRoutes(
       const imageBase64 = storage.getImageBase64(imageId)
       const buffer = Buffer.from(imageBase64, "base64")
 
+      // Source image's placement on the page, so each segment can record where
+      // it was extracted from (for recrop-from-page overlay).
+      const sourceMeta = storage.getPageImages(pageId).find((img) => img.imageId === imageId)
+
       const version = storage.putNodeData("image-segmentation", pageId, {
         results: [{
           imageId,
@@ -2339,6 +2344,10 @@ export function createPageRoutes(
           cropBottom: region.cropBottom,
         })
 
+        const bounds = sourceMeta?.bounds
+          ? segmentBoundsOnPage(sourceMeta.bounds, sourceMeta.width, sourceMeta.height, region)
+          : undefined
+
         const segIndex = i + 1
         storage.putSegmentedImage({
           sourceImageId: imageId,
@@ -2348,6 +2357,7 @@ export function createPageRoutes(
           buffer: cropped,
           width,
           height,
+          bounds,
         })
         segments.push({
           imageId: getSegmentedImageId(imageId, segIndex, version),

--- a/apps/api/src/services/stage-runner.ts
+++ b/apps/api/src/services/stage-runner.ts
@@ -68,6 +68,7 @@ import {
   getCroppedImageId,
   segmentPageImages,
   applySegmentation,
+  segmentBoundsOnPage,
   buildSegmentationConfig,
   getSegmentedImageId,
   createScreenshotRenderer,
@@ -2682,7 +2683,12 @@ async function runSegmentationPass(
           (imageId) => storage.getImageBase64(imageId),
           segDims,
         )
+        const srcMeta = new Map(images.map((img) => [img.imageId, img]))
         for (const seg of applied) {
+          const src = srcMeta.get(seg.sourceImageId)
+          const bounds = src?.bounds
+            ? segmentBoundsOnPage(src.bounds, src.width, src.height, seg)
+            : undefined
           storage.putSegmentedImage({
             sourceImageId: seg.sourceImageId,
             segmentIndex: seg.segmentIndex,
@@ -2691,6 +2697,7 @@ async function runSegmentationPass(
             buffer: seg.buffer,
             width: seg.width,
             height: seg.height,
+            bounds,
           })
           existing.images.push({
             imageId: getSegmentedImageId(seg.sourceImageId, seg.segmentIndex, segVersion),

--- a/apps/studio/src/components/pipeline/stages/extract/components/ExtractPageDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/extract/components/ExtractPageDetail.tsx
@@ -7,7 +7,7 @@ import { useActiveConfig } from "@/hooks/use-debug"
 import { useBookRun } from "@/hooks/use-book-run"
 import { Trans } from "@lingui/react/macro"
 import { useLingui } from "@lingui/react/macro"
-import { ImageCropDialog } from "@/components/pipeline/stages/storyboard/components/ImageCropDialog"
+import { ImageCropDialog, pageBoundsToCropRect } from "@/components/pipeline/stages/storyboard/components/ImageCropDialog"
 import { VersionPicker } from "@/components/pipeline/components/VersionPicker"
 import { usePendingChanges } from "@/components/pipeline/components/change-summary"
 import { resolveReflowableFont } from "@adt/types"
@@ -431,13 +431,19 @@ export function ExtractPageDetail({
 
       </div>
       </div>
-      {cropTarget && cropPageSrc && (
-        <ImageCropDialog
-          imageSrc={cropPageSrc}
-          onApply={handleCropApply}
-          onClose={() => { setCropTarget(null); setCropPageSrc(null) }}
-        />
-      )}
+      {cropTarget && cropPageSrc && (() => {
+        // Recrop is always from the full page image — overlay the selection on
+        // the region this image originally came from when its bounds are known.
+        const bounds = boundsByImageId.get(cropTarget)
+        return (
+          <ImageCropDialog
+            imageSrc={cropPageSrc}
+            initialRect={bounds ? pageBoundsToCropRect(bounds) : undefined}
+            onApply={handleCropApply}
+            onClose={() => { setCropTarget(null); setCropPageSrc(null) }}
+          />
+        )
+      })()}
     </div>
   )
 }

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/ImageCropDialog.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/ImageCropDialog.tsx
@@ -1,15 +1,30 @@
 import { useState, useRef, useEffect, useCallback } from "react"
-import { Loader2 } from "lucide-react"
+import { Loader2, Lock, Square, RectangleHorizontal, Pentagon } from "lucide-react"
 import { Trans, useLingui } from "@lingui/react/macro"
+import { cn } from "@/lib/utils"
 
 interface Point {
   x: number
   y: number
 }
 
+interface Rect {
+  left: number
+  top: number
+  right: number
+  bottom: number
+}
+
 interface ImageCropDialogProps {
   /** Image URL to crop */
   imageSrc: string
+  /**
+   * Optional initial crop rectangle, in the source image's natural-pixel
+   * coordinates. Used by recrop-from-page to overlay the selection on the
+   * region the image originally came from. Falls back to the full image when
+   * absent or degenerate.
+   */
+  initialRect?: { x: number; y: number; width: number; height: number }
   /** Called with the cropped image blob */
   onApply: (blob: Blob) => Promise<void>
   /** Called when user cancels */
@@ -18,30 +33,99 @@ interface ImageCropDialogProps {
 
 const VERTEX_RADIUS = 6
 const MIDPOINT_RADIUS = 4
+const EDGE_HANDLE = 8
 const MIN_POINTS = 3
+/** Minimum width/height of a rectangle crop, in image pixels. */
+const MIN_RECT = 16
+
+/**
+ * Full-page images are rendered at 2× PDF points (~144 DPI); see
+ * packages/pdf/src/extract.ts. PDF-point placement bounds (imagesMeta[].bounds)
+ * must be scaled by this to map onto the page image's pixels.
+ */
+export const PAGE_IMAGE_SCALE = 2
+
+/** Convert PDF-point placement bounds to a crop rect in page-image pixels. */
+export function pageBoundsToCropRect(bounds: { x: number; y: number; width: number; height: number }) {
+  return {
+    x: bounds.x * PAGE_IMAGE_SCALE,
+    y: bounds.y * PAGE_IMAGE_SCALE,
+    width: bounds.width * PAGE_IMAGE_SCALE,
+    height: bounds.height * PAGE_IMAGE_SCALE,
+  }
+}
+
+/**
+ * Crop modes:
+ * - `rect`: axis-aligned rectangle, resized freely (corners + edges). Default.
+ * - `polygon`: free-form polygon — drag/add/remove vertices and edges.
+ * - `lock`: rectangle locked to whatever aspect ratio it currently has.
+ * - `square`: rectangle locked to 1:1.
+ */
+type RatioMode = "rect" | "polygon" | "lock" | "square"
+
+interface RectHandleMeta {
+  key: string
+  /** Position as a fraction of the rect (0 = left/top, 1 = right/bottom). */
+  fx: number
+  fy: number
+  cursor: string
+  /** Which edges this handle moves. */
+  L: boolean
+  T: boolean
+  R: boolean
+  B: boolean
+}
+
+const RECT_HANDLES: RectHandleMeta[] = [
+  { key: "tl", fx: 0, fy: 0, cursor: "nwse-resize", L: true, T: true, R: false, B: false },
+  { key: "t", fx: 0.5, fy: 0, cursor: "ns-resize", L: false, T: true, R: false, B: false },
+  { key: "tr", fx: 1, fy: 0, cursor: "nesw-resize", L: false, T: true, R: true, B: false },
+  { key: "r", fx: 1, fy: 0.5, cursor: "ew-resize", L: false, T: false, R: true, B: false },
+  { key: "br", fx: 1, fy: 1, cursor: "nwse-resize", L: false, T: false, R: true, B: true },
+  { key: "b", fx: 0.5, fy: 1, cursor: "ns-resize", L: false, T: false, R: false, B: true },
+  { key: "bl", fx: 0, fy: 1, cursor: "nesw-resize", L: true, T: false, R: false, B: true },
+  { key: "l", fx: 0, fy: 0.5, cursor: "ew-resize", L: true, T: false, R: false, B: false },
+]
 
 type DragMode =
   | { type: "vertex"; index: number; startX: number; startY: number; origPoints: Point[] }
   | { type: "edge"; index: number; startX: number; startY: number; origPoints: Point[] }
+  | { type: "rect"; handle: RectHandleMeta; startX: number; startY: number; origRect: Rect }
+  | { type: "move"; startX: number; startY: number; origPoints: Point[] }
+
+const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v))
 
 /**
- * Full-screen dialog for cropping images with a draggable polygon.
- * Starts as a rectangle (4 corners). Users can drag vertices to reshape,
- * click midpoints on edges to add new vertices, or right-click vertices to remove them.
+ * Full-screen dialog for cropping images. Four modes share a single polygon
+ * source of truth: a free rectangle, a free-form polygon, an aspect-locked
+ * rectangle, and a 1:1 square.
+ *
  * The output is a rectangular PNG cropped to the polygon's bounding box,
  * with transparent pixels outside the polygon.
  */
-export function ImageCropDialog({ imageSrc, onApply, onClose }: ImageCropDialogProps) {
+export function ImageCropDialog({ imageSrc, initialRect, onApply, onClose }: ImageCropDialogProps) {
   const { t } = useLingui()
   const [points, setPoints] = useState<Point[]>([])
   const [imageNatural, setImageNatural] = useState<{ w: number; h: number } | null>(null)
   const [displaySize, setDisplaySize] = useState<{ w: number; h: number } | null>(null)
+  const [ratioMode, setRatioMode] = useState<RatioMode>("rect")
+  const [aspectRatio, setAspectRatio] = useState<number | null>(null)
   const [applying, setApplying] = useState(false)
   const containerRef = useRef<HTMLDivElement>(null)
   const dragRef = useRef<DragMode | null>(null)
   const imageRef = useRef<HTMLDivElement>(null)
   const loadedImageRef = useRef<HTMLImageElement | null>(null)
   const scaleRef = useRef(1)
+  const aspectRef = useRef<number | null>(null)
+  aspectRef.current = aspectRatio
+  // Read the latest initial rect inside the (image-load) effect without making
+  // it a dependency — it's set once when the dialog opens.
+  const initialRectRef = useRef(initialRect)
+  initialRectRef.current = initialRect
+
+  // Rectangle modes use 8 handles + drag-to-move; polygon mode is free-form.
+  const isRect = ratioMode !== "polygon"
 
   // Load image once with crossOrigin for canvas compatibility
   useEffect(() => {
@@ -51,13 +135,20 @@ export function ImageCropDialog({ imageSrc, onApply, onClose }: ImageCropDialogP
       loadedImageRef.current = img
       const nat = { w: img.naturalWidth, h: img.naturalHeight }
       setImageNatural(nat)
-      // Initialize with rectangle covering full image
-      setPoints([
-        { x: 0, y: 0 },
-        { x: nat.w, y: 0 },
-        { x: nat.w, y: nat.h },
-        { x: 0, y: nat.h },
-      ])
+      // Initialize as a free rectangle. If an initial region was supplied (e.g.
+      // recrop-from-page overlaying the image's original placement) start there;
+      // otherwise cover the full image.
+      const r = initialRectRef.current
+      const left = r ? clamp(Math.round(r.x), 0, nat.w) : 0
+      const top = r ? clamp(Math.round(r.y), 0, nat.h) : 0
+      const right = r ? clamp(Math.round(r.x + r.width), 0, nat.w) : nat.w
+      const bottom = r ? clamp(Math.round(r.y + r.height), 0, nat.h) : nat.h
+      const valid = right - left >= MIN_RECT && bottom - top >= MIN_RECT
+      setPoints(
+        bboxToPoints(valid ? { left, top, right, bottom } : { left: 0, top: 0, right: nat.w, bottom: nat.h })
+      )
+      setRatioMode("rect")
+      setAspectRatio(null)
     }
     img.src = imageSrc
   }, [imageSrc])
@@ -89,6 +180,65 @@ export function ImageCropDialog({ imageSrc, onApply, onClose }: ImageCropDialogP
         return { x: (p.x + next.x) / 2, y: (p.y + next.y) / 2 }
       })
     : []
+
+  // ── Mode switching ──────────────────────────────────────────────────────────
+
+  /**
+   * Build an axis-aligned rectangle of the given aspect ratio (w/h), inscribed
+   * in the current bounding box, centered, and clamped to image bounds.
+   */
+  const rectForRatio = useCallback(
+    (ratio: number): Point[] => {
+      if (!imageNatural) return points
+      const iw = imageNatural.w
+      const ih = imageNatural.h
+      const bbox = getBoundingBox(points)
+      const cx = (bbox.left + bbox.right) / 2
+      const cy = (bbox.top + bbox.bottom) / 2
+      const bw = Math.max(bbox.w, MIN_RECT)
+      const bh = Math.max(bbox.h, MIN_RECT)
+      let w = Math.min(bw, bh * ratio, iw, ih * ratio)
+      const h = w / ratio
+      const left = clamp(cx - w / 2, 0, iw - w)
+      const top = clamp(cy - h / 2, 0, ih - h)
+      return bboxToPoints({ left, top, right: left + w, bottom: top + h })
+    },
+    [imageNatural, points]
+  )
+
+  const applyRatioMode = useCallback(
+    (mode: RatioMode) => {
+      if (!imageNatural) return
+      if (mode === "polygon") {
+        // Keep the current shape; just allow free-form editing.
+        setRatioMode("polygon")
+        setAspectRatio(null)
+        return
+      }
+      const bbox = getBoundingBox(points)
+      if (mode === "rect") {
+        setRatioMode("rect")
+        setAspectRatio(null)
+        setPoints(bboxToPoints(bbox)) // rectangularize (e.g. when coming from polygon)
+        return
+      }
+      // Locked modes: snap to a rectangle of the target ratio.
+      if (mode === "square") {
+        setRatioMode("square")
+        setAspectRatio(1)
+        setPoints(rectForRatio(1))
+      } else {
+        // "lock" → keep whatever ratio the box currently has
+        const ratio = Math.max(bbox.w, MIN_RECT) / Math.max(bbox.h, MIN_RECT)
+        setRatioMode("lock")
+        setAspectRatio(ratio)
+        setPoints(bboxToPoints(bbox))
+      }
+    },
+    [imageNatural, points, rectForRatio]
+  )
+
+  // ── Polygon handlers ────────────────────────────────────────────────────────
 
   const handleVertexMouseDown = useCallback((e: React.MouseEvent, index: number) => {
     e.preventDefault()
@@ -133,7 +283,33 @@ export function ImageCropDialog({ imageSrc, onApply, onClose }: ImageCropDialogP
     })
   }, [midpoints])
 
-  // Global mouse move/up for vertex dragging
+  // ── Rectangle handlers ──────────────────────────────────────────────────────
+
+  const handleRectMouseDown = useCallback((e: React.MouseEvent, handle: RectHandleMeta) => {
+    e.preventDefault()
+    e.stopPropagation()
+    const bbox = getBoundingBox(points)
+    dragRef.current = {
+      type: "rect",
+      handle,
+      startX: e.clientX,
+      startY: e.clientY,
+      origRect: { left: bbox.left, top: bbox.top, right: bbox.right, bottom: bbox.bottom },
+    }
+  }, [points])
+
+  const handleBodyMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    dragRef.current = {
+      type: "move",
+      startX: e.clientX,
+      startY: e.clientY,
+      origPoints: points.map((p) => ({ ...p })),
+    }
+  }, [points])
+
+  // Global mouse move/up for all drag interactions
   useEffect(() => {
     if (!imageNatural) return
     const iw = imageNatural.w
@@ -148,15 +324,15 @@ export function ImageCropDialog({ imageSrc, onApply, onClose }: ImageCropDialogP
 
       if (drag.type === "vertex") {
         const orig = drag.origPoints[drag.index]
-        const newX = Math.max(0, Math.min(iw, Math.round(orig.x + dx)))
-        const newY = Math.max(0, Math.min(ih, Math.round(orig.y + dy)))
+        const newX = clamp(Math.round(orig.x + dx), 0, iw)
+        const newY = clamp(Math.round(orig.y + dy), 0, ih)
         setPoints((prev) => {
           const next = [...prev]
           next[drag.index] = { x: newX, y: newY }
           return next
         })
-      } else {
-        // Edge drag: move both endpoints of the edge together
+      } else if (drag.type === "edge") {
+        // Polygon edge drag: move both endpoints of the edge together
         const i1 = drag.index
         const i2 = (drag.index + 1) % drag.origPoints.length
         const orig1 = drag.origPoints[i1]
@@ -164,15 +340,34 @@ export function ImageCropDialog({ imageSrc, onApply, onClose }: ImageCropDialogP
         setPoints((prev) => {
           const next = [...prev]
           next[i1] = {
-            x: Math.max(0, Math.min(iw, Math.round(orig1.x + dx))),
-            y: Math.max(0, Math.min(ih, Math.round(orig1.y + dy))),
+            x: clamp(Math.round(orig1.x + dx), 0, iw),
+            y: clamp(Math.round(orig1.y + dy), 0, ih),
           }
           next[i2] = {
-            x: Math.max(0, Math.min(iw, Math.round(orig2.x + dx))),
-            y: Math.max(0, Math.min(ih, Math.round(orig2.y + dy))),
+            x: clamp(Math.round(orig2.x + dx), 0, iw),
+            y: clamp(Math.round(orig2.y + dy), 0, ih),
           }
           return next
         })
+      } else if (drag.type === "rect") {
+        const r = resizeRect(drag.origRect, drag.handle, dx, dy, aspectRef.current, iw, ih)
+        setPoints(bboxToPoints({
+          left: Math.round(r.left),
+          top: Math.round(r.top),
+          right: Math.round(r.right),
+          bottom: Math.round(r.bottom),
+        }))
+      } else {
+        // Move the whole rectangle, clamped so it stays within the image.
+        const bbox = getBoundingBox(drag.origPoints)
+        const tx = clamp(dx, -bbox.left, iw - bbox.right)
+        const ty = clamp(dy, -bbox.top, ih - bbox.bottom)
+        setPoints(
+          drag.origPoints.map((p) => ({
+            x: Math.round(p.x + tx),
+            y: Math.round(p.y + ty),
+          }))
+        )
       }
     }
 
@@ -207,12 +402,43 @@ export function ImageCropDialog({ imageSrc, onApply, onClose }: ImageCropDialogP
   // Compute bounding box dimensions for info display
   const bbox = hasValidRegion ? getBoundingBox(points) : null
 
+  const ratioOptions: Array<{ key: RatioMode; label: string; title: string; Icon: typeof Lock }> = [
+    { key: "rect", label: t`Rectangle`, title: t`Free rectangle — resize without skewing`, Icon: RectangleHorizontal },
+    { key: "polygon", label: t`Polygon`, title: t`Free-form polygon — move, add, and remove points`, Icon: Pentagon },
+    { key: "lock", label: t`Lock`, title: t`Lock the current aspect ratio`, Icon: Lock },
+    { key: "square", label: t`1:1`, title: t`Lock to a square`, Icon: Square },
+  ]
+
   return (
     <div className="fixed inset-0 z-[100] bg-black/80 flex flex-col">
       {/* Header */}
-      <div className="flex items-center justify-between px-4 py-3 bg-background border-b shrink-0">
-        <h2 className="text-sm font-medium">{t`Crop Image`}</h2>
-        <div className="flex items-center gap-2">
+      <div className="flex items-center justify-between gap-3 px-4 py-3 bg-background border-b shrink-0">
+        <div className="flex items-center gap-3 min-w-0">
+          <h2 className="text-sm font-medium shrink-0">{t`Crop Image`}</h2>
+          {/* Mode / ratio control */}
+          <div className="flex items-center rounded-md border bg-muted/50 p-0.5 gap-0.5">
+            {ratioOptions.map((opt) => (
+              <button
+                key={opt.key}
+                type="button"
+                onClick={() => applyRatioMode(opt.key)}
+                disabled={applying}
+                title={opt.title}
+                aria-pressed={ratioMode === opt.key}
+                className={cn(
+                  "flex items-center gap-1 rounded px-2 py-1 text-[11px] font-medium transition-colors cursor-pointer disabled:opacity-50",
+                  ratioMode === opt.key
+                    ? "bg-background shadow-sm text-foreground"
+                    : "text-muted-foreground hover:text-foreground"
+                )}
+              >
+                <opt.Icon className="h-3 w-3" />
+                <span>{opt.label}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
           <button
             type="button"
             onClick={onClose}
@@ -269,8 +495,8 @@ export function ImageCropDialog({ imageSrc, onApply, onClose }: ImageCropDialogP
               />
             )}
 
-            {/* SVG overlay for polygon edges, vertices, and midpoints */}
-            {hasValidRegion && (
+            {/* SVG overlay for edges, vertices, and handles */}
+            {hasValidRegion && bbox && (
               <svg
                 className="absolute inset-0"
                 width={displaySize.w}
@@ -285,55 +511,105 @@ export function ImageCropDialog({ imageSrc, onApply, onClose }: ImageCropDialogP
                   strokeWidth={2}
                 />
 
-                {/* Invisible wider edge hit areas for dragging */}
-                {points.map((p, i) => {
-                  const next = points[(i + 1) % points.length]
-                  return (
-                    <line
-                      key={`edge-${i}`}
-                      x1={p.x * scale}
-                      y1={p.y * scale}
-                      x2={next.x * scale}
-                      y2={next.y * scale}
-                      stroke="transparent"
-                      strokeWidth={12}
+                {isRect ? (
+                  <>
+                    {/* Draggable body for moving the rectangle */}
+                    <rect
+                      x={bbox.left * scale}
+                      y={bbox.top * scale}
+                      width={bbox.w * scale}
+                      height={bbox.h * scale}
+                      fill="transparent"
                       style={{ cursor: "move" }}
-                      onMouseDown={(e) => handleEdgeMouseDown(e, i)}
+                      onMouseDown={handleBodyMouseDown}
                     />
-                  )
-                })}
+                    {/* Corner + edge resize handles */}
+                    {RECT_HANDLES.map((h) => {
+                      const hx = (bbox.left + bbox.w * h.fx) * scale
+                      const hy = (bbox.top + bbox.h * h.fy) * scale
+                      const isCorner = (h.L || h.R) && (h.T || h.B)
+                      return isCorner ? (
+                        <circle
+                          key={h.key}
+                          cx={hx}
+                          cy={hy}
+                          r={VERTEX_RADIUS}
+                          fill="#3b82f6"
+                          stroke="white"
+                          strokeWidth={1.5}
+                          style={{ cursor: h.cursor }}
+                          onMouseDown={(e) => handleRectMouseDown(e, h)}
+                        />
+                      ) : (
+                        <rect
+                          key={h.key}
+                          x={hx - EDGE_HANDLE / 2}
+                          y={hy - EDGE_HANDLE / 2}
+                          width={EDGE_HANDLE}
+                          height={EDGE_HANDLE}
+                          rx={2}
+                          fill="#3b82f6"
+                          stroke="white"
+                          strokeWidth={1.5}
+                          style={{ cursor: h.cursor }}
+                          onMouseDown={(e) => handleRectMouseDown(e, h)}
+                        />
+                      )
+                    })}
+                  </>
+                ) : (
+                  <>
+                    {/* Invisible wider edge hit areas for dragging */}
+                    {points.map((p, i) => {
+                      const next = points[(i + 1) % points.length]
+                      return (
+                        <line
+                          key={`edge-${i}`}
+                          x1={p.x * scale}
+                          y1={p.y * scale}
+                          x2={next.x * scale}
+                          y2={next.y * scale}
+                          stroke="transparent"
+                          strokeWidth={12}
+                          style={{ cursor: "move" }}
+                          onMouseDown={(e) => handleEdgeMouseDown(e, i)}
+                        />
+                      )
+                    })}
 
-                {/* Midpoint handles (add point) */}
-                {midpoints.map((mp, i) => (
-                  <circle
-                    key={`mid-${i}`}
-                    cx={mp.x * scale}
-                    cy={mp.y * scale}
-                    r={MIDPOINT_RADIUS}
-                    fill="#3b82f6"
-                    fillOpacity={0.4}
-                    stroke="#3b82f6"
-                    strokeWidth={1}
-                    style={{ cursor: "copy" }}
-                    onMouseDown={(e) => handleMidpointClick(e, i)}
-                  />
-                ))}
+                    {/* Midpoint handles (add point) */}
+                    {midpoints.map((mp, i) => (
+                      <circle
+                        key={`mid-${i}`}
+                        cx={mp.x * scale}
+                        cy={mp.y * scale}
+                        r={MIDPOINT_RADIUS}
+                        fill="#3b82f6"
+                        fillOpacity={0.4}
+                        stroke="#3b82f6"
+                        strokeWidth={1}
+                        style={{ cursor: "copy" }}
+                        onMouseDown={(e) => handleMidpointClick(e, i)}
+                      />
+                    ))}
 
-                {/* Vertex handles */}
-                {points.map((p, i) => (
-                  <circle
-                    key={`v-${i}`}
-                    cx={p.x * scale}
-                    cy={p.y * scale}
-                    r={VERTEX_RADIUS}
-                    fill="#3b82f6"
-                    stroke="white"
-                    strokeWidth={1.5}
-                    style={{ cursor: "grab" }}
-                    onMouseDown={(e) => handleVertexMouseDown(e, i)}
-                    onContextMenu={(e) => handleVertexRightClick(e, i)}
-                  />
-                ))}
+                    {/* Vertex handles */}
+                    {points.map((p, i) => (
+                      <circle
+                        key={`v-${i}`}
+                        cx={p.x * scale}
+                        cy={p.y * scale}
+                        r={VERTEX_RADIUS}
+                        fill="#3b82f6"
+                        stroke="white"
+                        strokeWidth={1.5}
+                        style={{ cursor: "grab" }}
+                        onMouseDown={(e) => handleVertexMouseDown(e, i)}
+                        onContextMenu={(e) => handleVertexRightClick(e, i)}
+                      />
+                    ))}
+                  </>
+                )}
               </svg>
             )}
           </div>
@@ -343,11 +619,19 @@ export function ImageCropDialog({ imageSrc, onApply, onClose }: ImageCropDialogP
       {/* Info bar */}
       <div className="bg-background border-t shrink-0 px-4 py-2 flex items-center gap-4 text-[10px] text-muted-foreground">
         <span>
-          <Trans>Drag vertices to reshape. Click midpoints (+) to add points. Right-click a vertex to remove it.</Trans>
+          {ratioMode === "polygon" ? (
+            <Trans>Drag vertices to reshape. Click midpoints (+) to add points. Right-click a vertex to remove it.</Trans>
+          ) : aspectRatio !== null ? (
+            <Trans>Drag the handles to resize (aspect ratio locked). Drag inside to move.</Trans>
+          ) : (
+            <Trans>Drag the handles to crop a rectangle. Drag inside to move.</Trans>
+          )}
         </span>
         {bbox && (
           <span className="ml-auto font-mono">
-            {t`${bbox.w} × ${bbox.h}px · ${points.length} points`}
+            {ratioMode === "polygon"
+              ? t`${bbox.w} × ${bbox.h}px · ${points.length} points`
+              : t`${bbox.w} × ${bbox.h}px`}
           </span>
         )}
       </div>
@@ -363,14 +647,97 @@ function getBoundingBox(points: Point[]) {
     if (p.x > maxX) maxX = p.x
     if (p.y > maxY) maxY = p.y
   }
+  const left = Math.max(0, minX)
+  const top = Math.max(0, minY)
   return {
-    left: Math.max(0, minX),
-    top: Math.max(0, minY),
+    left,
+    top,
     right: maxX,
     bottom: maxY,
-    w: maxX - Math.max(0, minX),
-    h: maxY - Math.max(0, minY),
+    w: maxX - left,
+    h: maxY - top,
   }
+}
+
+/** Convert a rectangle to its 4 corner points in canonical order: TL, TR, BR, BL. */
+function bboxToPoints(r: Rect): Point[] {
+  return [
+    { x: r.left, y: r.top },
+    { x: r.right, y: r.top },
+    { x: r.right, y: r.bottom },
+    { x: r.left, y: r.bottom },
+  ]
+}
+
+/**
+ * Resize a rectangle by dragging one of its 8 handles.
+ * When `ratio` is null, sides move freely. Otherwise the aspect ratio (w/h) is
+ * preserved: corner handles anchor at the opposite corner; edge handles grow the
+ * perpendicular dimension symmetrically about the rect's center.
+ */
+function resizeRect(orig: Rect, h: RectHandleMeta, dx: number, dy: number, ratio: number | null, iw: number, ih: number): Rect {
+  if (ratio == null) {
+    let { left, top, right, bottom } = orig
+    if (h.L) left = clamp(orig.left + dx, 0, orig.right - MIN_RECT)
+    if (h.R) right = clamp(orig.right + dx, orig.left + MIN_RECT, iw)
+    if (h.T) top = clamp(orig.top + dy, 0, orig.bottom - MIN_RECT)
+    if (h.B) bottom = clamp(orig.bottom + dy, orig.top + MIN_RECT, ih)
+    return { left, top, right, bottom }
+  }
+
+  const isCorner = (h.L || h.R) && (h.T || h.B)
+  if (isCorner) {
+    const anchorX = h.L ? orig.right : orig.left
+    const anchorY = h.T ? orig.bottom : orig.top
+    const signX = h.L ? -1 : 1
+    const signY = h.T ? -1 : 1
+    const cornerX = h.L ? orig.left : orig.right
+    const cornerY = h.T ? orig.top : orig.bottom
+    const desiredW = Math.max(MIN_RECT, (cornerX + dx - anchorX) * signX)
+    const desiredH = Math.max(MIN_RECT, (cornerY + dy - anchorY) * signY)
+    let w = desiredW / ratio >= desiredH ? desiredW : desiredH * ratio
+    const maxW = signX > 0 ? iw - anchorX : anchorX
+    const maxH = signY > 0 ? ih - anchorY : anchorY
+    w = Math.max(MIN_RECT, Math.min(w, maxW, maxH * ratio))
+    const hh = w / ratio
+    const left = signX > 0 ? anchorX : anchorX - w
+    const top = signY > 0 ? anchorY : anchorY - hh
+    return { left, top, right: left + w, bottom: top + hh }
+  }
+
+  if (h.L || h.R) {
+    // Horizontal edge: width drives, height follows ratio, centered vertically.
+    const cy = (orig.top + orig.bottom) / 2
+    const anchorX = h.L ? orig.right : orig.left
+    const sign = h.L ? -1 : 1
+    const movingX = h.L ? orig.left : orig.right
+    let w = Math.max(MIN_RECT, (movingX + dx - anchorX) * sign)
+    w = Math.min(w, sign > 0 ? iw - anchorX : anchorX)
+    let hh = w / ratio
+    const maxH = 2 * Math.min(cy, ih - cy)
+    if (hh > maxH) { hh = maxH; w = hh * ratio }
+    w = Math.max(w, MIN_RECT)
+    hh = w / ratio
+    const left = sign > 0 ? anchorX : anchorX - w
+    const top = cy - hh / 2
+    return { left, top, right: left + w, bottom: top + hh }
+  }
+
+  // Vertical edge: height drives, width follows ratio, centered horizontally.
+  const cx = (orig.left + orig.right) / 2
+  const anchorY = h.T ? orig.bottom : orig.top
+  const sign = h.T ? -1 : 1
+  const movingY = h.T ? orig.top : orig.bottom
+  let hh = Math.max(MIN_RECT, (movingY + dy - anchorY) * sign)
+  hh = Math.min(hh, sign > 0 ? ih - anchorY : anchorY)
+  let w = hh * ratio
+  const maxW = 2 * Math.min(cx, iw - cx)
+  if (w > maxW) { w = maxW; hh = w / ratio }
+  hh = Math.max(hh, MIN_RECT)
+  w = hh * ratio
+  const top = sign > 0 ? anchorY : anchorY - hh
+  const left = cx - w / 2
+  return { left, top, right: left + w, bottom: top + hh }
 }
 
 /**
@@ -403,28 +770,28 @@ function getCroppedImagePolygon(image: HTMLImageElement, points: Point[]): Promi
     return Promise.reject(new Error("Crop region is empty"))
   }
 
-  // Scale output to original image width so display size is preserved in layouts
-  const scaleUp = iw / cropW
-  const outputWidth = iw
-  const outputHeight = Math.round(cropH * scaleUp)
+  // Output at the selection's native resolution (no upscaling) so a small
+  // region cropped out of a large page image stays sharp and compact.
+  const outputWidth = Math.round(cropW)
+  const outputHeight = Math.round(cropH)
 
   const canvas = document.createElement("canvas")
   canvas.width = outputWidth
   canvas.height = outputHeight
   const ctx = canvas.getContext("2d")!
 
-  // Draw clipping polygon (translated to canvas coordinates)
+  // Draw clipping polygon (translated to canvas coordinates, 1:1)
   ctx.beginPath()
   for (let i = 0; i < clamped.length; i++) {
-    const px = (clamped[i].x - minX) * scaleUp
-    const py = (clamped[i].y - minY) * scaleUp
+    const px = clamped[i].x - minX
+    const py = clamped[i].y - minY
     if (i === 0) ctx.moveTo(px, py)
     else ctx.lineTo(px, py)
   }
   ctx.closePath()
   ctx.clip()
 
-  // Draw the image cropped to the bounding box
+  // Draw the image cropped to the bounding box at 1:1
   ctx.drawImage(
     image,
     minX, minY, cropW, cropH,

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/SectioningOverview.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/SectioningOverview.tsx
@@ -16,7 +16,7 @@ import {
 } from "lucide-react"
 import { SectionActionsDropdown } from "./SectionActionsDropdown"
 import { SectionEditToolbar } from "./SectionEditToolbar"
-import { ImageCropDialog } from "./ImageCropDialog"
+import { ImageCropDialog, pageBoundsToCropRect } from "./ImageCropDialog"
 import { AiImageDialog } from "./AiImageDialog"
 import { SectionTreeEditor } from "@/components/section-tree-editor/SectionTreeEditor"
 import { useApiKey } from "@/hooks/use-api-key"
@@ -1019,13 +1019,23 @@ function SectionDetail({
       />
 
       {/* Crop dialog */}
-      {cropTarget && (
-        <ImageCropDialog
-          imageSrc={recropPageSrc ?? `${BASE_URL}/books/${bookLabel}/images/${cropTarget}`}
-          onApply={handleCropApply}
-          onClose={() => { setCropTarget(null); setRecropPageSrc(null) }}
-        />
-      )}
+      {cropTarget && (() => {
+        // Overlay the original placement only when recropping from the full page;
+        // an in-place crop uses the image itself, where the full frame is correct.
+        const bounds = recropPageSrc
+          ? queryClient
+              .getQueryData<PageDetail>(["books", bookLabel, "pages", pageId])
+              ?.imagesMeta.find((m) => m.imageId === cropTarget)?.bounds
+          : undefined
+        return (
+          <ImageCropDialog
+            imageSrc={recropPageSrc ?? `${BASE_URL}/books/${bookLabel}/images/${cropTarget}`}
+            initialRect={bounds ? pageBoundsToCropRect(bounds) : undefined}
+            onApply={handleCropApply}
+            onClose={() => { setCropTarget(null); setRecropPageSrc(null) }}
+          />
+        )
+      })()}
 
       {/* AI image dialog */}
       {aiImageTarget && (

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
@@ -64,7 +64,7 @@ import {
   DEVICE_WIDTHS,
   useDeviceView,
 } from "./style-editor/device-breakpoint"
-import { ImageCropDialog } from "./ImageCropDialog"
+import { ImageCropDialog, pageBoundsToCropRect } from "./ImageCropDialog"
 import { AiImageDialog } from "./AiImageDialog"
 import { AddImageDialog } from "./AddImageDialog"
 import { ReplaceFromBookDialog } from "./ReplaceFromBookDialog"
@@ -2380,13 +2380,21 @@ export function StoryboardSectionDetail({
     />
 
     {/* Image crop dialog */}
-    {cropTarget && (
-      <ImageCropDialog
-        imageSrc={recropPageSrc ?? `${BASE_URL}/books/${bookLabel}/images/${cropTarget}`}
-        onApply={handleCropApply}
-        onClose={() => { setCropTarget(null); setRecropPageSrc(null) }}
-      />
-    )}
+    {cropTarget && (() => {
+      // Overlay the original placement only when recropping from the full page;
+      // an in-place crop uses the image itself, where the full frame is correct.
+      const bounds = recropPageSrc
+        ? page.imagesMeta.find((m) => m.imageId === cropTarget)?.bounds
+        : undefined
+      return (
+        <ImageCropDialog
+          imageSrc={recropPageSrc ?? `${BASE_URL}/books/${bookLabel}/images/${cropTarget}`}
+          initialRect={bounds ? pageBoundsToCropRect(bounds) : undefined}
+          onApply={handleCropApply}
+          onClose={() => { setCropTarget(null); setRecropPageSrc(null) }}
+        />
+      )
+    })()}
 
     {/* Replace from book dialog */}
     {replaceFromBookTarget && (

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -80,6 +80,11 @@ msgstr "{0} / {1}"
 
 #. placeholder {0}: bbox.w
 #. placeholder {1}: bbox.h
+msgid "{0} × {1}px"
+msgstr "{0} × {1}px"
+
+#. placeholder {0}: bbox.w
+#. placeholder {1}: bbox.h
 #. placeholder {2}: points.length
 msgid "{0} × {1}px · {2} points"
 msgstr "{0} × {1}px · {2} points"
@@ -402,6 +407,9 @@ msgstr "1 section"
 
 msgid "1 selected image is no longer in the storyboard."
 msgstr "1 selected image is no longer in the storyboard."
+
+msgid "1:1"
+msgstr "1:1"
 
 msgid "1.1 Background"
 msgstr "1.1 Background"
@@ -2192,6 +2200,15 @@ msgstr "Download update"
 msgid "Downloading… {0}% · {1}/s"
 msgstr "Downloading… {0}% · {1}/s"
 
+#~ msgid "Drag corners to resize (aspect ratio locked). Drag inside to move. Choose “Free” to edit as a polygon."
+#~ msgstr "Drag corners to resize (aspect ratio locked). Drag inside to move. Choose “Free” to edit as a polygon."
+
+msgid "Drag the handles to crop a rectangle. Drag inside to move."
+msgstr "Drag the handles to crop a rectangle. Drag inside to move."
+
+msgid "Drag the handles to resize (aspect ratio locked). Drag inside to move."
+msgstr "Drag the handles to resize (aspect ratio locked). Drag inside to move."
+
 msgid "Drag to move"
 msgstr "Drag to move"
 
@@ -2777,6 +2794,18 @@ msgstr "Forms & controls"
 
 msgid "FR"
 msgstr "FR"
+
+#~ msgid "Free"
+#~ msgstr "Free"
+
+msgid "Free rectangle — resize without skewing"
+msgstr "Free rectangle — resize without skewing"
+
+msgid "Free-form polygon — move, add, and remove points"
+msgstr "Free-form polygon — move, add, and remove points"
+
+#~ msgid "Free-form polygon (no ratio lock)"
+#~ msgstr "Free-form polygon (no ratio lock)"
 
 msgid "French"
 msgstr "French"
@@ -3623,6 +3652,18 @@ msgstr "Loading…"
 
 msgid "Localization"
 msgstr "Localization"
+
+msgid "Lock"
+msgstr "Lock"
+
+msgid "Lock the current aspect ratio"
+msgstr "Lock the current aspect ratio"
+
+msgid "Lock to a square"
+msgstr "Lock to a square"
+
+#~ msgid "Lock to the image's aspect ratio"
+#~ msgstr "Lock to the image's aspect ratio"
 
 msgid "Logs"
 msgstr "Logs"
@@ -4723,6 +4764,9 @@ msgstr "Play video"
 msgid "Polishing paragraphs to perfection..."
 msgstr "Polishing paragraphs to perfection..."
 
+msgid "Polygon"
+msgstr "Polygon"
+
 msgid "Portuguese (BR)"
 msgstr "Portuguese (BR)"
 
@@ -5054,6 +5098,9 @@ msgstr "Recrop from page"
 
 msgid "Recrop from Page"
 msgstr "Recrop from Page"
+
+msgid "Rectangle"
+msgstr "Rectangle"
 
 msgid "Reference"
 msgstr "Reference"

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -80,6 +80,11 @@ msgstr "{0} / {1}"
 
 #. placeholder {0}: bbox.w
 #. placeholder {1}: bbox.h
+msgid "{0} × {1}px"
+msgstr "{0} × {1}px"
+
+#. placeholder {0}: bbox.w
+#. placeholder {1}: bbox.h
 #. placeholder {2}: points.length
 msgid "{0} × {1}px · {2} points"
 msgstr "{0} × {1}px · {2} puntos"
@@ -402,6 +407,9 @@ msgstr "1 sección"
 
 msgid "1 selected image is no longer in the storyboard."
 msgstr "1 imagen seleccionada ya no está en el guion gráfico."
+
+msgid "1:1"
+msgstr "1:1"
 
 msgid "1.1 Background"
 msgstr "1.1 Antecedentes"
@@ -2192,6 +2200,15 @@ msgstr "Descargar actualización"
 msgid "Downloading… {0}% · {1}/s"
 msgstr "Descargando… {0}% · {1}/s"
 
+#~ msgid "Drag corners to resize (aspect ratio locked). Drag inside to move. Choose “Free” to edit as a polygon."
+#~ msgstr "Arrastra las esquinas para redimensionar (relación de aspecto bloqueada). Arrastra dentro para mover. Elige «Libre» para editar como polígono."
+
+msgid "Drag the handles to crop a rectangle. Drag inside to move."
+msgstr "Arrastra los controladores para recortar un rectángulo. Arrastra dentro para mover."
+
+msgid "Drag the handles to resize (aspect ratio locked). Drag inside to move."
+msgstr "Arrastra los controladores para redimensionar (relación de aspecto bloqueada). Arrastra dentro para mover."
+
 msgid "Drag to move"
 msgstr "Arrastrar para mover"
 
@@ -2777,6 +2794,18 @@ msgstr "Forms & controls"
 
 msgid "FR"
 msgstr "FR"
+
+#~ msgid "Free"
+#~ msgstr "Libre"
+
+msgid "Free rectangle — resize without skewing"
+msgstr "Rectángulo libre: redimensiona sin deformar"
+
+msgid "Free-form polygon — move, add, and remove points"
+msgstr "Polígono libre: mueve, añade y elimina puntos"
+
+#~ msgid "Free-form polygon (no ratio lock)"
+#~ msgstr "Polígono libre (sin bloqueo de relación)"
 
 msgid "French"
 msgstr "Francés"
@@ -3623,6 +3652,18 @@ msgstr "Cargando…"
 
 msgid "Localization"
 msgstr "Localización"
+
+msgid "Lock"
+msgstr "Bloquear"
+
+msgid "Lock the current aspect ratio"
+msgstr "Bloquear la relación de aspecto actual"
+
+msgid "Lock to a square"
+msgstr "Bloquear como cuadrado"
+
+#~ msgid "Lock to the image's aspect ratio"
+#~ msgstr "Bloquear a la relación de aspecto de la imagen"
 
 msgid "Logs"
 msgstr "Registros"
@@ -4723,6 +4764,9 @@ msgstr "Reproducir video"
 msgid "Polishing paragraphs to perfection..."
 msgstr "Puliendo párrafos a la perfección..."
 
+msgid "Polygon"
+msgstr "Polígono"
+
 msgid "Portuguese (BR)"
 msgstr "Portugués (BR)"
 
@@ -5054,6 +5098,9 @@ msgstr "Recortar desde la página"
 
 msgid "Recrop from Page"
 msgstr "Recortar desde la página"
+
+msgid "Rectangle"
+msgstr "Rectángulo"
 
 msgid "Reference"
 msgstr "Referencia"

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -82,6 +82,11 @@ msgstr "{0} / {1}"
 
 #. placeholder {0}: bbox.w
 #. placeholder {1}: bbox.h
+msgid "{0} × {1}px"
+msgstr "{0} × {1}px"
+
+#. placeholder {0}: bbox.w
+#. placeholder {1}: bbox.h
 #. placeholder {2}: points.length
 msgid "{0} × {1}px · {2} points"
 msgstr "{0} × {1}px · {2} points"
@@ -404,6 +409,9 @@ msgstr "1 section"
 
 msgid "1 selected image is no longer in the storyboard."
 msgstr "1 image sélectionnée ne figure plus dans le storyboard."
+
+msgid "1:1"
+msgstr "1:1"
 
 msgid "1.1 Background"
 msgstr "1.1 Contexte"
@@ -2194,6 +2202,15 @@ msgstr "Télécharger la mise à jour"
 msgid "Downloading… {0}% · {1}/s"
 msgstr "Téléchargement… {0}% · {1}/s"
 
+#~ msgid "Drag corners to resize (aspect ratio locked). Drag inside to move. Choose “Free” to edit as a polygon."
+#~ msgstr "Faites glisser les coins pour redimensionner (rapport d'aspect verrouillé). Faites glisser à l'intérieur pour déplacer. Choisissez « Libre » pour modifier en tant que polygone."
+
+msgid "Drag the handles to crop a rectangle. Drag inside to move."
+msgstr "Faites glisser les poignées pour rogner un rectangle. Faites glisser à l'intérieur pour déplacer."
+
+msgid "Drag the handles to resize (aspect ratio locked). Drag inside to move."
+msgstr "Faites glisser les poignées pour redimensionner (rapport d'aspect verrouillé). Faites glisser à l'intérieur pour déplacer."
+
 msgid "Drag to move"
 msgstr "Glisser pour déplacer"
 
@@ -2779,6 +2796,18 @@ msgstr "Formulaires et contrôles"
 
 msgid "FR"
 msgstr "FR"
+
+#~ msgid "Free"
+#~ msgstr "Libre"
+
+msgid "Free rectangle — resize without skewing"
+msgstr "Rectangle libre — redimensionner sans déformer"
+
+msgid "Free-form polygon — move, add, and remove points"
+msgstr "Polygone libre — déplacer, ajouter et supprimer des points"
+
+#~ msgid "Free-form polygon (no ratio lock)"
+#~ msgstr "Polygone libre (sans verrouillage du rapport)"
 
 msgid "French"
 msgstr "Français"
@@ -3625,6 +3654,18 @@ msgstr "Chargement…"
 
 msgid "Localization"
 msgstr "Localisation"
+
+msgid "Lock"
+msgstr "Verrouiller"
+
+msgid "Lock the current aspect ratio"
+msgstr "Verrouiller le rapport d'aspect actuel"
+
+msgid "Lock to a square"
+msgstr "Verrouiller en carré"
+
+#~ msgid "Lock to the image's aspect ratio"
+#~ msgstr "Verrouiller au rapport d'aspect de l'image"
 
 msgid "Logs"
 msgstr "Journaux"
@@ -4725,6 +4766,9 @@ msgstr "Lire la vidéo"
 msgid "Polishing paragraphs to perfection..."
 msgstr "Peaufinage des paragraphes à la perfection..."
 
+msgid "Polygon"
+msgstr "Polygone"
+
 msgid "Portuguese (BR)"
 msgstr "Portugais (BR)"
 
@@ -5056,6 +5100,9 @@ msgstr "Recadrer depuis la page"
 
 msgid "Recrop from Page"
 msgstr "Recadrer depuis la page"
+
+msgid "Rectangle"
+msgstr "Rectangle"
 
 msgid "Reference"
 msgstr "Référence"

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -80,6 +80,11 @@ msgstr "{0} / {1}"
 
 #. placeholder {0}: bbox.w
 #. placeholder {1}: bbox.h
+msgid "{0} × {1}px"
+msgstr "{0} × {1}px"
+
+#. placeholder {0}: bbox.w
+#. placeholder {1}: bbox.h
 #. placeholder {2}: points.length
 msgid "{0} × {1}px · {2} points"
 msgstr "{0} × {1}px · {2} pontos"
@@ -402,6 +407,9 @@ msgstr "1 seção"
 
 msgid "1 selected image is no longer in the storyboard."
 msgstr "1 imagem selecionada não está mais no storyboard."
+
+msgid "1:1"
+msgstr "1:1"
 
 msgid "1.1 Background"
 msgstr "1.1 Contexto"
@@ -2192,6 +2200,15 @@ msgstr "Baixar atualização"
 msgid "Downloading… {0}% · {1}/s"
 msgstr "Baixando… {0}% · {1}/s"
 
+#~ msgid "Drag corners to resize (aspect ratio locked). Drag inside to move. Choose “Free” to edit as a polygon."
+#~ msgstr "Arraste os cantos para redimensionar (proporção bloqueada). Arraste dentro para mover. Escolha “Livre” para editar como polígono."
+
+msgid "Drag the handles to crop a rectangle. Drag inside to move."
+msgstr "Arraste as alças para recortar um retângulo. Arraste dentro para mover."
+
+msgid "Drag the handles to resize (aspect ratio locked). Drag inside to move."
+msgstr "Arraste as alças para redimensionar (proporção bloqueada). Arraste dentro para mover."
+
 msgid "Drag to move"
 msgstr "Arrastar para mover"
 
@@ -2777,6 +2794,18 @@ msgstr "Forms & controls"
 
 msgid "FR"
 msgstr "FR"
+
+#~ msgid "Free"
+#~ msgstr "Livre"
+
+msgid "Free rectangle — resize without skewing"
+msgstr "Retângulo livre — redimensione sem distorcer"
+
+msgid "Free-form polygon — move, add, and remove points"
+msgstr "Polígono livre — mova, adicione e remova pontos"
+
+#~ msgid "Free-form polygon (no ratio lock)"
+#~ msgstr "Polígono livre (sem bloqueio de proporção)"
 
 msgid "French"
 msgstr "Francês"
@@ -3623,6 +3652,18 @@ msgstr "Carregando…"
 
 msgid "Localization"
 msgstr "Localização"
+
+msgid "Lock"
+msgstr "Bloquear"
+
+msgid "Lock the current aspect ratio"
+msgstr "Bloquear a proporção atual"
+
+msgid "Lock to a square"
+msgstr "Bloquear como quadrado"
+
+#~ msgid "Lock to the image's aspect ratio"
+#~ msgstr "Bloquear na proporção da imagem"
 
 msgid "Logs"
 msgstr "Logs"
@@ -4723,6 +4764,9 @@ msgstr "Reproduzir vídeo"
 msgid "Polishing paragraphs to perfection..."
 msgstr "Polindo parágrafos até a perfeição..."
 
+msgid "Polygon"
+msgstr "Polígono"
+
 msgid "Portuguese (BR)"
 msgstr "Português (BR)"
 
@@ -5054,6 +5098,9 @@ msgstr "Recortar da página"
 
 msgid "Recrop from Page"
 msgstr "Recortar da página"
+
+msgid "Rectangle"
+msgstr "Retângulo"
 
 msgid "Reference"
 msgstr "Referência"

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -81,6 +81,11 @@ msgstr "{0} / {1}"
 
 #. placeholder {0}: bbox.w
 #. placeholder {1}: bbox.h
+msgid "{0} × {1}px"
+msgstr "{0} × {1}px"
+
+#. placeholder {0}: bbox.w
+#. placeholder {1}: bbox.h
 #. placeholder {2}: points.length
 msgid "{0} × {1}px · {2} points"
 msgstr "{0} × {1}px · {2} pika"
@@ -403,6 +408,9 @@ msgstr "1 seksion"
 
 msgid "1 selected image is no longer in the storyboard."
 msgstr "1 imazh i zgjedhur nuk është më në storyboard."
+
+msgid "1:1"
+msgstr "1:1"
 
 msgid "1.1 Background"
 msgstr "1.1 Sfondi"
@@ -2193,6 +2201,15 @@ msgstr "Shkarko përditësimin"
 msgid "Downloading… {0}% · {1}/s"
 msgstr "Po shkarkohet… {0}% · {1}/s"
 
+#~ msgid "Drag corners to resize (aspect ratio locked). Drag inside to move. Choose “Free” to edit as a polygon."
+#~ msgstr "Tërhiqni qoshet për të ripërmasuar (raporti i pamjes i kyçur). Tërhiqni brenda për ta lëvizur. Zgjidhni “I lirë” për ta redaktuar si poligon."
+
+msgid "Drag the handles to crop a rectangle. Drag inside to move."
+msgstr "Tërhiqni dorezat për të prerë një drejtkëndësh. Tërhiqni brenda për ta lëvizur."
+
+msgid "Drag the handles to resize (aspect ratio locked). Drag inside to move."
+msgstr "Tërhiqni dorezat për të ripërmasuar (raporti i pamjes i kyçur). Tërhiqni brenda për ta lëvizur."
+
 msgid "Drag to move"
 msgstr "Tërhiq për të lëvizur"
 
@@ -2778,6 +2795,18 @@ msgstr "Formularë dhe kontrolle"
 
 msgid "FR"
 msgstr "FR"
+
+#~ msgid "Free"
+#~ msgstr "I lirë"
+
+msgid "Free rectangle — resize without skewing"
+msgstr "Drejtkëndësh i lirë — ripërmaso pa shtrembëruar"
+
+msgid "Free-form polygon — move, add, and remove points"
+msgstr "Poligon i lirë — lëviz, shto dhe hiq pika"
+
+#~ msgid "Free-form polygon (no ratio lock)"
+#~ msgstr "Poligon i lirë (pa kyçje raporti)"
 
 msgid "French"
 msgstr "Frëngjisht"
@@ -3624,6 +3653,18 @@ msgstr "Duke ngarkuar…"
 
 msgid "Localization"
 msgstr "Lokalizim"
+
+msgid "Lock"
+msgstr "Kyç"
+
+msgid "Lock the current aspect ratio"
+msgstr "Kyç raportin aktual të pamjes"
+
+msgid "Lock to a square"
+msgstr "Kyç si katror"
+
+#~ msgid "Lock to the image's aspect ratio"
+#~ msgstr "Kyç në raportin e pamjes së figurës"
 
 msgid "Logs"
 msgstr "Regjistra"
@@ -4724,6 +4765,9 @@ msgstr "Luaj videon"
 msgid "Polishing paragraphs to perfection..."
 msgstr "Polisim paragrafet deri në përsosmëri..."
 
+msgid "Polygon"
+msgstr "Poligon"
+
 msgid "Portuguese (BR)"
 msgstr "Portugalisht (BR)"
 
@@ -5055,6 +5099,9 @@ msgstr "Rirritjo nga faqja"
 
 msgid "Recrop from Page"
 msgstr "Rirritjo nga Faqja"
+
+msgid "Rectangle"
+msgstr "Drejtkëndësh"
 
 msgid "Reference"
 msgstr "Referencë"

--- a/packages/pipeline/src/__tests__/image-segmentation.test.ts
+++ b/packages/pipeline/src/__tests__/image-segmentation.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest"
+import { segmentBoundsOnPage } from "../image-segmentation.js"
+
+describe("segmentBoundsOnPage", () => {
+  it("maps a sub-region of the source image to page points", () => {
+    // Source image placed at (100,200) on the page, 300x150 pt, rendered 600x300 px.
+    const srcBounds = { x: 100, y: 200, width: 300, height: 150 }
+    const out = segmentBoundsOnPage(srcBounds, 600, 300, {
+      cropLeft: 0,
+      cropTop: 0,
+      cropRight: 300,
+      cropBottom: 150,
+    })
+    // Top-left quarter (px) → top-left quarter of the placement (pt).
+    expect(out).toEqual({ x: 100, y: 200, width: 150, height: 75 })
+  })
+
+  it("offsets by the crop origin within the source image", () => {
+    const srcBounds = { x: 0, y: 0, width: 200, height: 200 }
+    const out = segmentBoundsOnPage(srcBounds, 400, 400, {
+      cropLeft: 100,
+      cropTop: 200,
+      cropRight: 300,
+      cropBottom: 400,
+    })
+    // scale 0.5: origin (100,200)px → (50,100)pt; size 200x200px → 100x100pt.
+    expect(out).toEqual({ x: 50, y: 100, width: 100, height: 100 })
+  })
+
+  it("returns the source bounds unchanged for degenerate source dimensions", () => {
+    const srcBounds = { x: 5, y: 6, width: 10, height: 20 }
+    expect(
+      segmentBoundsOnPage(srcBounds, 0, 0, { cropLeft: 0, cropTop: 0, cropRight: 1, cropBottom: 1 })
+    ).toEqual(srcBounds)
+  })
+})

--- a/packages/pipeline/src/image-segmentation.ts
+++ b/packages/pipeline/src/image-segmentation.ts
@@ -188,6 +188,34 @@ export interface AppliedSegment {
   buffer: Buffer
   width: number
   height: number
+  /** Final crop box (after padding/clamping) in the source image's pixels. */
+  cropLeft: number
+  cropTop: number
+  cropRight: number
+  cropBottom: number
+}
+
+/**
+ * Map a segment's crop box (in the source image's pixels) to a placement on the
+ * page, in PDF points (top-left origin) — the same coordinate space as the
+ * source image's own `bounds`. Used so recrop-from-page can overlay the crop
+ * box on the region the segment was extracted from.
+ */
+export function segmentBoundsOnPage(
+  sourceBounds: { x: number; y: number; width: number; height: number },
+  sourceWidth: number,
+  sourceHeight: number,
+  crop: { cropLeft: number; cropTop: number; cropRight: number; cropBottom: number },
+): { x: number; y: number; width: number; height: number } {
+  if (sourceWidth <= 0 || sourceHeight <= 0) return { ...sourceBounds }
+  const sx = sourceBounds.width / sourceWidth
+  const sy = sourceBounds.height / sourceHeight
+  return {
+    x: sourceBounds.x + crop.cropLeft * sx,
+    y: sourceBounds.y + crop.cropTop * sy,
+    width: (crop.cropRight - crop.cropLeft) * sx,
+    height: (crop.cropBottom - crop.cropTop) * sy,
+  }
 }
 
 const DEFAULT_SEGMENT_PADDING = 10
@@ -256,6 +284,10 @@ export function applySegmentation(
         buffer: cropped,
         width,
         height,
+        cropLeft: left,
+        cropTop: top,
+        cropRight: right,
+        cropBottom: bottom,
       })
     }
   }

--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -40,6 +40,7 @@ export {
 export {
   segmentPageImages,
   applySegmentation,
+  segmentBoundsOnPage,
   buildSegmentationConfig,
   getSegmentedImageId,
   type AppliedSegment,

--- a/packages/pipeline/src/pipeline-dag.ts
+++ b/packages/pipeline/src/pipeline-dag.ts
@@ -34,7 +34,7 @@ import {
 import { classifyPageImages, buildImageClassifyConfig } from "./image-filtering.js"
 import { filterPageImageMeaningfulness, buildMeaningfulnessConfig } from "./image-meaningfulness.js"
 import { cropPageImages, applyCrops, buildCroppingConfig, getCroppedImageId } from "./image-cropping.js"
-import { segmentPageImages, applySegmentation, buildSegmentationConfig, getSegmentedImageId } from "./image-segmentation.js"
+import { segmentPageImages, applySegmentation, segmentBoundsOnPage, buildSegmentationConfig, getSegmentedImageId } from "./image-segmentation.js"
 import { renderPage, buildRenderStrategyResolver } from "./web-rendering.js"
 import { translatePageTree, buildTranslationConfig } from "./translation.js"
 import { createTemplateEngine } from "./render-template.js"
@@ -297,7 +297,12 @@ export async function runFullPipeline(
               (imageId) => storage.getImageBase64(imageId),
               segDims,
             )
+            const srcMeta = new Map(allImages.map((img) => [img.imageId, img]))
             for (const seg of applied) {
+              const src = srcMeta.get(seg.sourceImageId)
+              const bounds = src?.bounds
+                ? segmentBoundsOnPage(src.bounds, src.width, src.height, seg)
+                : undefined
               storage.putSegmentedImage({
                 sourceImageId: seg.sourceImageId,
                 segmentIndex: seg.segmentIndex,
@@ -306,6 +311,7 @@ export async function runFullPipeline(
                 buffer: seg.buffer,
                 width: seg.width,
                 height: seg.height,
+                bounds,
               })
               const segImageId = getSegmentedImageId(seg.sourceImageId, seg.segmentIndex, segVersion)
               imageClassification.images.push({

--- a/packages/storage/src/__tests__/book-storage.test.ts
+++ b/packages/storage/src/__tests__/book-storage.test.ts
@@ -155,6 +155,53 @@ describe("createBookStorage", () => {
     storage.close()
   })
 
+  it("persists segment placement bounds and returns them in getPageImages", () => {
+    const { storage } = createTempStorage()
+    storage.putExtractedPage(makePage(1))
+
+    storage.putSegmentedImage({
+      sourceImageId: "pg001_im001",
+      segmentIndex: 1,
+      pageId: "pg001",
+      version: 1,
+      buffer: fakePng(80, 60),
+      width: 80,
+      height: 60,
+      bounds: { x: 12, y: 34, width: 80, height: 60 },
+    })
+
+    const seg = storage
+      .getPageImages("pg001")
+      .find((img) => img.imageId === "pg001_im001_seg001_v1")
+    expect(seg).toBeDefined()
+    expect(seg!.bounds).toEqual({ x: 12, y: 34, width: 80, height: 60 })
+
+    storage.close()
+  })
+
+  it("stores a segment without bounds when none are provided", () => {
+    const { storage } = createTempStorage()
+    storage.putExtractedPage(makePage(1))
+
+    storage.putSegmentedImage({
+      sourceImageId: "pg001_im001",
+      segmentIndex: 1,
+      pageId: "pg001",
+      version: 1,
+      buffer: fakePng(80, 60),
+      width: 80,
+      height: 60,
+    })
+
+    const seg = storage
+      .getPageImages("pg001")
+      .find((img) => img.imageId === "pg001_im001_seg001_v1")
+    expect(seg).toBeDefined()
+    expect(seg!.bounds).toBeUndefined()
+
+    storage.close()
+  })
+
   it("writes translated image variants and looks them up by source id", () => {
     const { storage, paths } = createTempStorage()
     storage.putExtractedPage(makePage(1))

--- a/packages/storage/src/book-storage.ts
+++ b/packages/storage/src/book-storage.ts
@@ -195,17 +195,22 @@ export function createBookStorage(label: string, booksRoot: string): Storage {
       const filename = `${segId}.png`
       fs.writeFileSync(path.join(paths.imagesDir, filename), input.buffer)
 
+      const b = input.bounds
       db.run(
         `INSERT INTO images
-           (image_id, page_id, path, hash, width, height, source)
-         VALUES (?, ?, ?, ?, ?, ?, ?)
+           (image_id, page_id, path, hash, width, height, source, bounds_x, bounds_y, bounds_w, bounds_h)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
          ON CONFLICT (image_id) DO UPDATE SET
            page_id = excluded.page_id,
            path = excluded.path,
            hash = excluded.hash,
            width = excluded.width,
            height = excluded.height,
-           source = excluded.source`,
+           source = excluded.source,
+           bounds_x = excluded.bounds_x,
+           bounds_y = excluded.bounds_y,
+           bounds_w = excluded.bounds_w,
+           bounds_h = excluded.bounds_h`,
         [
           segId,
           input.pageId,
@@ -214,6 +219,10 @@ export function createBookStorage(label: string, booksRoot: string): Storage {
           input.width,
           input.height,
           "segment",
+          b ? b.x : null,
+          b ? b.y : null,
+          b ? b.width : null,
+          b ? b.height : null,
         ]
       )
     },

--- a/packages/storage/src/storage.ts
+++ b/packages/storage/src/storage.ts
@@ -40,6 +40,12 @@ export interface SegmentedImageInput {
   buffer: Buffer
   width: number
   height: number
+  /**
+   * Placement of this segment on the page in PDF points (top-left origin),
+   * derived from the source image's placement. Persisted so recrop-from-page
+   * can overlay the crop box where the segment was extracted.
+   */
+  bounds?: { x: number; y: number; width: number; height: number }
 }
 
 export interface TranslatedImageInput {


### PR DESCRIPTION
Reworks the shared `ImageCropDialog` (used by both the storyboard and the extract image viewer) to add four selectable crop modes: a free **Rectangle** (default — resize via corner/edge handles without skewing), the existing free-form **Polygon**, **Lock** to the current aspect ratio, and **1:1** square, all with drag-to-move. **Recrop-from-page** now opens the crop rectangle overlaid on the region the image originally came from (derived from `imagesMeta` PDF-point bounds scaled to the 2× page image), and crops now export at the selection's **native resolution** instead of upscaling to the source image's full width, fixing blurry/oversized recropped images. Bounds are wired through all three consumers (`ExtractPageDetail`, `StoryboardSectionDetail`, `SectioningOverview`), only on the recrop-from-page path. Lingui catalogs are updated and fully translated for all locales (en, es, fr, pt-BR, sq). Verified with `tsc --build`, `eslint`, and `lingui extract`/`compile`.