### PR TITLE
fix(studio): restore i18n in production builds after Lingui v6 upgrade

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -54,6 +54,7 @@
   },
   "devDependencies": {
     "@ai-sdk/openai": "^1.0.0",
+    "@lingui/babel-plugin-lingui-macro": "^6.4.0",
     "@lingui/cli": "^6.4.0",
     "@lingui/vite-plugin": "^6.4.0",
     "@tailwindcss/vite": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -428,6 +428,9 @@ importers:
       '@ai-sdk/openai':
         specifier: ^1.0.0
         version: 1.3.24(zod@3.25.76)
+      '@lingui/babel-plugin-lingui-macro':
+        specifier: ^6.4.0
+        version: 6.4.0
       '@lingui/cli':
         specifier: ^6.4.0
         version: 6.4.0(babel-plugin-macros@3.1.0)


### PR DESCRIPTION
## Problem

In production/desktop builds, many UI strings render as raw hash IDs (e.g. `w/w3zZ`, `1p7y+v`, `6JCb++`, `/bY0Wo`, `Vj/PKg`, `/5E4c5`, `u/dofq`) instead of translated text. Dev mode looked fine. This started after the dependency update (#521).

## Root cause

#521 bumped Studio to **Lingui v6** and **removed** `@lingui/babel-plugin-lingui-macro` from Studio's direct devDependencies, assuming `@lingui/vite-plugin` would provide it. But `linguiTransformerBabelPreset()` references the macro by bare name, so Babel resolved it to the **stale v5 copy** that `apps/desktop` still drags into the workspace.

Lingui v6 changed `generateMessageId` from **standard base64** to **URL-safe base64** (`/`→`_`, `+`→`-`):

| | `generateMessageId` output |
|---|---|
| v5.9.x | standard base64 → contains `/` and `+` (`w/w3zZ`, `/bY0Wo`) |
| v6.4.0 | URL-safe base64 (`w_w3zZ`, `_bY0Wo`) |

So the v6 `.po` catalog compiler keyed messages URL-safe, while the v5 macro emitted standard-base64 IDs. Any string whose hash contained `/` or `+` failed to resolve at runtime. In dev the source-text fallback hides this; the production transform strips the fallback, exposing the raw hash ID.

## Fix

Re-add `@lingui/babel-plugin-lingui-macro@^6.4.0` as a direct Studio devDependency so Babel resolves the **v6** macro, aligning macro IDs with the compiled catalog. (It was a direct dep in the v5 setup; the update dropped it.)

## Verification

Reproduced and fixed against a **production build** (served with a live API, driven headlessly):

- **Bundle:** 0 of 2478 referenced i18n IDs orphaned from the catalog (was hundreds).
- **Runtime A/B**, identical library + pipeline sidebar render:
  - before fix → 10 leaked hash-IDs (matches the reported screenshot)
  - after fix → **0 leaked**, in both `en` and `pt-BR`, no console errors.

## Follow-up (optional, not in this PR)

Migrate `apps/desktop` to Lingui v6 so the workspace carries a single Lingui major and this resolution ambiguity can't recur.