### PR TITLE
fix: sign videos loop

### DIFF
--- a/apps/adt-runtime/src/features/sign-language/components/SLVideo.test.tsx
+++ b/apps/adt-runtime/src/features/sign-language/components/SLVideo.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import { cleanup, render } from "@testing-library/react"
+import { createStore, Provider } from "jotai"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { currentLanguageAtom, videoFilesAtom } from "@/features/language/state/language.atoms"
+import { currentPageNumberAtom, pagesAtom } from "@/features/navigation/state/nav.atoms"
+import { appConfigAtom } from "@/shared/state/config.atoms"
+import { signLanguageModeAtom } from "@/shared/state/ui.atoms"
+import { SLVideo } from "./SLVideo"
+
+vi.mock("@atlaskit/pragmatic-drag-and-drop/element/adapter", () => ({
+  draggable: () => () => {},
+}))
+
+vi.mock("@atlaskit/pragmatic-drag-and-drop/element/disable-native-drag-preview", () => ({
+  disableNativeDragPreview: () => {},
+}))
+
+afterEach(() => {
+  cleanup()
+  localStorage.clear()
+})
+
+describe("SLVideo", () => {
+  it("plays the assigned sign-language video once instead of looping", () => {
+    const store = createStore()
+    store.set(appConfigAtom, {
+      languages: { available: ["en"], default: "en" },
+      features: { signLanguage: true },
+    })
+    store.set(signLanguageModeAtom, true)
+    store.set(currentLanguageAtom, "en")
+    store.set(currentPageNumberAtom, 1)
+    store.set(pagesAtom, [{ section_id: "section-1", href: "page-1.html" }])
+    store.set(videoFilesAtom, { "video-1": "section-1.mp4" })
+
+    const { container } = render(
+      <Provider store={store}>
+        <SLVideo />
+      </Provider>,
+    )
+
+    const video = container.querySelector("video")
+    expect(video).toBeInstanceOf(HTMLVideoElement)
+    expect(video!.loop).toBe(false)
+    expect(video!.hasAttribute("loop")).toBe(false)
+  })
+})

--- a/apps/adt-runtime/src/features/sign-language/components/SLVideo.tsx
+++ b/apps/adt-runtime/src/features/sign-language/components/SLVideo.tsx
@@ -153,7 +153,6 @@ export function SLVideo() {
           key={src}
           src={src}
           autoPlay
-          loop
           playsInline
           controls
           onLoadedMetadata={(e) => {


### PR DESCRIPTION
### Problem
Currently Sign Vídeos are in loop.

### Fix
Remove attribute from vídeo tag to run once and Add a test to guarantee that is working 

 
 
 
 
Closes: https://github.com/unicef/adt-studio/issues/504
