### PR TITLE
feat(speech): TTS read-aloud muting and live speech generation view

### DIFF
--- a/apps/api/src/routes/adt-preview.test.ts
+++ b/apps/api/src/routes/adt-preview.test.ts
@@ -284,7 +284,7 @@ describe("ADT preview routes", () => {
     expect(pages.at(-1)).toEqual({ section_id: "qz001", href: "qz001.html" })
   })
 
-  it("serves runtime timecodes and enables highlight when word timestamps exist", async () => {
+	  it("serves runtime timecodes and enables highlight when word timestamps exist", async () => {
     fs.writeFileSync(
       path.join(tmpDir, label, "config.yaml"),
       "speech:\n  word_highlighting: true\n",
@@ -347,9 +347,82 @@ describe("ADT preview routes", () => {
     const config = await configRes.json() as { bundleVersion: string; features: { highlight: boolean } }
     expect(config.features.highlight).toBe(true)
     expect(config.bundleVersion).not.toBe("1")
-  })
+	  })
 
-  it("enables highlight fallback when TTS exists without stored word timestamps", async () => {
+	  it("excludes muted entries from preview audio and timecode maps", async () => {
+	    fs.writeFileSync(
+	      path.join(tmpDir, label, "config.yaml"),
+	      "speech:\n  word_highlighting: true\n  excluded_text_ids:\n    - pg001_t002\n",
+	    )
+	    const storage = createBookStorage(label, tmpDir)
+	    try {
+	      storage.putNodeData("tts", "en", {
+	        entries: [
+	          {
+	            textId: "pg001_t001",
+	            language: "en",
+	            fileName: "pg001_t001.mp3",
+	            voice: "alloy",
+	            model: "gpt-4o-mini-tts",
+	            cached: false,
+	          },
+	          {
+	            textId: "pg001_t002",
+	            language: "en",
+	            fileName: "pg001_t002.mp3",
+	            voice: "alloy",
+	            model: "gpt-4o-mini-tts",
+	            cached: false,
+	          },
+	        ],
+	        generatedAt: "2026-01-01T00:00:00.000Z",
+	      })
+	      storage.putNodeData("tts-timestamps", "en", {
+	        entries: {
+	          pg001_t001: {
+	            textId: "pg001_t001",
+	            language: "en",
+	            duration: 0.4,
+	            words: [{ word: "Hello", start: 0, end: 0.4 }],
+	          },
+	          pg001_t002: {
+	            textId: "pg001_t002",
+	            language: "en",
+	            duration: 0.4,
+	            words: [{ word: "Muted", start: 0, end: 0.4 }],
+	          },
+	        },
+	        generatedAt: "2026-01-01T00:00:00.000Z",
+	      })
+	    } finally {
+	      storage.close()
+	    }
+
+	    const app = createAdtPreviewRoutes(tmpDir, webAssetsDir, path.resolve(process.cwd(), "config.yaml"))
+
+	    const audioRes = await app.request(`/books/${label}/adt-preview/content/i18n/en/audios.json`)
+	    expect(audioRes.status).toBe(200)
+	    expect(await audioRes.json()).toEqual({
+	      pg001_t001: "pg001_t001.mp3",
+	    })
+
+	    const timecodeRes = await app.request(
+	      `/books/${label}/adt-preview/content/i18n/en/timecode/timecode_output.json`,
+	    )
+	    expect(timecodeRes.status).toBe(200)
+	    expect(await timecodeRes.json()).toEqual({
+	      pg001_t001: {
+	        timecodes: [
+	          null,
+	          {
+	            word_timestamps: [{ text: "Hello", start: 0, end: 0.4 }],
+	          },
+	        ],
+	      },
+	    })
+	  })
+
+	  it("enables highlight fallback when TTS exists without stored word timestamps", async () => {
     fs.writeFileSync(
       path.join(tmpDir, label, "config.yaml"),
       "speech:\n  word_highlighting: true\n",

--- a/apps/api/src/routes/adt-preview.ts
+++ b/apps/api/src/routes/adt-preview.ts
@@ -4,7 +4,7 @@ import { createHash } from "node:crypto"
 import { pathToFileURL } from "node:url"
 import { Hono } from "hono"
 import { HTTPException } from "hono/http-exception"
-import { parseBookLabel } from "@adt/types"
+import { isTtsExcluded, parseBookLabel } from "@adt/types"
 import {
   WebRenderingOutput,
   type SpeechConfig,
@@ -224,6 +224,7 @@ function getWordTimestamps(
 
 function buildRuntimeTimecodeMap(
   timestamps: WordTimestampOutput | undefined,
+  speechConfig?: SpeechConfig,
 ): Record<string, {
   timecodes: [null, {
     word_timestamps: Array<{ text: string; start: number; end: number }>
@@ -237,6 +238,7 @@ function buildRuntimeTimecodeMap(
 
   for (const [textId, entry] of Object.entries(timestamps?.entries ?? {})) {
     if (entry.words.length === 0) continue
+    if (isTtsExcluded(textId, speechConfig)) continue
     map[textId] = {
       timecodes: [
         null,
@@ -759,7 +761,8 @@ export function createAdtPreviewRoutes(
   // /content/i18n/:lang/audios.json — Audio file mapping
   app.get("/books/:label/adt-preview/content/i18n/:lang/audios.json", (c) => {
     const lang = normalizeLocale(c.req.param("lang"))
-    const audioMap = withStorage(c.req.param("label"), (storage) => {
+    const audioMap = withStorage(c.req.param("label"), (storage, safeLabel) => {
+      const speechConfig = loadBookConfig(safeLabel, booksDir, configPath).speech
       const legacyLang = lang.replace("-", "_")
       const ttsRow =
         storage.getLatestNodeData("tts", lang) ??
@@ -767,7 +770,10 @@ export function createAdtPreviewRoutes(
       const ttsData = ttsRow?.data as TTSOutput | undefined
       const map: Record<string, string> = {}
       if (ttsData?.entries) {
-        for (const entry of ttsData.entries) map[entry.textId] = entry.fileName
+        for (const entry of ttsData.entries) {
+          if (isTtsExcluded(entry.textId, speechConfig)) continue
+          map[entry.textId] = entry.fileName
+        }
       }
       return map
     })
@@ -783,7 +789,7 @@ export function createAdtPreviewRoutes(
     const bookConfig = loadBookConfig(safeLabel, booksDir, configPath)
     const timecodes = bookConfig.speech?.word_highlighting === true
       ? withStorage(c.req.param("label"), (storage) =>
-          buildRuntimeTimecodeMap(getWordTimestamps(storage, lang))
+          buildRuntimeTimecodeMap(getWordTimestamps(storage, lang), bookConfig.speech)
         )
       : {}
     setNoStoreHeaders(c)

--- a/apps/api/src/routes/tts.test.ts
+++ b/apps/api/src/routes/tts.test.ts
@@ -35,7 +35,10 @@ speech:
   )
 }
 
-function seedBook(label: string): void {
+function seedBook(
+  label: string,
+  entries: Array<{ id: string; text: string }> = [{ id: "pg001_t001", text: "Hello world" }]
+): void {
   const storage = createBookStorage(label, tmpDir)
   try {
     storage.putNodeData("metadata", "book", {
@@ -47,7 +50,7 @@ function seedBook(label: string): void {
       reasoning: "test",
     })
     storage.putNodeData("text-catalog", "book", {
-      entries: [{ id: "pg001_t001", text: "Hello world" }],
+      entries,
       generatedAt: new Date().toISOString(),
     })
   } finally {
@@ -136,6 +139,124 @@ describe("POST /books/:label/tts/generate-one", () => {
     expect(
       fs.existsSync(path.join(tmpDir, label, "audio", "en", "pg001_t001.wav"))
     ).toBe(true)
+  })
+
+  it("treats excluded catalog entries as complete after generating the remaining audio", async () => {
+    const label = "excluded-completion"
+    seedBook(label, [
+      { id: "pg001_t001", text: "Hello world" },
+      { id: "pg001_t002", text: "Muted text" },
+    ])
+    fs.writeFileSync(
+      path.join(tmpDir, label, "config.yaml"),
+      "speech:\n  excluded_text_ids:\n    - pg001_t002\n",
+    )
+
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    inlineData: {
+                      data: Buffer.from(new Uint8Array([1, 2, 3, 4])).toString("base64"),
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }
+      )
+    )
+
+    const app = createTTSRoutes(tmpDir, configPath)
+    const res = await app.request(`/books/${label}/tts/generate-one`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Gemini-API-Key": "gm-test",
+      },
+      body: JSON.stringify({ textId: "pg001_t001", language: "en" }),
+    })
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.completed).toBe(true)
+    expect(body.remainingItems).toBe(0)
+  })
+
+  it("preserves failure records for other entries when one item is regenerated", async () => {
+    const label = "preserve-failures"
+    seedBook(label, [
+      { id: "pg001_t001", text: "Hello world" },
+      { id: "pg001_t002", text: "Still missing" },
+    ])
+    const storage = createBookStorage(label, tmpDir)
+    try {
+      storage.putNodeData("tts", "en", {
+        entries: [],
+        generatedAt: "2026-01-01T00:00:00.000Z",
+        failed: [
+          { textId: "pg001_t001", error: "old failure" },
+          { textId: "pg001_t002", error: "still failed" },
+        ],
+      })
+    } finally {
+      storage.close()
+    }
+
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    inlineData: {
+                      data: Buffer.from(new Uint8Array([1, 2, 3, 4])).toString("base64"),
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }
+      )
+    )
+
+    const app = createTTSRoutes(tmpDir, configPath)
+    const res = await app.request(`/books/${label}/tts/generate-one`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Gemini-API-Key": "gm-test",
+      },
+      body: JSON.stringify({ textId: "pg001_t001", language: "en" }),
+    })
+
+    expect(res.status).toBe(200)
+
+    const after = createBookStorage(label, tmpDir)
+    try {
+      const ttsRow = after.getLatestNodeData("tts", "en")
+      expect((ttsRow?.data as { failed?: Array<{ textId: string; error: string }> }).failed).toEqual([
+        { textId: "pg001_t002", error: "still failed" },
+      ])
+    } finally {
+      after.close()
+    }
   })
 
   it("generates Gemini audio when the response includes a text part before the audio part", async () => {

--- a/apps/api/src/routes/tts.ts
+++ b/apps/api/src/routes/tts.ts
@@ -7,6 +7,7 @@ import { z } from "zod"
 import {
   parseBookLabel,
   TTSOutput,
+  isTtsExcluded,
   type SpeechFileEntry,
   type TTSProviderConfig,
   type TextCatalogEntry,
@@ -159,13 +160,20 @@ function getLatestTtsEntries(
   storage: ReturnType<typeof createBookStorage>,
   language: string
 ): SpeechFileEntry[] {
+  return getLatestTtsOutput(storage, language)?.entries ?? []
+}
+
+function getLatestTtsOutput(
+  storage: ReturnType<typeof createBookStorage>,
+  language: string
+): TTSOutput | undefined {
   const normalizedLanguage = normalizeLocale(language)
   const legacyLanguage = normalizedLanguage.replace("-", "_")
   const row =
     storage.getLatestNodeData("tts", normalizedLanguage) ??
     storage.getLatestNodeData("tts", legacyLanguage)
 
-  return row ? (row.data as { entries?: SpeechFileEntry[] }).entries ?? [] : []
+  return row ? (row.data as TTSOutput) : undefined
 }
 
 function mergeSpeechEntry(
@@ -182,6 +190,23 @@ function mergeSpeechEntry(
       (order.get(left.textId) ?? Number.MAX_SAFE_INTEGER) -
       (order.get(right.textId) ?? Number.MAX_SAFE_INTEGER)
   )
+}
+
+function buildUpdatedTtsOutput(
+  storage: ReturnType<typeof createBookStorage>,
+  language: string,
+  entries: SpeechFileEntry[],
+  resolvedTextId: string
+): TTSOutput {
+  const previous = getLatestTtsOutput(storage, language)
+  const failed = (previous?.failed ?? []).filter(
+    (entry) => entry.textId !== resolvedTextId
+  )
+  return {
+    entries,
+    generatedAt: new Date().toISOString(),
+    ...(failed.length > 0 ? { failed } : {}),
+  }
 }
 
 function getTtsCompletionSummary(
@@ -211,6 +236,7 @@ function getTtsCompletionSummary(
       getLatestTtsEntries(storage, language).map((entry) => entry.textId)
     )
     for (const entry of expectedEntries) {
+      if (isTtsExcluded(entry.id, config.speech)) continue
       if (!availableIds.has(entry.id)) {
         remainingItems++
       }
@@ -584,10 +610,11 @@ export function createTTSRoutes(booksDir: string, configPath?: string, taskServi
         languageEntries.map((entry) => entry.id)
       )
 
-      const version = storage.putNodeData("tts", normalizedLanguage, {
-        entries: mergedEntries,
-        generatedAt: new Date().toISOString(),
-      })
+      const version = storage.putNodeData(
+        "tts",
+        normalizedLanguage,
+        buildUpdatedTtsOutput(storage, normalizedLanguage, mergedEntries, textEntry.id)
+      )
 
       clearWordTimestampEntry(storage, normalizedLanguage, textEntry.id)
 
@@ -823,10 +850,11 @@ export function createTTSRoutes(booksDir: string, configPath?: string, taskServi
           languageEntries.map((item) => item.id)
         )
 
-        const version = storage.putNodeData("tts", normalizedLanguage, {
-          entries: mergedEntries,
-          generatedAt: new Date().toISOString(),
-        })
+        const version = storage.putNodeData(
+          "tts",
+          normalizedLanguage,
+          buildUpdatedTtsOutput(storage, normalizedLanguage, mergedEntries, textEntry.id)
+        )
 
         const completion = getTtsCompletionSummary(
           storage,
@@ -897,10 +925,11 @@ export function createTTSRoutes(booksDir: string, configPath?: string, taskServi
                 languageEntries.map((item) => item.id)
               )
 
-              const version = storage.putNodeData("tts", normalizedLanguage, {
-                entries: mergedEntries,
-                generatedAt: new Date().toISOString(),
-              })
+              const version = storage.putNodeData(
+                "tts",
+                normalizedLanguage,
+                buildUpdatedTtsOutput(storage, normalizedLanguage, mergedEntries, textEntry.id)
+              )
 
               const completion = getTtsCompletionSummary(
                 storage,

--- a/apps/api/src/routes/tts.ts
+++ b/apps/api/src/routes/tts.ts
@@ -36,6 +36,7 @@ import {
   generateWordTimestamps,
   type ProviderRouting,
 } from "@adt/pipeline"
+import { getLiveSpeechRun } from "../services/speech-progress.js"
 
 const GenerateSingleTTSBody = z
   .object({
@@ -355,6 +356,46 @@ export function createTTSRoutes(booksDir: string, configPath?: string, taskServi
       throw new HTTPException(404, { message: `Book not found: ${safeLabel}` })
     }
 
+    const resolvedBooksDir = path.resolve(booksDir)
+    const mapEntries = (language: string, entries: Array<{ textId: string; fileName: string; voice: string; model: string; cached: boolean; provider?: string }>) => {
+      const audioDir = path.join(resolvedBooksDir, safeLabel, "audio", language)
+      return entries.map((e) => {
+        let cacheKey: string | undefined
+        try {
+          cacheKey = fs.statSync(path.join(audioDir, e.fileName)).mtimeMs.toString(36)
+        } catch {
+          // file missing — leave cacheKey undefined
+        }
+        return {
+          textId: e.textId,
+          fileName: e.fileName,
+          voice: e.voice,
+          model: e.model,
+          cached: e.cached,
+          provider: e.provider,
+          cacheKey,
+        }
+      })
+    }
+
+    const languages: Record<string, { entries: Array<{ textId: string; fileName: string; voice: string; model: string; cached: boolean; provider?: string; cacheKey?: string }>; failed?: Array<{ textId: string; error: string }>; generatedAt: string; version: number }> = {}
+
+    // While a speech run is active, serve its live snapshot — node data is
+    // only persisted at the end of the run, but audio files land on disk per
+    // item, so this lets the Speech view fill in progressively.
+    const live = getLiveSpeechRun(safeLabel)
+    if (live) {
+      for (const [lang, data] of Object.entries(live.languages)) {
+        languages[lang] = {
+          entries: mapEntries(lang, data.entries),
+          ...(data.failed.length > 0 ? { failed: data.failed } : {}),
+          generatedAt: live.startedAt,
+          version: 0,
+        }
+      }
+      return c.json({ languages, live: true })
+    }
+
     const db = openBookDb(dbPath)
     try {
       // TTS is stored per language: node="tts", item_id=language code
@@ -367,32 +408,16 @@ export function createTTSRoutes(booksDir: string, configPath?: string, taskServi
         ["tts", "tts"]
       ) as Array<{ item_id: string; data: string; version: number }>
 
-      const languages: Record<string, { entries: Array<{ textId: string; fileName: string; voice: string; model: string; cached: boolean; provider?: string; cacheKey?: string }>; generatedAt: string; version: number }> = {}
-      const resolvedBooksDir = path.resolve(booksDir)
       for (const row of rows) {
         try {
           const parsed = JSON.parse(row.data)
           const validated = TTSOutput.safeParse(parsed)
           if (!validated.success) continue
-          const audioDir = path.join(resolvedBooksDir, safeLabel, "audio", row.item_id)
           languages[row.item_id] = {
-            entries: validated.data.entries.map((e) => {
-              let cacheKey: string | undefined
-              try {
-                cacheKey = fs.statSync(path.join(audioDir, e.fileName)).mtimeMs.toString(36)
-              } catch {
-                // file missing — leave cacheKey undefined
-              }
-              return {
-                textId: e.textId,
-                fileName: e.fileName,
-                voice: e.voice,
-                model: e.model,
-                cached: e.cached,
-                provider: e.provider,
-                cacheKey,
-              }
-            }),
+            entries: mapEntries(row.item_id, validated.data.entries),
+            ...(validated.data.failed && validated.data.failed.length > 0
+              ? { failed: validated.data.failed }
+              : {}),
             generatedAt: validated.data.generatedAt,
             version: row.version,
           }

--- a/apps/api/src/services/speech-progress.test.ts
+++ b/apps/api/src/services/speech-progress.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest"
+import type { SpeechFileEntry, SpeechFailedEntry } from "@adt/types"
+import { beginSpeechRun, endSpeechRun, getLiveSpeechRun } from "./speech-progress.js"
+
+function makeEntry(textId: string): SpeechFileEntry {
+  return {
+    textId,
+    language: "en",
+    fileName: `${textId}.mp3`,
+    voice: "alloy",
+    model: "gpt-4o-mini-tts",
+    cached: false,
+  }
+}
+
+describe("speech-progress registry", () => {
+  it("returns null when no run is active", () => {
+    expect(getLiveSpeechRun("no-such-book")).toBeNull()
+  })
+
+  it("reflects entries and failures pushed after the run began", () => {
+    const entriesByLang = new Map<string, SpeechFileEntry[]>([["en", []]])
+    const failedByLang = new Map<string, SpeechFailedEntry[]>([["en", []]])
+    beginSpeechRun("live-book", entriesByLang, failedByLang)
+    try {
+      expect(getLiveSpeechRun("live-book")?.languages.en.entries).toEqual([])
+
+      // The registry holds live references — pushes show up in later snapshots
+      entriesByLang.get("en")!.push(makeEntry("pg001_t001"))
+      failedByLang.get("en")!.push({ textId: "pg001_t002", error: "rate limited" })
+
+      const snapshot = getLiveSpeechRun("live-book")
+      expect(snapshot?.languages.en.entries.map((e) => e.textId)).toEqual(["pg001_t001"])
+      expect(snapshot?.languages.en.failed).toEqual([
+        { textId: "pg001_t002", error: "rate limited" },
+      ])
+    } finally {
+      endSpeechRun("live-book")
+    }
+    expect(getLiveSpeechRun("live-book")).toBeNull()
+  })
+
+  it("snapshots are copies — mutating them does not affect the run", () => {
+    const entriesByLang = new Map<string, SpeechFileEntry[]>([["en", [makeEntry("pg001_t001")]]])
+    const failedByLang = new Map<string, SpeechFailedEntry[]>([["en", []]])
+    beginSpeechRun("copy-book", entriesByLang, failedByLang)
+    try {
+      const snapshot = getLiveSpeechRun("copy-book")!
+      snapshot.languages.en.entries.pop()
+      expect(getLiveSpeechRun("copy-book")?.languages.en.entries).toHaveLength(1)
+    } finally {
+      endSpeechRun("copy-book")
+    }
+  })
+
+  it("tracks runs per book label independently", () => {
+    beginSpeechRun("book-a", new Map([["en", [makeEntry("a1")]]]), new Map([["en", []]]))
+    beginSpeechRun("book-b", new Map([["fr", [makeEntry("b1")]]]), new Map([["fr", []]]))
+    try {
+      expect(getLiveSpeechRun("book-a")?.languages.en.entries[0]?.textId).toBe("a1")
+      expect(getLiveSpeechRun("book-b")?.languages.fr.entries[0]?.textId).toBe("b1")
+    } finally {
+      endSpeechRun("book-a")
+      endSpeechRun("book-b")
+    }
+  })
+})

--- a/apps/api/src/services/speech-progress.ts
+++ b/apps/api/src/services/speech-progress.ts
@@ -1,0 +1,58 @@
+import type { SpeechFileEntry, SpeechFailedEntry } from "@adt/types"
+
+/**
+ * In-memory live view of an in-flight speech run, keyed by book label.
+ *
+ * The speech step only persists its TTS node data once the whole run
+ * finishes, but audio files land on disk per item as they're generated. This
+ * registry holds live references to the runner's per-language result arrays
+ * so GET /books/:label/tts can serve a progressively-growing snapshot while
+ * the run is active, letting the Speech view show each audio as it appears.
+ *
+ * The registry stores the same array/map instances the runner mutates — no
+ * copying or per-item bookkeeping. Entries are removed in the runner's
+ * `finally`, after the final node data is persisted, so readers fall back to
+ * storage without a gap.
+ */
+interface LiveSpeechRun {
+  entriesByLang: Map<string, SpeechFileEntry[]>
+  failedByLang: Map<string, SpeechFailedEntry[]>
+  startedAt: string
+}
+
+const liveRuns = new Map<string, LiveSpeechRun>()
+
+export function beginSpeechRun(
+  label: string,
+  entriesByLang: Map<string, SpeechFileEntry[]>,
+  failedByLang: Map<string, SpeechFailedEntry[]>,
+): void {
+  liveRuns.set(label, {
+    entriesByLang,
+    failedByLang,
+    startedAt: new Date().toISOString(),
+  })
+}
+
+export function endSpeechRun(label: string): void {
+  liveRuns.delete(label)
+}
+
+export interface LiveSpeechSnapshot {
+  startedAt: string
+  languages: Record<string, { entries: SpeechFileEntry[]; failed: SpeechFailedEntry[] }>
+}
+
+/** Snapshot of the live run for a book, or null when no speech run is active. */
+export function getLiveSpeechRun(label: string): LiveSpeechSnapshot | null {
+  const run = liveRuns.get(label)
+  if (!run) return null
+  const languages: LiveSpeechSnapshot["languages"] = {}
+  for (const [lang, entries] of run.entriesByLang) {
+    languages[lang] = {
+      entries: [...entries],
+      failed: [...(run.failedByLang.get(lang) ?? [])],
+    }
+  }
+  return { startedAt: run.startedAt, languages }
+}

--- a/apps/api/src/services/stage-runner.ts
+++ b/apps/api/src/services/stage-runner.ts
@@ -82,7 +82,8 @@ import type { PageSectioningConfig, TranslationConfig, QuizPageInput, ProviderRo
 import { loadStyleguideContent } from "./styleguide.js"
 import { createTTSSynthesizer, createAzureTTSSynthesizer, createGeminiTTSSynthesizer } from "@adt/llm"
 import type { TTSSynthesizer } from "@adt/llm"
-import { STAGE_ORDER } from "@adt/types"
+import { STAGE_ORDER, isTtsExcluded } from "@adt/types"
+import { beginSpeechRun, endSpeechRun } from "./speech-progress.js"
 import type {
   AppConfig,
   ImageClassificationOutput,
@@ -94,6 +95,7 @@ import type {
   TextCatalogEntry,
   EasyReadOutput,
   SpeechFileEntry,
+  SpeechFailedEntry,
   TTSOutput,
   WordTimestampEntry,
   WordTimestampOutput,
@@ -2174,11 +2176,16 @@ async function runSpeechStep(
     const ttsWorkItems: TTSWorkItem[] = []
     const textByLanguage = new Map<string, Map<string, string>>()
     const ttsResultsByLang = new Map<string, SpeechFileEntry[]>()
+    const failedByLang = new Map<string, SpeechFailedEntry[]>()
     const reusedEntriesByLang = new Map<string, number>()
     for (const lang of outputLanguages) {
       ttsResultsByLang.set(lang, [])
+      failedByLang.set(lang, [])
       reusedEntriesByLang.set(lang, 0)
     }
+    // Expose the (live-mutated) result arrays so GET /tts can serve a
+    // progressive snapshot while this run is active. Cleared in `finally`.
+    beginSpeechRun(label, ttsResultsByLang, failedByLang)
 
     for (const lang of outputLanguages) {
       const baseSource = getBaseLanguage(sourceLanguage)
@@ -2203,6 +2210,9 @@ async function runSpeechStep(
 
       const languageTextMap = new Map<string, string>()
       for (const entry of entries) {
+        // Excluded entries get no audio at all — not generated, not reused
+        // into the new TTS output version.
+        if (isTtsExcluded(entry.id, config.speech)) continue
         languageTextMap.set(entry.id, entry.text)
 
         const provider = resolveProviderForLanguage(lang, routing)
@@ -2373,6 +2383,7 @@ async function runSpeechStep(
           const durationMs = Date.now() - startMs
           console.error(`[stage-run] ${label}: TTS failed for ${item.textId} (${item.language}): ${msg}`)
           failedItems.push(`${item.textId}: ${msg}`)
+          failedByLang.get(item.language)?.push({ textId: item.textId, error: msg })
           if (provider === "gemini") {
             geminiFailedItems.push(`${item.textId}: ${msg}`)
           }
@@ -2425,9 +2436,11 @@ async function runSpeechStep(
     for (const lang of outputLanguages) {
       const entries = ttsResultsByLang.get(lang)
       if (!entries) continue
+      const failed = failedByLang.get(lang) ?? []
       const output: TTSOutput = {
         entries,
         generatedAt: new Date().toISOString(),
+        ...(failed.length > 0 ? { failed } : {}),
       }
       storage.putNodeData("tts", lang, output)
     }
@@ -2497,6 +2510,7 @@ async function runSpeechStep(
 
     console.log(`[stage-run] ${label}: speech complete`)
   } finally {
+    endSpeechRun(label)
     storage.close()
   }
 }

--- a/apps/studio/src/api/client.ts
+++ b/apps/studio/src/api/client.ts
@@ -495,14 +495,23 @@ export interface TTSEntry {
   cacheKey?: string
 }
 
+export interface TTSFailedEntry {
+  textId: string
+  error: string
+}
+
 export interface TTSLanguageData {
   entries: TTSEntry[]
+  /** Items whose generation failed in the run that produced this data */
+  failed?: TTSFailedEntry[]
   generatedAt: string
   version: number
 }
 
 export interface TTSResponse {
   languages: Record<string, TTSLanguageData>
+  /** True when served from an in-flight speech run's live snapshot */
+  live?: boolean
 }
 
 export interface GenerateSingleTTSResponse {

--- a/apps/studio/src/components/pipeline/stages/languages/LanguageSettings.tsx
+++ b/apps/studio/src/components/pipeline/stages/languages/LanguageSettings.tsx
@@ -65,6 +65,7 @@ export function LanguageSettings({ bookLabel, tab = "general", stageSlug = "tran
   const [sampleRate, setSampleRate] = useState("")
   const [wordHighlighting, setWordHighlighting] = useState(false)
   const [easyReadTts, setEasyReadTts] = useState(false)
+  const [excludedCategories, setExcludedCategories] = useState<Set<string>>(new Set())
 
   const { markedTabs, markTab, resetMarkedTabs } = useDirtyTabTracker()
   const [dirty, setDirty] = useState<Record<string, boolean>>({})
@@ -106,6 +107,9 @@ export function LanguageSettings({ bookLabel, tab = "general", stageSlug = "tran
       if (s.bit_rate) setBitRate(String(s.bit_rate))
       if (s.sample_rate) setSampleRate(String(s.sample_rate))
       setWordHighlighting(s.word_highlighting === true)
+      setExcludedCategories(
+        new Set(Array.isArray(s.excluded_categories) ? (s.excluded_categories as string[]) : [])
+      )
       if (s.providers && typeof s.providers === "object") {
         const providers = s.providers as Record<string, Record<string, unknown>>
         if (providers.openai) {
@@ -182,6 +186,7 @@ export function LanguageSettings({ bookLabel, tab = "general", stageSlug = "tran
         bit_rate: bitRate.trim() || undefined,
         sample_rate: sampleRate.trim() ? Number(sampleRate.trim()) : undefined,
         word_highlighting: wordHighlighting,
+        excluded_categories: excludedCategories.size > 0 ? Array.from(excludedCategories) : undefined,
       }
     }
     return overrides
@@ -301,6 +306,18 @@ export function LanguageSettings({ bookLabel, tab = "general", stageSlug = "tran
           sampleRate={sampleRate} setSampleRate={setSampleRate}
           wordHighlighting={wordHighlighting} setWordHighlighting={setWordHighlighting}
           markDirty={markDirty}
+        />
+        <ReadAloudContentSection
+          excludedCategories={excludedCategories}
+          onToggle={(category, readAloud) => {
+            setExcludedCategories((prev) => {
+              const next = new Set(prev)
+              if (readAloud) next.delete(category)
+              else next.add(category)
+              return next
+            })
+            markDirty("speech")
+          }}
         />
         </>
       )}
@@ -451,6 +468,54 @@ export function LanguageSettings({ bookLabel, tab = "general", stageSlug = "tran
       {tab === "voices" && (
         <VoiceMappingsEditor bookLabel={bookLabel} />
       )}
+    </div>
+  )
+}
+
+/* ---------- Read-aloud content types ---------- */
+
+function ReadAloudContentSection({
+  excludedCategories,
+  onToggle,
+}: {
+  excludedCategories: Set<string>
+  onToggle: (category: string, readAloud: boolean) => void
+}) {
+  const { t } = useLingui()
+
+  const rows: Array<{ key: string; label: string; hint: string }> = [
+    { key: "text", label: t`Text`, hint: t`Page text, headings, and quiz content.` },
+    { key: "captions", label: t`Image captions`, hint: t`Descriptions spoken for images.` },
+    { key: "answers", label: t`Activity answers`, hint: t`Answers revealed in activities.` },
+    { key: "glossary", label: t`Glossary`, hint: t`Glossary words and their definitions.` },
+    { key: "easy-read", label: t`Easy Read`, hint: t`Simplified Easy Read text variants.` },
+  ]
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{t`Read-Aloud Content`}</h3>
+        <p className="text-[11px] text-muted-foreground mt-1">
+          {t`Choose which kinds of on-screen text are read aloud. Disabled types get no audio in the reader. You can also mute individual entries from the Speech and Language views.`}
+        </p>
+      </div>
+      <div className="rounded-lg border divide-y">
+        {rows.map((row) => (
+          <div key={row.key} className="flex items-center justify-between gap-3 px-4 py-2.5">
+            <div className="space-y-0.5 pr-3">
+              <Label htmlFor={`read-aloud-${row.key}`} className="text-xs cursor-pointer">
+                {row.label}
+              </Label>
+              <p className="text-[11px] text-muted-foreground">{row.hint}</p>
+            </div>
+            <Switch
+              id={`read-aloud-${row.key}`}
+              checked={!excludedCategories.has(row.key)}
+              onCheckedChange={(v) => onToggle(row.key, v)}
+            />
+          </div>
+        ))}
+      </div>
     </div>
   )
 }

--- a/apps/studio/src/components/pipeline/stages/languages/LanguageSettings.tsx
+++ b/apps/studio/src/components/pipeline/stages/languages/LanguageSettings.tsx
@@ -186,7 +186,7 @@ export function LanguageSettings({ bookLabel, tab = "general", stageSlug = "tran
         bit_rate: bitRate.trim() || undefined,
         sample_rate: sampleRate.trim() ? Number(sampleRate.trim()) : undefined,
         word_highlighting: wordHighlighting,
-        excluded_categories: excludedCategories.size > 0 ? Array.from(excludedCategories) : undefined,
+        excluded_categories: Array.from(excludedCategories),
       }
     }
     return overrides
@@ -813,4 +813,3 @@ function SpeechLanguageCards({
     </div>
   )
 }
-

--- a/apps/studio/src/components/pipeline/stages/languages/LanguageView.tsx
+++ b/apps/studio/src/components/pipeline/stages/languages/LanguageView.tsx
@@ -122,16 +122,24 @@ export function LanguageView({ bookLabel, stageSlug = "translate", selectedPageI
     ? speechConfig as Record<string, unknown>
     : null
   const wordHighlightingEnabled = speechConfigRecord?.word_highlighting === true
+  const configExcludedTextIds = useMemo(
+    () => Array.isArray(speechConfigRecord?.excluded_text_ids)
+      ? (speechConfigRecord.excluded_text_ids as string[])
+      : [],
+    [speechConfigRecord]
+  )
+  const [pendingExcludedTextIds, setPendingExcludedTextIds] = useState<string[] | null>(null)
+  const pendingExcludedTextIdsRef = useRef<string[] | null>(null)
+  const configUpdateQueueRef = useRef<Promise<unknown>>(Promise.resolve())
+  const effectiveExcludedTextIds = pendingExcludedTextIds ?? configExcludedTextIds
   // Effective read-aloud exclusions (merged config) — category-level from the
   // speech settings plus individually muted entry ids.
   const ttsExclusionConfig = useMemo(() => ({
     excluded_categories: Array.isArray(speechConfigRecord?.excluded_categories)
       ? (speechConfigRecord.excluded_categories as string[])
       : undefined,
-    excluded_text_ids: Array.isArray(speechConfigRecord?.excluded_text_ids)
-      ? (speechConfigRecord.excluded_text_ids as string[])
-      : undefined,
-  }), [speechConfigRecord])
+    excluded_text_ids: effectiveExcludedTextIds,
+  }), [effectiveExcludedTextIds, speechConfigRecord])
   const excludedTextIdSet = useMemo(
     () => new Set(ttsExclusionConfig.excluded_text_ids ?? []),
     [ttsExclusionConfig]
@@ -229,15 +237,32 @@ export function LanguageView({ bookLabel, stageSlug = "translate", selectedPageI
       : {}
     // Toggle against the effective (merged) exclusions so the write matches
     // what the user currently sees.
-    const next = new Set(ttsExclusionConfig.excluded_text_ids ?? [])
+    const next = new Set(pendingExcludedTextIdsRef.current ?? effectiveExcludedTextIds)
     if (next.has(textId)) next.delete(textId)
     else next.add(textId)
+    const nextIds = Array.from(next)
+    pendingExcludedTextIdsRef.current = nextIds
+    setPendingExcludedTextIds(nextIds)
     currentConfig.speech = {
       ...existingSpeech,
-      excluded_text_ids: next.size > 0 ? Array.from(next) : undefined,
+      // Empty array is intentional: it overrides any project-level excluded ids.
+      excluded_text_ids: nextIds,
     }
-    updateConfig.mutate({ label: bookLabel, config: currentConfig })
-  }, [bookConfigData?.config, bookLabel, ttsExclusionConfig, updateConfig])
+    configUpdateQueueRef.current = configUpdateQueueRef.current
+      .catch(() => undefined)
+      .then(async () => {
+        const updated = await updateConfig.mutateAsync({ label: bookLabel, config: currentConfig })
+        await queryClient.invalidateQueries({ queryKey: ["debug", "config", bookLabel] })
+        return updated
+      })
+      .finally(() => {
+        if (pendingExcludedTextIdsRef.current === nextIds) {
+          pendingExcludedTextIdsRef.current = null
+          setPendingExcludedTextIds(null)
+        }
+      })
+    void configUpdateQueueRef.current.catch(() => undefined)
+  }, [bookConfigData?.config, bookLabel, effectiveExcludedTextIds, queryClient, updateConfig])
 
   // Fetch word timestamps for the active language on the speech page
   const { data: timestampData } = useQuery({
@@ -499,6 +524,25 @@ export function LanguageView({ bookLabel, stageSlug = "translate", selectedPageI
     [audioLang, apiKey, transcribeMutation]
   )
 
+  // Resolve speech config summary for display.
+  const speechSummary = useMemo(() => {
+    const provider =
+      (speechConfig && typeof speechConfig === "object"
+        ? ((speechConfig as Record<string, unknown>).default_provider as string)
+        : undefined) ?? "openai"
+    const defaultVoice = DEFAULT_TTS_VOICE[provider] ?? DEFAULT_TTS_VOICE.openai
+    const defaultModel = DEFAULT_TTS_MODEL[provider] ?? DEFAULT_TTS_MODEL.openai
+    if (!speechConfig || typeof speechConfig !== "object") {
+      return { provider, voice: defaultVoice, model: defaultModel }
+    }
+    const sc = speechConfig as Record<string, unknown>
+    const voice = (sc.voice as string) ?? defaultVoice
+    const model = (sc.model as string) ?? undefined
+    const providers = sc.providers as Record<string, Record<string, unknown>> | undefined
+    const providerModel = providers?.[provider]?.model as string | undefined
+    return { provider, voice, model: providerModel ?? model ?? defaultModel }
+  }, [speechConfig])
+
   const headerControls = catalog ? (
     <div className="flex items-center gap-1.5 ml-auto">
       {isSpeechStage && isRunning && (
@@ -592,25 +636,6 @@ export function LanguageView({ bookLabel, stageSlug = "translate", selectedPageI
   if (!showRunCard && isLoading) {
     return <LoadingState stageSlug="translate" label={t`Loading text catalog...`} />
   }
-
-  // Resolve speech config summary for display
-  const speechSummary = useMemo(() => {
-    const provider =
-      (speechConfig && typeof speechConfig === "object"
-        ? ((speechConfig as Record<string, unknown>).default_provider as string)
-        : undefined) ?? "openai"
-    const defaultVoice = DEFAULT_TTS_VOICE[provider] ?? DEFAULT_TTS_VOICE.openai
-    const defaultModel = DEFAULT_TTS_MODEL[provider] ?? DEFAULT_TTS_MODEL.openai
-    if (!speechConfig || typeof speechConfig !== "object") {
-      return { provider, voice: defaultVoice, model: defaultModel }
-    }
-    const sc = speechConfig as Record<string, unknown>
-    const voice = (sc.voice as string) ?? defaultVoice
-    const model = (sc.model as string) ?? undefined
-    const providers = sc.providers as Record<string, Record<string, unknown>> | undefined
-    const providerModel = providers?.[provider]?.model as string | undefined
-    return { provider, voice, model: providerModel ?? model ?? defaultModel }
-  }, [speechConfig])
 
   if (showRunCard || !catalog || entries.length === 0) {
     return (

--- a/apps/studio/src/components/pipeline/stages/languages/LanguageView.tsx
+++ b/apps/studio/src/components/pipeline/stages/languages/LanguageView.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useCallback, useMemo, type ChangeEvent } from "react"
 import { createPortal } from "react-dom"
 import { Link } from "@tanstack/react-router"
-import { AudioLines, ChevronDown, ChevronRight, ChevronUp, Languages, Loader2, Play, Pause, Plus, RotateCcw, Save, Settings, Trash2, Type, Upload, WandSparkles, X } from "lucide-react"
+import { AudioLines, ChevronDown, ChevronRight, ChevronUp, Languages, Loader2, Play, Pause, Plus, RotateCcw, Save, Settings, Trash2, Type, Upload, Volume2, VolumeX, WandSparkles, X } from "lucide-react"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { api, getAudioUrl, BASE_URL } from "@/api/client"
 import type { TextCatalogEntry, WordTimestamp, WordTimestampEntry } from "@/api/client"
@@ -29,7 +29,9 @@ import { resolveTranslationLanguageState } from "./lib/translations-view-state"
 import {
   type CatalogCategory,
   getEntryCategory,
+  getEntryTtsExclusion,
   isAnswerEntry,
+  isEasyReadEntry,
   isGlossaryEntry,
   isImageEntry,
 } from "./lib/catalog-entries"
@@ -57,7 +59,7 @@ export function LanguageView({ bookLabel, stageSlug = "translate", selectedPageI
   const { data: activeConfigData } = useActiveConfig(bookLabel)
   const { data: book, isLoading: isBookLoading } = useBook(bookLabel)
   const queryClient = useQueryClient()
-  const { stageState, queueRun, error: runError } = useBookRun()
+  const { stageState, stepProgress, queueRun, error: runError } = useBookRun()
   const { isTaskRunning } = useBookTasks(bookLabel)
   const { apiKey, hasApiKey, azureKey, azureRegion, geminiKey } = useApiKey()
   const translateState = stageState("translate")
@@ -83,7 +85,8 @@ export function LanguageView({ bookLabel, stageSlug = "translate", selectedPageI
   const stageMissing = useStageMissingCounts(bookLabel)
   const missingForCurrentStage =
     isSpeechStage ? stageMissing.speech : stageMissing.translate
-  const showMissingBanner = stageDone && !isRunning && missingForCurrentStage > 0
+  const showMissingBanner =
+    (stageDone || (isSpeechStage && hasStageError)) && !isRunning && missingForCurrentStage > 0
 
   const handleDeleteTTS = useCallback(async () => {
     await api.deleteTTS(bookLabel)
@@ -119,6 +122,20 @@ export function LanguageView({ bookLabel, stageSlug = "translate", selectedPageI
     ? speechConfig as Record<string, unknown>
     : null
   const wordHighlightingEnabled = speechConfigRecord?.word_highlighting === true
+  // Effective read-aloud exclusions (merged config) — category-level from the
+  // speech settings plus individually muted entry ids.
+  const ttsExclusionConfig = useMemo(() => ({
+    excluded_categories: Array.isArray(speechConfigRecord?.excluded_categories)
+      ? (speechConfigRecord.excluded_categories as string[])
+      : undefined,
+    excluded_text_ids: Array.isArray(speechConfigRecord?.excluded_text_ids)
+      ? (speechConfigRecord.excluded_text_ids as string[])
+      : undefined,
+  }), [speechConfigRecord])
+  const excludedTextIdSet = useMemo(
+    () => new Set(ttsExclusionConfig.excluded_text_ids ?? []),
+    [ttsExclusionConfig]
+  )
   const outputLanguages = Array.from(
     new Set(((merged?.output_languages as string[] | undefined) ?? []).map((code) => normalizeLocale(code)))
   )
@@ -184,21 +201,14 @@ export function LanguageView({ bookLabel, stageSlug = "translate", selectedPageI
     (hasExplicitOutputLanguages ? (outputLanguages[0] ?? editingLanguage) : editingLanguage)
   const currentLanguageUsesGemini =
     !!audioLang && languageUsesSpeechProvider(audioLang, "gemini", speechConfig)
-  const geminiRoutedLanguages = (
-    outputLanguages.length > 0
-      ? outputLanguages
-      : editingLanguage
-        ? [editingLanguage]
-        : []
-  ).filter((language, index, array) =>
-    languageUsesSpeechProvider(language, "gemini", speechConfig) &&
-    array.indexOf(language) === index
-  )
-  const allowGeminiPartialView =
-    isSpeechStage &&
-    hasStageError &&
-    geminiRoutedLanguages.length > 0
-  const showRunCard = (!stageDone || isRunning) && !allowGeminiPartialView
+  // Speech keeps the entry list on screen during runs (audio fills in live via
+  // the run's snapshot) and after failures (failed rows are marked); the run
+  // card only shows before the first speech run. Translate keeps the original
+  // behavior: run card until the stage is done.
+  const showRunCard = isSpeechStage
+    ? !(stageDone || isRunning || hasStageError)
+    : (!stageDone || isRunning)
+  const ttsProgress = isSpeechStage && isRunning ? stepProgress("tts") : undefined
 
   const toggleWordHighlighting = useCallback(() => {
     const currentConfig = { ...(bookConfigData?.config ?? {}) } as Record<string, unknown>
@@ -211,6 +221,23 @@ export function LanguageView({ bookLabel, stageSlug = "translate", selectedPageI
     }
     updateConfig.mutate({ label: bookLabel, config: currentConfig })
   }, [bookConfigData?.config, bookLabel, updateConfig, wordHighlightingEnabled])
+
+  const toggleEntryMuted = useCallback((textId: string) => {
+    const currentConfig = { ...(bookConfigData?.config ?? {}) } as Record<string, unknown>
+    const existingSpeech = currentConfig.speech && typeof currentConfig.speech === "object"
+      ? { ...(currentConfig.speech as Record<string, unknown>) }
+      : {}
+    // Toggle against the effective (merged) exclusions so the write matches
+    // what the user currently sees.
+    const next = new Set(ttsExclusionConfig.excluded_text_ids ?? [])
+    if (next.has(textId)) next.delete(textId)
+    else next.add(textId)
+    currentConfig.speech = {
+      ...existingSpeech,
+      excluded_text_ids: next.size > 0 ? Array.from(next) : undefined,
+    }
+    updateConfig.mutate({ label: bookLabel, config: currentConfig })
+  }, [bookConfigData?.config, bookLabel, ttsExclusionConfig, updateConfig])
 
   // Fetch word timestamps for the active language on the speech page
   const { data: timestampData } = useQuery({
@@ -286,6 +313,14 @@ export function LanguageView({ bookLabel, stageSlug = "translate", selectedPageI
       audioMap.set(e.textId, { fileName: e.fileName, voice: e.voice, cacheKey: e.cacheKey })
     }
   }
+  // Per-item generation failures for the selected language (from the last run,
+  // or streamed live while a run is in progress)
+  const failedAudioMap = new Map<string, string>()
+  if (ttsData && audioLang) {
+    for (const f of ttsData.languages[audioLang]?.failed ?? []) {
+      failedAudioMap.set(f.textId, f.error)
+    }
+  }
   // Separate base-language audio map for the source column in translation view
   const baseAudioMap = new Map<string, { fileName: string; voice: string; cacheKey?: string }>()
   if (ttsData && editingLanguage && ttsData.languages[editingLanguage] && audioLang !== editingLanguage) {
@@ -309,8 +344,12 @@ export function LanguageView({ bookLabel, stageSlug = "translate", selectedPageI
   const totalAudioFiles = ttsData
     ? Object.values(ttsData.languages).reduce((sum, lang) => sum + lang.entries.length, 0)
     : 0
-  const generatedAudioCount = displayEntries.filter((entry) => audioMap.has(entry.id)).length
-  const missingAudioCount = Math.max(displayEntries.length - generatedAudioCount, 0)
+  // Muted entries neither need audio nor count as missing
+  const speakableEntries = displayEntries.filter(
+    (entry) => !getEntryTtsExclusion(entry.id, ttsExclusionConfig).excluded
+  )
+  const generatedAudioCount = speakableEntries.filter((entry) => audioMap.has(entry.id)).length
+  const missingAudioCount = Math.max(speakableEntries.length - generatedAudioCount, 0)
 
   // Track playback state for the currently-playing entry (only one plays at a time)
   const [playingEntryId, setPlayingEntryId] = useState<string | null>(null)
@@ -462,13 +501,21 @@ export function LanguageView({ bookLabel, stageSlug = "translate", selectedPageI
 
   const headerControls = catalog ? (
     <div className="flex items-center gap-1.5 ml-auto">
+      {isSpeechStage && isRunning && (
+        <span className="text-[10px] bg-white/20 rounded-full px-2 py-0.5 inline-flex items-center gap-1">
+          <Loader2 className="w-2.5 h-2.5 animate-spin" />
+          {ttsProgress?.totalPages
+            ? t`Generating ${String(ttsProgress.page ?? 0)}/${String(ttsProgress.totalPages)}`
+            : t`Preparing speech...`}
+        </span>
+      )}
       <span className="text-[10px] bg-white/20 rounded-full px-2 py-0.5">{t`${String(displayEntries.length)} texts`}</span>
       {outputLanguages.length > 1 && (
         <span className="text-[10px] bg-white/20 rounded-full px-2 py-0.5">{t`${String(outputLanguages.length)} languages`}</span>
       )}
       {currentLanguageUsesGemini ? (
         <span className="text-[10px] bg-white/20 rounded-full px-2 py-0.5">
-          {t`${String(generatedAudioCount)}/${String(displayEntries.length)} audio`}
+          {t`${String(generatedAudioCount)}/${String(speakableEntries.length)} audio`}
         </span>
       ) : totalAudioFiles > 0 && (
         <span className="text-[10px] bg-white/20 rounded-full px-2 py-0.5">{t`${String(totalAudioFiles)} audio`}</span>
@@ -519,7 +566,7 @@ export function LanguageView({ bookLabel, stageSlug = "translate", selectedPageI
               if (!window.confirm(t`Are you sure you want to generate word-level timestamps for ${langDisplay}?`)) return
               transcribeAllMutation.mutate(audioLang)
             }}
-            disabled={!apiKey || totalAudioFiles === 0 || transcribeAllMutation.isPending || isTaskRunning("transcribe-timestamps")}
+            disabled={!apiKey || totalAudioFiles === 0 || isRunning || transcribeAllMutation.isPending || isTaskRunning("transcribe-timestamps")}
             title={apiKey ? t`Calculate word timestamps for all entries` : t`OpenAI key required`}
             className="text-white/60 hover:text-white transition-colors disabled:opacity-30 cursor-pointer disabled:cursor-default"
           >
@@ -531,7 +578,7 @@ export function LanguageView({ bookLabel, stageSlug = "translate", selectedPageI
               if (!window.confirm(t`Are you sure you want to delete generated speech?`)) return
               handleDeleteTTS()
             }}
-            disabled={totalAudioFiles === 0}
+            disabled={totalAudioFiles === 0 || isRunning}
             title={t`Delete all speech`}
             className="text-white/60 hover:text-white transition-colors disabled:opacity-30 cursor-pointer disabled:cursor-default"
           >
@@ -678,7 +725,7 @@ export function LanguageView({ bookLabel, stageSlug = "translate", selectedPageI
     <div className="flex flex-col h-full">
       {/* Fixed header: alerts, language tabs, column headers */}
       <div className="shrink-0 px-4 pt-4 space-y-3">
-        {allowGeminiPartialView && runError && (
+        {isSpeechStage && hasStageError && runError && (
           <Alert variant="destructive" className="rounded-md">
             <AlertDescription className="text-xs whitespace-pre-wrap break-words">
               {runError}
@@ -830,6 +877,47 @@ export function LanguageView({ bookLabel, stageSlug = "translate", selectedPageI
             const baseAudio = baseAudioMap.get(entry.id)
             const isImg = isImageEntry(entry.id)
             const isAnswer = isAnswerEntry(entry.id)
+            const exclusion = getEntryTtsExclusion(entry.id, ttsExclusionConfig)
+            // Easy Read variants inherit their source entry's mute — only the
+            // source row can undo it, so lock the toggle on the variant row.
+            const mutedViaSource =
+              exclusion.byId && isEasyReadEntry(entry.id) && !excludedTextIdSet.has(entry.id)
+            const muteLockedReason = exclusion.byCategory
+              ? t`Muted by a content type switch in the Speech settings`
+              : mutedViaSource
+                ? t`Muted via its source text entry`
+                : undefined
+            const muteToggle = (
+              <TtsMuteToggle
+                muted={exclusion.excluded}
+                lockedReason={muteLockedReason}
+                onToggle={() => toggleEntryMuted(entry.id)}
+              />
+            )
+            // Audio status for the selected language: a recorded failure shows
+            // immediately (even mid-run); plain "no audio" only after a run has
+            // finished. Muting an entry clears both — it no longer needs audio.
+            const audioFailure =
+              isSpeechStage && !isAnswer && !exclusion.excluded && !audio
+                ? failedAudioMap.get(entry.id)
+                : undefined
+            const audioMissing =
+              isSpeechStage && !isAnswer && !exclusion.excluded && !audio && !audioFailure &&
+              !isRunning && (stageDone || hasStageError)
+            const audioStatusBadges = (
+              <>
+                {audioFailure && (
+                  <span title={audioFailure} className="ml-1.5 text-[9px] font-medium text-red-700 bg-red-100 rounded px-1 py-0.5 cursor-help">
+                    {t`Failed`}
+                  </span>
+                )}
+                {audioMissing && (
+                  <span className="ml-1.5 text-[9px] font-medium text-amber-700 bg-amber-100 rounded px-1 py-0.5">
+                    {t`No audio`}
+                  </span>
+                )}
+              </>
+            )
 
             return (
               <div
@@ -863,7 +951,10 @@ export function LanguageView({ bookLabel, stageSlug = "translate", selectedPageI
                           <span className="text-[10px] text-muted-foreground">
                             {entry.id}
                             {isAnswer && <span className="ml-1.5 text-[9px] font-medium text-amber-700 bg-amber-100 rounded px-1 py-0.5">{t`Answer`}</span>}
-                            {isSpeechStage && audio && <span className="ml-1.5 text-[9px] text-muted-foreground/60">{audio.fileName}</span>}
+                            {exclusion.excluded && <span className="ml-1.5 text-[9px] font-medium text-rose-700 bg-rose-100 rounded px-1 py-0.5">{t`Muted`}</span>}
+                            {audioStatusBadges}
+                            {isSpeechStage && audio && !exclusion.excluded && <span className="ml-1.5 text-[9px] text-muted-foreground/60">{audio.fileName}</span>}
+                            {muteToggle}
                           </span>
                           <HighlightedText
                             text={entry.text}
@@ -873,7 +964,7 @@ export function LanguageView({ bookLabel, stageSlug = "translate", selectedPageI
                           />
                         </div>
                       </div>
-                      {isSpeechStage && !isAnswer && <AudioAction
+                      {isSpeechStage && !isAnswer && !exclusion.excluded && (audio || !isRunning) && <AudioAction
                         audio={audio}
                         audioLang={audioLang}
                         bookLabel={bookLabel}
@@ -930,12 +1021,14 @@ export function LanguageView({ bookLabel, stageSlug = "translate", selectedPageI
                               <span className="text-[10px] text-muted-foreground">
                                 {entry.id}
                                 {isAnswer && <span className="ml-1.5 text-[9px] font-medium text-amber-700 bg-amber-100 rounded px-1 py-0.5">{t`Answer`}</span>}
-                                {isSpeechStage && baseAudio && <span className="ml-1.5 text-[9px] text-muted-foreground/60">{baseAudio.fileName}</span>}
+                                {exclusion.excluded && <span className="ml-1.5 text-[9px] font-medium text-rose-700 bg-rose-100 rounded px-1 py-0.5">{t`Muted`}</span>}
+                                {isSpeechStage && baseAudio && !exclusion.excluded && <span className="ml-1.5 text-[9px] text-muted-foreground/60">{baseAudio.fileName}</span>}
+                                {muteToggle}
                               </span>
                               <p className="text-sm leading-relaxed mt-0.5">{entry.text}</p>
                             </div>
                           </div>
-                          {isSpeechStage && !isAnswer && baseAudio && editingLanguage && (
+                          {isSpeechStage && !isAnswer && !exclusion.excluded && baseAudio && editingLanguage && (
                             <WaveformPlayer
                               key={`base-${editingLanguage}:${baseAudio.fileName}:${baseAudio.cacheKey ?? ""}`}
                               audioUrl={getAudioUrl(bookLabel, editingLanguage, baseAudio.fileName, baseAudio.cacheKey)}
@@ -971,7 +1064,8 @@ export function LanguageView({ bookLabel, stageSlug = "translate", selectedPageI
                             <div className="min-w-0 flex-1">
                             <span className="text-[10px] text-muted-foreground">
                               &nbsp;
-                              {isSpeechStage && audio && <span className="text-[9px] text-muted-foreground/60">{audio.fileName}</span>}
+                              {audioStatusBadges}
+                              {isSpeechStage && audio && !exclusion.excluded && <span className="text-[9px] text-muted-foreground/60">{audio.fileName}</span>}
                             </span>
                             {isSpeechStage ? (
                               <HighlightedText
@@ -992,7 +1086,7 @@ export function LanguageView({ bookLabel, stageSlug = "translate", selectedPageI
                             )}
                             </div>
                           </div>
-                          {isSpeechStage && !isAnswer && <AudioAction
+                          {isSpeechStage && !isAnswer && !exclusion.excluded && (audio || !isRunning) && <AudioAction
                             audio={audio}
                             audioLang={audioLang}
                             bookLabel={bookLabel}
@@ -1489,6 +1583,35 @@ function WordTimestampViewer({ timestamps, onSave, isSaving, columns = 2 }: {
         </div>
       )}
     </div>
+  )
+}
+
+/** Per-entry read-aloud mute toggle. Locked (non-interactive) when the mute
+ * comes from a content-type switch or is inherited from the source entry. */
+function TtsMuteToggle({ muted, lockedReason, onToggle }: {
+  muted: boolean
+  lockedReason?: string
+  onToggle: () => void
+}) {
+  const { t } = useLingui()
+  const title = lockedReason ?? (muted ? t`Include in read-aloud` : t`Exclude from read-aloud`)
+  return (
+    <button
+      type="button"
+      onClick={lockedReason ? undefined : onToggle}
+      disabled={!!lockedReason}
+      title={title}
+      aria-label={title}
+      className={cn(
+        "ml-1.5 inline-flex items-center justify-center w-4 h-4 rounded align-middle transition-colors",
+        muted
+          ? "text-rose-600 hover:bg-rose-50"
+          : "text-muted-foreground/40 hover:text-foreground hover:bg-muted",
+        lockedReason ? "opacity-50 cursor-default" : "cursor-pointer",
+      )}
+    >
+      {muted ? <VolumeX className="w-3 h-3" /> : <Volume2 className="w-3 h-3" />}
+    </button>
   )
 }
 

--- a/apps/studio/src/components/pipeline/stages/languages/lib/catalog-entries.ts
+++ b/apps/studio/src/components/pipeline/stages/languages/lib/catalog-entries.ts
@@ -2,20 +2,24 @@
  * Classifies a text-catalog entry by its id pattern. Catalog entries cover
  * regular text, image captions, quiz answers, and glossary terms — each
  * stage's UI surfaces these as separate sub-categories.
+ *
+ * Classification is shared with the pipeline via `getTextCatalogCategory`
+ * in @adt/types so read-aloud exclusions resolve identically in the UI and
+ * during TTS generation/packaging.
  */
+import {
+  getTextCatalogCategory,
+  isTtsExcluded,
+  type TextCatalogCategory,
+  type TtsExclusionConfig,
+} from "@adt/types"
 
 const IMAGE_ID_RE = /_im\d{3}/
 const ANSWER_ID_RE = /_ans_/
 const GLOSSARY_ID_RE = /^gl(?:\d{3}|_manual_)/
 const EASY_READ_ID_RE = /_easy_read$/
 
-export type CatalogCategory =
-  | "all"
-  | "text"
-  | "captions"
-  | "answers"
-  | "glossary"
-  | "easy-read"
+export type CatalogCategory = "all" | TextCatalogCategory
 
 export function isImageEntry(id: string): boolean {
   return IMAGE_ID_RE.test(id)
@@ -34,11 +38,29 @@ export function isEasyReadEntry(id: string): boolean {
 }
 
 export function getEntryCategory(id: string): CatalogCategory {
-  // Easy Read ids are `{sourceId}_easy_read`; check first so they are not
-  // mistaken for plain text entries.
-  if (isEasyReadEntry(id)) return "easy-read"
-  if (isImageEntry(id)) return "captions"
-  if (isAnswerEntry(id)) return "answers"
-  if (isGlossaryEntry(id)) return "glossary"
-  return "text"
+  return getTextCatalogCategory(id)
+}
+
+/** Read-aloud exclusion state of an entry, split by cause so the UI can
+ * distinguish an individually muted entry (toggleable per row) from one
+ * muted by its content type in the speech settings. */
+export interface EntryTtsExclusion {
+  excluded: boolean
+  /** Muted via speech settings' content-type switches */
+  byCategory: boolean
+  /** Muted individually (its own id, or its source entry for easy-read variants) */
+  byId: boolean
+}
+
+export function getEntryTtsExclusion(
+  id: string,
+  config: TtsExclusionConfig | null | undefined,
+): EntryTtsExclusion {
+  const byId = isTtsExcluded(id, {
+    excluded_text_ids: config?.excluded_text_ids,
+  })
+  const byCategory =
+    !byId &&
+    isTtsExcluded(id, { excluded_categories: config?.excluded_categories })
+  return { excluded: byId || byCategory, byCategory, byId }
 }

--- a/apps/studio/src/hooks/use-book-config.ts
+++ b/apps/studio/src/hooks/use-book-config.ts
@@ -22,6 +22,7 @@ export function useUpdateBookConfig() {
     onSuccess: (_data, { label }) => {
       queryClient.invalidateQueries({ queryKey: ["book-config", label] })
       queryClient.invalidateQueries({ queryKey: ["validation", "catalog", label] })
+      queryClient.invalidateQueries({ queryKey: ["debug", "config", label] })
       queryClient.invalidateQueries({ queryKey: ["debug"] })
     },
   })

--- a/apps/studio/src/hooks/use-book-run.ts
+++ b/apps/studio/src/hooks/use-book-run.ts
@@ -136,6 +136,9 @@ export function useBookRunStatus(label: string): BookRunContextValue {
   // Throttle progressive page invalidations during storyboard runs
   const lastPageInvalidateRef = useRef<number>(0)
 
+  // Throttle progressive TTS-list invalidations during speech runs
+  const lastTtsInvalidateRef = useRef<number>(0)
+
   // Serialized run queue — chains API calls so they arrive in click order
   const runChainRef = useRef<Promise<void>>(Promise.resolve())
 
@@ -233,6 +236,16 @@ export function useBookRunStatus(label: string): BookRunContextValue {
             queryClient.invalidateQueries({ queryKey: ["books", label, "pages"] })
           }
         }
+        // Progressively refresh the TTS list during speech generation — GET
+        // /tts serves the run's live snapshot, so each completed audio shows
+        // up in the Speech view as it lands (throttled to ~2s).
+        if (pipelineStep === "tts") {
+          const now = Date.now()
+          if (now - lastTtsInvalidateRef.current > 2000) {
+            lastTtsInvalidateRef.current = now
+            queryClient.invalidateQueries({ queryKey: ["books", label, "tts"] })
+          }
+        }
       } else if (d.type === "step-complete" || d.type === "step-skip") {
         // Mark step as done/skipped, recompute stage state
         const nextStepState: StepState = d.type === "step-skip" ? "skipped" : "done"
@@ -291,6 +304,11 @@ export function useBookRunStatus(label: string): BookRunContextValue {
         // Assertive: a failed step blocks progress; the user needs to know now.
         announceRef.current(i18n._(msg`${getStageLabelI18n(uiStage)} failed`), "assertive")
         progressRef.current.delete(pipelineStep)
+        // Speech errors persist per-item failures into the TTS output —
+        // refetch so the Speech view can mark the failed entries.
+        if (pipelineStep === "tts") {
+          queryClient.invalidateQueries({ queryKey: ["books", label, "tts"] })
+        }
       }
     })
 

--- a/apps/studio/src/hooks/use-stage-missing-counts.ts
+++ b/apps/studio/src/hooks/use-stage-missing-counts.ts
@@ -1,5 +1,6 @@
 import { useMemo } from "react"
 import { useQuery } from "@tanstack/react-query"
+import { isTtsExcluded, type TtsExclusionConfig } from "@adt/types"
 import { api } from "@/api/client"
 import { useBook } from "@/hooks/use-books"
 import { useActiveConfig } from "@/hooks/use-debug"
@@ -57,18 +58,26 @@ export function useStageMissingCounts(label: string): { translate: number; speec
       translate += Math.max(total - filled.size, 0)
     }
 
+    // Entries excluded from read-aloud never need audio, so they don't count
+    // as missing for the speech stage (translations are still expected).
+    const speechExclusions = (merged?.speech ?? undefined) as TtsExclusionConfig | undefined
+    const speakableIds = new Set(
+      [...catalogIds].filter((id) => !isTtsExcluded(id, speechExclusions)),
+    )
+    const speakableTotal = speakableIds.size
+
     let speech = 0
     for (const lang of outputLanguages) {
       const langData = tts?.languages?.[lang]
       if (!langData) {
-        speech += total
+        speech += speakableTotal
         continue
       }
       const filled = new Set<string>()
       for (const e of langData.entries) {
-        if (catalogIds.has(e.textId)) filled.add(e.textId)
+        if (speakableIds.has(e.textId)) filled.add(e.textId)
       }
-      speech += Math.max(total - filled.size, 0)
+      speech += Math.max(speakableTotal - filled.size, 0)
     }
 
     return { translate, speech }

--- a/apps/studio/src/hooks/use-stage-missing-counts.ts
+++ b/apps/studio/src/hooks/use-stage-missing-counts.ts
@@ -65,6 +65,9 @@ export function useStageMissingCounts(label: string): { translate: number; speec
       [...catalogIds].filter((id) => !isTtsExcluded(id, speechExclusions)),
     )
     const speakableTotal = speakableIds.size
+    if (tts?.live) {
+      return { translate, speech: 0 }
+    }
 
     let speech = 0
     for (const lang of outputLanguages) {

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -247,7 +247,7 @@ msgid "{0} translations"
 msgstr "{0} translations"
 
 #. placeholder {0}: String(generatedAudioCount)
-#. placeholder {1}: String(displayEntries.length)
+#. placeholder {1}: String(speakableEntries.length)
 msgid "{0}/{1} audio"
 msgstr "{0}/{1} audio"
 
@@ -671,6 +671,9 @@ msgstr "Activity"
 
 msgid "Activity 5.1"
 msgstr "Activity 5.1"
+
+msgid "Activity answers"
+msgstr "Activity answers"
 
 msgid "Activity Converter"
 msgstr "Activity Converter"
@@ -1110,6 +1113,9 @@ msgstr "answer_key"
 
 msgid "Answers"
 msgstr "Answers"
+
+msgid "Answers revealed in activities."
+msgstr "Answers revealed in activities."
 
 msgid "Anthropic"
 msgstr "Anthropic"
@@ -1672,6 +1678,9 @@ msgstr "Choose the part file that was shared with you, or export it again."
 msgid "Choose the source pages and where the quiz lands in the page editor."
 msgstr "Choose the source pages and where the quiz lands in the page editor."
 
+msgid "Choose which kinds of on-screen text are read aloud. Disabled types get no audio in the reader. You can also mute individual entries from the Speech and Language views."
+msgstr "Choose which kinds of on-screen text are read aloud. Disabled types get no audio in the reader. You can also mute individual entries from the Speech and Language views."
+
 msgid "Choose which per-page validation items reviewers must check, customize the wording and guidance, and add your own checklist items for this document."
 msgstr "Choose which per-page validation items reviewers must check, customize the wording and guidance, and add your own checklist items for this document."
 
@@ -2232,6 +2241,9 @@ msgstr "Description"
 msgid "Description..."
 msgstr "Description..."
 
+msgid "Descriptions spoken for images."
+msgstr "Descriptions spoken for images."
+
 msgid "Deselect all"
 msgstr "Deselect all"
 
@@ -2702,6 +2714,9 @@ msgstr "Every Storyboard section has a sign-language video assigned. You can swi
 msgid "Example Books"
 msgstr "Example Books"
 
+msgid "Exclude from read-aloud"
+msgstr "Exclude from read-aloud"
+
 msgid "Exclude from render"
 msgstr "Exclude from render"
 
@@ -3132,6 +3147,11 @@ msgstr "Generates descriptive alt-text for images so screen readers can describe
 msgid "Generates the interactive HTML for this activity type."
 msgstr "Generates the interactive HTML for this activity type."
 
+#. placeholder {0}: String(ttsProgress.page ?? 0)
+#. placeholder {1}: String(ttsProgress.totalPages)
+msgid "Generating {0}/{1}"
+msgstr "Generating {0}/{1}"
+
 msgid "Generating Easy Read..."
 msgstr "Generating Easy Read..."
 
@@ -3182,6 +3202,9 @@ msgstr "Glossary Preview"
 
 msgid "Glossary Prompt"
 msgstr "Glossary Prompt"
+
+msgid "Glossary words and their definitions."
+msgstr "Glossary words and their definitions."
 
 msgid "Go to {stageLabel}"
 msgstr "Go to {stageLabel}"
@@ -3363,6 +3386,9 @@ msgstr "Image Alt-Text"
 msgid "Image Captioning"
 msgstr "Image Captioning"
 
+msgid "Image captions"
+msgstr "Image captions"
+
 msgid "Image Captions"
 msgstr "Image Captions"
 
@@ -3511,6 +3537,9 @@ msgstr "in progress"
 
 msgid "in the book"
 msgstr "in the book"
+
+msgid "Include in read-aloud"
+msgstr "Include in read-aloud"
 
 msgid "Include in render"
 msgstr "Include in render"
@@ -4198,6 +4227,15 @@ msgstr "Multi-format publications"
 msgid "multiple choice"
 msgstr "multiple choice"
 
+msgid "Muted"
+msgstr "Muted"
+
+msgid "Muted by a content type switch in the Speech settings"
+msgstr "Muted by a content type switch in the Speech settings"
+
+msgid "Muted via its source text entry"
+msgstr "Muted via its source text entry"
+
 msgid "my-book-slug"
 msgstr "my-book-slug"
 
@@ -4282,6 +4320,9 @@ msgstr "No API key for {0} yet. Add one in Book settings to enable this provider
 
 msgid "No assessment"
 msgstr "No assessment"
+
+msgid "No audio"
+msgstr "No audio"
 
 msgid "No audio for this page"
 msgstr "No audio for this page"
@@ -4937,6 +4978,9 @@ msgstr "Page Sectioning Prompt"
 msgid "Page Sectioning Refinement Prompt"
 msgstr "Page Sectioning Refinement Prompt"
 
+msgid "Page text, headings, and quiz content."
+msgstr "Page text, headings, and quiz content."
+
 msgid "pages"
 msgstr "pages"
 
@@ -5183,6 +5227,9 @@ msgstr "Precipitation"
 
 msgid "Prefer terms central to the book's subject matter. Skip generic vocabulary and proper nouns that don't carry meaning beyond the page."
 msgstr "Prefer terms central to the book's subject matter. Skip generic vocabulary and proper nouns that don't carry meaning beyond the page."
+
+msgid "Preparing speech..."
+msgstr "Preparing speech..."
 
 msgid "Preserves the source PDF's exact page layout"
 msgstr "Preserves the source PDF's exact page layout"
@@ -5435,6 +5482,9 @@ msgstr "Re-running clears later stages"
 
 msgid "Read the prompt aloud"
 msgstr "Read the prompt aloud"
+
+msgid "Read-Aloud Content"
+msgstr "Read-Aloud Content"
 
 msgid "Read-only"
 msgstr "Read-only"
@@ -6399,6 +6449,9 @@ msgstr "Sign language video overlays for each page"
 
 msgid "Sign language videos provide access for deaf and hard of hearing readers who may not be fluent in written language."
 msgstr "Sign language videos provide access for deaf and hard of hearing readers who may not be fluent in written language."
+
+msgid "Simplified Easy Read text variants."
+msgstr "Simplified Easy Read text variants."
 
 msgid "Single"
 msgstr "Single"

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -247,7 +247,7 @@ msgid "{0} translations"
 msgstr "{0} traducciones"
 
 #. placeholder {0}: String(generatedAudioCount)
-#. placeholder {1}: String(displayEntries.length)
+#. placeholder {1}: String(speakableEntries.length)
 msgid "{0}/{1} audio"
 msgstr "{0}/{1} audio"
 
@@ -671,6 +671,9 @@ msgstr "Actividad"
 
 msgid "Activity 5.1"
 msgstr "Actividad 5.1"
+
+msgid "Activity answers"
+msgstr "Respuestas de actividades"
 
 msgid "Activity Converter"
 msgstr "Convertidor de actividades"
@@ -1110,6 +1113,9 @@ msgstr "clave_de_respuestas"
 
 msgid "Answers"
 msgstr "Respuestas"
+
+msgid "Answers revealed in activities."
+msgstr "Respuestas reveladas en las actividades."
 
 msgid "Anthropic"
 msgstr "Anthropic"
@@ -1672,6 +1678,9 @@ msgstr "Elige el archivo de parte que te compartieron, o expórtalo de nuevo."
 msgid "Choose the source pages and where the quiz lands in the page editor."
 msgstr "Elige las páginas de origen y dónde se ubica el cuestionario en el editor de páginas."
 
+msgid "Choose which kinds of on-screen text are read aloud. Disabled types get no audio in the reader. You can also mute individual entries from the Speech and Language views."
+msgstr "Elige qué tipos de texto en pantalla se leen en voz alta. Los tipos desactivados no reciben audio en el lector. También puedes silenciar entradas individuales desde las vistas de Voz e Idioma."
+
 msgid "Choose which per-page validation items reviewers must check, customize the wording and guidance, and add your own checklist items for this document."
 msgstr "Choose which per-page validation items reviewers must check, customize the wording and guidance, and add your own checklist items for this document."
 
@@ -2232,6 +2241,9 @@ msgstr "Descripción"
 msgid "Description..."
 msgstr "Descripción..."
 
+msgid "Descriptions spoken for images."
+msgstr "Descripciones habladas de las imágenes."
+
 msgid "Deselect all"
 msgstr "Deseleccionar todo"
 
@@ -2702,6 +2714,9 @@ msgstr "Cada sección del Storyboard tiene un video de lenguaje de señas asigna
 msgid "Example Books"
 msgstr "Libros de Ejemplo"
 
+msgid "Exclude from read-aloud"
+msgstr "Excluir de la lectura en voz alta"
+
 msgid "Exclude from render"
 msgstr "Excluir de la renderización"
 
@@ -3132,6 +3147,11 @@ msgstr "Genera texto alternativo descriptivo para imágenes para que los lectore
 msgid "Generates the interactive HTML for this activity type."
 msgstr "Genera el HTML interactivo para este tipo de actividad."
 
+#. placeholder {0}: String(ttsProgress.page ?? 0)
+#. placeholder {1}: String(ttsProgress.totalPages)
+msgid "Generating {0}/{1}"
+msgstr "Generando {0}/{1}"
+
 msgid "Generating Easy Read..."
 msgstr "Generando Lectura Fácil..."
 
@@ -3182,6 +3202,9 @@ msgstr "Vista previa del Glosario"
 
 msgid "Glossary Prompt"
 msgstr "Prompt de glosario"
+
+msgid "Glossary words and their definitions."
+msgstr "Palabras del glosario y sus definiciones."
 
 msgid "Go to {stageLabel}"
 msgstr "Ir a {stageLabel}"
@@ -3363,6 +3386,9 @@ msgstr "Texto Alternativo de Imagen"
 msgid "Image Captioning"
 msgstr "Subtitulado de imágenes"
 
+msgid "Image captions"
+msgstr "Subtítulos de imágenes"
+
 msgid "Image Captions"
 msgstr "Leyendas de Imágenes"
 
@@ -3511,6 +3537,9 @@ msgstr "en curso"
 
 msgid "in the book"
 msgstr "en el libro"
+
+msgid "Include in read-aloud"
+msgstr "Incluir en la lectura en voz alta"
 
 msgid "Include in render"
 msgstr "Incluir en la renderización"
@@ -4198,6 +4227,15 @@ msgstr "Publicaciones multiformato"
 msgid "multiple choice"
 msgstr "opción múltiple"
 
+msgid "Muted"
+msgstr "Silenciado"
+
+msgid "Muted by a content type switch in the Speech settings"
+msgstr "Silenciado por un interruptor de tipo de contenido en la configuración de Voz"
+
+msgid "Muted via its source text entry"
+msgstr "Silenciado a través de su entrada de texto de origen"
+
 msgid "my-book-slug"
 msgstr "mi-libro-slug"
 
@@ -4282,6 +4320,9 @@ msgstr "Aún no hay clave API para {0}. Añade una en la configuración del libr
 
 msgid "No assessment"
 msgstr "No assessment"
+
+msgid "No audio"
+msgstr "Sin audio"
 
 msgid "No audio for this page"
 msgstr "No hay audio para esta página"
@@ -4937,6 +4978,9 @@ msgstr "Prompt de seccionamiento de página"
 msgid "Page Sectioning Refinement Prompt"
 msgstr "Prompt de refinamiento de sección"
 
+msgid "Page text, headings, and quiz content."
+msgstr "Texto de página, encabezados y contenido de cuestionarios."
+
 msgid "pages"
 msgstr "páginas"
 
@@ -5183,6 +5227,9 @@ msgstr "Precipitación"
 
 msgid "Prefer terms central to the book's subject matter. Skip generic vocabulary and proper nouns that don't carry meaning beyond the page."
 msgstr "Prefiere términos centrales al tema del libro. Omite vocabulario genérico y nombres propios que no tienen significado más allá de la página."
+
+msgid "Preparing speech..."
+msgstr "Preparando el audio..."
 
 msgid "Preserves the source PDF's exact page layout"
 msgstr "Conserva el diseño de página exacto del PDF original"
@@ -5435,6 +5482,9 @@ msgstr "Re-ejecutar borra etapas posteriores"
 
 msgid "Read the prompt aloud"
 msgstr "Leer el aviso en voz alta"
+
+msgid "Read-Aloud Content"
+msgstr "Contenido de lectura en voz alta"
 
 msgid "Read-only"
 msgstr "Solo lectura"
@@ -6399,6 +6449,9 @@ msgstr "Superposiciones de video en lengua de señas para cada página"
 
 msgid "Sign language videos provide access for deaf and hard of hearing readers who may not be fluent in written language."
 msgstr "Los videos en lenguaje de señas brindan acceso a lectores sordos y con dificultades auditivas que pueden no ser fluidos en el lenguaje escrito."
+
+msgid "Simplified Easy Read text variants."
+msgstr "Variantes de texto simplificadas de Lectura Fácil."
 
 msgid "Single"
 msgstr "Único"

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -249,7 +249,7 @@ msgid "{0} translations"
 msgstr "{0} traductions"
 
 #. placeholder {0}: String(generatedAudioCount)
-#. placeholder {1}: String(displayEntries.length)
+#. placeholder {1}: String(speakableEntries.length)
 msgid "{0}/{1} audio"
 msgstr "{0}/{1} audio"
 
@@ -673,6 +673,9 @@ msgstr "Activité"
 
 msgid "Activity 5.1"
 msgstr "Activité 5.1"
+
+msgid "Activity answers"
+msgstr "Réponses des activités"
 
 msgid "Activity Converter"
 msgstr "Convertisseur d'activités"
@@ -1112,6 +1115,9 @@ msgstr "clé_de_réponse"
 
 msgid "Answers"
 msgstr "Réponses"
+
+msgid "Answers revealed in activities."
+msgstr "Réponses révélées dans les activités."
 
 msgid "Anthropic"
 msgstr "Anthropic"
@@ -1674,6 +1680,9 @@ msgstr "Choisissez le fichier de partie qui vous a été partagé, ou exportez-l
 msgid "Choose the source pages and where the quiz lands in the page editor."
 msgstr "Choisissez les pages sources et l'emplacement du quiz dans l'éditeur de pages."
 
+msgid "Choose which kinds of on-screen text are read aloud. Disabled types get no audio in the reader. You can also mute individual entries from the Speech and Language views."
+msgstr "Choisissez quels types de texte à l'écran sont lus à haute voix. Les types désactivés n'ont pas d'audio dans le lecteur. Vous pouvez aussi couper le son d'entrées individuelles depuis les vues Parole et Langue."
+
 msgid "Choose which per-page validation items reviewers must check, customize the wording and guidance, and add your own checklist items for this document."
 msgstr "Choisissez quels éléments de validation par page les réviseurs doivent vérifier, personnalisez la formulation et les consignes, et ajoutez vos propres éléments de liste de contrôle pour ce document."
 
@@ -2234,6 +2243,9 @@ msgstr "Description"
 msgid "Description..."
 msgstr "Description..."
 
+msgid "Descriptions spoken for images."
+msgstr "Descriptions lues pour les images."
+
 msgid "Deselect all"
 msgstr "Tout désélectionner"
 
@@ -2704,6 +2716,9 @@ msgstr "Chaque section du Storyboard a une vidéo en langue des signes assignée
 msgid "Example Books"
 msgstr "Exemple Livres"
 
+msgid "Exclude from read-aloud"
+msgstr "Exclure de la lecture à voix haute"
+
 msgid "Exclude from render"
 msgstr "Exclure du rendu"
 
@@ -3134,6 +3149,11 @@ msgstr "Génère du texte alternatif descriptif pour les images afin que les lec
 msgid "Generates the interactive HTML for this activity type."
 msgstr "Génère le HTML interactif pour ce type d'activité."
 
+#. placeholder {0}: String(ttsProgress.page ?? 0)
+#. placeholder {1}: String(ttsProgress.totalPages)
+msgid "Generating {0}/{1}"
+msgstr "Génération {0}/{1}"
+
 msgid "Generating Easy Read..."
 msgstr "Génération de Lecture Facile..."
 
@@ -3184,6 +3204,9 @@ msgstr "Aperçu du glossaire"
 
 msgid "Glossary Prompt"
 msgstr "Glossary Invite"
+
+msgid "Glossary words and their definitions."
+msgstr "Mots du glossaire et leurs définitions."
 
 msgid "Go to {stageLabel}"
 msgstr "Aller à {stageLabel}"
@@ -3365,6 +3388,9 @@ msgstr "Texte alternatif de l'image"
 msgid "Image Captioning"
 msgstr "Légendes d'images"
 
+msgid "Image captions"
+msgstr "Légendes d'images"
+
 msgid "Image Captions"
 msgstr "Image Légendes"
 
@@ -3513,6 +3539,9 @@ msgstr "en cours"
 
 msgid "in the book"
 msgstr "dans le livre"
+
+msgid "Include in read-aloud"
+msgstr "Inclure dans la lecture à voix haute"
 
 msgid "Include in render"
 msgstr "Inclure dans le rendu"
@@ -4200,6 +4229,15 @@ msgstr "Publications multi-format"
 msgid "multiple choice"
 msgstr "choix multiple"
 
+msgid "Muted"
+msgstr "Muet"
+
+msgid "Muted by a content type switch in the Speech settings"
+msgstr "Muet via un interrupteur de type de contenu dans les paramètres de Parole"
+
+msgid "Muted via its source text entry"
+msgstr "Muet via son entrée de texte source"
+
 msgid "my-book-slug"
 msgstr "my-livre-slug"
 
@@ -4284,6 +4322,9 @@ msgstr "Pas encore de clé API pour {0}. Ajoutez-en une dans les paramètres du 
 
 msgid "No assessment"
 msgstr "Aucune évaluation"
+
+msgid "No audio"
+msgstr "Pas d'audio"
 
 msgid "No audio for this page"
 msgstr "Pas de son pour cette page"
@@ -4939,6 +4980,9 @@ msgstr "Page Sectioning Invite"
 msgid "Page Sectioning Refinement Prompt"
 msgstr "Prompt de raffinement du sectionnement"
 
+msgid "Page text, headings, and quiz content."
+msgstr "Texte de page, titres et contenu des quiz."
+
 msgid "pages"
 msgstr "pages"
 
@@ -5185,6 +5229,9 @@ msgstr "Précipitations"
 
 msgid "Prefer terms central to the book's subject matter. Skip generic vocabulary and proper nouns that don't carry meaning beyond the page."
 msgstr "Privilégiez les termes centraux au sujet du livre. Évitez le vocabulaire générique et les noms propres qui n'ont pas de signification au-delà de la page."
+
+msgid "Preparing speech..."
+msgstr "Préparation de la synthèse vocale..."
 
 msgid "Preserves the source PDF's exact page layout"
 msgstr "Préserve la mise en page exacte du PDF source"
@@ -5437,6 +5484,9 @@ msgstr "Relancer efface les étapes ultérieures"
 
 msgid "Read the prompt aloud"
 msgstr "Lire l'invite à haute voix"
+
+msgid "Read-Aloud Content"
+msgstr "Contenu de lecture à voix haute"
 
 msgid "Read-only"
 msgstr "Lecture seule"
@@ -6401,6 +6451,9 @@ msgstr "Superpositions vidéo en langue des signes pour chaque page"
 
 msgid "Sign language videos provide access for deaf and hard of hearing readers who may not be fluent in written language."
 msgstr "Les vidéos en langue des signes offrent un accès aux lecteurs sourds et malentendants qui peuvent ne pas être à l'aise avec la langue écrite."
+
+msgid "Simplified Easy Read text variants."
+msgstr "Variantes de texte simplifiées en Lecture Facile."
 
 msgid "Single"
 msgstr "Simple"

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -247,7 +247,7 @@ msgid "{0} translations"
 msgstr "{0} traduções"
 
 #. placeholder {0}: String(generatedAudioCount)
-#. placeholder {1}: String(displayEntries.length)
+#. placeholder {1}: String(speakableEntries.length)
 msgid "{0}/{1} audio"
 msgstr "{0}/{1} áudio"
 
@@ -671,6 +671,9 @@ msgstr "Atividade"
 
 msgid "Activity 5.1"
 msgstr "Atividade 5.1"
+
+msgid "Activity answers"
+msgstr "Respostas de atividades"
 
 msgid "Activity Converter"
 msgstr "Conversão de atividades"
@@ -1110,6 +1113,9 @@ msgstr "gabarito"
 
 msgid "Answers"
 msgstr "Respostas"
+
+msgid "Answers revealed in activities."
+msgstr "Respostas reveladas nas atividades."
 
 msgid "Anthropic"
 msgstr "Anthropic"
@@ -1672,6 +1678,9 @@ msgstr "Escolha o arquivo de parte que foi compartilhado com você, ou exporte-o
 msgid "Choose the source pages and where the quiz lands in the page editor."
 msgstr "Escolha as páginas de origem e onde o questionário será inserido no editor de páginas."
 
+msgid "Choose which kinds of on-screen text are read aloud. Disabled types get no audio in the reader. You can also mute individual entries from the Speech and Language views."
+msgstr "Escolha quais tipos de texto na tela são lidos em voz alta. Tipos desativados não recebem áudio no leitor. Você também pode silenciar entradas individuais nas visualizações de Fala e Idioma."
+
 msgid "Choose which per-page validation items reviewers must check, customize the wording and guidance, and add your own checklist items for this document."
 msgstr "Choose which per-page validation items reviewers must check, customize the wording and guidance, and add your own checklist items for this document."
 
@@ -2232,6 +2241,9 @@ msgstr "Descrição"
 msgid "Description..."
 msgstr "Descrição..."
 
+msgid "Descriptions spoken for images."
+msgstr "Descrições faladas para as imagens."
+
 msgid "Deselect all"
 msgstr "Desmarcar tudo"
 
@@ -2702,6 +2714,9 @@ msgstr "Cada seção do Storyboard tem um vídeo em linguagem de sinais atribuí
 msgid "Example Books"
 msgstr "Livros de Exemplo"
 
+msgid "Exclude from read-aloud"
+msgstr "Excluir da leitura em voz alta"
+
 msgid "Exclude from render"
 msgstr "Excluir da renderização"
 
@@ -3132,6 +3147,11 @@ msgstr "Gera texto alternativo descritivo para imagens para que leitores de tela
 msgid "Generates the interactive HTML for this activity type."
 msgstr "Gera o HTML interativo para este tipo de atividade."
 
+#. placeholder {0}: String(ttsProgress.page ?? 0)
+#. placeholder {1}: String(ttsProgress.totalPages)
+msgid "Generating {0}/{1}"
+msgstr "Gerando {0}/{1}"
+
 msgid "Generating Easy Read..."
 msgstr "Gerando Leitura Fácil..."
 
@@ -3182,6 +3202,9 @@ msgstr "Pré-visualização do Glossário"
 
 msgid "Glossary Prompt"
 msgstr "Prompt de glossário"
+
+msgid "Glossary words and their definitions."
+msgstr "Palavras do glossário e suas definições."
 
 msgid "Go to {stageLabel}"
 msgstr "Ir para {stageLabel}"
@@ -3363,6 +3386,9 @@ msgstr "Texto Alternativo da Imagem"
 msgid "Image Captioning"
 msgstr "Legendagem de imagens"
 
+msgid "Image captions"
+msgstr "Legendas de imagens"
+
 msgid "Image Captions"
 msgstr "Legendas de Imagens"
 
@@ -3511,6 +3537,9 @@ msgstr "em andamento"
 
 msgid "in the book"
 msgstr "no livro"
+
+msgid "Include in read-aloud"
+msgstr "Incluir na leitura em voz alta"
 
 msgid "Include in render"
 msgstr "Incluir na renderização"
@@ -4198,6 +4227,15 @@ msgstr "Publicações multi-formato"
 msgid "multiple choice"
 msgstr "múltipla escolha"
 
+msgid "Muted"
+msgstr "Silenciado"
+
+msgid "Muted by a content type switch in the Speech settings"
+msgstr "Silenciado por um interruptor de tipo de conteúdo nas configurações de Fala"
+
+msgid "Muted via its source text entry"
+msgstr "Silenciado por meio de sua entrada de texto de origem"
+
 msgid "my-book-slug"
 msgstr "meu-livro-slug"
 
@@ -4282,6 +4320,9 @@ msgstr "Ainda não há chave de API para {0}. Adicione uma nas configurações d
 
 msgid "No assessment"
 msgstr "No assessment"
+
+msgid "No audio"
+msgstr "Sem áudio"
 
 msgid "No audio for this page"
 msgstr "Sem áudio para esta página"
@@ -4937,6 +4978,9 @@ msgstr "Prompt de secionamento de página"
 msgid "Page Sectioning Refinement Prompt"
 msgstr "Prompt de refinamento de seção"
 
+msgid "Page text, headings, and quiz content."
+msgstr "Texto da página, títulos e conteúdo de questionários."
+
 msgid "pages"
 msgstr "páginas"
 
@@ -5183,6 +5227,9 @@ msgstr "Precipitação"
 
 msgid "Prefer terms central to the book's subject matter. Skip generic vocabulary and proper nouns that don't carry meaning beyond the page."
 msgstr "Prefira termos centrais ao assunto do livro. Pule vocabulário genérico e nomes próprios que não carregam significado além da página."
+
+msgid "Preparing speech..."
+msgstr "Preparando o áudio..."
 
 msgid "Preserves the source PDF's exact page layout"
 msgstr "Preserva o layout de página exato do PDF de origem"
@@ -5435,6 +5482,9 @@ msgstr "Reexecutar limpa etapas posteriores"
 
 msgid "Read the prompt aloud"
 msgstr "Leia o prompt em voz alta"
+
+msgid "Read-Aloud Content"
+msgstr "Conteúdo de leitura em voz alta"
 
 msgid "Read-only"
 msgstr "Somente leitura"
@@ -6399,6 +6449,9 @@ msgstr "Sobreposições de vídeo em língua de sinais para cada página"
 
 msgid "Sign language videos provide access for deaf and hard of hearing readers who may not be fluent in written language."
 msgstr "Vídeos em língua de sinais oferecem acesso para leitores surdos e com deficiência auditiva que podem não ser fluentes em linguagem escrita."
+
+msgid "Simplified Easy Read text variants."
+msgstr "Variantes de texto simplificadas de Leitura Fácil."
 
 msgid "Single"
 msgstr "Individual"

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -248,7 +248,7 @@ msgid "{0} translations"
 msgstr "{0} përkthime"
 
 #. placeholder {0}: String(generatedAudioCount)
-#. placeholder {1}: String(displayEntries.length)
+#. placeholder {1}: String(speakableEntries.length)
 msgid "{0}/{1} audio"
 msgstr "{0}/{1} audio"
 
@@ -672,6 +672,9 @@ msgstr "Aktivitet"
 
 msgid "Activity 5.1"
 msgstr "Aktiviteti 5.1"
+
+msgid "Activity answers"
+msgstr "Përgjigjet e aktiviteteve"
 
 msgid "Activity Converter"
 msgstr "Konvertues Aktivitetesh"
@@ -1111,6 +1114,9 @@ msgstr "answer_key"
 
 msgid "Answers"
 msgstr "Përgjigjet"
+
+msgid "Answers revealed in activities."
+msgstr "Përgjigjet që shfaqen në aktivitete."
 
 msgid "Anthropic"
 msgstr "Anthropic"
@@ -1673,6 +1679,9 @@ msgstr "Zgjidhni skedarin e pjesës që ju është ndarë, ose eksportojeni për
 msgid "Choose the source pages and where the quiz lands in the page editor."
 msgstr "Zgjidhni faqet burimore dhe ku vendoset testi në redaktorin e faqeve."
 
+msgid "Choose which kinds of on-screen text are read aloud. Disabled types get no audio in the reader. You can also mute individual entries from the Speech and Language views."
+msgstr "Zgjidhni cilat lloje të tekstit në ekran lexohen me zë. Llojet e çaktivizuara nuk marrin audio në lexues. Mund të heshtni edhe zëra të veçantë nga pamjet e Të folurit dhe Gjuhës."
+
 msgid "Choose which per-page validation items reviewers must check, customize the wording and guidance, and add your own checklist items for this document."
 msgstr "Zgjidhni cilat artikuj validimi për faqe duhet të kontrollojnë rishikuesit, personalizoni formulimin dhe udhëzimet dhe shtoni artikujt tuaj të listës së kontrollit për këtë dokument."
 
@@ -2233,6 +2242,9 @@ msgstr "Përshkrim"
 msgid "Description..."
 msgstr "Përshkrim..."
 
+msgid "Descriptions spoken for images."
+msgstr "Përshkrime që lexohen për imazhet."
+
 msgid "Deselect all"
 msgstr "Hiq zgjedhjen e të gjithave"
 
@@ -2703,6 +2715,9 @@ msgstr "Çdo seksion i Storyboard-it ka një video të gjuhës së shenjave të 
 msgid "Example Books"
 msgstr "Libra shembull"
 
+msgid "Exclude from read-aloud"
+msgstr "Përjashto nga leximi me zë"
+
 msgid "Exclude from render"
 msgstr "Përjashto nga renderimi"
 
@@ -3133,6 +3148,11 @@ msgstr "Gjeneron tekst alternativ përshkrues për imazhet që lexuesit e ekrani
 msgid "Generates the interactive HTML for this activity type."
 msgstr "Gjeneron HTML interaktiv për këtë lloj aktiviteti."
 
+#. placeholder {0}: String(ttsProgress.page ?? 0)
+#. placeholder {1}: String(ttsProgress.totalPages)
+msgid "Generating {0}/{1}"
+msgstr "Duke gjeneruar {0}/{1}"
+
 msgid "Generating Easy Read..."
 msgstr "Duke gjeneruar Easy Read..."
 
@@ -3183,6 +3203,9 @@ msgstr "Pamje Paraprake e Glosariumit"
 
 msgid "Glossary Prompt"
 msgstr "Prompt i Glosariumit"
+
+msgid "Glossary words and their definitions."
+msgstr "Fjalët e glosarit dhe përkufizimet e tyre."
 
 msgid "Go to {stageLabel}"
 msgstr "Shko te {stageLabel}"
@@ -3364,6 +3387,9 @@ msgstr "Teksti Alternativ i Imazhit"
 msgid "Image Captioning"
 msgstr "Titullimi i Imazheve"
 
+msgid "Image captions"
+msgstr "Përshkrimet e imazheve"
+
 msgid "Image Captions"
 msgstr "Titujt e Imazheve"
 
@@ -3512,6 +3538,9 @@ msgstr "në proces"
 
 msgid "in the book"
 msgstr "në libër"
+
+msgid "Include in read-aloud"
+msgstr "Përfshi në leximin me zë"
 
 msgid "Include in render"
 msgstr "Përfshi në paraqitje"
@@ -4199,6 +4228,15 @@ msgstr "Botime me shumë formate"
 msgid "multiple choice"
 msgstr "me zgjedhje të shumëfishta"
 
+msgid "Muted"
+msgstr "I heshtur"
+
+msgid "Muted by a content type switch in the Speech settings"
+msgstr "Heshtur nga një çelës i llojit të përmbajtjes në cilësimet e Të folurit"
+
+msgid "Muted via its source text entry"
+msgstr "Heshtur përmes zërit të tekstit burimor"
+
 msgid "my-book-slug"
 msgstr "my-book-slug"
 
@@ -4283,6 +4321,9 @@ msgstr "Nuk ka ende çelës API për {0}. Shto një te cilësimet e Librit për 
 
 msgid "No assessment"
 msgstr "Pa vlerësim"
+
+msgid "No audio"
+msgstr "Pa audio"
 
 msgid "No audio for this page"
 msgstr "Nuk ka audio për këtë faqe"
@@ -4938,6 +4979,9 @@ msgstr "Prompt i Ndarjes së Faqeve"
 msgid "Page Sectioning Refinement Prompt"
 msgstr "Prompt i Rafinimit të Ndarjes së Faqeve"
 
+msgid "Page text, headings, and quiz content."
+msgstr "Teksti i faqes, titujt dhe përmbajtja e kuizeve."
+
 msgid "pages"
 msgstr "faqe"
 
@@ -5184,6 +5228,9 @@ msgstr "Reshje"
 
 msgid "Prefer terms central to the book's subject matter. Skip generic vocabulary and proper nouns that don't carry meaning beyond the page."
 msgstr "Preferoni terma qendrore për lëndën e librit. Anashkaloni fjalor gjeneral dhe emra të përveçëm që nuk bartin kuptim përtej faqes."
+
+msgid "Preparing speech..."
+msgstr "Duke përgatitur audion..."
 
 msgid "Preserves the source PDF's exact page layout"
 msgstr "Ruan paraqitjen e saktë të faqes nga PDF-ja burimore"
@@ -5436,6 +5483,9 @@ msgstr "Ri-ekzekutimi fshin fazat e mëvonshme"
 
 msgid "Read the prompt aloud"
 msgstr "Lexo kërkesën me zë"
+
+msgid "Read-Aloud Content"
+msgstr "Përmbajtja e leximit me zë"
 
 msgid "Read-only"
 msgstr "Vetëm për lexim"
@@ -6400,6 +6450,9 @@ msgstr "Mbivendosje videosh të gjuhës së shenjave për çdo faqe"
 
 msgid "Sign language videos provide access for deaf and hard of hearing readers who may not be fluent in written language."
 msgstr "Videot e gjuhës së shenjave ofrojnë qasje për lexuesit shurdhamutë dhe me dëgjim të kufizuar, të cilët mund të mos jenë të rrjedhshëm në gjuhën e shkruar."
+
+msgid "Simplified Easy Read text variants."
+msgstr "Variante të thjeshtuara të tekstit Easy Read."
 
 msgid "Single"
 msgstr "Të vetëm"

--- a/packages/pipeline/src/__tests__/package-web.test.ts
+++ b/packages/pipeline/src/__tests__/package-web.test.ts
@@ -836,6 +836,116 @@ describe("packageAdtWeb", () => {
     expect(preloader).toContain("timecode/timecode_output.json")
   })
 
+  it("drops read-aloud excluded entries from audios.json and timecodes", async () => {
+    const bookDir = path.join(tmpDir, "book")
+    const webAssetsDir = path.join(tmpDir, "assets-web")
+    const audioDir = path.join(bookDir, "audio", "en")
+    fs.mkdirSync(bookDir, { recursive: true })
+    fs.mkdirSync(audioDir, { recursive: true })
+    createWebAssets(webAssetsDir)
+    fs.writeFileSync(path.join(audioDir, "pg001_t001.mp3"), "audio")
+    fs.writeFileSync(path.join(audioDir, "pg001_t002.mp3"), "audio")
+    fs.writeFileSync(path.join(audioDir, "pg001_im001.mp3"), "audio")
+
+    const pages: PageData[] = [
+      { pageId: "pg001", pageNumber: 1, text: "Page one" },
+    ]
+
+    const ttsEntry = (textId: string) => ({
+      textId,
+      language: "en",
+      fileName: `${textId}.mp3`,
+      voice: "alloy",
+      model: "gpt-4o-mini-tts",
+      cached: false,
+    })
+    const timestampEntry = (textId: string) => ({
+      textId,
+      language: "en",
+      duration: 0.5,
+      words: [{ word: "Hello", start: 0, end: 0.5 }],
+    })
+
+    const storage = createMockStorage(pages, {
+      "web-rendering": {
+        pg001: {
+          sections: [
+            {
+              sectionIndex: 0,
+              sectionType: "content",
+              reasoning: "ok",
+              html: '<p data-id="pg001_t001">Kept</p><p data-id="pg001_t002">Muted</p>',
+            },
+          ],
+        },
+      },
+      "page-sectioning": {
+        pg001: {
+          reasoning: "ok",
+          sections: [
+            {
+              sectionId: "pg001_sec001",
+              sectionType: "content",
+              nodes: [],
+              backgroundColor: "#fff",
+              textColor: "#000",
+              pageNumber: 1,
+              isPruned: false,
+            },
+          ],
+        },
+      },
+      "tts": {
+        en: {
+          entries: [ttsEntry("pg001_t001"), ttsEntry("pg001_t002"), ttsEntry("pg001_im001")],
+          generatedAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+      "tts-timestamps": {
+        en: {
+          entries: {
+            pg001_t001: timestampEntry("pg001_t001"),
+            pg001_t002: timestampEntry("pg001_t002"),
+            pg001_im001: timestampEntry("pg001_im001"),
+          },
+          generatedAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    })
+
+    await packageAdtWeb(storage, {
+      bookDir,
+      label: "book",
+      language: "en",
+      outputLanguages: ["en"],
+      title: "Book Title",
+      webAssetsDir,
+      speechConfig: {
+        word_highlighting: true,
+        excluded_text_ids: ["pg001_t002"],
+        excluded_categories: ["captions"],
+      },
+    })
+
+    const audios = JSON.parse(
+      fs.readFileSync(path.join(bookDir, "adt", "content", "i18n", "en", "audios.json"), "utf-8"),
+    ) as Record<string, string>
+    expect(audios).toEqual({ pg001_t001: "pg001_t001.mp3" })
+
+    const bundledAudioDir = path.join(bookDir, "adt", "content", "i18n", "en", "audio")
+    expect(fs.existsSync(path.join(bundledAudioDir, "pg001_t001.mp3"))).toBe(true)
+    expect(fs.existsSync(path.join(bundledAudioDir, "pg001_t002.mp3"))).toBe(false)
+    expect(fs.existsSync(path.join(bundledAudioDir, "pg001_im001.mp3"))).toBe(false)
+
+    const timecodes = JSON.parse(
+      fs.readFileSync(
+        path.join(bookDir, "adt", "content", "i18n", "en", "timecode", "timecode_output.json"),
+        "utf-8",
+      ),
+    ) as Record<string, unknown>
+    expect(Object.keys(timecodes)).toEqual(["pg001_t001"])
+  })
+
   it("emits defaultSettings and lockedSettings in config.json when provided", async () => {
     const bookDir = path.join(tmpDir, "book")
     const webAssetsDir = path.join(tmpDir, "assets-web")

--- a/packages/pipeline/src/package-web.ts
+++ b/packages/pipeline/src/package-web.ts
@@ -31,7 +31,7 @@ import type {
   Quiz,
   ImageCaptioningOutput,
 } from "@adt/types"
-import { WebRenderingOutput as WebRenderingOutputSchema } from "@adt/types"
+import { WebRenderingOutput as WebRenderingOutputSchema, isTtsExcluded } from "@adt/types"
 import {
   GOOGLE_FONTS,
   googleFontsReferencedIn,
@@ -132,11 +132,13 @@ export function getWordTimestamps(
 
 function buildRuntimeTimecodeMap(
   timestamps: WordTimestampOutput | undefined,
+  speechConfig?: SpeechConfig,
 ): Record<string, RuntimeTimecodeEntry> {
   const map: Record<string, RuntimeTimecodeEntry> = {}
 
   for (const [textId, entry] of Object.entries(timestamps?.entries ?? {})) {
     if (entry.words.length === 0) continue
+    if (isTtsExcluded(textId, speechConfig)) continue
     map[textId] = {
       timecodes: [
         null,
@@ -579,6 +581,9 @@ export async function packageAdtWeb(
 
       if (ttsData?.entries) {
         for (const entry of ttsData.entries) {
+          // Exclusions apply at packaging time too, so muting an element
+          // takes effect without regenerating speech.
+          if (isTtsExcluded(entry.textId, speechConfig)) continue
           const srcFile = path.join(bookDir, "audio", lang, entry.fileName)
           const legacySrcFile = path.join(bookDir, "audio", legacyLang, entry.fileName)
           const resolvedSrcFile = fs.existsSync(srcFile) ? srcFile : legacySrcFile
@@ -598,7 +603,7 @@ export async function packageAdtWeb(
     writeJson(
       path.join(timecodeDir, "timecode_output.json"),
       highlightEnabled
-        ? buildRuntimeTimecodeMap(getWordTimestamps(storage, lang))
+        ? buildRuntimeTimecodeMap(getWordTimestamps(storage, lang), speechConfig)
         : {},
     )
 

--- a/packages/pipeline/src/pipeline-dag.ts
+++ b/packages/pipeline/src/pipeline-dag.ts
@@ -24,6 +24,7 @@ import type {
   TTSOutput,
   WebRenderingOutput,
 } from "@adt/types"
+import { isTtsExcluded } from "@adt/types"
 import { extractPDF } from "./pdf-extraction.js"
 import {
   resolveFontsCacheDir,
@@ -893,6 +894,7 @@ export async function runFullPipeline(
           entries = (translatedRow.data as TextCatalogOutput).entries
         }
         for (const entry of entries) {
+          if (isTtsExcluded(entry.id, config.speech)) continue
           workItems.push({ textId: entry.id, text: entry.text, language: lang })
         }
       }

--- a/packages/types/src/__tests__/speech.test.ts
+++ b/packages/types/src/__tests__/speech.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest"
+import { SpeechConfig, TTSOutput, isTtsExcluded } from "../speech.js"
+import { getTextCatalogCategory } from "../text-catalog.js"
+
+describe("getTextCatalogCategory", () => {
+  it("classifies catalog entry ids by their conventions", () => {
+    expect(getTextCatalogCategory("pg001_t001")).toBe("text")
+    expect(getTextCatalogCategory("qz001_que")).toBe("text")
+    expect(getTextCatalogCategory("pg001_im001")).toBe("captions")
+    expect(getTextCatalogCategory("pg001_sec001_ans_a")).toBe("answers")
+    expect(getTextCatalogCategory("gl001")).toBe("glossary")
+    expect(getTextCatalogCategory("gl001_def")).toBe("glossary")
+    expect(getTextCatalogCategory("gl_manual_1")).toBe("glossary")
+    expect(getTextCatalogCategory("pg001_t001_easy_read")).toBe("easy-read")
+  })
+
+  it("prefers easy-read over the source entry's category", () => {
+    expect(getTextCatalogCategory("pg001_im001_easy_read")).toBe("easy-read")
+    expect(getTextCatalogCategory("gl001_easy_read")).toBe("easy-read")
+  })
+})
+
+describe("isTtsExcluded", () => {
+  it("is not excluded without config", () => {
+    expect(isTtsExcluded("pg001_t001")).toBe(false)
+    expect(isTtsExcluded("pg001_t001", {})).toBe(false)
+    expect(isTtsExcluded("pg001_t001", null)).toBe(false)
+  })
+
+  it("excludes individually muted ids", () => {
+    const config = { excluded_text_ids: ["pg001_t002"] }
+    expect(isTtsExcluded("pg001_t002", config)).toBe(true)
+    expect(isTtsExcluded("pg001_t001", config)).toBe(false)
+  })
+
+  it("mutes the easy-read variant of a muted source entry", () => {
+    const config = { excluded_text_ids: ["pg001_t002"] }
+    expect(isTtsExcluded("pg001_t002_easy_read", config)).toBe(true)
+    expect(isTtsExcluded("pg001_t001_easy_read", config)).toBe(false)
+  })
+
+  it("excludes whole categories", () => {
+    const config = { excluded_categories: ["captions", "glossary"] }
+    expect(isTtsExcluded("pg001_im001", config)).toBe(true)
+    expect(isTtsExcluded("gl001_def", config)).toBe(true)
+    expect(isTtsExcluded("pg001_t001", config)).toBe(false)
+    expect(isTtsExcluded("pg001_sec001_ans_a", config)).toBe(false)
+  })
+
+  it("applies the source entry's excluded category to its easy-read variant", () => {
+    const config = { excluded_categories: ["captions"] }
+    expect(isTtsExcluded("pg001_im001_easy_read", config)).toBe(true)
+    expect(isTtsExcluded("pg001_t001_easy_read", config)).toBe(false)
+  })
+
+  it("excludes all easy-read variants when the easy-read category is muted", () => {
+    const config = { excluded_categories: ["easy-read"] }
+    expect(isTtsExcluded("pg001_t001_easy_read", config)).toBe(true)
+    expect(isTtsExcluded("pg001_t001", config)).toBe(false)
+  })
+})
+
+describe("SpeechConfig exclusions", () => {
+  it("accepts exclusion fields", () => {
+    const result = SpeechConfig.safeParse({
+      excluded_categories: ["captions", "easy-read"],
+      excluded_text_ids: ["pg001_t001"],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it("rejects unknown categories", () => {
+    const result = SpeechConfig.safeParse({
+      excluded_categories: ["page-numbers"],
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe("TTSOutput", () => {
+  const entry = {
+    textId: "pg001_t001",
+    language: "en",
+    fileName: "pg001_t001.mp3",
+    voice: "alloy",
+    model: "gpt-4o-mini-tts",
+    cached: false,
+  }
+
+  it("accepts output without failures (existing data)", () => {
+    const result = TTSOutput.safeParse({
+      entries: [entry],
+      generatedAt: "2026-01-01T00:00:00.000Z",
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it("accepts per-item failures", () => {
+    const result = TTSOutput.safeParse({
+      entries: [entry],
+      generatedAt: "2026-01-01T00:00:00.000Z",
+      failed: [{ textId: "pg001_t002", error: "Gemini rate limit" }],
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.failed).toHaveLength(1)
+    }
+  })
+})

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -220,6 +220,8 @@ export {
 export {
   TextCatalogEntry,
   TextCatalogOutput,
+  TextCatalogCategory,
+  getTextCatalogCategory,
 } from "./text-catalog.js"
 
 export {
@@ -232,7 +234,10 @@ export {
   TTSProviderConfig,
   SpeechConfig,
   isSpeechWordHighlightingEnabled,
+  type TtsExclusionConfig,
+  isTtsExcluded,
   SpeechFileEntry,
+  SpeechFailedEntry,
   TTSOutput,
   WordTimestamp,
   WordTimestampEntry,

--- a/packages/types/src/speech.ts
+++ b/packages/types/src/speech.ts
@@ -1,4 +1,5 @@
 import { z } from "zod"
+import { TextCatalogCategory, getTextCatalogCategory } from "./text-catalog.js"
 
 export const TTSProviderConfig = z.object({
   model: z.string().optional(),
@@ -17,6 +18,10 @@ export const SpeechConfig = z.object({
   providers: z.record(z.string(), TTSProviderConfig).optional(),
   bit_rate: z.string().optional(),
   sample_rate: z.number().optional(),
+  /** Text categories excluded from read-aloud (no audio generated or packaged) */
+  excluded_categories: z.array(TextCatalogCategory).optional(),
+  /** Individual text ids excluded from read-aloud; also mutes their `_easy_read` variants */
+  excluded_text_ids: z.array(z.string()).optional(),
 })
 export type SpeechConfig = z.infer<typeof SpeechConfig>
 
@@ -24,6 +29,36 @@ export function isSpeechWordHighlightingEnabled(
   config?: Pick<SpeechConfig, "word_highlighting"> | null,
 ): boolean {
   return config?.word_highlighting === true
+}
+
+/** Accepts plain string arrays so callers can pass unvalidated config data;
+ * unknown category values simply never match. */
+export interface TtsExclusionConfig {
+  excluded_categories?: string[]
+  excluded_text_ids?: string[]
+}
+
+const EASY_READ_SUFFIX_RE = /_easy_read$/
+
+/**
+ * Whether a text catalog entry is excluded from read-aloud, either by its
+ * category or individually by id. An `{id}_easy_read` variant inherits the
+ * exclusion of its source entry, so muting an element silences both its
+ * regular and Easy Read audio.
+ */
+export function isTtsExcluded(
+  textId: string,
+  config?: TtsExclusionConfig | null,
+): boolean {
+  if (!config) return false
+  const baseId = textId.replace(EASY_READ_SUFFIX_RE, "")
+  if (config.excluded_text_ids?.some((id) => id === textId || id === baseId)) {
+    return true
+  }
+  const categories = config.excluded_categories
+  if (!categories || categories.length === 0) return false
+  if (categories.includes(getTextCatalogCategory(textId))) return true
+  return baseId !== textId && categories.includes(getTextCatalogCategory(baseId))
 }
 
 export const SpeechFileEntry = z.object({
@@ -37,9 +72,19 @@ export const SpeechFileEntry = z.object({
 })
 export type SpeechFileEntry = z.infer<typeof SpeechFileEntry>
 
+/** A catalog entry whose speech generation failed during the last run. */
+export const SpeechFailedEntry = z.object({
+  textId: z.string(),
+  error: z.string(),
+})
+export type SpeechFailedEntry = z.infer<typeof SpeechFailedEntry>
+
 export const TTSOutput = z.object({
   entries: z.array(SpeechFileEntry),
   generatedAt: z.string(),
+  /** Per-item failures from the run that produced this output, so the UI can
+   * mark them without re-running. Cleared by the next successful run. */
+  failed: z.array(SpeechFailedEntry).optional(),
 })
 export type TTSOutput = z.infer<typeof TTSOutput>
 

--- a/packages/types/src/text-catalog.ts
+++ b/packages/types/src/text-catalog.ts
@@ -11,3 +11,37 @@ export const TextCatalogOutput = z.object({
   generatedAt: z.string(),
 })
 export type TextCatalogOutput = z.infer<typeof TextCatalogOutput>
+
+/**
+ * Categories of text catalog entries, inferred from entry id patterns.
+ * Catalog entries carry no explicit type field, so the id conventions used
+ * by the producing steps are the single source of truth:
+ * - captions:  image ids contain `_im{NNN}` (image-captioning)
+ * - answers:   activity answer ids contain `_ans_` (page sectioning)
+ * - glossary:  `gl{NNN}` / `gl_manual_*` (glossary generation)
+ * - easy-read: `{sourceId}_easy_read` (easy-read flattening)
+ * - text:      everything else (page text, quiz content, TOC)
+ */
+export const TextCatalogCategory = z.enum([
+  "text",
+  "captions",
+  "answers",
+  "glossary",
+  "easy-read",
+])
+export type TextCatalogCategory = z.infer<typeof TextCatalogCategory>
+
+const IMAGE_ID_RE = /_im\d{3}/
+const ANSWER_ID_RE = /_ans_/
+const GLOSSARY_ID_RE = /^gl(?:\d{3}|_manual_)/
+const EASY_READ_ID_RE = /_easy_read$/
+
+export function getTextCatalogCategory(id: string): TextCatalogCategory {
+  // Easy Read ids are `{sourceId}_easy_read`; check first so they are not
+  // mistaken for their source entry's category.
+  if (EASY_READ_ID_RE.test(id)) return "easy-read"
+  if (IMAGE_ID_RE.test(id)) return "captions"
+  if (ANSWER_ID_RE.test(id)) return "answers"
+  if (GLOSSARY_ID_RE.test(id)) return "glossary"
+  return "text"
+}


### PR DESCRIPTION
Adds read-aloud (TTS) exclusions: whole text types can be disabled via new switches in the Speech settings, and individual text entries can be muted from the Language/Speech views, with Easy Read variants inheriting their source entry's mute. Exclusions are enforced in the TTS step (Studio stage runner and CLI pipeline), in web/EPUB packaging (`audios.json` and word-highlight timecodes), and in missing-audio counts, so muting takes effect without regenerating speech. The Speech view now stays on the entry catalog during generation, showing each audio progressively — served from a new in-memory live-run snapshot behind `GET /tts` — with a "Generating X/Y" counter fed by SSE step progress. Per-item TTS failures are persisted in the TTS output and surfaced as red **Failed** (with the error as tooltip) and amber **No audio** badges; muting a failed entry drops it from the required set so re-runs skip it. Includes unit tests for the exclusion helpers, packaging filter, and live registry, plus fully translated Lingui catalogs for es/fr/pt-BR/sq.