### PR TITLE
fix(studio): keep fullscreen image overlays clickable under the Electron title bar

### DIFF
--- a/apps/studio/src/components/pipeline/stages/languages/components/ImageLightbox.tsx
+++ b/apps/studio/src/components/pipeline/stages/languages/components/ImageLightbox.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react"
 import { X } from "lucide-react"
 import { useLingui } from "@lingui/react/macro"
+import { NO_DRAG_REGION } from "@/constants"
 
 interface ImageLightboxProps {
   src: string
@@ -27,6 +28,7 @@ export function ImageLightbox({ src, alt, caption, onClose }: ImageLightboxProps
     <div
       className="fixed inset-0 z-[120] bg-black/85 flex items-center justify-center p-6 cursor-zoom-out"
       onClick={onClose}
+      style={NO_DRAG_REGION}
     >
       <button
         type="button"

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/ImageCropDialog.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/ImageCropDialog.tsx
@@ -2,6 +2,10 @@ import { useState, useRef, useEffect, useCallback } from "react"
 import { Loader2, Lock, Square, RectangleHorizontal, Pentagon } from "lucide-react"
 import { Trans, useLingui } from "@lingui/react/macro"
 import { cn } from "@/lib/utils"
+import { NO_DRAG_REGION } from "@/constants"
+import { usePlatform } from "@/hooks/use-platform"
+import { useWindowControls } from "@/hooks/use-window-controls"
+import { MacOSTrafficLightSpacer } from "@/components/title-bar"
 
 interface Point {
   x: number
@@ -106,6 +110,9 @@ const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v
  */
 export function ImageCropDialog({ imageSrc, initialRect, onApply, onClose }: ImageCropDialogProps) {
   const { t } = useLingui()
+  const platform = usePlatform()
+  const { available: hasWindowControls } = useWindowControls()
+  const showMacOSSpacer = hasWindowControls && platform === "macos"
   const [points, setPoints] = useState<Point[]>([])
   const [imageNatural, setImageNatural] = useState<{ w: number; h: number } | null>(null)
   const [displaySize, setDisplaySize] = useState<{ w: number; h: number } | null>(null)
@@ -410,10 +417,15 @@ export function ImageCropDialog({ imageSrc, initialRect, onApply, onClose }: Ima
   ]
 
   return (
-    <div className="fixed inset-0 z-[100] bg-black/80 flex flex-col">
-      {/* Header */}
-      <div className="flex items-center justify-between gap-3 px-4 py-3 bg-background border-b shrink-0">
+    <div className="fixed inset-0 z-[100] bg-black/80 flex flex-col" style={NO_DRAG_REGION}>
+      {/* Header — `drag-region` lets the window be moved by the empty header
+          area; its interactive children are reset to no-drag via CSS. Electron
+          computes app regions globally (ignoring z-index), so the overlay must
+          declare no-drag or the app's title-bar drag strip beneath it would
+          swallow clicks on these buttons in the packaged desktop app. */}
+      <div className="flex items-center justify-between gap-3 px-4 py-3 bg-background border-b shrink-0 drag-region">
         <div className="flex items-center gap-3 min-w-0">
+          {showMacOSSpacer && <MacOSTrafficLightSpacer />}
           <h2 className="text-sm font-medium shrink-0">{t`Crop Image`}</h2>
           {/* Mode / ratio control */}
           <div className="flex items-center rounded-md border bg-muted/50 p-0.5 gap-0.5">

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/SegmentPreviewDialog.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/SegmentPreviewDialog.tsx
@@ -1,6 +1,10 @@
 import { useState, useRef, useCallback, useEffect } from "react"
 import { Loader2 } from "lucide-react"
 import { Trans, useLingui } from "@lingui/react/macro"
+import { NO_DRAG_REGION } from "@/constants"
+import { usePlatform } from "@/hooks/use-platform"
+import { useWindowControls } from "@/hooks/use-window-controls"
+import { MacOSTrafficLightSpacer } from "@/components/title-bar"
 
 export interface SegmentRegion {
   label: string
@@ -34,6 +38,9 @@ export function SegmentPreviewDialog({
   onClose,
 }: SegmentPreviewDialogProps) {
   const { t } = useLingui()
+  const platform = usePlatform()
+  const { available: hasWindowControls } = useWindowControls()
+  const showMacOSSpacer = hasWindowControls && platform === "macos"
   const [regions, setRegions] = useState<SegmentRegion[]>(initialRegions)
   const [applying, setApplying] = useState(false)
   const [selectedIdx, setSelectedIdx] = useState<number | null>(null)
@@ -203,10 +210,13 @@ export function SegmentPreviewDialog({
   }
 
   return (
-    <div className="fixed inset-0 z-[100] bg-black/80 flex flex-col">
-      {/* Header */}
-      <div className="flex items-center justify-between px-4 py-3 bg-background border-b shrink-0">
-        <h2 className="text-sm font-medium">
+    <div className="fixed inset-0 z-[100] bg-black/80 flex flex-col" style={NO_DRAG_REGION}>
+      {/* Header — see ImageCropDialog: the overlay must opt out of the app's
+          title-bar drag region so these buttons stay clickable in the packaged
+          desktop app; `drag-region` keeps the empty header area draggable. */}
+      <div className="flex items-center justify-between px-4 py-3 bg-background border-b shrink-0 drag-region">
+        <h2 className="flex items-center text-sm font-medium">
+          {showMacOSSpacer && <MacOSTrafficLightSpacer />}
           <Trans>Segment Preview</Trans>
           <span className="ml-2 text-xs text-muted-foreground">
             {t`${regionCount} {regionCount, plural, one {region} other {regions}} detected`}


### PR DESCRIPTION
## Summary

Fixes the desktop-only bug where the **image crop** dialog's **Apply / Cancel** buttons (and the mode toolbar) are unresponsive — the only escape is force-quitting the app (#406). The same root cause affected two sibling full-screen overlays, so they're fixed here too.

### Root cause
On macOS the window is frameless (`titleBarStyle: "hiddenInset"`, traffic lights inset at `{x:14, y:14}`) and on Windows/Linux it's `frame: false`. In both cases the app draws its own draggable title strip (`.drag-region` on `StudioTopBar` / the step header).

The overlays render as `fixed inset-0 z-[100]` but declared **no** `-webkit-app-region`. Electron computes draggable regions **globally, ignoring z-index/stacking**, so the title-bar drag strip *beneath* the overlay still owned that band of the window. Mouse-downs on buttons sitting in that band were treated as **window-drags instead of clicks**.

This is why it only reproduces in the **packaged desktop app** — `-webkit-app-region` is inert in a plain browser, matching the reporter's "works when run locally from the repo" note.

### Fix
Same pattern the app already uses in `StudioTopBar` / `OnboardingFlow`:
- Overlay root → `NO_DRAG_REGION`, neutralizing the underlying drag strip so all controls are clickable.
- Header → `drag-region` class, so the empty header area can still move the window (interactive children auto-reset to `no-drag` via the existing `.drag-region *` CSS rule).
- `MacOSTrafficLightSpacer` before the title on macOS so the toolbar clears the inset traffic lights.

### Components fixed
- `ImageCropDialog` — shared by **Extract**, **Storyboard**, and **Sectioning overview** (one fix, all three crop entry points).
- `SegmentPreviewDialog` — Storyboard segment preview; `Cancel` / `Apply Segmentation` were dead in the top strip.
- `ImageLightbox` — Localization → Language; the close ✕ (`top-4 right-4`) was dead in the top strip (lower severity — backdrop-click / Escape still closed it).

Centered dialogs (`AiImageDialog`, `AddImageDialog`, `ReplaceFromBookDialog`, `SelectImagesDialog`) place content in a padded, centered card below the strip and are unaffected.

---

## Test plan (QA — please verify on **Windows** packaged build)

> ⚠️ This bug is **build-only**. It does **not** reproduce in the browser / dev server (`pnpm dev`) — `-webkit-app-region` is a no-op there. Test the **packaged desktop app** (installed build), not `pnpm dev:desktop` in a browser tab.

### 1. Image crop — Extract (the reported #406 path)
1. Open a book → **Extract** stage → open a page that has an image.
2. Open the **Crop Image** dialog.
3. Drag the crop handles to adjust the region (should work as before).
4. ✅ Click **Cancel** → dialog closes.
5. Re-open, adjust, then ✅ click **Apply** → crop is applied, dialog closes.
6. ✅ Switch modes in the toolbar (**Rectangle / Polygon / Lock / 1:1**) — all buttons respond.
7. ✅ On Windows: the window Minimize/Maximize/Close controls are **not** overlapped/blocked; dragging the empty header area still moves the window.

### 2. Image crop — Storyboard & Sectioning (same component)
1. **Storyboard**: open a section → crop an image → verify **Apply / Cancel** work.
2. **Sectioning overview**: trigger the crop dialog → verify **Apply / Cancel** work.

### 3. Segment preview — Storyboard
1. Open the **Segment Preview** overlay (segment an image in Storyboard).
2. Drag/resize the detected region boxes (works as before).
3. ✅ Click **Cancel** → closes.
4. ✅ Click **Apply Segmentation** → applies, closes.

### 4. Image lightbox — Localization → Language
1. Go to **Localization → Language**.
2. Click an image thumbnail (small zoom-in thumbnail on an image entry, or a thumbnail inside the "select images" dialog) → the full-screen lightbox opens.
3. ✅ Click the **✕** button (top-right) → closes.
4. ✅ Backdrop click and **Escape** also close it.

### Regression checks
- [ ] Window can still be dragged by the empty header area of the crop/segment overlays.
- [ ] Crop handle dragging, polygon editing, and aspect-ratio locking behave exactly as before.
- [ ] No visual overlap between the overlay title/toolbar and the macOS traffic lights.
- [ ] Repeat the Extract crop flow on **macOS** and **Linux** packaged builds if available.

Closes #406
