### PR TITLE
fix(epub): size read-aloud highlight to cover each word in fixed layout

### DIFF
--- a/packages/pipeline/src/__tests__/package-epub.test.ts
+++ b/packages/pipeline/src/__tests__/package-epub.test.ts
@@ -106,6 +106,33 @@ describe("wrapWordSpans", () => {
     )
   })
 
+  it("sizes each word wrapper to its largest segment font-size so the read-aloud highlight covers the word", () => {
+    // The media-overlay active class paints the word wrapper's own inline
+    // background box, whose height follows the wrapper's font-size. In
+    // fixed-layout the size lives only on the inner styled spans, so an
+    // unsized wrapper would inherit the ~16px page default and highlight a
+    // thin sliver behind a 48px word. The wrapper must mirror the word's
+    // size — the largest segment size when a word straddles two sizes.
+    const segments = [
+      { text: "big ", style: { "font-size": "48px", color: "#000000" } },
+      // "wo|rd" straddles a 24px → 48px style boundary; the wrapper takes 48.
+      { text: "wo", style: { "font-size": "24px", color: "#000000" } },
+      { text: "rd", style: { "font-size": "48px", color: "#000000" } },
+    ]
+    const dataSegments = JSON.stringify(segments).replace(/"/g, "&quot;")
+    const html =
+      `<html><body><p data-id="pg001_p000" data-segments="${dataSegments}">` +
+      `<span style="font-size:48px;color:#000000">big </span>` +
+      `<span style="font-size:24px;color:#000000">wo</span>` +
+      `<span style="font-size:48px;color:#000000">rd</span>` +
+      `</p></body></html>`
+    const out = wrapWordSpans(html)
+    // Single-size word takes that size.
+    expect(out).toContain(`<span id="pg001_p000_w001" style="font-size:48px">`)
+    // Straddling word takes the largest of its two segment sizes.
+    expect(out).toContain(`<span id="pg001_p000_w002" style="font-size:48px">`)
+  })
+
   it("styles inter-word separators with the surrounding segment so spaces keep the display font-size", () => {
     // Regression: in fixed-layout the font-size lives only on the per-segment
     // span and the <p> has none, so a bare-text-node space inherits the page
@@ -122,9 +149,10 @@ describe("wrapWordSpans", () => {
       `</p></body></html>`
     const out = wrapWordSpans(html)
     // The space between the two words is wrapped in a font-sized span, not a
-    // bare text node directly under <p>.
+    // bare text node directly under <p>. The word wrappers also carry the
+    // word's font-size so the media-overlay highlight box covers the glyphs.
     expect(out).toMatch(
-      /<span id="pg001_p000_w001"><span style="font-size:48px;color:#000000">I<\/span><\/span><span style="font-size:48px;color:#000000"> <\/span><span id="pg001_p000_w002">/,
+      /<span id="pg001_p000_w001" style="font-size:48px"><span style="font-size:48px;color:#000000">I<\/span><\/span><span style="font-size:48px;color:#000000"> <\/span><span id="pg001_p000_w002" style="font-size:48px">/,
     )
     // And no bare space sits directly between the closing word span and the
     // next word span.

--- a/packages/pipeline/src/package-epub.ts
+++ b/packages/pipeline/src/package-epub.ts
@@ -927,9 +927,48 @@ function wrapBySegments(
     wordIdx += 1
     const wrap = doc.createElement("span")
     wrap.setAttribute("id", wordIdFor(dataId, wordIdx))
+    // Fixed-layout words carry font-size only on the inner per-segment
+    // spans; the word wrapper itself would inherit the page's ~16px
+    // default. The media-overlay read-aloud highlight (media:active-class)
+    // paints the *wrapper's* inline background box, whose height is the
+    // wrapper's own font content-area — so without a matching font-size the
+    // yellow bar renders as a ~16px sliver behind a 48px word. Mirror the
+    // word's own (largest) segment size onto the wrapper so the highlight
+    // covers the whole word. Purely a paint-box hint: all glyphs live in the
+    // styled pieces, so the wrapper renders no text and its width/advance is
+    // unchanged. Emitted inline so the runtime auto-fit script shrinks it in
+    // lockstep with the pieces it also targets.
+    const wordFontSize = maxSegmentFontSize(segments, segOffsets, tok.start, tok.end)
+    if (wordFontSize !== undefined) wrap.setAttribute("style", `font-size:${wordFontSize}px`)
     for (const piece of buildPieces(tok.start, tok.end)) wrap.appendChild(piece)
     parent.appendChild(wrap)
   }
+}
+
+/**
+ * Largest `font-size` (in px) among the segments overlapping [start, end)
+ * in concat coordinates, or `undefined` when none of them declares one.
+ * Fixed-layout segment sizes are always authored in px by the renderer, so
+ * a bare number of px is a safe round-trip.
+ */
+function maxSegmentFontSize(
+  segments: { text?: string; style?: Record<string, string> }[],
+  segOffsets: number[],
+  start: number,
+  end: number,
+): number | undefined {
+  let max = 0
+  for (let i = 0; i < segments.length; i++) {
+    const segStart = segOffsets[i]
+    const segEnd = segStart + (segments[i]?.text ?? "").length
+    if (segEnd <= start) continue
+    if (segStart >= end) break
+    const fsRaw = segments[i]?.style?.["font-size"]
+    if (!fsRaw) continue
+    const fs = parseFloat(fsRaw)
+    if (Number.isFinite(fs) && fs > max) max = fs
+  }
+  return max > 0 ? max : undefined
 }
 
 function wrapTextNodes(

--- a/packages/pipeline/src/package-web.ts
+++ b/packages/pipeline/src/package-web.ts
@@ -1030,10 +1030,18 @@ body {
 
 /* SMIL media-overlay active class — declared in the OPF as
    media:active-class. EPUB readers toggle this on the active text
-   element during read-aloud playback. */
+   element (a per-word span with an id) during read-aloud playback. The
+   word wrapper carries the word's own font-size (set by wrapWordSpans), so
+   this inline background box is sized to the glyphs and covers the whole
+   word. The em radius tracks that font-size; vertical padding gives the
+   highlight a little breathing room without affecting layout (inline
+   vertical padding doesn't shift surrounding text), so toggling the class
+   causes no reflow. */
 .-epub-media-overlay-active {
-  background: rgba(255, 235, 59, 0.4);
-  border-radius: 0.15em;
+  background: rgba(255, 222, 74, 0.55);
+  border-radius: 0.18em;
+  padding-top: 0.05em;
+  padding-bottom: 0.05em;
 }
 </style>`
 


### PR DESCRIPTION
## Problem

Media-overlay (read-aloud) highlighting in fixed-layout EPUBs painted a thin yellow strip that didn't cover each word — a ~16px band behind 48px display text.

## Cause

The word wrappers `<span id="…_wNNN">` — the SMIL `media:active-class` targets — carry no font-size; in fixed layout the size lives only on the inner per-segment spans. An inline element's background box is painted over its own font content-area (font-size-driven, **not** line-height), so the unsized wrapper inherited the page's ~16px default and highlighted a sliver behind the glyphs.

## Fix

- Mirror each word's largest segment font-size onto its wrapper so the highlight box matches the glyphs — including mixed-size words that straddle style runs. The wrapper has to stay the single per-word id (epubcheck forbids duplicate ids; Whisper emits one timestamp per word), so inverting the nesting isn't a clean option. Emitted inline so the runtime auto-fit script scales it in lockstep with the pieces it already targets.
- Warm up the active-class rule: more opaque yellow, slightly larger radius, small vertical padding for breathing room (toggle-safe — inline vertical padding doesn't reflow surrounding text).