### PR TITLE
feat(studio): gate Split & merge panel on split intent

### DIFF
--- a/apps/studio/src/components/parts/BookPartsPanel.tsx
+++ b/apps/studio/src/components/parts/BookPartsPanel.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, type ReactNode } from "react"
+import { useEffect, useRef, useState, type ReactNode } from "react"
 import { Plural, Trans, useLingui } from "@lingui/react/macro"
 import { Scissors, Combine, Upload, AlertTriangle, CheckCircle2, Loader2, Sparkles, ArrowRight, FileArchive, X, Info } from "lucide-react"
 import { useBook, useRegenerateBookSummary } from "../../hooks/use-books"
@@ -26,17 +26,40 @@ export function BookPartsPanel({ bookLabel }: { bookLabel: string }) {
   const { data: partInfo, isLoading: partInfoLoading } = usePartInfo(bookLabel)
   const { data: pdfInfo, isLoading: pdfInfoLoading } = useSourcePdfInfo(bookLabel)
   const { data: splitStatus, isLoading: splitStatusLoading } = useSplitStatus(bookLabel)
-  const { data: activeConfig } = useActiveConfig(bookLabel)
+  const { data: activeConfig, isLoading: configLoading } = useActiveConfig(bookLabel)
   const spreadMode = activeConfig?.merged?.spread_mode === true
   // Base the export range on the full source PDF (works before extraction and
   // isn't capped when the book was extracted with a window). Fall back to the
   // extracted page count.
   const pageCount = splitStatus?.pageCount ?? pdfInfo?.pageCount ?? book?.pageCount ?? 0
-  // Until these settle we know neither whether this is an imported part nor the
-  // page count — render a stable skeleton instead of flashing the wrong body
-  // (the export/merge grid, then snapping to the part notice / adding the
-  // "Preview & split pages" button once the queries resolve).
-  const loading = partInfoLoading || pdfInfoLoading || splitStatusLoading
+  const loading =
+    partInfoLoading || pdfInfoLoading || splitStatusLoading || configLoading
+
+  // Only books in the split/merge world show the panel: those the user chose to
+  // split (`split_mode`), those with existing split activity (covers books
+  // split before the flag existed), and imported parts.
+  const splitMode = activeConfig?.merged?.split_mode === true
+  const hasSplitActivity =
+    !!splitStatus &&
+    (splitStatus.exported.length > 0 || splitStatus.mergedRanges.length > 0)
+  const relevant = !!partInfo || splitMode || hasSplitActivity
+
+  // The wizard leaves a one-shot flag to scroll to and briefly highlight this
+  // panel after finishing with the "split into parts" intent.
+  const sectionRef = useRef<HTMLElement>(null)
+  const [focus, setFocus] = useState(false)
+  useEffect(() => {
+    if (loading || !relevant) return
+    if (typeof window === "undefined") return
+    if (window.sessionStorage.getItem("adt:focus-parts") !== bookLabel) return
+    window.sessionStorage.removeItem("adt:focus-parts")
+    setFocus(true)
+    sectionRef.current?.scrollIntoView({ behavior: "smooth", block: "center" })
+    const timer = setTimeout(() => setFocus(false), 2400)
+    return () => clearTimeout(timer)
+  }, [bookLabel, loading, relevant])
+
+  if (loading || !relevant) return null
 
   // Book metadata (title, authors) is only carried in by the part that contains
   // page 1, so a split book stays untitled until that part is merged. Nudge the
@@ -48,7 +71,13 @@ export function BookPartsPanel({ bookLabel }: { bookLabel: string }) {
     !!splitStatus && splitStatus.exported.length > 0 && !page1Merged && !book?.title
 
   return (
-    <section className="overflow-hidden rounded-2xl border border-border bg-card shadow-sm">
+    <section
+      ref={sectionRef}
+      className={cn(
+        "overflow-hidden rounded-2xl border border-border bg-card shadow-sm transition-shadow duration-500",
+        focus && "ring-2 ring-primary ring-offset-2 ring-offset-background",
+      )}
+    >
       <header className="flex items-center gap-2 border-b border-border/60 bg-muted/20 px-6 py-4">
         <Scissors className="h-4 w-4 text-muted-foreground" strokeWidth={2} />
         <h2 className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
@@ -63,9 +92,7 @@ export function BookPartsPanel({ bookLabel }: { bookLabel: string }) {
         )}
       </header>
 
-      {loading ? (
-        <PartsPanelSkeleton />
-      ) : partInfo ? (
+      {partInfo ? (
         <p className="px-6 py-5 text-xs leading-relaxed text-muted-foreground">
           <Trans>
             Parts can't be split further. Process the assigned pages, then return
@@ -75,23 +102,22 @@ export function BookPartsPanel({ bookLabel }: { bookLabel: string }) {
         </p>
       ) : (
         <>
-          {splitStatus &&
-            (splitStatus.exported.length > 0 || splitStatus.mergedRanges.length > 0) && (
-              <div className="flex flex-col gap-3 border-b border-border/60 px-6 py-4">
-                <CoverageBar status={splitStatus} />
-                {showPageOneHint && (
-                  <div className="flex items-start gap-2 text-xs leading-relaxed text-muted-foreground">
-                    <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" strokeWidth={2} />
-                    <p>
-                      <Trans>
-                        The book's title and metadata arrive with the part that
-                        contains page 1 — merge that part to fill them in.
-                      </Trans>
-                    </p>
-                  </div>
-                )}
-              </div>
-            )}
+          {hasSplitActivity && (
+            <div className="flex flex-col gap-3 border-b border-border/60 px-6 py-4">
+              <CoverageBar status={splitStatus} />
+              {showPageOneHint && (
+                <div className="flex items-start gap-2 text-xs leading-relaxed text-muted-foreground">
+                  <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" strokeWidth={2} />
+                  <p>
+                    <Trans>
+                      The book's title and metadata arrive with the part that
+                      contains page 1 — merge that part to fill them in.
+                    </Trans>
+                  </p>
+                </div>
+              )}
+            </div>
+          )}
           <div className="relative grid grid-cols-1 items-stretch gap-px bg-border/60 md:grid-cols-2">
             <ExportPart bookLabel={bookLabel} pageCount={pageCount} spreadMode={spreadMode} status={splitStatus} />
             <MergePart bookLabel={bookLabel} status={splitStatus} />
@@ -107,28 +133,6 @@ export function BookPartsPanel({ bookLabel }: { bookLabel: string }) {
         </>
       )}
     </section>
-  )
-}
-
-/**
- * Placeholder shown while the part/split queries load, sized to roughly match
- * the two-column export/merge grid so the card doesn't jump once data arrives.
- */
-function PartsPanelSkeleton() {
-  return (
-    <div
-      className="grid animate-pulse grid-cols-1 gap-px bg-border/60 md:grid-cols-2"
-      aria-hidden
-    >
-      {[0, 1].map((col) => (
-        <div key={col} className="flex flex-col gap-3 bg-card p-6">
-          <div className="h-4 w-32 rounded bg-muted" />
-          <div className="h-3 w-full rounded bg-muted/70" />
-          <div className="h-3 w-4/5 rounded bg-muted/70" />
-          <div className="mt-2 h-9 w-40 rounded bg-muted" />
-        </div>
-      ))}
-    </div>
   )
 }
 

--- a/apps/studio/src/components/pipeline/stages/BookView.tsx
+++ b/apps/studio/src/components/pipeline/stages/BookView.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useRef, useState, type MouseEvent, type ReactNode } from "react"
+import { Fragment, useState, type MouseEvent, type ReactNode } from "react"
 import { useNavigate } from "@tanstack/react-router"
 import {
   AlertTriangle,
@@ -58,20 +58,6 @@ const RECOMMENDED_STAGES = new Set<string>(["captions"])
 export function BookView({ bookLabel }: ViewProps) {
   const { t } = useLingui()
   const overviewSteps = getBookOverviewStages()
-
-  // When the create-book wizard finished with the "split into parts" intent, it
-  // leaves a one-shot flag so we scroll to and briefly highlight the split panel.
-  const partsRef = useRef<HTMLDivElement>(null)
-  const [focusParts, setFocusParts] = useState(false)
-  useEffect(() => {
-    if (typeof window === "undefined") return
-    if (window.sessionStorage.getItem("adt:focus-parts") !== bookLabel) return
-    window.sessionStorage.removeItem("adt:focus-parts")
-    setFocusParts(true)
-    partsRef.current?.scrollIntoView({ behavior: "smooth", block: "center" })
-    const timer = setTimeout(() => setFocusParts(false), 2400)
-    return () => clearTimeout(timer)
-  }, [bookLabel])
   const {
     stageState,
     stepState,
@@ -154,15 +140,7 @@ export function BookView({ bookLabel }: ViewProps) {
     <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-6">
       <BookOverviewCard bookLabel={bookLabel} />
 
-      <div
-        ref={partsRef}
-        className={cn(
-          "rounded-2xl transition-shadow duration-500",
-          focusParts && "ring-2 ring-primary ring-offset-2 ring-offset-background",
-        )}
-      >
-        <BookPartsPanel bookLabel={bookLabel} />
-      </div>
+      <BookPartsPanel bookLabel={bookLabel} />
 
       {/* Core Pipeline cluster — connectors hug the cards. */}
       <div className="flex flex-col gap-2">

--- a/apps/studio/src/components/wizard/bookCreationConfig.ts
+++ b/apps/studio/src/components/wizard/bookCreationConfig.ts
@@ -68,6 +68,7 @@ export function buildConfigOverrides(values: WizardFormValues): Record<string, u
     if (validPageRange && parsedStartPage !== undefined) config.start_page = parsedStartPage
     if (validPageRange && parsedEndPage !== undefined) config.end_page = parsedEndPage
   }
+  if (values.scope === "split") config.split_mode = true
   if (values.imageSegmentation && values.segmentationMinSide.trim()) {
     const n = Number(values.segmentationMinSide.trim())
     if (Number.isInteger(n) && n >= 0) config.image_segmentation = { min_side: n }

--- a/apps/studio/src/components/wizard/wizardForm.ts
+++ b/apps/studio/src/components/wizard/wizardForm.ts
@@ -41,7 +41,8 @@ export const defaultWizardValues = {
    *  - "split" — this is the canonical full book; defer extraction and hand
    *    out page-range parts to merge back later.
    *  Only "range" writes `start_page`/`end_page` to config; only "whole"/"range"
-   *  kick off extraction. Not itself written to book config. */
+   *  kick off extraction. "split" persists `split_mode: true` to book config so
+   *  the overview can gate the Split & merge panel on the choice. */
   scope: "whole" as "whole" | "range" | "split",
 }
 

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -171,6 +171,7 @@ export const AppConfig = z
     image_cropping: StepConfig.optional(),
     layout_type: LayoutType.optional(),
     spread_mode: z.boolean().optional(),
+    split_mode: z.boolean().optional(),
     vector_text_grouping: z.boolean().optional(),
     apply_body_background: z.boolean().optional(),
     generate_activities: z.boolean().optional(),


### PR DESCRIPTION
## What

The Split & merge card on the book overview was shown for **every** book. It now only appears for books that are actually part of the split/merge workflow.

## Why

The wizard's \`scope: "split"\` choice was never persisted, so a freshly-created split book was byte-identical to a whole book — there was no signal to gate on.

## How

- **Persist the intent:** added \`split_mode\` to \`AppConfig\`; \`buildConfigOverrides\` writes \`split_mode: true\` when the wizard's *Split into parts* is chosen.
- **Gate the panel:** \`BookPartsPanel\` renders only when the book is \`relevant\` — \`split_mode\` is set, the book already has split activity (covers books split before the flag existed), or it's an imported part. A plain whole/range book renders nothing.
- **No phantom gap:** the wizard focus/scroll-and-highlight behaviour moved from a \`BookView\` wrapper \`<div>\` into the panel's own \`<section>\`, so no empty flex item / extra gap is reserved when the panel is hidden.

## Notes

- \`split_mode\` is intentionally **not** in \`fingerprint.ts\`'s allowlists, so it does not affect any LLM cache key.
- No new user-visible strings, so no i18n extraction needed.

## Test plan

- [ ] Create a book with **Whole book** / **Page range** → no Split & merge card on overview.
- [ ] Create a book with **Split into parts** → card appears and is scrolled-to/highlighted.
- [ ] Open an imported part → card shows the "can't split further" notice.
- [ ] Existing split book with exported/merged parts → card still appears.