### PR TITLE
fix(desktop): keep electron-builder plist on xmldom 0.8 line

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     ],
     "overrides": {
       "form-data": "^4.0.6",
-      "@xmldom/xmldom": "0.9.10"
+      "@xmldom/xmldom": "0.9.10",
+      "plist>@xmldom/xmldom": "^0.8.13"
     }
   },
   "license": "AGPL-3.0-or-later"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   form-data: ^4.0.6
   '@xmldom/xmldom': 0.9.10
+  plist>@xmldom/xmldom: ^0.8.13
 
 importers:
 
@@ -2999,9 +3000,9 @@ packages:
   '@vitest/utils@4.1.9':
     resolution: {integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==}
 
-  '@xmldom/xmldom@0.9.10':
-    resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
-    engines: {node: '>=14.6'}
+  '@xmldom/xmldom@0.8.13':
+    resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
+    engines: {node: '>=10.0.0'}
 
   abbrev@3.0.1:
     resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
@@ -8354,7 +8355,7 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@xmldom/xmldom@0.9.10': {}
+  '@xmldom/xmldom@0.8.13': {}
 
   abbrev@3.0.1: {}
 
@@ -10604,7 +10605,7 @@ snapshots:
 
   plist@3.1.0:
     dependencies:
-      '@xmldom/xmldom': 0.9.10
+      '@xmldom/xmldom': 0.8.13
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
 


### PR DESCRIPTION
## Problem

The desktop release fails on the **macOS** `Package MacOS` step:

```
⨯ DOMParser.parseFromString: the provided mimeType "undefined" is not valid.
  at DOMParser.parseFromString (@xmldom/xmldom@0.9.10/lib/dom-parser.js)
  at parse (plist@3.1.0/lib/parse.js)
  at parsePlistFile (app-builder-lib/util/plist.ts)
  at createMacApp (app-builder-lib/electron/electronMac.ts)
```

Failing run: https://github.com/unicef/adt-studio/actions/runs/28565309888 (Linux built fine; only macOS parses `Info.plist` during packaging).

## Cause

PR #521 added a **global** pnpm override forcing `@xmldom/xmldom` to `0.9.10` to clear a Dependabot alert. The 0.9.x line tightened `DOMParser.parseFromString` to the WHATWG spec — it now **requires a mimeType argument**. But `plist@3.1.0` (which electron-builder uses to parse the app's `Info.plist`) calls it **without** one, so it throws. `plist` declares `@xmldom/xmldom@^0.8.8`; the global override yanked it onto an incompatible major.

## Fix

`plist` is the **only** consumer of xmldom in the tree (`pnpm why @xmldom/xmldom` → all paths go through `plist` → the electron-builder chain). The 0.8 line has patched releases (`0.8.11`+) carrying the same security fixes, so scope the override to keep plist on the compatible, still-patched `0.8.13` while leaving `0.9.10` as the default for any future direct consumer:

```json
"overrides": {
  "form-data": "^4.0.6",
  "@xmldom/xmldom": "0.9.10",
  "plist>@xmldom/xmldom": "^0.8.13"
}
```

## Validation

Reproduced the CI mac build locally on macOS:
- **Before:** died immediately at `createMacApp` with the `mimeType "undefined"` error.
- **After:** electron-builder parses `Info.plist`, assembles `ADT-Studio.app` (built bundle passes `plutil -lint: OK`), and proceeds to code-signing.

`pnpm why -r @xmldom/xmldom` confirms a single resolved version: `0.8.13`.