### PR TITLE
fix(desktop): quit-confirmation dialogs that actually close the app (#549)

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -16,6 +16,7 @@ import {
 
 import { registerAppInfoIpc } from "./ipc/app-info";
 import { registerTitleBarIpc } from "./ipc/title-bar";
+import { registerWindowCloseIpc } from "./ipc/window-close";
 import { registerFileDialogIpc } from "./ipc/file-dialog";
 import { registerSplashIpc } from "./ipc/splash";
 import { registerUpdatesIpc } from "./ipc/updates";
@@ -56,6 +57,7 @@ app.whenReady().then(async () => {
   registerStudioAppProtocol(join(__dirname, "../renderer"));
   registerHtmlRenderProtocol();
   registerTitleBarIpc();
+  registerWindowCloseIpc();
   registerFileDialogIpc();
 
   let apiProcess: Electron.UtilityProcess;
@@ -102,7 +104,7 @@ app.whenReady().then(async () => {
   });
 });
 
-app.on("before-quit", () => {
+app.on("will-quit", () => {
   stopApiServer();
 });
 

--- a/apps/desktop/src/main/ipc/window-close.ts
+++ b/apps/desktop/src/main/ipc/window-close.ts
@@ -1,0 +1,37 @@
+import { app, ipcMain, BrowserWindow } from "electron";
+
+const confirmedWindows = new WeakSet<BrowserWindow>();
+
+let isQuitting = false;
+
+app.on("before-quit", () => {
+  isQuitting = true;
+});
+
+export function attachCloseGuard(window: BrowserWindow): void {
+  window.webContents.on("will-prevent-unload", (event) => {
+    if (confirmedWindows.has(window)) {
+      confirmedWindows.delete(window);
+      event.preventDefault();
+      return;
+    }
+    window.webContents.send("window:close-requested");
+  });
+}
+
+export function registerWindowCloseIpc(): void {
+  ipcMain.on("window:confirm-close", (event) => {
+    const window = BrowserWindow.fromWebContents(event.sender);
+    if (!window) return;
+    confirmedWindows.add(window);
+    if (isQuitting) {
+      app.quit();
+    } else {
+      window.close();
+    }
+  });
+
+  ipcMain.on("window:cancel-close", () => {
+    isQuitting = false;
+  });
+}

--- a/apps/desktop/src/main/windows/main.ts
+++ b/apps/desktop/src/main/windows/main.ts
@@ -1,9 +1,10 @@
-import { app, shell, BrowserWindow, dialog } from "electron";
+import { app, shell, BrowserWindow } from "electron";
 import { join } from "path";
 import { is } from "@electron-toolkit/utils";
 import icon from "../../../build/icon.png?asset";
 import betaIcon from "../../../build/beta-icons/icon.png?asset";
 import { STUDIO_APP_ORIGIN } from "../protocols/studio-app";
+import { attachCloseGuard } from "../ipc/window-close";
 
 const appIcon = app.getVersion().includes("-beta") ? betaIcon : icon;
 
@@ -45,22 +46,7 @@ export function createMainWindow(): BrowserWindow {
     mainWindow.show();
   });
 
-  mainWindow.webContents.on("will-prevent-unload", async (event) => {
-    // TODO: ADD TRANSLATIONS
-    const { response } = await dialog.showMessageBox(mainWindow, {
-      type: "warning",
-      buttons: ["Stay", "Quit"],
-      defaultId: 0,
-      cancelId: 0,
-      noLink: true,
-      message: "Leave the app?",
-      detail: "Your current progress will be lost.",
-    });
-
-    if (response === 1) {
-      event.preventDefault();
-    }
-  });
+  attachCloseGuard(mainWindow);
 
   mainWindow.webContents.setWindowOpenHandler((details) => {
     shell.openExternal(details.url);

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -10,6 +10,9 @@ export interface WindowControlsApi {
   minimize: () => Promise<void>
   toggleMaximize: () => Promise<boolean>
   close: () => Promise<void>
+  confirmClose: () => void
+  cancelClose: () => void
+  onCloseRequested: (cb: () => void) => () => void
   isMaximized: () => Promise<boolean>
   isFullscreen: () => Promise<boolean>
   onMaximizeChange: (cb: (isMaximized: boolean) => void) => () => void

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -16,6 +16,13 @@ const windowControls = {
   toggleMaximize: (): Promise<boolean> =>
     ipcRenderer.invoke('window:toggle-maximize'),
   close: (): Promise<void> => ipcRenderer.invoke('window:close'),
+  confirmClose: (): void => ipcRenderer.send('window:confirm-close'),
+  cancelClose: (): void => ipcRenderer.send('window:cancel-close'),
+  onCloseRequested: (cb: () => void): (() => void) => {
+    const handler = () => cb()
+    ipcRenderer.on('window:close-requested', handler)
+    return () => ipcRenderer.off('window:close-requested', handler)
+  },
   isMaximized: (): Promise<boolean> => ipcRenderer.invoke('window:is-maximized'),
   isFullscreen: (): Promise<boolean> =>
     ipcRenderer.invoke('window:is-fullscreen'),

--- a/apps/studio/src/components/close-guard/CloseGuard.tsx
+++ b/apps/studio/src/components/close-guard/CloseGuard.tsx
@@ -1,0 +1,252 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type ComponentType,
+  type ReactNode,
+} from "react"
+import { Trans } from "@lingui/react/macro"
+import {
+  ArrowLeft,
+  DoorOpen,
+  Info,
+  LogOut,
+  TriangleAlert,
+  Wand2,
+} from "lucide-react"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import { cn } from "@/lib/utils"
+
+export type QuitIntent = "wizard" | "unsaved-changes"
+
+interface CloseGuardContextValue {
+  setIntent: (id: string, intent: QuitIntent | null) => void
+}
+
+const CloseGuardContext = createContext<CloseGuardContextValue | null>(null)
+
+const ACCENTS = {
+  amber: {
+    band: "bg-amber-500/10",
+    chip: "bg-amber-500/15 text-amber-600 ring-amber-500/25 dark:text-amber-400",
+    eyebrow: "text-amber-600/90 dark:text-amber-400/90",
+    callout: "border-amber-500/25 bg-amber-500/5",
+    calloutIcon: "text-amber-600 dark:text-amber-400",
+  },
+  sky: {
+    band: "bg-sky-500/10",
+    chip: "bg-sky-500/15 text-sky-600 ring-sky-500/25 dark:text-sky-400",
+    eyebrow: "text-sky-600/90 dark:text-sky-400/90",
+    callout: "border-sky-500/25 bg-sky-500/5",
+    calloutIcon: "text-sky-600 dark:text-sky-400",
+  },
+} as const
+
+function QuitDialogShell({
+  accent,
+  HeaderIcon,
+  CalloutIcon,
+  eyebrow,
+  title,
+  body,
+  callout,
+  confirmLabel,
+  onQuit,
+}: {
+  accent: keyof typeof ACCENTS
+  HeaderIcon: ComponentType<{ className?: string }>
+  CalloutIcon: ComponentType<{ className?: string }>
+  eyebrow: ReactNode
+  title: ReactNode
+  body: ReactNode
+  callout: ReactNode
+  confirmLabel: ReactNode
+  onQuit: () => void
+}) {
+  const a = ACCENTS[accent]
+  return (
+    <AlertDialogContent className="max-w-md gap-0 overflow-hidden p-0 [--tw-enter-translate-x:0]! [--tw-enter-translate-y:0]! [--tw-exit-translate-x:0]! [--tw-exit-translate-y:0]!">
+      <div className={cn("flex items-center gap-3.5 px-6 py-5", a.band)}>
+        <div
+          className={cn(
+            "flex h-12 w-12 shrink-0 items-center justify-center rounded-full ring-1",
+            a.chip,
+          )}
+        >
+          <HeaderIcon className="h-6 w-6" />
+        </div>
+        <div className="min-w-0 space-y-0.5">
+          <p
+            className={cn(
+              "text-[11px] font-semibold uppercase tracking-wide",
+              a.eyebrow,
+            )}
+          >
+            {eyebrow}
+          </p>
+          <AlertDialogTitle className="text-lg font-semibold leading-tight">
+            {title}
+          </AlertDialogTitle>
+        </div>
+      </div>
+
+      <div className="space-y-4 px-6 py-5">
+        <AlertDialogDescription className="text-sm leading-relaxed text-muted-foreground">
+          {body}
+        </AlertDialogDescription>
+        <div
+          className={cn(
+            "flex items-start gap-2.5 rounded-lg border px-3.5 py-3",
+            a.callout,
+          )}
+        >
+          <CalloutIcon className={cn("mt-0.5 h-4 w-4 shrink-0", a.calloutIcon)} />
+          <span className="text-sm text-muted-foreground">{callout}</span>
+        </div>
+      </div>
+
+      <AlertDialogFooter className="border-t bg-muted/20 px-6 py-4">
+        <AlertDialogCancel className="mt-0 gap-1.5">
+          <ArrowLeft className="h-4 w-4" />
+          <Trans>Stay</Trans>
+        </AlertDialogCancel>
+        <AlertDialogAction
+          onClick={onQuit}
+          className="gap-1.5 bg-destructive text-destructive-foreground transition-colors hover:bg-destructive/90"
+        >
+          <LogOut className="h-4 w-4" />
+          {confirmLabel}
+        </AlertDialogAction>
+      </AlertDialogFooter>
+    </AlertDialogContent>
+  )
+}
+
+/**
+ * Renders the desktop quit-confirmation modal.
+ *
+ * The Electron main process gates every window-close path (title-bar button,
+ * macOS traffic light, Cmd+Q, taskbar) and, when the renderer has a pending
+ * `beforeunload`, asks us to confirm via `onCloseRequested`. Which dialog we
+ * show depends on the active close intent registered via `useCloseIntent`:
+ * the wizard (no save concept) vs. unsaved pipeline changes. No-op on web.
+ */
+export function CloseGuardProvider({ children }: { children: ReactNode }) {
+  const controls =
+    typeof window !== "undefined" ? window.api?.windowControls : undefined
+
+  const intentsRef = useRef<Map<string, QuitIntent>>(new Map())
+  const quittingRef = useRef(false)
+  const [open, setOpen] = useState(false)
+  const [intent, setActiveIntent] = useState<QuitIntent>("unsaved-changes")
+
+  const setIntent = useCallback((id: string, next: QuitIntent | null) => {
+    if (next) intentsRef.current.set(id, next)
+    else intentsRef.current.delete(id)
+  }, [])
+
+  useEffect(() => {
+    if (!controls?.onCloseRequested) return
+    return controls.onCloseRequested(() => {
+      const active = new Set(intentsRef.current.values())
+      if (active.size === 0) {
+        controls.confirmClose()
+        return
+      }
+      quittingRef.current = false
+      setActiveIntent(active.has("unsaved-changes") ? "unsaved-changes" : "wizard")
+      setOpen(true)
+    })
+  }, [controls])
+
+  const quit = useCallback(() => {
+    quittingRef.current = true
+    setOpen(false)
+    controls?.confirmClose()
+  }, [controls])
+
+  const handleOpenChange = useCallback(
+    (next: boolean) => {
+      if (!next && !quittingRef.current) controls?.cancelClose()
+      setOpen(next)
+    },
+    [controls],
+  )
+
+  return (
+    <CloseGuardContext.Provider value={{ setIntent }}>
+      {children}
+      <AlertDialog open={open} onOpenChange={handleOpenChange}>
+        {intent === "wizard" ? (
+          <QuitDialogShell
+            accent="sky"
+            HeaderIcon={Wand2}
+            CalloutIcon={Info}
+            onQuit={quit}
+            eyebrow={<Trans>Book setup</Trans>}
+            title={<Trans>Leave without finishing?</Trans>}
+            body={
+              <Trans>
+                You're partway through setting up a book. There's nothing to save
+                yet — leaving now discards your progress and you'll start over.
+              </Trans>
+            }
+            callout={
+              <Trans>
+                The file you uploaded and the options you picked won't be kept.
+              </Trans>
+            }
+            confirmLabel={<Trans>Leave setup</Trans>}
+          />
+        ) : (
+          <QuitDialogShell
+            accent="amber"
+            HeaderIcon={DoorOpen}
+            CalloutIcon={TriangleAlert}
+            onQuit={quit}
+            eyebrow={<Trans>Unsaved changes</Trans>}
+            title={<Trans>Quit without saving?</Trans>}
+            body={
+              <Trans>
+                You have changes that haven't been saved yet. If you quit now,
+                they'll be lost.
+              </Trans>
+            }
+            callout={
+              <Trans>Save your work first if you want to keep these changes.</Trans>
+            }
+            confirmLabel={<Trans>Quit anyway</Trans>}
+          />
+        )}
+      </AlertDialog>
+    </CloseGuardContext.Provider>
+  )
+}
+
+/**
+ * Declare the reason the app should confirm before quitting, so the desktop
+ * quit dialog can show the right message. While `active` is true this intent is
+ * registered; higher-specificity intents win when several are active. No-op on
+ * the web build (the browser shows its native beforeunload prompt instead).
+ */
+export function useCloseIntent(active: boolean, intent: QuitIntent): void {
+  const ctx = useContext(CloseGuardContext)
+  const id = useId()
+  useEffect(() => {
+    if (!ctx) return
+    ctx.setIntent(id, active ? intent : null)
+    return () => ctx.setIntent(id, null)
+  }, [ctx, id, active, intent])
+}

--- a/apps/studio/src/components/pipeline/components/UnsavedChangesGuard.tsx
+++ b/apps/studio/src/components/pipeline/components/UnsavedChangesGuard.tsx
@@ -24,6 +24,7 @@ import {
 import { getSettingsTabLabel } from "../settings-tabs"
 import { STAGES } from "../stage-config"
 import { getStageLabelI18n } from "../pipeline-i18n"
+import { useCloseIntent } from "@/components/close-guard/CloseGuard"
 
 const STAGE_BY_SLUG = new Map<string, (typeof STAGES)[number]>(STAGES.map((s) => [s.slug, s]))
 
@@ -32,6 +33,8 @@ export function UnsavedChangesGuard() {
   const hasFloatingUnsaved = useHasUnsavedChanges()
   const hasDirtyTab = useHasAnyDirtyTab()
   const hasUnsaved = hasFloatingUnsaved || hasDirtyTab
+
+  useCloseIntent(hasUnsaved, "unsaved-changes")
   const dirtyEntries = useDirtyTabEntries()
   const floatingDirtyEntries = useFloatingSaveDirtyEntries()
   const ephemeralDirtyTabs = useEphemeralDirtyTabs()

--- a/apps/studio/src/components/wizard/index.tsx
+++ b/apps/studio/src/components/wizard/index.tsx
@@ -9,6 +9,7 @@ import {
 } from "react"
 import type { ImageProcessingPreviewFocus } from "./step3ContentProcessing/imageProcessingPreviewTypes"
 import type { PresetId } from "./constants"
+import { useCloseIntent } from "@/components/close-guard/CloseGuard"
 
 export type WizardPhase = "upload" | "wizard"
 
@@ -36,14 +37,18 @@ export function WizardProvider({ children }: { children: ReactNode }) {
     setPhaseRaw(next)
   }, [])
 
+  const hasProgress = !(phase === "upload" && currentStep === 0)
+
+  useCloseIntent(hasProgress, "wizard")
+
   useEffect(() => {
-    if (phase === "upload" && currentStep === 0) return
+    if (!hasProgress) return
     const handler = (e: BeforeUnloadEvent) => {
       e.preventDefault()
     }
     window.addEventListener("beforeunload", handler)
     return () => window.removeEventListener("beforeunload", handler)
-  }, [phase, currentStep])
+  }, [hasProgress])
 
   const [previewFocus, setPreviewFocusRaw] =
     useState<ImageProcessingPreviewFocus>("idle")

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -1447,6 +1447,9 @@ msgstr "Book preview"
 msgid "Book Preview"
 msgstr "Book Preview"
 
+msgid "Book setup"
+msgstr "Book setup"
+
 msgid "Book Summary"
 msgstr "Book Summary"
 
@@ -3787,6 +3790,12 @@ msgstr "Leave empty to output only in the book language."
 msgid "Leave empty to use the book language."
 msgstr "Leave empty to use the book language."
 
+msgid "Leave setup"
+msgstr "Leave setup"
+
+msgid "Leave without finishing?"
+msgstr "Leave without finishing?"
+
 msgid "Legal and compliance manuals"
 msgstr "Legal and compliance manuals"
 
@@ -5414,6 +5423,12 @@ msgstr "queued"
 msgid "Queued"
 msgstr "Queued"
 
+msgid "Quit anyway"
+msgstr "Quit anyway"
+
+msgid "Quit without saving?"
+msgstr "Quit without saving?"
+
 msgid "quiz"
 msgstr "quiz"
 
@@ -6086,6 +6101,9 @@ msgstr "Save selection"
 
 msgid "Save settings"
 msgstr "Save settings"
+
+msgid "Save your work first if you want to keep these changes."
+msgstr "Save your work first if you want to keep these changes."
 
 msgid "Saved. Re-package Preview to apply."
 msgstr "Saved. Re-package Preview to apply."
@@ -7018,6 +7036,9 @@ msgstr "The entire page is treated as a single section - all text and images sta
 
 msgid "The file may be damaged or incomplete. Try downloading it again from the source."
 msgstr "The file may be damaged or incomplete. Try downloading it again from the source."
+
+msgid "The file you uploaded and the options you picked won't be kept."
+msgstr "The file you uploaded and the options you picked won't be kept."
 
 msgid "The following terms are used throughout this manual. Familiarity with these definitions is required before proceeding to the implementation chapters."
 msgstr "The following terms are used throughout this manual. Familiarity with these definitions is required before proceeding to the implementation chapters."
@@ -7994,6 +8015,9 @@ msgstr "Wraps 'Generate new' requests. Supports user_prompt, style, and image_ty
 msgid "You can export at this stage"
 msgstr "You can export at this stage"
 
+msgid "You have changes that haven't been saved yet. If you quit now, they'll be lost."
+msgstr "You have changes that haven't been saved yet. If you quit now, they'll be lost."
+
 #~ msgid "You have unsaved changes. If you leave, they'll be lost."
 #~ msgstr "You have unsaved changes. If you leave, they'll be lost."
 
@@ -8005,6 +8029,9 @@ msgstr "You're all set"
 
 msgid "You're now running ADT Studio {label}"
 msgstr "You're now running ADT Studio {label}"
+
+msgid "You're partway through setting up a book. There's nothing to save yet — leaving now discards your progress and you'll start over."
+msgstr "You're partway through setting up a book. There's nothing to save yet — leaving now discards your progress and you'll start over."
 
 msgid "You're running the latest version of ADT Studio."
 msgstr "You're running the latest version of ADT Studio."

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -1447,6 +1447,9 @@ msgstr "Vista previa del libro"
 msgid "Book Preview"
 msgstr "Vista Previa del Libro"
 
+msgid "Book setup"
+msgstr "Configuración del libro"
+
 msgid "Book Summary"
 msgstr "Resumen del libro"
 
@@ -3787,6 +3790,12 @@ msgstr "Dejar vacío para generar solo en el idioma del libro."
 msgid "Leave empty to use the book language."
 msgstr "Deja vacío para usar el idioma del libro."
 
+msgid "Leave setup"
+msgstr "Salir de la configuración"
+
+msgid "Leave without finishing?"
+msgstr "¿Salir sin terminar?"
+
 msgid "Legal and compliance manuals"
 msgstr "Manuales legales y de cumplimiento"
 
@@ -5414,6 +5423,12 @@ msgstr "en cola"
 msgid "Queued"
 msgstr "En cola"
 
+msgid "Quit anyway"
+msgstr "Salir de todos modos"
+
+msgid "Quit without saving?"
+msgstr "¿Salir sin guardar?"
+
 msgid "quiz"
 msgstr "cuestionario"
 
@@ -6086,6 +6101,9 @@ msgstr "Guardar selección"
 
 msgid "Save settings"
 msgstr "Save settings"
+
+msgid "Save your work first if you want to keep these changes."
+msgstr "Guarda tu trabajo primero si quieres conservar estos cambios."
 
 msgid "Saved. Re-package Preview to apply."
 msgstr "Saved. Re-package Preview to apply."
@@ -7018,6 +7036,9 @@ msgstr "Toda la página se trata como una sola sección - todo el texto e imáge
 
 msgid "The file may be damaged or incomplete. Try downloading it again from the source."
 msgstr "El archivo puede estar dañado o incompleto. Intenta descargarlo nuevamente desde la fuente."
+
+msgid "The file you uploaded and the options you picked won't be kept."
+msgstr "No se conservarán el archivo que subiste ni las opciones que elegiste."
 
 msgid "The following terms are used throughout this manual. Familiarity with these definitions is required before proceeding to the implementation chapters."
 msgstr "Los siguientes términos se utilizan a lo largo de este manual. Se requiere familiaridad con estas definiciones antes de proceder a los capítulos de implementación."
@@ -7994,6 +8015,9 @@ msgstr "Envuelve solicitudes de 'Generar nueva'. Soporta variables user_prompt, 
 msgid "You can export at this stage"
 msgstr "Puedes exportar en esta etapa"
 
+msgid "You have changes that haven't been saved yet. If you quit now, they'll be lost."
+msgstr "Tienes cambios que aún no se han guardado. Si sales ahora, se perderán."
+
 #~ msgid "You have unsaved changes. If you leave, they'll be lost."
 #~ msgstr "Tienes cambios no guardados. Si sales, se perderán."
 
@@ -8005,6 +8029,9 @@ msgstr "Todo listo"
 
 msgid "You're now running ADT Studio {label}"
 msgstr "Ahora estás usando ADT Studio {label}"
+
+msgid "You're partway through setting up a book. There's nothing to save yet — leaving now discards your progress and you'll start over."
+msgstr "Estás configurando un libro y todavía no hay nada que guardar: si sales ahora, descartarás tu progreso y tendrás que empezar de nuevo."
 
 msgid "You're running the latest version of ADT Studio."
 msgstr "Estás usando la última versión de ADT Studio."

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -1449,6 +1449,9 @@ msgstr "Livre aperçu"
 msgid "Book Preview"
 msgstr "Livre Aperçu"
 
+msgid "Book setup"
+msgstr "Configuration du livre"
+
 msgid "Book Summary"
 msgstr "Livre Résumé"
 
@@ -3789,6 +3792,12 @@ msgstr "Laissez vide pour une sortie uniquement dans la langue du livre."
 msgid "Leave empty to use the book language."
 msgstr "Laissez vide pour utiliser la langue du livre."
 
+msgid "Leave setup"
+msgstr "Quitter la configuration"
+
+msgid "Leave without finishing?"
+msgstr "Quitter sans terminer ?"
+
 msgid "Legal and compliance manuals"
 msgstr "Manuels juridiques et de conformité"
 
@@ -5416,6 +5425,12 @@ msgstr "en file d’attente"
 msgid "Queued"
 msgstr "En file d'attente"
 
+msgid "Quit anyway"
+msgstr "Quitter quand même"
+
+msgid "Quit without saving?"
+msgstr "Quitter sans enregistrer ?"
+
 msgid "quiz"
 msgstr "quiz"
 
@@ -6088,6 +6103,9 @@ msgstr "Enregistrer la sélection"
 
 msgid "Save settings"
 msgstr "Enregistrer les paramètres"
+
+msgid "Save your work first if you want to keep these changes."
+msgstr "Enregistrez d'abord votre travail si vous souhaitez conserver ces modifications."
 
 msgid "Saved. Re-package Preview to apply."
 msgstr "Enregistré. Ré-empaquetez l'aperçu pour appliquer."
@@ -7020,6 +7038,9 @@ msgstr "La page entière est traitée comme une seule section — tout le texte 
 
 msgid "The file may be damaged or incomplete. Try downloading it again from the source."
 msgstr "Le fichier peut être endommagé ou incomplet. Essayez de le télécharger à nouveau depuis la source."
+
+msgid "The file you uploaded and the options you picked won't be kept."
+msgstr "Le fichier que vous avez importé et les options que vous avez choisies ne seront pas conservés."
 
 msgid "The following terms are used throughout this manual. Familiarity with these definitions is required before proceeding to the implementation chapters."
 msgstr "Les termes suivants sont utilisés tout au long de ce manuel. La connaissance de ces définitions est requise avant de passer aux chapitres de mise en œuvre."
@@ -7996,6 +8017,9 @@ msgstr "Encapsule les requêtes « Générer nouveau ». Prend en charge les var
 msgid "You can export at this stage"
 msgstr "Vous pouvez exporter à cette étape"
 
+msgid "You have changes that haven't been saved yet. If you quit now, they'll be lost."
+msgstr "Vous avez des modifications qui n'ont pas encore été enregistrées. Si vous quittez maintenant, elles seront perdues."
+
 #~ msgid "You have unsaved changes. If you leave, they'll be lost."
 #~ msgstr "Vous avez des modifications non enregistrées. Si vous quittez, elles seront perdues."
 
@@ -8007,6 +8031,9 @@ msgstr "Vous êtes à jour"
 
 msgid "You're now running ADT Studio {label}"
 msgstr "Vous utilisez maintenant ADT Studio {label}"
+
+msgid "You're partway through setting up a book. There's nothing to save yet — leaving now discards your progress and you'll start over."
+msgstr "Vous êtes en train de configurer un livre et il n'y a encore rien à enregistrer : quitter maintenant supprime votre progression et vous devrez tout recommencer."
 
 msgid "You're running the latest version of ADT Studio."
 msgstr "Vous utilisez la dernière version d’ADT Studio."

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -1447,6 +1447,9 @@ msgstr "Pré-visualização do livro"
 msgid "Book Preview"
 msgstr "Pré-visualização do Livro"
 
+msgid "Book setup"
+msgstr "Configuração do livro"
+
 msgid "Book Summary"
 msgstr "Resumo do livro"
 
@@ -3787,6 +3790,12 @@ msgstr "Deixe vazio para gerar apenas no idioma do livro."
 msgid "Leave empty to use the book language."
 msgstr "Deixe vazio para usar o idioma do livro."
 
+msgid "Leave setup"
+msgstr "Sair da configuração"
+
+msgid "Leave without finishing?"
+msgstr "Sair sem concluir?"
+
 msgid "Legal and compliance manuals"
 msgstr "Manuais legais e de conformidade"
 
@@ -5414,6 +5423,12 @@ msgstr "na fila"
 msgid "Queued"
 msgstr "Na fila"
 
+msgid "Quit anyway"
+msgstr "Sair mesmo assim"
+
+msgid "Quit without saving?"
+msgstr "Sair sem salvar?"
+
 msgid "quiz"
 msgstr "questionário"
 
@@ -6086,6 +6101,9 @@ msgstr "Salvar seleção"
 
 msgid "Save settings"
 msgstr "Save settings"
+
+msgid "Save your work first if you want to keep these changes."
+msgstr "Salve seu trabalho primeiro se quiser manter estas alterações."
 
 msgid "Saved. Re-package Preview to apply."
 msgstr "Saved. Re-package Preview to apply."
@@ -7018,6 +7036,9 @@ msgstr "A página inteira é tratada como uma única seção - todo o texto e im
 
 msgid "The file may be damaged or incomplete. Try downloading it again from the source."
 msgstr "O arquivo pode estar danificado ou incompleto. Tente baixá-lo novamente da fonte."
+
+msgid "The file you uploaded and the options you picked won't be kept."
+msgstr "O arquivo que você enviou e as opções que você escolheu não serão mantidos."
 
 msgid "The following terms are used throughout this manual. Familiarity with these definitions is required before proceeding to the implementation chapters."
 msgstr "Os seguintes termos são usados ao longo deste manual. Familiaridade com essas definições é necessária antes de prosseguir para os capítulos de implementação."
@@ -7994,6 +8015,9 @@ msgstr "Envolve solicitações de 'Gerar nova'. Suporta variáveis user_prompt, 
 msgid "You can export at this stage"
 msgstr "Você pode exportar nesta etapa"
 
+msgid "You have changes that haven't been saved yet. If you quit now, they'll be lost."
+msgstr "Você tem alterações que ainda não foram salvas. Se sair agora, elas serão perdidas."
+
 #~ msgid "You have unsaved changes. If you leave, they'll be lost."
 #~ msgstr "Você tem alterações não salvas. Se sair, elas serão perdidas."
 
@@ -8005,6 +8029,9 @@ msgstr "Tudo certo"
 
 msgid "You're now running ADT Studio {label}"
 msgstr "Agora você está usando o ADT Studio {label}"
+
+msgid "You're partway through setting up a book. There's nothing to save yet — leaving now discards your progress and you'll start over."
+msgstr "Você está configurando um livro e ainda não há nada para salvar: sair agora descarta seu progresso e você terá que começar de novo."
 
 msgid "You're running the latest version of ADT Studio."
 msgstr "Você está usando a versão mais recente do ADT Studio."

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -1448,6 +1448,9 @@ msgstr "Pamje paraprake e librit"
 msgid "Book Preview"
 msgstr "Pamje paraprake e librit"
 
+msgid "Book setup"
+msgstr "Konfigurimi i librit"
+
 msgid "Book Summary"
 msgstr "Përmbledhje e librit"
 
@@ -3788,6 +3791,12 @@ msgstr "Lëre bosh për të dalë vetëm në gjuhën e librit."
 msgid "Leave empty to use the book language."
 msgstr "Lëre bosh për të përdorur gjuhën e librit."
 
+msgid "Leave setup"
+msgstr "Dil nga konfigurimi"
+
+msgid "Leave without finishing?"
+msgstr "Dil pa përfunduar?"
+
 msgid "Legal and compliance manuals"
 msgstr "Manuale ligjore dhe të pajtueshmërisë"
 
@@ -5415,6 +5424,12 @@ msgstr "në radhë"
 msgid "Queued"
 msgstr "Në radhë"
 
+msgid "Quit anyway"
+msgstr "Dil gjithsesi"
+
+msgid "Quit without saving?"
+msgstr "Dil pa ruajtur?"
+
 msgid "quiz"
 msgstr "kuiz"
 
@@ -6087,6 +6102,9 @@ msgstr "Ruaj zgjedhjen"
 
 msgid "Save settings"
 msgstr "Ruaj cilësimet"
+
+msgid "Save your work first if you want to keep these changes."
+msgstr "Ruaje punën tënde më parë nëse dëshiron t'i mbash këto ndryshime."
 
 msgid "Saved. Re-package Preview to apply."
 msgstr "U ruajt. Ri-pako Parapamjen për ta aplikuar."
@@ -7019,6 +7037,9 @@ msgstr "I gjithë faqja trajtohet si një seksion i vetëm — i gjithë teksti 
 
 msgid "The file may be damaged or incomplete. Try downloading it again from the source."
 msgstr "Skedari mund të jetë i dëmtuar ose i paplotë. Provo ta shkarkosh sërish nga burimi."
+
+msgid "The file you uploaded and the options you picked won't be kept."
+msgstr "Skedari që ngarkove dhe opsionet që zgjodhe nuk do të ruhen."
 
 msgid "The following terms are used throughout this manual. Familiarity with these definitions is required before proceeding to the implementation chapters."
 msgstr "Termat e mëposhtëm përdoren gjatë gjithë këtij manuali. Njohja me këto përkufizime kërkohet para se të vazhdohet me kapitujt e zbatimit."
@@ -7995,6 +8016,9 @@ msgstr "Mbështjell kërkesat 'Gjenero të re'. Mbështet variablat user_prompt,
 msgid "You can export at this stage"
 msgstr "Mund të eksportosh në këtë fazë"
 
+msgid "You have changes that haven't been saved yet. If you quit now, they'll be lost."
+msgstr "Ke ndryshime që ende nuk janë ruajtur. Nëse del tani, ato do të humbasin."
+
 #~ msgid "You have unsaved changes. If you leave, they'll be lost."
 #~ msgstr "Ke ndryshime të paruajtura. Nëse largohesh, ato do të humbasin."
 
@@ -8006,6 +8030,9 @@ msgstr "Je gati"
 
 msgid "You're now running ADT Studio {label}"
 msgstr "Tani po përdor ADT Studio {label}"
+
+msgid "You're partway through setting up a book. There's nothing to save yet — leaving now discards your progress and you'll start over."
+msgstr "Je duke konfiguruar një libër dhe ende s'ka asgjë për të ruajtur — nëse del tani, progresi yt humbet dhe do të fillosh nga e para."
 
 msgid "You're running the latest version of ADT Studio."
 msgstr "Po përdor versionin më të fundit të ADT Studio."

--- a/apps/studio/src/main.tsx
+++ b/apps/studio/src/main.tsx
@@ -6,6 +6,7 @@ import { I18nProvider } from "@lingui/react"
 import { i18n } from "@lingui/core"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { LiveRegionAnnouncer } from "@/components/a11y/LiveRegionAnnouncer"
+import { CloseGuardProvider } from "@/components/close-guard/CloseGuard"
 import { usePreviewSettingsListener } from "@/hooks/use-preview-settings-listener"
 import { messages as enMessages } from "./locales/en.po"
 import { messages as ptBRMessages } from "./locales/pt-BR.po"
@@ -79,7 +80,9 @@ createRoot(document.getElementById("root")!).render(
         <TooltipProvider delayDuration={300}>
           <PreviewSettingsListener />
           <LiveRegionAnnouncer>
-            <RouterProvider router={router} />
+            <CloseGuardProvider>
+              <RouterProvider router={router} />
+            </CloseGuardProvider>
           </LiveRegionAnnouncer>
         </TooltipProvider>
       </QueryClientProvider>

--- a/apps/studio/src/vite-env.d.ts
+++ b/apps/studio/src/vite-env.d.ts
@@ -48,6 +48,9 @@ interface ElectronWindowControls {
   minimize: () => Promise<void>
   toggleMaximize: () => Promise<boolean>
   close: () => Promise<void>
+  confirmClose: () => void
+  cancelClose: () => void
+  onCloseRequested: (cb: () => void) => () => void
   isMaximized: () => Promise<boolean>
   isFullscreen: () => Promise<boolean>
   onMaximizeChange: (cb: (isMaximized: boolean) => void) => () => void


### PR DESCRIPTION
Closes #549.

## Problem

On the Choose a Preset screen (and any screen past the wizard's first step), clicking **Quit** in the "Leave the app?" confirmation did nothing — the app stayed open. The `will-prevent-unload` handler `await`ed an async `showMessageBox`, so `event.preventDefault()` (the call that *allows* the unload) ran after the synchronous event had already resolved to "block." Every close path hit the same dead end.

## Fix

Replaces the native OS dialog with an in-app, translatable confirmation, while keeping a single robust gate in the main process.

**Main process**
- One `will-prevent-unload` gate on the window — it catches every close path (title-bar button, macOS traffic light, `Cmd+Q`, taskbar) and both `beforeunload` sources (the wizard and the TanStack Router unsaved-changes blocker). Instead of a native dialog it sends `window:close-requested` to the renderer and closes only after `window:confirm-close`.
- `Cmd+Q` is distinguished from a plain window close: confirm runs `app.quit()` vs `window.close()`, **Stay** resets the quit intent (`window:cancel-close`), and the API is stopped on `will-quit` instead of `before-quit` so a cancelled quit no longer leaves a dead API server.

**Renderer**
- `CloseGuardProvider` shows the confirmation and picks the dialog by *close intent*:
  - **Wizard** — no save concept: _"Leave without finishing?"_
  - **Unsaved changes** — _"Quit without saving?"_
- A shared `QuitDialogShell` keeps them visually consistent (header band + icon, warning callout, footer). Centered fade/zoom (the corner-slide of the base `AlertDialogContent` is neutralized).
- No-op on the web build — the browser's native `beforeunload` prompt still applies.

## i18n
All new strings use Lingui macros; catalogs extracted and translated for `en`, `es`, `pt-BR`, `fr`, `sq` (0 missing).
