### PR TITLE
fix: only one audio track at a time

### DIFF
--- a/apps/adt-runtime/src/features/audio/hooks/useAudioPlayer.ts
+++ b/apps/adt-runtime/src/features/audio/hooks/useAudioPlayer.ts
@@ -1,6 +1,7 @@
 import { useAtom, useAtomValue, useSetAtom } from "jotai"
 import { useCallback, useEffect, useMemo, useRef } from "react"
 import {
+  activeMediaAtom,
   audioSpeedAtom,
   audioVolumeAtom,
   autoplayModeAtom,
@@ -116,6 +117,8 @@ export function useAudioPlayer(): UseAudioPlayer {
   const playSessionRef = useRef(0)
   const [isPlaying, setIsPlaying] = useAtom(isPlayingAtom)
   const [currentIndex, setCurrentIndex] = useAtom(currentAudioIndexAtom)
+  const activeMedia = useAtomValue(activeMediaAtom)
+  const setActiveMedia = useSetAtom(activeMediaAtom)
   const audioFiles = useAtomValue(audioFilesAtom)
   const translations = useAtomValue(translationsAtom)
   const language = useAtomValue(currentLanguageAtom) as string
@@ -267,6 +270,7 @@ export function useAudioPlayer(): UseAudioPlayer {
         .play()
         .then(() => {
           if (session !== playSessionRef.current) return
+          setActiveMedia("tts")
           setIsPlaying(true)
         })
         .catch((err) => {
@@ -281,6 +285,7 @@ export function useAudioPlayer(): UseAudioPlayer {
       language,
       setIsPlaying,
       setCurrentIndex,
+      setActiveMedia,
       stopAndClear,
       setupHighlight,
       teardownActive,
@@ -307,12 +312,22 @@ export function useAudioPlayer(): UseAudioPlayer {
     ) {
       audio
         .play()
-        .then(() => setIsPlaying(true))
+        .then(() => {
+          setActiveMedia("tts")
+          setIsPlaying(true)
+        })
         .catch(() => setIsPlaying(false))
       return
     }
     playAtIndex(currentIndex || 0)
-  }, [items.length, currentIndex, playAtIndex, setIsPlaying, setReadAloudMode])
+  }, [
+    items.length,
+    currentIndex,
+    playAtIndex,
+    setActiveMedia,
+    setIsPlaying,
+    setReadAloudMode,
+  ])
 
   const togglePlayPause = useCallback(() => {
     const audio = audioRef.current
@@ -353,6 +368,20 @@ export function useAudioPlayer(): UseAudioPlayer {
     setIsPlaying(false)
     setCurrentIndex(0)
   }, [readAloudMode, stopAndClear, setIsPlaying, setCurrentIndex])
+
+  useEffect(() => {
+    if (activeMedia !== "sign-language") return
+    stopAndClear()
+    setIsPlaying(false)
+    setCurrentIndex(0)
+    setReadAloudMode(false)
+  }, [
+    activeMedia,
+    stopAndClear,
+    setIsPlaying,
+    setCurrentIndex,
+    setReadAloudMode,
+  ])
 
   useEffect(() => {
     if (audioRef.current) audioRef.current.playbackRate = speed

--- a/apps/adt-runtime/src/features/audio/state/audio.atoms.ts
+++ b/apps/adt-runtime/src/features/audio/state/audio.atoms.ts
@@ -31,6 +31,9 @@ export const currentAudioIndexAtom = ephemeralAtom(0)
 export const playBarVisibleAtom = ephemeralAtom(false)
 export const speedMenuOpenAtom = ephemeralAtom(false)
 
+export type ActiveMediaKind = "tts" | "sign-language"
+export const activeMediaAtom = ephemeralAtom<ActiveMediaKind | null>(null)
+
 /**
  * The list of `[data-id]`-bearing nodes the runtime found in `#content`,
  * in reading order. Each one becomes a TTS unit. Populated once per page

--- a/apps/adt-runtime/src/features/sign-language/components/SLVideo.tsx
+++ b/apps/adt-runtime/src/features/sign-language/components/SLVideo.tsx
@@ -1,6 +1,6 @@
 import { draggable } from "@atlaskit/pragmatic-drag-and-drop/element/adapter"
 import { disableNativeDragPreview } from "@atlaskit/pragmatic-drag-and-drop/element/disable-native-drag-preview"
-import { useAtom, useAtomValue } from "jotai"
+import { useAtom, useAtomValue, useSetAtom } from "jotai"
 import { GripHorizontal, VideoOff } from "lucide-react"
 import { useEffect, useMemo, useRef, useState } from "react"
 import { appConfigAtom } from "@/shared/state/config.atoms"
@@ -14,6 +14,7 @@ import {
   currentSectionIdAtom,
   pagesAtom,
 } from "@/features/navigation/state/nav.atoms"
+import { activeMediaAtom } from "@/features/audio/state/audio.atoms"
 import { useTranslation } from "@/features/language/hooks/useTranslation"
 import { cn } from "@/shared/lib/utils"
 
@@ -26,6 +27,8 @@ export function SLVideo() {
   const features = useAtomValue(appConfigAtom).features
   const slMode = useAtomValue(signLanguageModeAtom)
   const videoFiles = useAtomValue(videoFilesAtom)
+  const activeMedia = useAtomValue(activeMediaAtom)
+  const setActiveMedia = useSetAtom(activeMediaAtom)
   const sectionId = useAtomValue(currentSectionIdAtom)
   const pageNumber = useAtomValue(currentPageNumberAtom)
   const pages = useAtomValue(pagesAtom)
@@ -33,6 +36,7 @@ export function SLVideo() {
   const { t } = useTranslation()
 
   const containerRef = useRef<HTMLDivElement>(null)
+  const videoRef = useRef<HTMLVideoElement>(null)
   const handleRef = useRef<HTMLDivElement>(null)
   const [position, setPosition] = useAtom(slVideoPositionAtom)
   const [isDragging, setIsDragging] = useState(false)
@@ -105,6 +109,11 @@ export function SLVideo() {
     setAspectRatio(null)
   }, [src])
 
+  useEffect(() => {
+    if (activeMedia !== "tts") return
+    videoRef.current?.pause()
+  }, [activeMedia])
+
   if (!visible) return null
 
   const positioned = position !== null
@@ -150,6 +159,7 @@ export function SLVideo() {
       </div>
       {src ? (
         <video
+          ref={videoRef}
           key={src}
           src={src}
           autoPlay
@@ -162,6 +172,7 @@ export function SLVideo() {
               setAspectRatio(v.videoWidth / v.videoHeight)
             }
           }}
+          onPlay={() => setActiveMedia("sign-language")}
           className="w-full h-[calc(100%-1.5rem)] object-contain bg-black"
         />
       ) : (


### PR DESCRIPTION
### Problem
More than one audio track at the same time.

### Fix
- If TTS is running and you play sign vídeo, TTS stops.
- If Sign videos is running and you start TTS, the vídeo stops.

Closes: https://github.com/unicef/adt-studio/issues/505