### PR TITLE
fix(extract): disambiguate same-size images in shared resource dicts

### DIFF
--- a/packages/pdf/src/__tests__/extract-shared-resources.test.ts
+++ b/packages/pdf/src/__tests__/extract-shared-resources.test.ts
@@ -93,8 +93,10 @@ describe("shared resource dictionary — same-dimension image disambiguation", (
     const distinct = new Set(drawn.map((d) => d.contentHash))
     expect(distinct.size).toBe(n)
 
-    // Exact correctness: keys sort I0..I{n-1}, so extraction assigns im001=I0,
-    // im002=I1, … Page i draws /I{i}, so it must map to im00{i+1}.
+    // Exact correctness: keys sort I0..I{n-1} (alphabetical == numerical for
+    // n < 10), so extraction assigns im001=I0, im002=I1, … Page i draws /I{i},
+    // so it must map to im00{i+1}. (Digest matching itself is order-independent;
+    // only this exact-imageId assertion relies on the key sort.)
     drawn.forEach((d, i) => {
       expect(d.imageId).toMatch(new RegExp(`_im${String(i + 1).padStart(3, "0")}$`))
     })

--- a/packages/pdf/src/__tests__/extract-shared-resources.test.ts
+++ b/packages/pdf/src/__tests__/extract-shared-resources.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Regression: pages that SHARE one resource dictionary listing several
+ * same-dimension images must each render the image their own content stream
+ * draws — not all collapse to the first one.
+ *
+ * This reproduces the structure emitted by layer-compositing PDF tools (e.g.
+ * a "LayerPDF" generator): a single `/Resources` object, referenced by every
+ * page, whose `/XObject` dict lists every full-page layer image. Each page's
+ * content stream draws exactly one of them (`/I{n} Do`), a different one per
+ * page, but they all share identical native dimensions.
+ *
+ * The bug this guards: `stampRasterPlacementsFromOps` matched draw-ops to
+ * extracted images by native dimensions alone and consumed the first
+ * candidate. With every page seeing all N same-size images, every page paired
+ * its single draw-op with the FIRST image — so every page rendered the same
+ * background. The fix disambiguates same-dimension candidates by a pixel
+ * content digest (recorder `contentDigest` ↔ extracted `pixelDigest`).
+ */
+import { describe, it, expect } from "vitest"
+import mupdf from "mupdf"
+import { createHash } from "node:crypto"
+import { extractPdf } from "../extract.js"
+
+const PAGE_W = 612
+const PAGE_H = 792
+const IMG = 64
+
+/**
+ * Build an N-page PDF where all pages reference ONE shared resources object
+ * listing N distinct, identically-sized images (`I0`..`I{N-1}`). Page i draws
+ * `/I{i}` full-page. Each image is filled with a distinct per-layer pattern so
+ * the layers have different pixels (and therefore different content digests).
+ */
+function createSharedResourceLayerPdf(n: number): Buffer {
+  const doc = new mupdf.PDFDocument()
+
+  const xobjects = doc.newDictionary()
+  for (let layer = 0; layer < n; layer++) {
+    const pixmap = new mupdf.Pixmap(mupdf.ColorSpace.DeviceRGB, [0, 0, IMG, IMG], false)
+    pixmap.clear(255)
+    const samples = pixmap.getPixels()
+    // A per-layer gradient keyed on the layer index — distinct pixels per layer.
+    for (let y = 0; y < IMG; y++) {
+      for (let x = 0; x < IMG; x++) {
+        const i = (y * IMG + x) * 3
+        samples[i] = (x * 4 + layer * 40) % 256 // R
+        samples[i + 1] = (y * 4 + layer * 25) % 256 // G
+        samples[i + 2] = (layer * 60) % 256 // B
+      }
+    }
+    xobjects.put(`I${layer}`, doc.addImage(new mupdf.Image(pixmap)))
+  }
+
+  // ONE shared resources object, handed to every page below.
+  const resourcesDict = doc.newDictionary()
+  resourcesDict.put("XObject", xobjects)
+  const resources = doc.addObject(resourcesDict)
+
+  for (let page = 0; page < n; page++) {
+    const stream = `q\n${PAGE_W} 0 0 ${PAGE_H} 0 0 cm\n/I${page} Do\nQ\n`
+    const buf = new mupdf.Buffer()
+    buf.writeLine(stream)
+    doc.insertPage(-1, doc.addPage([0, 0, PAGE_W, PAGE_H], 0, resources, buf))
+  }
+
+  return Buffer.from(doc.saveToBuffer("").asUint8Array())
+}
+
+/** The single image draw item on a page, with the byte hash of the extracted
+ *  image it references. */
+function drawnImage(page: {
+  positionedText: { drawItems: Array<Record<string, unknown>> }
+  images: Array<{ imageId: string; buffer: Buffer }>
+}): { imageId: string; contentHash: string } {
+  const imageItems = page.positionedText.drawItems.filter((d) => d.kind === "image")
+  expect(imageItems).toHaveLength(1)
+  const imageId = imageItems[0].imageId as string
+  const img = page.images.find((im) => im.imageId === imageId)
+  if (!img) throw new Error(`drawItem references missing image ${imageId}`)
+  return { imageId, contentHash: createHash("md5").update(img.buffer).digest("hex") }
+}
+
+describe("shared resource dictionary — same-dimension image disambiguation", () => {
+  it("renders each page's OWN layer, not the first one, when all layers share a resources dict", async () => {
+    const n = 4
+    const result = await extractPdf({ pdfBuffer: createSharedResourceLayerPdf(n), fixedLayout: true })
+    expect(result.pages).toHaveLength(n)
+
+    const drawn = result.pages.map(drawnImage)
+
+    // Core regression: every page draws a DISTINCT background. Before the fix
+    // all pages collapsed to a single image, so this set had size 1.
+    const distinct = new Set(drawn.map((d) => d.contentHash))
+    expect(distinct.size).toBe(n)
+
+    // Exact correctness: keys sort I0..I{n-1}, so extraction assigns im001=I0,
+    // im002=I1, … Page i draws /I{i}, so it must map to im00{i+1}.
+    drawn.forEach((d, i) => {
+      expect(d.imageId).toMatch(new RegExp(`_im${String(i + 1).padStart(3, "0")}$`))
+    })
+
+    // Every page sees the full shared set of N images (proves the dict is
+    // genuinely shared — the precondition that made matching ambiguous).
+    for (const page of result.pages) {
+      const raster = page.images.filter((im) => /_im\d+$/.test(im.imageId))
+      expect(raster).toHaveLength(n)
+    }
+  })
+
+  it("leaves a normal page (one image, unique dimensions) unchanged", async () => {
+    // Single page, single image — no dimension collision, so the cheap
+    // dimension-only match (no digests) still applies and must still work.
+    const result = await extractPdf({ pdfBuffer: createSharedResourceLayerPdf(1), fixedLayout: true })
+    expect(result.pages).toHaveLength(1)
+    const { imageId } = drawnImage(result.pages[0])
+    expect(imageId).toMatch(/_im001$/)
+  })
+})

--- a/packages/pdf/src/extract.ts
+++ b/packages/pdf/src/extract.ts
@@ -1051,6 +1051,15 @@ function stampRasterPlacementsFromOps(
         (c) => c.pixelDigest !== undefined && c.pixelDigest === op.contentDigest,
       );
       if (idx >= 0) matched = candidates.splice(idx, 1)[0];
+      else {
+        // This op has a digest but no candidate matches it — only reachable on
+        // a partial digest failure (one side hashed, the other couldn't) or
+        // when the op's image was filtered out (e.g. figure-covered). Consume a
+        // candidate that has NO digest of its own first, so we don't steal one
+        // that a later digest-bearing op still needs to match.
+        const undigested = candidates.findIndex((c) => c.pixelDigest === undefined);
+        if (undigested >= 0) matched = candidates.splice(undigested, 1)[0];
+      }
     }
     // Unambiguous bucket, or no digest match — pair in stream order.
     if (!matched) matched = candidates.shift();

--- a/packages/pdf/src/extract.ts
+++ b/packages/pdf/src/extract.ts
@@ -26,6 +26,7 @@ import {
 } from "./positioned-text.js";
 import {
   recordPageStream,
+  hashImagePixels,
   type StreamOp,
   type ImageStreamOp,
   type PathStreamOp,
@@ -123,6 +124,17 @@ export interface ExtractedImage {
    *     constituent shape bboxes (see `shapeGeomBoxes`).
    */
   streamSeqno?: number;
+  /**
+   * Pixel-content digest, set ONLY when this image shares its native
+   * dimensions with another image on the same page (a dimension collision).
+   * `stampRasterPlacementsFromOps` uses it to match a draw op to the exact
+   * XObject it references — dimension alone is ambiguous when a page can see
+   * several same-size images (e.g. pages sharing one resource dictionary that
+   * lists every full-page layer). Computed from the same `toPixmap()` samples
+   * as the recorder's `ImageStreamOp.contentDigest` so the two compare equal.
+   * Transient: not persisted to the images table.
+   */
+  pixelDigest?: string;
   /**
    * Geometry bboxes of this vector figure's constituent SVG shapes, in the
    * same coordinate space as recorder ops (page coords + spread xOffset).
@@ -778,7 +790,13 @@ async function extractPage(doc: MupdfDocument, pageIndex: number, vectorTextGrou
   // is a layout reconstruction (reading flow, not stream order) so it can't be
   // used for z-order — but the device callbacks fire once per content-stream
   // operator, in stream order, with fully-resolved CTMs.
-  const recorder = runRecorderInViewport(page, pageBounds, 0, 0);
+  const recorder = runRecorderInViewport(
+    page,
+    pageBounds,
+    0,
+    0,
+    hasDuplicateDimensions(rasterImages),
+  );
   stampRasterPlacementsFromOps(rasterImages, recorder.ops);
 
   // Reuse the StructuredText already built above — no extra pass. Build
@@ -835,10 +853,11 @@ function runRecorderInViewport(
   pageBounds: number[],
   xShift: number,
   seqnoShift: number,
+  hashImages: boolean = false,
 ): { ops: StreamOp[] } {
   const pageOriginX = pageBounds[0];
   const pageOriginY = pageBounds[1];
-  const rawOps = recordPageStream(page);
+  const rawOps = recordPageStream(page, { hashImages });
   const dx = -pageOriginX + xShift;
   const dy = -pageOriginY;
   const shiftBBox = (b: StreamBBox): StreamBBox => ({
@@ -981,14 +1000,34 @@ function selectImageClipPath(op: ImageStreamOp): string | undefined {
 }
 
 /**
- * Match each `fillImage` / `fillImageMask` op to an extracted raster XObject
- * by native pixel dimensions, consuming candidates in stream order. The
- * matched raster gets its `streamSeqno` and its `bounds` (from the op's CTM)
- * stamped on it.
+ * True when two or more images share identical native dimensions. This is the
+ * condition under which dimension-only op→image matching is ambiguous, so it
+ * gates the extra pixel-hashing work (recorder `hashImages` + extraction
+ * `pixelDigest`). False — the common case — keeps the cheap dimension match.
+ */
+function hasDuplicateDimensions(images: ExtractedImage[]): boolean {
+  const seen = new Set<string>();
+  for (const img of images) {
+    const key = `${img.width}x${img.height}`;
+    if (seen.has(key)) return true;
+    seen.add(key);
+  }
+  return false;
+}
+
+/**
+ * Match each `fillImage` / `fillImageMask` op to an extracted raster XObject,
+ * stamping the matched raster's `streamSeqno` and `bounds` (from the op's CTM).
  *
- * Multiple instances of the same image dimensions are paired in stream
- * order — first op with WxH matches first remaining ExtractedImage with
- * WxH. This is how mupdf placement order maps to XObject extraction order.
+ * Matching keys on native pixel dimensions. When a dimension bucket holds more
+ * than one image the match is ambiguous: a page that can see several same-size
+ * images (e.g. pages sharing one resource dictionary listing every full-page
+ * layer) would otherwise pair every op with the FIRST candidate, so every page
+ * renders the same image. To disambiguate, both the op (`contentDigest`) and
+ * the image (`pixelDigest`) carry a pixel-content hash; we pick the candidate
+ * whose digest matches. Single-candidate buckets — and any bucket without
+ * digests — fall back to stream-order pairing (first op with WxH ↔ first
+ * remaining image with WxH), the long-standing behaviour for unambiguous pages.
  */
 function stampRasterPlacementsFromOps(
   rasters: ExtractedImage[],
@@ -1004,7 +1043,17 @@ function stampRasterPlacementsFromOps(
   for (const op of ops) {
     if (op.kind !== "image" && op.kind !== "imageMask") continue;
     const candidates = byDim.get(`${op.nativeWidth}x${op.nativeHeight}`);
-    const matched = candidates?.shift();
+    if (!candidates || candidates.length === 0) continue;
+    let matched: ExtractedImage | undefined;
+    // Disambiguate same-dimension candidates by pixel content when available.
+    if (candidates.length > 1 && op.contentDigest) {
+      const idx = candidates.findIndex(
+        (c) => c.pixelDigest !== undefined && c.pixelDigest === op.contentDigest,
+      );
+      if (idx >= 0) matched = candidates.splice(idx, 1)[0];
+    }
+    // Unambiguous bucket, or no digest match — pair in stream order.
+    if (!matched) matched = candidates.shift();
     if (!matched) continue;
     matched.streamSeqno = op.seqno;
     matched.bounds = bboxToImageBounds(op.bbox);
@@ -1536,7 +1585,13 @@ async function extractSpreadPage(
   // Run the recorder on both pages, in viewport coords; right-page x is shifted
   // by left page width so positions address the stitched spread, and right-page
   // seqnos shift past left so cross-page sort puts left ahead of right.
-  const leftRecorder = runRecorderInViewport(leftPage, leftBounds, 0, 0);
+  const leftRecorder = runRecorderInViewport(
+    leftPage,
+    leftBounds,
+    0,
+    0,
+    hasDuplicateDimensions(leftRaster),
+  );
   const leftMaxSeqno = leftRecorder.ops.reduce(
     (m, o) => Math.max(m, o.seqno),
     -1,
@@ -1546,6 +1601,7 @@ async function extractSpreadPage(
     rightBounds,
     leftPageWidthPt,
     leftMaxSeqno + 1,
+    hasDuplicateDimensions(rightRaster),
   );
   const ops: StreamOp[] = [...leftRecorder.ops, ...rightRecorder.ops];
   // Rasters: stamp per page so dim-tied images on different pages don't
@@ -1606,6 +1662,10 @@ function extractRasterImagesFromPdf(
   startIndex: number = 0
 ): ExtractedImage[] {
   const images: ExtractedImage[] = [];
+  // The mupdf stream object each image was decoded from, parallel to `images`.
+  // Kept so we can re-decode an image to a pixmap for content hashing without
+  // re-walking the dict — only done for dimension-colliding images (below).
+  const sources: PDFObject[] = [];
   const seen = new Set<number>(); // Track object numbers to avoid duplicates
   let imgIndex = startIndex;
 
@@ -1750,6 +1810,7 @@ function extractRasterImagesFromPdf(
           hash: hashBuffer(buf),
           renderMethod: "raster",
         });
+        sources.push(streamObj);
       } catch (err) {
         console.warn(
           `[extractRasterImagesFromPdf] Failed to extract image on ${pageId}:`,
@@ -1767,7 +1828,44 @@ function extractRasterImagesFromPdf(
   if (xobject.isNull() || !xobject.isDictionary()) return images;
 
   extractFromXObjectDict(xobject);
+  stampPixelDigestsOnCollisions(doc, images, sources);
   return images;
+}
+
+/**
+ * Set `pixelDigest` on each image that shares its native dimensions with at
+ * least one other image in the set. Draw-op→image matching keys on dimensions
+ * (see `stampRasterPlacementsFromOps`); when a page can see several same-size
+ * images, that match is ambiguous and needs pixel content to disambiguate.
+ *
+ * Unique-dimension images (the common case) get no digest and pay no decode
+ * cost. The digest hashes `toPixmap()` samples — the same basis the recorder
+ * uses in `hashImagePixels` — so an op's `contentDigest` compares equal to the
+ * matching image's `pixelDigest`.
+ */
+function stampPixelDigestsOnCollisions(
+  doc: PDFDocument,
+  images: ExtractedImage[],
+  sources: PDFObject[],
+): void {
+  const dimCounts = new Map<string, number>();
+  for (const img of images) {
+    const key = `${img.width}x${img.height}`;
+    dimCounts.set(key, (dimCounts.get(key) ?? 0) + 1);
+  }
+  for (let i = 0; i < images.length; i++) {
+    if ((dimCounts.get(`${images[i].width}x${images[i].height}`) ?? 0) < 2) continue;
+    try {
+      const image = doc.loadImage(sources[i]);
+      images[i].pixelDigest = hashImagePixels(image);
+      image.destroy();
+    } catch (err) {
+      console.warn(
+        `[extractRasterImagesFromPdf] Failed to digest ${images[i].imageId} on ${images[i].pageId}:`,
+        err instanceof Error ? err.message : err
+      );
+    }
+  }
 }
 
 /**

--- a/packages/pdf/src/page-stream-recorder.ts
+++ b/packages/pdf/src/page-stream-recorder.ts
@@ -174,6 +174,19 @@ export function recordPageStream(
   const groupStack: { blendMode: BlendMode; alpha: number }[] = []
   let seqno = 0
 
+  // Content digest for an image op, computed only when requested. Guarded:
+  // a decode failure on an unusual image (imagemask, exotic colorspace) must
+  // degrade to "no digest" — the matcher then falls back to dimension order —
+  // rather than throwing out of `page.run` and aborting the whole page.
+  const imageDigest = (image: MupdfImage): { contentDigest?: string } => {
+    if (!hashImages) return {}
+    try {
+      return { contentDigest: hashImagePixels(image) }
+    } catch {
+      return {}
+    }
+  }
+
   const activeClipBbox = (): BBox | null =>
     clipStack.length > 0 ? clipStack[clipStack.length - 1].bbox : null
   const activeClipPaths = (): ClipPath[] => clipStack.slice()
@@ -284,7 +297,7 @@ export function recordPageStream(
         activeClipPaths: activeClipPaths(),
         blendMode: activeBlendMode(),
         alpha: composedAlpha(alpha ?? 1),
-        ...(hashImages ? { contentDigest: hashImagePixels(image) } : {}),
+        ...imageDigest(image),
       })
     },
     fillImageMask(image, ctm, _cs, _color, alpha) {
@@ -299,7 +312,7 @@ export function recordPageStream(
         activeClipPaths: activeClipPaths(),
         blendMode: activeBlendMode(),
         alpha: composedAlpha(alpha ?? 1),
-        ...(hashImages ? { contentDigest: hashImagePixels(image) } : {}),
+        ...imageDigest(image),
       })
     },
     clipImageMask(_image, ctm) {

--- a/packages/pdf/src/page-stream-recorder.ts
+++ b/packages/pdf/src/page-stream-recorder.ts
@@ -15,11 +15,13 @@
  * The recorder is page-scoped and stateless across pages: callers run it
  * once per page and consume the resulting `StreamOp[]`.
  */
+import { createHash } from "node:crypto"
 import mupdf, {
   type BlendMode,
   type Color,
   type ColorSpace,
   type Document as MupdfDocument,
+  type Image as MupdfImage,
   type Matrix as MupdfMatrix,
   type StrokeState,
 } from "mupdf"
@@ -89,6 +91,14 @@ export interface ImageStreamOp extends BaseStreamOp {
   /** Composed alpha at draw time: product of every enclosing transparency
    *  group's alpha and the per-op `alpha` argument. 1.0 when fully opaque. */
   alpha: number
+  /** Pixel-content digest of the image drawn by this op, present only when the
+   *  recorder was run with `hashImages: true`. Lets `stampRasterPlacementsFromOps`
+   *  pick the EXACT extracted XObject when several share identical native
+   *  dimensions (e.g. a PDF whose pages share one resource dictionary listing
+   *  multiple same-size full-page images — dimension-only matching can't tell
+   *  them apart). Undefined when hashing was disabled (the common,
+   *  unambiguous case). See `hashImagePixels`. */
+  contentDigest?: string
 }
 
 export interface PathStreamOp extends BaseStreamOp {
@@ -124,13 +134,41 @@ export type StreamOp =
 type AnyPage = ReturnType<MupdfDocument["loadPage"]>
 
 /**
+ * Compute a content digest of an image's decoded pixels. Used to disambiguate
+ * which extracted XObject a draw op refers to when several share identical
+ * native dimensions (dimension-only matching in `stampRasterPlacementsFromOps`
+ * can't tell them apart). Hashes the raw native pixmap samples so the SAME
+ * digest is produced wherever the same XObject is decoded — both here (stream
+ * recording) and at raster extraction (`extractRasterImagesFromPdf`), which
+ * both call `toPixmap()` on the same underlying image object.
+ */
+export function hashImagePixels(image: MupdfImage): string {
+  const px = image.toPixmap()
+  try {
+    return createHash("sha256").update(px.getPixels()).digest("hex").slice(0, 16)
+  } finally {
+    px.destroy()
+  }
+}
+
+/**
  * Run `page` through a recording device; return draw ops in stream order.
  *
  * Clip-only ops (`clipPath`, `clipImageMask`, `popClip`, etc.) are tracked
  * internally for the `activeClipBbox` field but not emitted, since they
  * don't draw pixels themselves.
+ *
+ * `opts.hashImages` makes each image op carry a `contentDigest` (see
+ * `hashImagePixels`). It's off by default because decoding every image to a
+ * pixmap just to hash it is wasted work for the overwhelmingly common case
+ * where a page's images all have distinct dimensions; callers enable it only
+ * when they've detected a same-dimension collision among extracted images.
  */
-export function recordPageStream(page: AnyPage): StreamOp[] {
+export function recordPageStream(
+  page: AnyPage,
+  opts: { hashImages?: boolean } = {},
+): StreamOp[] {
+  const { hashImages = false } = opts
   const ops: StreamOp[] = []
   const clipStack: ClipPath[] = []
   const groupStack: { blendMode: BlendMode; alpha: number }[] = []
@@ -246,6 +284,7 @@ export function recordPageStream(page: AnyPage): StreamOp[] {
         activeClipPaths: activeClipPaths(),
         blendMode: activeBlendMode(),
         alpha: composedAlpha(alpha ?? 1),
+        ...(hashImages ? { contentDigest: hashImagePixels(image) } : {}),
       })
     },
     fillImageMask(image, ctm, _cs, _color, alpha) {
@@ -260,6 +299,7 @@ export function recordPageStream(page: AnyPage): StreamOp[] {
         activeClipPaths: activeClipPaths(),
         blendMode: activeBlendMode(),
         alpha: composedAlpha(alpha ?? 1),
+        ...(hashImages ? { contentDigest: hashImagePixels(image) } : {}),
       })
     },
     clipImageMask(_image, ctm) {


### PR DESCRIPTION
## Problem

Fixed-layout books whose PDF shares a single `/Resources` dictionary across all pages — each listing every full-page layer image (e.g. output from a "LayerPDF" tool) — rendered the **same background on every page**. `stampRasterPlacementsFromOps` matched each draw-op to an extracted image by native pixel dimensions alone and consumed the first candidate, so when every page could see all N identically-sized images, each page paired its single draw-op with image #1.

## Fix

Disambiguate same-dimension candidates by a pixel-content digest: image ops optionally carry a `contentDigest` (computed in the stream recorder) which is matched against each image's `pixelDigest` (computed at extraction), both hashing the same `toPixmap()` samples. This work is gated on an actual same-dimension collision, so unambiguous pages keep the cheap dimension-only match and pay no hashing cost. Adds a regression test that reproduces the shared resource-dictionary structure and asserts each page renders its own distinct layer.

Verified against the real PDF (every page now maps to its correct layer) and the full PDF suite passes (147 tests); books already extracted under the old code must re-run the Extract stage.