### PR TITLE
fix(studio): small-window layout issues in onboarding & wizard

### DIFF
--- a/apps/desktop/src/main/windows/main.ts
+++ b/apps/desktop/src/main/windows/main.ts
@@ -27,8 +27,8 @@ export function createMainWindow(): BrowserWindow {
   const mainWindow = new BrowserWindow({
     width: 1400,
     height: 900,
-    minWidth: 900,
-    minHeight: 600,
+    minWidth: 1280,
+    minHeight: 720,
     show: false,
     autoHideMenuBar: true,
     backgroundColor: "#fff",

--- a/apps/studio/src/components/onboarding/scenes/ApiKeyScene.tsx
+++ b/apps/studio/src/components/onboarding/scenes/ApiKeyScene.tsx
@@ -157,7 +157,7 @@ export function ApiKeyStep(_props: OnboardingStepProps) {
             ))}
           </TabsList>
 
-          <div className="relative grid overflow-hidden">
+          <div className="relative grid overflow-hidden px-2 py-2">
             <AnimatedTabsContent value="openai" active={tab}>
               <div className="space-y-2">
                 <Label htmlFor="onb-openai-key">


### PR DESCRIPTION
Fixes a set of small-window layout bugs reported by @NatanaelLopes99.

## Changes

- **Raise desktop minimum window size to `1280×720`** (`apps/desktop/src/main/windows/main.ts`, was `900×600`). Empirically, the onboarding flow and the Add Book wizard render cleanly at `1280×720`: content no longer overlaps the fixed top/bottom bars, and the title bar / window controls no longer scroll together with page content. This addresses both:
  - **#511** — Header and window controls scroll with page content on wizard step 2 at small window sizes.
  - **#501** — Responsive layout overlaps in onboarding screens when the window is resized small.
- **Pad the onboarding API-key provider-tab container** (`px-2 py-2`) so the input's focus ring is no longer clipped on the left/right edges by the tab slide-animation's `overflow:hidden`. This is structural (independent of window size).
  - **#510** — API key input focus outline is clipped on smaller window sizes.

## Verification

- Screenshotted all five onboarding scenes (Welcome, Pitch, How-it-works, API key, Finale) at `1280×720` — no overlaps.
- Confirmed the API-key focus ring is fully visible after the padding fix (8px inset vs 4px ring).
- Lint clean.

Closes #501
Closes #510
Closes #511