### PR TITLE
fix(release): drop pnpm cache from prepare job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,10 +108,12 @@ jobs:
 
       - uses: pnpm/action-setup@v4
 
+      # No `cache: pnpm` here: this job never runs `pnpm install`, so the
+      # pnpm store is never created and the post-run cache save fails with
+      # "Path Validation Error: Path(s) specified ... do(es) not exist".
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: pnpm
 
       - name: Update issue template version dropdowns
         env:


### PR DESCRIPTION
## Problem

The beta release pipeline fails on the `prepare` job at the **`Post Run actions/setup-node@v4`** step:

```
##[error]Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.
```

The `prepare` job only resolves/validates the tag, bumps `apps/desktop/package.json`, and uploads staged metadata — it **never runs `pnpm install`**. So the pnpm store directory is never created. On the post-run cache **save** step, `actions/setup-node` with `cache: pnpm` tries to archive a non-existent store path, errors out, and turns the whole `prepare` job (and therefore the entire release) red.

Failing run: https://github.com/unicef/adt-studio/actions/runs/28560299743

## Fix

Remove `cache: pnpm` from the `setup-node` step in the `prepare` job — there is nothing to cache in a job that doesn't install dependencies.

The `desktop` job's `setup-node` keeps `cache: pnpm` since it does run `pnpm install --frozen-lockfile`.