### PR TITLE
fix(glossary): persist manual, edited & pruned terms across re-runs; fix Book order sort

### DIFF
--- a/apps/api/src/routes/stages.ts
+++ b/apps/api/src/routes/stages.ts
@@ -5,7 +5,7 @@ import { streamSSE } from "hono/streaming"
 import { HTTPException } from "hono/http-exception"
 import { z } from "zod"
 import { createBookStorage, openBookDb } from "@adt/storage"
-import { StageName, STAGE_ORDER, PIPELINE, parseBookLabel, getStageClearNodes, getStageClearOrder } from "@adt/types"
+import { StageName, STAGE_ORDER, PIPELINE, parseBookLabel, getStageRerunClearNodes, getStageClearOrder } from "@adt/types"
 import type { StageService } from "../services/stage-service.js"
 import type { BookEventBus, BookSSEEvent } from "../services/book-event-bus.js"
 
@@ -19,7 +19,7 @@ const StageRunBody = z
 
 /** Build a beforeRun callback that clears downstream data for a stage.
  *  The returned function is idempotent — only runs once even if called multiple times. */
-function makeBeforeRun(label: string, fromStage: StageName, booksDir: string): () => void {
+function makeBeforeRun(label: string, fromStage: StageName, toStage: StageName, booksDir: string): () => void {
   let ran = false
   return () => {
     if (ran) return
@@ -30,7 +30,7 @@ function makeBeforeRun(label: string, fromStage: StageName, booksDir: string): (
         // clearExtractedData also clears step_runs
         storage.clearExtractedData()
       } else {
-        const nodes = getStageClearNodes(fromStage)
+        const nodes = getStageRerunClearNodes(fromStage, toStage)
         if (nodes.length > 0) {
           storage.clearNodesByType(nodes)
         }
@@ -103,7 +103,7 @@ export function createStageRoutes(
 
     console.log(`[stages] ${label}: ${fromStage}→${toStage}${renderOnly ? " (render-only)" : ""} azureKey=${azureSpeechKey ? "set" : "NOT SET"} azureRegion=${azureSpeechRegion ?? "NOT SET"} geminiKey=${geminiApiKey ? "set" : "NOT SET"}`)
 
-    const clearData = makeBeforeRun(label, fromStage, booksDir)
+    const clearData = makeBeforeRun(label, fromStage, toStage, booksDir)
 
     const result = stageService.startStageRun(label, {
       booksDir,

--- a/apps/api/src/services/stage-runner.ts
+++ b/apps/api/src/services/stage-runner.ts
@@ -28,10 +28,8 @@ import {
   captionPageImages,
   buildCaptionConfig,
   extractImageIds,
-  generateGlossary,
+  regenerateGlossaryPreservingEdits,
   buildGlossaryConfig,
-  mergeGeneratedGlossaryWithManualItems,
-  getPrunedGlossaryWords,
   generateToc,
   buildTocGenerationConfig,
   generateAllQuizzes,
@@ -89,7 +87,6 @@ import type {
   PageSectioningOutput,
   WebRenderingOutput,
   ImageCaptioningOutput,
-  GlossaryOutput,
   TextCatalogOutput,
   TextCatalogEntry,
   EasyReadOutput,
@@ -1475,18 +1472,12 @@ async function runGlossaryStep(
 
     console.log(`[stage-run] ${label}: generating glossary from ${pages.length} pages`)
 
-    const existingGlossaryRow = storage.getLatestNodeData("glossary", "book")
-    const existingGlossary = existingGlossaryRow?.data as GlossaryOutput | undefined
-
-    const excludedWords = getPrunedGlossaryWords(existingGlossary?.items ?? [])
-
-    const generatedGlossary = await generateGlossary({
+    const glossary = await regenerateGlossaryPreservingEdits({
       storage,
       pages,
       config: glossaryConfig,
       llmModel: glossaryModel,
       concurrency: effectiveConcurrency,
-      excludedWords,
       onBatchComplete: (completed, total) => {
         progress.emit({
           type: "step-progress",
@@ -1497,10 +1488,6 @@ async function runGlossaryStep(
         })
       },
     })
-    const glossary = mergeGeneratedGlossaryWithManualItems(
-      generatedGlossary,
-      existingGlossary?.items ?? [],
-    )
     storage.putNodeData("glossary", "book", glossary)
 
     progress.emit({

--- a/apps/studio/src/components/pipeline/stages/glossary/GlossaryView.tsx
+++ b/apps/studio/src/components/pipeline/stages/glossary/GlossaryView.tsx
@@ -205,7 +205,9 @@ export function GlossaryView({ bookLabel }: { bookLabel: string }) {
       ...base,
       generatedAt: base.generatedAt || new Date().toISOString(),
       items: base.items.map((item) =>
-        (item.id ?? item.word) === itemId ? { ...item, definition: newDefinition } : item
+        (item.id ?? item.word) === itemId
+          ? { ...item, definition: newDefinition, source: "manual" }
+          : item
       ),
     })
   }
@@ -217,7 +219,9 @@ export function GlossaryView({ bookLabel }: { bookLabel: string }) {
       ...base,
       generatedAt: base.generatedAt || new Date().toISOString(),
       items: base.items.map((item) =>
-        (item.id ?? item.word) === itemId ? { ...item, emojis: newEmojis } : item
+        (item.id ?? item.word) === itemId
+          ? { ...item, emojis: newEmojis, source: "manual" }
+          : item
       ),
     })
   }

--- a/apps/studio/src/components/pipeline/stages/glossary/GlossaryView.tsx
+++ b/apps/studio/src/components/pipeline/stages/glossary/GlossaryView.tsx
@@ -131,12 +131,16 @@ export function GlossaryView({ bookLabel }: { bookLabel: string }) {
         .toLocaleLowerCase()
       return haystack.includes(q)
     })
-    if (sortMode === "default") return list
     const usage = (item: GlossaryItem) => occurrences.get(item.id ?? item.word)?.count ?? 0
+    const firstPage = (item: GlossaryItem) =>
+      occurrences.get(item.id ?? item.word)?.pages[0] ?? Infinity
     const byWord = (a: GlossaryItem, b: GlossaryItem) =>
       a.word.localeCompare(b.word, undefined, { sensitivity: "base" })
     const sorted = [...list]
     switch (sortMode) {
+      case "default":
+        sorted.sort((a, b) => firstPage(a) - firstPage(b) || byWord(a, b))
+        break
       case "az":
         sorted.sort(byWord)
         break

--- a/packages/pipeline/src/glossary.ts
+++ b/packages/pipeline/src/glossary.ts
@@ -270,6 +270,22 @@ export async function generateGlossary(
   return aiGlossary
 }
 
+/** Regenerate the glossary while preserving manually added, edited, and pruned
+ * terms from the previous version. Shared by both pipeline runners so the
+ * behavior can't drift; the caller persists the returned glossary. Relies on the
+ * prior glossary node surviving any pre-run clear (see getStageRerunClearNodes). */
+export async function regenerateGlossaryPreservingEdits(
+  options: Omit<GenerateGlossaryOptions, "excludedWords">
+): Promise<GlossaryOutput> {
+  const existingRow = options.storage.getLatestNodeData("glossary", "book")
+  const existingItems = (existingRow?.data as GlossaryOutput | undefined)?.items ?? []
+  const generated = await generateGlossary({
+    ...options,
+    excludedWords: getPrunedGlossaryWords(existingItems),
+  })
+  return mergeGeneratedGlossaryWithManualItems(generated, existingItems)
+}
+
 export interface GenerateGlossaryItemOptions {
   word: string
   context?: string

--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -118,6 +118,7 @@ export {
 } from "./image-captioning.js"
 export {
   generateGlossary,
+  regenerateGlossaryPreservingEdits,
   generateGlossaryItem,
   buildGlossaryConfig,
   stripHtml,

--- a/packages/pipeline/src/pipeline-dag.ts
+++ b/packages/pipeline/src/pipeline-dag.ts
@@ -44,7 +44,7 @@ import { renderPage, buildRenderStrategyResolver } from "./web-rendering.js"
 import { translatePageTree, buildTranslationConfig } from "./translation.js"
 import { createTemplateEngine } from "./render-template.js"
 import { captionPageImages, buildCaptionConfig, extractImageIds } from "./image-captioning.js"
-import { generateGlossary, buildGlossaryConfig } from "./glossary.js"
+import { regenerateGlossaryPreservingEdits, buildGlossaryConfig } from "./glossary.js"
 import { generateToc, buildTocGenerationConfig } from "./toc-generation.js"
 import { generateAllQuizzes, buildQuizGenerationConfig, type QuizPageInput } from "./quiz-generation.js"
 import { buildTextCatalog } from "./text-catalog.js"
@@ -690,7 +690,8 @@ export async function runFullPipeline(
       const glossaryConfig = buildGlossaryConfig(config, language)
       const model = getModel(glossaryConfig.modelId)
       const pages = storage.getPages()
-      const glossary = await generateGlossary({
+
+      const glossary = await regenerateGlossaryPreservingEdits({
         storage,
         pages,
         config: glossaryConfig,

--- a/packages/types/src/__tests__/pipeline-effects.test.ts
+++ b/packages/types/src/__tests__/pipeline-effects.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 import {
   getStageClearNodes,
+  getStageRerunClearNodes,
   getCacheResourcesForNode,
   getCacheResourcesForStageOutput,
   getCacheResourcesForStageClear,
@@ -18,6 +19,14 @@ describe("pipeline effects", () => {
       "package-web",
       "accessibility-assessment",
     ])
+  })
+
+  it("spares the glossary node only when the glossary stage is re-run", () => {
+    expect(getStageClearNodes("glossary")).toContain("glossary")
+    expect(getStageRerunClearNodes("glossary", "glossary")).not.toContain("glossary")
+    expect(getStageRerunClearNodes("storyboard", "package")).not.toContain("glossary")
+    expect(getStageClearNodes("storyboard")).toContain("glossary")
+    expect(getStageRerunClearNodes("storyboard", "storyboard")).toContain("glossary")
   })
 
   it("derives stage-clear cache resources from cleared nodes", () => {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -79,6 +79,7 @@ export {
   STAGE_OUTPUT_NODES,
   getStageClearOrder,
   getStageClearNodes,
+  getStageRerunClearNodes,
   getCacheResourcesForNode,
   getCacheResourcesForNodes,
   getCacheResourcesForStageOutput,

--- a/packages/types/src/pipeline-effects.ts
+++ b/packages/types/src/pipeline-effects.ts
@@ -1,4 +1,4 @@
-import { PIPELINE } from "./pipeline.js"
+import { PIPELINE, STAGE_ORDER } from "./pipeline.js"
 import type { StageName, StepName } from "./pipeline.js"
 
 export type PipelineNodeName =
@@ -163,6 +163,33 @@ export function getStageClearNodes(stage: StageName): PipelineNodeName[] {
   }
 
   return nodes
+}
+
+/** Stages whose handler merges its own prior output on re-run (e.g. glossary
+ * preserves manual, edited, and pruned terms) rather than replacing it. */
+const STAGES_PRESERVING_OWN_OUTPUT: readonly StageName[] = ["glossary"]
+
+/** Like getStageClearNodes(fromStage), but keeps a merge-preserving stage's own
+ * output when that stage is inside the [fromStage, toStage] run range so its
+ * handler can re-merge the prior version. Outside the range it is still cleared. */
+export function getStageRerunClearNodes(
+  fromStage: StageName,
+  toStage: StageName
+): PipelineNodeName[] {
+  const clearNodes = getStageClearNodes(fromStage)
+  const fromIndex = STAGE_ORDER.indexOf(fromStage)
+  const toIndex = STAGE_ORDER.indexOf(toStage)
+
+  const preservedNodes = new Set<PipelineNodeName>()
+  for (const stage of STAGES_PRESERVING_OWN_OUTPUT) {
+    const index = STAGE_ORDER.indexOf(stage)
+    if (index >= fromIndex && index <= toIndex) {
+      for (const node of STAGE_OUTPUT_NODES[stage]) preservedNodes.add(node)
+    }
+  }
+
+  if (preservedNodes.size === 0) return clearNodes
+  return clearNodes.filter((node) => !preservedNodes.has(node))
 }
 
 /** Resource tags that should be refreshed when a node is updated or cleared. */


### PR DESCRIPTION
## What & why

On a re-run of the **Glossary** step, manually added terms, user-edited terms, and pruned state were silently lost. This delivers the **Glossary** item of #327 (lock manually edited items from being re-generated) and is a concrete step toward #144 (smarter handling of user-edited content).

## Root causes

1. **Manually added / pruned terms wiped on re-run.** The API/UI re-run path clears a stage's output nodes *before* the step handler runs (`makeBeforeRun` → `clearNodesByType`). For glossary this hard-deleted the node, so `runGlossaryStep`'s existing merge read an empty prior version and preserved nothing — the merge was effectively dead code.
2. **Edited AI terms lost.** Editing an AI term's definition/emoji kept `source: "ai"`. The merge only preserves `source: "manual"` (and pruned) items, so regeneration overwrote the edit.

## Changes

- **Keep the glossary node across a re-run** via a new range-aware `getStageRerunClearNodes(fromStage, toStage)` in `@adt/types`. A merge-preserving stage's own output is spared from the destructive pre-run clear **only when that stage is inside the run range** (so it will actually re-merge). When glossary is merely a downstream dependent that won't re-run, it's still cleared — stale AI glossary never survives silently.
- **Promote edited AI terms to `source: "manual"`** in `GlossaryView`, so edits survive regeneration through the existing (tested) manual-item merge path.
- **Shared helper** `regenerateGlossaryPreservingEdits()` in `@adt/pipeline` — consolidates the read → exclude-pruned → generate → merge logic that was duplicated (and had drifted) between the API stage runner and the CLI DAG runner, so the two can't diverge again.
- **"Book order" sort now actually sorts by book order.** The default glossary sort labeled *Book order* was returning the stored (alphabetical) order. It now sorts by each term's first appearance in the book (first-occurrence page), alphabetical tiebreak; terms not found in the text fall to the end.

## Testing

- `tsc --build` clean across types / pipeline / api / studio.
- Tests pass: glossary, pipeline-dag, `pipeline-effects` (new range-aware spare cases), stage-runner, books.
- Studio lint clean.

## Notes / out of scope

- **text-catalog freshness:** a glossary *stage* re-run doesn't rebuild `text-catalog` (only the manual-edit PUT route does). Pre-existing and follows the pipeline's stage-dependency model; left as-is to keep scope focused.
- **UX:** an edited AI term now shows as manual (pencil icon; Delete instead of Prune). Consistent with the product model ("manual entries stay across re-runs"); can switch to a dedicated `edited` flag if the affordance change is unwanted.

Relates to #327 (Glossary), #144.
