### PR TITLE
feat(studio): "What's new" button + fix release banner layout shift

### DIFF
--- a/apps/studio/src/components/updates/PostUpdateDialog.tsx
+++ b/apps/studio/src/components/updates/PostUpdateDialog.tsx
@@ -62,7 +62,7 @@ export function PostUpdateContent({
   const notes = releaseNotes?.trim()
 
   return (
-    <div className="flex h-[31rem] max-h-[calc(100vh-2rem)] flex-col">
+    <div className="flex h-160 max-h-[calc(100vh-2rem)] flex-col">
       <div className="flex shrink-0 items-center gap-3 px-6 pb-4 pt-6">
         <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
           <Sparkles className="size-5" />

--- a/apps/studio/src/components/updates/ReleaseFallbackBanner.tsx
+++ b/apps/studio/src/components/updates/ReleaseFallbackBanner.tsx
@@ -3,6 +3,7 @@ import { cn } from "@/lib/utils"
 import {
   formatVersion,
   getReleaseChannel,
+  RELEASE_BANNER_ASPECT,
   type ReleaseChannel,
 } from "./release-banner-utils"
 import betaIconSrc from "../../assets/update-icons/beta-512x512.png?url"
@@ -32,7 +33,8 @@ export function ReleaseFallbackBanner({
   return (
     <div
       className={cn(
-        "relative isolate aspect-[16/9] w-full overflow-hidden rounded-lg border",
+        "relative isolate w-full overflow-hidden rounded-lg border",
+        RELEASE_BANNER_ASPECT,
         "shadow-[0_18px_50px_oklch(0.22_0.04_260/0.16)]",
         isBeta
           ? "border-[oklch(0.72_0.22_302/0.34)] bg-[oklch(0.26_0.14_298)] text-[oklch(0.98_0.01_300)]"

--- a/apps/studio/src/components/updates/ReleaseNotesMarkdown.tsx
+++ b/apps/studio/src/components/updates/ReleaseNotesMarkdown.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode } from "react"
 import { cn } from "@/lib/utils"
+import { RELEASE_BANNER_ASPECT } from "./release-banner-utils"
 
 export interface ReleaseNotesMarkdownProps {
   children: string
@@ -58,7 +59,10 @@ export function ReleaseNotesMarkdown({
               src={block.src}
               alt={block.alt}
               loading="lazy"
-              className="max-w-full rounded-lg border"
+              className={cn(
+                "w-full rounded-lg border bg-muted/30 object-cover",
+                RELEASE_BANNER_ASPECT,
+              )}
             />
           )
         }

--- a/apps/studio/src/components/updates/UpdateDialog.tsx
+++ b/apps/studio/src/components/updates/UpdateDialog.tsx
@@ -27,6 +27,7 @@ export interface UpdateDialogProps {
   onOpenChange: (open: boolean) => void
   statusOverride?: UpdateStatus
   modal?: boolean
+  onShowWhatsNew?: () => void
 }
 
 type Tone = "muted" | "info" | "success" | "danger"
@@ -47,6 +48,7 @@ export function UpdateDialog({
   onOpenChange,
   statusOverride,
   modal,
+  onShowWhatsNew,
 }: UpdateDialogProps) {
   const currentVersion = useAppVersion()
   const live = useUpdateStatus()
@@ -74,6 +76,7 @@ export function UpdateDialog({
             close()
           }}
           onClose={close}
+          onShowWhatsNew={onShowWhatsNew}
         />
       </DialogContent>
     </Dialog>
@@ -89,6 +92,7 @@ export interface UpdateStateSurfaceProps {
   onInstallNow?: () => void
   onInstallLater?: () => void
   onClose?: () => void
+  onShowWhatsNew?: () => void
   TitleTag?: ElementType
 }
 
@@ -101,6 +105,7 @@ export function UpdateStateSurface({
   onInstallNow,
   onInstallLater,
   onClose,
+  onShowWhatsNew,
   TitleTag = "h2",
 }: UpdateStateSurfaceProps) {
   const noop = () => {}
@@ -113,6 +118,7 @@ export function UpdateStateSurface({
     onInstallNow: onInstallNow ?? noop,
     onInstallLater: onInstallLater ?? noop,
     onClose: onClose ?? noop,
+    onShowWhatsNew,
   })
 
   if (view.loading) {
@@ -173,6 +179,7 @@ interface BuildViewArgs {
   onInstallNow: () => void
   onInstallLater: () => void
   onClose: () => void
+  onShowWhatsNew?: () => void
 }
 
 function buildView({
@@ -184,6 +191,7 @@ function buildView({
   onInstallNow,
   onInstallLater,
   onClose,
+  onShowWhatsNew,
 }: BuildViewArgs): DialogView {
   const current = currentVersion ?? undefined
 
@@ -329,9 +337,17 @@ function buildView({
       </div>
     ) : undefined,
     actions: (
-      <Button onClick={onClose}>
-        <Trans>Done</Trans>
-      </Button>
+      <>
+        {onShowWhatsNew && (
+          <Button variant="outline" onClick={onShowWhatsNew}>
+            <Sparkles />
+            <Trans>What's new</Trans>
+          </Button>
+        )}
+        <Button onClick={onClose}>
+          <Trans>Done</Trans>
+        </Button>
+      </>
     ),
   }
 }

--- a/apps/studio/src/components/updates/UpdateDialogProvider.tsx
+++ b/apps/studio/src/components/updates/UpdateDialogProvider.tsx
@@ -10,6 +10,7 @@ import {
 } from "react"
 import { UpdateDialog } from "./UpdateDialog"
 import { PostUpdateDialog } from "./PostUpdateDialog"
+import { useAppVersion } from "@/hooks/use-app-version"
 import { useUpdateStatus } from "@/hooks/use-update-status"
 import { isElectron } from "@/lib/utils"
 
@@ -29,12 +30,14 @@ export function useUpdateDialog(): UpdateDialogContextValue {
 
 export function UpdateDialogProvider({ children }: { children: ReactNode }) {
   const { status, check } = useUpdateStatus()
+  const currentVersion = useAppVersion()
   const [open, setOpen] = useState(false)
   const autoOpenedFor = useRef<string | null>(null)
 
   const [postUpdate, setPostUpdate] = useState<ElectronPostUpdateInfo | null>(
     null,
   )
+  const [whatsNewOpen, setWhatsNewOpen] = useState(false)
 
   const phase = status.phase
   const hasPendingUpdate =
@@ -65,23 +68,39 @@ export function UpdateDialogProvider({ children }: { children: ReactNode }) {
     }
   }, [phase, check])
 
+  const showWhatsNew = useCallback(() => {
+    setOpen(false)
+    setWhatsNewOpen(true)
+  }, [])
+
   const value = useMemo(
     () => ({ openUpdateDialog, hasPendingUpdate }),
     [openUpdateDialog, hasPendingUpdate],
   )
 
+  const whatsNewVersion = postUpdate?.version ?? currentVersion ?? ""
+  const whatsNewNotes = postUpdate?.releaseNotes
+  const showPostUpdate = Boolean(postUpdate) || whatsNewOpen
+
   return (
     <UpdateDialogContext value={value}>
       {children}
-      <UpdateDialog open={open} onOpenChange={setOpen} />
-      {postUpdate && (
+      <UpdateDialog
+        open={open}
+        onOpenChange={setOpen}
+        onShowWhatsNew={showWhatsNew}
+      />
+      {showPostUpdate && (
         <PostUpdateDialog
           open
           onOpenChange={(next) => {
-            if (!next) setPostUpdate(null)
+            if (!next) {
+              setPostUpdate(null)
+              setWhatsNewOpen(false)
+            }
           }}
-          version={postUpdate.version}
-          releaseNotes={postUpdate.releaseNotes}
+          version={whatsNewVersion}
+          releaseNotes={whatsNewNotes}
         />
       )}
     </UpdateDialogContext>

--- a/apps/studio/src/components/updates/release-banner-utils.ts
+++ b/apps/studio/src/components/updates/release-banner-utils.ts
@@ -1,4 +1,5 @@
 export type ReleaseChannel = "stable" | "beta"
+export const RELEASE_BANNER_ASPECT = "aspect-[3/2]"
 
 export function getReleaseChannel(version: string): ReleaseChannel {
   return version.toLowerCase().includes("-beta") ? "beta" : "stable"


### PR DESCRIPTION
## What & why

Reworks the **What's new** update experience so users can revisit release notes and the modal no longer jumps when the release image loads.

### Changes
- **"What's new" button** — added to the update dialog's *"You're all set"* view so users can reopen the What's new modal for the current version at any time (previously it only appeared automatically right after an update).
- **Taller dialog** — the What's new modal gets more vertical room so the release notes are no longer clipped behind the banner image.
- **No layout shift** — introduced a shared `RELEASE_BANNER_ASPECT` (3:2, matching the generated 1536×1024 release images) used by both the fallback banner and the loaded release image. The image slot now reserves its box before load, so content no longer reflows when the real image finishes loading. The fallback banner was 16:9 and is now 3:2 to stay consistent.

### Verified
- Measured the modal with the release image load delayed: image box and footer position are identical before (`naturalWidth: 0`) and after (`naturalWidth: 1536`) the image loads — **0px shift**.
- `pnpm --filter @adt/studio extract` → no new/missing catalog entries (the "What's new" string already existed).
- Typecheck clean on the touched files.

### Notes
- When opened **manually** (vs. right after an update), the modal shows the current version with the fallback banner + generic "general improvements and fixes" text, since release notes for the *installed* version aren't available at runtime. Wiring the manual button to fetch the real changelog (IPC → GitHub releases) is a possible follow-up.
