### PR TITLE
fix(studio): unify unsaved-changes safeguard across save & re-run and editor saves

### DIFF
--- a/apps/studio/src/components/pipeline/components/UnsavedChangesGuard.tsx
+++ b/apps/studio/src/components/pipeline/components/UnsavedChangesGuard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react"
+import { Fragment, useCallback, useRef, useState } from "react"
 import { useBlocker, type ShouldBlockFn } from "@tanstack/react-router"
 import { Trans, useLingui } from "@lingui/react/macro"
 import { Loader2, Play, TriangleAlert } from "lucide-react"
@@ -11,7 +11,11 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog"
 import { cn } from "@/lib/utils"
-import { useHasUnsavedChanges, useFloatingSaveLeaveAction } from "./floating-save"
+import {
+  useHasUnsavedChanges,
+  useFloatingSaveLeaveAction,
+  useFloatingSaveDirtyEntries,
+} from "./floating-save"
 import {
   useHasAnyDirtyTab,
   useDirtyTabEntries,
@@ -29,6 +33,7 @@ export function UnsavedChangesGuard() {
   const hasDirtyTab = useHasAnyDirtyTab()
   const hasUnsaved = hasFloatingUnsaved || hasDirtyTab
   const dirtyEntries = useDirtyTabEntries()
+  const floatingDirtyEntries = useFloatingSaveDirtyEntries()
   const ephemeralDirtyTabs = useEphemeralDirtyTabs()
   const { canSave, willRerun, saveAndStay } = useFloatingSaveLeaveAction()
   const [saving, setSaving] = useState(false)
@@ -57,7 +62,8 @@ export function UnsavedChangesGuard() {
     withResolver: true,
   })
 
-  const primaryStage = dirtyEntries[0]?.stage
+  const isSettings = dirtyEntries.length > 0
+  const primaryStage = dirtyEntries[0]?.stage ?? floatingDirtyEntries.find((e) => e.stage)?.stage
   const stageDef = primaryStage ? STAGE_BY_SLUG.get(primaryStage) : undefined
   const HeaderIcon = stageDef?.icon ?? TriangleAlert
   const headerColor = stageDef?.color ?? "bg-gray-700"
@@ -70,6 +76,10 @@ export function UnsavedChangesGuard() {
       dotColor: def?.color ?? "bg-amber-500",
     }))
   })
