### PR TITLE
fix(release): pin changelog baseline with --notes-start-tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
       version: ${{ steps.tag.outputs.version }}
       prerelease: ${{ steps.tag.outputs.prerelease }}
       docker_tags: ${{ steps.tag.outputs.docker_tags }}
+      prev_tag: ${{ steps.tag.outputs.prev_tag }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -96,9 +97,20 @@ jobs:
           if [[ "$PRERELEASE" == "false" ]]; then
             DOCKER_TAGS="$DOCKER_TAGS"$'\n'"ghcr.io/unicef/adt-studio:latest"
           fi
+          # Changelog baseline: pin the previous tag so release-note generation
+          # never falls back to the repo's first commit when GitHub can't infer
+          # an ancestor (stable and beta tags live on divergent branch lines).
+          # Stable releases diff against the previous stable so the notes cover
+          # the whole beta cycle; prereleases diff against the most recent tag.
+          if [[ "$PRERELEASE" == "false" ]]; then
+            PREV_TAG=$(git tag --list 'v*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
+          else
+            PREV_TAG=$(git tag --list 'v*' | sort -V | tail -1)
+          fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "prerelease=$PRERELEASE" >> "$GITHUB_OUTPUT"
+          echo "prev_tag=$PREV_TAG" >> "$GITHUB_OUTPUT"
           {
             echo "docker_tags<<EOF"
             echo "$DOCKER_TAGS"
@@ -351,12 +363,15 @@ jobs:
           TAG: ${{ needs.prepare.outputs.tag }}
           REPO: ${{ github.repository }}
           PRERELEASE: ${{ needs.prepare.outputs.prerelease }}
+          PREV_TAG: ${{ needs.prepare.outputs.prev_tag }}
         run: |
           PRERELEASE_FLAG=""
           [[ "$PRERELEASE" == "true" ]] && PRERELEASE_FLAG="--prerelease"
+          START_TAG_FLAG=()
+          [[ -n "$PREV_TAG" ]] && START_TAG_FLAG=(--notes-start-tag "$PREV_TAG")
           gh release create "$TAG" --repo "$REPO" \
             --title "ADT Studio $TAG" \
-            --generate-notes $PRERELEASE_FLAG \
+            --generate-notes "${START_TAG_FLAG[@]}" $PRERELEASE_FLAG \
             dist/* \
             docker-compose.yml \
             scripts/windows-setup-and-run.bat


### PR DESCRIPTION
## Problem

The **v0.7.4** stable release notes were auto-generated with **168 PR entries starting from #130** — essentially the entire project history — instead of just the v0.7.4 changes.

`finalize` calls `gh release create --generate-notes` with **no `--notes-start-tag`**. GitHub's auto-baseline must be an *ancestor* of the new tag, but for a fresh stable neither prior tag qualifies:

- Stable tags (`v0.7.2`/`v0.7.3`) live on the `main` line.
- Beta tags (`v0.7.4-beta.*`) live on `develop`.

So neither `v0.7.3` nor `v0.7.4-beta.4` is an ancestor of `v0.7.4`, GitHub finds no baseline, and falls back to listing everything from the first commit.

## Fix

Compute the previous tag in the `prepare` job and pass it explicitly via `--notes-start-tag`:

- **Stable** releases diff against the previous **stable** tag → notes cover the whole beta cycle.
- **Prereleases** diff against the most recent tag of any kind.
- First-ever release (no prior tag) → flag omitted, falls back to auto (unchanged).

This bounds note generation regardless of branch-ancestry, so the blow-up can't recur.

## Notes

- The already-published v0.7.4 notes were rewritten by hand to the correct changelog; this PR prevents the next release from regenerating incorrectly.
- Longer term, consider keeping stable/beta tags on a shared lineage (e.g. merge `main` back into `develop` after each stable) so ancestry-based tooling behaves predictably.
