### PR TITLE
fix(studio): restore draggable title bar and window controls on settings pages

### DIFF
--- a/apps/studio/src/components/pipeline/components/StepHeaderBar.tsx
+++ b/apps/studio/src/components/pipeline/components/StepHeaderBar.tsx
@@ -6,13 +6,8 @@ import { LinuxControls } from "@/components/title-bar/LinuxControls"
 import { WindowsControls } from "@/components/title-bar/WindowsControls"
 
 /**
- * The colored bar at the top of a step view (step title, settings entry, etc.).
- *
- * Owns the two behaviours every step header must share so they can't drift out
- * of sync: it is a `drag-region` (the frameless desktop window is moved by
- * dragging it) and it hosts the Windows/Linux window controls, which are the
- * only min/maximize/close affordance when the OS chrome is hidden. Interactive
- * children opt out of dragging automatically via the `.drag-region *` rule.
+ * Colored bar at the top of a step view. Owns the `drag-region` and the
+ * Windows/Linux window controls so every step header keeps them in sync.
  */
 export function StepHeaderBar({
   color,
@@ -32,7 +27,6 @@ export function StepHeaderBar({
       className={cn(
         "shrink-0 h-10 px-4 flex items-center gap-3 text-white drag-region",
         color,
-        // Let the window controls sit flush to the right edge on Win/Linux.
         hasWindowControls && platform !== "macos" && "pr-0",
         className,
       )}

--- a/apps/studio/src/components/pipeline/components/StepHeaderBar.tsx
+++ b/apps/studio/src/components/pipeline/components/StepHeaderBar.tsx
@@ -1,0 +1,45 @@
+import type { ReactNode } from "react"
+import { cn } from "@/lib/utils"
+import { useWindowControls } from "@/hooks/use-window-controls"
+import { usePlatform } from "@/hooks/use-platform"
+import { LinuxControls } from "@/components/title-bar/LinuxControls"
+import { WindowsControls } from "@/components/title-bar/WindowsControls"
+
+/**
+ * The colored bar at the top of a step view (step title, settings entry, etc.).
+ *
+ * Owns the two behaviours every step header must share so they can't drift out
+ * of sync: it is a `drag-region` (the frameless desktop window is moved by
+ * dragging it) and it hosts the Windows/Linux window controls, which are the
+ * only min/maximize/close affordance when the OS chrome is hidden. Interactive
+ * children opt out of dragging automatically via the `.drag-region *` rule.
+ */
+export function StepHeaderBar({
+  color,
+  className,
+  children,
+}: {
+  /** Stage accent background color class (e.g. `stage.color`). */
+  color: string
+  className?: string
+  children: ReactNode
+}) {
+  const { available: hasWindowControls } = useWindowControls()
+  const platform = usePlatform()
+
+  return (
+    <div
+      className={cn(
+        "shrink-0 h-10 px-4 flex items-center gap-3 text-white drag-region",
+        color,
+        // Let the window controls sit flush to the right edge on Win/Linux.
+        hasWindowControls && platform !== "macos" && "pr-0",
+        className,
+      )}
+    >
+      {children}
+      <LinuxControls className="self-stretch" />
+      <WindowsControls variant="dark" className="self-stretch" />
+    </div>
+  )
+}

--- a/apps/studio/src/components/pipeline/components/StepViewRouter.tsx
+++ b/apps/studio/src/components/pipeline/components/StepViewRouter.tsx
@@ -29,10 +29,7 @@ import {
 } from "../stages";
 import { cn } from "@/lib/utils";
 import { Trans } from "@lingui/react/macro";
-import { useWindowControls } from "@/hooks/use-window-controls";
-import { usePlatform } from "@/hooks/use-platform";
-import { LinuxControls } from "@/components/title-bar/LinuxControls";
-import { WindowsControls } from "@/components/title-bar/WindowsControls";
+import { StepHeaderBar } from "./StepHeaderBar";
 
 // Context for views to inject content into the step header
 interface StepHeaderControls {
@@ -93,7 +90,6 @@ export function StepViewRouter({
   selectedPageId?: string;
   onSelectPage?: (pageId: string | null) => void;
 }) {
-  const { available: hasWindows } = useWindowControls();
   const entry = VIEW_MAP[step];
   const stepConfig = STAGES.find((s) => s.slug === step);
   const [headerExtra, setHeaderExtra] = useState<ReactNode>(null);
@@ -101,8 +97,6 @@ export function StepViewRouter({
     fn: () => void;
   } | null>(null);
   const [headerSlotEl, setHeaderSlotEl] = useState<HTMLElement | null>(null);
-
-  const platform = usePlatform();
 
   const setOnLabelClick = useCallback((handler: (() => void) | null) => {
     setLabelClickHandler(handler ? { fn: handler } : null);
@@ -131,13 +125,7 @@ export function StepViewRouter({
     <StepHeaderContext.Provider value={controls}>
       <div className="flex flex-col h-full">
         {/* Step header */}
-        <div
-          className={cn(
-            "shrink-0 h-10 px-4 flex items-center gap-3 text-white drag-region",
-            stepConfig.color,
-            hasWindows && platform !== "macos" && "pr-0",
-          )}
-        >
+        <StepHeaderBar color={stepConfig.color}>
           <div className="flex items-center justify-center w-6 h-6 rounded-full bg-white/20">
             <Icon className="w-3 h-3" />
           </div>
@@ -168,9 +156,7 @@ export function StepViewRouter({
               <Settings className="w-3.5 h-3.5" />
             </Link>
           )}
-          <LinuxControls className="self-stretch" />
-          <WindowsControls variant="dark" className="self-stretch" />
-        </div>
+        </StepHeaderBar>
 
         {/* Step content */}
         {entry.fullHeight ? (

--- a/apps/studio/src/routes/books.$label.$step.settings.test.tsx
+++ b/apps/studio/src/routes/books.$label.$step.settings.test.tsx
@@ -27,6 +27,16 @@ vi.mock("@tanstack/react-router", () => ({
 
 vi.mock("@lingui/react/macro", () => ({
   Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useLingui: () => ({
+    t(strings: TemplateStringsArray, ...values: unknown[]) {
+      let text = ""
+      for (let index = 0; index < strings.length; index += 1) {
+        text += strings[index]
+        if (index < values.length) text += String(values[index])
+      }
+      return text
+    },
+  }),
 }))
 
 vi.mock("@/components/pipeline/stage-config", async () => {

--- a/apps/studio/src/routes/books.$label.$step.settings.tsx
+++ b/apps/studio/src/routes/books.$label.$step.settings.tsx
@@ -26,7 +26,7 @@ import { SpeechSettings } from "@/components/pipeline/stages/speech/SpeechSettin
 import { SpeechLandingPage } from "@/components/pipeline/stages/speech/SpeechLandingPage"
 import { ValidationSettings } from "@/components/pipeline/stages/ValidationSettings"
 import { getStageLabelI18n } from "@/components/pipeline/pipeline-i18n"
-import { cn } from "@/lib/utils"
+import { StepHeaderBar } from "@/components/pipeline/components/StepHeaderBar"
 import { Trans } from "@lingui/react/macro"
 
 export const Route = createFileRoute("/books/$label/$step/settings")({
@@ -44,9 +44,9 @@ export function StepSettingsPage() {
   if (!stage) {
     return (
       <div className="flex flex-col h-full">
-        <div className="shrink-0 h-10 px-4 flex items-center gap-2 text-white bg-gray-700">
+        <StepHeaderBar color="bg-gray-700" className="gap-2">
           <span className="text-sm font-semibold"><Trans>Unknown stage</Trans></span>
-        </div>
+        </StepHeaderBar>
         <div className="p-4 max-w-2xl">
           <p className="text-sm text-muted-foreground">
             <Trans>Unknown step slug: {step}</Trans>
@@ -71,7 +71,7 @@ export function StepSettingsPage() {
   return (
     <div className="flex flex-col h-full">
       {/* Step header */}
-      <div className={cn("shrink-0 h-10 px-4 flex items-center gap-2 text-white", stage.color)}>
+      <StepHeaderBar color={stage.color} className="gap-2">
         <div className="flex items-center justify-center w-6 h-6 rounded-full bg-white/20">
           <Icon className="w-3 h-3" />
         </div>
@@ -92,7 +92,7 @@ export function StepSettingsPage() {
         >
           <X className="w-4 h-4" />
         </Link>
-      </div>
+      </StepHeaderBar>
 
       {/* Settings content */}
       <SettingsRemountProvider value={() => setDiscardNonce((n) => n + 1)}>


### PR DESCRIPTION
## Summary

On the step **Settings** pages (`/books/$label/$step/settings`), the top bar lost its window affordances: the frameless desktop window could no longer be **dragged**, and on **Windows/Linux** the **minimize / maximize / close** buttons **disappeared** entirely.

### Root cause
The app has two separate top-bar implementations for a stage view:
- `StepViewRouter.tsx` (normal stage view) — a `drag-region` header that also renders the Windows/Linux window controls.
- `books.$label.$step.settings.tsx` (settings view) — a **hand-rolled copy** of that header that was missing **both** the `drag-region` class **and** the `LinuxControls`/`WindowsControls`.

Because the desktop window is frameless (`titleBarStyle: "hiddenInset"` on macOS, `frame: false` on Windows/Linux), the app's own header *is* the title bar. On the settings page that header wasn't draggable, and on Windows/Linux it had no window controls — so there was no way to move, minimize, maximize, or close the window from a settings page. Two copies of the same header had drifted apart.

### Fix (refactor for reuse)
Extract the shared header into a reusable **`StepHeaderBar`** component that owns the two must-have behaviours so they can't drift again:
- it's a `drag-region` (empty area drags the window; interactive children opt out via the existing `.drag-region *` rule), and
- it renders the platform window controls (`LinuxControls` / `WindowsControls`), which are the only min/max/close affordance when the OS chrome is hidden.

Then route both call sites through it:
- `StepViewRouter` — replaced its inline header (and dropped the now-unused `useWindowControls` / `usePlatform` / control imports).
- `books.$label.$step.settings.tsx` — the settings header **and** its "Unknown stage" fallback now use `StepHeaderBar`.

No behavioural change on the normal stage view; the settings view gains the drag region + window controls it was missing.

---

## Test plan (QA — please verify on **Windows** packaged build)

> ⚠️ Frameless-window behaviour (custom title bar, drag, window controls) only manifests in the **packaged desktop app** — not the dev browser (`pnpm dev`), where the real OS title bar is present. Test an installed/packaged build.

### Windows / Linux — the reported bug
1. Open a book → open any stage (e.g. **Extract**, **Storyboard**).
2. ✅ The normal stage view shows Minimize / Maximize / Close at the top-right and the header is draggable (unchanged — regression check).
3. Click the **⚙ Settings** gear (or navigate to a stage's Settings).
4. ✅ **Minimize / Maximize / Close are still present** at the top-right on the settings page (previously gone).
5. ✅ Dragging the empty area of the settings header **moves the window** (previously dead).
6. ✅ Min / Max / Close all work from the settings page.
7. ✅ The settings header's **✕ (close settings → back to stage)** button still works and is distinct from the OS close button.

### macOS
1. Open a stage → open its Settings.
2. ✅ The window can be dragged by the settings header.
3. ✅ No visual overlap with the traffic lights (they sit over the sidebar, unaffected).

### Cross-stage
- [ ] Spot-check settings for a couple of stages (Extract, Storyboard, Validation) — header renders with title, ⚙-close, drag, and window controls.
- [ ] "Unknown stage" fallback (navigating to a bogus stage's settings) also shows a proper draggable header with window controls.

### Regression
- [ ] Normal (non-settings) stage headers are unchanged: title, settings gear, drag, window controls.

---

### Notes for reviewers
- Verified locally: `eslint` clean and `tsc --noEmit` reports no errors in the changed files.
- The existing `books.$label.$step.settings.test.tsx` currently fails, **but it fails identically on unmodified `develop`** (a pre-existing test-harness issue: the Lingui macro compiles `<Trans>` to the real component, defeating the test's mock). Not introduced by this PR.
- Desktop-only behaviour couldn't be exercised from the dev browser here; the fix reuses the exact pattern already proven in `StepViewRouter`, hence the Windows QA pass above.