+
+  const editorLabels = isSettings
+    ? []
+    : floatingDirtyEntries.filter((e) => e.label != null)
 
   const handleSaveAndContinue = async () => {
     setSaving(true)
@@ -92,7 +102,11 @@ export function UnsavedChangesGuard() {
           </div>
           <div className="min-w-0">
             <p className="truncate text-xs font-semibold uppercase tracking-wide text-white/75">
-              {stageDef ? `${getStageLabelI18n(stageDef.slug)} · ${t`Settings`}` : t`Heads up`}
+              {stageDef
+                ? isSettings
+                  ? `${getStageLabelI18n(stageDef.slug)} · ${t`Settings`}`
+                  : getStageLabelI18n(stageDef.slug)
+                : t`Heads up`}
             </p>
             <AlertDialogTitle className="text-lg font-semibold leading-tight text-white">
               <Trans>Unsaved changes</Trans>
@@ -112,21 +126,25 @@ export function UnsavedChangesGuard() {
             )}
           </AlertDialogDescription>
 
-          {changeChips.length > 0 && (
+          {(changeChips.length > 0 || editorLabels.length > 0) && (
             <div className="rounded-lg border bg-muted/30 px-3.5 py-3">
               <p className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
                 <Trans>Pending edits</Trans>
               </p>
               <div className="flex flex-wrap gap-1.5">
-                {changeChips.map((chip) => (
-                  <span
-                    key={chip.key}
-                    className="inline-flex items-center gap-1.5 rounded-md border bg-background px-2 py-1 text-xs font-medium text-foreground"
-                  >
-                    <span className={cn("h-1.5 w-1.5 shrink-0 rounded-full", chip.dotColor)} aria-hidden />
-                    {chip.label}
-                  </span>
-                ))}
+                {changeChips.length > 0
+                  ? changeChips.map((chip) => (
+                      <span
+                        key={chip.key}
+                        className="inline-flex items-center gap-1.5 rounded-md border bg-background px-2 py-1 text-xs font-medium text-foreground"
+                      >
+                        <span className={cn("h-1.5 w-1.5 shrink-0 rounded-full", chip.dotColor)} aria-hidden />
+                        {chip.label}
+                      </span>
+                    ))
+                  : editorLabels.map((entry) => (
+                      <Fragment key={entry.id}>{entry.label}</Fragment>
+                    ))}
               </div>
             </div>
           )}

--- a/apps/studio/src/components/pipeline/components/VersionPicker.tsx
+++ b/apps/studio/src/components/pipeline/components/VersionPicker.tsx
@@ -12,6 +12,7 @@ import {
 import { msg } from "@lingui/core/macro"
 import type { MessageDescriptor } from "@lingui/core"
 import { useLingui } from "@lingui/react/macro"
+import { STEP_TO_STAGE, type StageName } from "@adt/types"
 import { api } from "@/api/client"
 import type { VersionEntry } from "@/api/client"
 import {
@@ -119,8 +120,12 @@ export function VersionPicker({
     <PendingChip icon={stepPending.icon}>{i18n._(stepPending.label)}</PendingChip>
   ) : undefined
 
+  const stage: StageName =
+    step === "text-catalog-translation" ? "translate" : STEP_TO_STAGE[step]
+
   useFloatingSave({
     id: `${step}:${itemId}`,
+    stage,
     dirty: dirty && renderSaveBar && currentVersion != null,
     saving,
     label: pendingLabel ?? defaultLabel,

--- a/apps/studio/src/components/pipeline/components/floating-save.tsx
+++ b/apps/studio/src/components/pipeline/components/floating-save.tsx
@@ -8,6 +8,7 @@ import {
   type ReactNode,
 } from "react"
 import type { LucideIcon } from "lucide-react"
+import type { StageName } from "@adt/types"
 import { useLingui } from "@lingui/react/macro"
 import { FloatingSaveBar } from "./FloatingSaveBar"
 
@@ -44,6 +45,8 @@ export interface FloatingSaveEntry {
   dirty: boolean
   saving: boolean
   label?: ReactNode
+  /** Stage this surface belongs to, so the unsaved-changes guard can style its dialog with the stage icon/color. */
+  stage?: StageName
   onSave?: () => void
   onSaveAndRerun?: () => void
   onSaveStay?: () => void | Promise<void>
@@ -69,6 +72,7 @@ function signature(e: FloatingSaveEntry): string {
     e.saveDisabledReason ?? "",
     e.rerunDisabledReason ?? "",
     e.labelKey ?? "",
+    e.stage ?? "",
   ].join("|")
 }
 
@@ -207,6 +211,24 @@ export function useHasUnsavedChanges(): boolean {
   const subscribe = store ? store.subscribe : noopSubscribe
   const getSnapshot = () => (store ? store.active().length > 0 : false)
   return useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+}
+
+export interface FloatingSaveDirtyEntry {
+  id: string
+  stage?: StageName
+  label?: ReactNode
+}
+
+/** Stage + label of every surface with unsaved changes, so the guard can style its dialog and list pending edits. */
+export function useFloatingSaveDirtyEntries(): FloatingSaveDirtyEntry[] {
+  const store = useContext(FloatingSaveContext)
+  useSyncExternalStore(
+    store ? store.subscribe : noopSubscribe,
+    store ? store.getVersion : () => 0,
+    store ? store.getVersion : () => 0,
+  )
+  if (!store) return []
+  return store.active().map((e) => ({ id: e.id, stage: e.stage, label: e.label }))
 }
 
 export interface FloatingSaveLeaveAction {

--- a/apps/studio/src/components/pipeline/components/floating-save.tsx
+++ b/apps/studio/src/components/pipeline/components/floating-save.tsx
@@ -45,7 +45,6 @@ export interface FloatingSaveEntry {
   dirty: boolean
   saving: boolean
   label?: ReactNode
-  /** Stage this surface belongs to, so the unsaved-changes guard can style its dialog with the stage icon/color. */
   stage?: StageName
   onSave?: () => void
   onSaveAndRerun?: () => void
@@ -219,7 +218,6 @@ export interface FloatingSaveDirtyEntry {
   label?: ReactNode
 }
 
-/** Stage + label of every surface with unsaved changes, so the guard can style its dialog and list pending edits. */
 export function useFloatingSaveDirtyEntries(): FloatingSaveDirtyEntry[] {
   const store = useContext(FloatingSaveContext)
   useSyncExternalStore(

--- a/apps/studio/src/components/pipeline/stages/languages/components/SpeechPromptsEditor.tsx
+++ b/apps/studio/src/components/pipeline/stages/languages/components/SpeechPromptsEditor.tsx
@@ -82,7 +82,11 @@ export function SpeechPromptsEditor({ bookLabel }: SpeechPromptsEditorProps) {
     onSaveAndRerun: async () => {
       await handleSave()
       queueRun({ fromStage: "speech", toStage: "speech", apiKey })
-      navigate({ to: "/books/$label/$step", params: { label: bookLabel, step: "speech" } })
+      navigate({
+        to: "/books/$label/$step",
+        params: { label: bookLabel, step: "speech" },
+        ignoreBlocker: true,
+      })
     },
     onSaveStay: async () => {
       await handleSave()

--- a/apps/studio/src/components/pipeline/stages/languages/components/VoiceMappingsEditor.tsx
+++ b/apps/studio/src/components/pipeline/stages/languages/components/VoiceMappingsEditor.tsx
@@ -177,7 +177,11 @@ export function VoiceMappingsEditor({ bookLabel }: VoiceMappingsEditorProps) {
     onSaveAndRerun: async () => {
       await handleSave()
       queueRun({ fromStage: "speech", toStage: "speech", apiKey })
-      navigate({ to: "/books/$label/$step", params: { label: bookLabel, step: "speech" } })
+      navigate({
+        to: "/books/$label/$step",
+        params: { label: bookLabel, step: "speech" },
+        ignoreBlocker: true,
+      })
     },
     onSaveStay: async () => {
       await handleSave()

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
@@ -787,6 +787,7 @@ export function StoryboardSectionDetail({
   }
   useFloatingSave({
     id: `storyboard:${pageId}`,
+    stage: "storyboard",
     dirty: dirty || renderingDirty,
     saving,
     labelKey: pendingChipCats.join(","),

--- a/apps/studio/src/hooks/use-stage-settings-bar.tsx
+++ b/apps/studio/src/hooks/use-stage-settings-bar.tsx
@@ -37,7 +37,11 @@ export function useStageSettingsBar({
     onSaveAndRerun: async () => {
       await save()
       queueRun({ fromStage: stage, toStage: stage, apiKey })
-      navigate({ to: "/books/$label/$step", params: { label: bookLabel, step: stage } })
+      navigate({
+        to: "/books/$label/$step",
+        params: { label: bookLabel, step: stage },
+        ignoreBlocker: true,
+      })
     },
     onSaveStay: async () => {
       await save()


### PR DESCRIPTION
## Problem

Two issues with the unsaved-changes safeguard dialog:

1. **Save & Re-run wrongly tripped the guard.** On settings pages, clicking **Save & Re-run** saved and then navigated, but the dirty state clears via React `setState` (one render later than the navigation). At the instant `navigate()` fired, the dirty stores still reported unsaved changes, so the guard blocked the navigation and popped a stale "Unsaved changes" dialog — with no Save button, since the stores emptied out by the time it painted.

2. **The "just save" (editor) dialog looked different from the "save & re-run" (settings) one.** Both are the same `UnsavedChangesGuard`, but its styled look (stage icon, colored header/button, pending-edit chips) only rendered when a **stage** could be resolved. Stages were only known via `DirtyTabsStore`, populated exclusively by settings surfaces. Editor surfaces (storyboard page, version-backed editors) carried no stage → generic gray/alert fallback.

## Fix

- Use TanStack Router's first-party `ignoreBlocker: true` on the intentional save-and-navigate calls (`useStageSettingsBar`, plus the speech prompts / voice mappings editors that had the same defect).
- Add an optional `stage` to `FloatingSaveEntry`, exposed via `useFloatingSaveDirtyEntries`. The guard now resolves its icon, color, eyebrow, and pending-edit chips from the floating entries when there's no settings dirty-tab entry — so editor saves get the same styled dialog.
- `StoryboardSectionDetail` and `VersionPicker` now declare their stage (the latter via the canonical `STEP_TO_STAGE`, with the UI-only `text-catalog-translation` mapped to `translate`).

## Testing

- `pnpm --filter @adt/studio` typecheck (`tsc --noEmit`) — pass
- eslint on changed files — pass
- No new user-visible strings (reuses existing stage labels).