### PR TITLE
fix(studio): only show Split & merge panel for real split/merge activity

### DIFF
--- a/apps/api/src/services/part-service.ts
+++ b/apps/api/src/services/part-service.ts
@@ -115,12 +115,12 @@ function ledgerPath(bookDir: string): string {
 
 function readLedger(bookDir: string): PartsLedger {
   const p = ledgerPath(bookDir)
-  if (!fs.existsSync(p)) return { exported: [] }
+  if (!fs.existsSync(p)) return { exported: [], merged: [] }
   try {
     const parsed = PartsLedger.safeParse(JSON.parse(fs.readFileSync(p, "utf-8")))
-    return parsed.success ? parsed.data : { exported: [] }
+    return parsed.success ? parsed.data : { exported: [], merged: [] }
   } catch {
-    return { exported: [] }
+    return { exported: [], merged: [] }
   }
 }
 
@@ -131,12 +131,27 @@ function recordExportedRange(
   at: string,
   pageCount: number,
 ): void {
-  const exported = readLedger(bookDir).exported.filter(
+  const prev = readLedger(bookDir)
+  const exported = prev.exported.filter(
     (e) => !(e.startPage === range.startPage && e.endPage === range.endPage),
   )
   exported.push({ startPage: range.startPage, endPage: range.endPage, at })
   exported.sort((a, b) => a.startPage - b.startPage || a.endPage - b.endPage)
-  const ledger: PartsLedger = { exported, pageCount }
+  const ledger: PartsLedger = { exported, merged: prev.merged, pageCount }
+  fs.writeFileSync(ledgerPath(bookDir), JSON.stringify(ledger, null, 2) + "\n")
+}
+
+/** Record a merged page range in the coordinator's ledger. This is what marks a
+ *  book as genuinely assembled from parts — distinct from the pages-present
+ *  coverage, which every extracted book has. */
+function recordMergedRange(bookDir: string, range: PartRange, at: string): void {
+  const prev = readLedger(bookDir)
+  const merged = prev.merged.filter(
+    (e) => !(e.startPage === range.startPage && e.endPage === range.endPage),
+  )
+  merged.push({ startPage: range.startPage, endPage: range.endPage, at })
+  merged.sort((a, b) => a.startPage - b.startPage || a.endPage - b.endPage)
+  const ledger: PartsLedger = { exported: prev.exported, merged, pageCount: prev.pageCount }
   fs.writeFileSync(ledgerPath(bookDir), JSON.stringify(ledger, null, 2) + "\n")
 }
 
@@ -202,6 +217,10 @@ export interface SplitStatus {
   missingRanges: PartRange[]
   /** Every page is present. */
   fullyMerged: boolean
+  /** At least one part has actually been merged into this book (from the
+   *  ledger, not inferred from pages present). Distinguishes a genuinely
+   *  assembled coordinator book from a normally-extracted whole book. */
+  hasMergeActivity: boolean
 }
 
 export function computeSplitStatus(label: string, booksDir: string): SplitStatus {
@@ -209,7 +228,8 @@ export function computeSplitStatus(label: string, booksDir: string): SplitStatus
   const bookDir = path.join(path.resolve(booksDir), safeLabel)
   const pageCount = countPdfPages(readPdfBytes(bookDir, safeLabel))
 
-  const exported = readLedger(bookDir).exported.map((e) => ({
+  const ledger = readLedger(bookDir)
+  const exported = ledger.exported.map((e) => ({
     startPage: e.startPage,
     endPage: e.endPage,
   }))
@@ -227,6 +247,7 @@ export function computeSplitStatus(label: string, booksDir: string): SplitStatus
     mergedRanges,
     missingRanges,
     fullyMerged: pageCount > 0 && missingRanges.length === 0,
+    hasMergeActivity: ledger.merged.length > 0,
   }
 }
 
@@ -851,6 +872,10 @@ export function mergePart(
     } finally {
       targetDb.close()
     }
+
+    // Mark the coordinator as genuinely assembled from parts, so the split/merge
+    // panel stays visible for merge-only books (which carry no export ledger).
+    recordMergedRange(targetPaths.bookDir, manifest.range, manifest.createdAt)
 
     return {
       targetLabel: safeTarget,

--- a/apps/studio/src/api/client.ts
+++ b/apps/studio/src/api/client.ts
@@ -138,6 +138,7 @@ export interface SplitStatus {
   mergedRanges: PageRange[]
   missingRanges: PageRange[]
   fullyMerged: boolean
+  hasMergeActivity: boolean
 }
 
 /** Preview shape returned by the import endpoints for a lightweight part

--- a/apps/studio/src/components/parts/BookPartsPanel.tsx
+++ b/apps/studio/src/components/parts/BookPartsPanel.tsx
@@ -36,12 +36,13 @@ export function BookPartsPanel({ bookLabel }: { bookLabel: string }) {
     partInfoLoading || pdfInfoLoading || splitStatusLoading || configLoading
 
   // Only books in the split/merge world show the panel: those the user chose to
-  // split (`split_mode`), those with existing split activity (covers books
-  // split before the flag existed), and imported parts.
+  // split (`split_mode`), those with real split activity (exported parts or
+  // merged-in parts, tracked in the ledger — not inferred from pages present,
+  // which every extracted book has), and imported parts.
   const splitMode = activeConfig?.merged?.split_mode === true
   const hasSplitActivity =
     !!splitStatus &&
-    (splitStatus.exported.length > 0 || splitStatus.mergedRanges.length > 0)
+    (splitStatus.exported.length > 0 || splitStatus.hasMergeActivity)
   const relevant = !!partInfo || splitMode || hasSplitActivity
 
   // The wizard leaves a one-shot flag to scroll to and briefly highlight this

--- a/packages/types/src/part.ts
+++ b/packages/types/src/part.ts
@@ -58,6 +58,11 @@ export type ExportedPartEntry = z.infer<typeof ExportedPartEntry>
 
 export const PartsLedger = z.object({
   exported: z.array(ExportedPartEntry).default([]),
+  /** Page ranges merged into this book from completed parts. Recorded on merge
+   *  so the split/merge panel can tell a genuinely-assembled coordinator book
+   *  apart from a normally-extracted whole book (both have pages present, but
+   *  only merged books carry an entry here). */
+  merged: z.array(ExportedPartEntry).default([]),
   /** Total pages in the source PDF, recorded at export time so the book list
    *  can summarize split/merge coverage without re-parsing the PDF. */
   pageCount: z.number().int().min(0).optional(),


### PR DESCRIPTION
## Problem

The **Split & merge** panel on the book overview showed for regular whole books (e.g. a freshly generated \`raven\`), even though the user selected "whole book" and never split anything.

The visibility gate in \`BookPartsPanel\` was:

\`\`\`ts
const hasSplitActivity =
  !!splitStatus &&
  (splitStatus.exported.length > 0 || splitStatus.mergedRanges.length > 0)
\`\`\`

`mergedRanges` comes from `computeSplitStatus` → `contiguousRanges(pagesPresent(...))`, i.e. **every page present in the book's DB**. For any normally-extracted book that's non-empty, so the gate fired for essentially every book — defeating its purpose. The comment claimed it covered "books split before the flag existed," but pages-present can't distinguish "merged from parts" from "extracted normally."

## Fix

Track merge activity explicitly in the coordinator ledger instead of inferring it from pages present:

- `packages/types` — add a `merged[]` array to `PartsLedger`.
- `part-service` — carry `merged` through `readLedger`/`recordExportedRange`; add `recordMergedRange`, called in `mergePart` after a successful commit; expose `hasMergeActivity` on `SplitStatus`.
- `studio` — add `hasMergeActivity` to the `SplitStatus` client type; gate is now `exported.length > 0 || hasMergeActivity`.

`mergedRanges` is untouched, so the CoverageBar and page-1 hint still render coverage as before.

## Effect on existing books

| Book type | Marker | Result |
|---|---|---|
| Regular whole book | pages only | **hidden** ✅ (was the bug) |
| Imported part | `part.json` | shown (partInfo) |
| Coordinator that exported parts | `parts-ledger.json` exported | shown |
| Wizard "split" book | `split_mode` | shown |
| Merge-only book (going forward) | ledger `merged` | shown |

No on-disk migration — read-time gate change plus a new ledger write on future merges. Books merged *before* this change don't get a retroactive `merged` entry, but the normal coordinator workflow exports first (so they already have an `exported` ledger and stay visible).

## Testing

- `pnpm tsc --build` clean
- `vitest run part-service` — 13/13 pass