### PR TITLE
feature(pipeline): cancel running stages, error toast/sound, and page-error

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -23,6 +23,7 @@ import { createStageRoutes } from "./routes/stages.js"
 import { createTaskRoutes } from "./routes/tasks.js"
 import { createBookEventBus } from "./services/book-event-bus.js"
 import { createStageService } from "./services/stage-service.js"
+import { createPageErrorDecisions } from "./services/page-error-decisions.js"
 import { createStageRunner } from "./services/stage-runner.js"
 import { createTaskService } from "./services/task-service.js"
 import { createPresetRoutes } from "./routes/presets.js"
@@ -68,8 +69,9 @@ if (adtResourcesZip && fs.existsSync(adtResourcesZip)) {
 }
 
 const eventBus = createBookEventBus()
+const pageErrorDecisions = createPageErrorDecisions(eventBus)
 const stageRunner = createStageRunner()
-const stageService = createStageService(stageRunner, eventBus)
+const stageService = createStageService(stageRunner, eventBus, pageErrorDecisions)
 const taskService = createTaskService(eventBus)
 
 const app = new Hono()
@@ -104,7 +106,7 @@ app.route("/api", createFontRoutes(booksDir, promptsDir, configPath, taskService
 app.route("/api", createTTSRoutes(booksDir, configPath, taskService))
 app.route(
   "/api",
-  createStageRoutes(stageService, eventBus, booksDir, promptsDir, webAssetsDir, configPath)
+  createStageRoutes(stageService, eventBus, pageErrorDecisions, booksDir, promptsDir, webAssetsDir, configPath)
 )
 app.route("/api", createTaskRoutes(taskService))
 app.route("/api", createPresetRoutes(configPath))

--- a/apps/api/src/routes/books.test.ts
+++ b/apps/api/src/routes/books.test.ts
@@ -12,10 +12,12 @@ import type {
   StageRunOptions,
 } from "../services/stage-service.js"
 import { createBookEventBus } from "../services/book-event-bus.js"
+import { createPageErrorDecisions } from "../services/page-error-decisions.js"
 import { createBookRoutes } from "./books.js"
 import { createStageRoutes } from "./stages.js"
 
 const mockEventBus = createBookEventBus()
+const mockDecisions = createPageErrorDecisions(mockEventBus)
 
 let tmpDir: string
 
@@ -687,7 +689,7 @@ describe("POST /books/:label/stages/run", () => {
       },
     }
 
-    const app = createStageRoutes(stageService, mockEventBus, tmpDir, "", "")
+    const app = createStageRoutes(stageService, mockEventBus, mockDecisions, tmpDir, "", "")
     const res = await app.request(`/books/${label}/stages/run`, {
       method: "POST",
       headers: {
@@ -731,7 +733,7 @@ describe("POST /books/:label/stages/run", () => {
       },
     }
 
-    const app = createStageRoutes(stageService, mockEventBus, tmpDir, "", "")
+    const app = createStageRoutes(stageService, mockEventBus, mockDecisions, tmpDir, "", "")
     const res = await app.request(`/books/${label}/stages/run`, {
       method: "POST",
       headers: {
@@ -797,7 +799,7 @@ describe("GET /books/:label/step-status", () => {
   }
 
   it("returns all stages/steps idle when DB is missing and no run state exists", async () => {
-    const app = createStageRoutes(mockStageService(), mockEventBus, tmpDir, "", "")
+    const app = createStageRoutes(mockStageService(), mockEventBus, mockDecisions, tmpDir, "", "")
     const res = await app.request("/books/missing-db/step-status")
     expect(res.status).toBe(200)
     const body = await res.json()
@@ -817,6 +819,7 @@ describe("GET /books/:label/step-status", () => {
     const app = createStageRoutes(
       mockStageService({ queuedStages: ["extract", "storyboard"] }),
       mockEventBus,
+      mockDecisions,
       tmpDir,
       "",
       ""
@@ -837,6 +840,7 @@ describe("GET /books/:label/step-status", () => {
         active: makeActiveRun({ status: "failed", error: "pipeline failed" }),
       }),
       mockEventBus,
+      mockDecisions,
       tmpDir,
       "",
       ""
@@ -866,6 +870,7 @@ describe("GET /books/:label/step-status", () => {
         }),
       }),
       mockEventBus,
+      mockDecisions,
       tmpDir,
       "",
       ""
@@ -888,7 +893,7 @@ describe("GET /books/:label/step-status", () => {
     } finally {
       storage.close()
     }
-    const app = createStageRoutes(mockStageService(), mockEventBus, tmpDir, "", "")
+    const app = createStageRoutes(mockStageService(), mockEventBus, mockDecisions, tmpDir, "", "")
 
     const res = await app.request("/books/extract-incomplete/step-status")
     expect(res.status).toBe(200)
@@ -903,7 +908,7 @@ describe("GET /books/:label/step-status", () => {
   it("marks extract complete when all extract steps are done", async () => {
     createTestBook("extract-complete")
     markExtractStageComplete("extract-complete")
-    const app = createStageRoutes(mockStageService(), mockEventBus, tmpDir, "", "")
+    const app = createStageRoutes(mockStageService(), mockEventBus, mockDecisions, tmpDir, "", "")
 
     const res = await app.request("/books/extract-complete/step-status")
     expect(res.status).toBe(200)
@@ -919,6 +924,7 @@ describe("GET /books/:label/step-status", () => {
     const app = createStageRoutes(
       mockStageService({ queuedStages: ["extract"] }),
       mockEventBus,
+      mockDecisions,
       tmpDir,
       "",
       ""
@@ -940,7 +946,7 @@ describe("GET /books/:label/step-status", () => {
     } finally {
       storage.close()
     }
-    const app = createStageRoutes(mockStageService(), mockEventBus, tmpDir, "", "")
+    const app = createStageRoutes(mockStageService(), mockEventBus, mockDecisions, tmpDir, "", "")
 
     const res = await app.request("/books/step-error-test/step-status")
     expect(res.status).toBe(200)
@@ -959,7 +965,7 @@ describe("GET /books/:label/step-status", () => {
     } finally {
       storage.close()
     }
-    const app = createStageRoutes(mockStageService(), mockEventBus, tmpDir, "", "")
+    const app = createStageRoutes(mockStageService(), mockEventBus, mockDecisions, tmpDir, "", "")
 
     const res = await app.request("/books/step-running-test/step-status")
     expect(res.status).toBe(200)
@@ -977,7 +983,7 @@ describe("GET /books/:label/step-status", () => {
     } finally {
       storage.close()
     }
-    const app = createStageRoutes(mockStageService(), mockEventBus, tmpDir, "", "")
+    const app = createStageRoutes(mockStageService(), mockEventBus, mockDecisions, tmpDir, "", "")
 
     const res = await app.request("/books/step-message-test/step-status")
     expect(res.status).toBe(200)
@@ -1001,6 +1007,7 @@ describe("GET /books/:label/step-status", () => {
         active: makeActiveRun({ fromStage: "extract", toStage: "storyboard" }),
       }),
       mockEventBus,
+      mockDecisions,
       tmpDir,
       "",
       ""
@@ -1024,6 +1031,7 @@ describe("GET /books/:label/step-status", () => {
         active: makeActiveRun({ fromStage: "extract", toStage: "storyboard" }),
       }),
       mockEventBus,
+      mockDecisions,
       tmpDir,
       "",
       ""
@@ -1041,7 +1049,7 @@ describe("GET /books/:label/step-status", () => {
   it("returns null stepErrors when no errors exist", async () => {
     createTestBook("no-errors")
     markExtractStageComplete("no-errors")
-    const app = createStageRoutes(mockStageService(), mockEventBus, tmpDir, "", "")
+    const app = createStageRoutes(mockStageService(), mockEventBus, mockDecisions, tmpDir, "", "")
 
     const res = await app.request("/books/no-errors/step-status")
     expect(res.status).toBe(200)
@@ -1057,7 +1065,7 @@ describe("GET /books/:label/step-status", () => {
     } finally {
       storage.close()
     }
-    const app = createStageRoutes(mockStageService(), mockEventBus, tmpDir, "", "")
+    const app = createStageRoutes(mockStageService(), mockEventBus, mockDecisions, tmpDir, "", "")
 
     const res = await app.request("/books/derived-error/step-status")
     expect(res.status).toBe(200)
@@ -1079,7 +1087,7 @@ describe("GET /books/:label/step-status", () => {
     } finally {
       storage.close()
     }
-    const app = createStageRoutes(mockStageService(), mockEventBus, tmpDir, "", "")
+    const app = createStageRoutes(mockStageService(), mockEventBus, mockDecisions, tmpDir, "", "")
 
     const res = await app.request("/books/skipped-steps/step-status")
     expect(res.status).toBe(200)
@@ -1091,7 +1099,7 @@ describe("GET /books/:label/step-status", () => {
     createTestBook("preview-done")
     fs.mkdirSync(path.join(tmpDir, "preview-done", "adt"), { recursive: true })
 
-    const app = createStageRoutes(mockStageService(), mockEventBus, tmpDir, "", "")
+    const app = createStageRoutes(mockStageService(), mockEventBus, mockDecisions, tmpDir, "", "")
     const res = await app.request("/books/preview-done/step-status")
     expect(res.status).toBe(200)
     const body = await res.json()
@@ -1099,7 +1107,7 @@ describe("GET /books/:label/step-status", () => {
   })
 
   it("returns 400 for invalid book labels", async () => {
-    const app = createStageRoutes(mockStageService(), mockEventBus, tmpDir, "", "")
+    const app = createStageRoutes(mockStageService(), mockEventBus, mockDecisions, tmpDir, "", "")
     const res = await app.request("/books/-bad/step-status")
     expect(res.status).toBe(400)
   })

--- a/apps/api/src/routes/stages.ts
+++ b/apps/api/src/routes/stages.ts
@@ -5,15 +5,17 @@ import { streamSSE } from "hono/streaming"
 import { HTTPException } from "hono/http-exception"
 import { z } from "zod"
 import { createBookStorage, openBookDb } from "@adt/storage"
-import { StageName, STAGE_ORDER, PIPELINE, parseBookLabel, getStageRerunClearNodes, getStageClearOrder } from "@adt/types"
+import { StageName, STAGE_ORDER, PIPELINE, parseBookLabel, getStageRerunClearNodes, getStageClearOrder, PageErrorPolicy, DecisionBody } from "@adt/types"
 import type { StageService } from "../services/stage-service.js"
 import type { BookEventBus, BookSSEEvent } from "../services/book-event-bus.js"
+import type { PageErrorDecisions } from "../services/page-error-decisions.js"
 
 const StageRunBody = z
   .object({
     fromStage: StageName,
     toStage: StageName,
     renderOnly: z.boolean().optional(),
+    pageErrorPolicy: PageErrorPolicy.optional(),
   })
   .strict()
 
@@ -59,6 +61,7 @@ function formatStepErrors(stepErrors: Record<string, string>): string {
 export function createStageRoutes(
   stageService: StageService,
   eventBus: BookEventBus,
+  decisions: PageErrorDecisions,
   booksDir: string,
   promptsDir: string,
   webAssetsDir: string,
@@ -91,7 +94,7 @@ export function createStageRoutes(
       })
     }
 
-    const { fromStage, toStage, renderOnly } = parsed.data
+    const { fromStage, toStage, renderOnly, pageErrorPolicy } = parsed.data
 
     const anthropicApiKey = c.req.header("X-Anthropic-API-Key") || undefined
     const googleApiKey = c.req.header("X-Google-API-Key") || undefined
@@ -118,6 +121,7 @@ export function createStageRoutes(
       fromStage,
       toStage,
       renderOnly,
+      pageErrorPolicy,
       azureSpeechKey,
       azureSpeechRegion,
       geminiApiKey,
@@ -132,6 +136,42 @@ export function createStageRoutes(
     }
 
     return c.json({ status: result.status, label, fromStage, toStage })
+  })
+
+  // POST /books/:label/stages/cancel — Cancel the active run and clear the queue.
+  app.post("/books/:label/stages/cancel", (c) => {
+    const { label } = c.req.param()
+    const result = stageService.cancelStageRun(label)
+    if (!result) {
+      // Nothing to cancel. Benign race: the run may have completed between the
+      // click and this request — the frontend treats 404 as silent success.
+      throw new HTTPException(404, { message: "No active run to cancel" })
+    }
+    return c.json(result, 202)
+  })
+
+  // POST /books/:label/stages/decision — Resolve a pending page-error decision.
+  app.post("/books/:label/stages/decision", async (c) => {
+    let body: unknown
+    try {
+      body = await c.req.json()
+    } catch {
+      throw new HTTPException(400, { message: "Invalid JSON body" })
+    }
+    const parsed = DecisionBody.safeParse(body)
+    if (!parsed.success) {
+      throw new HTTPException(400, {
+        message: `Invalid decision: ${parsed.error.message}`,
+      })
+    }
+    const { decisionId, action, applyToAll } = parsed.data
+    const ok = decisions.resolveDecision(decisionId, action, applyToAll)
+    if (!ok) {
+      // Already resolved (timeout/cancel) or unknown — the frontend drops the
+      // stale dialog silently on 409.
+      throw new HTTPException(409, { message: "Decision already resolved" })
+    }
+    return c.json({ ok: true })
   })
 
   // GET /books/:label/step-status — Unified stage + step status
@@ -210,7 +250,9 @@ export function createStageRoutes(
         if (row?.status === "error" && row.error) {
           stepErrors[step.name] = row.error
         }
-        if (status === "running" && row?.message) {
+        // Surface the message for running steps (page X/Y) and for done steps
+        // (e.g. "Completed — 2 page(s) skipped") so a skip note survives refetch.
+        if ((status === "running" || status === "done") && row?.message) {
           stepMessages[step.name] = row.message
         }
       }
@@ -249,12 +291,20 @@ export function createStageRoutes(
     const hasStepMessages = Object.keys(stepMessages).length > 0
     const error = active?.error ?? (hasStepErrors ? formatStepErrors(stepErrors) : null)
 
+    // Expose the run's job status so `isCancelling` (and any future run-level
+    // state) survives a refresh, and any pending page-error decisions so the
+    // decision dialog can be recovered via polling after a reconnect/F5.
+    const runStatus = active?.status ?? "idle"
+    const pendingDecisions = decisions.getPendingDecisions(label)
+
     return c.json({
       stages,
       steps,
       error,
       stepErrors: hasStepErrors ? stepErrors : null,
       stepMessages: hasStepMessages ? stepMessages : null,
+      runStatus,
+      pendingDecisions,
     })
   })
 
@@ -311,6 +361,21 @@ export function createStageRoutes(
                     error: event.error,
                   }),
                 })
+              } else if (event.type === "stage-run-cancelled") {
+                await stream.writeSSE({
+                  event: "cancelled",
+                  data: JSON.stringify({ label: event.label }),
+                })
+              } else if (event.type === "decision-required") {
+                await stream.writeSSE({
+                  event: "decision-required",
+                  data: JSON.stringify({
+                    decisionId: event.decisionId,
+                    step: event.step,
+                    pageId: event.pageId,
+                    error: event.error,
+                  }),
+                })
               } else if (event.type === "task") {
                 await stream.writeSSE({
                   event: "task",
@@ -336,7 +401,9 @@ export function createStageRoutes(
     if (!active) {
       return c.json({ status: "idle", label, queue: [] })
     }
-    return c.json({ ...active, queue })
+    // Omit the internal AbortController from the serialized payload.
+    const { controller: _controller, ...activepublic } = active
+    return c.json({ ...activepublic, queue })
   })
 
   // Removed Feb 2026: POST /books/:label/steps/run was renamed to /stages/run.

--- a/apps/api/src/routes/stages.ts
+++ b/apps/api/src/routes/stages.ts
@@ -138,7 +138,7 @@ export function createStageRoutes(
     return c.json({ status: result.status, label, fromStage, toStage })
   })
 
-  // POST /books/:label/stages/cancel — Cancel the active run and clear the queue.
+  // POST /books/:label/stages/cancel — Cancel the active run. Queued runs remain queued.
   app.post("/books/:label/stages/cancel", (c) => {
     const { label } = c.req.param()
     const result = stageService.cancelStageRun(label)

--- a/apps/api/src/services/book-event-bus.ts
+++ b/apps/api/src/services/book-event-bus.ts
@@ -4,7 +4,16 @@ export type BookSSEEvent =
   | { type: "progress"; data: ProgressEvent }
   | { type: "stage-run-complete"; label: string }
   | { type: "stage-run-error"; label: string; error: string }
+  | { type: "stage-run-cancelled"; label: string }
   | { type: "queue-next"; label: string; fromStage: string; toStage: string }
+  | {
+      type: "decision-required"
+      label: string
+      decisionId: string
+      step: string
+      pageId: string
+      error: string
+    }
   | { type: "task"; data: TaskEvent }
 
 export type BookEventListener = (event: BookSSEEvent) => void
@@ -12,6 +21,9 @@ export type BookEventListener = (event: BookSSEEvent) => void
 export interface BookEventBus {
   emit(label: string, event: BookSSEEvent): void
   addListener(label: string, listener: BookEventListener): () => void
+  /** Whether at least one SSE listener is currently connected for a label.
+   *  Used by the page-error decision broker to detect a closed tab/app. */
+  hasListeners(label: string): boolean
 }
 
 export function createBookEventBus(): BookEventBus {
@@ -44,6 +56,11 @@ export function createBookEventBus(): BookEventBus {
           listeners.delete(label)
         }
       }
+    },
+
+    hasListeners(label: string): boolean {
+      const set = listeners.get(label)
+      return !!set && set.size > 0
     },
   }
 }

--- a/apps/api/src/services/page-error-decisions.test.ts
+++ b/apps/api/src/services/page-error-decisions.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, afterEach } from "vitest"
+import { createBookEventBus } from "./book-event-bus.js"
+import { createPageErrorDecisions } from "./page-error-decisions.js"
+
+const LABEL = "book-1"
+
+function withListener() {
+  const bus = createBookEventBus()
+  const unsub = bus.addListener(LABEL, () => {})
+  return { bus, unsub }
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe("page-error decisions broker", () => {
+  it("resolves with the user's choice (skip / stop)", async () => {
+    const { bus } = withListener()
+    const broker = createPageErrorDecisions(bus)
+
+    const p = broker.requestDecision({ label: LABEL, step: "web-rendering", pageId: "pg001", error: "x" })
+    const pending = broker.getPendingDecisions(LABEL)
+    expect(pending).toHaveLength(1)
+    expect(broker.resolveDecision(pending[0].decisionId, "skip")).toBe(true)
+    await expect(p).resolves.toBe("skip")
+    expect(broker.getPendingDecisions(LABEL)).toHaveLength(0)
+  })
+
+  it("applyToAll auto-resolves subsequent decisions without prompting", async () => {
+    const { bus } = withListener()
+    const broker = createPageErrorDecisions(bus)
+
+    const p1 = broker.requestDecision({ label: LABEL, step: "web-rendering", pageId: "pg001", error: "x" })
+    const id1 = broker.getPendingDecisions(LABEL)[0].decisionId
+    broker.resolveDecision(id1, "skip", true)
+    await expect(p1).resolves.toBe("skip")
+
+    // No prompt for the next one — resolves immediately from the bulk policy.
+    const p2 = broker.requestDecision({ label: LABEL, step: "web-rendering", pageId: "pg002", error: "y" })
+    await expect(p2).resolves.toBe("skip")
+    expect(broker.getPendingDecisions(LABEL)).toHaveLength(0)
+  })
+
+  it("resolveDecision on an unknown id returns false", () => {
+    const { bus } = withListener()
+    const broker = createPageErrorDecisions(bus)
+    expect(broker.resolveDecision("nope", "stop")).toBe(false)
+  })
+
+  it("clearForRun resolves pending as stop and drops the bulk policy", async () => {
+    const { bus } = withListener()
+    const broker = createPageErrorDecisions(bus)
+
+    const p = broker.requestDecision({ label: LABEL, step: "captions", pageId: "pg001", error: "x" })
+    broker.clearForRun(LABEL, "stop")
+    await expect(p).resolves.toBe("stop")
+    expect(broker.getPendingDecisions(LABEL)).toHaveLength(0)
+  })
+
+  it("with no listener, falls back to stop only after the grace period", async () => {
+    vi.useFakeTimers()
+    const bus = createBookEventBus() // no listener
+    const broker = createPageErrorDecisions(bus)
+
+    const p = broker.requestDecision({ label: LABEL, step: "web-rendering", pageId: "pg001", error: "x" })
+    // Consultable immediately from the start of the grace period.
+    expect(broker.getPendingDecisions(LABEL)).toHaveLength(1)
+
+    // Still pending well before the grace period elapses.
+    await vi.advanceTimersByTimeAsync(5_000)
+    expect(broker.getPendingDecisions(LABEL)).toHaveLength(1)
+
+    // After ~30s with no listener, resolves stop.
+    await vi.advanceTimersByTimeAsync(30_000)
+    await expect(p).resolves.toBe("stop")
+  })
+
+  it("a listener reconnecting within the grace period keeps the decision pending", async () => {
+    vi.useFakeTimers()
+    const bus = createBookEventBus()
+    const broker = createPageErrorDecisions(bus)
+
+    const p = broker.requestDecision({ label: LABEL, step: "web-rendering", pageId: "pg001", error: "x" })
+    // Listener appears after 2s (within grace).
+    await vi.advanceTimersByTimeAsync(2_000)
+    const unsub = bus.addListener(LABEL, () => {})
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    // Grace window passing no longer resolves it — it's on the 10-min timeout now.
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(broker.getPendingDecisions(LABEL)).toHaveLength(1)
+
+    // The 10-minute safety timeout still resolves stop eventually.
+    await vi.advanceTimersByTimeAsync(10 * 60 * 1000)
+    await expect(p).resolves.toBe("stop")
+    unsub()
+  })
+
+  it("resolves stop via the safety timeout when a listener is connected but idle", async () => {
+    vi.useFakeTimers()
+    const bus = createBookEventBus()
+    bus.addListener(LABEL, () => {})
+    const broker = createPageErrorDecisions(bus)
+
+    const p = broker.requestDecision({ label: LABEL, step: "web-rendering", pageId: "pg001", error: "x" })
+    await vi.advanceTimersByTimeAsync(10 * 60 * 1000)
+    await expect(p).resolves.toBe("stop")
+  })
+})

--- a/apps/api/src/services/page-error-decisions.ts
+++ b/apps/api/src/services/page-error-decisions.ts
@@ -1,0 +1,163 @@
+import crypto from "node:crypto"
+import type { PageErrorAction, PendingDecision } from "@adt/types"
+import type { BookEventBus } from "./book-event-bus.js"
+
+/** Safety net when a UI is connected but the user walks away. */
+const DECISION_TIMEOUT_MS = 10 * 60 * 1000
+/** Wait this long for an SSE listener to (re)connect before assuming the tab is
+ *  really gone. Covers the reconnect blip inherent to the SSE+polling hybrid. */
+const LISTENER_GRACE_MS = 30 * 1000
+/** Poll cadence while waiting out the grace period. */
+const LISTENER_POLL_MS = 1000
+
+export interface RequestDecisionInput {
+  label: string
+  step: string
+  pageId: string
+  error: string
+}
+
+export interface PageErrorDecisions {
+  /** Ask the user how to handle a failed page. Resolves to the chosen action.
+   *  Falls back to "stop" on timeout or when no UI is reachable. */
+  requestDecision(input: RequestDecisionInput): Promise<PageErrorAction>
+  /** Resolve a pending decision (from the UI). Returns false if the id is
+   *  unknown (already resolved by timeout/cancel — the caller returns 409). */
+  resolveDecision(
+    decisionId: string,
+    action: PageErrorAction,
+    applyToAll?: boolean
+  ): boolean
+  /** Pending decisions for a label — consumed by the polled step-status. */
+  getPendingDecisions(label: string): PendingDecision[]
+  /** Resolve every pending decision for a label and drop its apply-to-all
+   *  policy. Called at run end (success/error) and cancel. Defaults to "stop". */
+  clearForRun(label: string, action?: PageErrorAction): void
+}
+
+interface PendingEntry {
+  decisionId: string
+  label: string
+  step: string
+  pageId: string
+  error: string
+  resolve: (action: PageErrorAction) => void
+  resolved: boolean
+  safetyTimer?: ReturnType<typeof setTimeout>
+  graceTimer?: ReturnType<typeof setInterval>
+}
+
+export function createPageErrorDecisions(
+  eventBus: BookEventBus
+): PageErrorDecisions {
+  const pending = new Map<string, PendingEntry>()
+  // Per-label "apply to all" policy set once the user checks the box.
+  const bulkPolicy = new Map<string, PageErrorAction>()
+
+  function finish(entry: PendingEntry, action: PageErrorAction): void {
+    if (entry.resolved) return
+    entry.resolved = true
+    if (entry.safetyTimer) clearTimeout(entry.safetyTimer)
+    if (entry.graceTimer) clearInterval(entry.graceTimer)
+    pending.delete(entry.decisionId)
+    entry.resolve(action)
+  }
+
+  /** Surface a pending decision to a connected UI and arm the safety timeout. */
+  function arm(entry: PendingEntry): void {
+    eventBus.emit(entry.label, {
+      type: "decision-required",
+      label: entry.label,
+      decisionId: entry.decisionId,
+      step: entry.step,
+      pageId: entry.pageId,
+      error: entry.error,
+    })
+    entry.safetyTimer = setTimeout(() => finish(entry, "stop"), DECISION_TIMEOUT_MS)
+  }
+
+  return {
+    requestDecision(input: RequestDecisionInput): Promise<PageErrorAction> {
+      // Honor a previously chosen "apply to all" without prompting again.
+      const bulk = bulkPolicy.get(input.label)
+      if (bulk) return Promise.resolve(bulk)
+
+      const decisionId = crypto.randomUUID()
+      return new Promise<PageErrorAction>((resolve) => {
+        const entry: PendingEntry = {
+          decisionId,
+          label: input.label,
+          step: input.step,
+          pageId: input.pageId,
+          error: input.error,
+          resolve,
+          resolved: false,
+        }
+        // Consultable immediately (a poll landing during the grace period sees it).
+        pending.set(decisionId, entry)
+
+        if (eventBus.hasListeners(input.label)) {
+          arm(entry)
+          return
+        }
+
+        // No UI connected — a genuinely closed tab, or a reconnect blip. Wait a
+        // short grace period for a listener to (re)appear before falling back to
+        // "stop"; if one does, surface the dialog and switch to the 10-min timeout.
+        const startedAt = Date.now()
+        entry.graceTimer = setInterval(() => {
+          if (entry.resolved) return
+          if (eventBus.hasListeners(input.label)) {
+            clearInterval(entry.graceTimer)
+            entry.graceTimer = undefined
+            arm(entry)
+          } else if (Date.now() - startedAt >= LISTENER_GRACE_MS) {
+            finish(entry, "stop")
+          }
+        }, LISTENER_POLL_MS)
+      })
+    },
+
+    resolveDecision(
+      decisionId: string,
+      action: PageErrorAction,
+      applyToAll?: boolean
+    ): boolean {
+      const entry = pending.get(decisionId)
+      if (!entry) return false
+      if (applyToAll) {
+        bulkPolicy.set(entry.label, action)
+        // Apply the bulk decision to every other pending decision for this label.
+        for (const other of [...pending.values()]) {
+          if (other.label === entry.label && other.decisionId !== decisionId) {
+            finish(other, action)
+          }
+        }
+      }
+      finish(entry, action)
+      return true
+    },
+
+    getPendingDecisions(label: string): PendingDecision[] {
+      const result: PendingDecision[] = []
+      for (const entry of pending.values()) {
+        if (entry.label === label && !entry.resolved) {
+          result.push({
+            decisionId: entry.decisionId,
+            step: entry.step,
+            pageId: entry.pageId,
+            error: entry.error,
+          })
+        }
+      }
+      return result
+    },
+
+    clearForRun(label: string, action: PageErrorAction = "stop"): void {
+      bulkPolicy.delete(label)
+      for (const entry of [...pending.values()]) {
+        if (entry.label === label) finish(entry, action)
+      }
+    },
+  }
+}

--- a/apps/api/src/services/stage-runner.test.ts
+++ b/apps/api/src/services/stage-runner.test.ts
@@ -1091,6 +1091,81 @@ speech:
     }
   })
 
+  it("stops admitting TTS items and unwinds without step errors when the run is cancelled", async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "stage-runner-tts-"))
+    const booksDir = path.join(tmpDir, "books")
+    const promptsDir = path.join(tmpDir, "prompts")
+    const configPath = path.join(tmpDir, "config.yaml")
+    fs.mkdirSync(promptsDir, { recursive: true })
+    fs.writeFileSync(
+      configPath,
+      `role_types:
+  section_text: Main body text
+structure_types:
+  paragraph: Paragraph
+concurrency: 1
+speech:
+  default_provider: gemini
+  providers:
+    gemini:
+      languages:
+        - en
+`
+    )
+    seedTextAndSpeechBook(booksDir, "gemini-tts-cancel")
+    // Second catalog entry so there is still work queued when the cancel lands.
+    const seedStorage = createBookStorage("gemini-tts-cancel", booksDir)
+    try {
+      seedStorage.putNodeData("text-catalog", "book", {
+        entries: [
+          { id: "pg001_t001", text: "Hello world" },
+          { id: "pg001_t002", text: "Second entry" },
+        ],
+        generatedAt: "2026-01-01T00:00:00.000Z",
+      })
+    } finally {
+      seedStorage.close()
+    }
+
+    const controller = new AbortController()
+    generateSpeechFileMock.mockImplementation(async () => {
+      controller.abort()
+      return undefined
+    })
+
+    const events: ProgressEvent[] = []
+    const runner = createStageRunner()
+    await expect(
+      runner.run(
+        "gemini-tts-cancel",
+        {
+          booksDir,
+          apiKey: "sk-test",
+          geminiApiKey: "gm-test",
+          promptsDir,
+          configPath,
+          fromStage: "speech",
+          toStage: "speech",
+          signal: controller.signal,
+        },
+        { emit: (event) => events.push(event) }
+      )
+    ).rejects.toThrow("Run cancelled")
+
+    // The second item must never start once the cancel has landed.
+    expect(generateSpeechFileMock).toHaveBeenCalledTimes(1)
+    // A cancel is not a failure: no step-error, and no partial tts output committed.
+    expect(events.some((event) => event.type === "step-error")).toBe(false)
+    const storage = createBookStorage("gemini-tts-cancel", booksDir)
+    try {
+      expect(storage.getLatestNodeData("tts", "en")).toBeFalsy()
+      const ttsStep = storage.getStepRuns().find((step) => step.step === "tts")
+      expect(ttsStep?.status).not.toBe("error")
+    } finally {
+      storage.close()
+    }
+  })
+
   it("stores word timestamps for generated speech files", async () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "stage-runner-tts-"))
     const booksDir = path.join(tmpDir, "books")

--- a/apps/api/src/services/stage-runner.test.ts
+++ b/apps/api/src/services/stage-runner.test.ts
@@ -523,6 +523,7 @@ describe("createStageRunner storyboard render-only", () => {
     seedStoryboardBook(booksDir, "render-only")
 
     const events: ProgressEvent[] = []
+    const controller = new AbortController()
     const runner = createStageRunner()
     await runner.run(
       "render-only",
@@ -534,12 +535,16 @@ describe("createStageRunner storyboard render-only", () => {
         fromStage: "storyboard",
         toStage: "storyboard",
         renderOnly: true,
+        signal: controller.signal,
       },
       { emit: (event) => events.push(event) }
     )
 
     expect(sectionPageMock).not.toHaveBeenCalled()
     expect(renderPageMock).toHaveBeenCalledTimes(1)
+    expect(renderPageMock.mock.calls[0]?.[5]).toEqual({
+      signal: controller.signal,
+    })
     expect(
       events.some(
         (event) =>

--- a/apps/api/src/services/stage-runner.ts
+++ b/apps/api/src/services/stage-runner.ts
@@ -151,15 +151,6 @@ function isCancellation(
   return signals.some((s) => s?.aborted === true)
 }
 
-function combineSignals(
-  ...signals: Array<AbortSignal | undefined>
-): AbortSignal | undefined {
-  const present = signals.filter((s): s is AbortSignal => Boolean(s))
-  if (present.length === 0) return undefined
-  if (present.length === 1) return present[0]
-  return AbortSignal.any(present)
-}
-
 interface FailedPage {
   pageId: string
   step: StepName

--- a/apps/api/src/services/stage-runner.ts
+++ b/apps/api/src/services/stage-runner.ts
@@ -1313,6 +1313,8 @@ async function runStoryboardStep(
       effectiveConcurrency,
       async (page: PageData) => {
         try {
+          if (options.signal?.aborted) throw new RunCancelledError()
+
           const structuringRow = storage.getLatestNodeData("page-sectioning", page.pageId)
           if (!structuringRow) {
             console.log(
@@ -1344,10 +1346,12 @@ async function runStoryboardStep(
           )
           const renderImages = new Map<string, { base64: string; width?: number; height?: number }>()
           for (const imageId of unprunedImageIds) {
+            if (options.signal?.aborted) throw new RunCancelledError()
             const dims = pageDims.get(imageId)
             renderImages.set(imageId, { base64: storage.getImageBase64(imageId), width: dims?.width, height: dims?.height })
           }
 
+          if (options.signal?.aborted) throw new RunCancelledError()
           const pageImageBase64 = storage.getPageImageBase64(page.pageId)
 
           console.log(`[stage-run] ${label}: rendering ${page.pageId}`)
@@ -1365,7 +1369,9 @@ async function runStoryboardStep(
             resolveRenderModel,
             templateEngine,
             visualRefinement,
+            { signal: options.signal },
           )
+          if (options.signal?.aborted) throw new RunCancelledError()
           storage.putNodeData("web-rendering", page.pageId, renderResult)
           completedRendering++
           progress.emit({
@@ -1376,9 +1382,11 @@ async function runStoryboardStep(
             totalPages,
           })
         } catch (err) {
-          console.error(
-            `[stage-run] ${label}: ${page.pageId} failed at web-rendering: ${toErrorMessage(err)}`
-          )
+          if (!isCancellation(err, [options.signal])) {
+            console.error(
+              `[stage-run] ${label}: ${page.pageId} failed at web-rendering: ${toErrorMessage(err)}`
+            )
+          }
           await reportPageFailure(pageFailureDeps, progress, "web-rendering", page.pageId, err)
         }
       },

--- a/apps/api/src/services/stage-runner.ts
+++ b/apps/api/src/services/stage-runner.ts
@@ -81,6 +81,7 @@ import { loadStyleguideContent } from "./styleguide.js"
 import { createTTSSynthesizer, createAzureTTSSynthesizer, createGeminiTTSSynthesizer } from "@adt/llm"
 import type { TTSSynthesizer } from "@adt/llm"
 import { STAGE_ORDER, isTtsExcluded } from "@adt/types"
+import type { PageErrorPolicy, PageErrorAction } from "@adt/types"
 import { beginSpeechRun, endSpeechRun } from "./speech-progress.js"
 import type {
   AppConfig,
@@ -126,6 +127,207 @@ class StepError extends Error {
 
 function toErrorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err)
+}
+
+/** Thrown at a cancellation checkpoint. Distinguished from real errors so the
+ *  general catch neither records step errors nor emits step-error on cancel. */
+export class RunCancelledError extends Error {
+  constructor(message = "Run cancelled") {
+    super(message)
+    this.name = "RunCancelledError"
+  }
+}
+
+/** True when an error is (or was caused by) an abort from one of the given
+ *  signals. Detection is by signal state, not error name: the internal timeout
+ *  and the external cancel both surface as AbortError/TimeoutError and SDKs wrap
+ *  them, so `err.name` is unreliable. A TimeoutError with intact signals is a
+ *  normal page failure and returns false here. */
+function isCancellation(
+  err: unknown,
+  signals: Array<AbortSignal | undefined>
+): boolean {
+  if (err instanceof RunCancelledError) return true
+  return signals.some((s) => s?.aborted === true)
+}
+
+function combineSignals(
+  ...signals: Array<AbortSignal | undefined>
+): AbortSignal | undefined {
+  const present = signals.filter((s): s is AbortSignal => Boolean(s))
+  if (present.length === 0) return undefined
+  if (present.length === 1) return present[0]
+  return AbortSignal.any(present)
+}
+
+interface FailedPage {
+  pageId: string
+  step: StepName
+  msg: string
+}
+
+/** One-shot admission gate for processWithConcurrency. Closed while a page-error
+ *  decision is pending (interactive mode) so no new items start; in-flight work
+ *  continues. Opened again once the decision resolves. */
+class AdmissionGate {
+  private closed = false
+  private waiters: Array<() => void> = []
+  close(): void {
+    this.closed = true
+  }
+  open(): void {
+    this.closed = false
+    const waiters = this.waiters
+    this.waiters = []
+    for (const w of waiters) w()
+  }
+  wait(): Promise<void> {
+    if (!this.closed) return Promise.resolve()
+    return new Promise((resolve) => this.waiters.push(resolve))
+  }
+}
+
+interface PageFailureContext {
+  step: StepName
+  pageId: string
+  err: unknown
+  failedPages: FailedPage[]
+  /** step name → set of pageIds skipped by user decision (interactive mode). */
+  skippedByStep: Map<string, Set<string>>
+  progress: StageRunProgress
+  runSignal?: AbortSignal
+  /** Aborts the current step when the user chooses "stop". */
+  stepController: AbortController
+  gate: AdmissionGate
+  policy: PageErrorPolicy
+  requestDecision?: (input: {
+    step: StepName
+    pageId: string
+    error: string
+  }) => Promise<PageErrorAction>
+}
+
+/** Shared handling for a page failure inside a per-page step. Covers all six
+ *  emission points. Returns after recording/handling; throws only to unwind a
+ *  run cancel (an aborted page is not a failure — it re-runs cheaply via cache). */
+async function handlePageFailure(ctx: PageFailureContext): Promise<void> {
+  const { runSignal, stepController } = ctx
+
+  // 1. Run cancel — re-throw so the run tears down at once.
+  if (isCancellation(ctx.err, [runSignal])) {
+    throw ctx.err instanceof RunCancelledError ? ctx.err : new RunCancelledError()
+  }
+  // 2. Step already stopping (a prior "stop" decision aborted in-flight work) —
+  //    swallow quietly; the step throws its own StepError after the loop.
+  if (stepController.signal.aborted) return
+
+  const msg = toErrorMessage(ctx.err)
+  // Emit step-error as before (per-page). In interactive mode this briefly paints
+  // the step red until the decision resolves; the step-complete hygiene clears it.
+  ctx.progress.emit({
+    type: "step-error",
+    step: ctx.step,
+    error: `${ctx.pageId} failed: ${msg}`,
+  })
+
+  if (ctx.policy === "ask" && ctx.requestDecision) {
+    ctx.gate.close()
+    let action: PageErrorAction
+    try {
+      action = await ctx.requestDecision({
+        step: ctx.step,
+        pageId: ctx.pageId,
+        error: msg,
+      })
+    } finally {
+      ctx.gate.open()
+    }
+    if (action === "skip") {
+      let set = ctx.skippedByStep.get(ctx.step)
+      if (!set) {
+        set = new Set()
+        ctx.skippedByStep.set(ctx.step, set)
+      }
+      set.add(ctx.pageId)
+      return
+    }
+    // "stop": abort the step. processWithConcurrency stops admitting new items;
+    // the step then throws a StepError so it's marked error and later stages halt.
+    stepController.abort()
+    return
+  }
+
+  // Default "stop" policy: accumulate and fail the step at the end.
+  ctx.failedPages.push({ pageId: ctx.pageId, step: ctx.step, msg })
+}
+
+/** Per-step failure-handling dependencies, built once per page-processing step
+ *  and reused for every page. `progress`, `step`, `pageId` and `err` are supplied
+ *  per call by reportPageFailure. */
+type PageFailureDeps = Omit<
+  PageFailureContext,
+  "step" | "pageId" | "err" | "progress"
+>
+
+/** Build the per-step failure deps from run options. */
+function buildPageFailureDeps(
+  options: StageRunOptions,
+  shared: {
+    failedPages: FailedPage[]
+    skippedByStep: Map<string, Set<string>>
+    gate: AdmissionGate
+    stepController: AbortController
+  }
+): PageFailureDeps {
+  return {
+    ...shared,
+    runSignal: options.signal,
+    policy: options.pageErrorPolicy ?? "stop",
+    requestDecision: options.requestPageDecision,
+  }
+}
+
+function reportPageFailure(
+  deps: PageFailureDeps,
+  progress: StageRunProgress,
+  step: StepName,
+  pageId: string,
+  err: unknown
+): Promise<void> {
+  return handlePageFailure({ ...deps, progress, step, pageId, err })
+}
+
+/** Compose the "Completed — N page(s) skipped" message, or undefined if none. */
+function skipMessage(
+  skippedByStep: Map<string, Set<string>>,
+  step: StepName
+): string | undefined {
+  const n = skippedByStep.get(step)?.size ?? 0
+  return n > 0 ? `Completed — ${n} page(s) skipped` : undefined
+}
+
+/** Finalize one page-processing step: throw if it accumulated real failures
+ *  ("stop" policy), otherwise emit step-complete (with a skip message if the
+ *  user chose to skip pages). */
+function finishPageStep(
+  progress: StageRunProgress,
+  step: StepName,
+  deps: Pick<PageFailureDeps, "failedPages" | "skippedByStep">
+): void {
+  const failures = deps.failedPages.filter((f) => f.step === step)
+  if (failures.length > 0) {
+    throw new StepError(
+      step,
+      `${failures.length} page(s) failed:\n${failures
+        .map((f) => `${f.pageId}: ${f.msg}`)
+        .join("\n")}`
+    )
+  }
+  progress.emit({
+    type: "step-complete",
+    step,
+    message: skipMessage(deps.skippedByStep, step),
+  })
 }
 
 /**
@@ -181,22 +383,46 @@ export function buildStageRunnerImageClassifyConfig(
   }
 }
 
+interface ConcurrencyControls {
+  /** Run cancel — never start remaining items; throw RunCancelledError. */
+  runSignal?: AbortSignal
+  /** Step "stop" — stop admitting new items (in-flight ones finish). */
+  stopSignal?: AbortSignal
+  /** Pause admission while a page-error decision is pending. */
+  gate?: AdmissionGate
+}
+
 async function processWithConcurrency<T>(
   items: T[],
   concurrency: number,
-  fn: (item: T) => Promise<void>
+  fn: (item: T) => Promise<void>,
+  controls?: ConcurrencyControls
 ): Promise<void> {
   const executing = new Set<Promise<void>>()
-  for (const item of items) {
-    const p = fn(item).finally(() => {
-      executing.delete(p)
-    })
-    executing.add(p)
-    if (executing.size >= concurrency) {
-      await Promise.race(executing)
+  try {
+    for (const item of items) {
+      if (controls?.runSignal?.aborted) throw new RunCancelledError()
+      if (controls?.gate) await controls.gate.wait()
+      // Re-check after the gate: a cancel or "stop" may have arrived while paused.
+      if (controls?.runSignal?.aborted) throw new RunCancelledError()
+      if (controls?.stopSignal?.aborted) break
+      const p = fn(item).finally(() => {
+        executing.delete(p)
+      })
+      executing.add(p)
+      if (executing.size >= concurrency) {
+        await Promise.race(executing)
+      }
     }
+    await Promise.all(executing)
+  } catch (err) {
+    // Drain any still-running items so none are orphaned (which would surface as
+    // unhandled rejections when they later abort). On cancel their rejections are
+    // expected; swallow them and re-throw a single RunCancelledError.
+    await Promise.allSettled(executing)
+    if (isCancellation(err, [controls?.runSignal])) throw new RunCancelledError()
+    throw err
   }
-  await Promise.all(executing)
 }
 
 function emitSpeechStepProgress(
@@ -500,11 +726,14 @@ export function createStageRunner(): StageRunner {
         const trackingProgress: StageRunProgress = {
           emit(event) {
             if (event.type === "step-start") {
+              // Cancellation checkpoint before every step: a cancel that lands
+              // between steps stops the run here, before the step is recorded.
+              if (options.signal?.aborted) throw new RunCancelledError()
               runningSteps.add(event.step)
               completionStorage.markStepStarted(event.step)
             } else if (event.type === "step-complete") {
               runningSteps.delete(event.step)
-              completionStorage.markStepCompleted(event.step)
+              completionStorage.markStepCompleted(event.step, event.message)
             } else if (event.type === "step-skip") {
               runningSteps.delete(event.step)
               completionStorage.markStepSkipped(event.step)
@@ -519,10 +748,18 @@ export function createStageRunner(): StageRunner {
         }
 
         for (let i = fromIndex; i <= toIndex; i++) {
+          if (options.signal?.aborted) throw new RunCancelledError()
           const stage = STAGE_ORDER[i]
           await STAGE_RUNNERS[stage](label, options, trackingProgress)
         }
       } catch (err) {
+        // A cancel is a deliberate action, not a failure: don't record step
+        // errors or emit step-error (that would paint the sidebar red and, with
+        // the error toast/sound, beep on cancel). Just re-throw — executeJob's
+        // abort branch handles persistence cleanup.
+        if (isCancellation(err, [options.signal])) {
+          throw err
+        }
         const message = toErrorMessage(err)
         for (const step of runningSteps) {
           completionStorage.recordStepError(step, message)
@@ -615,6 +852,7 @@ async function runExtractStep(
       rateLimiter,
       onLog: onLlmLog,
       credentials: llmCredentials,
+      signal: options.signal,
     })
 
     const pages = storage.getPages()
@@ -651,6 +889,7 @@ async function runExtractStep(
         rateLimiter,
         onLog: onLlmLog,
         credentials: llmCredentials,
+        signal: options.signal,
       })
       const summaryPages = pages.map((page) => ({
         pageNumber: page.pageNumber,
@@ -661,6 +900,9 @@ async function runExtractStep(
       progress.emit({ type: "step-complete", step: "book-summary" })
       console.log(`[stage-run] ${label}: book summary complete`)
     } catch (err) {
+      // A cancel aborts the summary LLM call — re-throw without emitting
+      // step-error so the run tears down cleanly rather than showing a failure.
+      if (isCancellation(err, [options.signal])) throw err
       const msg = toErrorMessage(err)
       console.error(`[stage-run] ${label}: book summary failed: ${msg}`)
       progress.emit({ type: "step-error", step: "book-summary", error: msg })
@@ -682,6 +924,7 @@ async function runExtractStep(
           rateLimiter,
           onLog: onLlmLog,
           credentials: llmCredentials,
+          signal: options.signal,
         })
       : null
 
@@ -693,6 +936,7 @@ async function runExtractStep(
           rateLimiter,
           onLog: onLlmLog,
           credentials: llmCredentials,
+          signal: options.signal,
         })
       : null
 
@@ -704,6 +948,7 @@ async function runExtractStep(
           rateLimiter,
           onLog: onLlmLog,
           credentials: llmCredentials,
+          signal: options.signal,
         })
       : null
 
@@ -712,31 +957,59 @@ async function runExtractStep(
     console.log(`[stage-run] ${label}: classifying images for ${totalPages} pages (concurrency=${effectiveConcurrency})`)
 
     const pageResults = new Map<string, ImageClassificationOutput>()
-    const failedPages: string[] = []
+    // The four classification passes share one failure/skip/gate/step-controller
+    // context: a "stop" decision in any pass halts the whole classification phase,
+    // and the end-of-stage throw considers real (non-skipped) failures per step.
+    const failedPages: FailedPage[] = []
+    const skippedByStep = new Map<string, Set<string>>()
+    const gate = new AdmissionGate()
+    const stepController = new AbortController()
+    const pageFailureDeps = buildPageFailureDeps(options, {
+      failedPages,
+      skippedByStep,
+      gate,
+      stepController,
+    })
 
     await runFilterPass(
       label, pages, storage, imageClassifyConfig,
-      effectiveConcurrency, pageResults, failedPages, progress
+      effectiveConcurrency, pageResults, pageFailureDeps, progress
     )
 
-    await runMeaningfulnessPass(
-      label, pages, storage, meaningfulnessConfig, meaningfulnessModel,
-      effectiveConcurrency, pageResults, failedPages, progress
-    )
+    if (!stepController.signal.aborted) {
+      await runMeaningfulnessPass(
+        label, pages, storage, meaningfulnessConfig, meaningfulnessModel,
+        effectiveConcurrency, pageResults, pageFailureDeps, progress
+      )
+    }
 
-    await runSegmentationPass(
-      label, pages, storage, segmentationConfig, segmentationModel,
-      effectiveConcurrency, pageResults, progress
-    )
+    if (!stepController.signal.aborted) {
+      await runSegmentationPass(
+        label, pages, storage, segmentationConfig, segmentationModel,
+        effectiveConcurrency, pageResults, progress, options.signal
+      )
+    }
 
-    await runCroppingPass(
-      label, pages, storage, croppingConfig, croppingModel,
-      effectiveConcurrency, pageResults, progress
-    )
+    if (!stepController.signal.aborted) {
+      await runCroppingPass(
+        label, pages, storage, croppingConfig, croppingModel,
+        effectiveConcurrency, pageResults, progress, options.signal
+      )
+    }
 
+    // A "stop" decision aborts the classification phase; the failing step is
+    // already recorded as error via its per-page step-error.
+    if (stepController.signal.aborted) {
+      throw new Error("Stopped by a page-error decision")
+    }
+
+    // Only real (non-skipped) failures fail the stage — matches the per-pass
+    // step-complete gating in runFilterPass/runMeaningfulnessPass.
     if (failedPages.length > 0) {
       throw new Error(
-        `${failedPages.length} page(s) failed:\n${failedPages.join("\n")}`
+        `${failedPages.length} page(s) failed:\n${failedPages
+          .map((f) => `${f.pageId} [${f.step}]: ${f.msg}`)
+          .join("\n")}`
       )
     }
   } finally {
@@ -798,6 +1071,7 @@ async function runSectioningStep(
       rateLimiter,
       onLog: onLlmLog,
       credentials: llmCredentials,
+      signal: options.signal,
     })
 
     const translationModel = translationConfig
@@ -808,6 +1082,7 @@ async function runSectioningStep(
           rateLimiter,
           onLog: onLlmLog,
           credentials: llmCredentials,
+          signal: options.signal,
         })
       : null
 
@@ -820,7 +1095,16 @@ async function runSectioningStep(
     progress.emit({ type: "step-start", step: "page-sectioning" })
     let completedStructuring = 0
     let completedTranslation = 0
-    const failedPages: string[] = []
+    const failedPages: FailedPage[] = []
+    const skippedByStep = new Map<string, Set<string>>()
+    const gate = new AdmissionGate()
+    const stepController = new AbortController()
+    const pageFailureDeps = buildPageFailureDeps(options, {
+      failedPages,
+      skippedByStep,
+      gate,
+      stepController,
+    })
 
     await processWithConcurrency(
       pages,
@@ -876,28 +1160,21 @@ async function runSectioningStep(
             })
           }
         } catch (err) {
-          const msg = toErrorMessage(err)
           const step = err instanceof StepError ? err.step : "page-sectioning"
-          console.error(`[stage-run] ${label}: ${page.pageId} failed at ${step}: ${msg}`)
-          failedPages.push(`${page.pageId} [${step}]: ${msg}`)
-          progress.emit({
-            type: "step-error",
-            step,
-            error: `${page.pageId} failed: ${msg}`,
-          })
+          console.error(`[stage-run] ${label}: ${page.pageId} failed at ${step}: ${toErrorMessage(err)}`)
+          await reportPageFailure(pageFailureDeps, progress, step, page.pageId, err)
         }
       },
+      { runSignal: options.signal, stopSignal: stepController.signal, gate },
     )
 
-    if (failedPages.length > 0) {
-      throw new Error(
-        `${failedPages.length} page(s) failed:\n${failedPages.join("\n")}`
-      )
+    if (stepController.signal.aborted) {
+      throw new StepError("page-sectioning", "Stopped by a page-error decision")
     }
 
-    progress.emit({ type: "step-complete", step: "page-sectioning" })
+    finishPageStep(progress, "page-sectioning", pageFailureDeps)
     if (translationConfig) {
-      progress.emit({ type: "step-complete", step: "translation" })
+      finishPageStep(progress, "translation", pageFailureDeps)
     } else {
       progress.emit({ type: "step-skip", step: "translation" })
     }
@@ -966,6 +1243,7 @@ async function runStoryboardStep(
         rateLimiter,
         onLog: onLlmLog,
         credentials: llmCredentials,
+        signal: options.signal,
       })
       renderModels.set(modelId, model)
       return model
@@ -1019,7 +1297,16 @@ async function runStoryboardStep(
     await ensureBookGoogleFontsCached(storage, resolveFontsCacheDir(booksDir))
 
     let completedRendering = 0
-    const failedPages: string[] = []
+    const failedPages: FailedPage[] = []
+    const skippedByStep = new Map<string, Set<string>>()
+    const gate = new AdmissionGate()
+    const stepController = new AbortController()
+    const pageFailureDeps = buildPageFailureDeps(options, {
+      failedPages,
+      skippedByStep,
+      gate,
+      stepController,
+    })
 
     await processWithConcurrency(
       pages,
@@ -1089,27 +1376,20 @@ async function runStoryboardStep(
             totalPages,
           })
         } catch (err) {
-          const msg = toErrorMessage(err)
           console.error(
-            `[stage-run] ${label}: ${page.pageId} failed at web-rendering: ${msg}`
+            `[stage-run] ${label}: ${page.pageId} failed at web-rendering: ${toErrorMessage(err)}`
           )
-          failedPages.push(`${page.pageId} [web-rendering]: ${msg}`)
-          progress.emit({
-            type: "step-error",
-            step: "web-rendering",
-            error: `${page.pageId} failed: ${msg}`,
-          })
+          await reportPageFailure(pageFailureDeps, progress, "web-rendering", page.pageId, err)
         }
-      }
+      },
+      { runSignal: options.signal, stopSignal: stepController.signal, gate },
     )
 
-    if (failedPages.length > 0) {
-      throw new Error(
-        `${failedPages.length} page(s) failed:\n${failedPages.join("\n")}`
-      )
+    if (stepController.signal.aborted) {
+      throw new StepError("web-rendering", "Stopped by a page-error decision")
     }
 
-    progress.emit({ type: "step-complete", step: "web-rendering" })
+    finishPageStep(progress, "web-rendering", pageFailureDeps)
     console.log(`[stage-run] ${label}: storyboard complete`)
   } finally {
     if (visualRefinement) {
@@ -1178,6 +1458,7 @@ async function runQuizzesStep(
       rateLimiter,
       onLog: onLlmLog,
       credentials: llmCredentials,
+      signal: options.signal,
     })
 
     const effectiveConcurrency = config.concurrency ?? 32
@@ -1283,13 +1564,23 @@ async function runCaptionsStep(
       rateLimiter,
       onLog: onLlmLog,
       credentials: llmCredentials,
+      signal: options.signal,
     })
 
     const pages = storage.getPages()
     const totalPages = pages.length
     const effectiveConcurrency = config.concurrency ?? 32
     let completedCaptions = 0
-    const failedPages: string[] = []
+    const failedPages: FailedPage[] = []
+    const skippedByStep = new Map<string, Set<string>>()
+    const gate = new AdmissionGate()
+    const stepController = new AbortController()
+    const pageFailureDeps = buildPageFailureDeps(options, {
+      failedPages,
+      skippedByStep,
+      gate,
+      stepController,
+    })
 
     progress.emit({ type: "step-start", step: "image-captioning" })
     progress.emit({
@@ -1388,24 +1679,17 @@ async function runCaptionsStep(
             totalPages,
           })
         } catch (err) {
-          const msg = toErrorMessage(err)
-          failedPages.push(`${page.pageId}: ${msg}`)
-          progress.emit({
-            type: "step-error",
-            step: "image-captioning",
-            error: `${page.pageId} failed: ${msg}`,
-          })
+          await reportPageFailure(pageFailureDeps, progress, "image-captioning", page.pageId, err)
         }
-      }
+      },
+      { runSignal: options.signal, stopSignal: stepController.signal, gate },
     )
 
-    if (failedPages.length > 0) {
-      throw new Error(
-        `${failedPages.length} page(s) failed captioning:\n${failedPages.join("\n")}`
-      )
+    if (stepController.signal.aborted) {
+      throw new StepError("image-captioning", "Stopped by a page-error decision")
     }
 
-    progress.emit({ type: "step-complete", step: "image-captioning" })
+    finishPageStep(progress, "image-captioning", pageFailureDeps)
     console.log(`[stage-run] ${label}: captions complete`)
   } finally {
     storage.close()
@@ -1465,6 +1749,7 @@ async function runGlossaryStep(
       rateLimiter,
       onLog: onLlmLog,
       credentials: llmCredentials,
+      signal: options.signal,
     })
 
     const pages = storage.getPages()
@@ -1556,6 +1841,7 @@ async function runTocStep(
       rateLimiter,
       onLog: onLlmLog,
       credentials: llmCredentials,
+      signal: options.signal,
     })
 
     const pages = storage.getPages()
@@ -1684,6 +1970,7 @@ async function runEasyReadStep(
           rateLimiter,
           onLog: onLlmLog,
           credentials: llmCredentials,
+          signal: options.signal,
         })
         const totalEntries = blocks.reduce((sum, block) => sum + block.entries.length, 0)
         progress.emit({
@@ -1818,6 +2105,7 @@ async function runTranslateStep(
         rateLimiter,
         onLog: onLlmLog,
         credentials: llmCredentials,
+        signal: options.signal,
       })
 
       const batchSize = translationConfig.batchSize
@@ -1874,7 +2162,8 @@ async function runTranslateStep(
             page: completedBatches,
             totalPages: totalBatches,
           })
-        }
+        },
+        { runSignal: options.signal },
       )
 
       for (const lang of targetLanguages) {
@@ -2016,6 +2305,7 @@ async function runTranslateStep(
                 promptName,
               },
               onLog: onLlmLog,
+              signal: options.signal,
             })
 
             storage.putTranslatedImage({
@@ -2027,6 +2317,7 @@ async function runTranslateStep(
               height: result.height,
             })
           } catch (err) {
+            if (isCancellation(err, [options.signal])) throw err
             const message = toErrorMessage(err)
             console.warn(
               `[stage-run] ${label}: image-translation failed for ${item.imageId} → ${item.targetLanguage}: ${message}`
@@ -2041,7 +2332,7 @@ async function runTranslateStep(
               totalPages: total,
             })
           }
-        })
+        }, { runSignal: options.signal })
 
         progress.emit({ type: "step-complete", step: "image-translation" })
         console.log(`[stage-run] ${label}: image translation complete (${completed}/${total})`)
@@ -2509,39 +2800,48 @@ async function runFilterPass(
   config: ReturnType<typeof buildStageRunnerImageClassifyConfig>,
   concurrency: number,
   results: Map<string, ImageClassificationOutput>,
-  failedPages: string[],
+  deps: PageFailureDeps,
   progress: StageRunProgress,
 ): Promise<void> {
   const total = pages.length
   let completed = 0
   progress.emit({ type: "step-start", step: "image-filtering" })
-  await processWithConcurrency(pages, concurrency, async (page) => {
-    try {
-      const images = storage.getPageImages(page.pageId)
-      const result = classifyPageImages(page.pageId, images, config)
-      results.set(page.pageId, result)
-      storage.putNodeData("image-filtering", page.pageId, result)
-    } catch (err) {
-      const msg = toErrorMessage(err)
-      console.error(`[stage-run] ${label}: ${page.pageId} failed at image-filtering: ${msg}`)
-      failedPages.push(`${page.pageId} [image-filtering]: ${msg}`)
-      progress.emit({
-        type: "step-error",
-        step: "image-filtering",
-        error: `${page.pageId} failed: ${msg}`,
-      })
-    } finally {
-      completed++
-      progress.emit({
-        type: "step-progress",
-        step: "image-filtering",
-        message: `${completed}/${total}`,
-        page: completed,
-        totalPages: total,
-      })
-    }
-  })
-  progress.emit({ type: "step-complete", step: "image-filtering" })
+  await processWithConcurrency(
+    pages,
+    concurrency,
+    async (page) => {
+      try {
+        const images = storage.getPageImages(page.pageId)
+        const result = classifyPageImages(page.pageId, images, config)
+        results.set(page.pageId, result)
+        storage.putNodeData("image-filtering", page.pageId, result)
+      } catch (err) {
+        console.error(`[stage-run] ${label}: ${page.pageId} failed at image-filtering: ${toErrorMessage(err)}`)
+        await reportPageFailure(deps, progress, "image-filtering", page.pageId, err)
+      } finally {
+        completed++
+        progress.emit({
+          type: "step-progress",
+          step: "image-filtering",
+          message: `${completed}/${total}`,
+          page: completed,
+          totalPages: total,
+        })
+      }
+    },
+    { runSignal: deps.runSignal, stopSignal: deps.stepController.signal, gate: deps.gate },
+  )
+  // Only mark the step done when it had no real failures of its own and wasn't
+  // stopped. A spurious step-complete here would overwrite the per-page error in
+  // the DB with "done", leaving the run failing with no step attributed.
+  const failed = deps.failedPages.some((f) => f.step === "image-filtering")
+  if (!failed && !deps.stepController.signal.aborted) {
+    progress.emit({
+      type: "step-complete",
+      step: "image-filtering",
+      message: skipMessage(deps.skippedByStep, "image-filtering"),
+    })
+  }
 }
 
 async function runMeaningfulnessPass(
@@ -2552,7 +2852,7 @@ async function runMeaningfulnessPass(
   model: ReturnType<typeof createLLMModel> | null,
   concurrency: number,
   results: Map<string, ImageClassificationOutput>,
-  failedPages: string[],
+  deps: PageFailureDeps,
   progress: StageRunProgress,
 ): Promise<void> {
   if (!config || !model) {
@@ -2563,7 +2863,10 @@ async function runMeaningfulnessPass(
   const total = pages.length
   let completed = 0
   progress.emit({ type: "step-start", step: "image-meaningfulness" })
-  await processWithConcurrency(pages, concurrency, async (page) => {
+  await processWithConcurrency(
+    pages,
+    concurrency,
+    async (page) => {
     const existing = results.get(page.pageId)
     if (!existing) {
       completed++
@@ -2605,14 +2908,8 @@ async function runMeaningfulnessPass(
         storage.putNodeData("image-filtering", page.pageId, updated)
       }
     } catch (err) {
-      const msg = toErrorMessage(err)
-      console.error(`[stage-run] ${label}: ${page.pageId} failed at image-meaningfulness: ${msg}`)
-      failedPages.push(`${page.pageId} [image-meaningfulness]: ${msg}`)
-      progress.emit({
-        type: "step-error",
-        step: "image-meaningfulness",
-        error: `${page.pageId} failed: ${msg}`,
-      })
+      console.error(`[stage-run] ${label}: ${page.pageId} failed at image-meaningfulness: ${toErrorMessage(err)}`)
+      await reportPageFailure(deps, progress, "image-meaningfulness", page.pageId, err)
     } finally {
       completed++
       progress.emit({
@@ -2623,8 +2920,17 @@ async function runMeaningfulnessPass(
         totalPages: total,
       })
     }
-  })
-  progress.emit({ type: "step-complete", step: "image-meaningfulness" })
+    },
+    { runSignal: deps.runSignal, stopSignal: deps.stepController.signal, gate: deps.gate },
+  )
+  const failed = deps.failedPages.some((f) => f.step === "image-meaningfulness")
+  if (!failed && !deps.stepController.signal.aborted) {
+    progress.emit({
+      type: "step-complete",
+      step: "image-meaningfulness",
+      message: skipMessage(deps.skippedByStep, "image-meaningfulness"),
+    })
+  }
 }
 
 async function runSegmentationPass(
@@ -2636,6 +2942,7 @@ async function runSegmentationPass(
   concurrency: number,
   results: Map<string, ImageClassificationOutput>,
   progress: StageRunProgress,
+  runSignal?: AbortSignal,
 ): Promise<void> {
   if (!config || !model) {
     progress.emit({ type: "step-skip", step: "image-segmentation" })
@@ -2725,6 +3032,7 @@ async function runSegmentationPass(
         }
       }
     } catch (err) {
+      if (isCancellation(err, [runSignal])) throw err
       console.error(`[stage-run] ${label}: image segmentation failed for ${page.pageId}: ${toErrorMessage(err)}`)
     } finally {
       completed++
@@ -2736,7 +3044,8 @@ async function runSegmentationPass(
         totalPages: total,
       })
     }
-  })
+  }, { runSignal })
+  if (runSignal?.aborted) return
   progress.emit({ type: "step-complete", step: "image-segmentation" })
 }
 
@@ -2749,6 +3058,7 @@ async function runCroppingPass(
   concurrency: number,
   results: Map<string, ImageClassificationOutput>,
   progress: StageRunProgress,
+  runSignal?: AbortSignal,
 ): Promise<void> {
   if (!config || !model) {
     progress.emit({ type: "step-skip", step: "image-cropping" })
@@ -2824,6 +3134,7 @@ async function runCroppingPass(
         }
       }
     } catch (err) {
+      if (isCancellation(err, [runSignal])) throw err
       console.error(`[stage-run] ${label}: image cropping failed for ${page.pageId}: ${toErrorMessage(err)}`)
     } finally {
       completed++
@@ -2835,6 +3146,7 @@ async function runCroppingPass(
         totalPages: total,
       })
     }
-  })
+  }, { runSignal })
+  if (runSignal?.aborted) return
   progress.emit({ type: "step-complete", step: "image-cropping" })
 }

--- a/apps/api/src/services/stage-runner.ts
+++ b/apps/api/src/services/stage-runner.ts
@@ -363,8 +363,24 @@ function parseGeminiRetryDelayMs(message: string): number | null {
   return Math.min(baseMs > 0 ? baseMs + 250 : 0, GEMINI_TTS_MAX_RETRY_DELAY_MS)
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms))
+/** Resolves early (never rejects) when the signal aborts, so retry backoffs
+ *  don't hold a cancelled run open — callers re-check the signal after. */
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal?.aborted) {
+      resolve()
+      return
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort)
+      resolve()
+    }, ms)
+    const onAbort = () => {
+      clearTimeout(timer)
+      resolve()
+    }
+    signal?.addEventListener("abort", onAbort, { once: true })
+  })
 }
 
 function wrapStepError(step: StepName, err: unknown): never {
@@ -587,6 +603,8 @@ interface GenerateSpeechWordTimestampsOptions {
   textByLanguage: Map<string, Map<string, string>>
   concurrency: number
   progress: StageRunProgress
+  /** Run cancel — stops admitting new transcription items. */
+  signal?: AbortSignal
 }
 
 async function generateSpeechWordTimestamps(
@@ -605,6 +623,7 @@ async function generateSpeechWordTimestamps(
     textByLanguage,
     concurrency,
     progress,
+    signal,
   } = options
 
   const entriesByLanguage = new Map<string, Record<string, WordTimestampEntry>>()
@@ -674,6 +693,7 @@ async function generateSpeechWordTimestamps(
         emitWordTimestampStepProgress(progress, completed, workItems.length, failedItems.length)
       }
     },
+    { runSignal: signal },
   )
 
   return { entriesByLanguage, failedItems }
@@ -2605,12 +2625,14 @@ async function runSpeechStep(
                 ttsSynthesizer,
                 rateLimiter: provider === "gemini" ? geminiTtsRateLimiter : undefined,
                 provider,
+                signal: options.signal,
               })
               break
             } catch (err) {
               const msg = toErrorMessage(err)
               if (
                 provider === "gemini" &&
+                !options.signal?.aborted &&
                 isGeminiTtsRateLimitMessage(msg) &&
                 attemptCount <= GEMINI_TTS_MAX_RATE_LIMIT_RETRIES
               ) {
@@ -2623,7 +2645,8 @@ async function runSpeechStep(
                 console.warn(
                   `[stage-run] ${label}: Gemini TTS rate limited for ${item.textId} (${item.language}); retrying ${attemptCount + 1}/${GEMINI_TTS_MAX_RATE_LIMIT_RETRIES + 1} in ${retryDelayMs}ms`
                 )
-                await sleep(retryDelayMs)
+                await sleep(retryDelayMs, options.signal)
+                if (options.signal?.aborted) throw new RunCancelledError()
                 continue
               }
               throw err
@@ -2665,6 +2688,11 @@ async function runSpeechStep(
             ttsResultsByLang.get(item.language)?.push(entry)
           }
         } catch (err) {
+          // Run cancel — re-throw so processWithConcurrency unwinds; an aborted
+          // item is not a failure (it re-runs cheaply via the TTS cache).
+          if (isCancellation(err, [options.signal])) {
+            throw err instanceof RunCancelledError ? err : new RunCancelledError()
+          }
           const msg = toErrorMessage(err)
           const durationMs = Date.now() - startMs
           console.error(`[stage-run] ${label}: TTS failed for ${item.textId} (${item.language}): ${msg}`)
@@ -2712,7 +2740,8 @@ async function runSpeechStep(
 
         completedItems++
         emitSpeechStepProgress(progress, completedItems, totalItems, failedItems.length, reusedItems)
-      }
+      },
+      { runSignal: options.signal }
     )
 
     if (failedItems.length > 0) {
@@ -2760,6 +2789,7 @@ async function runSpeechStep(
         textByLanguage,
         concurrency: effectiveConcurrency,
         progress,
+        signal: options.signal,
       })
       wordTimestampsByLang = generatedWordTimestamps.entriesByLanguage
       timestampFailedItems = generatedWordTimestamps.failedItems

--- a/apps/api/src/services/stage-service.test.ts
+++ b/apps/api/src/services/stage-service.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { openBookDb } from "@adt/storage"
+import { createBookEventBus, type BookSSEEvent } from "./book-event-bus.js"
+import { createPageErrorDecisions } from "./page-error-decisions.js"
+import {
+  createStageService,
+  type StageRunner,
+  type StageRunOptions,
+  type StageRunProgress,
+} from "./stage-service.js"
+
+let tmpDir: string
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "adt-stage-service-"))
+})
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+})
+
+function makeBook(label: string): void {
+  const bookDir = path.join(tmpDir, label)
+  fs.mkdirSync(bookDir, { recursive: true })
+  const db = openBookDb(path.join(bookDir, `${label}.db`))
+  // A step left "running" — the cancel cleanup should delete it.
+  db.run(
+    "INSERT INTO step_runs (step, status, started_at) VALUES (?, 'running', ?)",
+    ["page-sectioning", new Date().toISOString()]
+  )
+  db.close()
+}
+
+function stepRunStatuses(label: string): Map<string, string> {
+  const db = openBookDb(path.join(tmpDir, label, `${label}.db`))
+  try {
+    const rows = db.all("SELECT step, status FROM step_runs") as Array<{
+      step: string
+      status: string
+    }>
+    return new Map(rows.map((r) => [r.step, r.status]))
+  } finally {
+    db.close()
+  }
+}
+
+/** A runner whose run() blocks until we resolve it, and observes the signal. */
+function controllableRunner() {
+  let resolveRun: (() => void) | undefined
+  let rejectRun: ((err: unknown) => void) | undefined
+  let capturedSignal: AbortSignal | undefined
+  let started = false
+  const runner: StageRunner = {
+    run(_label: string, options: StageRunOptions, _progress: StageRunProgress) {
+      started = true
+      capturedSignal = options.signal
+      return new Promise<void>((resolve, reject) => {
+        resolveRun = resolve
+        rejectRun = reject
+      })
+    },
+  }
+  return {
+    runner,
+    finish: () => resolveRun?.(),
+    fail: (err: unknown) => rejectRun?.(err),
+    signal: () => capturedSignal,
+    hasStarted: () => started,
+  }
+}
+
+const baseOptions = (label: string): StageRunOptions => ({
+  booksDir: tmpDir,
+  apiKey: "sk-test",
+  promptsDir: "",
+  fromStage: "storyboard",
+  toStage: "storyboard",
+})
+
+async function tick(): Promise<void> {
+  // Let setImmediate-deferred jobs and microtasks run.
+  await new Promise((r) => setTimeout(r, 10))
+}
+
+describe("stage-service cancellation", () => {
+  it("cancelling an active run: cancelling → cancelled, resets running steps, no error event", async () => {
+    const label = "cancel-active"
+    makeBook(label)
+    const bus = createBookEventBus()
+    const events: BookSSEEvent[] = []
+    bus.addListener(label, (e) => events.push(e))
+    const rc = controllableRunner()
+    const svc = createStageService(rc.runner, bus)
+
+    svc.startStageRun(label, baseOptions(label))
+    await tick()
+    expect(rc.hasStarted()).toBe(true)
+
+    const result = svc.cancelStageRun(label)
+    expect(result).toEqual({ status: "cancelling" })
+    expect(svc.getStatus(label).active?.status).toBe("cancelling")
+    expect(rc.signal()?.aborted).toBe(true)
+
+    // The abort branch only runs after runner.run() settles.
+    rc.fail(new Error("aborted mid-run"))
+    await tick()
+
+    expect(events.some((e) => e.type === "stage-run-cancelled")).toBe(true)
+    expect(events.some((e) => e.type === "stage-run-error")).toBe(false)
+    // Cancelled job is cleared from active (fully captured in DB).
+    expect(svc.getStatus(label).active).toBeNull()
+    // The running step returned to idle (row deleted).
+    expect(stepRunStatuses(label).has("page-sectioning")).toBe(false)
+  })
+
+  it("empties the queue on cancel and does not run queued jobs", async () => {
+    const label = "cancel-queue"
+    makeBook(label)
+    const bus = createBookEventBus()
+    const rc = controllableRunner()
+    const svc = createStageService(rc.runner, bus)
+
+    svc.startStageRun(label, baseOptions(label))
+    await tick()
+    const queued = svc.startStageRun(label, baseOptions(label))
+    expect(queued.status).toBe("queued")
+    expect(svc.getStatus(label).queue).toHaveLength(1)
+
+    svc.cancelStageRun(label)
+    expect(svc.getStatus(label).queue).toHaveLength(0)
+  })
+
+  it("a start during cancelling queues (never runs in parallel) and drains after cancel", async () => {
+    const label = "start-during-cancel"
+    makeBook(label)
+    const bus = createBookEventBus()
+    const runInvocations: number[] = []
+    let resolveFirst: (() => void) | undefined
+    let calls = 0
+    const runner: StageRunner = {
+      run() {
+        const n = ++calls
+        runInvocations.push(n)
+        return new Promise<void>((resolve, reject) => {
+          if (n === 1) resolveFirst = () => reject(new Error("cancelled"))
+          else resolve()
+        })
+      },
+    }
+    const svc = createStageService(runner, bus)
+
+    svc.startStageRun(label, baseOptions(label))
+    await tick()
+    svc.cancelStageRun(label)
+    // Start arrives while the first run is still unwinding.
+    const during = svc.startStageRun(label, baseOptions(label))
+    expect(during.status).toBe("queued")
+    // Only the first run has started so far — no parallel second runner.
+    expect(runInvocations).toEqual([1])
+
+    // First run settles → drainQueue starts the queued one.
+    resolveFirst?.()
+    await tick()
+    expect(runInvocations).toEqual([1, 2])
+  })
+
+  it("cancel with a hung failed job and empty queue returns null (→ 404)", async () => {
+    const label = "cancel-failed"
+    makeBook(label)
+    const bus = createBookEventBus()
+    const rc = controllableRunner()
+    const svc = createStageService(rc.runner, bus)
+
+    svc.startStageRun(label, baseOptions(label))
+    await tick()
+    rc.fail(new Error("boom"))
+    await tick()
+    expect(svc.getStatus(label).active?.status).toBe("failed")
+
+    expect(svc.cancelStageRun(label)).toBeNull()
+  })
+
+  it("a second cancel while cancelling is an idempotent no-op", async () => {
+    const label = "double-cancel"
+    makeBook(label)
+    const bus = createBookEventBus()
+    const rc = controllableRunner()
+    const svc = createStageService(rc.runner, bus)
+
+    svc.startStageRun(label, baseOptions(label))
+    await tick()
+    expect(svc.cancelStageRun(label)).toEqual({ status: "cancelling" })
+    expect(svc.cancelStageRun(label)).toEqual({ status: "cancelling" })
+  })
+
+  it("run() that resolves with the signal aborted is treated as completed (no cancelled event)", async () => {
+    const label = "resolve-after-abort"
+    makeBook(label)
+    const bus = createBookEventBus()
+    const events: BookSSEEvent[] = []
+    bus.addListener(label, (e) => events.push(e))
+    const rc = controllableRunner()
+    const svc = createStageService(rc.runner, bus)
+
+    svc.startStageRun(label, baseOptions(label))
+    await tick()
+    svc.cancelStageRun(label)
+    // The run finished all remaining work before the abort took effect.
+    rc.finish()
+    await tick()
+
+    expect(events.some((e) => e.type === "stage-run-complete")).toBe(true)
+    expect(events.some((e) => e.type === "stage-run-cancelled")).toBe(false)
+  })
+
+  it("cancel resolves pending page-error decisions as stop", async () => {
+    const label = "cancel-decisions"
+    makeBook(label)
+    const bus = createBookEventBus()
+    // A listener so the broker arms the decision instead of waiting a grace period.
+    bus.addListener(label, () => {})
+    const decisions = createPageErrorDecisions(bus)
+    const rc = controllableRunner()
+    const svc = createStageService(rc.runner, bus, decisions)
+
+    svc.startStageRun(label, baseOptions(label))
+    await tick()
+
+    const decisionPromise = decisions.requestDecision({
+      label,
+      step: "web-rendering",
+      pageId: "pg001",
+      error: "boom",
+    })
+
+    svc.cancelStageRun(label)
+    await expect(decisionPromise).resolves.toBe("stop")
+  })
+})

--- a/apps/api/src/services/stage-service.test.ts
+++ b/apps/api/src/services/stage-service.test.ts
@@ -116,20 +116,53 @@ describe("stage-service cancellation", () => {
     expect(stepRunStatuses(label).has("page-sectioning")).toBe(false)
   })
 
-  it("empties the queue on cancel and does not run queued jobs", async () => {
-    const label = "cancel-queue"
+  it("preserves queued jobs when cancelling the active run and drains them after cancel", async () => {
+    const label = "cancel-active-preserve-queue"
     makeBook(label)
     const bus = createBookEventBus()
-    const rc = controllableRunner()
-    const svc = createStageService(rc.runner, bus)
+    const runInvocations: string[] = []
+    let rejectFirst: ((err: unknown) => void) | undefined
+    let calls = 0
+    const runner: StageRunner = {
+      run(_label: string, options: StageRunOptions) {
+        calls++
+        runInvocations.push(`${options.fromStage}->${options.toStage}`)
+        return new Promise<void>((resolve, reject) => {
+          if (calls === 1) {
+            rejectFirst = reject
+            return
+          }
+          resolve()
+        })
+      },
+    }
+    const svc = createStageService(runner, bus)
 
-    svc.startStageRun(label, baseOptions(label))
+    svc.startStageRun(label, {
+      ...baseOptions(label),
+      fromStage: "captions",
+      toStage: "captions",
+    })
     await tick()
-    const queued = svc.startStageRun(label, baseOptions(label))
+    const queued = svc.startStageRun(label, {
+      ...baseOptions(label),
+      fromStage: "glossary",
+      toStage: "glossary",
+    })
     expect(queued.status).toBe("queued")
     expect(svc.getStatus(label).queue).toHaveLength(1)
 
     svc.cancelStageRun(label)
+    expect(svc.getStatus(label).active?.status).toBe("cancelling")
+    expect(svc.getStatus(label).queue).toEqual([
+      expect.objectContaining({ fromStage: "glossary", toStage: "glossary" }),
+    ])
+    expect(runInvocations).toEqual(["captions->captions"])
+
+    rejectFirst?.(new Error("cancelled"))
+    await tick()
+
+    expect(runInvocations).toEqual(["captions->captions", "glossary->glossary"])
     expect(svc.getStatus(label).queue).toHaveLength(0)
   })
 

--- a/apps/api/src/services/stage-service.ts
+++ b/apps/api/src/services/stage-service.ts
@@ -94,9 +94,10 @@ export interface StageService {
     label: string,
     options: StageRunOptions
   ): { status: "started" | "queued"; id: string }
-  /** Request cancellation of the active run and clear the queue. Returns
-   *  "cancelling" while the run unwinds, "cancelled" if only a queue was
-   *  cleared, or null when there is nothing to cancel (→ 404). */
+  /** Request cancellation of the active run. Queued runs are preserved and will
+   *  start after the active run unwinds. Returns "cancelling" while the run
+   *  unwinds, "cancelled" if only a queue was cleared, or null when there is
+   *  nothing to cancel (→ 404). */
   cancelStageRun(label: string): { status: "cancelling" | "cancelled" } | null
 }
 
@@ -315,9 +316,6 @@ export function createStageService(
       }
 
       if (active?.status === "running") {
-        // Empty the queue first: cancelling a run without clearing the queue
-        // would just start the next item straight after.
-        if (state) state.queue = []
         active.status = "cancelling"
         active.controller.abort()
         // Unblock any pending page-error decision so the runner unwinds now

--- a/apps/api/src/services/stage-service.ts
+++ b/apps/api/src/services/stage-service.ts
@@ -1,8 +1,16 @@
 import { STAGE_ORDER, type ProgressEvent } from "@adt/types"
-import type { StageName } from "@adt/types"
+import type { StageName, StepName, PageErrorPolicy, PageErrorAction } from "@adt/types"
+import { createBookStorage } from "@adt/storage"
 import type { BookEventBus } from "./book-event-bus.js"
+import type { PageErrorDecisions } from "./page-error-decisions.js"
 
-export type StageRunStatus = "idle" | "running" | "completed" | "failed"
+export type StageRunStatus =
+  | "idle"
+  | "running"
+  | "cancelling"
+  | "cancelled"
+  | "completed"
+  | "failed"
 
 export interface StageRunJob {
   label: string
@@ -12,6 +20,8 @@ export interface StageRunJob {
   error?: string
   startedAt?: number
   completedAt?: number
+  /** Per-job cancellation. abort() is called by cancelStageRun. */
+  controller: AbortController
 }
 
 export interface QueuedStageRun {
@@ -49,6 +59,19 @@ export interface StageRunOptions {
   azureSpeechRegion?: string
   geminiApiKey?: string
   beforeRun?: () => void
+  /** Cancellation signal for the run. Aborts in-flight LLM calls and stops the
+   *  runner at the next checkpoint. Set by the service per job. */
+  signal?: AbortSignal
+  /** How to react when a page fails inside a per-page step. Defaults to "stop"
+   *  (accumulate + fail at the end — the historical behavior). */
+  pageErrorPolicy?: PageErrorPolicy
+  /** Ask the user how to handle a failed page (only used when pageErrorPolicy
+   *  is "ask"). Bound to this run's label by the service. */
+  requestPageDecision?: (input: {
+    step: StepName
+    pageId: string
+    error: string
+  }) => Promise<PageErrorAction>
 }
 
 export interface StageRunProgress {
@@ -71,13 +94,18 @@ export interface StageService {
     label: string,
     options: StageRunOptions
   ): { status: "started" | "queued"; id: string }
+  /** Request cancellation of the active run and clear the queue. Returns
+   *  "cancelling" while the run unwinds, "cancelled" if only a queue was
+   *  cleared, or null when there is nothing to cancel (→ 404). */
+  cancelStageRun(label: string): { status: "cancelling" | "cancelled" } | null
 }
 
 let nextId = 1
 
 export function createStageService(
   runner: StageRunner,
-  eventBus: BookEventBus
+  eventBus: BookEventBus,
+  decisions?: PageErrorDecisions
 ): StageService {
   const books = new Map<string, BookRunState>()
 
@@ -101,19 +129,56 @@ export function createStageService(
       },
     }
 
+    // Inject the cancellation signal and (interactive-mode) decision hook. Done
+    // here — not in the route — so both immediate and queued jobs get the job's
+    // own controller and a label-bound broker.
+    const effectiveOptions: StageRunOptions = {
+      ...options,
+      signal: job.controller.signal,
+      requestPageDecision: decisions
+        ? (input) => decisions.requestDecision({ label, ...input })
+        : undefined,
+    }
+
     try {
       options.beforeRun?.()
-      await runner.run(label, options, progress)
+      await runner.run(label, effectiveOptions, progress)
+      // Resolved: either a real completion, or a cancel that landed after the
+      // last checkpoint so all remaining work finished. Both are "completed" —
+      // no cancelled event, no step reset (the run genuinely finished).
       job.status = "completed"
       job.completedAt = Date.now()
       eventBus.emit(label, { type: "stage-run-complete", label })
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err)
-      console.error(`[stage-run] ${label} failed:`, message)
-      job.status = "failed"
-      job.error = message
-      job.completedAt = Date.now()
-      eventBus.emit(label, { type: "stage-run-error", label, error: message })
+      if (job.controller.signal.aborted) {
+        // Cancel branch — runs only here, after runner.run() has settled, so the
+        // runner is no longer touching step_runs. Return in-flight steps to idle
+        // (deliberate action, not a failure) and announce completion of the cancel.
+        try {
+          const storage = createBookStorage(label, options.booksDir)
+          try {
+            storage.clearRunningStepRuns()
+          } finally {
+            storage.close()
+          }
+        } catch (cleanupErr) {
+          console.error(`[stage-run] ${label} cancel cleanup failed:`, cleanupErr)
+        }
+        job.status = "cancelled"
+        job.completedAt = Date.now()
+        eventBus.emit(label, { type: "stage-run-cancelled", label })
+      } else {
+        const message = err instanceof Error ? err.message : String(err)
+        console.error(`[stage-run] ${label} failed:`, message)
+        job.status = "failed"
+        job.error = message
+        job.completedAt = Date.now()
+        eventBus.emit(label, { type: "stage-run-error", label, error: message })
+      }
+    } finally {
+      // Clear any per-run page-error policy / pending decisions so they never
+      // leak into the next run of this book.
+      decisions?.clearForRun(label)
     }
 
     drainQueue(label)
@@ -124,7 +189,9 @@ export function createStageService(
     if (!state) return
     if (state.queue.length === 0) {
       // Keep failed jobs so active?.error survives page refresh.
-      // Only clear completed jobs — their state is fully captured in the DB.
+      // Clear completed AND cancelled jobs — their post-run state is fully
+      // captured in the DB (cancelled steps are back to idle), so there's
+      // nothing to preserve for a refresh.
       if (state.active?.status !== "failed") {
         state.active = null
       }
@@ -138,6 +205,7 @@ export function createStageService(
       fromStage: next.fromStage,
       toStage: next.toStage,
       startedAt: Date.now(),
+      controller: new AbortController(),
     }
     state.active = job
 
@@ -190,8 +258,15 @@ export function createStageService(
       const state = getOrCreateState(label)
       const id = String(nextId++)
 
-      if (state.active?.status === "running") {
-        // Queue behind the active run
+      // Queue behind a run that is active OR still unwinding a cancel. Without
+      // the "cancelling" case a start during the cancel window would begin
+      // immediately, in parallel with the run still tearing down — two runners
+      // on one book, and the cancel's cleanup would delete the new run's rows.
+      // The post-cancel drainQueue picks this up instead.
+      if (
+        state.active?.status === "running" ||
+        state.active?.status === "cancelling"
+      ) {
         state.queue.push({
           id,
           fromStage: options.fromStage,
@@ -208,6 +283,7 @@ export function createStageService(
         fromStage: options.fromStage,
         toStage: options.toStage,
         startedAt: Date.now(),
+        controller: new AbortController(),
       }
       state.active = job
 
@@ -224,6 +300,45 @@ export function createStageService(
       })
 
       return { status: "started", id }
+    },
+
+    cancelStageRun(
+      label: string
+    ): { status: "cancelling" | "cancelled" } | null {
+      const state = books.get(label)
+      const active = state?.active
+
+      // Second click / duplicate request while the cancel is already unwinding:
+      // idempotent no-op.
+      if (active?.status === "cancelling") {
+        return { status: "cancelling" }
+      }
+
+      if (active?.status === "running") {
+        // Empty the queue first: cancelling a run without clearing the queue
+        // would just start the next item straight after.
+        if (state) state.queue = []
+        active.status = "cancelling"
+        active.controller.abort()
+        // Unblock any pending page-error decision so the runner unwinds now
+        // rather than waiting out the safety timeout.
+        decisions?.clearForRun(label, "stop")
+        // The abort branch of executeJob emits stage-run-cancelled once the
+        // runner settles and flips the status to "cancelled".
+        return { status: "cancelling" }
+      }
+
+      // No active running job. Only a queue to clear (e.g. jobs waiting behind
+      // one that already finished, or a hung failed job kept for its error).
+      if (state && state.queue.length > 0) {
+        state.queue = []
+        return { status: "cancelled" }
+      }
+
+      // Nothing to cancel — includes a "failed" job pinned as active with no
+      // queue. Aborting it would strand isCancelling forever with no executeJob
+      // to emit "cancelled".
+      return null
     },
   }
 }

--- a/apps/desktop/src/main/services/screenshot.ts
+++ b/apps/desktop/src/main/services/screenshot.ts
@@ -16,22 +16,26 @@ async function screenshot(
     show: false,
     webPreferences: { offscreen: true },
   });
+  windows.add(win);
 
-  const loadPromise = new Promise<void>((resolve, reject) => {
-    win.webContents.once("did-finish-load", resolve);
-    win.webContents.once("did-fail-load", (_, _code, desc) =>
-      reject(new Error(desc)),
-    );
-  });
+  try {
+    const loadPromise = new Promise<void>((resolve, reject) => {
+      win.webContents.once("did-finish-load", resolve);
+      win.webContents.once("did-fail-load", (_, _code, desc) =>
+        reject(new Error(desc)),
+      );
+    });
 
-  await win.loadURL(`html-render://${id}`);
-  await loadPromise;
+    await win.loadURL(`html-render://${id}`);
+    await loadPromise;
 
-  const image = await win.webContents.capturePage();
-  win.destroy();
-  htmlStore.delete(id);
-
-  return image.toPNG().toString("base64");
+    const image = await win.webContents.capturePage();
+    return image.toPNG().toString("base64");
+  } finally {
+    windows.delete(win);
+    if (!win.isDestroyed()) win.destroy();
+    htmlStore.delete(id);
+  }
 }
 
 async function close(): Promise<void> {

--- a/apps/studio/src/api/client.ts
+++ b/apps/studio/src/api/client.ts
@@ -205,6 +205,9 @@ export interface RunStagesOptions {
   toStage: string
   /** When true, skip page-sectioning and only re-render from existing section data. */
   renderOnly?: boolean
+  /** How to react when a page fails inside a per-page step. The Studio sends
+   *  "ask" so page errors surface an interactive skip/stop dialog. */
+  pageErrorPolicy?: "ask" | "stop"
 }
 
 function buildApiHeaders(
@@ -236,9 +239,16 @@ function buildApiHeaders(
   return headers
 }
 
+export interface PendingDecision {
+  decisionId: string
+  step: string
+  pageId: string
+  error: string
+}
+
 export interface StageRunStatus {
   label: string
-  status: "idle" | "running" | "completed" | "failed"
+  status: "idle" | "running" | "cancelling" | "cancelled" | "completed" | "failed"
   fromStage?: string
   toStage?: string
   error?: string
@@ -880,6 +890,33 @@ export const api = {
   getStagesStatus: (label: string) =>
     request<StageRunStatus>(`/books/${label}/stages/status`),
 
+  /** Cancel the active run and clear the queue. A 404 (nothing to cancel — the
+   *  run may have finished between the click and this request) resolves silently. */
+  cancelRun: async (label: string): Promise<void> => {
+    const res = await fetch(`${BASE_URL}/books/${label}/stages/cancel`, {
+      method: "POST",
+    })
+    if (res.ok || res.status === 404) return
+    const text = await res.text().catch(() => "")
+    throw new Error(text || `Cancel failed: ${res.status}`)
+  },
+
+  /** Resolve a pending page-error decision. A 409 (already resolved by
+   *  timeout/cancel) is treated as success — the caller drops the stale dialog. */
+  resolveDecision: async (
+    label: string,
+    body: { decisionId: string; action: "skip" | "stop"; applyToAll?: boolean },
+  ): Promise<void> => {
+    const res = await fetch(`${BASE_URL}/books/${label}/stages/decision`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    })
+    if (res.ok || res.status === 409) return
+    const text = await res.text().catch(() => "")
+    throw new Error(text || `Decision failed: ${res.status}`)
+  },
+
   getPages: (label: string) =>
     request<PageSummaryItem[]>(`/books/${label}/pages`),
 
@@ -1306,6 +1343,8 @@ export const api = {
       error: string | null
       stepErrors: Record<string, string> | null
       stepMessages: Record<string, string> | null
+      runStatus: "idle" | "running" | "cancelling" | "cancelled" | "completed" | "failed"
+      pendingDecisions: PendingDecision[]
     }>(`/books/${label}/step-status`),
 
   getTTS: (label: string) =>

--- a/apps/studio/src/api/client.ts
+++ b/apps/studio/src/api/client.ts
@@ -890,8 +890,10 @@ export const api = {
   getStagesStatus: (label: string) =>
     request<StageRunStatus>(`/books/${label}/stages/status`),
 
-  /** Cancel the active run and clear the queue. A 404 (nothing to cancel — the
-   *  run may have finished between the click and this request) resolves silently. */
+  /** Cancel the active run. Queued runs are preserved and start after it unwinds;
+   *  a pending queue with no active run is cleared instead. A 404 (nothing to
+   *  cancel — the run may have finished between the click and this request)
+   *  resolves silently. */
   cancelRun: async (label: string): Promise<void> => {
     const res = await fetch(`${BASE_URL}/books/${label}/stages/cancel`, {
       method: "POST",

--- a/apps/studio/src/components/pipeline/StageSidebar.test.tsx
+++ b/apps/studio/src/components/pipeline/StageSidebar.test.tsx
@@ -189,6 +189,8 @@ describe("StageSidebar", () => {
 
     const cancelButton = screen.getByTitle("Cancel Storyboard step")
     expect(cancelButton.className).toContain("bg-red-600")
+    expect(cancelButton.className).toContain("left-2")
+    expect(cancelButton.className).not.toContain("left-2.5")
 
     fireEvent.click(cancelButton)
 

--- a/apps/studio/src/components/pipeline/StageSidebar.test.tsx
+++ b/apps/studio/src/components/pipeline/StageSidebar.test.tsx
@@ -1,13 +1,15 @@
 // @vitest-environment jsdom
 import React from "react"
 import { afterEach, describe, expect, it, vi } from "vitest"
-import { cleanup, render, screen } from "@testing-library/react"
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
 
 const defaultStageState = (slug: string) => {
   if (slug === "storyboard" || slug === "validation") return "done"
   return "idle"
 }
 const stageStateMock = vi.fn(defaultStageState)
+const cancelRunMock = vi.fn()
+const toastInfoMock = vi.fn()
 const matchRouteMock = vi.fn(() => true)
 const searchMock = { tab: "reviewer-checklist" }
 
@@ -65,7 +67,15 @@ vi.mock("@/hooks/use-book-run", () => ({
     stageState: stageStateMock,
     stepState: vi.fn(() => "idle"),
     stepProgress: vi.fn(() => null),
+    cancelRun: cancelRunMock,
+    isCancelling: false,
   }),
+}))
+
+vi.mock("@/components/ui/sonner", () => ({
+  toast: {
+    info: toastInfoMock,
+  },
 }))
 
 vi.mock("@/hooks/use-debug", () => ({
@@ -161,5 +171,28 @@ describe("StageSidebar", () => {
     expect(errorBadge.className).toContain("bg-red-600")
     expect(errorBadge.getAttribute("role")).toBe("img")
     expect(container.querySelector('circle[stroke="#ef4444"]')).toBeNull()
+  })
+
+  it("shows a cancel button over a running stage icon and requests cancellation", async () => {
+    stageStateMock.mockImplementation((slug: string) => {
+      if (slug === "storyboard") return "running"
+      return defaultStageState(slug)
+    })
+
+    const { StageSidebar } = await import("./components/StageSidebar")
+    render(
+      <StageSidebar
+        bookLabel="demo-book"
+        activeStep="storyboard"
+      />,
+    )
+
+    const cancelButton = screen.getByTitle("Cancel Storyboard step")
+    expect(cancelButton.className).toContain("bg-red-600")
+
+    fireEvent.click(cancelButton)
+
+    expect(cancelRunMock).toHaveBeenCalledTimes(1)
+    expect(toastInfoMock).toHaveBeenCalledWith("Cancelling Storyboard step")
   })
 })

--- a/apps/studio/src/components/pipeline/StageSidebar.test.tsx
+++ b/apps/studio/src/components/pipeline/StageSidebar.test.tsx
@@ -3,10 +3,11 @@ import React from "react"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { cleanup, render, screen } from "@testing-library/react"
 
-const stageStateMock = vi.fn((slug: string) => {
+const defaultStageState = (slug: string) => {
   if (slug === "storyboard" || slug === "validation") return "done"
   return "idle"
-})
+}
+const stageStateMock = vi.fn(defaultStageState)
 const matchRouteMock = vi.fn(() => true)
 const searchMock = { tab: "reviewer-checklist" }
 
@@ -118,6 +119,7 @@ vi.mock("@/routes/books.$label", () => ({
 afterEach(() => {
   cleanup()
   vi.clearAllMocks()
+  stageStateMock.mockImplementation(defaultStageState)
 })
 
 describe("StageSidebar", () => {
@@ -139,5 +141,25 @@ describe("StageSidebar", () => {
     expect(screen.getByText("Reviewer Checklist")).toBeTruthy()
     expect(container.textContent).toContain("Validation")
     expect(container.textContent).toContain("Preview")
+  })
+
+  it("shows a red error badge on failed stages", async () => {
+    stageStateMock.mockImplementation((slug: string) => {
+      if (slug === "storyboard") return "error"
+      return defaultStageState(slug)
+    })
+
+    const { StageSidebar } = await import("./components/StageSidebar")
+    const { container } = render(
+      <StageSidebar
+        bookLabel="demo-book"
+        activeStep="storyboard"
+      />,
+    )
+
+    const errorBadge = screen.getByTitle("Storyboard: failed")
+    expect(errorBadge.className).toContain("bg-red-600")
+    expect(errorBadge.getAttribute("role")).toBe("img")
+    expect(container.querySelector('circle[stroke="#ef4444"]')).toBeNull()
   })
 })

--- a/apps/studio/src/components/pipeline/components/LandingPageShell.tsx
+++ b/apps/studio/src/components/pipeline/components/LandingPageShell.tsx
@@ -1,6 +1,6 @@
 import { useState, type CSSProperties, type ReactNode } from "react"
 import { Link } from "@tanstack/react-router"
-import { Play, Loader2, Settings, CircleStop, Square, X } from "lucide-react"
+import { Play, Loader2, Settings, X } from "lucide-react"
 import { Trans } from "@lingui/react/macro"
 import { useBookRun } from "@/hooks/use-book-run"
 import { cn } from "@/lib/utils"

--- a/apps/studio/src/components/pipeline/components/LandingPageShell.tsx
+++ b/apps/studio/src/components/pipeline/components/LandingPageShell.tsx
@@ -1,6 +1,6 @@
 import { useState, type CSSProperties, type ReactNode } from "react"
 import { Link } from "@tanstack/react-router"
-import { Play, Loader2, Settings, CircleStop } from "lucide-react"
+import { Play, Loader2, Settings, CircleStop, Square, X } from "lucide-react"
 import { Trans } from "@lingui/react/macro"
 import { useBookRun } from "@/hooks/use-book-run"
 import { cn } from "@/lib/utils"
@@ -106,7 +106,7 @@ export function LandingPageShell({
       className={cn(
         "h-10 px-5 font-medium text-white transition-[background-color,opacity] border-0",
         "disabled:opacity-60 disabled:cursor-default",
-        "bg-gray-600 hover:bg-gray-700"
+        "bg-red-500 hover:bg-red-700"
       )}
     >
       {isCancelling ? (
@@ -116,7 +116,7 @@ export function LandingPageShell({
         </>
       ) : (
         <>
-          <CircleStop className="w-4 h-4 mr-2" />
+          <X className="size-5 mr-2" />
           <Trans>Cancel</Trans>
         </>
       )}

--- a/apps/studio/src/components/pipeline/components/LandingPageShell.tsx
+++ b/apps/studio/src/components/pipeline/components/LandingPageShell.tsx
@@ -1,7 +1,8 @@
 import { useState, type CSSProperties, type ReactNode } from "react"
 import { Link } from "@tanstack/react-router"
-import { Play, Loader2, Settings } from "lucide-react"
+import { Play, Loader2, Settings, CircleStop } from "lucide-react"
 import { Trans } from "@lingui/react/macro"
+import { useBookRun } from "@/hooks/use-book-run"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import {
@@ -69,6 +70,7 @@ export function LandingPageShell({
   const [confirmOpen, setConfirmOpen] = useState(false)
   const downstreamAffected = useDownstreamWithOutput(stageSlug)
   const needsConfirmation = isCompleted && downstreamAffected.length > 0
+  const { isCancelling, cancelRun } = useBookRun()
 
   const accentStyle: CSSProperties = {}
   if (accentColor) {
@@ -97,7 +99,29 @@ export function LandingPageShell({
 
   const stageLabel = getStageLabelI18n(stageSlug)
 
-  const runButton = (
+  const runButton = isRunning ? (
+    <Button
+      onClick={() => cancelRun()}
+      disabled={isCancelling}
+      className={cn(
+        "h-10 px-5 font-medium text-white transition-[background-color,opacity] border-0",
+        "disabled:opacity-60 disabled:cursor-default",
+        "bg-gray-600 hover:bg-gray-700"
+      )}
+    >
+      {isCancelling ? (
+        <>
+          <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+          <Trans>Cancelling...</Trans>
+        </>
+      ) : (
+        <>
+          <CircleStop className="w-4 h-4 mr-2" />
+          <Trans>Cancel</Trans>
+        </>
+      )}
+    </Button>
+  ) : (
     <Button
       onClick={handleRunClick}
       disabled={isDisabled}
@@ -107,17 +131,8 @@ export function LandingPageShell({
         hasError ? errorColorClass : colorClass
       )}
     >
-      {isRunning ? (
-        <>
-          <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-          <Trans>Running...</Trans>
-        </>
-      ) : (
-        <>
-          <Play className="w-4 h-4 mr-2" />
-          {isCompleted || hasError ? rerunLabel : runLabel}
-        </>
-      )}
+      <Play className="w-4 h-4 mr-2" />
+      {isCompleted || hasError ? rerunLabel : runLabel}
     </Button>
   )
 

--- a/apps/studio/src/components/pipeline/components/PageErrorDecisionDialog.tsx
+++ b/apps/studio/src/components/pipeline/components/PageErrorDecisionDialog.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useState } from "react"
+import { SkipForward, CircleStop } from "lucide-react"
+import { Trans } from "@lingui/react/macro"
+import { useLingui } from "@lingui/react"
+import { msg } from "@lingui/core/macro"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { useBookRun } from "@/hooks/use-book-run"
+import { getStepLabelI18n } from "../pipeline-i18n"
+
+/**
+ * Interactive prompt shown when a page fails inside a per-page step and the run
+ * is waiting for the user to decide: skip that page and keep going, or stop the
+ * whole step. Decisions queue — one is shown at a time. Mounted at the book
+ * layout so it appears on any screen of the book.
+ */
+export function PageErrorDecisionDialog() {
+  const { i18n } = useLingui()
+  const { pendingDecisions, resolveDecision } = useBookRun()
+  const current = pendingDecisions[0]
+  const [applyToAll, setApplyToAll] = useState(false)
+
+  // Reset the "apply to all" checkbox whenever a new decision comes to the head.
+  useEffect(() => {
+    setApplyToAll(false)
+  }, [current?.decisionId])
+
+  if (!current) return null
+
+  const stepLabel = getStepLabelI18n(current.step)
+
+  const resolve = (action: "skip" | "stop") => {
+    resolveDecision(current.decisionId, action, applyToAll)
+  }
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        // Dismissing without choosing is not allowed — the run is blocked on a
+        // decision. Ignore close attempts; the buttons are the only exits.
+        if (!open) return
+      }}
+    >
+      <DialogContent className="gap-5 p-6 sm:max-w-md [&>button]:hidden">
+        <DialogHeader className="text-left">
+          <DialogTitle className="text-[16px] font-semibold leading-tight tracking-tight">
+            <Trans>A page failed in {stepLabel}</Trans>
+          </DialogTitle>
+          <DialogDescription className="text-[13px] leading-snug text-muted-foreground">
+            <Trans>
+              Skip this page and continue the step, or stop the step entirely.
+            </Trans>
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-1.5 rounded-lg border bg-muted/40 px-3 py-2.5">
+          <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground/70">
+            <Trans>Page</Trans> {current.pageId}
+          </p>
+          <p className="max-h-32 overflow-y-auto whitespace-pre-wrap break-words text-xs text-foreground/80">
+            {current.error}
+          </p>
+        </div>
+
+        <label className="flex items-center gap-2 text-[13px] text-muted-foreground">
+          <input
+            type="checkbox"
+            checked={applyToAll}
+            onChange={(e) => setApplyToAll(e.target.checked)}
+            className="h-4 w-4 rounded border-input accent-current"
+          />
+          <Trans>Apply to all errors in this run</Trans>
+        </label>
+
+        <DialogFooter className="-mt-1 gap-2">
+          <Button
+            variant="ghost"
+            onClick={() => resolve("skip")}
+            className="h-10 px-4 font-medium"
+            title={i18n._(msg`Skip page and continue`)}
+          >
+            <SkipForward className="mr-2 h-4 w-4" />
+            <Trans>Skip page and continue</Trans>
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={() => resolve("stop")}
+            className="h-10 px-5 font-medium"
+            title={i18n._(msg`Stop step`)}
+          >
+            <CircleStop className="mr-2 h-4 w-4" />
+            <Trans>Stop step</Trans>
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/studio/src/components/pipeline/components/StageRunCard.tsx
+++ b/apps/studio/src/components/pipeline/components/StageRunCard.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode } from "react"
 import { Link } from "@tanstack/react-router"
-import { ArrowRight, Check, CircleStop, Loader2, Minus, Play, RotateCcw, X, XCircle } from "lucide-react"
+import { ArrowRight, Check, Loader2, Minus, Play, RotateCcw, X, XCircle } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Card, CardHeader, CardTitle, CardContent, CardFooter } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"

--- a/apps/studio/src/components/pipeline/components/StageRunCard.tsx
+++ b/apps/studio/src/components/pipeline/components/StageRunCard.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode } from "react"
 import { Link } from "@tanstack/react-router"
-import { ArrowRight, Check, Loader2, Minus, Play, RotateCcw, XCircle } from "lucide-react"
+import { ArrowRight, Check, CircleStop, Loader2, Minus, Play, RotateCcw, XCircle } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Card, CardHeader, CardTitle, CardContent, CardFooter } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
@@ -67,7 +67,7 @@ export function StageRunCard({
 }: StageRunCardProps) {
   const { t } = useLingui()
   const stage = STAGES.find((s) => s.slug === stageSlug) ?? STAGES[0]
-  const { stageState, stepState, stepProgress, stepError, error } = useBookRun()
+  const { stageState, stepState, stepProgress, stepError, error, isCancelling, cancelRun } = useBookRun()
   const stageStatus = stageState(stageSlug)
   const subSteps = STAGE_SUB_STEPS[stageSlug as StageName] ?? []
   const Icon = stage.icon
@@ -200,21 +200,39 @@ export function StageRunCard({
         {showRunButton && (
           <div className="shrink-0">
             {isRunning ? (
-              // Keep a real (disabled) button so the control stays in the a11y
-              // tree with an accessible name and an announced busy state, rather
-              // than vanishing into a nameless spinner <div>.
-              <button
-                type="button"
-                disabled
-                aria-busy="true"
-                aria-label={t`Running ${stageLabel}`}
-                className={cn(
-                  "flex items-center justify-center w-12 h-12 rounded-full opacity-60 cursor-default",
-                  color, "text-white",
-                )}
-              >
-                <Loader2 className="w-5 h-5 animate-spin" />
-              </button>
+              isCancelling ? (
+                // Cancel requested — disabled until the run finishes unwinding.
+                <button
+                  type="button"
+                  disabled
+                  aria-busy="true"
+                  aria-label={t`Cancelling ${stageLabel}`}
+                  title={t`Cancelling…`}
+                  className={cn(
+                    "flex items-center justify-center w-12 h-12 rounded-full opacity-60 cursor-default",
+                    "bg-gray-400 text-white",
+                  )}
+                >
+                  <Loader2 className="w-5 h-5 animate-spin" />
+                </button>
+              ) : (
+                // Running — the spinner button doubles as a stop control.
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={(e) => { e.stopPropagation(); e.preventDefault(); cancelRun() }}
+                  aria-label={t`Cancel ${stageLabel}`}
+                  title={t`Cancel run`}
+                  className={cn(
+                    "group/stop w-12 h-12 rounded-full transition-all cursor-pointer [&_svg]:size-5",
+                    "hover:scale-105 active:scale-95",
+                    color, "text-white",
+                  )}
+                >
+                  <Loader2 className="w-5 h-5 animate-spin group-hover/stop:hidden" />
+                  <CircleStop className="w-5 h-5 hidden group-hover/stop:block" />
+                </Button>
+              )
             ) : (
               <Button
                 variant="ghost"

--- a/apps/studio/src/components/pipeline/components/StageRunCard.tsx
+++ b/apps/studio/src/components/pipeline/components/StageRunCard.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode } from "react"
 import { Link } from "@tanstack/react-router"
-import { ArrowRight, Check, CircleStop, Loader2, Minus, Play, RotateCcw, XCircle } from "lucide-react"
+import { ArrowRight, Check, CircleStop, Loader2, Minus, Play, RotateCcw, X, XCircle } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Card, CardHeader, CardTitle, CardContent, CardFooter } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
@@ -218,7 +218,7 @@ export function StageRunCard({
               ) : (
                 // Running — the spinner button doubles as a stop control.
                 <Button
-                  variant="ghost"
+                  variant="destructive"
                   size="icon"
                   onClick={(e) => { e.stopPropagation(); e.preventDefault(); cancelRun() }}
                   aria-label={t`Cancel ${stageLabel}`}
@@ -230,7 +230,7 @@ export function StageRunCard({
                   )}
                 >
                   <Loader2 className="w-5 h-5 animate-spin group-hover/stop:hidden" />
-                  <CircleStop className="w-5 h-5 hidden group-hover/stop:block" />
+                  <X className="w-5 h-5 hidden group-hover/stop:block" />
                 </Button>
               )
             ) : (

--- a/apps/studio/src/components/pipeline/components/StageSidebar.tsx
+++ b/apps/studio/src/components/pipeline/components/StageSidebar.tsx
@@ -3,6 +3,7 @@ import { createPortal } from "react-dom"
 import { Link, useMatchRoute, useSearch } from "@tanstack/react-router"
 import { Trans } from "@lingui/react/macro"
 import {
+  CircleStop,
   Loader2,
   RotateCcw,
   Settings,
@@ -399,7 +400,7 @@ export function StageSidebar({
 function TaskIndicator({ bookLabel }: { bookLabel: string }) {
   const { i18n } = useLingui()
   const { runningTasks, runningCount } = useBookTasks(bookLabel)
-  const { stepState, stepProgress } = useBookRun()
+  const { stepState, stepProgress, isCancelling, cancelRun } = useBookRun()
 
   // Running steps with visible progress (pages, entries, batches, etc.)
   const stageProgressRows: { step: string; label: string; progressLabel: string }[] = []
@@ -423,6 +424,8 @@ function TaskIndicator({ bookLabel }: { bookLabel: string }) {
   }
 
   const totalCount = runningCount + stageProgressRows.length + activeSteps.length
+  // A pipeline stage run (not just ad-hoc tasks) is active — offer to cancel it.
+  const pipelineActive = stageProgressRows.length + activeSteps.length > 0
 
   if (totalCount === 0) return null
 
@@ -465,6 +468,27 @@ function TaskIndicator({ bookLabel }: { bookLabel: string }) {
         <span className="text-xs font-medium text-muted-foreground whitespace-nowrap">
           {totalCount === 1 ? i18n._(msg`Task Running`) : i18n._(msg`Tasks Running`)}
         </span>
+        {pipelineActive && (
+          <button
+            type="button"
+            onClick={cancelRun}
+            disabled={isCancelling}
+            title={isCancelling ? i18n._(msg`Cancelling…`) : i18n._(msg`Cancel run`)}
+            aria-label={isCancelling ? i18n._(msg`Cancelling run`) : i18n._(msg`Cancel run`)}
+            className={cn(
+              "ml-auto shrink-0 inline-flex items-center justify-center w-6 h-6 rounded-full transition-colors",
+              isCancelling
+                ? "text-muted-foreground/50 cursor-default"
+                : "text-muted-foreground hover:text-red-600 hover:bg-red-50 cursor-pointer",
+            )}
+          >
+            {isCancelling ? (
+              <Loader2 className="w-3.5 h-3.5 animate-spin" />
+            ) : (
+              <CircleStop className="w-3.5 h-3.5" />
+            )}
+          </button>
+        )}
       </div>
     </div>
   )

--- a/apps/studio/src/components/pipeline/components/StageSidebar.tsx
+++ b/apps/studio/src/components/pipeline/components/StageSidebar.tsx
@@ -3,6 +3,7 @@ import { createPortal } from "react-dom"
 import { Link, useMatchRoute, useSearch } from "@tanstack/react-router"
 import { Trans } from "@lingui/react/macro"
 import {
+  AlertCircle,
   CircleStop,
   Loader2,
   RotateCcw,
@@ -179,7 +180,7 @@ export function StageSidebar({
     const stageNeedsRerun =
       (step.slug === "translate" && translateNeedsRerun) ||
       (step.slug === "speech" && speechNeedsRerun)
-    const ringState = stageNeedsRerun ? "idle" : state
+    const ringState = stageNeedsRerun || state === "error" ? "idle" : state
 
     // "book" is always filled; all other stages fill when their own completion signal is met.
     const iconFilled = step.slug === "book" ? true : stageCompleted
@@ -237,7 +238,16 @@ export function StageSidebar({
                 <Icon className="w-3.5 h-3.5" />
               </div>
               <StepProgressRing size={28} state={ringState} colorClass={isActive ? "bg-white" : step.color} />
-              {step.slug === "extract" && hasNoTextLayer && (
+              {state === "error" ? (
+                <span
+                  role="img"
+                  aria-label={stepAriaLabel}
+                  title={stepAriaLabel}
+                  className="absolute -top-1 -right-1 z-20 flex items-center justify-center w-3.5 h-3.5 rounded-full bg-red-600 ring-2 ring-background"
+                >
+                  <AlertCircle className="w-2.5 h-2.5 text-white" aria-hidden="true" />
+                </span>
+              ) : step.slug === "extract" && hasNoTextLayer ? (
                 <span
                   role="img"
                   aria-label={noTextLayerLabel}
@@ -246,7 +256,7 @@ export function StageSidebar({
                 >
                   <TriangleAlert className="w-2 h-2 text-white" aria-hidden="true" />
                 </span>
-              )}
+              ) : null}
             </div>
             <span className={cn("truncate hidden", x.showLabel)}>
               {stepLabel}
@@ -366,7 +376,7 @@ export function StageSidebar({
 
         {/* Pages panel — only when pages are open and not in settings. */}
         {effectivePagesOpen && !isSettings && (
-          <div className="flex-1 min-w-0 flex flex-col overflow-hidden border-l">
+          <div className="flex-1 min-w-0 flex flex-col overflow-hidden">
             {activeStep === "storyboard" ? (
               <StoryboardSidebarBridge
                 bookLabel={bookLabel}

--- a/apps/studio/src/components/pipeline/components/StageSidebar.tsx
+++ b/apps/studio/src/components/pipeline/components/StageSidebar.tsx
@@ -16,6 +16,7 @@ import { useLingui } from "@lingui/react"
 import { msg } from "@lingui/core/macro"
 import type { MessageDescriptor } from "@lingui/core"
 import { Button } from "@/components/ui/button"
+import { toast } from "@/components/ui/sonner"
 import { useBookRun } from "@/hooks/use-book-run"
 import { useAccessibilityAssessment } from "@/hooks/use-debug"
 import { useBookTasks } from "@/hooks/use-book-tasks"
@@ -76,7 +77,7 @@ export function StageSidebar({
   const { i18n } = useLingui()
   const matchRoute = useMatchRoute()
   const search = useSearch({ strict: false }) as { tab?: string }
-  const { stageState } = useBookRun()
+  const { stageState, cancelRun, isCancelling } = useBookRun()
   const { data: accessibilityAssessment } = useAccessibilityAssessment(bookLabel)
   const { data: signLanguageData } = useSignLanguageVideos(bookLabel)
   const { data: packageStatus } = usePackageAdtStatus(bookLabel)
@@ -193,6 +194,7 @@ export function StageSidebar({
     const stepAriaLabel = statusKey
       ? i18n._(msg`${stepLabel}: ${getStageStatusLabelI18n(statusKey)}`)
       : stepLabel
+    const cancelStepLabel = i18n._(msg`Cancel ${stepLabel} step`)
 
     const nextStep = STAGES[index + 1]
     const nextGroup = nextStep && "group" in nextStep ? (nextStep as { group?: StageGroup }).group : undefined
@@ -207,7 +209,7 @@ export function StageSidebar({
         {/* Step row */}
         <div
           className={cn(
-            "group/row flex items-center py-2 text-sm transition-colors overflow-hidden",
+            "group/row relative flex items-center py-2 text-sm transition-colors overflow-hidden",
             x.gap,
             isActive
               ? cn(step.color, "text-white font-medium rounded-l-[14px] ml-0.5 pl-2 pr-2.5")
@@ -262,6 +264,32 @@ export function StageSidebar({
               {stepLabel}
             </span>
           </Link>
+
+          {state === "running" && (
+            <button
+              type="button"
+              onClick={(event) => {
+                event.preventDefault()
+                event.stopPropagation()
+                if (isCancelling) return
+                cancelRun()
+                toast.info(i18n._(msg`Cancelling ${stepLabel} step`))
+              }}
+              disabled={isCancelling}
+              title={cancelStepLabel}
+              aria-label={cancelStepLabel}
+              className={cn(
+                "pointer-events-none absolute left-2.5 top-1/2 z-30 flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-full bg-red-600 text-white opacity-0 shadow-sm ring-2 ring-background transition-opacity focus-visible:pointer-events-auto focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-red-300 group-hover/row:pointer-events-auto group-hover/row:opacity-100",
+                isCancelling ? "cursor-default bg-red-500/80" : "cursor-pointer hover:bg-red-700",
+              )}
+            >
+              {isCancelling ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+              ) : (
+                <CircleStop className="h-3.5 w-3.5" aria-hidden="true" />
+              )}
+            </button>
+          )}
 
           {settingsTabs ? (
             <Link

--- a/apps/studio/src/components/pipeline/components/StageSidebar.tsx
+++ b/apps/studio/src/components/pipeline/components/StageSidebar.tsx
@@ -4,11 +4,11 @@ import { Link, useMatchRoute, useSearch } from "@tanstack/react-router"
 import { Trans } from "@lingui/react/macro"
 import {
   AlertCircle,
-  CircleStop,
   Loader2,
   RotateCcw,
   Settings,
   TriangleAlert,
+  X,
 } from "lucide-react"
 import { useVirtualizer } from "@tanstack/react-virtual"
 import { cn } from "@/lib/utils"
@@ -279,14 +279,15 @@ export function StageSidebar({
               title={cancelStepLabel}
               aria-label={cancelStepLabel}
               className={cn(
-                "pointer-events-none absolute left-2.5 top-1/2 z-30 flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-full bg-red-600 text-white opacity-0 shadow-sm ring-2 ring-background transition-opacity focus-visible:pointer-events-auto focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-red-300 group-hover/row:pointer-events-auto group-hover/row:opacity-100",
+                "pointer-events-none absolute top-1/2 z-30 flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-full bg-red-600 text-white opacity-0 shadow-sm ring-2 ring-background transition-opacity focus-visible:pointer-events-auto focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-red-300 group-hover/row:pointer-events-auto group-hover/row:opacity-100",
+                isActive ? "left-2" : "left-2.5",
                 isCancelling ? "cursor-default bg-red-500/80" : "cursor-pointer hover:bg-red-700",
               )}
             >
               {isCancelling ? (
                 <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
               ) : (
-                <CircleStop className="h-3.5 w-3.5" aria-hidden="true" />
+                <X className="size-3.5 stroke-3" aria-hidden="true" />
               )}
             </button>
           )}
@@ -523,7 +524,7 @@ function TaskIndicator({ bookLabel }: { bookLabel: string }) {
             {isCancelling ? (
               <Loader2 className="w-3.5 h-3.5 animate-spin" />
             ) : (
-              <CircleStop className="w-3.5 h-3.5" />
+              <X className="w-3.5 h-3.5" />
             )}
           </button>
         )}

--- a/apps/studio/src/components/pipeline/stages/extract/ExtractView.tsx
+++ b/apps/studio/src/components/pipeline/stages/extract/ExtractView.tsx
@@ -136,7 +136,15 @@ export function ExtractView({ bookLabel, selectedPageId: selectedPageIdProp, onS
   // no pages exist yet — remaining steps (and re-queued derived steps like
   // book-summary) run in the background TaskIndicator without hiding the grid.
   const hasPages = (pages ?? []).length > 0
-  const showRunCard = extractError ? true : !hasPages
+  // A cancelled/interrupted run leaves the stage with pages but incomplete
+  // steps, collapsing to "idle" (not done, not error, nothing running). Without
+  // surfacing the run card here the page grid would show with no way to finish
+  // the stage — the only escape would be to dirty a setting. An "idle" extract
+  // that already has pages can only mean an interrupted run: a healthy stage is
+  // "done"/"running"/"queued", and a background derived-step re-queue keeps it
+  // "running"/"queued" (never idle), so this doesn't hide progressive pages.
+  const extractInterrupted = hasPages && extractState === "idle"
+  const showRunCard = extractError || extractInterrupted ? true : !hasPages
 
   const handleRetryExtract = useCallback(() => {
     if (!hasApiKey || extractRunning) return
@@ -245,7 +253,7 @@ export function ExtractView({ bookLabel, selectedPageId: selectedPageIdProp, onS
           isRunning={extractRunning}
           completed={extractDone}
           onRun={handleRetryExtract}
-          disabled={!extractError || !hasApiKey || extractRunning}
+          disabled={(!extractError && !extractInterrupted) || !hasApiKey || extractRunning}
         />
       ) : pageList.length === 0 ? (
         <StageEmptyState

--- a/apps/studio/src/components/pipeline/stages/languages/LanguageView.tsx
+++ b/apps/studio/src/components/pipeline/stages/languages/LanguageView.tsx
@@ -1,31 +1,66 @@
-import { useState, useEffect, useRef, useCallback, useMemo, type ChangeEvent } from "react"
-import { createPortal } from "react-dom"
-import { Link } from "@tanstack/react-router"
-import { AudioLines, ChevronDown, ChevronRight, ChevronUp, Languages, Loader2, Play, Pause, Plus, RotateCcw, Save, Settings, Trash2, Type, Upload, Volume2, VolumeX, WandSparkles, X } from "lucide-react"
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
-import { api, getAudioUrl, BASE_URL } from "@/api/client"
-import type { TextCatalogEntry, WordTimestamp, WordTimestampEntry } from "@/api/client"
-import { VersionPicker } from "@/components/pipeline/components/VersionPicker"
-import { useBookConfig, useUpdateBookConfig } from "@/hooks/use-book-config"
-import { useActiveConfig } from "@/hooks/use-debug"
-import { useBook } from "@/hooks/use-books"
-import { useStepHeader } from "../../components/StepViewRouter"
-import { LoadingState } from "../../components/LoadingState"
-import { useBookRun } from "@/hooks/use-book-run"
-import { useBookTasks } from "@/hooks/use-book-tasks"
-import { useStageMissingCounts } from "@/hooks/use-stage-missing-counts"
-import { useApiKey } from "@/hooks/use-api-key"
-import { StageRunCard } from "../../components/StageRunCard"
-import { StageEmptyState } from "../../components/StageEmptyState"
-import { useVirtualizer } from "@tanstack/react-virtual"
-import { cn } from "@/lib/utils"
-import { normalizeLocale } from "@/lib/languages"
-import { languageUsesSpeechProvider, resolveSpeechProviderForLanguage } from "@/lib/speech-routing"
-import { Alert, AlertDescription } from "@/components/ui/alert"
-import { Button } from "@/components/ui/button"
-import { Label } from "@/components/ui/label"
-import { Switch } from "@/components/ui/switch"
-import { resolveTranslationLanguageState } from "./lib/translations-view-state"
+import {
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  useMemo,
+  type ChangeEvent,
+} from "react";
+import { createPortal } from "react-dom";
+import { Link } from "@tanstack/react-router";
+import {
+  AudioLines,
+  ChevronDown,
+  ChevronRight,
+  ChevronUp,
+  CircleStop,
+  Languages,
+  Loader2,
+  Play,
+  Pause,
+  Plus,
+  RotateCcw,
+  Save,
+  Settings,
+  Trash2,
+  Type,
+  Upload,
+  Volume2,
+  VolumeX,
+  WandSparkles,
+  X,
+} from "lucide-react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { api, getAudioUrl, BASE_URL } from "@/api/client";
+import type {
+  TextCatalogEntry,
+  WordTimestamp,
+  WordTimestampEntry,
+} from "@/api/client";
+import { VersionPicker } from "@/components/pipeline/components/VersionPicker";
+import { useBookConfig, useUpdateBookConfig } from "@/hooks/use-book-config";
+import { useActiveConfig } from "@/hooks/use-debug";
+import { useBook } from "@/hooks/use-books";
+import { useStepHeader } from "../../components/StepViewRouter";
+import { LoadingState } from "../../components/LoadingState";
+import { useBookRun } from "@/hooks/use-book-run";
+import { useBookTasks } from "@/hooks/use-book-tasks";
+import { useStageMissingCounts } from "@/hooks/use-stage-missing-counts";
+import { useApiKey } from "@/hooks/use-api-key";
+import { StageRunCard } from "../../components/StageRunCard";
+import { StageEmptyState } from "../../components/StageEmptyState";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { cn } from "@/lib/utils";
+import { normalizeLocale } from "@/lib/languages";
+import {
+  languageUsesSpeechProvider,
+  resolveSpeechProviderForLanguage,
+} from "@/lib/speech-routing";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { resolveTranslationLanguageState } from "./lib/translations-view-state";
 import {
   type CatalogCategory,
   getEntryCategory,
@@ -34,43 +69,68 @@ import {
   isEasyReadEntry,
   isGlossaryEntry,
   isImageEntry,
-} from "./lib/catalog-entries"
-import { displayLang } from "./lib/display-lang"
-import { ImageLightbox } from "./components/ImageLightbox"
-import { WordHighlightPreview } from "./components/WordHighlightPreview"
-import { usePendingChanges } from "../../components/change-summary"
-import { msg } from "@lingui/core/macro"
-import { useLingui } from "@lingui/react/macro"
+} from "./lib/catalog-entries";
+import { displayLang } from "./lib/display-lang";
+import { ImageLightbox } from "./components/ImageLightbox";
+import { WordHighlightPreview } from "./components/WordHighlightPreview";
+import { usePendingChanges } from "../../components/change-summary";
+import { msg } from "@lingui/core/macro";
+import { useLingui } from "@lingui/react/macro";
 
 // Per-provider default TTS voice/model shown in the speech summary when the book hasn't
 // pinned one. Mirrors resolveVoice()/resolveSpeechModel() in @adt/pipeline (and
 // config/voices.yaml) so we never show an OpenAI voice/model for a Gemini/Azure provider.
 // Values are voice/model identifiers, not user-facing copy — display only.
 // eslint-disable-next-line lingui/no-unlocalized-strings -- voice identifiers
-const DEFAULT_TTS_VOICE: Record<string, string> = { openai: "alloy", azure: "en-US-JennyNeural", gemini: "Kore" }
-const DEFAULT_TTS_MODEL: Record<string, string> = { openai: "gpt-4o-mini-tts", azure: "azure-tts", gemini: "gemini-2.5-pro-preview-tts" }
+const DEFAULT_TTS_VOICE: Record<string, string> = {
+  openai: "alloy",
+  azure: "en-US-JennyNeural",
+  gemini: "Kore",
+};
+const DEFAULT_TTS_MODEL: Record<string, string> = {
+  openai: "gpt-4o-mini-tts",
+  azure: "azure-tts",
+  gemini: "gemini-2.5-pro-preview-tts",
+};
 
-export function LanguageView({ bookLabel, stageSlug = "translate", selectedPageId, onSelectPage }: { bookLabel: string; stageSlug?: string; selectedPageId?: string; onSelectPage?: (pageId: string | null) => void }) {
-  const isSpeechStage = stageSlug === "speech"
-  const { t, i18n } = useLingui()
-  const { headerSlotEl } = useStepHeader()
-  const { data: bookConfigData } = useBookConfig(bookLabel)
-  const updateConfig = useUpdateBookConfig()
-  const { data: activeConfigData } = useActiveConfig(bookLabel)
-  const { data: book, isLoading: isBookLoading } = useBook(bookLabel)
-  const queryClient = useQueryClient()
-  const { stageState, stepProgress, queueRun, error: runError } = useBookRun()
-  const { isTaskRunning } = useBookTasks(bookLabel)
-  const { apiKey, hasApiKey, azureKey, azureRegion, geminiKey } = useApiKey()
-  const translateState = stageState("translate")
-  const speechState = stageState("speech")
-  const activeState = isSpeechStage ? speechState : translateState
-  const stageDone = activeState === "done"
-  const hasStageError = activeState === "error"
-  const isRunning = activeState === "running" || activeState === "queued"
+export function LanguageView({
+  bookLabel,
+  stageSlug = "translate",
+  selectedPageId,
+  onSelectPage,
+}: {
+  bookLabel: string;
+  stageSlug?: string;
+  selectedPageId?: string;
+  onSelectPage?: (pageId: string | null) => void;
+}) {
+  const isSpeechStage = stageSlug === "speech";
+  const { t, i18n } = useLingui();
+  const { headerSlotEl } = useStepHeader();
+  const { data: bookConfigData } = useBookConfig(bookLabel);
+  const updateConfig = useUpdateBookConfig();
+  const { data: activeConfigData } = useActiveConfig(bookLabel);
+  const { data: book, isLoading: isBookLoading } = useBook(bookLabel);
+  const queryClient = useQueryClient();
+  const {
+    stageState,
+    stepProgress,
+    queueRun,
+    cancelRun,
+    isCancelling,
+    error: runError,
+  } = useBookRun();
+  const { isTaskRunning } = useBookTasks(bookLabel);
+  const { apiKey, hasApiKey, azureKey, azureRegion, geminiKey } = useApiKey();
+  const translateState = stageState("translate");
+  const speechState = stageState("speech");
+  const activeState = isSpeechStage ? speechState : translateState;
+  const stageDone = activeState === "done";
+  const hasStageError = activeState === "error";
+  const isRunning = activeState === "running" || activeState === "queued";
 
   const handleRun = useCallback(() => {
-    if (!hasApiKey || isRunning) return
+    if (!hasApiKey || isRunning) return;
     // Speech depends on translate, so always start from translate when running
     // speech — new catalog entries (e.g. from a glossary addition) need their
     // translations populated before TTS can synthesize them. The per-item cache
@@ -79,26 +139,33 @@ export function LanguageView({ bookLabel, stageSlug = "translate", selectedPageI
       fromStage: "translate",
       toStage: stageSlug as "translate" | "speech",
       apiKey,
-    })
-  }, [hasApiKey, isRunning, apiKey, queueRun, stageSlug])
+    });
+  }, [hasApiKey, isRunning, apiKey, queueRun, stageSlug]);
 
-  const stageMissing = useStageMissingCounts(bookLabel)
-  const missingForCurrentStage =
-    isSpeechStage ? stageMissing.speech : stageMissing.translate
+  const stageMissing = useStageMissingCounts(bookLabel);
+  const missingForCurrentStage = isSpeechStage
+    ? stageMissing.speech
+    : stageMissing.translate;
   const showMissingBanner =
-    (stageDone || (isSpeechStage && hasStageError)) && !isRunning && missingForCurrentStage > 0
+    (stageDone || (isSpeechStage && hasStageError)) &&
+    !isRunning &&
+    missingForCurrentStage > 0;
 
   const handleDeleteTTS = useCallback(async () => {
-    await api.deleteTTS(bookLabel)
-    await queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "tts"] })
-    await queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "step-status"] })
-  }, [bookLabel, queryClient])
+    await api.deleteTTS(bookLabel);
+    await queryClient.invalidateQueries({
+      queryKey: ["books", bookLabel, "tts"],
+    });
+    await queryClient.invalidateQueries({
+      queryKey: ["books", bookLabel, "step-status"],
+    });
+  }, [bookLabel, queryClient]);
 
   const { data: catalog, isLoading } = useQuery({
     queryKey: ["books", bookLabel, "text-catalog"],
     queryFn: () => api.getTextCatalog(bookLabel),
     enabled: !!bookLabel,
-  })
+  });
 
   // Easy Read source entries (`{sourceId}_easy_read`) live in their own node,
   // not the text catalog, but their translations are merged into
@@ -108,53 +175,74 @@ export function LanguageView({ bookLabel, stageSlug = "translate", selectedPageI
     queryKey: ["books", bookLabel, "easy-read"],
     queryFn: () => api.getEasyRead(bookLabel),
     enabled: !!bookLabel,
-  })
+  });
 
   const { data: ttsData } = useQuery({
     queryKey: ["books", bookLabel, "tts"],
     queryFn: () => api.getTTS(bookLabel),
     enabled: !!bookLabel,
-  })
+  });
 
-  const merged = activeConfigData?.merged as Record<string, unknown> | undefined
-  const speechConfig = merged?.speech
-  const speechConfigRecord = speechConfig && typeof speechConfig === "object"
-    ? speechConfig as Record<string, unknown>
-    : null
-  const wordHighlightingEnabled = speechConfigRecord?.word_highlighting === true
+  const merged = activeConfigData?.merged as
+    Record<string, unknown> | undefined;
+  const speechConfig = merged?.speech;
+  const speechConfigRecord =
+    speechConfig && typeof speechConfig === "object"
+      ? (speechConfig as Record<string, unknown>)
+      : null;
+  const wordHighlightingEnabled =
+    speechConfigRecord?.word_highlighting === true;
   const configExcludedTextIds = useMemo(
-    () => Array.isArray(speechConfigRecord?.excluded_text_ids)
-      ? (speechConfigRecord.excluded_text_ids as string[])
-      : [],
-    [speechConfigRecord]
-  )
-  const [pendingExcludedTextIds, setPendingExcludedTextIds] = useState<string[] | null>(null)
-  const pendingExcludedTextIdsRef = useRef<string[] | null>(null)
-  const configUpdateQueueRef = useRef<Promise<unknown>>(Promise.resolve())
-  const effectiveExcludedTextIds = pendingExcludedTextIds ?? configExcludedTextIds
+    () =>
+      Array.isArray(speechConfigRecord?.excluded_text_ids)
+        ? (speechConfigRecord.excluded_text_ids as string[])
+        : [],
+    [speechConfigRecord],
+  );
+  const [pendingExcludedTextIds, setPendingExcludedTextIds] = useState<
+    string[] | null
+  >(null);
+  const pendingExcludedTextIdsRef = useRef<string[] | null>(null);
+  const configUpdateQueueRef = useRef<Promise<unknown>>(Promise.resolve());
+  const effectiveExcludedTextIds =
+    pendingExcludedTextIds ?? configExcludedTextIds;
   // Effective read-aloud exclusions (merged config) — category-level from the
   // speech settings plus individually muted entry ids.
-  const ttsExclusionConfig = useMemo(() => ({
-    excluded_categories: Array.isArray(speechConfigRecord?.excluded_categories)
-      ? (speechConfigRecord.excluded_categories as string[])
-      : undefined,
-    excluded_text_ids: effectiveExcludedTextIds,
-  }), [effectiveExcludedTextIds, speechConfigRecord])
+  const ttsExclusionConfig = useMemo(
+    () => ({
+      excluded_categories: Array.isArray(
+        speechConfigRecord?.excluded_categories,
+      )
+        ? (speechConfigRecord.excluded_categories as string[])
+        : undefined,
+      excluded_text_ids: effectiveExcludedTextIds,
+    }),
+    [effectiveExcludedTextIds, speechConfigRecord],
+  );
   const excludedTextIdSet = useMemo(
     () => new Set(ttsExclusionConfig.excluded_text_ids ?? []),
-    [ttsExclusionConfig]
-  )
+    [ttsExclusionConfig],
+  );
   const outputLanguages = Array.from(
-    new Set(((merged?.output_languages as string[] | undefined) ?? []).map((code) => normalizeLocale(code)))
-  )
-  const bookLanguage = book?.languageCode ?? book?.metadata?.language_code ?? null
-  const configuredEditingLanguage = merged?.editing_language as string | undefined
+    new Set(
+      ((merged?.output_languages as string[] | undefined) ?? []).map((code) =>
+        normalizeLocale(code),
+      ),
+    ),
+  );
+  const bookLanguage =
+    book?.languageCode ?? book?.metadata?.language_code ?? null;
+  const configuredEditingLanguage = merged?.editing_language as
+    string | undefined;
 
-  const hasExplicitOutputLanguages = outputLanguages.length > 0
+  const hasExplicitOutputLanguages = outputLanguages.length > 0;
 
-  const [selectedLang, setSelectedLang] = useState<string | null>(null)
-  const [categoryFilter, setCategoryFilter] = useState<CatalogCategory>("all")
-  const [lightbox, setLightbox] = useState<{ src: string; caption?: string } | null>(null)
+  const [selectedLang, setSelectedLang] = useState<string | null>(null);
+  const [categoryFilter, setCategoryFilter] = useState<CatalogCategory>("all");
+  const [lightbox, setLightbox] = useState<{
+    src: string;
+    caption?: string;
+  } | null>(null);
 
   // Map of `${sourceImageId}::${language}` → translated image id, used to
   // render the localized variant alongside captions in the translation view.
@@ -162,135 +250,198 @@ export function LanguageView({ bookLabel, stageSlug = "translate", selectedPageI
     queryKey: ["books", bookLabel, "translated-images"],
     queryFn: () => api.listTranslatedImages(bookLabel),
     enabled: !!bookLabel,
-  })
+  });
   const translatedImageMap = useMemo(() => {
-    const map = new Map<string, string>()
+    const map = new Map<string, string>();
     for (const row of translatedImagesData?.images ?? []) {
-      map.set(`${row.sourceImageId}::${normalizeLocale(row.language)}`, row.imageId)
+      map.set(
+        `${row.sourceImageId}::${normalizeLocale(row.language)}`,
+        row.imageId,
+      );
     }
-    return map
-  }, [translatedImagesData])
+    return map;
+  }, [translatedImagesData]);
 
   // Default to first output language when available
   useEffect(() => {
-    if (hasExplicitOutputLanguages && outputLanguages.length > 0 && !selectedLang) {
-      setSelectedLang(outputLanguages[0])
+    if (
+      hasExplicitOutputLanguages &&
+      outputLanguages.length > 0 &&
+      !selectedLang
+    ) {
+      setSelectedLang(outputLanguages[0]);
     }
-  }, [outputLanguages.length, hasExplicitOutputLanguages])
+  }, [outputLanguages.length, hasExplicitOutputLanguages]);
 
   const easyReadEntries = useMemo(
     () =>
       (easyReadData?.blocks ?? []).flatMap((block) =>
-        block.entries.map((entry) => ({ id: entry.easyReadId, text: entry.text }))
+        block.entries.map((entry) => ({
+          id: entry.easyReadId,
+          text: entry.text,
+        })),
       ),
-    [easyReadData]
-  )
+    [easyReadData],
+  );
   const entries = useMemo(() => {
-    const base = catalog?.entries ?? []
-    return easyReadEntries.length > 0 ? [...base, ...easyReadEntries] : base
-  }, [catalog?.entries, easyReadEntries])
+    const base = catalog?.entries ?? [];
+    return easyReadEntries.length > 0 ? [...base, ...easyReadEntries] : base;
+  }, [catalog?.entries, easyReadEntries]);
   const pageFilteredEntries = selectedPageId
     ? entries.filter((e) => e.id.startsWith(selectedPageId + "_"))
-    : entries
-  const displayEntries = categoryFilter === "all"
-    ? pageFilteredEntries
-    : pageFilteredEntries.filter((e) => getEntryCategory(e.id) === categoryFilter)
+    : entries;
+  const displayEntries =
+    categoryFilter === "all"
+      ? pageFilteredEntries
+      : pageFilteredEntries.filter(
+          (e) => getEntryCategory(e.id) === categoryFilter,
+        );
 
   // When no output languages are configured, we're always viewing the source language.
   // When explicit output languages exist, check if the selected one matches the editing language.
-  const { editingLanguage, isSourceLang: isSelectedSourceLang, isSourceLanguagePending } = resolveTranslationLanguageState({
+  const {
+    editingLanguage,
+    isSourceLang: isSelectedSourceLang,
+    isSourceLanguagePending,
+  } = resolveTranslationLanguageState({
     selectedLang,
     configuredEditingLanguage,
     bookLanguage,
     isBookLoading,
-  })
-  const isSourceLang = !hasExplicitOutputLanguages || isSelectedSourceLang
-  const audioLang = selectedLang ??
-    (hasExplicitOutputLanguages ? (outputLanguages[0] ?? editingLanguage) : editingLanguage)
+  });
+  const isSourceLang = !hasExplicitOutputLanguages || isSelectedSourceLang;
+  const audioLang =
+    selectedLang ??
+    (hasExplicitOutputLanguages
+      ? (outputLanguages[0] ?? editingLanguage)
+      : editingLanguage);
   const currentLanguageUsesGemini =
-    !!audioLang && languageUsesSpeechProvider(audioLang, "gemini", speechConfig)
+    !!audioLang &&
+    languageUsesSpeechProvider(audioLang, "gemini", speechConfig);
   // Speech keeps the entry list on screen during runs (audio fills in live via
   // the run's snapshot) and after failures (failed rows are marked); the run
   // card only shows before the first speech run. Translate keeps the original
   // behavior: run card until the stage is done.
   const showRunCard = isSpeechStage
     ? !(stageDone || isRunning || hasStageError)
-    : (!stageDone || isRunning)
-  const ttsProgress = isSpeechStage && isRunning ? stepProgress("tts") : undefined
+    : !stageDone || isRunning;
+  const ttsProgress =
+    isSpeechStage && isRunning ? stepProgress("tts") : undefined;
 
   const toggleWordHighlighting = useCallback(() => {
-    const currentConfig = { ...(bookConfigData?.config ?? {}) } as Record<string, unknown>
-    const existingSpeech = currentConfig.speech && typeof currentConfig.speech === "object"
-      ? { ...(currentConfig.speech as Record<string, unknown>) }
-      : {}
+    const currentConfig = { ...(bookConfigData?.config ?? {}) } as Record<
+      string,
+      unknown
+    >;
+    const existingSpeech =
+      currentConfig.speech && typeof currentConfig.speech === "object"
+        ? { ...(currentConfig.speech as Record<string, unknown>) }
+        : {};
     currentConfig.speech = {
       ...existingSpeech,
       word_highlighting: !wordHighlightingEnabled,
-    }
-    updateConfig.mutate({ label: bookLabel, config: currentConfig })
-  }, [bookConfigData?.config, bookLabel, updateConfig, wordHighlightingEnabled])
+    };
+    updateConfig.mutate({ label: bookLabel, config: currentConfig });
+  }, [
+    bookConfigData?.config,
+    bookLabel,
+    updateConfig,
+    wordHighlightingEnabled,
+  ]);
 
-  const toggleEntryMuted = useCallback((textId: string) => {
-    const currentConfig = { ...(bookConfigData?.config ?? {}) } as Record<string, unknown>
-    const existingSpeech = currentConfig.speech && typeof currentConfig.speech === "object"
-      ? { ...(currentConfig.speech as Record<string, unknown>) }
-      : {}
-    // Toggle against the effective (merged) exclusions so the write matches
-    // what the user currently sees.
-    const next = new Set(pendingExcludedTextIdsRef.current ?? effectiveExcludedTextIds)
-    if (next.has(textId)) next.delete(textId)
-    else next.add(textId)
-    const nextIds = Array.from(next)
-    pendingExcludedTextIdsRef.current = nextIds
-    setPendingExcludedTextIds(nextIds)
-    currentConfig.speech = {
-      ...existingSpeech,
-      // Empty array is intentional: it overrides any project-level excluded ids.
-      excluded_text_ids: nextIds,
-    }
-    configUpdateQueueRef.current = configUpdateQueueRef.current
-      .catch(() => undefined)
-      .then(async () => {
-        const updated = await updateConfig.mutateAsync({ label: bookLabel, config: currentConfig })
-        await queryClient.invalidateQueries({ queryKey: ["debug", "config", bookLabel] })
-        return updated
-      })
-      .finally(() => {
-        if (pendingExcludedTextIdsRef.current === nextIds) {
-          pendingExcludedTextIdsRef.current = null
-          setPendingExcludedTextIds(null)
-        }
-      })
-    void configUpdateQueueRef.current.catch(() => undefined)
-  }, [bookConfigData?.config, bookLabel, effectiveExcludedTextIds, queryClient, updateConfig])
+  const toggleEntryMuted = useCallback(
+    (textId: string) => {
+      const currentConfig = { ...(bookConfigData?.config ?? {}) } as Record<
+        string,
+        unknown
+      >;
+      const existingSpeech =
+        currentConfig.speech && typeof currentConfig.speech === "object"
+          ? { ...(currentConfig.speech as Record<string, unknown>) }
+          : {};
+      // Toggle against the effective (merged) exclusions so the write matches
+      // what the user currently sees.
+      const next = new Set(
+        pendingExcludedTextIdsRef.current ?? effectiveExcludedTextIds,
+      );
+      if (next.has(textId)) next.delete(textId);
+      else next.add(textId);
+      const nextIds = Array.from(next);
+      pendingExcludedTextIdsRef.current = nextIds;
+      setPendingExcludedTextIds(nextIds);
+      currentConfig.speech = {
+        ...existingSpeech,
+        // Empty array is intentional: it overrides any project-level excluded ids.
+        excluded_text_ids: nextIds,
+      };
+      configUpdateQueueRef.current = configUpdateQueueRef.current
+        .catch(() => undefined)
+        .then(async () => {
+          const updated = await updateConfig.mutateAsync({
+            label: bookLabel,
+            config: currentConfig,
+          });
+          await queryClient.invalidateQueries({
+            queryKey: ["debug", "config", bookLabel],
+          });
+          return updated;
+        })
+        .finally(() => {
+          if (pendingExcludedTextIdsRef.current === nextIds) {
+            pendingExcludedTextIdsRef.current = null;
+            setPendingExcludedTextIds(null);
+          }
+        });
+      void configUpdateQueueRef.current.catch(() => undefined);
+    },
+    [
+      bookConfigData?.config,
+      bookLabel,
+      effectiveExcludedTextIds,
+      queryClient,
+      updateConfig,
+    ],
+  );
 
   // Fetch word timestamps for the active language on the speech page
   const { data: timestampData } = useQuery({
     queryKey: ["books", bookLabel, "tts-timestamps", audioLang],
     queryFn: () => api.getWordTimestamps(bookLabel, audioLang!),
     enabled: isSpeechStage && !!bookLabel && !!audioLang,
-  })
-  const timestampMap = timestampData?.entries ?? {}
+  });
+  const timestampMap = timestampData?.entries ?? {};
 
   // Pending state for edits (keyed by language)
-  const [pendingEntries, setPendingEntries] = useState<TextCatalogEntry[] | null>(null)
-  const [saving, setSaving] = useState(false)
-  const [generateErrorById, setGenerateErrorById] = useState<Record<string, string>>({})
-  const [uploadErrorById, setUploadErrorById] = useState<Record<string, string>>({})
+  const [pendingEntries, setPendingEntries] = useState<
+    TextCatalogEntry[] | null
+  >(null);
+  const [saving, setSaving] = useState(false);
+  const [generateErrorById, setGenerateErrorById] = useState<
+    Record<string, string>
+  >({});
+  const [uploadErrorById, setUploadErrorById] = useState<
+    Record<string, string>
+  >({});
 
   // Get translated entries for selected language
-  const translationData = selectedLang ? catalog?.translations?.[selectedLang] : undefined
-  const translatedEntries = isSourceLang ? entries : (translationData?.entries ?? [])
-  const translationVersion = isSourceLang ? (catalog?.version ?? null) : (translationData?.version ?? null)
+  const translationData = selectedLang
+    ? catalog?.translations?.[selectedLang]
+    : undefined;
+  const translatedEntries = isSourceLang
+    ? entries
+    : (translationData?.entries ?? []);
+  const translationVersion = isSourceLang
+    ? (catalog?.version ?? null)
+    : (translationData?.version ?? null);
 
   // Reset pending when version or language changes
   useEffect(() => {
-    setPendingEntries(null)
-  }, [translationVersion, selectedLang])
+    setPendingEntries(null);
+  }, [translationVersion, selectedLang]);
 
   // Effective translated entries (pending overrides fetched data)
-  const effectiveEntries = pendingEntries ?? translatedEntries
-  const translatedMap = new Map(effectiveEntries.map((e) => [e.id, e.text]))
+  const effectiveEntries = pendingEntries ?? translatedEntries;
+  const translatedMap = new Map(effectiveEntries.map((e) => [e.id, e.text]));
 
   const {
     label: pendingLabel,
@@ -302,96 +453,136 @@ export function LanguageView({ bookLabel, stageSlug = "translate", selectedPageI
     keyOf: (e) => e.id,
     isEqual: (a, b) => a.text === b.text,
     noun: { one: t`translation`, other: t`translations` },
-  })
+  });
 
   const saveTranslation = useCallback(async () => {
-    if (!pendingEntries || !selectedLang) return
-    setSaving(true)
-    const minDelay = new Promise((r) => setTimeout(r, 400))
-    await api.updateTranslation(bookLabel, selectedLang, { entries: pendingEntries })
-    setPendingEntries(null)
-    await queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "text-catalog"] })
-    await minDelay
-    setSaving(false)
-  }, [pendingEntries, selectedLang, bookLabel, queryClient])
+    if (!pendingEntries || !selectedLang) return;
+    setSaving(true);
+    const minDelay = new Promise((r) => setTimeout(r, 400));
+    await api.updateTranslation(bookLabel, selectedLang, {
+      entries: pendingEntries,
+    });
+    setPendingEntries(null);
+    await queryClient.invalidateQueries({
+      queryKey: ["books", bookLabel, "text-catalog"],
+    });
+    await minDelay;
+    setSaving(false);
+  }, [pendingEntries, selectedLang, bookLabel, queryClient]);
 
-  const saveRef = useRef(saveTranslation)
-  saveRef.current = saveTranslation
+  const saveRef = useRef(saveTranslation);
+  saveRef.current = saveTranslation;
 
   const updateEntry = (entryId: string, newText: string) => {
-    const base = pendingEntries ?? translatedEntries
+    const base = pendingEntries ?? translatedEntries;
     // If no existing entry for this id, add one
-    const exists = base.some((e) => e.id === entryId)
+    const exists = base.some((e) => e.id === entryId);
     if (exists) {
       setPendingEntries(
-        base.map((e) => (e.id === entryId ? { ...e, text: newText } : e))
-      )
+        base.map((e) => (e.id === entryId ? { ...e, text: newText } : e)),
+      );
     } else {
-      setPendingEntries([...base, { id: entryId, text: newText }])
+      setPendingEntries([...base, { id: entryId, text: newText }]);
     }
-  }
+  };
 
   // Build audio lookup — use selected language, or editing language when no output languages
-  const audioMap = new Map<string, { fileName: string; voice: string; cacheKey?: string }>()
+  const audioMap = new Map<
+    string,
+    { fileName: string; voice: string; cacheKey?: string }
+  >();
   if (ttsData && audioLang && ttsData.languages[audioLang]) {
     for (const e of ttsData.languages[audioLang].entries) {
-      audioMap.set(e.textId, { fileName: e.fileName, voice: e.voice, cacheKey: e.cacheKey })
+      audioMap.set(e.textId, {
+        fileName: e.fileName,
+        voice: e.voice,
+        cacheKey: e.cacheKey,
+      });
     }
   }
   // Per-item generation failures for the selected language (from the last run,
   // or streamed live while a run is in progress)
-  const failedAudioMap = new Map<string, string>()
+  const failedAudioMap = new Map<string, string>();
   if (ttsData && audioLang) {
     for (const f of ttsData.languages[audioLang]?.failed ?? []) {
-      failedAudioMap.set(f.textId, f.error)
+      failedAudioMap.set(f.textId, f.error);
     }
   }
   // Separate base-language audio map for the source column in translation view
-  const baseAudioMap = new Map<string, { fileName: string; voice: string; cacheKey?: string }>()
-  if (ttsData && editingLanguage && ttsData.languages[editingLanguage] && audioLang !== editingLanguage) {
+  const baseAudioMap = new Map<
+    string,
+    { fileName: string; voice: string; cacheKey?: string }
+  >();
+  if (
+    ttsData &&
+    editingLanguage &&
+    ttsData.languages[editingLanguage] &&
+    audioLang !== editingLanguage
+  ) {
     for (const e of ttsData.languages[editingLanguage].entries) {
-      baseAudioMap.set(e.textId, { fileName: e.fileName, voice: e.voice, cacheKey: e.cacheKey })
+      baseAudioMap.set(e.textId, {
+        fileName: e.fileName,
+        voice: e.voice,
+        cacheKey: e.cacheKey,
+      });
     }
   }
   // Build per-language model/voice summary from TTS data
   const langTtsSummary = useMemo(() => {
-    const map = new Map<string, { provider: string; model: string; voice: string }>()
-    if (!ttsData) return map
+    const map = new Map<
+      string,
+      { provider: string; model: string; voice: string }
+    >();
+    if (!ttsData) return map;
     for (const [lang, data] of Object.entries(ttsData.languages)) {
-      const first = data.entries[0]
+      const first = data.entries[0];
       if (first) {
-        map.set(lang, { provider: first.provider ?? "", model: first.model, voice: first.voice })
+        map.set(lang, {
+          provider: first.provider ?? "",
+          model: first.model,
+          voice: first.voice,
+        });
       }
     }
-    return map
-  }, [ttsData])
+    return map;
+  }, [ttsData]);
 
   const totalAudioFiles = ttsData
-    ? Object.values(ttsData.languages).reduce((sum, lang) => sum + lang.entries.length, 0)
-    : 0
+    ? Object.values(ttsData.languages).reduce(
+        (sum, lang) => sum + lang.entries.length,
+        0,
+      )
+    : 0;
   // Muted entries neither need audio nor count as missing
   const speakableEntries = displayEntries.filter(
-    (entry) => !getEntryTtsExclusion(entry.id, ttsExclusionConfig).excluded
-  )
-  const generatedAudioCount = speakableEntries.filter((entry) => audioMap.has(entry.id)).length
-  const missingAudioCount = Math.max(speakableEntries.length - generatedAudioCount, 0)
+    (entry) => !getEntryTtsExclusion(entry.id, ttsExclusionConfig).excluded,
+  );
+  const generatedAudioCount = speakableEntries.filter((entry) =>
+    audioMap.has(entry.id),
+  ).length;
+  const missingAudioCount = Math.max(
+    speakableEntries.length - generatedAudioCount,
+    0,
+  );
 
   // Track playback state for the currently-playing entry (only one plays at a time)
-  const [playingEntryId, setPlayingEntryId] = useState<string | null>(null)
-  const [playbackTime, setPlaybackTime] = useState(0)
+  const [playingEntryId, setPlayingEntryId] = useState<string | null>(null);
+  const [playbackTime, setPlaybackTime] = useState(0);
 
-  const scrollRef = useRef<HTMLDivElement>(null)
+  const scrollRef = useRef<HTMLDivElement>(null);
   const virtualizer = useVirtualizer({
     count: displayEntries.length,
     getScrollElement: () => scrollRef.current,
     estimateSize: () => 60,
     overscan: 5,
-  })
+  });
 
   const generateAudioMutation = useMutation({
     mutationFn: async (variables: { textId: string; language: string }) => {
       if (!geminiKey) {
-        throw new Error(i18n._(msg`Gemini API key is required to generate audio.`))
+        throw new Error(
+          i18n._(msg`Gemini API key is required to generate audio.`),
+        );
       }
       return api.generateGeminiTTSForItem(
         bookLabel,
@@ -400,148 +591,197 @@ export function LanguageView({ bookLabel, stageSlug = "translate", selectedPageI
         {
           geminiApiKey: geminiKey,
           openaiApiKey: apiKey || undefined,
-          azure: azureKey && azureRegion
-            ? { key: azureKey, region: azureRegion }
-            : undefined,
-        }
-      )
+          azure:
+            azureKey && azureRegion
+              ? { key: azureKey, region: azureRegion }
+              : undefined,
+        },
+      );
     },
     onMutate: (variables) => {
       setGenerateErrorById((prev) => {
-        if (!(variables.textId in prev)) return prev
-        const next = { ...prev }
-        delete next[variables.textId]
-        return next
-      })
+        if (!(variables.textId in prev)) return prev;
+        const next = { ...prev };
+        delete next[variables.textId];
+        return next;
+      });
     },
     onSuccess: async () => {
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "tts"] }),
-        queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "step-status"] }),
-      ])
+        queryClient.invalidateQueries({
+          queryKey: ["books", bookLabel, "tts"],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: ["books", bookLabel, "step-status"],
+        }),
+      ]);
     },
     onError: (error, variables) => {
       setGenerateErrorById((prev) => ({
         ...prev,
         [variables.textId]:
           error instanceof Error ? error.message : String(error),
-      }))
-      queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "step-status"] })
+      }));
+      queryClient.invalidateQueries({
+        queryKey: ["books", bookLabel, "step-status"],
+      });
     },
-  })
+  });
 
   const handleGenerateAudio = useCallback(
     (textId: string) => {
-      if (!audioLang || !currentLanguageUsesGemini) return
-      generateAudioMutation.mutate({ textId, language: audioLang })
+      if (!audioLang || !currentLanguageUsesGemini) return;
+      generateAudioMutation.mutate({ textId, language: audioLang });
     },
-    [audioLang, currentLanguageUsesGemini, generateAudioMutation]
-  )
+    [audioLang, currentLanguageUsesGemini, generateAudioMutation],
+  );
 
   const uploadAudioMutation = useMutation({
-    mutationFn: async (variables: { textId: string; language: string; file: File }) =>
-      api.uploadTTSForItem(bookLabel, variables.textId, variables.language, variables.file),
+    mutationFn: async (variables: {
+      textId: string;
+      language: string;
+      file: File;
+    }) =>
+      api.uploadTTSForItem(
+        bookLabel,
+        variables.textId,
+        variables.language,
+        variables.file,
+      ),
     onMutate: (variables) => {
       setUploadErrorById((prev) => {
-        if (!(variables.textId in prev)) return prev
-        const next = { ...prev }
-        delete next[variables.textId]
-        return next
-      })
+        if (!(variables.textId in prev)) return prev;
+        const next = { ...prev };
+        delete next[variables.textId];
+        return next;
+      });
       setGenerateErrorById((prev) => {
-        if (!(variables.textId in prev)) return prev
-        const next = { ...prev }
-        delete next[variables.textId]
-        return next
-      })
+        if (!(variables.textId in prev)) return prev;
+        const next = { ...prev };
+        delete next[variables.textId];
+        return next;
+      });
     },
     onSuccess: async () => {
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "tts"] }),
-        queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "tts-timestamps", audioLang] }),
-        queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "step-status"] }),
-      ])
+        queryClient.invalidateQueries({
+          queryKey: ["books", bookLabel, "tts"],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: ["books", bookLabel, "tts-timestamps", audioLang],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: ["books", bookLabel, "step-status"],
+        }),
+      ]);
     },
     onError: (error, variables) => {
       setUploadErrorById((prev) => ({
         ...prev,
         [variables.textId]:
           error instanceof Error ? error.message : String(error),
-      }))
+      }));
     },
-  })
+  });
 
   const handleUploadAudio = useCallback(
     (textId: string, file: File) => {
-      if (!audioLang) return
-      uploadAudioMutation.mutate({ textId, language: audioLang, file })
+      if (!audioLang) return;
+      uploadAudioMutation.mutate({ textId, language: audioLang, file });
     },
-    [audioLang, uploadAudioMutation]
-  )
+    [audioLang, uploadAudioMutation],
+  );
 
   const transcribeMutation = useMutation({
     mutationFn: async (variables: { textId: string; language: string }) => {
-      if (!apiKey) throw new Error("OpenAI API key required for transcription")
-      return api.transcribeOne(bookLabel, variables.textId, variables.language, apiKey)
+      if (!apiKey) throw new Error("OpenAI API key required for transcription");
+      return api.transcribeOne(
+        bookLabel,
+        variables.textId,
+        variables.language,
+        apiKey,
+      );
     },
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "tts-timestamps", audioLang] })
+      await queryClient.invalidateQueries({
+        queryKey: ["books", bookLabel, "tts-timestamps", audioLang],
+      });
     },
-  })
+  });
 
   const transcribeAllMutation = useMutation({
     mutationFn: async (language: string) => {
-      if (!apiKey) throw new Error("OpenAI API key required for transcription")
-      return api.transcribeAll(bookLabel, language, apiKey)
+      if (!apiKey) throw new Error("OpenAI API key required for transcription");
+      return api.transcribeAll(bookLabel, language, apiKey);
     },
-  })
+  });
 
   const saveTimestampsMutation = useMutation({
-    mutationFn: async (variables: { textId: string; language: string; words: WordTimestamp[]; duration: number }) => {
-      return api.saveWordTimestamps(bookLabel, variables.language, variables.textId, {
-        words: variables.words,
-        duration: variables.duration,
-      })
+    mutationFn: async (variables: {
+      textId: string;
+      language: string;
+      words: WordTimestamp[];
+      duration: number;
+    }) => {
+      return api.saveWordTimestamps(
+        bookLabel,
+        variables.language,
+        variables.textId,
+        {
+          words: variables.words,
+          duration: variables.duration,
+        },
+      );
     },
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "tts-timestamps", audioLang] })
+      await queryClient.invalidateQueries({
+        queryKey: ["books", bookLabel, "tts-timestamps", audioLang],
+      });
     },
-  })
+  });
 
   const handleSaveTimestamps = useCallback(
     (textId: string, words: WordTimestamp[], duration: number) => {
-      if (!audioLang) return
-      saveTimestampsMutation.mutate({ textId, language: audioLang, words, duration })
+      if (!audioLang) return;
+      saveTimestampsMutation.mutate({
+        textId,
+        language: audioLang,
+        words,
+        duration,
+      });
     },
-    [audioLang, saveTimestampsMutation]
-  )
+    [audioLang, saveTimestampsMutation],
+  );
 
   const handleTranscribe = useCallback(
     (textId: string) => {
-      if (!audioLang || !apiKey) return
-      transcribeMutation.mutate({ textId, language: audioLang })
+      if (!audioLang || !apiKey) return;
+      transcribeMutation.mutate({ textId, language: audioLang });
     },
-    [audioLang, apiKey, transcribeMutation]
-  )
+    [audioLang, apiKey, transcribeMutation],
+  );
 
   // Resolve speech config summary for display.
   const speechSummary = useMemo(() => {
     const provider =
       (speechConfig && typeof speechConfig === "object"
         ? ((speechConfig as Record<string, unknown>).default_provider as string)
-        : undefined) ?? "openai"
-    const defaultVoice = DEFAULT_TTS_VOICE[provider] ?? DEFAULT_TTS_VOICE.openai
-    const defaultModel = DEFAULT_TTS_MODEL[provider] ?? DEFAULT_TTS_MODEL.openai
+        : undefined) ?? "openai";
+    const defaultVoice =
+      DEFAULT_TTS_VOICE[provider] ?? DEFAULT_TTS_VOICE.openai;
+    const defaultModel =
+      DEFAULT_TTS_MODEL[provider] ?? DEFAULT_TTS_MODEL.openai;
     if (!speechConfig || typeof speechConfig !== "object") {
-      return { provider, voice: defaultVoice, model: defaultModel }
+      return { provider, voice: defaultVoice, model: defaultModel };
     }
-    const sc = speechConfig as Record<string, unknown>
-    const voice = (sc.voice as string) ?? defaultVoice
-    const model = (sc.model as string) ?? undefined
-    const providers = sc.providers as Record<string, Record<string, unknown>> | undefined
-    const providerModel = providers?.[provider]?.model as string | undefined
-    return { provider, voice, model: providerModel ?? model ?? defaultModel }
-  }, [speechConfig])
+    const sc = speechConfig as Record<string, unknown>;
+    const voice = (sc.voice as string) ?? defaultVoice;
+    const model = (sc.model as string) ?? undefined;
+    const providers = sc.providers as
+      Record<string, Record<string, unknown>> | undefined;
+    const providerModel = providers?.[provider]?.model as string | undefined;
+    return { provider, voice, model: providerModel ?? model ?? defaultModel };
+  }, [speechConfig]);
 
   const headerControls = catalog ? (
     <div className="flex items-center gap-1.5 ml-auto">
@@ -553,6 +793,7 @@ export function LanguageView({ bookLabel, stageSlug = "translate", selectedPageI
             : t`Preparing speech...`}
         </span>
       )}
+
       <span className="text-[10px] bg-white/20 rounded-full px-2 py-0.5">{t`${String(displayEntries.length)} texts`}</span>
       {outputLanguages.length > 1 && (
         <span className="text-[10px] bg-white/20 rounded-full px-2 py-0.5">{t`${String(outputLanguages.length)} languages`}</span>
@@ -561,38 +802,47 @@ export function LanguageView({ bookLabel, stageSlug = "translate", selectedPageI
         <span className="text-[10px] bg-white/20 rounded-full px-2 py-0.5">
           {t`${String(generatedAudioCount)}/${String(speakableEntries.length)} audio`}
         </span>
-      ) : totalAudioFiles > 0 && (
-        <span className="text-[10px] bg-white/20 rounded-full px-2 py-0.5">{t`${String(totalAudioFiles)} audio`}</span>
+      ) : (
+        totalAudioFiles > 0 && (
+          <span className="text-[10px] bg-white/20 rounded-full px-2 py-0.5">{t`${String(totalAudioFiles)} audio`}</span>
+        )
       )}
       {currentLanguageUsesGemini && missingAudioCount > 0 && (
         <span className="text-[10px] bg-amber-100 text-amber-900 rounded-full px-2 py-0.5">
           {t`${missingAudioCount} missing`}
         </span>
       )}
-      {selectedLang && translationVersion != null && !isSourceLang && !isSpeechStage && (
-        <VersionPicker
-          step="text-catalog-translation"
-          itemId={selectedLang}
-          currentVersion={translationVersion}
-          saving={saving}
-          dirty={dirty}
-          bookLabel={bookLabel}
-          pendingLabel={pendingLabel}
-          pendingLabelKey={pendingLabelKey}
-          onPreview={(d) => {
-            const data = d as { entries?: TextCatalogEntry[] }
-            setPendingEntries(data?.entries ?? [])
-          }}
-          onSave={() => saveRef.current()}
-          onDiscard={() => setPendingEntries(null)}
-        />
-      )}
+      {selectedLang &&
+        translationVersion != null &&
+        !isSourceLang &&
+        !isSpeechStage && (
+          <VersionPicker
+            step="text-catalog-translation"
+            itemId={selectedLang}
+            currentVersion={translationVersion}
+            saving={saving}
+            dirty={dirty}
+            bookLabel={bookLabel}
+            pendingLabel={pendingLabel}
+            pendingLabelKey={pendingLabelKey}
+            onPreview={(d) => {
+              const data = d as { entries?: TextCatalogEntry[] };
+              setPendingEntries(data?.entries ?? []);
+            }}
+            onSave={() => saveRef.current()}
+            onDiscard={() => setPendingEntries(null)}
+          />
+        )}
       <div className="w-px h-4 bg-white/20" />
       <button
         type="button"
         onClick={() => {
-          if (!hasApiKey || isRunning) return
-          queueRun({ fromStage: "translate", toStage: stageSlug as "translate" | "speech", apiKey })
+          if (!hasApiKey || isRunning) return;
+          queueRun({
+            fromStage: "translate",
+            toStage: stageSlug as "translate" | "speech",
+            apiKey,
+          });
         }}
         disabled={!hasApiKey || isRunning}
         title={isSpeechStage ? t`Re-run speech` : t`Re-run translation`}
@@ -605,13 +855,28 @@ export function LanguageView({ bookLabel, stageSlug = "translate", selectedPageI
           <button
             type="button"
             onClick={() => {
-              if (!audioLang) return
-              const langDisplay = displayLang(audioLang)
-              if (!window.confirm(t`Are you sure you want to generate word-level timestamps for ${langDisplay}?`)) return
-              transcribeAllMutation.mutate(audioLang)
+              if (!audioLang) return;
+              const langDisplay = displayLang(audioLang);
+              if (
+                !window.confirm(
+                  t`Are you sure you want to generate word-level timestamps for ${langDisplay}?`,
+                )
+              )
+                return;
+              transcribeAllMutation.mutate(audioLang);
             }}
-            disabled={!apiKey || totalAudioFiles === 0 || isRunning || transcribeAllMutation.isPending || isTaskRunning("transcribe-timestamps")}
-            title={apiKey ? t`Calculate word timestamps for all entries` : t`OpenAI key required`}
+            disabled={
+              !apiKey ||
+              totalAudioFiles === 0 ||
+              isRunning ||
+              transcribeAllMutation.isPending ||
+              isTaskRunning("transcribe-timestamps")
+            }
+            title={
+              apiKey
+                ? t`Calculate word timestamps for all entries`
+                : t`OpenAI key required`
+            }
             className="text-white/60 hover:text-white transition-colors disabled:opacity-30 cursor-pointer disabled:cursor-default"
           >
             <Type className="w-3.5 h-3.5" />
@@ -619,8 +884,13 @@ export function LanguageView({ bookLabel, stageSlug = "translate", selectedPageI
           <button
             type="button"
             onClick={() => {
-              if (!window.confirm(t`Are you sure you want to delete generated speech?`)) return
-              handleDeleteTTS()
+              if (
+                !window.confirm(
+                  t`Are you sure you want to delete generated speech?`,
+                )
+              )
+                return;
+              handleDeleteTTS();
             }}
             disabled={totalAudioFiles === 0 || isRunning}
             title={t`Delete all speech`}
@@ -628,107 +898,143 @@ export function LanguageView({ bookLabel, stageSlug = "translate", selectedPageI
           >
             <Trash2 className="w-3.5 h-3.5" />
           </button>
+          {isRunning && (
+            <button
+              type="button"
+              onClick={() => cancelRun()}
+              disabled={isCancelling}
+              title={isCancelling ? t`Cancelling…` : t`Cancel run`}
+              aria-label={isCancelling ? t`Cancelling run` : t`Cancel run`}
+              className="flex text-xs text-white/60 hover:text-white transition-colors disabled:opacity-30 cursor-pointer disabled:cursor-default"
+            >
+              {isCancelling ? (
+                <Loader2 className="w-2.5 h-2.5 animate-spin" />
+              ) : (
+                <CircleStop className="w-3 h-3" />
+              )}
+            </button>
+          )}
         </>
       )}
     </div>
-  ) : null
+  ) : null;
 
   if (!showRunCard && isLoading) {
-    return <LoadingState stageSlug="translate" label={t`Loading text catalog...`} />
+    return (
+      <LoadingState stageSlug="translate" label={t`Loading text catalog...`} />
+    );
   }
 
   if (showRunCard || !catalog || entries.length === 0) {
     return (
       <>
-      {headerSlotEl && headerControls && createPortal(headerControls, headerSlotEl)}
-      <div className="p-4">
-        <StageRunCard
-          stageSlug={stageSlug}
-          isRunning={isRunning}
-          completed={stageDone}
-          onRun={handleRun}
-          disabled={!hasApiKey || isRunning}
-        >
-          {!isSpeechStage ? (
-            <div className="space-y-3">
-              <div>
-                <p className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">{t`Book Language`}</p>
-                <p className="text-sm mt-0.5">
-                  {bookLanguage ? (
-                    <>{displayLang(bookLanguage)} <span className="text-muted-foreground">({bookLanguage})</span></>
-                  ) : (
-                    <span className="text-muted-foreground italic">{t`Not detected`}</span>
-                  )}
-                </p>
-              </div>
-              {outputLanguages.length > 0 && (
+        {headerSlotEl &&
+          headerControls &&
+          createPortal(headerControls, headerSlotEl)}
+        <div className="p-4">
+          <StageRunCard
+            stageSlug={stageSlug}
+            isRunning={isRunning}
+            completed={stageDone}
+            onRun={handleRun}
+            disabled={!hasApiKey || isRunning}
+          >
+            {!isSpeechStage ? (
+              <div className="space-y-3">
                 <div>
-                  <p className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">{t`Output Languages`}</p>
-                  <div className="flex flex-wrap gap-1.5 mt-1">
-                    {outputLanguages.map((lang) => (
-                      <span key={lang} className="inline-flex items-center text-xs bg-muted rounded-md px-2 py-0.5">
-                        {displayLang(lang)} <span className="text-muted-foreground ml-1">({lang})</span>
-                      </span>
-                    ))}
-                  </div>
+                  <p className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">{t`Book Language`}</p>
+                  <p className="text-sm mt-0.5">
+                    {bookLanguage ? (
+                      <>
+                        {displayLang(bookLanguage)}{" "}
+                        <span className="text-muted-foreground">
+                          ({bookLanguage})
+                        </span>
+                      </>
+                    ) : (
+                      <span className="text-muted-foreground italic">{t`Not detected`}</span>
+                    )}
+                  </p>
                 </div>
-              )}
-              <Link
-                to="/books/$label/$step/settings"
-                params={{ label: bookLabel, step: "translate" }}
-                search={{ tab: "general" }}
-                className="inline-flex items-center gap-1 text-xs font-medium text-pink-600 hover:text-pink-700 transition-colors"
-              >
-                <Settings className="w-3 h-3" />
-                {t`Add Translations`}
-              </Link>
-            </div>
-          ) : (
-            <div className="space-y-3">
-              <div>
-                <p className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">{t`Voice`}</p>
-                <p className="text-sm mt-0.5">
-                  <span className="capitalize">{speechSummary.provider}</span>
-                  {" · "}
-                  {speechSummary.voice}
-                  {" · "}
-                  <span className="text-muted-foreground">{speechSummary.model}</span>
-                </p>
-              </div>
-              <div className="space-y-2">
-                <div className="flex flex-row items-center justify-between rounded-lg border bg-background p-3">
-                  <div className="space-y-0.5 pr-3">
-                    <Label htmlFor="word-highlight-landing" className="text-sm font-medium cursor-pointer">
-                      {t`Word-level highlighting`}
-                    </Label>
-                    <p className="text-xs text-muted-foreground">
-                      {t`Highlights words in sync with the audio. Adds noticeable time to speech generation.`}
-                    </p>
+                {outputLanguages.length > 0 && (
+                  <div>
+                    <p className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">{t`Output Languages`}</p>
+                    <div className="flex flex-wrap gap-1.5 mt-1">
+                      {outputLanguages.map((lang) => (
+                        <span
+                          key={lang}
+                          className="inline-flex items-center text-xs bg-muted rounded-md px-2 py-0.5"
+                        >
+                          {displayLang(lang)}{" "}
+                          <span className="text-muted-foreground ml-1">
+                            ({lang})
+                          </span>
+                        </span>
+                      ))}
+                    </div>
                   </div>
-                  <Switch
-                    id="word-highlight-landing"
-                    checked={wordHighlightingEnabled}
-                    onCheckedChange={toggleWordHighlighting}
-                    disabled={updateConfig.isPending || isRunning}
-                  />
-                </div>
-                <WordHighlightPreview enabled={wordHighlightingEnabled} />
+                )}
+                <Link
+                  to="/books/$label/$step/settings"
+                  params={{ label: bookLabel, step: "translate" }}
+                  search={{ tab: "general" }}
+                  className="inline-flex items-center gap-1 text-xs font-medium text-pink-600 hover:text-pink-700 transition-colors"
+                >
+                  <Settings className="w-3 h-3" />
+                  {t`Add Translations`}
+                </Link>
               </div>
-              <Link
-                to="/books/$label/$step/settings"
-                params={{ label: bookLabel, step: "speech" }}
-                search={{ tab: "general" }}
-                className="inline-flex items-center gap-1 text-xs font-medium text-rose-600 hover:text-rose-700 transition-colors"
-              >
-                <Settings className="w-3 h-3" />
-                {t`Choose Provider`}
-              </Link>
-            </div>
-          )}
-        </StageRunCard>
-      </div>
+            ) : (
+              <div className="space-y-3">
+                <div>
+                  <p className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">{t`Voice`}</p>
+                  <p className="text-sm mt-0.5">
+                    <span className="capitalize">{speechSummary.provider}</span>
+                    {" · "}
+                    {speechSummary.voice}
+                    {" · "}
+                    <span className="text-muted-foreground">
+                      {speechSummary.model}
+                    </span>
+                  </p>
+                </div>
+                <div className="space-y-2">
+                  <div className="flex flex-row items-center justify-between rounded-lg border bg-background p-3">
+                    <div className="space-y-0.5 pr-3">
+                      <Label
+                        htmlFor="word-highlight-landing"
+                        className="text-sm font-medium cursor-pointer"
+                      >
+                        {t`Word-level highlighting`}
+                      </Label>
+                      <p className="text-xs text-muted-foreground">
+                        {t`Highlights words in sync with the audio. Adds noticeable time to speech generation.`}
+                      </p>
+                    </div>
+                    <Switch
+                      id="word-highlight-landing"
+                      checked={wordHighlightingEnabled}
+                      onCheckedChange={toggleWordHighlighting}
+                      disabled={updateConfig.isPending || isRunning}
+                    />
+                  </div>
+                  <WordHighlightPreview enabled={wordHighlightingEnabled} />
+                </div>
+                <Link
+                  to="/books/$label/$step/settings"
+                  params={{ label: bookLabel, step: "speech" }}
+                  search={{ tab: "general" }}
+                  className="inline-flex items-center gap-1 text-xs font-medium text-rose-600 hover:text-rose-700 transition-colors"
+                >
+                  <Settings className="w-3 h-3" />
+                  {t`Choose Provider`}
+                </Link>
+              </div>
+            )}
+          </StageRunCard>
+        </div>
       </>
-    )
+    );
   }
 
   const showAllButton = selectedPageId ? (
@@ -741,442 +1047,620 @@ export function LanguageView({ bookLabel, stageSlug = "translate", selectedPageI
         {t`Show all translations`}
       </button>
     </div>
-  ) : null
+  ) : null;
 
   // Language tabs + entries
   return (
     <>
-    {headerSlotEl && headerControls && createPortal(headerControls, headerSlotEl)}
-    <div className="flex flex-col h-full">
-      {/* Fixed header: alerts, language tabs, column headers */}
-      <div className="shrink-0 px-4 pt-4 space-y-3">
-        {isSpeechStage && hasStageError && runError && (
-          <Alert variant="destructive" className="rounded-md">
-            <AlertDescription className="text-xs whitespace-pre-wrap break-words">
-              {runError}
-            </AlertDescription>
-          </Alert>
-        )}
-
-        {showMissingBanner && (
-          <div className="flex items-center justify-between gap-3 rounded-md border border-amber-200 bg-amber-50 px-3 py-2">
-            <div className="text-xs text-amber-900">
-              {isSpeechStage
-                ? t`${missingForCurrentStage} entry/entries are missing audio. Re-run to generate the missing items.`
-                : t`${missingForCurrentStage} entry/entries are missing translations. Re-run to fill the missing items.`}
-            </div>
-            <Button
-              size="sm"
-              variant="outline"
-              className="h-7 px-3 text-xs border-amber-300 bg-white text-amber-900 hover:bg-amber-100"
-              onClick={handleRun}
-              disabled={!hasApiKey || isRunning}
-            >
-              <RotateCcw className="mr-1 h-3 w-3" />
-              {isSpeechStage ? t`Re-run speech` : t`Re-run translation`}
-            </Button>
-          </div>
-        )}
-
-        {/* Language filter pills — always shown, base language first */}
-        {editingLanguage && (
-        <div className="flex gap-1.5 items-center flex-wrap">
-          {[editingLanguage, ...outputLanguages.filter((l) => l !== editingLanguage)].map((lang) => {
-            const isBase = lang === editingLanguage
-            const isActive = hasExplicitOutputLanguages ? selectedLang === lang : isBase
-            const ttsSummary = isSpeechStage ? langTtsSummary.get(lang) : undefined
-            return (
-              <button
-                key={lang}
-                type="button"
-                onClick={() => setSelectedLang(lang)}
-                className={cn(
-                  "text-xs px-3 rounded-md font-medium transition-colors cursor-pointer text-left",
-                  isSpeechStage && ttsSummary ? "h-auto py-1.5" : "h-7",
-                  isActive
-                    ? "bg-foreground text-background"
-                    : "bg-muted text-muted-foreground hover:bg-accent"
-                )}
-              >
-                <span>
-                  {displayLang(lang)}
-                  <span className={cn(
-                    "ml-1 text-[10px]",
-                    isActive ? "opacity-60" : "opacity-50"
-                  )}>
-                    {isBase ? t`(base)` : `(${lang})`}
-                  </span>
-                </span>
-                {isSpeechStage && ttsSummary && (
-                  <span className={cn(
-                    "block text-[10px] leading-tight mt-0.5",
-                    isActive ? "opacity-50" : "opacity-40"
-                  )}>
-                    {ttsSummary.model} · {ttsSummary.voice}
-                  </span>
-                )}
-              </button>
-            )
-          })}
-          {!isSpeechStage && (
-            <Link
-              to="/books/$label/$step/settings"
-              params={{ label: bookLabel, step: "translate" }}
-              search={{ tab: "general" }}
-              className="flex items-center justify-center w-7 h-7 rounded-md text-muted-foreground bg-muted hover:bg-accent hover:text-accent-foreground transition-colors"
-              title={t`Add language`}
-            >
-              <Plus className="w-3.5 h-3.5" />
-            </Link>
+      {headerSlotEl &&
+        headerControls &&
+        createPortal(headerControls, headerSlotEl)}
+      <div className="flex flex-col h-full">
+        {/* Fixed header: alerts, language tabs, column headers */}
+        <div className="shrink-0 px-4 pt-4 space-y-3">
+          {isSpeechStage && hasStageError && runError && (
+            <Alert variant="destructive" className="rounded-md">
+              <AlertDescription className="text-xs whitespace-pre-wrap break-words">
+                {runError}
+              </AlertDescription>
+            </Alert>
           )}
-        </div>
-        )}
 
-        {/* Category filter pills */}
-        {pageFilteredEntries.length > 0 && (
-        <div className="flex gap-1.5">
-          {([
-            ["all", t`All`],
-            ["text", t`Text`],
-            ["captions", t`Captions`],
-            ["answers", t`Answers`],
-            ["glossary", t`Glossary`],
-            ["easy-read", t`Easy Read`],
-          ] as const).map(([key, label]) => {
-            const count = key === "all"
-              ? pageFilteredEntries.length
-              : pageFilteredEntries.filter((e) => getEntryCategory(e.id) === key).length
-            if (key !== "all" && count === 0) return null
-            return (
-              <button
-                key={key}
-                type="button"
-                onClick={() => setCategoryFilter(key)}
-                className={cn(
-                  "text-xs h-7 px-3 rounded-md font-medium transition-colors cursor-pointer",
-                  categoryFilter === key
-                    ? "bg-foreground text-background"
-                    : "bg-muted text-muted-foreground hover:bg-accent"
-                )}
+          {showMissingBanner && (
+            <div className="flex items-center justify-between gap-3 rounded-md border border-amber-200 bg-amber-50 px-3 py-2">
+              <div className="text-xs text-amber-900">
+                {isSpeechStage
+                  ? t`${missingForCurrentStage} entry/entries are missing audio. Re-run to generate the missing items.`
+                  : t`${missingForCurrentStage} entry/entries are missing translations. Re-run to fill the missing items.`}
+              </div>
+              <Button
+                size="sm"
+                variant="outline"
+                className="h-7 px-3 text-xs border-amber-300 bg-white text-amber-900 hover:bg-amber-100"
+                onClick={handleRun}
+                disabled={!hasApiKey || isRunning}
               >
-                {label}
-                <span className={cn(
-                  "ml-1 text-[10px] tabular-nums",
-                  categoryFilter === key ? "opacity-60" : "opacity-50"
-                )}>
-                  {count}
-                </span>
-              </button>
-            )
-          })}
-        </div>
-        )}
+                <RotateCcw className="mr-1 h-3 w-3" />
+                {isSpeechStage ? t`Re-run speech` : t`Re-run translation`}
+              </Button>
+            </div>
+          )}
 
-        {!isSourceLang && !isSourceLanguagePending && displayEntries.length > 0 && (
-          <div className="grid grid-cols-2 gap-3 px-3 py-1.5">
-            <span className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">
-              {displayLang(editingLanguage)}
-            </span>
-            <span className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">{selectedLang ? displayLang(selectedLang) : selectedLang}</span>
-          </div>
-        )}
-      </div>
-
-      {/* Entries */}
-      {isSourceLanguagePending ? (
-        <LoadingState stageSlug="translate" label={t`Resolving source language...`} />
-      ) : selectedPageId && displayEntries.length === 0 && entries.length > 0 ? (
-        <StageEmptyState
-          icon={isSpeechStage ? AudioLines : Languages}
-          color={isSpeechStage ? "rose" : "pink"}
-          title={isSpeechStage ? t`No audio for this page` : t`No translations for this page`}
-          subtitle={isSpeechStage ? t`This page has no entries to synthesize` : t`This page has no translatable text entries`}
-        />
-      ) : (
-      <div ref={scrollRef} className="flex-1 min-h-0 overflow-y-auto px-4 pb-4">
-        <div style={{ height: virtualizer.getTotalSize(), width: "100%", position: "relative" }}>
-          {virtualizer.getVirtualItems().map((virtualRow) => {
-            const entry = displayEntries[virtualRow.index]
-            const translated = translatedMap.get(entry.id)
-            const audio = audioMap.get(entry.id)
-            const baseAudio = baseAudioMap.get(entry.id)
-            const isImg = isImageEntry(entry.id)
-            const isAnswer = isAnswerEntry(entry.id)
-            const exclusion = getEntryTtsExclusion(entry.id, ttsExclusionConfig)
-            // Easy Read variants inherit their source entry's mute — only the
-            // source row can undo it, so lock the toggle on the variant row.
-            const mutedViaSource =
-              exclusion.byId && isEasyReadEntry(entry.id) && !excludedTextIdSet.has(entry.id)
-            const muteLockedReason = exclusion.byCategory
-              ? t`Muted by a content type switch in the Speech settings`
-              : mutedViaSource
-                ? t`Muted via its source text entry`
-                : undefined
-            const muteToggle = (
-              <TtsMuteToggle
-                muted={exclusion.excluded}
-                lockedReason={muteLockedReason}
-                onToggle={() => toggleEntryMuted(entry.id)}
-              />
-            )
-            // Audio status for the selected language: a recorded failure shows
-            // immediately (even mid-run); plain "no audio" only after a run has
-            // finished. Muting an entry clears both — it no longer needs audio.
-            const audioFailure =
-              isSpeechStage && !isAnswer && !exclusion.excluded && !audio
-                ? failedAudioMap.get(entry.id)
-                : undefined
-            const audioMissing =
-              isSpeechStage && !isAnswer && !exclusion.excluded && !audio && !audioFailure &&
-              !isRunning && (stageDone || hasStageError)
-            const audioStatusBadges = (
-              <>
-                {audioFailure && (
-                  <span title={audioFailure} className="ml-1.5 text-[9px] font-medium text-red-700 bg-red-100 rounded px-1 py-0.5 cursor-help">
-                    {t`Failed`}
-                  </span>
-                )}
-                {audioMissing && (
-                  <span className="ml-1.5 text-[9px] font-medium text-amber-700 bg-amber-100 rounded px-1 py-0.5">
-                    {t`No audio`}
-                  </span>
-                )}
-              </>
-            )
-
-            return (
-              <div
-                key={entry.id}
-                data-index={virtualRow.index}
-                ref={virtualizer.measureElement}
-                style={{
-                  position: "absolute",
-                  top: 0,
-                  left: 0,
-                  width: "100%",
-                  transform: `translateY(${virtualRow.start}px)`,
-                }}
-              >
-                <div className="pb-1">
-                  {isSourceLang ? (
-                    <div className={cn("px-3 py-2.5 rounded-md border", isAnswer ? "bg-amber-50/60" : "bg-card")}>
-                      <div className="flex items-start gap-3">
-                        {isImg && (
-                          <img
-                            src={`${BASE_URL}/books/${bookLabel}/images/${entry.id}`}
-                            alt=""
-                            className="shrink-0 w-16 h-12 rounded object-cover ring-1 ring-border cursor-zoom-in hover:ring-blue-500"
-                            onClick={() => setLightbox({
-                              src: `${BASE_URL}/books/${bookLabel}/images/${entry.id}`,
-                              caption: entry.text,
-                            })}
-                          />
+          {/* Language filter pills — always shown, base language first */}
+          {editingLanguage && (
+            <div className="flex gap-1.5 items-center flex-wrap">
+              {[
+                editingLanguage,
+                ...outputLanguages.filter((l) => l !== editingLanguage),
+              ].map((lang) => {
+                const isBase = lang === editingLanguage;
+                const isActive = hasExplicitOutputLanguages
+                  ? selectedLang === lang
+                  : isBase;
+                const ttsSummary = isSpeechStage
+                  ? langTtsSummary.get(lang)
+                  : undefined;
+                return (
+                  <button
+                    key={lang}
+                    type="button"
+                    onClick={() => setSelectedLang(lang)}
+                    className={cn(
+                      "text-xs px-3 rounded-md font-medium transition-colors cursor-pointer text-left",
+                      isSpeechStage && ttsSummary ? "h-auto py-1.5" : "h-7",
+                      isActive
+                        ? "bg-foreground text-background"
+                        : "bg-muted text-muted-foreground hover:bg-accent",
+                    )}
+                  >
+                    <span>
+                      {displayLang(lang)}
+                      <span
+                        className={cn(
+                          "ml-1 text-[10px]",
+                          isActive ? "opacity-60" : "opacity-50",
                         )}
-                        <div className="flex-1 min-w-0">
-                          <span className="text-[10px] text-muted-foreground">
-                            {entry.id}
-                            {isAnswer && <span className="ml-1.5 text-[9px] font-medium text-amber-700 bg-amber-100 rounded px-1 py-0.5">{t`Answer`}</span>}
-                            {exclusion.excluded && <span className="ml-1.5 text-[9px] font-medium text-rose-700 bg-rose-100 rounded px-1 py-0.5">{t`Muted`}</span>}
-                            {audioStatusBadges}
-                            {isSpeechStage && audio && !exclusion.excluded && <span className="ml-1.5 text-[9px] text-muted-foreground/60">{audio.fileName}</span>}
-                            {muteToggle}
-                          </span>
-                          <HighlightedText
-                            text={entry.text}
-                            timestamps={isSpeechStage ? timestampMap[entry.id] : undefined}
-                            currentTime={playingEntryId === entry.id ? playbackTime : 0}
-                            isPlaying={playingEntryId === entry.id}
-                          />
-                        </div>
-                      </div>
-                      {isSpeechStage && !isAnswer && !exclusion.excluded && (audio || !isRunning) && <AudioAction
-                        audio={audio}
-                        audioLang={audioLang}
-                        bookLabel={bookLabel}
-                        textId={entry.id}
-                        canGenerate={currentLanguageUsesGemini}
-                        hasGeminiKey={geminiKey.length > 0}
-                        onGenerate={handleGenerateAudio}
-                        isGenerating={
-                          generateAudioMutation.isPending &&
-                          generateAudioMutation.variables?.textId === entry.id &&
-                          generateAudioMutation.variables?.language === audioLang
-                        }
-                        onUpload={handleUploadAudio}
-                        isUploading={
-                          uploadAudioMutation.isPending &&
-                          uploadAudioMutation.variables?.textId === entry.id &&
-                          uploadAudioMutation.variables?.language === audioLang
-                        }
-                        errorMessage={uploadErrorById[entry.id] ?? generateErrorById[entry.id]}
-                        timestamps={timestampMap[entry.id]}
-                        onTranscribe={handleTranscribe}
-                        isTranscribing={
-                          transcribeMutation.isPending &&
-                          transcribeMutation.variables?.textId === entry.id
-                        }
-                        hasOpenaiKey={!!apiKey}
-                        onTimeUpdate={(time) => { setPlaybackTime(time); setPlayingEntryId(entry.id) }}
-                        onPlayingChange={(p) => { if (!p) setPlayingEntryId(null) ; else setPlayingEntryId(entry.id) }}
-                        onSaveTimestamps={(words, dur) => handleSaveTimestamps(entry.id, words, dur)}
-                        isSavingTimestamps={
-                          saveTimestampsMutation.isPending &&
-                          saveTimestampsMutation.variables?.textId === entry.id
-                        }
-                        timestampColumns={4}
-                      />}
-                    </div>
-                  ) : (
-                    <div className={cn("px-3 py-2.5 rounded-md border", isAnswer ? "bg-amber-50/60" : "bg-card")}>
-                      <div className="grid grid-cols-2 gap-3">
-                        <div>
+                      >
+                        {isBase ? t`(base)` : `(${lang})`}
+                      </span>
+                    </span>
+                    {isSpeechStage && ttsSummary && (
+                      <span
+                        className={cn(
+                          "block text-[10px] leading-tight mt-0.5",
+                          isActive ? "opacity-50" : "opacity-40",
+                        )}
+                      >
+                        {ttsSummary.model} · {ttsSummary.voice}
+                      </span>
+                    )}
+                  </button>
+                );
+              })}
+              {!isSpeechStage && (
+                <Link
+                  to="/books/$label/$step/settings"
+                  params={{ label: bookLabel, step: "translate" }}
+                  search={{ tab: "general" }}
+                  className="flex items-center justify-center w-7 h-7 rounded-md text-muted-foreground bg-muted hover:bg-accent hover:text-accent-foreground transition-colors"
+                  title={t`Add language`}
+                >
+                  <Plus className="w-3.5 h-3.5" />
+                </Link>
+              )}
+            </div>
+          )}
+
+          {/* Category filter pills */}
+          {pageFilteredEntries.length > 0 && (
+            <div className="flex gap-1.5">
+              {(
+                [
+                  ["all", t`All`],
+                  ["text", t`Text`],
+                  ["captions", t`Captions`],
+                  ["answers", t`Answers`],
+                  ["glossary", t`Glossary`],
+                  ["easy-read", t`Easy Read`],
+                ] as const
+              ).map(([key, label]) => {
+                const count =
+                  key === "all"
+                    ? pageFilteredEntries.length
+                    : pageFilteredEntries.filter(
+                        (e) => getEntryCategory(e.id) === key,
+                      ).length;
+                if (key !== "all" && count === 0) return null;
+                return (
+                  <button
+                    key={key}
+                    type="button"
+                    onClick={() => setCategoryFilter(key)}
+                    className={cn(
+                      "text-xs h-7 px-3 rounded-md font-medium transition-colors cursor-pointer",
+                      categoryFilter === key
+                        ? "bg-foreground text-background"
+                        : "bg-muted text-muted-foreground hover:bg-accent",
+                    )}
+                  >
+                    {label}
+                    <span
+                      className={cn(
+                        "ml-1 text-[10px] tabular-nums",
+                        categoryFilter === key ? "opacity-60" : "opacity-50",
+                      )}
+                    >
+                      {count}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+
+          {!isSourceLang &&
+            !isSourceLanguagePending &&
+            displayEntries.length > 0 && (
+              <div className="grid grid-cols-2 gap-3 px-3 py-1.5">
+                <span className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">
+                  {displayLang(editingLanguage)}
+                </span>
+                <span className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">
+                  {selectedLang ? displayLang(selectedLang) : selectedLang}
+                </span>
+              </div>
+            )}
+        </div>
+
+        {/* Entries */}
+        {isSourceLanguagePending ? (
+          <LoadingState
+            stageSlug="translate"
+            label={t`Resolving source language...`}
+          />
+        ) : selectedPageId &&
+          displayEntries.length === 0 &&
+          entries.length > 0 ? (
+          <StageEmptyState
+            icon={isSpeechStage ? AudioLines : Languages}
+            color={isSpeechStage ? "rose" : "pink"}
+            title={
+              isSpeechStage
+                ? t`No audio for this page`
+                : t`No translations for this page`
+            }
+            subtitle={
+              isSpeechStage
+                ? t`This page has no entries to synthesize`
+                : t`This page has no translatable text entries`
+            }
+          />
+        ) : (
+          <div
+            ref={scrollRef}
+            className="flex-1 min-h-0 overflow-y-auto px-4 pb-4"
+          >
+            <div
+              style={{
+                height: virtualizer.getTotalSize(),
+                width: "100%",
+                position: "relative",
+              }}
+            >
+              {virtualizer.getVirtualItems().map((virtualRow) => {
+                const entry = displayEntries[virtualRow.index];
+                const translated = translatedMap.get(entry.id);
+                const audio = audioMap.get(entry.id);
+                const baseAudio = baseAudioMap.get(entry.id);
+                const isImg = isImageEntry(entry.id);
+                const isAnswer = isAnswerEntry(entry.id);
+                const exclusion = getEntryTtsExclusion(
+                  entry.id,
+                  ttsExclusionConfig,
+                );
+                // Easy Read variants inherit their source entry's mute — only the
+                // source row can undo it, so lock the toggle on the variant row.
+                const mutedViaSource =
+                  exclusion.byId &&
+                  isEasyReadEntry(entry.id) &&
+                  !excludedTextIdSet.has(entry.id);
+                const muteLockedReason = exclusion.byCategory
+                  ? t`Muted by a content type switch in the Speech settings`
+                  : mutedViaSource
+                    ? t`Muted via its source text entry`
+                    : undefined;
+                const muteToggle = (
+                  <TtsMuteToggle
+                    muted={exclusion.excluded}
+                    lockedReason={muteLockedReason}
+                    onToggle={() => toggleEntryMuted(entry.id)}
+                  />
+                );
+                // Audio status for the selected language: a recorded failure shows
+                // immediately (even mid-run); plain "no audio" only after a run has
+                // finished. Muting an entry clears both — it no longer needs audio.
+                const audioFailure =
+                  isSpeechStage && !isAnswer && !exclusion.excluded && !audio
+                    ? failedAudioMap.get(entry.id)
+                    : undefined;
+                const audioMissing =
+                  isSpeechStage &&
+                  !isAnswer &&
+                  !exclusion.excluded &&
+                  !audio &&
+                  !audioFailure &&
+                  !isRunning &&
+                  (stageDone || hasStageError);
+                const audioStatusBadges = (
+                  <>
+                    {audioFailure && (
+                      <span
+                        title={audioFailure}
+                        className="ml-1.5 text-[9px] font-medium text-red-700 bg-red-100 rounded px-1 py-0.5 cursor-help"
+                      >
+                        {t`Failed`}
+                      </span>
+                    )}
+                    {audioMissing && (
+                      <span className="ml-1.5 text-[9px] font-medium text-amber-700 bg-amber-100 rounded px-1 py-0.5">
+                        {t`No audio`}
+                      </span>
+                    )}
+                  </>
+                );
+
+                return (
+                  <div
+                    key={entry.id}
+                    data-index={virtualRow.index}
+                    ref={virtualizer.measureElement}
+                    style={{
+                      position: "absolute",
+                      top: 0,
+                      left: 0,
+                      width: "100%",
+                      transform: `translateY(${virtualRow.start}px)`,
+                    }}
+                  >
+                    <div className="pb-1">
+                      {isSourceLang ? (
+                        <div
+                          className={cn(
+                            "px-3 py-2.5 rounded-md border",
+                            isAnswer ? "bg-amber-50/60" : "bg-card",
+                          )}
+                        >
                           <div className="flex items-start gap-3">
                             {isImg && (
                               <img
                                 src={`${BASE_URL}/books/${bookLabel}/images/${entry.id}`}
                                 alt=""
                                 className="shrink-0 w-16 h-12 rounded object-cover ring-1 ring-border cursor-zoom-in hover:ring-blue-500"
-                                onClick={() => setLightbox({
-                                  src: `${BASE_URL}/books/${bookLabel}/images/${entry.id}`,
-                                  caption: entry.text,
-                                })}
+                                onClick={() =>
+                                  setLightbox({
+                                    src: `${BASE_URL}/books/${bookLabel}/images/${entry.id}`,
+                                    caption: entry.text,
+                                  })
+                                }
                               />
                             )}
-                            <div className="min-w-0">
+                            <div className="flex-1 min-w-0">
                               <span className="text-[10px] text-muted-foreground">
                                 {entry.id}
-                                {isAnswer && <span className="ml-1.5 text-[9px] font-medium text-amber-700 bg-amber-100 rounded px-1 py-0.5">{t`Answer`}</span>}
-                                {exclusion.excluded && <span className="ml-1.5 text-[9px] font-medium text-rose-700 bg-rose-100 rounded px-1 py-0.5">{t`Muted`}</span>}
-                                {isSpeechStage && baseAudio && !exclusion.excluded && <span className="ml-1.5 text-[9px] text-muted-foreground/60">{baseAudio.fileName}</span>}
+                                {isAnswer && (
+                                  <span className="ml-1.5 text-[9px] font-medium text-amber-700 bg-amber-100 rounded px-1 py-0.5">{t`Answer`}</span>
+                                )}
+                                {exclusion.excluded && (
+                                  <span className="ml-1.5 text-[9px] font-medium text-rose-700 bg-rose-100 rounded px-1 py-0.5">{t`Muted`}</span>
+                                )}
+                                {audioStatusBadges}
+                                {isSpeechStage &&
+                                  audio &&
+                                  !exclusion.excluded && (
+                                    <span className="ml-1.5 text-[9px] text-muted-foreground/60">
+                                      {audio.fileName}
+                                    </span>
+                                  )}
                                 {muteToggle}
                               </span>
-                              <p className="text-sm leading-relaxed mt-0.5">{entry.text}</p>
-                            </div>
-                          </div>
-                          {isSpeechStage && !isAnswer && !exclusion.excluded && baseAudio && editingLanguage && (
-                            <WaveformPlayer
-                              key={`base-${editingLanguage}:${baseAudio.fileName}:${baseAudio.cacheKey ?? ""}`}
-                              audioUrl={getAudioUrl(bookLabel, editingLanguage, baseAudio.fileName, baseAudio.cacheKey)}
-                            />
-                          )}
-                        </div>
-                        <div>
-                          <div className="flex items-start gap-3">
-                            {isImg && (() => {
-                              const translatedId = selectedLang
-                                ? translatedImageMap.get(`${entry.id}::${selectedLang}`)
-                                : undefined
-                              if (translatedId) {
-                                const url = `${BASE_URL}/books/${bookLabel}/images/${translatedId}`
-                                return (
-                                  <img
-                                    src={url}
-                                    alt=""
-                                    className="shrink-0 w-16 h-12 rounded object-cover ring-1 ring-border cursor-zoom-in hover:ring-blue-500"
-                                    onClick={() => setLightbox({ src: url, caption: translated || entry.text })}
-                                  />
-                                )
-                              }
-                              return (
-                                <div
-                                  className="shrink-0 w-16 h-12 rounded ring-1 ring-dashed ring-border bg-muted/30 flex items-center justify-center"
-                                  title={t`Image not translated for this language`}
-                                >
-                                  <span className="text-[8px] text-muted-foreground uppercase tracking-wide">{t`No image`}</span>
-                                </div>
-                              )
-                            })()}
-                            <div className="min-w-0 flex-1">
-                            <span className="text-[10px] text-muted-foreground">
-                              &nbsp;
-                              {audioStatusBadges}
-                              {isSpeechStage && audio && !exclusion.excluded && <span className="text-[9px] text-muted-foreground/60">{audio.fileName}</span>}
-                            </span>
-                            {isSpeechStage ? (
                               <HighlightedText
-                                text={translated || ""}
-                                timestamps={timestampMap[entry.id]}
-                                currentTime={playingEntryId === entry.id ? playbackTime : 0}
+                                text={entry.text}
+                                timestamps={
+                                  isSpeechStage
+                                    ? timestampMap[entry.id]
+                                    : undefined
+                                }
+                                currentTime={
+                                  playingEntryId === entry.id ? playbackTime : 0
+                                }
                                 isPlaying={playingEntryId === entry.id}
                               />
-                            ) : (
-                              <textarea
-                                value={translated ?? ""}
-                                onChange={(e) => updateEntry(entry.id, e.target.value)}
-                                placeholder={t`Pending...`}
-                                className="w-full text-sm leading-relaxed mt-0.5 resize-none rounded border border-transparent bg-transparent p-1.5 -ml-1.5 hover:border-border hover:bg-muted/30 focus:border-ring focus:bg-white focus:outline-none focus:ring-1 focus:ring-ring transition-colors placeholder:text-muted-foreground placeholder:italic"
-                                style={{ fieldSizing: "content" } as React.CSSProperties}
-                                rows={1}
-                              />
-                            )}
                             </div>
                           </div>
-                          {isSpeechStage && !isAnswer && !exclusion.excluded && (audio || !isRunning) && <AudioAction
-                            audio={audio}
-                            audioLang={audioLang}
-                            bookLabel={bookLabel}
-                            textId={entry.id}
-                            canGenerate={currentLanguageUsesGemini}
-                            hasGeminiKey={geminiKey.length > 0}
-                            onGenerate={handleGenerateAudio}
-                            isGenerating={
-                              generateAudioMutation.isPending &&
-                              generateAudioMutation.variables?.textId === entry.id &&
-                              generateAudioMutation.variables?.language === audioLang
-                            }
-                            onUpload={handleUploadAudio}
-                            isUploading={
-                              uploadAudioMutation.isPending &&
-                              uploadAudioMutation.variables?.textId === entry.id &&
-                              uploadAudioMutation.variables?.language === audioLang
-                            }
-                            errorMessage={uploadErrorById[entry.id] ?? generateErrorById[entry.id]}
-                            timestamps={timestampMap[entry.id]}
-                            onTranscribe={handleTranscribe}
-                            isTranscribing={
-                              transcribeMutation.isPending &&
-                              transcribeMutation.variables?.textId === entry.id
-                            }
-                            hasOpenaiKey={!!apiKey}
-                            onTimeUpdate={(time) => { setPlaybackTime(time); setPlayingEntryId(entry.id) }}
-                            onPlayingChange={(p) => { if (!p) setPlayingEntryId(null); else setPlayingEntryId(entry.id) }}
-                            onSaveTimestamps={(words, dur) => handleSaveTimestamps(entry.id, words, dur)}
-                            isSavingTimestamps={
-                              saveTimestampsMutation.isPending &&
-                              saveTimestampsMutation.variables?.textId === entry.id
-                            }
-                          />}
+                          {isSpeechStage &&
+                            !isAnswer &&
+                            !exclusion.excluded &&
+                            (audio || !isRunning) && (
+                              <AudioAction
+                                audio={audio}
+                                audioLang={audioLang}
+                                bookLabel={bookLabel}
+                                textId={entry.id}
+                                canGenerate={currentLanguageUsesGemini}
+                                hasGeminiKey={geminiKey.length > 0}
+                                onGenerate={handleGenerateAudio}
+                                isGenerating={
+                                  generateAudioMutation.isPending &&
+                                  generateAudioMutation.variables?.textId ===
+                                    entry.id &&
+                                  generateAudioMutation.variables?.language ===
+                                    audioLang
+                                }
+                                onUpload={handleUploadAudio}
+                                isUploading={
+                                  uploadAudioMutation.isPending &&
+                                  uploadAudioMutation.variables?.textId ===
+                                    entry.id &&
+                                  uploadAudioMutation.variables?.language ===
+                                    audioLang
+                                }
+                                errorMessage={
+                                  uploadErrorById[entry.id] ??
+                                  generateErrorById[entry.id]
+                                }
+                                timestamps={timestampMap[entry.id]}
+                                onTranscribe={handleTranscribe}
+                                isTranscribing={
+                                  transcribeMutation.isPending &&
+                                  transcribeMutation.variables?.textId ===
+                                    entry.id
+                                }
+                                hasOpenaiKey={!!apiKey}
+                                onTimeUpdate={(time) => {
+                                  setPlaybackTime(time);
+                                  setPlayingEntryId(entry.id);
+                                }}
+                                onPlayingChange={(p) => {
+                                  if (!p) setPlayingEntryId(null);
+                                  else setPlayingEntryId(entry.id);
+                                }}
+                                onSaveTimestamps={(words, dur) =>
+                                  handleSaveTimestamps(entry.id, words, dur)
+                                }
+                                isSavingTimestamps={
+                                  saveTimestampsMutation.isPending &&
+                                  saveTimestampsMutation.variables?.textId ===
+                                    entry.id
+                                }
+                                timestampColumns={4}
+                              />
+                            )}
                         </div>
-                      </div>
+                      ) : (
+                        <div
+                          className={cn(
+                            "px-3 py-2.5 rounded-md border",
+                            isAnswer ? "bg-amber-50/60" : "bg-card",
+                          )}
+                        >
+                          <div className="grid grid-cols-2 gap-3">
+                            <div>
+                              <div className="flex items-start gap-3">
+                                {isImg && (
+                                  <img
+                                    src={`${BASE_URL}/books/${bookLabel}/images/${entry.id}`}
+                                    alt=""
+                                    className="shrink-0 w-16 h-12 rounded object-cover ring-1 ring-border cursor-zoom-in hover:ring-blue-500"
+                                    onClick={() =>
+                                      setLightbox({
+                                        src: `${BASE_URL}/books/${bookLabel}/images/${entry.id}`,
+                                        caption: entry.text,
+                                      })
+                                    }
+                                  />
+                                )}
+                                <div className="min-w-0">
+                                  <span className="text-[10px] text-muted-foreground">
+                                    {entry.id}
+                                    {isAnswer && (
+                                      <span className="ml-1.5 text-[9px] font-medium text-amber-700 bg-amber-100 rounded px-1 py-0.5">{t`Answer`}</span>
+                                    )}
+                                    {exclusion.excluded && (
+                                      <span className="ml-1.5 text-[9px] font-medium text-rose-700 bg-rose-100 rounded px-1 py-0.5">{t`Muted`}</span>
+                                    )}
+                                    {isSpeechStage &&
+                                      baseAudio &&
+                                      !exclusion.excluded && (
+                                        <span className="ml-1.5 text-[9px] text-muted-foreground/60">
+                                          {baseAudio.fileName}
+                                        </span>
+                                      )}
+                                    {muteToggle}
+                                  </span>
+                                  <p className="text-sm leading-relaxed mt-0.5">
+                                    {entry.text}
+                                  </p>
+                                </div>
+                              </div>
+                              {isSpeechStage &&
+                                !isAnswer &&
+                                !exclusion.excluded &&
+                                baseAudio &&
+                                editingLanguage && (
+                                  <WaveformPlayer
+                                    key={`base-${editingLanguage}:${baseAudio.fileName}:${baseAudio.cacheKey ?? ""}`}
+                                    audioUrl={getAudioUrl(
+                                      bookLabel,
+                                      editingLanguage,
+                                      baseAudio.fileName,
+                                      baseAudio.cacheKey,
+                                    )}
+                                  />
+                                )}
+                            </div>
+                            <div>
+                              <div className="flex items-start gap-3">
+                                {isImg &&
+                                  (() => {
+                                    const translatedId = selectedLang
+                                      ? translatedImageMap.get(
+                                          `${entry.id}::${selectedLang}`,
+                                        )
+                                      : undefined;
+                                    if (translatedId) {
+                                      const url = `${BASE_URL}/books/${bookLabel}/images/${translatedId}`;
+                                      return (
+                                        <img
+                                          src={url}
+                                          alt=""
+                                          className="shrink-0 w-16 h-12 rounded object-cover ring-1 ring-border cursor-zoom-in hover:ring-blue-500"
+                                          onClick={() =>
+                                            setLightbox({
+                                              src: url,
+                                              caption: translated || entry.text,
+                                            })
+                                          }
+                                        />
+                                      );
+                                    }
+                                    return (
+                                      <div
+                                        className="shrink-0 w-16 h-12 rounded ring-1 ring-dashed ring-border bg-muted/30 flex items-center justify-center"
+                                        title={t`Image not translated for this language`}
+                                      >
+                                        <span className="text-[8px] text-muted-foreground uppercase tracking-wide">{t`No image`}</span>
+                                      </div>
+                                    );
+                                  })()}
+                                <div className="min-w-0 flex-1">
+                                  <span className="text-[10px] text-muted-foreground">
+                                    &nbsp;
+                                    {audioStatusBadges}
+                                    {isSpeechStage &&
+                                      audio &&
+                                      !exclusion.excluded && (
+                                        <span className="text-[9px] text-muted-foreground/60">
+                                          {audio.fileName}
+                                        </span>
+                                      )}
+                                  </span>
+                                  {isSpeechStage ? (
+                                    <HighlightedText
+                                      text={translated || ""}
+                                      timestamps={timestampMap[entry.id]}
+                                      currentTime={
+                                        playingEntryId === entry.id
+                                          ? playbackTime
+                                          : 0
+                                      }
+                                      isPlaying={playingEntryId === entry.id}
+                                    />
+                                  ) : (
+                                    <textarea
+                                      value={translated ?? ""}
+                                      onChange={(e) =>
+                                        updateEntry(entry.id, e.target.value)
+                                      }
+                                      placeholder={t`Pending...`}
+                                      className="w-full text-sm leading-relaxed mt-0.5 resize-none rounded border border-transparent bg-transparent p-1.5 -ml-1.5 hover:border-border hover:bg-muted/30 focus:border-ring focus:bg-white focus:outline-none focus:ring-1 focus:ring-ring transition-colors placeholder:text-muted-foreground placeholder:italic"
+                                      style={
+                                        {
+                                          fieldSizing: "content",
+                                        } as React.CSSProperties
+                                      }
+                                      rows={1}
+                                    />
+                                  )}
+                                </div>
+                              </div>
+                              {isSpeechStage &&
+                                !isAnswer &&
+                                !exclusion.excluded &&
+                                (audio || !isRunning) && (
+                                  <AudioAction
+                                    audio={audio}
+                                    audioLang={audioLang}
+                                    bookLabel={bookLabel}
+                                    textId={entry.id}
+                                    canGenerate={currentLanguageUsesGemini}
+                                    hasGeminiKey={geminiKey.length > 0}
+                                    onGenerate={handleGenerateAudio}
+                                    isGenerating={
+                                      generateAudioMutation.isPending &&
+                                      generateAudioMutation.variables
+                                        ?.textId === entry.id &&
+                                      generateAudioMutation.variables
+                                        ?.language === audioLang
+                                    }
+                                    onUpload={handleUploadAudio}
+                                    isUploading={
+                                      uploadAudioMutation.isPending &&
+                                      uploadAudioMutation.variables?.textId ===
+                                        entry.id &&
+                                      uploadAudioMutation.variables
+                                        ?.language === audioLang
+                                    }
+                                    errorMessage={
+                                      uploadErrorById[entry.id] ??
+                                      generateErrorById[entry.id]
+                                    }
+                                    timestamps={timestampMap[entry.id]}
+                                    onTranscribe={handleTranscribe}
+                                    isTranscribing={
+                                      transcribeMutation.isPending &&
+                                      transcribeMutation.variables?.textId ===
+                                        entry.id
+                                    }
+                                    hasOpenaiKey={!!apiKey}
+                                    onTimeUpdate={(time) => {
+                                      setPlaybackTime(time);
+                                      setPlayingEntryId(entry.id);
+                                    }}
+                                    onPlayingChange={(p) => {
+                                      if (!p) setPlayingEntryId(null);
+                                      else setPlayingEntryId(entry.id);
+                                    }}
+                                    onSaveTimestamps={(words, dur) =>
+                                      handleSaveTimestamps(entry.id, words, dur)
+                                    }
+                                    isSavingTimestamps={
+                                      saveTimestampsMutation.isPending &&
+                                      saveTimestampsMutation.variables
+                                        ?.textId === entry.id
+                                    }
+                                  />
+                                )}
+                            </div>
+                          </div>
+                        </div>
+                      )}
                     </div>
-                  )}
-                </div>
-              </div>
-            )
-          })}
-        </div>
-        {showAllButton}
+                  </div>
+                );
+              })}
+            </div>
+            {showAllButton}
+          </div>
+        )}
+        {lightbox && (
+          <ImageLightbox
+            src={lightbox.src}
+            caption={lightbox.caption}
+            onClose={() => setLightbox(null)}
+          />
+        )}
       </div>
-      )}
-      {lightbox && (
-        <ImageLightbox
-          src={lightbox.src}
-          caption={lightbox.caption}
-          onClose={() => setLightbox(null)}
-        />
-      )}
-    </div>
     </>
-  )
+  );
 }
 
 /** Number of bars in the waveform visualisation */
-const WAVEFORM_BARS = 120
+const WAVEFORM_BARS = 120;
 
 function formatTime(seconds: number): string {
-  const m = Math.floor(seconds / 60)
-  const s = Math.floor(seconds % 60)
-  return `${m}:${String(s).padStart(2, "0")}`
+  const m = Math.floor(seconds / 60);
+  const s = Math.floor(seconds % 60);
+  return `${m}:${String(s).padStart(2, "0")}`;
 }
 
 /**
@@ -1185,142 +1669,166 @@ function formatTime(seconds: number): string {
  */
 async function decodeWaveform(url: string, bars: number): Promise<number[]> {
   try {
-    const res = await fetch(url)
-    const buf = await res.arrayBuffer()
-    const ctx = new (window.AudioContext || (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext)()
-    const decoded = await ctx.decodeAudioData(buf)
-    const raw = decoded.getChannelData(0)
-    const step = Math.floor(raw.length / bars)
-    const amps: number[] = []
+    const res = await fetch(url);
+    const buf = await res.arrayBuffer();
+    const ctx = new (
+      window.AudioContext ||
+      (window as unknown as { webkitAudioContext: typeof AudioContext })
+        .webkitAudioContext
+    )();
+    const decoded = await ctx.decodeAudioData(buf);
+    const raw = decoded.getChannelData(0);
+    const step = Math.floor(raw.length / bars);
+    const amps: number[] = [];
     for (let i = 0; i < bars; i++) {
-      let sum = 0
+      let sum = 0;
       for (let j = 0; j < step; j++) {
-        const v = raw[i * step + j]
-        sum += v * v
+        const v = raw[i * step + j];
+        sum += v * v;
       }
-      amps.push(Math.sqrt(sum / step))
+      amps.push(Math.sqrt(sum / step));
     }
-    const max = Math.max(...amps, 0.001)
-    await ctx.close()
-    return amps.map((a) => a / max)
+    const max = Math.max(...amps, 0.001);
+    await ctx.close();
+    return amps.map((a) => a / max);
   } catch {
-    return Array(bars).fill(0.3) as number[]
+    return Array(bars).fill(0.3) as number[];
   }
 }
 
 /** Global stop handle — only one waveform plays at a time */
-let activePlayerStop: (() => void) | null = null
+let activePlayerStop: (() => void) | null = null;
 
-function WaveformPlayer({ audioUrl, onTimeUpdate, onPlayingChange }: { audioUrl: string; onTimeUpdate?: (time: number) => void; onPlayingChange?: (playing: boolean) => void }) {
-  const [playing, setPlaying] = useState(false)
-  const [progress, setProgress] = useState(0)
-  const [duration, setDuration] = useState(0)
-  const [waveform, setWaveform] = useState<number[] | null>(null)
-  const audioRef = useRef<HTMLAudioElement | null>(null)
-  const rafRef = useRef<number>(0)
-  const waveContainerRef = useRef<HTMLDivElement>(null)
-  const onTimeUpdateRef = useRef(onTimeUpdate)
-  onTimeUpdateRef.current = onTimeUpdate
-  const onPlayingChangeRef = useRef(onPlayingChange)
-  onPlayingChangeRef.current = onPlayingChange
+function WaveformPlayer({
+  audioUrl,
+  onTimeUpdate,
+  onPlayingChange,
+}: {
+  audioUrl: string;
+  onTimeUpdate?: (time: number) => void;
+  onPlayingChange?: (playing: boolean) => void;
+}) {
+  const [playing, setPlaying] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const [duration, setDuration] = useState(0);
+  const [waveform, setWaveform] = useState<number[] | null>(null);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const rafRef = useRef<number>(0);
+  const waveContainerRef = useRef<HTMLDivElement>(null);
+  const onTimeUpdateRef = useRef(onTimeUpdate);
+  onTimeUpdateRef.current = onTimeUpdate;
+  const onPlayingChangeRef = useRef(onPlayingChange);
+  onPlayingChangeRef.current = onPlayingChange;
 
   // Decode waveform on mount
   useEffect(() => {
-    let cancelled = false
+    let cancelled = false;
     decodeWaveform(audioUrl, WAVEFORM_BARS).then((w) => {
-      if (!cancelled) setWaveform(w)
-    })
-    return () => { cancelled = true }
-  }, [audioUrl])
+      if (!cancelled) setWaveform(w);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [audioUrl]);
 
   // Time update loop
   const tick = useCallback(() => {
-    const el = audioRef.current
+    const el = audioRef.current;
     if (el && !el.paused) {
-      setProgress(el.currentTime)
-      onTimeUpdateRef.current?.(el.currentTime)
-      rafRef.current = requestAnimationFrame(tick)
+      setProgress(el.currentTime);
+      onTimeUpdateRef.current?.(el.currentTime);
+      rafRef.current = requestAnimationFrame(tick);
     }
-  }, [])
+  }, []);
 
   const ensureAudio = useCallback(() => {
     if (!audioRef.current) {
-      const el = new Audio(audioUrl)
-      el.addEventListener("loadedmetadata", () => setDuration(el.duration))
+      const el = new Audio(audioUrl);
+      el.addEventListener("loadedmetadata", () => setDuration(el.duration));
       el.addEventListener("ended", () => {
-        setPlaying(false)
-        setProgress(0)
-        onPlayingChangeRef.current?.(false)
-        onTimeUpdateRef.current?.(0)
-        cancelAnimationFrame(rafRef.current)
-      })
-      audioRef.current = el
+        setPlaying(false);
+        setProgress(0);
+        onPlayingChangeRef.current?.(false);
+        onTimeUpdateRef.current?.(0);
+        cancelAnimationFrame(rafRef.current);
+      });
+      audioRef.current = el;
     }
-    return audioRef.current
-  }, [audioUrl])
+    return audioRef.current;
+  }, [audioUrl]);
 
   const stopThis = useCallback(() => {
-    const el = audioRef.current
+    const el = audioRef.current;
     if (el) {
-      el.pause()
-      el.currentTime = 0
+      el.pause();
+      el.currentTime = 0;
     }
-    cancelAnimationFrame(rafRef.current)
-    setPlaying(false)
-    setProgress(0)
-    onPlayingChangeRef.current?.(false)
-    onTimeUpdateRef.current?.(0)
-    if (activePlayerStop === stopThisRef.current) activePlayerStop = null
-  }, [])
-  const stopThisRef = useRef(stopThis)
-  stopThisRef.current = stopThis
+    cancelAnimationFrame(rafRef.current);
+    setPlaying(false);
+    setProgress(0);
+    onPlayingChangeRef.current?.(false);
+    onTimeUpdateRef.current?.(0);
+    if (activePlayerStop === stopThisRef.current) activePlayerStop = null;
+  }, []);
+  const stopThisRef = useRef(stopThis);
+  stopThisRef.current = stopThis;
 
-  const startPlaying = useCallback((el: HTMLAudioElement) => {
-    // Stop any other playing instance first
-    if (activePlayerStop && activePlayerStop !== stopThisRef.current) activePlayerStop()
-    activePlayerStop = stopThisRef.current
-    el.play()
-    setPlaying(true)
-    onPlayingChangeRef.current?.(true)
-    rafRef.current = requestAnimationFrame(tick)
-  }, [tick])
+  const startPlaying = useCallback(
+    (el: HTMLAudioElement) => {
+      // Stop any other playing instance first
+      if (activePlayerStop && activePlayerStop !== stopThisRef.current)
+        activePlayerStop();
+      activePlayerStop = stopThisRef.current;
+      el.play();
+      setPlaying(true);
+      onPlayingChangeRef.current?.(true);
+      rafRef.current = requestAnimationFrame(tick);
+    },
+    [tick],
+  );
 
   const toggle = useCallback(() => {
-    const el = ensureAudio()
+    const el = ensureAudio();
     if (playing) {
-      el.pause()
-      cancelAnimationFrame(rafRef.current)
-      setPlaying(false)
-      onPlayingChangeRef.current?.(false)
-      if (activePlayerStop === stopThisRef.current) activePlayerStop = null
+      el.pause();
+      cancelAnimationFrame(rafRef.current);
+      setPlaying(false);
+      onPlayingChangeRef.current?.(false);
+      if (activePlayerStop === stopThisRef.current) activePlayerStop = null;
     } else {
-      startPlaying(el)
+      startPlaying(el);
     }
-  }, [playing, ensureAudio, startPlaying])
+  }, [playing, ensureAudio, startPlaying]);
 
-  const seek = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
-    const el = ensureAudio()
-    const rect = e.currentTarget.getBoundingClientRect()
-    const ratio = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width))
-    el.currentTime = ratio * (el.duration || 0)
-    setProgress(el.currentTime)
-    if (!playing) {
-      startPlaying(el)
-    }
-  }, [ensureAudio, playing, startPlaying])
+  const seek = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      const el = ensureAudio();
+      const rect = e.currentTarget.getBoundingClientRect();
+      const ratio = Math.max(
+        0,
+        Math.min(1, (e.clientX - rect.left) / rect.width),
+      );
+      el.currentTime = ratio * (el.duration || 0);
+      setProgress(el.currentTime);
+      if (!playing) {
+        startPlaying(el);
+      }
+    },
+    [ensureAudio, playing, startPlaying],
+  );
 
   useEffect(() => {
     return () => {
-      cancelAnimationFrame(rafRef.current)
-      if (activePlayerStop === stopThisRef.current) activePlayerStop = null
+      cancelAnimationFrame(rafRef.current);
+      if (activePlayerStop === stopThisRef.current) activePlayerStop = null;
       if (audioRef.current) {
-        audioRef.current.pause()
-        audioRef.current = null
+        audioRef.current.pause();
+        audioRef.current = null;
       }
-    }
-  }, [])
+    };
+  }, []);
 
-  const progressRatio = duration > 0 ? progress / duration : 0
+  const progressRatio = duration > 0 ? progress / duration : 0;
 
   return (
     <div className="flex items-center gap-2 mt-1.5 w-full">
@@ -1332,10 +1840,14 @@ function WaveformPlayer({ audioUrl, onTimeUpdate, onPlayingChange }: { audioUrl:
           "shrink-0 flex items-center justify-center w-6 h-6 rounded-full transition-all cursor-pointer",
           playing
             ? "bg-pink-500 text-white hover:bg-pink-600 scale-110"
-            : "bg-muted text-muted-foreground hover:bg-pink-100 hover:text-pink-600 hover:scale-110"
+            : "bg-muted text-muted-foreground hover:bg-pink-100 hover:text-pink-600 hover:scale-110",
         )}
       >
-        {playing ? <Pause className="w-2.5 h-2.5" /> : <Play className="w-2.5 h-2.5 ml-0.5" />}
+        {playing ? (
+          <Pause className="w-2.5 h-2.5" />
+        ) : (
+          <Play className="w-2.5 h-2.5 ml-0.5" />
+        )}
       </button>
 
       {/* Waveform */}
@@ -1344,23 +1856,25 @@ function WaveformPlayer({ audioUrl, onTimeUpdate, onPlayingChange }: { audioUrl:
         onClick={seek}
         className="flex-1 flex items-center h-8 cursor-pointer"
       >
-        {(waveform ?? Array(WAVEFORM_BARS).fill(0.1) as number[]).map((amp, i) => {
-          const barRatio = (i + 0.5) / WAVEFORM_BARS
-          const isPast = barRatio <= progressRatio
-          const minH = 1
-          const maxH = 28
-          const h = Math.max(minH, amp * maxH)
-          return (
-            <div
-              key={i}
-              className={cn(
-                "flex-1 rounded-full transition-colors",
-                isPast ? "bg-pink-400" : "bg-gray-300"
-              )}
-              style={{ height: `${h}px`, minWidth: "1px" }}
-            />
-          )
-        })}
+        {(waveform ?? (Array(WAVEFORM_BARS).fill(0.1) as number[])).map(
+          (amp, i) => {
+            const barRatio = (i + 0.5) / WAVEFORM_BARS;
+            const isPast = barRatio <= progressRatio;
+            const minH = 1;
+            const maxH = 28;
+            const h = Math.max(minH, amp * maxH);
+            return (
+              <div
+                key={i}
+                className={cn(
+                  "flex-1 rounded-full transition-colors",
+                  isPast ? "bg-pink-400" : "bg-gray-300",
+                )}
+                style={{ height: `${h}px`, minWidth: "1px" }}
+              />
+            );
+          },
+        )}
       </div>
 
       {/* Time */}
@@ -1368,24 +1882,29 @@ function WaveformPlayer({ audioUrl, onTimeUpdate, onPlayingChange }: { audioUrl:
         {duration > 0 ? formatTime(playing ? progress : duration) : ""}
       </span>
     </div>
-  )
+  );
 }
 
 /** Render the entry text with word-by-word highlighting synced to audio playback. */
-function HighlightedText({ text, timestamps, currentTime, isPlaying }: {
-  text: string
-  timestamps?: WordTimestampEntry
-  currentTime: number
-  isPlaying: boolean
+function HighlightedText({
+  text,
+  timestamps,
+  currentTime,
+  isPlaying,
+}: {
+  text: string;
+  timestamps?: WordTimestampEntry;
+  currentTime: number;
+  isPlaying: boolean;
 }) {
   if (!timestamps || !isPlaying) {
-    return <p className="text-sm leading-relaxed mt-0.5">{text}</p>
+    return <p className="text-sm leading-relaxed mt-0.5">{text}</p>;
   }
   return (
     <p className="text-sm leading-relaxed mt-0.5">
       {timestamps.words.map((w, i) => {
-        const active = currentTime >= w.start && currentTime < w.end
-        const past = currentTime >= w.end
+        const active = currentTime >= w.start && currentTime < w.end;
+        const past = currentTime >= w.end;
         return (
           <span
             key={i}
@@ -1395,54 +1914,64 @@ function HighlightedText({ text, timestamps, currentTime, isPlaying }: {
                 ? "bg-pink-500 text-white"
                 : past
                   ? "text-foreground"
-                  : "text-muted-foreground/50"
+                  : "text-muted-foreground/50",
             )}
           >
             {w.word}{" "}
           </span>
-        )
+        );
       })}
     </p>
-  )
+  );
 }
 
 /** Editable timecode field with visible up/down clicker arrows, increments by 0.1.
  * Clamps to [min, max]. Flashes red briefly when the user attempts to push past
  * a bound. */
-function TimecodeInput({ value, onChange, min = 0, max = Number.POSITIVE_INFINITY, title, className }: {
-  value: number
-  onChange: (v: number) => void
-  min?: number
-  max?: number
-  title?: string
-  className?: string
+function TimecodeInput({
+  value,
+  onChange,
+  min = 0,
+  max = Number.POSITIVE_INFINITY,
+  title,
+  className,
+}: {
+  value: number;
+  onChange: (v: number) => void;
+  min?: number;
+  max?: number;
+  title?: string;
+  className?: string;
 }) {
-  const [draft, setDraft] = useState<string | null>(null)
-  const [flash, setFlash] = useState(false)
-  const flashTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const display = draft ?? value.toFixed(3)
+  const [draft, setDraft] = useState<string | null>(null);
+  const [flash, setFlash] = useState(false);
+  const flashTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const display = draft ?? value.toFixed(3);
 
-  useEffect(() => () => {
-    if (flashTimerRef.current) clearTimeout(flashTimerRef.current)
-  }, [])
+  useEffect(
+    () => () => {
+      if (flashTimerRef.current) clearTimeout(flashTimerRef.current);
+    },
+    [],
+  );
 
   const triggerFlash = () => {
-    setFlash(true)
-    if (flashTimerRef.current) clearTimeout(flashTimerRef.current)
-    flashTimerRef.current = setTimeout(() => setFlash(false), 400)
-  }
+    setFlash(true);
+    if (flashTimerRef.current) clearTimeout(flashTimerRef.current);
+    flashTimerRef.current = setTimeout(() => setFlash(false), 400);
+  };
 
   const tryChange = (requested: number) => {
-    const clamped = Math.max(min, Math.min(max, requested))
-    if (clamped !== value) onChange(clamped)
-    if (Math.abs(clamped - requested) > 1e-6) triggerFlash()
-  }
+    const clamped = Math.max(min, Math.min(max, requested));
+    if (clamped !== value) onChange(clamped);
+    if (Math.abs(clamped - requested) > 1e-6) triggerFlash();
+  };
 
   const nudge = (direction: 1 | -1) => {
-    const next = Math.round((value + direction * 0.1) * 1000) / 1000
-    tryChange(next)
-    setDraft(null)
-  }
+    const next = Math.round((value + direction * 0.1) * 1000) / 1000;
+    tryChange(next);
+    setDraft(null);
+  };
 
   return (
     <span className="inline-flex items-center">
@@ -1453,20 +1982,20 @@ function TimecodeInput({ value, onChange, min = 0, max = Number.POSITIVE_INFINIT
         onChange={(e) => setDraft(e.target.value)}
         onBlur={() => {
           if (draft != null) {
-            const v = parseFloat(draft)
-            if (!isNaN(v)) tryChange(v)
-            setDraft(null)
+            const v = parseFloat(draft);
+            if (!isNaN(v)) tryChange(v);
+            setDraft(null);
           }
         }}
         onKeyDown={(e) => {
           if (e.key === "Enter") {
-            e.currentTarget.blur()
+            e.currentTarget.blur();
           } else if (e.key === "ArrowUp") {
-            e.preventDefault()
-            nudge(1)
+            e.preventDefault();
+            nudge(1);
           } else if (e.key === "ArrowDown") {
-            e.preventDefault()
-            nudge(-1)
+            e.preventDefault();
+            nudge(-1);
           }
         }}
         title={title}
@@ -1491,61 +2020,72 @@ function TimecodeInput({ value, onChange, min = 0, max = Number.POSITIVE_INFINIT
         </button>
       </span>
     </span>
-  )
+  );
 }
 
 /** Collapsible timestamp detail view — collapsed by default, expandable multi-column table. */
-function WordTimestampViewer({ timestamps, onSave, isSaving, columns = 2 }: {
-  timestamps: WordTimestampEntry
-  onSave?: (words: WordTimestamp[], duration: number) => void
-  isSaving?: boolean
-  columns?: number
+function WordTimestampViewer({
+  timestamps,
+  onSave,
+  isSaving,
+  columns = 2,
+}: {
+  timestamps: WordTimestampEntry;
+  onSave?: (words: WordTimestamp[], duration: number) => void;
+  isSaving?: boolean;
+  columns?: number;
 }) {
-  const { t } = useLingui()
-  const [expanded, setExpanded] = useState(false)
-  const [editWords, setEditWords] = useState<WordTimestamp[] | null>(null)
+  const { t } = useLingui();
+  const [expanded, setExpanded] = useState(false);
+  const [editWords, setEditWords] = useState<WordTimestamp[] | null>(null);
 
-  const words = editWords ?? timestamps.words
-  const dirty = editWords != null
+  const words = editWords ?? timestamps.words;
+  const dirty = editWords != null;
 
   const handleExpand = () => {
-    setExpanded(!expanded)
-    setEditWords(null)
-  }
+    setExpanded(!expanded);
+    setEditWords(null);
+  };
 
   const updateWord = (index: number, field: "start" | "end", value: number) => {
-    const base = editWords ?? [...timestamps.words]
-    const current = base[index]
+    const base = editWords ?? [...timestamps.words];
+    const current = base[index];
     // Clamp to keep boundaries non-overlapping: start ≥ prev.end and ≤ own end;
     // end ≥ own start and ≤ next.start. First word's lower bound is 0; last
     // word's upper bound is unbounded.
-    let clamped = Math.max(0, value)
+    let clamped = Math.max(0, value);
     if (field === "start") {
-      const lower = index > 0 ? base[index - 1].end : 0
-      clamped = Math.max(lower, Math.min(clamped, current.end))
+      const lower = index > 0 ? base[index - 1].end : 0;
+      clamped = Math.max(lower, Math.min(clamped, current.end));
     } else {
-      const upper = index < base.length - 1 ? base[index + 1].start : Number.POSITIVE_INFINITY
-      clamped = Math.min(upper, Math.max(clamped, current.start))
+      const upper =
+        index < base.length - 1
+          ? base[index + 1].start
+          : Number.POSITIVE_INFINITY;
+      clamped = Math.min(upper, Math.max(clamped, current.start));
     }
-    const updated = base.map((w, i) => i === index ? { ...w, [field]: clamped } : w)
-    setEditWords(updated)
-  }
+    const updated = base.map((w, i) =>
+      i === index ? { ...w, [field]: clamped } : w,
+    );
+    setEditWords(updated);
+  };
 
   const handleSave = () => {
-    if (!editWords || !onSave) return
-    const maxEnd = editWords.reduce((max, w) => Math.max(max, w.end), 0)
-    onSave(editWords, maxEnd)
-    setEditWords(null)
-  }
+    if (!editWords || !onSave) return;
+    const maxEnd = editWords.reduce((max, w) => Math.max(max, w.end), 0);
+    onSave(editWords, maxEnd);
+    setEditWords(null);
+  };
 
   // Split words into column chunks for multi-column layout
-  const rowCount = Math.ceil(words.length / columns)
-  const columnChunks: WordTimestamp[][] = []
+  const rowCount = Math.ceil(words.length / columns);
+  const columnChunks: WordTimestamp[][] = [];
   for (let c = 0; c < columns; c++) {
-    columnChunks.push(words.slice(c * rowCount, (c + 1) * rowCount))
+    columnChunks.push(words.slice(c * rowCount, (c + 1) * rowCount));
   }
 
-  const inputClass = "w-14 tabular-nums text-[10px] text-muted-foreground bg-transparent border-b border-transparent hover:border-muted-foreground/30 focus:border-pink-500 focus:outline-none transition-colors text-right appearance-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none [-moz-appearance:textfield]"
+  const inputClass =
+    "w-14 tabular-nums text-[10px] text-muted-foreground bg-transparent border-b border-transparent hover:border-muted-foreground/30 focus:border-pink-500 focus:outline-none transition-colors text-right appearance-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none [-moz-appearance:textfield]";
 
   return (
     <div className="mt-1.5">
@@ -1555,29 +2095,70 @@ function WordTimestampViewer({ timestamps, onSave, isSaving, columns = 2 }: {
         onClick={handleExpand}
         className="flex items-center gap-1 text-[10px] text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
       >
-        {expanded ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+        {expanded ? (
+          <ChevronDown className="h-3 w-3" />
+        ) : (
+          <ChevronRight className="h-3 w-3" />
+        )}
         <Type className="h-3 w-3" />
-        <span>{timestamps.words.length} {t`words`} · {timestamps.duration.toFixed(1)}s</span>
+        <span>
+          {timestamps.words.length} {t`words`} ·{" "}
+          {timestamps.duration.toFixed(1)}s
+        </span>
       </button>
 
       {/* Expanded multi-column table */}
       {expanded && (
         <div className="mt-1.5 border rounded-md overflow-hidden">
           <div className="max-h-56 overflow-y-auto">
-            <div className={cn("grid gap-x-3", columns === 1 && "grid-cols-1", columns === 2 && "grid-cols-2", columns === 3 && "grid-cols-3", columns >= 4 && "grid-cols-4")}>
+            <div
+              className={cn(
+                "grid gap-x-3",
+                columns === 1 && "grid-cols-1",
+                columns === 2 && "grid-cols-2",
+                columns === 3 && "grid-cols-3",
+                columns >= 4 && "grid-cols-4",
+              )}
+            >
               {columnChunks.map((chunk, colIdx) => (
                 <div key={colIdx} className={cn(colIdx > 0 && "border-l")}>
                   {chunk.map((w, rowIdx) => {
-                    const globalIdx = colIdx * rowCount + rowIdx
-                    const prevEnd = globalIdx > 0 ? words[globalIdx - 1].end : 0
-                    const nextStart = globalIdx < words.length - 1 ? words[globalIdx + 1].start : Number.POSITIVE_INFINITY
+                    const globalIdx = colIdx * rowCount + rowIdx;
+                    const prevEnd =
+                      globalIdx > 0 ? words[globalIdx - 1].end : 0;
+                    const nextStart =
+                      globalIdx < words.length - 1
+                        ? words[globalIdx + 1].start
+                        : Number.POSITIVE_INFINITY;
                     return (
-                      <div key={globalIdx} className={cn("flex items-center gap-1 px-1.5 py-0.5 text-xs", rowIdx > 0 && "border-t")}>
-                        <span className="flex-1 min-w-0 truncate">{w.word}</span>
-                        <TimecodeInput value={w.start} onChange={(v) => updateWord(globalIdx, "start", v)} min={prevEnd} max={w.end} title={t`Start`} className={inputClass} />
-                        <TimecodeInput value={w.end} onChange={(v) => updateWord(globalIdx, "end", v)} min={w.start} max={nextStart} title={t`End`} className={inputClass} />
+                      <div
+                        key={globalIdx}
+                        className={cn(
+                          "flex items-center gap-1 px-1.5 py-0.5 text-xs",
+                          rowIdx > 0 && "border-t",
+                        )}
+                      >
+                        <span className="flex-1 min-w-0 truncate">
+                          {w.word}
+                        </span>
+                        <TimecodeInput
+                          value={w.start}
+                          onChange={(v) => updateWord(globalIdx, "start", v)}
+                          min={prevEnd}
+                          max={w.end}
+                          title={t`Start`}
+                          className={inputClass}
+                        />
+                        <TimecodeInput
+                          value={w.end}
+                          onChange={(v) => updateWord(globalIdx, "end", v)}
+                          min={w.start}
+                          max={nextStart}
+                          title={t`End`}
+                          className={inputClass}
+                        />
                       </div>
-                    )
+                    );
                   })}
                 </div>
               ))}
@@ -1600,7 +2181,11 @@ function WordTimestampViewer({ timestamps, onSave, isSaving, columns = 2 }: {
                 disabled={isSaving}
                 className="flex items-center gap-1 text-[10px] font-medium text-pink-600 hover:text-pink-700 transition-colors cursor-pointer disabled:opacity-40"
               >
-                {isSaving ? <Loader2 className="h-3 w-3 animate-spin" /> : <Save className="h-3 w-3" />}
+                {isSaving ? (
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                ) : (
+                  <Save className="h-3 w-3" />
+                )}
                 {t`Save`}
               </button>
             </div>
@@ -1608,18 +2193,24 @@ function WordTimestampViewer({ timestamps, onSave, isSaving, columns = 2 }: {
         </div>
       )}
     </div>
-  )
+  );
 }
 
 /** Per-entry read-aloud mute toggle. Locked (non-interactive) when the mute
  * comes from a content-type switch or is inherited from the source entry. */
-function TtsMuteToggle({ muted, lockedReason, onToggle }: {
-  muted: boolean
-  lockedReason?: string
-  onToggle: () => void
+function TtsMuteToggle({
+  muted,
+  lockedReason,
+  onToggle,
+}: {
+  muted: boolean;
+  lockedReason?: string;
+  onToggle: () => void;
 }) {
-  const { t } = useLingui()
-  const title = lockedReason ?? (muted ? t`Include in read-aloud` : t`Exclude from read-aloud`)
+  const { t } = useLingui();
+  const title =
+    lockedReason ??
+    (muted ? t`Include in read-aloud` : t`Exclude from read-aloud`);
   return (
     <button
       type="button"
@@ -1635,9 +2226,13 @@ function TtsMuteToggle({ muted, lockedReason, onToggle }: {
         lockedReason ? "opacity-50 cursor-default" : "cursor-pointer",
       )}
     >
-      {muted ? <VolumeX className="w-3 h-3" /> : <Volume2 className="w-3 h-3" />}
+      {muted ? (
+        <VolumeX className="w-3 h-3" />
+      ) : (
+        <Volume2 className="w-3 h-3" />
+      )}
     </button>
-  )
+  );
 }
 
 function AudioAction({
@@ -1662,101 +2257,117 @@ function AudioAction({
   isSavingTimestamps,
   timestampColumns = 2,
 }: {
-  audio?: { fileName: string; voice: string; cacheKey?: string }
-  audioLang: string | null
-  bookLabel: string
-  textId: string
-  canGenerate: boolean
-  hasGeminiKey: boolean
-  onGenerate: (textId: string) => void
-  isGenerating: boolean
-  onUpload?: (textId: string, file: File) => void
-  isUploading?: boolean
-  errorMessage?: string
-  timestamps?: WordTimestampEntry
-  onTranscribe?: (textId: string) => void
-  isTranscribing?: boolean
-  hasOpenaiKey?: boolean
-  onTimeUpdate?: (time: number) => void
-  onPlayingChange?: (playing: boolean) => void
-  onSaveTimestamps?: (words: WordTimestamp[], duration: number) => void
-  isSavingTimestamps?: boolean
-  timestampColumns?: number
+  audio?: { fileName: string; voice: string; cacheKey?: string };
+  audioLang: string | null;
+  bookLabel: string;
+  textId: string;
+  canGenerate: boolean;
+  hasGeminiKey: boolean;
+  onGenerate: (textId: string) => void;
+  isGenerating: boolean;
+  onUpload?: (textId: string, file: File) => void;
+  isUploading?: boolean;
+  errorMessage?: string;
+  timestamps?: WordTimestampEntry;
+  onTranscribe?: (textId: string) => void;
+  isTranscribing?: boolean;
+  hasOpenaiKey?: boolean;
+  onTimeUpdate?: (time: number) => void;
+  onPlayingChange?: (playing: boolean) => void;
+  onSaveTimestamps?: (words: WordTimestamp[], duration: number) => void;
+  isSavingTimestamps?: boolean;
+  timestampColumns?: number;
 }) {
-  const { t } = useLingui()
-  const fileInputRef = useRef<HTMLInputElement | null>(null)
+  const { t } = useLingui();
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0]
-    event.currentTarget.value = ""
-    if (!file || !onUpload) return
-    onUpload(textId, file)
-  }
+    const file = event.target.files?.[0];
+    event.currentTarget.value = "";
+    if (!file || !onUpload) return;
+    onUpload(textId, file);
+  };
 
-  const uploadButton = onUpload && audioLang ? (
-    <>
-      <input
-        ref={fileInputRef}
-        type="file"
-        accept=".mp3,.wav,.ogg,audio/mpeg,audio/wav,audio/ogg"
-        className="hidden"
-        onChange={handleFileChange}
-      />
-      <Button
-        type="button"
-        variant={audio ? "ghost" : "outline"}
-        size="sm"
-        className="h-7 px-2 text-[10px]"
-        disabled={isUploading}
-        onClick={() => fileInputRef.current?.click()}
-        title={audio ? t`Replace this audio file` : t`Upload your own audio file`}
-      >
-        {isUploading ? (
-          <Loader2 className={cn("h-3 w-3 animate-spin", !audio && "mr-1")} />
-        ) : (
-          <Upload className={cn("h-3 w-3", !audio && "mr-1")} />
-        )}
-        {!audio && t`Upload`}
-      </Button>
-    </>
-  ) : null
+  const uploadButton =
+    onUpload && audioLang ? (
+      <>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept=".mp3,.wav,.ogg,audio/mpeg,audio/wav,audio/ogg"
+          className="hidden"
+          onChange={handleFileChange}
+        />
+        <Button
+          type="button"
+          variant={audio ? "ghost" : "outline"}
+          size="sm"
+          className="h-7 px-2 text-[10px]"
+          disabled={isUploading}
+          onClick={() => fileInputRef.current?.click()}
+          title={
+            audio ? t`Replace this audio file` : t`Upload your own audio file`
+          }
+        >
+          {isUploading ? (
+            <Loader2 className={cn("h-3 w-3 animate-spin", !audio && "mr-1")} />
+          ) : (
+            <Upload className={cn("h-3 w-3", !audio && "mr-1")} />
+          )}
+          {!audio && t`Upload`}
+        </Button>
+      </>
+    ) : null;
 
   if (audio && audioLang) {
     return (
       <div>
         {uploadButton && (
-          <div className="mb-1 flex justify-end">
-            {uploadButton}
-          </div>
+          <div className="mb-1 flex justify-end">{uploadButton}</div>
         )}
         <WaveformPlayer
           key={`${audioLang}:${audio.fileName}:${audio.cacheKey ?? ""}`}
-          audioUrl={getAudioUrl(bookLabel, audioLang, audio.fileName, audio.cacheKey)}
+          audioUrl={getAudioUrl(
+            bookLabel,
+            audioLang,
+            audio.fileName,
+            audio.cacheKey,
+          )}
           onTimeUpdate={onTimeUpdate}
           onPlayingChange={onPlayingChange}
         />
         {timestamps ? (
           <WordTimestampViewer
             timestamps={timestamps}
-            onSave={onSaveTimestamps ? (words, duration) => onSaveTimestamps(words, duration) : undefined}
+            onSave={
+              onSaveTimestamps
+                ? (words, duration) => onSaveTimestamps(words, duration)
+                : undefined
+            }
             isSaving={isSavingTimestamps}
             columns={timestampColumns}
           />
-        ) : onTranscribe && (
-          <button
-            type="button"
-            onClick={() => onTranscribe(textId)}
-            disabled={isTranscribing || !hasOpenaiKey}
-            className="mt-1 flex items-center gap-1 text-[10px] text-muted-foreground hover:text-foreground transition-colors disabled:opacity-40 cursor-pointer disabled:cursor-default"
-            title={hasOpenaiKey ? t`Generate word timestamps` : t`OpenAI key required`}
-          >
-            {isTranscribing ? (
-              <Loader2 className="h-3 w-3 animate-spin" />
-            ) : (
-              <Type className="h-3 w-3" />
-            )}
-            {t`Timestamps`}
-          </button>
+        ) : (
+          onTranscribe && (
+            <button
+              type="button"
+              onClick={() => onTranscribe(textId)}
+              disabled={isTranscribing || !hasOpenaiKey}
+              className="mt-1 flex items-center gap-1 text-[10px] text-muted-foreground hover:text-foreground transition-colors disabled:opacity-40 cursor-pointer disabled:cursor-default"
+              title={
+                hasOpenaiKey
+                  ? t`Generate word timestamps`
+                  : t`OpenAI key required`
+              }
+            >
+              {isTranscribing ? (
+                <Loader2 className="h-3 w-3 animate-spin" />
+              ) : (
+                <Type className="h-3 w-3" />
+              )}
+              {t`Timestamps`}
+            </button>
+          )
         )}
         {errorMessage && (
           <p className="mt-1 max-w-52 text-[10px] leading-tight text-red-500 text-right ml-auto">
@@ -1764,11 +2375,11 @@ function AudioAction({
           </p>
         )}
       </div>
-    )
+    );
   }
 
   if (!canGenerate && !uploadButton) {
-    return null
+    return null;
   }
 
   return (
@@ -1804,5 +2415,5 @@ function AudioAction({
         </p>
       )}
     </div>
-  )
+  );
 }

--- a/apps/studio/src/components/pipeline/stages/languages/LanguageView.tsx
+++ b/apps/studio/src/components/pipeline/stages/languages/LanguageView.tsx
@@ -81,10 +81,12 @@ import { useLingui } from "@lingui/react/macro";
 // pinned one. Mirrors resolveVoice()/resolveSpeechModel() in @adt/pipeline (and
 // config/voices.yaml) so we never show an OpenAI voice/model for a Gemini/Azure provider.
 // Values are voice/model identifiers, not user-facing copy — display only.
-// eslint-disable-next-line lingui/no-unlocalized-strings -- voice identifiers
+
 const DEFAULT_TTS_VOICE: Record<string, string> = {
   openai: "alloy",
+// eslint-disable-next-line lingui/no-unlocalized-strings -- voice identifiers
   azure: "en-US-JennyNeural",
+// eslint-disable-next-line lingui/no-unlocalized-strings -- voice identifiers
   gemini: "Kore",
 };
 const DEFAULT_TTS_MODEL: Record<string, string> = {

--- a/apps/studio/src/hooks/use-book-run.ts
+++ b/apps/studio/src/hooks/use-book-run.ts
@@ -85,7 +85,8 @@ export interface BookRunContextValue {
   isStatusLoading: boolean
   /** Queue a stage run */
   queueRun(options: QueueRunOptions): void
-  /** Request cancellation of the active run (and clear the queue). */
+  /** Request cancellation of the active run. Queued runs are preserved and
+   *  start after it unwinds (a queue with no active run is cleared instead). */
   cancelRun(): void
   /** Page failures awaiting a skip/stop decision (interactive mode). */
   pendingDecisions: PendingDecision[]

--- a/apps/studio/src/hooks/use-book-run.ts
+++ b/apps/studio/src/hooks/use-book-run.ts
@@ -3,6 +3,7 @@ import { useQueryClient, useQuery } from "@tanstack/react-query"
 import { useNavigate } from "@tanstack/react-router"
 import { i18n } from "@lingui/core"
 import { msg } from "@lingui/core/macro"
+import { toast } from "sonner"
 import {
   api,
   BASE_URL,
@@ -10,11 +11,12 @@ import {
   type StageRunProviderCredentials,
   type PageSummaryItem,
   type PageDetail,
+  type PendingDecision,
 } from "@/api/client"
 import { STEP_TO_STAGE, PIPELINE, getStageClearOrder, PAGE_PROGRESS_STEPS } from "@adt/types"
 import type { StageName } from "@adt/types"
 import { isStageComplete } from "./run-state"
-import { playCompletionSound } from "@/lib/completion-sound"
+import { playCompletionSound, playErrorSound } from "@/lib/completion-sound"
 import { useAnnouncer } from "@/components/a11y/LiveRegionAnnouncer"
 import { getStageLabelI18n, getStageRunningLabelI18n } from "@/components/pipeline/pipeline-i18n"
 import { bookTasksKey } from "./use-book-tasks"
@@ -56,6 +58,8 @@ interface StepStatusResponse {
   error: string | null
   stepErrors?: Record<string, string> | null
   stepMessages?: Record<string, string> | null
+  runStatus?: "idle" | "running" | "cancelling" | "cancelled" | "completed" | "failed"
+  pendingDecisions?: PendingDecision[]
 }
 
 // ---------------------------------------------------------------------------
@@ -75,10 +79,18 @@ export interface BookRunContextValue {
   error: string | null
   /** Is any stage running or queued? */
   isRunning: boolean
+  /** True from the cancel click until the run finishes unwinding. */
+  isCancelling: boolean
   /** True while the initial step-status fetch is in flight */
   isStatusLoading: boolean
   /** Queue a stage run */
   queueRun(options: QueueRunOptions): void
+  /** Request cancellation of the active run (and clear the queue). */
+  cancelRun(): void
+  /** Page failures awaiting a skip/stop decision (interactive mode). */
+  pendingDecisions: PendingDecision[]
+  /** Resolve the head pending decision. */
+  resolveDecision(decisionId: string, action: "skip" | "stop", applyToAll?: boolean): void
 }
 
 const BookRunContext = createContext<BookRunContextValue | null>(null)
@@ -112,6 +124,10 @@ export function useBookRunStatus(label: string): BookRunContextValue {
   announceRef.current = announce
 
   const navigate = useNavigate()
+  // Held in a ref so the always-on SSE effect can navigate (from a toast action)
+  // without listing navigate as a dependency and re-subscribing.
+  const navigateRef = useRef(navigate)
+  navigateRef.current = navigate
 
   // Primary source of truth: enriched step-status from the server
   const { data, isPending } = useQuery<StepStatusResponse>({
@@ -142,6 +158,24 @@ export function useBookRunStatus(label: string): BookRunContextValue {
   // Serialized run queue — chains API calls so they arrive in click order
   const runChainRef = useRef<Promise<void>>(Promise.resolve())
 
+  // Cancellation UI state. Held in a ref too so the always-on SSE effect (keyed
+  // on [label, queryClient]) can read/clear it without re-subscribing.
+  const [isCancelling, setIsCancelling] = useState(false)
+  const isCancellingRef = useRef(false)
+  isCancellingRef.current = isCancelling
+
+  // Interactive page-error decisions, keyed by decisionId. Fed by both the SSE
+  // `decision-required` event and the polled `pendingDecisions` (recovery after
+  // refresh/reconnect), deduped by id.
+  const [pendingDecisions, setPendingDecisions] = useState<PendingDecision[]>([])
+
+  // Per-step failed-page counts for toast/sound dedup within one run. A page
+  // step emits one step-error per failed page; without this we'd fire a toast +
+  // beep for each. Reset per step on step-start and wholesale on run boundaries.
+  const errorCountByStepRef = useRef<Map<string, number>>(new Map())
+  // Whether we've already played the error sound for the current run-level error.
+  const runErrorNotifiedRef = useRef(false)
+
   // ------------------------------------------------------------------
   // Always-on SSE — opens on mount, closes on unmount
   // ------------------------------------------------------------------
@@ -171,6 +205,9 @@ export function useBookRunStatus(label: string): BookRunContextValue {
       }
 
       if (d.type === "step-start") {
+        // Fresh attempt at this step — reset its error toast/beep dedup so a new
+        // failure notifies again, and clear any stale error state in the cache.
+        errorCountByStepRef.current.delete(pipelineStep)
         // Mark step as running in the query cache
         queryClient.setQueryData<StepStatusResponse>(stepStatusKey(label), (old) => {
           if (!old) return old
@@ -179,6 +216,7 @@ export function useBookRunStatus(label: string): BookRunContextValue {
             stages: { ...old.stages, [uiStage]: "running" },
             steps: { ...old.steps, [pipelineStep]: "running" },
             stepMessages: removeStepMessage(old.stepMessages, pipelineStep),
+            stepErrors: removeStepError(old.stepErrors, pipelineStep),
           }
         })
         // Clear progress for this step
@@ -247,32 +285,54 @@ export function useBookRunStatus(label: string): BookRunContextValue {
           }
         }
       } else if (d.type === "step-complete" || d.type === "step-skip") {
+        // The step finished — its failure toast/beep dedup no longer applies.
+        errorCountByStepRef.current.delete(pipelineStep)
         // Mark step as done/skipped, recompute stage state
         const nextStepState: StepState = d.type === "step-skip" ? "skipped" : "done"
         // Only chime on the transition into done — not on every trailing
         // step event for a stage that's already complete (which would
         // re-register the same completion and beep repeatedly).
         let stageJustCompleted = false
+        const completeMessage =
+          typeof d.message === "string" && d.message.trim().length > 0 ? d.message : undefined
         queryClient.setQueryData<StepStatusResponse>(stepStatusKey(label), (old) => {
           if (!old) return old
           const wasComplete = old.stages[uiStage] === "done"
           const steps = { ...old.steps, [pipelineStep]: nextStepState }
-          const stepMessages = removeStepMessage(old.stepMessages, pipelineStep)
+          // A completed step is no longer in error — drop any stale per-page
+          // error so a "skip and continue" outcome clears the red state. Also
+          // preserve a completion message (e.g. "2 page(s) skipped") if present.
+          const stepErrors = removeStepError(old.stepErrors, pipelineStep)
+          const stepMessages = completeMessage
+            ? { ...(old.stepMessages ?? {}), [pipelineStep]: completeMessage }
+            : removeStepMessage(old.stepMessages, pipelineStep)
 
-          // Recompute the parent stage: if all steps are done/skipped, stage is done
+          // Recompute the parent stage from its steps without assuming "error":
+          // done if all steps done/skipped, else error only if a step is still
+          // errored, else preserve the running/queued state.
           const stageDef = PIPELINE.find((s) => s.name === uiStage)
-          const allDone = isStageComplete(stageDef?.steps.map((s) => steps[s.name]) ?? [])
-          const stages = {
-            ...old.stages,
-            [uiStage]: allDone ? "done" : old.stages[uiStage],
-          }
+          const stageStepStates = stageDef?.steps.map((s) => steps[s.name]) ?? []
+          const allDone = isStageComplete(stageStepStates)
+          const anyError = stageStepStates.some((s) => s === "error")
+          const nextStageState = allDone
+            ? "done"
+            : anyError
+              ? "error"
+              : old.stages[uiStage]
+          const stages = { ...old.stages, [uiStage]: nextStageState }
+
+          // Recompute the run-level error banner from the remaining step errors.
+          const remainingErrors = stepErrors ?? {}
+          const error = Object.keys(remainingErrors).length > 0 ? old.error : null
 
           stageJustCompleted = allDone && !wasComplete
           return {
             ...old,
             stages,
             steps,
+            stepErrors,
             stepMessages,
+            error,
           }
         })
         if (stageJustCompleted) {
@@ -304,6 +364,30 @@ export function useBookRunStatus(label: string): BookRunContextValue {
         // Assertive: a failed step blocks progress; the user needs to know now.
         announceRef.current(i18n._(msg`${getStageLabelI18n(uiStage)} failed`), "assertive")
         progressRef.current.delete(pipelineStep)
+
+        // Toast + error sound, deduplicated per step. A per-page step emits one
+        // step-error per failed page; we notify once and then update the same
+        // toast with the aggregated count. Honest wording: a page failing does
+        // NOT mean the step stopped — it keeps processing the other pages.
+        // Suppressed during a cancel (a deliberate action shouldn't beep).
+        if (!isCancellingRef.current) {
+          const count = (errorCountByStepRef.current.get(pipelineStep) ?? 0) + 1
+          errorCountByStepRef.current.set(pipelineStep, count)
+          const stageLabel = getStageLabelI18n(uiStage)
+          const message =
+            count === 1
+              ? i18n._(msg`A page failed in ${stageLabel}`)
+              : i18n._(msg`${count} pages failed in ${stageLabel}`)
+          if (count === 1) playErrorSound()
+          toast.error(message, {
+            id: `step-error:${pipelineStep}`,
+            action: {
+              label: i18n._(msg`View details`),
+              onClick: () =>
+                navigateRef.current({ to: "/books/$label/$step", params: { label, step: uiStage } }),
+            },
+          })
+        }
         // Speech errors persist per-item failures into the TTS output —
         // refetch so the Speech view can mark the failed entries.
         if (pipelineStep === "tts") {
@@ -316,26 +400,90 @@ export function useBookRunStatus(label: string): BookRunContextValue {
     es.addEventListener("queue-next", () => {
       progressRef.current.clear()
       lastPageInvalidateRef.current = 0
+      errorCountByStepRef.current.clear()
+      runErrorNotifiedRef.current = false
       queryClient.invalidateQueries({ queryKey: stepStatusKey(label) })
     })
 
     // Run completed — full refetch to reconcile with DB
     es.addEventListener("complete", () => {
       progressRef.current.clear()
+      errorCountByStepRef.current.clear()
+      runErrorNotifiedRef.current = false
+      // A cancel that raced past the last checkpoint resolves as a normal
+      // completion — clear the intermediate "cancelling…" state here too.
+      setIsCancelling(false)
       queryClient.invalidateQueries({ queryKey: stepStatusKey(label) })
       invalidateBookQueries(queryClient, label)
+    })
+
+    // Cancellation finished unwinding — reset in-flight steps to idle and clear
+    // the "cancelling…" state. No error toast/beep: this was deliberate.
+    es.addEventListener("cancelled", () => {
+      progressRef.current.clear()
+      errorCountByStepRef.current.clear()
+      runErrorNotifiedRef.current = false
+      setIsCancelling(false)
+      setPendingDecisions([])
+      queryClient.setQueryData<StepStatusResponse>(stepStatusKey(label), (old) => {
+        if (!old) return old
+        const steps = { ...old.steps }
+        for (const [step, state] of Object.entries(steps)) {
+          if (state === "running") steps[step] = "idle"
+        }
+        const stages = { ...old.stages }
+        for (const stage of PIPELINE) {
+          const ss = stage.steps.map((s) => steps[s.name])
+          if (ss.some((s) => s === "running")) continue
+          if (stages[stage.name] === "running") {
+            stages[stage.name] = ss.some((s) => s === "error") ? "error" : "idle"
+          }
+        }
+        return { ...old, steps, stages, runStatus: "cancelled" }
+      })
+      announceRef.current(i18n._(msg`Run cancelled`))
+      toast.info(i18n._(msg`Run cancelled`))
+      queryClient.invalidateQueries({ queryKey: stepStatusKey(label) })
+      invalidateBookQueries(queryClient, label)
+    })
+
+    // A page failed and the run is waiting for a skip/stop decision.
+    es.addEventListener("decision-required", (e) => {
+      const me = e as MessageEvent
+      if (!me.data) return
+      try {
+        const d = JSON.parse(me.data) as PendingDecision
+        setPendingDecisions((prev) =>
+          prev.some((p) => p.decisionId === d.decisionId) ? prev : [...prev, d],
+        )
+      } catch { /* ignore */ }
     })
 
     es.addEventListener("error", (e) => {
       if (es.readyState === EventSource.CLOSED) return
       const me = e as MessageEvent
+      // EventSource fires "error" for connection drops/reconnects too — those
+      // carry no `data`. Only treat events WITH data as a real run error, so a
+      // network blip never toasts or beeps.
       if (me.data) {
         try {
           const d = JSON.parse(me.data)
+          const runError = d.error ?? i18n._(msg`Step run failed`)
           queryClient.setQueryData<StepStatusResponse>(stepStatusKey(label), (old) => {
             if (!old) return old
-            return { ...old, error: d.error ?? i18n._(msg`Step run failed`) }
+            return { ...old, error: runError }
           })
+          // A cancel never emits stage-run-error, so any error here is real.
+          setIsCancelling(false)
+          if (!isCancellingRef.current) {
+            // Only beep if per-page step-errors didn't already (they usually
+            // arrive just before the run-error for the same failure).
+            if (errorCountByStepRef.current.size === 0 && !runErrorNotifiedRef.current) {
+              playErrorSound()
+            }
+            runErrorNotifiedRef.current = true
+            toast.error(runError, { id: `run-error:${label}` })
+          }
         } catch { /* ignore */ }
       }
       // Refetch to get the authoritative state
@@ -546,7 +694,8 @@ export function useBookRunStatus(label: string): BookRunContextValue {
       // Chain the API call so they arrive in click order
       runChainRef.current = runChainRef.current.then(async () => {
         try {
-          await api.runStages(label, apiKey, { fromStage, toStage, renderOnly }, providerCredentials)
+          // The Studio always opts into interactive page-error handling.
+          await api.runStages(label, apiKey, { fromStage, toStage, renderOnly, pageErrorPolicy: "ask" }, providerCredentials)
           // Refetch to reconcile — backend cleared step_runs
           queryClient.invalidateQueries({ queryKey: stepStatusKey(label) })
         } catch {
@@ -598,6 +747,64 @@ export function useBookRunStatus(label: string): BookRunContextValue {
     (s) => s === "running" || s === "queued"
   )
 
+  // ------------------------------------------------------------------
+  // Cancel + page-error decisions
+  // ------------------------------------------------------------------
+  const cancelRun = useCallback(() => {
+    setIsCancelling(true)
+    announceRef.current(i18n._(msg`Cancelling run…`), "assertive")
+    void api.cancelRun(label).catch(() => {
+      // 404s resolve inside api.cancelRun; anything else means the request
+      // didn't take — refetch so the UI reflects the true state.
+      queryClient.invalidateQueries({ queryKey: stepStatusKey(label) })
+    })
+  }, [label, queryClient])
+
+  const resolveDecision = useCallback(
+    (decisionId: string, action: "skip" | "stop", applyToAll?: boolean) => {
+      // Optimistically drop it from the local queue; the server call (409 ==
+      // already resolved) is treated as success.
+      setPendingDecisions((prev) => prev.filter((p) => p.decisionId !== decisionId))
+      void api.resolveDecision(label, { decisionId, action, applyToAll }).catch(() => {
+        queryClient.invalidateQueries({ queryKey: stepStatusKey(label) })
+      })
+    },
+    [label, queryClient]
+  )
+
+  // Reconcile "cancelling…" across refresh/reconnect from the polled runStatus.
+  // Force true when the server says "cancelling"; clear only on a terminal state.
+  // "running" is deliberately left alone: right after the cancel click the poll
+  // may still report "running" before the abort is processed, and resetting here
+  // would flicker the button back to "Cancel".
+  const polledRunStatus = data?.runStatus
+  useEffect(() => {
+    if (polledRunStatus === "cancelling") {
+      setIsCancelling(true)
+    } else if (
+      polledRunStatus === "idle" ||
+      polledRunStatus === "completed" ||
+      polledRunStatus === "failed" ||
+      polledRunStatus === "cancelled"
+    ) {
+      setIsCancelling(false)
+    }
+  }, [polledRunStatus])
+
+  // Recover pending decisions from the poll (after refresh/reconnect) — union
+  // with the SSE-learned ones, deduped by id. Resolution is driven by
+  // resolveDecision / the cancelled event / a 409, not by absence here, so a
+  // just-arrived SSE decision doesn't flicker while the poll catches up.
+  const polledDecisions = data?.pendingDecisions
+  useEffect(() => {
+    if (!polledDecisions || polledDecisions.length === 0) return
+    setPendingDecisions((prev) => {
+      const ids = new Set(prev.map((p) => p.decisionId))
+      const additions = polledDecisions.filter((d) => !ids.has(d.decisionId))
+      return additions.length > 0 ? [...prev, ...additions] : prev
+    })
+  }, [polledDecisions])
+
   return {
     stageState,
     stepState: stepStateAccessor,
@@ -605,8 +812,12 @@ export function useBookRunStatus(label: string): BookRunContextValue {
     stepError: stepErrorAccessor,
     error: data?.error ?? null,
     isRunning,
+    isCancelling,
     isStatusLoading: isPending,
     queueRun,
+    cancelRun,
+    pendingDecisions,
+    resolveDecision,
   }
 }
 
@@ -646,6 +857,16 @@ function removeStepMessage(
 ): Record<string, string> | null {
   if (!messages?.[step]) return messages ?? null
   const next = { ...messages }
+  delete next[step]
+  return Object.keys(next).length > 0 ? next : null
+}
+
+function removeStepError(
+  errors: Record<string, string> | null | undefined,
+  step: string,
+): Record<string, string> | null {
+  if (!errors?.[step]) return errors ?? null
+  const next = { ...errors }
   delete next[step]
   return Object.keys(next).length > 0 ? next : null
 }

--- a/apps/studio/src/lib/completion-sound.ts
+++ b/apps/studio/src/lib/completion-sound.ts
@@ -56,3 +56,46 @@ export function playCompletionSound(): void {
     // Audio not available — silently ignore
   }
 }
+
+/**
+ * Play a short two-note descending tone (E5 → C5) to signal an error.
+ * Same synthesis approach as the completion chime — no assets, no deps.
+ */
+export function playErrorSound(): void {
+  try {
+    const ctx = getAudioContext()
+
+    if (ctx.state === "suspended") {
+      void ctx.resume()
+    }
+
+    const now = ctx.currentTime
+    const volume = 0.15
+
+    // Two-note descending tone: E5 (659 Hz) → C5 (523 Hz)
+    const notes = [
+      { freq: 659.25, start: 0, duration: 0.14 },
+      { freq: 523.25, start: 0.12, duration: 0.22 },
+    ]
+
+    for (const note of notes) {
+      const osc = ctx.createOscillator()
+      const gain = ctx.createGain()
+
+      osc.type = "sine"
+      osc.frequency.setValueAtTime(note.freq, now + note.start)
+
+      gain.gain.setValueAtTime(0, now + note.start)
+      gain.gain.linearRampToValueAtTime(volume, now + note.start + 0.015)
+      gain.gain.exponentialRampToValueAtTime(0.001, now + note.start + note.duration)
+
+      osc.connect(gain)
+      gain.connect(ctx.destination)
+
+      osc.start(now + note.start)
+      osc.stop(now + note.start + note.duration + 0.01)
+    }
+  } catch {
+    // Audio not available — silently ignore
+  }
+}

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -1567,6 +1567,9 @@ msgstr "Cancel"
 msgid "Cancel {stageLabel}"
 msgstr "Cancel {stageLabel}"
 
+msgid "Cancel {stepLabel} step"
+msgstr "Cancel {stepLabel} step"
+
 msgid "Cancel download"
 msgstr "Cancel download"
 
@@ -1576,11 +1579,17 @@ msgstr "Cancel run"
 msgid "Cancelling {stageLabel}"
 msgstr "Cancelling {stageLabel}"
 
+msgid "Cancelling {stepLabel} step"
+msgstr "Cancelling {stepLabel} step"
+
 msgid "Cancelling run"
 msgstr "Cancelling run"
 
 msgid "Cancelling run…"
 msgstr "Cancelling run…"
+
+#~ msgid "Cancelling step"
+#~ msgstr "Cancelling step"
 
 msgid "Cancelling..."
 msgstr "Cancelling..."

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -295,6 +295,9 @@ msgstr "{count} {count, plural, one {issue} other {issues}}"
 msgid "{count} {count, plural, one {manual review item} other {manual review items}}"
 msgstr "{count} {count, plural, one {manual review item} other {manual review items}}"
 
+msgid "{count} pages failed in {stageLabel}"
+msgstr "{count} pages failed in {stageLabel}"
+
 msgid "{count} translations"
 msgstr "{count} translations"
 
@@ -535,6 +538,12 @@ msgstr "A multiple choice activity."
 
 #~ msgid "A new version is available for download."
 #~ msgstr "A new version is available for download."
+
+msgid "A page failed in {stageLabel}"
+msgstr "A page failed in {stageLabel}"
+
+msgid "A page failed in {stepLabel}"
+msgstr "A page failed in {stepLabel}"
 
 msgid "A question worth asking"
 msgstr "A question worth asking"
@@ -1189,6 +1198,9 @@ msgstr "Apply page background colors"
 msgid "Apply Segmentation"
 msgstr "Apply Segmentation"
 
+msgid "Apply to all errors in this run"
+msgstr "Apply to all errors in this run"
+
 msgid "AR"
 msgstr "AR"
 
@@ -1552,8 +1564,29 @@ msgstr "Calls"
 msgid "Cancel"
 msgstr "Cancel"
 
+msgid "Cancel {stageLabel}"
+msgstr "Cancel {stageLabel}"
+
 msgid "Cancel download"
 msgstr "Cancel download"
+
+msgid "Cancel run"
+msgstr "Cancel run"
+
+msgid "Cancelling {stageLabel}"
+msgstr "Cancelling {stageLabel}"
+
+msgid "Cancelling run"
+msgstr "Cancelling run"
+
+msgid "Cancelling run…"
+msgstr "Cancelling run…"
+
+msgid "Cancelling..."
+msgstr "Cancelling..."
+
+msgid "Cancelling…"
+msgstr "Cancelling…"
 
 #. placeholder {0}: String(MAX_ENTRIES)
 msgid "capped at {0}"
@@ -5919,6 +5952,9 @@ msgstr "Run {stageLabel}"
 msgid "Run {upstreamLabel} first"
 msgstr "Run {upstreamLabel} first"
 
+msgid "Run cancelled"
+msgstr "Run cancelled"
+
 msgid "Run Captions"
 msgstr "Run Captions"
 
@@ -5994,8 +6030,8 @@ msgstr "Running"
 msgid "RUNNING"
 msgstr "RUNNING"
 
-msgid "Running {stageLabel}"
-msgstr "Running {stageLabel}"
+#~ msgid "Running {stageLabel}"
+#~ msgstr "Running {stageLabel}"
 
 msgid "Running Sectioning will run Extract first, then section the extracted pages."
 msgstr "Running Sectioning will run Extract first, then section the extracted pages."
@@ -6006,8 +6042,8 @@ msgstr "Running Storyboard will run the earlier core stages it depends on first,
 msgid "Running Validation..."
 msgstr "Running Validation..."
 
-msgid "Running..."
-msgstr "Running..."
+#~ msgid "Running..."
+#~ msgstr "Running..."
 
 msgid "Runs accessibility checks against the packaged book."
 msgstr "Runs accessibility checks against the packaged book."
@@ -6558,8 +6594,14 @@ msgstr "Skip for now"
 msgid "Skip intro"
 msgstr "Skip intro"
 
+msgid "Skip page and continue"
+msgstr "Skip page and continue"
+
 msgid "Skip segmentation for images whose shortest side is below this threshold."
 msgstr "Skip segmentation for images whose shortest side is below this threshold."
+
+msgid "Skip this page and continue the step, or stop the step entirely."
+msgstr "Skip this page and continue the step, or stop the step entirely."
 
 msgid "Skipped"
 msgstr "Skipped"
@@ -6758,6 +6800,9 @@ msgstr "Step failed"
 
 msgid "Step run failed"
 msgstr "Step run failed"
+
+msgid "Stop step"
+msgstr "Stop step"
 
 msgid "Storyboard"
 msgstr "Storyboard"
@@ -7791,6 +7836,9 @@ msgstr "videos"
 
 msgid "Videos"
 msgstr "Videos"
+
+msgid "View details"
+msgstr "View details"
 
 msgid "View HTML source"
 msgstr "View HTML source"

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -1567,6 +1567,9 @@ msgstr "Cancelar"
 msgid "Cancel {stageLabel}"
 msgstr "Cancelar {stageLabel}"
 
+msgid "Cancel {stepLabel} step"
+msgstr "Cancelar paso {stepLabel}"
+
 msgid "Cancel download"
 msgstr "Cancelar descarga"
 
@@ -1576,11 +1579,17 @@ msgstr "Cancelar ejecución"
 msgid "Cancelling {stageLabel}"
 msgstr "Cancelando {stageLabel}"
 
+msgid "Cancelling {stepLabel} step"
+msgstr "Cancelando paso {stepLabel}"
+
 msgid "Cancelling run"
 msgstr "Cancelando ejecución"
 
 msgid "Cancelling run…"
 msgstr "Cancelando ejecución…"
+
+#~ msgid "Cancelling step"
+#~ msgstr "Cancelando paso"
 
 msgid "Cancelling..."
 msgstr "Cancelando..."

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -295,6 +295,9 @@ msgstr "{count} {count, plural, one {problema} other {problemas}}"
 msgid "{count} {count, plural, one {manual review item} other {manual review items}}"
 msgstr "{count} {count, plural, one {elemento de revisión manual} other {elementos de revisión manual}}"
 
+msgid "{count} pages failed in {stageLabel}"
+msgstr "{count} páginas fallaron en {stageLabel}"
+
 msgid "{count} translations"
 msgstr "{count} traducciones"
 
@@ -535,6 +538,12 @@ msgstr "Una actividad de selección múltiple."
 
 #~ msgid "A new version is available for download."
 #~ msgstr "Una nueva versión está disponible para descargar."
+
+msgid "A page failed in {stageLabel}"
+msgstr "Una página falló en {stageLabel}"
+
+msgid "A page failed in {stepLabel}"
+msgstr "Una página falló en {stepLabel}"
 
 msgid "A question worth asking"
 msgstr "Una pregunta que vale la pena hacer"
@@ -1189,6 +1198,9 @@ msgstr "Aplicar colores de fondo de página"
 msgid "Apply Segmentation"
 msgstr "Apply Segmentation"
 
+msgid "Apply to all errors in this run"
+msgstr "Aplicar a todos los errores de esta ejecución"
+
 msgid "AR"
 msgstr "AR"
 
@@ -1552,8 +1564,29 @@ msgstr "Llamadas"
 msgid "Cancel"
 msgstr "Cancelar"
 
+msgid "Cancel {stageLabel}"
+msgstr "Cancelar {stageLabel}"
+
 msgid "Cancel download"
 msgstr "Cancelar descarga"
+
+msgid "Cancel run"
+msgstr "Cancelar ejecución"
+
+msgid "Cancelling {stageLabel}"
+msgstr "Cancelando {stageLabel}"
+
+msgid "Cancelling run"
+msgstr "Cancelando ejecución"
+
+msgid "Cancelling run…"
+msgstr "Cancelando ejecución…"
+
+msgid "Cancelling..."
+msgstr "Cancelando..."
+
+msgid "Cancelling…"
+msgstr "Cancelando…"
 
 #. placeholder {0}: String(MAX_ENTRIES)
 msgid "capped at {0}"
@@ -5919,6 +5952,9 @@ msgstr "Ejecutar {0}"
 msgid "Run {upstreamLabel} first"
 msgstr "Ejecuta {upstreamLabel} primero"
 
+msgid "Run cancelled"
+msgstr "Ejecución cancelada"
+
 msgid "Run Captions"
 msgstr "Ejecutar Subtítulos"
 
@@ -5994,8 +6030,8 @@ msgstr "En ejecución"
 msgid "RUNNING"
 msgstr "EN CURSO"
 
-msgid "Running {stageLabel}"
-msgstr "Ejecutando {stageLabel}"
+#~ msgid "Running {stageLabel}"
+#~ msgstr "Ejecutando {stageLabel}"
 
 msgid "Running Sectioning will run Extract first, then section the extracted pages."
 msgstr "Ejecutar Sectioning ejecutará primero Extracción y luego dividirá en secciones las páginas extraídas."
@@ -6006,8 +6042,8 @@ msgstr "Ejecutar Storyboard ejecutará primero las etapas principales anteriores
 msgid "Running Validation..."
 msgstr "Running Validation..."
 
-msgid "Running..."
-msgstr "Ejecutando..."
+#~ msgid "Running..."
+#~ msgstr "Ejecutando..."
 
 msgid "Runs accessibility checks against the packaged book."
 msgstr "Realiza comprobaciones de accesibilidad en el libro empaquetado."
@@ -6558,8 +6594,14 @@ msgstr "Omitir por ahora"
 msgid "Skip intro"
 msgstr "Omitir intro"
 
+msgid "Skip page and continue"
+msgstr "Omitir página y continuar"
+
 msgid "Skip segmentation for images whose shortest side is below this threshold."
 msgstr "Omitir segmentación para imágenes cuyo lado más corto esté por debajo de este umbral."
+
+msgid "Skip this page and continue the step, or stop the step entirely."
+msgstr "Omite esta página y continúa el paso, o detén el paso por completo."
 
 msgid "Skipped"
 msgstr "Omitido"
@@ -6758,6 +6800,9 @@ msgstr "Step failed"
 
 msgid "Step run failed"
 msgstr "Step run failed"
+
+msgid "Stop step"
+msgstr "Detener paso"
 
 msgid "Storyboard"
 msgstr "Storyboard"
@@ -7791,6 +7836,9 @@ msgstr "videos"
 
 msgid "Videos"
 msgstr "Videos"
+
+msgid "View details"
+msgstr "Ver detalles"
 
 msgid "View HTML source"
 msgstr "Ver código HTML"

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -1569,6 +1569,9 @@ msgstr "Annuler"
 msgid "Cancel {stageLabel}"
 msgstr "Annuler {stageLabel}"
 
+msgid "Cancel {stepLabel} step"
+msgstr "Annuler l’étape {stepLabel}"
+
 msgid "Cancel download"
 msgstr "Annuler le téléchargement"
 
@@ -1578,11 +1581,17 @@ msgstr "Annuler l’exécution"
 msgid "Cancelling {stageLabel}"
 msgstr "Annulation de {stageLabel}"
 
+msgid "Cancelling {stepLabel} step"
+msgstr "Annulation de l’étape {stepLabel}"
+
 msgid "Cancelling run"
 msgstr "Annulation de l’exécution"
 
 msgid "Cancelling run…"
 msgstr "Annulation de l’exécution…"
+
+#~ msgid "Cancelling step"
+#~ msgstr "Annulation de l’étape"
 
 msgid "Cancelling..."
 msgstr "Annulation..."

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -297,6 +297,9 @@ msgstr "{count} {count, plural, one {problème} other {problèmes}}"
 msgid "{count} {count, plural, one {manual review item} other {manual review items}}"
 msgstr "{count} {count, plural, one {élément de révision manuelle} other {éléments de révision manuelle}}"
 
+msgid "{count} pages failed in {stageLabel}"
+msgstr "{count} pages ont échoué dans {stageLabel}"
+
 msgid "{count} translations"
 msgstr "{count} traductions"
 
@@ -537,6 +540,12 @@ msgstr "Une activité à choix multiple."
 
 #~ msgid "A new version is available for download."
 #~ msgstr "Une nouvelle version est disponible au téléchargement."
+
+msgid "A page failed in {stageLabel}"
+msgstr "Une page a échoué dans {stageLabel}"
+
+msgid "A page failed in {stepLabel}"
+msgstr "Une page a échoué dans {stepLabel}"
 
 msgid "A question worth asking"
 msgstr "Une question qui mérite d'être posée"
@@ -1191,6 +1200,9 @@ msgstr "Appliquer page background colors"
 msgid "Apply Segmentation"
 msgstr "Appliquer Segmentation"
 
+msgid "Apply to all errors in this run"
+msgstr "Appliquer à toutes les erreurs de cette exécution"
+
 msgid "AR"
 msgstr "AR"
 
@@ -1554,8 +1566,29 @@ msgstr "Appels"
 msgid "Cancel"
 msgstr "Annuler"
 
+msgid "Cancel {stageLabel}"
+msgstr "Annuler {stageLabel}"
+
 msgid "Cancel download"
 msgstr "Annuler le téléchargement"
+
+msgid "Cancel run"
+msgstr "Annuler l’exécution"
+
+msgid "Cancelling {stageLabel}"
+msgstr "Annulation de {stageLabel}"
+
+msgid "Cancelling run"
+msgstr "Annulation de l’exécution"
+
+msgid "Cancelling run…"
+msgstr "Annulation de l’exécution…"
+
+msgid "Cancelling..."
+msgstr "Annulation..."
+
+msgid "Cancelling…"
+msgstr "Annulation…"
 
 #. placeholder {0}: String(MAX_ENTRIES)
 msgid "capped at {0}"
@@ -5921,6 +5954,9 @@ msgstr "Exécuter {stageLabel}"
 msgid "Run {upstreamLabel} first"
 msgstr "Exécutez d'abord {upstreamLabel}"
 
+msgid "Run cancelled"
+msgstr "Exécution annulée"
+
 msgid "Run Captions"
 msgstr "Exécuter les sous-titres"
 
@@ -5996,8 +6032,8 @@ msgstr "En cours"
 msgid "RUNNING"
 msgstr "EN COURS"
 
-msgid "Running {stageLabel}"
-msgstr "Exécution de {stageLabel}"
+#~ msgid "Running {stageLabel}"
+#~ msgstr "Exécution de {stageLabel}"
 
 msgid "Running Sectioning will run Extract first, then section the extracted pages."
 msgstr "Lancer Sectioning exécutera d'abord Extraction, puis découpera en sections les pages extraites."
@@ -6008,8 +6044,8 @@ msgstr "Lancer Storyboard exécutera d'abord les étapes principales précédent
 msgid "Running Validation..."
 msgstr "Validation en cours..."
 
-msgid "Running..."
-msgstr "En cours..."
+#~ msgid "Running..."
+#~ msgstr "En cours..."
 
 msgid "Runs accessibility checks against the packaged book."
 msgstr "Effectue des vérifications d'accessibilité sur le livre empaqueté."
@@ -6560,8 +6596,14 @@ msgstr "Passer pour l'instant"
 msgid "Skip intro"
 msgstr "Passer l'intro"
 
+msgid "Skip page and continue"
+msgstr "Ignorer la page et continuer"
+
 msgid "Skip segmentation for images whose shortest side is below this threshold."
 msgstr "Ignorer la segmentation pour les images dont le côté le plus court est inférieur à ce seuil."
+
+msgid "Skip this page and continue the step, or stop the step entirely."
+msgstr "Ignorez cette page et continuez l’étape, ou arrêtez complètement l’étape."
 
 msgid "Skipped"
 msgstr "Ignoré"
@@ -6760,6 +6802,9 @@ msgstr "L'étape a échoué"
 
 msgid "Step run failed"
 msgstr "L'exécution de l'étape a échoué"
+
+msgid "Stop step"
+msgstr "Arrêter l’étape"
 
 msgid "Storyboard"
 msgstr "Scénarimage"
@@ -7793,6 +7838,9 @@ msgstr "vidéos"
 
 msgid "Videos"
 msgstr "Vidéos"
+
+msgid "View details"
+msgstr "Voir les détails"
 
 msgid "View HTML source"
 msgstr "Voir le code source HTML"

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -1567,6 +1567,9 @@ msgstr "Cancelar"
 msgid "Cancel {stageLabel}"
 msgstr "Cancelar {stageLabel}"
 
+msgid "Cancel {stepLabel} step"
+msgstr "Cancelar etapa {stepLabel}"
+
 msgid "Cancel download"
 msgstr "Cancelar download"
 
@@ -1576,11 +1579,17 @@ msgstr "Cancelar execução"
 msgid "Cancelling {stageLabel}"
 msgstr "Cancelando {stageLabel}"
 
+msgid "Cancelling {stepLabel} step"
+msgstr "Cancelando etapa {stepLabel}"
+
 msgid "Cancelling run"
 msgstr "Cancelando execução"
 
 msgid "Cancelling run…"
 msgstr "Cancelando execução…"
+
+#~ msgid "Cancelling step"
+#~ msgstr "Cancelando etapa"
 
 msgid "Cancelling..."
 msgstr "Cancelando..."

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -295,6 +295,9 @@ msgstr "{count} {count, plural, one {problema} other {problemas}}"
 msgid "{count} {count, plural, one {manual review item} other {manual review items}}"
 msgstr "{count} {count, plural, one {item de revisão manual} other {itens de revisão manual}}"
 
+msgid "{count} pages failed in {stageLabel}"
+msgstr "{count} páginas falharam em {stageLabel}"
+
 msgid "{count} translations"
 msgstr "{count} traduções"
 
@@ -535,6 +538,12 @@ msgstr "Uma atividade de múltipla escolha."
 
 #~ msgid "A new version is available for download."
 #~ msgstr "Uma nova versão está disponível para download."
+
+msgid "A page failed in {stageLabel}"
+msgstr "Uma página falhou em {stageLabel}"
+
+msgid "A page failed in {stepLabel}"
+msgstr "Uma página falhou em {stepLabel}"
 
 msgid "A question worth asking"
 msgstr "Uma pergunta que vale a pena fazer"
@@ -1189,6 +1198,9 @@ msgstr "Aplicar cores de fundo da página"
 msgid "Apply Segmentation"
 msgstr "Apply Segmentation"
 
+msgid "Apply to all errors in this run"
+msgstr "Aplicar a todos os erros desta execução"
+
 msgid "AR"
 msgstr "AR"
 
@@ -1552,8 +1564,29 @@ msgstr "Chamadas"
 msgid "Cancel"
 msgstr "Cancelar"
 
+msgid "Cancel {stageLabel}"
+msgstr "Cancelar {stageLabel}"
+
 msgid "Cancel download"
 msgstr "Cancelar download"
+
+msgid "Cancel run"
+msgstr "Cancelar execução"
+
+msgid "Cancelling {stageLabel}"
+msgstr "Cancelando {stageLabel}"
+
+msgid "Cancelling run"
+msgstr "Cancelando execução"
+
+msgid "Cancelling run…"
+msgstr "Cancelando execução…"
+
+msgid "Cancelling..."
+msgstr "Cancelando..."
+
+msgid "Cancelling…"
+msgstr "Cancelando…"
 
 #. placeholder {0}: String(MAX_ENTRIES)
 msgid "capped at {0}"
@@ -5919,6 +5952,9 @@ msgstr "Executar {0}"
 msgid "Run {upstreamLabel} first"
 msgstr "Execute {upstreamLabel} primeiro"
 
+msgid "Run cancelled"
+msgstr "Execução cancelada"
+
 msgid "Run Captions"
 msgstr "Executar Legendas"
 
@@ -5994,8 +6030,8 @@ msgstr "Em execução"
 msgid "RUNNING"
 msgstr "EM EXECUÇÃO"
 
-msgid "Running {stageLabel}"
-msgstr "Executando {stageLabel}"
+#~ msgid "Running {stageLabel}"
+#~ msgstr "Executando {stageLabel}"
 
 msgid "Running Sectioning will run Extract first, then section the extracted pages."
 msgstr "Executar Sectioning executará primeiro a Extração e depois dividirá em seções as páginas extraídas."
@@ -6006,8 +6042,8 @@ msgstr "Executar Storyboard executará primeiro as etapas principais anteriores 
 msgid "Running Validation..."
 msgstr "Running Validation..."
 
-msgid "Running..."
-msgstr "Executando..."
+#~ msgid "Running..."
+#~ msgstr "Executando..."
 
 msgid "Runs accessibility checks against the packaged book."
 msgstr "Executa verificações de acessibilidade no livro empacotado."
@@ -6558,8 +6594,14 @@ msgstr "Pular por enquanto"
 msgid "Skip intro"
 msgstr "Pular intro"
 
+msgid "Skip page and continue"
+msgstr "Pular página e continuar"
+
 msgid "Skip segmentation for images whose shortest side is below this threshold."
 msgstr "Pular segmentação para imagens cujo lado menor está abaixo deste limite."
+
+msgid "Skip this page and continue the step, or stop the step entirely."
+msgstr "Pule esta página e continue a etapa, ou pare a etapa por completo."
 
 msgid "Skipped"
 msgstr "Ignorado"
@@ -6758,6 +6800,9 @@ msgstr "Step failed"
 
 msgid "Step run failed"
 msgstr "Step run failed"
+
+msgid "Stop step"
+msgstr "Parar etapa"
 
 msgid "Storyboard"
 msgstr "Storyboard"
@@ -7791,6 +7836,9 @@ msgstr "vídeos"
 
 msgid "Videos"
 msgstr "Vídeos"
+
+msgid "View details"
+msgstr "Ver detalhes"
 
 msgid "View HTML source"
 msgstr "Ver código HTML"

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -296,6 +296,9 @@ msgstr "{count} {count, plural, one {problem} other {probleme}}"
 msgid "{count} {count, plural, one {manual review item} other {manual review items}}"
 msgstr "{count} {count, plural, one {element për rishikim manual} other {elemente për rishikim manual}}"
 
+msgid "{count} pages failed in {stageLabel}"
+msgstr "{count} faqe dështuan te {stageLabel}"
+
 msgid "{count} translations"
 msgstr "{count} përkthime"
 
@@ -536,6 +539,12 @@ msgstr "Një aktivitet me zgjedhje të shumëfishtë."
 
 #~ msgid "A new version is available for download."
 #~ msgstr "Një version i ri është i disponueshëm për shkarkim."
+
+msgid "A page failed in {stageLabel}"
+msgstr "Një faqe dështoi te {stageLabel}"
+
+msgid "A page failed in {stepLabel}"
+msgstr "Një faqe dështoi te {stepLabel}"
 
 msgid "A question worth asking"
 msgstr "Një pyetje që vlen të bëhet"
@@ -1190,6 +1199,9 @@ msgstr "Apliko ngjyrat e sfondit të faqes"
 msgid "Apply Segmentation"
 msgstr "Apliko segmentimin"
 
+msgid "Apply to all errors in this run"
+msgstr "Zbato për të gjitha gabimet e këtij ekzekutimi"
+
 msgid "AR"
 msgstr "AR"
 
@@ -1553,8 +1565,29 @@ msgstr "Thirrje"
 msgid "Cancel"
 msgstr "Anulo"
 
+msgid "Cancel {stageLabel}"
+msgstr "Anulo {stageLabel}"
+
 msgid "Cancel download"
 msgstr "Anulo shkarkimin"
+
+msgid "Cancel run"
+msgstr "Anulo ekzekutimin"
+
+msgid "Cancelling {stageLabel}"
+msgstr "Duke anuluar {stageLabel}"
+
+msgid "Cancelling run"
+msgstr "Duke anuluar ekzekutimin"
+
+msgid "Cancelling run…"
+msgstr "Duke anuluar ekzekutimin…"
+
+msgid "Cancelling..."
+msgstr "Duke anuluar..."
+
+msgid "Cancelling…"
+msgstr "Duke anuluar…"
 
 #. placeholder {0}: String(MAX_ENTRIES)
 msgid "capped at {0}"
@@ -5920,6 +5953,9 @@ msgstr "Ekzekuto {stageLabel}"
 msgid "Run {upstreamLabel} first"
 msgstr "Ekzekuto {upstreamLabel} së pari"
 
+msgid "Run cancelled"
+msgstr "Ekzekutimi u anulua"
+
 msgid "Run Captions"
 msgstr "Ekzekuto Titujt"
 
@@ -5995,8 +6031,8 @@ msgstr "Duke ekzekutuar"
 msgid "RUNNING"
 msgstr "NË EKZEKUTIM"
 
-msgid "Running {stageLabel}"
-msgstr "Duke ekzekutuar {stageLabel}"
+#~ msgid "Running {stageLabel}"
+#~ msgstr "Duke ekzekutuar {stageLabel}"
 
 msgid "Running Sectioning will run Extract first, then section the extracted pages."
 msgstr "Ekzekutimi i Seksionimit do të ekzekutojë Ekstraktimin së pari, pastaj do të seksionojë faqet e ekstraktuara."
@@ -6007,8 +6043,8 @@ msgstr "Ekzekutimi i Storyboard-it do të ekzekutojë fazat kryesore të mëpars
 msgid "Running Validation..."
 msgstr "Duke ekzekutuar Validimin..."
 
-msgid "Running..."
-msgstr "Duke ekzekutuar..."
+#~ msgid "Running..."
+#~ msgstr "Duke ekzekutuar..."
 
 msgid "Runs accessibility checks against the packaged book."
 msgstr "Ekzekuton kontrolle aksesueshmërie kundrejt librit të paketuar."
@@ -6559,8 +6595,14 @@ msgstr "Kalo tani"
 msgid "Skip intro"
 msgstr "Kalo hyrjen"
 
+msgid "Skip page and continue"
+msgstr "Kapërce faqen dhe vazhdo"
+
 msgid "Skip segmentation for images whose shortest side is below this threshold."
 msgstr "Kalo segmentimin për imazhet çdofaqja më e shkurtër e të cilave është nën këtë prag."
+
+msgid "Skip this page and continue the step, or stop the step entirely."
+msgstr "Kapërce këtë faqe dhe vazhdo hapin, ose ndale hapin plotësisht."
 
 msgid "Skipped"
 msgstr "Kaluar"
@@ -6759,6 +6801,9 @@ msgstr "Hapi dështoi"
 
 msgid "Step run failed"
 msgstr "Ekzekutimi i hapit dështoi"
+
+msgid "Stop step"
+msgstr "Ndalo hapin"
 
 msgid "Storyboard"
 msgstr "Storyboard"
@@ -7792,6 +7837,9 @@ msgstr "video"
 
 msgid "Videos"
 msgstr "Video"
+
+msgid "View details"
+msgstr "Shiko detajet"
 
 msgid "View HTML source"
 msgstr "Shiko burimin HTML"

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -1568,6 +1568,9 @@ msgstr "Anulo"
 msgid "Cancel {stageLabel}"
 msgstr "Anulo {stageLabel}"
 
+msgid "Cancel {stepLabel} step"
+msgstr "Anulo hapin {stepLabel}"
+
 msgid "Cancel download"
 msgstr "Anulo shkarkimin"
 
@@ -1577,11 +1580,17 @@ msgstr "Anulo ekzekutimin"
 msgid "Cancelling {stageLabel}"
 msgstr "Duke anuluar {stageLabel}"
 
+msgid "Cancelling {stepLabel} step"
+msgstr "Duke anuluar hapin {stepLabel}"
+
 msgid "Cancelling run"
 msgstr "Duke anuluar ekzekutimin"
 
 msgid "Cancelling run…"
 msgstr "Duke anuluar ekzekutimin…"
+
+#~ msgid "Cancelling step"
+#~ msgstr "Duke anuluar hapin"
 
 msgid "Cancelling..."
 msgstr "Duke anuluar..."

--- a/apps/studio/src/routes/books.$label.tsx
+++ b/apps/studio/src/routes/books.$label.tsx
@@ -13,6 +13,7 @@ import { Button } from "@/components/ui/button"
 import { DebugPanel } from "@/components/debug/DebugPanel"
 import { DebugPanelStateProvider, type DebugTabValue } from "@/components/debug/debug-panel-state"
 import { StageSidebar } from "@/components/pipeline/components/StageSidebar"
+import { PageErrorDecisionDialog } from "@/components/pipeline/components/PageErrorDecisionDialog"
 import { FloatingSaveProvider } from "@/components/pipeline/components/floating-save"
 import { UnsavedChangesGuard } from "@/components/pipeline/components/UnsavedChangesGuard"
 import { SettingsDirtyTabsProvider } from "@/hooks/use-settings-dirty-tabs"
@@ -47,6 +48,7 @@ function BookLayout() {
   return (
     <BookRunProvider value={bookRun}>
       <BookLayoutInner label={label} isRunning={bookRun.isRunning} />
+      <PageErrorDecisionDialog />
     </BookRunProvider>
   )
 }

--- a/packages/llm/src/__tests__/client.test.ts
+++ b/packages/llm/src/__tests__/client.test.ts
@@ -142,3 +142,73 @@ describe("createLLMModel credentials", () => {
     )
   })
 })
+
+describe("createLLMModel cancellation", () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("combines the external signal into the request abort signal", async () => {
+    openaiProviderMock.mockReturnValue({ provider: "openai" })
+    let captured: AbortSignal | undefined
+    generateObjectMock.mockImplementation((opts: { abortSignal?: AbortSignal }) => {
+      captured = opts.abortSignal
+      return Promise.resolve({
+        object: { ok: true },
+        usage: { promptTokens: 1, completionTokens: 1 },
+      })
+    })
+
+    const controller = new AbortController()
+    const llm = createLLMModel({ modelId: "openai:gpt-4.1", signal: controller.signal })
+    await llm.generateObject({
+      schema: z.object({ ok: z.boolean() }),
+      messages: [{ role: "user", content: "hi" }],
+    })
+
+    expect(captured).toBeInstanceOf(AbortSignal)
+    expect(captured?.aborted).toBe(false)
+    // Aborting the external signal aborts the combined request signal.
+    controller.abort()
+    expect(captured?.aborted).toBe(true)
+  })
+
+  it("does not retry when the external signal is aborted", async () => {
+    openaiProviderMock.mockReturnValue({ provider: "openai" })
+    generateObjectMock.mockRejectedValue(new Error("aborted"))
+
+    const controller = new AbortController()
+    controller.abort()
+    const llm = createLLMModel({ modelId: "openai:gpt-4.1", signal: controller.signal })
+
+    await expect(
+      llm.generateObject({
+        schema: z.object({ ok: z.boolean() }),
+        messages: [{ role: "user", content: "hi" }],
+        maxRetries: 5,
+      }),
+    ).rejects.toThrow()
+    // Cancelled: exactly one attempt, no retries despite maxRetries: 5.
+    expect(generateObjectMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("still retries a normal failure when no signal is aborted", async () => {
+    openaiProviderMock.mockReturnValue({ provider: "openai" })
+    generateObjectMock
+      .mockRejectedValueOnce(new Error("transient"))
+      .mockResolvedValueOnce({
+        object: { ok: true },
+        usage: { promptTokens: 1, completionTokens: 1 },
+      })
+
+    const llm = createLLMModel({ modelId: "openai:gpt-4.1" })
+    const result = await llm.generateObject<{ ok: boolean }>({
+      schema: z.object({ ok: z.boolean() }),
+      messages: [{ role: "user", content: "hi" }],
+      maxRetries: 1,
+    })
+
+    expect(result.object).toEqual({ ok: true })
+    expect(generateObjectMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/llm/src/__tests__/rate-limiter.test.ts
+++ b/packages/llm/src/__tests__/rate-limiter.test.ts
@@ -77,4 +77,42 @@ describe("createRateLimiter", () => {
     await Promise.all([p1, p2])
     expect(order).toEqual([1, 2])
   })
+
+  it("rejects immediately when the signal is already aborted", async () => {
+    const limiter = createRateLimiter(3)
+    const controller = new AbortController()
+    controller.abort()
+
+    await expect(limiter.acquire(controller.signal)).rejects.toMatchObject({
+      name: "AbortError",
+    })
+  })
+
+  it("rejects queued waiters when the signal aborts and frees their slot", async () => {
+    vi.useFakeTimers()
+    const limiter = createRateLimiter(1) // 1 per minute
+
+    // Drain the bucket so the next acquire queues
+    await limiter.acquire()
+
+    const controller = new AbortController()
+    const aborted = limiter.acquire(controller.signal)
+    const abortedResult = aborted.then(
+      () => "resolved",
+      (err: { name?: string }) => err?.name ?? "rejected"
+    )
+
+    controller.abort()
+    expect(await abortedResult).toBe("AbortError")
+
+    // The aborted waiter must not consume the next token: a later waiter
+    // gets it as soon as one refills.
+    let granted = false
+    const next = limiter.acquire().then(() => {
+      granted = true
+    })
+    await vi.advanceTimersByTimeAsync(60_000)
+    await next
+    expect(granted).toBe(true)
+  })
 })

--- a/packages/llm/src/client.ts
+++ b/packages/llm/src/client.ts
@@ -33,6 +33,10 @@ export interface CreateLLMModelOptions {
   credentials?: LLMProviderCredentials
   /** Console log level. Defaults to "info" (show all). Use "silent" to suppress. */
   logLevel?: LogLevel
+  /** External cancellation signal applied to every call this model makes.
+   *  Combined with each request's internal timeout; when it aborts, in-flight
+   *  calls abort and the retry loop stops (a run cancel, not a timeout). */
+  signal?: AbortSignal
 }
 
 /**
@@ -45,7 +49,7 @@ export interface CreateLLMModelOptions {
  * - Optional prompt rendering (pass promptEngine + use prompt option)
  */
 export function createLLMModel(options: CreateLLMModelOptions): LLMModel {
-  const { modelId, cacheDir, promptEngine, onLog, rateLimiter, credentials, logLevel } = options
+  const { modelId, cacheDir, promptEngine, onLog, rateLimiter, credentials, logLevel, signal: modelSignal } = options
   const log = createLogger(logLevel)
 
   return {
@@ -64,6 +68,8 @@ export function createLLMModel(options: CreateLLMModelOptions): LLMModel {
       let messages = opts.messages ?? []
 
       const context = opts.context ?? {}
+      // Per-call signal wins over the model-level signal; either one cancels.
+      const externalSignal = opts.signal ?? modelSignal
 
       if (opts.prompt) {
         if (!promptEngine) {
@@ -121,7 +127,8 @@ export function createLLMModel(options: CreateLLMModelOptions): LLMModel {
                 }),
                 opts,
                 system,
-                currentMessages
+                currentMessages,
+                externalSignal
               )
               result = generated.object
               totalUsage.inputTokens += generated.usage.inputTokens
@@ -137,7 +144,8 @@ export function createLLMModel(options: CreateLLMModelOptions): LLMModel {
               }),
               opts,
               system,
-              currentMessages
+              currentMessages,
+              externalSignal
             )
             result = generated.object
             totalUsage.inputTokens += generated.usage.inputTokens
@@ -238,6 +246,15 @@ export function createLLMModel(options: CreateLLMModelOptions): LLMModel {
           allErrors.push(errMsg)
           if (cacheDir) bustCache(cacheDir, hash)
 
+          // A deliberate external cancel never retries — detected by the signal,
+          // not the error name (the SDK may wrap the AbortError). The internal
+          // timeout also aborts the call but leaves the signal intact, so those
+          // keep retrying as before.
+          if (externalSignal?.aborted) {
+            log.error(`[LLM] ${label} | cancelled | ${errMsg}`)
+            throw err
+          }
+
           if (attempt < maxRetries) {
             const delayMs = backoffDelay(attempt)
             log.error(
@@ -268,7 +285,12 @@ export function createLLMModel(options: CreateLLMModelOptions): LLMModel {
                 ),
               })
             }
-            await sleep(delayMs)
+            await sleep(delayMs, externalSignal)
+            // Cancelled during backoff — stop instead of firing one more attempt.
+            if (externalSignal?.aborted) {
+              log.error(`[LLM] ${label} | cancelled during backoff`)
+              throw err
+            }
             continue
           }
 
@@ -376,8 +398,24 @@ function formatError(err: unknown): string {
   return String(err)
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms))
+/** Sleep that resolves early when `signal` aborts, so a cancel during backoff
+ *  doesn't have to wait out the full delay (which can reach ~66s). */
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal?.aborted) {
+      resolve()
+      return
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort)
+      resolve()
+    }, ms)
+    const onAbort = () => {
+      clearTimeout(timer)
+      resolve()
+    }
+    signal?.addEventListener("abort", onAbort, { once: true })
+  })
 }
 
 function backoffDelay(attempt: number): number {
@@ -389,16 +427,25 @@ async function callLLM<T>(
   model: LanguageModel,
   opts: GenerateObjectOptions,
   system: string | undefined,
-  messages: Message[]
+  messages: Message[],
+  externalSignal?: AbortSignal
 ): Promise<{ object: T; usage: TokenUsage }> {
   const coreMessages = convertMessages(messages)
+  // Combine the internal request timeout with the caller's cancellation signal.
+  // Requires Node 20.3+ (see the "engines" field). The timeout rejects with a
+  // TimeoutError (still a retryable failure); the external signal aborts with an
+  // AbortError (a deliberate cancel — the retry loop stops on it).
+  const timeoutSignal = AbortSignal.timeout(opts.timeoutMs ?? 90_000)
+  const abortSignal = externalSignal
+    ? AbortSignal.any([timeoutSignal, externalSignal])
+    : timeoutSignal
   const generateOpts: Record<string, unknown> = {
     model,
     schema: opts.schema,
     system,
     messages: coreMessages,
     maxRetries: 0,
-    abortSignal: AbortSignal.timeout(opts.timeoutMs ?? 90_000),
+    abortSignal,
   }
   if (opts.mode) {
     generateOpts.mode = opts.mode

--- a/packages/llm/src/image.ts
+++ b/packages/llm/src/image.ts
@@ -23,6 +23,8 @@ export interface GenerateImageWithCacheOptions {
   }
   onLog?: (entry: LlmLogEntry) => void
   logLevel?: LogLevel
+  /** External cancellation signal, combined with the internal timeout. */
+  signal?: AbortSignal
 }
 
 export interface GenerateImageWithCacheResult {
@@ -50,6 +52,7 @@ export async function generateImageWithCache(
     log: logOptions,
     onLog,
     logLevel,
+    signal: externalSignal,
   } = options
 
   const logger = createLogger(logLevel)
@@ -88,7 +91,11 @@ export async function generateImageWithCache(
   }
 
   try {
-    const abortSignal = timeoutMs > 0 ? AbortSignal.timeout(timeoutMs) : undefined
+    const timeoutSignal = timeoutMs > 0 ? AbortSignal.timeout(timeoutMs) : undefined
+    const abortSignal =
+      timeoutSignal && externalSignal
+        ? AbortSignal.any([timeoutSignal, externalSignal])
+        : (timeoutSignal ?? externalSignal)
     const result =
       referenceImages.length > 0
         ? await editImage({

--- a/packages/llm/src/rate-limiter.ts
+++ b/packages/llm/src/rate-limiter.ts
@@ -1,5 +1,11 @@
 export interface RateLimiter {
-  acquire(): Promise<void>
+  /** Waits for a token. Rejects with `signal.reason` if the signal aborts
+   *  first (or is already aborted), so cancelled work never sits in the queue. */
+  acquire(signal?: AbortSignal): Promise<void>
+}
+
+interface Waiter {
+  grant: () => void
 }
 
 /**
@@ -12,7 +18,8 @@ export function createRateLimiter(requestsPerMinute: number): RateLimiter {
   const refillRate = requestsPerMinute / 60_000 // tokens per ms
   let tokens = requestsPerMinute
   let lastRefill = Date.now()
-  const waiters: Array<() => void> = []
+  const waiters: Waiter[] = []
+  let drainScheduled = false
 
   function refill() {
     const now = Date.now()
@@ -22,7 +29,11 @@ export function createRateLimiter(requestsPerMinute: number): RateLimiter {
   }
 
   return {
-    acquire(): Promise<void> {
+    acquire(signal?: AbortSignal): Promise<void> {
+      if (signal?.aborted) {
+        return Promise.reject(signal.reason)
+      }
+
       refill()
 
       if (tokens >= 1) {
@@ -31,23 +42,35 @@ export function createRateLimiter(requestsPerMinute: number): RateLimiter {
       }
 
       // Wait for enough time for 1 token to refill
-      return new Promise<void>((resolve) => {
-        waiters.push(resolve)
-
-        if (waiters.length === 1) {
-          scheduleDrain()
+      return new Promise<void>((resolve, reject) => {
+        const waiter: Waiter = {
+          grant: () => {
+            signal?.removeEventListener("abort", onAbort)
+            resolve()
+          },
         }
+        const onAbort = () => {
+          const index = waiters.indexOf(waiter)
+          if (index !== -1) waiters.splice(index, 1)
+          reject(signal?.reason)
+        }
+        signal?.addEventListener("abort", onAbort, { once: true })
+        waiters.push(waiter)
+        scheduleDrain()
       })
     },
   }
 
   function scheduleDrain() {
+    if (drainScheduled) return
+    drainScheduled = true
     const msPerToken = 1 / refillRate
     setTimeout(() => {
+      drainScheduled = false
       refill()
       while (waiters.length > 0 && tokens >= 1) {
         tokens -= 1
-        waiters.shift()!()
+        waiters.shift()!.grant()
       }
       if (waiters.length > 0) {
         scheduleDrain()

--- a/packages/llm/src/speech.ts
+++ b/packages/llm/src/speech.ts
@@ -4,6 +4,8 @@ export interface SynthesizeSpeechOptions {
   input: string
   responseFormat: string
   instructions?: string
+  /** Aborts the in-flight HTTP request (run cancellation). */
+  signal?: AbortSignal
 }
 
 export interface TTSSynthesizer {
@@ -306,6 +308,7 @@ export function createAzureTTSSynthesizer(
           "X-Microsoft-OutputFormat": outputFormat,
         },
         body: ssml,
+        signal: options.signal,
       })
       if (!response.ok) {
         const message = await response.text()
@@ -346,6 +349,7 @@ export function createTTSSynthesizer(apiKey?: string): TTSSynthesizer {
           response_format: options.responseFormat,
           instructions: options.instructions,
         }),
+        signal: options.signal,
       })
       if (!response.ok) {
         const message = await response.text()
@@ -410,6 +414,7 @@ export function createGeminiTTSSynthesizer(
               },
             },
           }),
+          signal: options.signal,
         })
 
         const responseText = await response.text()

--- a/packages/llm/src/types.ts
+++ b/packages/llm/src/types.ts
@@ -32,6 +32,9 @@ export interface GenerateObjectOptions {
   maxTokens?: number
   temperature?: number
   timeoutMs?: number
+  /** External cancellation signal. Combined with the internal request timeout;
+   *  when it aborts, the in-flight call aborts and the retry loop stops. */
+  signal?: AbortSignal
   log?: {
     taskType: string
     pageId?: string

--- a/packages/pipeline/src/__tests__/web-rendering.test.ts
+++ b/packages/pipeline/src/__tests__/web-rendering.test.ts
@@ -184,6 +184,82 @@ describe("renderPage", () => {
     content: '<div id="content" class="container"><section data-section-type="text_only" data-section-id="pg001_sec001"><p data-id="pg001_gp001_tx001">Hello</p></section></div>',
   }
 
+  it("passes the cancellation signal to LLM calls and stops between sections", async () => {
+    const controller = new AbortController()
+    const seenSignals: Array<AbortSignal | undefined> = []
+    let calls = 0
+
+    const fakeLlm: LLMModel = {
+      generateObject: async <T>(opts: GenerateObjectOptions) => {
+        calls++
+        seenSignals.push(opts.signal)
+        const context = opts.context as {
+          section_id: string
+          section_type: string
+          leaf_texts: Array<{ text_id: string; text: string }>
+        }
+        const leaf = context.leaf_texts[0]
+        controller.abort()
+        return {
+          object: {
+            reasoning: "test",
+            content: `<div id="content" class="container"><section data-section-type="${context.section_type}" data-section-id="${context.section_id}"><p data-id="${leaf.text_id}">${leaf.text}</p></section></div>`,
+          } as T,
+        } as GenerateObjectResult<T>
+      },
+    }
+
+    await expect(
+      renderPage(
+        {
+          label: "test-book",
+          pageId: "pg001",
+          pageImageBase64: "base64img",
+          sectioning: {
+            reasoning: "test",
+            sections: [
+              {
+                sectionId: "pg001_sec001",
+                sectionType: "text_only",
+                nodes: [
+                  groupNode("pg001_gp001", "paragraph", [
+                    leafNode("pg001_gp001_tx001", "section_text", "Hello"),
+                  ]),
+                ],
+                backgroundColor: "#ffffff",
+                textColor: "#000000",
+                pageNumber: 1,
+                isPruned: false,
+              },
+              {
+                sectionId: "pg001_sec002",
+                sectionType: "text_only",
+                nodes: [
+                  groupNode("pg001_gp002", "paragraph", [
+                    leafNode("pg001_gp002_tx001", "section_text", "Second"),
+                  ]),
+                ],
+                backgroundColor: "#ffffff",
+                textColor: "#000000",
+                pageNumber: 1,
+                isPruned: false,
+              },
+            ],
+          },
+          images: new Map(),
+        },
+        defaultResolveConfig,
+        fakeLlm,
+        undefined,
+        undefined,
+        { signal: controller.signal },
+      )
+    ).rejects.toThrow()
+
+    expect(calls).toBe(1)
+    expect(seenSignals).toEqual([controller.signal])
+  })
+
   it("skips pruned sections", async () => {
     const calls: string[] = []
     const fakeLlm: LLMModel = {

--- a/packages/pipeline/src/image-translation.ts
+++ b/packages/pipeline/src/image-translation.ts
@@ -33,6 +33,7 @@ export interface TranslateImageOptions {
   cacheDir?: string
   log?: { taskType: string; pageId?: string; promptName: string }
   onLog?: (entry: LlmLogEntry) => void
+  signal?: AbortSignal
 }
 
 export interface TranslatedImageResult {
@@ -65,6 +66,7 @@ export async function translateImage(
     cacheDir: options.cacheDir,
     log: options.log,
     onLog: options.onLog,
+    signal: options.signal,
   })
 
   const buffer = Buffer.from(result.base64, "base64")

--- a/packages/pipeline/src/render-llm.ts
+++ b/packages/pipeline/src/render-llm.ts
@@ -3,7 +3,7 @@ import { webRenderingLLMSchema, activityAnswersLLMSchema } from "@adt/types"
 import type { LLMModel, ValidationResult } from "@adt/llm"
 import { validateSectionHtml } from "./validate-html.js"
 import { getViewportBreakpoints, type ScreenshotRenderer } from "./screenshot.js"
-import type { RenderConfig, RenderSectionInput } from "./web-rendering.js"
+import type { RenderConfig, RenderExecutionOptions, RenderSectionInput } from "./web-rendering.js"
 import { runVisualReviewLoop } from "./visual-review.js"
 
 /** Dependencies for the optional visual refinement loop. */
@@ -29,6 +29,7 @@ export async function renderSectionLlm(
   config: RenderConfig,
   llmModel: LLMModel,
   visualRefinement?: VisualRefinementDeps,
+  options: RenderExecutionOptions = {},
 ): Promise<SectionRendering> {
   const isActivity = config.renderType === "activity"
   const taskType = isActivity ? "activity-rendering" : "web-rendering"
@@ -62,6 +63,7 @@ export async function renderSectionLlm(
     maxTokens: 16384,
     temperature: config.temperature,
     timeoutMs: config.timeoutMs,
+    signal: options.signal,
     log: {
       taskType,
       pageId: input.pageId,
@@ -108,6 +110,7 @@ export async function renderSectionLlm(
       firstIterationScreenshotsText: "\nHere are screenshots of the current rendered HTML at three viewport sizes:\n",
       nextIterationScreenshotsText: "Here are the updated screenshots after your revision:\n",
       trailingContextText: `Section type: ${section.sectionType}`,
+      signal: options.signal,
       validateHtml: (candidateHtml) => {
         const check = validateWebRendering(
           { reasoning: "visual-review", content: candidateHtml },
@@ -140,6 +143,7 @@ export async function renderSectionLlm(
       maxTokens: 4096,
       temperature: config.temperature,
       timeoutMs: config.timeoutMs,
+      signal: options.signal,
       log: {
         taskType: "activity-answers",
         pageId: input.pageId,

--- a/packages/pipeline/src/screenshot.ts
+++ b/packages/pipeline/src/screenshot.ts
@@ -37,10 +37,16 @@ export interface ScreenshotRenderer {
   /** Render HTML to a PNG screenshot and return it as base64. */
   screenshot(
     html: string,
-    viewport?: { width: number; height: number }
+    viewport?: { width: number; height: number },
+    options?: { signal?: AbortSignal },
   ): Promise<string>
   /** Release browser resources. */
   close(): Promise<void>
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (!signal?.aborted) return
+  throw signal.reason instanceof Error ? signal.reason : new Error("Operation aborted")
 }
 
 /**
@@ -61,18 +67,29 @@ export async function _createScreenshotRenderer(): Promise<ScreenshotRenderer> {
   return {
     async screenshot(
       html: string,
-      viewport = { width: 1024, height: 768 }
+      viewport = { width: 1024, height: 768 },
+      options: { signal?: AbortSignal } = {},
     ): Promise<string> {
+      throwIfAborted(options.signal)
       const context = await browser.newContext({ viewport })
+      const onAbort = () => {
+        void context.close().catch(() => {})
+      }
+      options.signal?.addEventListener("abort", onAbort, { once: true })
       try {
+        throwIfAborted(options.signal)
         const page = await context.newPage()
         await page.setContent(html, { waitUntil: "load" })
+        throwIfAborted(options.signal)
         // Wait for web fonts to finish loading before screenshotting
         await page.waitForFunction("document.fonts.ready")
+        throwIfAborted(options.signal)
         const buffer = await page.screenshot({ fullPage: true, type: "png" })
+        throwIfAborted(options.signal)
         return buffer.toString("base64")
       } finally {
-        await context.close()
+        options.signal?.removeEventListener("abort", onAbort)
+        await context.close().catch(() => {})
       }
     },
 
@@ -126,23 +143,35 @@ export async function _createElectronScreenshotRenderer(): Promise<ScreenshotRen
   return {
     async screenshot(
       html: string,
-      viewport = { width: 1024, height: 768 }
+      viewport = { width: 1024, height: 768 },
+      options: { signal?: AbortSignal } = {},
     ): Promise<string> {
+      throwIfAborted(options.signal)
       const id = randomUUID()
       return new Promise((resolve, reject) => {
+        const cleanup = () => {
+          parentPort.off("message", onMessage)
+          options.signal?.removeEventListener("abort", onAbort)
+        }
         const onMessage = (ev: { data: unknown }) => {
           const parsed = screenshotIpcReplySchema.safeParse(ev.data)
           if (!parsed.success) return
           const msg = parsed.data
           if (msg.id !== id) return
-          parentPort.off("message", onMessage)
+          cleanup()
           if ("error" in msg) {
             reject(new Error(msg.error))
             return
           }
           resolve(msg.base64)
         }
+        const onAbort = () => {
+          cleanup()
+          parentPort.postMessage(screenshotIpcCloseSchema.parse({ type: "screenshot-close" }))
+          reject(new Error("Operation aborted"))
+        }
         parentPort.on("message", onMessage)
+        options.signal?.addEventListener("abort", onAbort, { once: true })
         const payload = screenshotIpcRequestSchema.parse({
           type: "screenshot-base64",
           id,

--- a/packages/pipeline/src/speech.ts
+++ b/packages/pipeline/src/speech.ts
@@ -223,6 +223,8 @@ export interface GenerateSpeechFileOptions {
   ttsSynthesizer: TTSSynthesizer
   rateLimiter?: RateLimiter
   provider?: string
+  /** Run cancellation — aborts the rate-limiter wait and the TTS request. */
+  signal?: AbortSignal
 }
 
 /**
@@ -246,6 +248,7 @@ export async function generateSpeechFile(
     ttsSynthesizer,
     rateLimiter,
     provider,
+    signal,
   } = options
 
   // Strip emojis and validate
@@ -298,13 +301,15 @@ export async function generateSpeechFile(
   }
 
   // Generate speech via shared LLM TTS client
-  await rateLimiter?.acquire()
+  await rateLimiter?.acquire(signal)
+  signal?.throwIfAborted()
   const audioBytes = await ttsSynthesizer.synthesize({
     model,
     voice,
     input: sanitized,
     responseFormat: safeFormat,
     instructions: instructions || undefined,
+    signal,
   })
 
   const buffer = Buffer.from(audioBytes)

--- a/packages/pipeline/src/visual-review.ts
+++ b/packages/pipeline/src/visual-review.ts
@@ -35,6 +35,7 @@ export interface RunVisualReviewLoopOptions {
   nextIterationScreenshotsText: string
   trailingContextText: string
   validateHtml: (html: string) => VisualReviewValidation
+  signal?: AbortSignal
 }
 
 export interface VisualReviewResult {
@@ -74,6 +75,11 @@ function normalizeForCompare(s: string): string {
   return s.replace(/\s+/g, " ").trim()
 }
 
+function throwIfAborted(signal?: AbortSignal): void {
+  if (!signal?.aborted) return
+  throw signal.reason instanceof Error ? signal.reason : new Error("Operation aborted")
+}
+
 export async function runVisualReviewLoop(
   options: RunVisualReviewLoopOptions
 ): Promise<VisualReviewResult> {
@@ -94,12 +100,15 @@ export async function runVisualReviewLoop(
     nextIterationScreenshotsText,
     trailingContextText,
     validateHtml,
+    signal,
   } = options
 
+  throwIfAborted(signal)
   const initialMessages = await deps.llmModel.renderPrompt(promptName, {
     ...(promptContext ?? {}),
     viewports: getViewportBreakpoints(),
   })
+  throwIfAborted(signal)
   const systemMsg = initialMessages.find((m) => m.role === "system")
   const systemPrompt = typeof systemMsg?.content === "string" ? systemMsg.content : undefined
 
@@ -113,6 +122,7 @@ export async function runVisualReviewLoop(
   let pendingValidationFeedback: string | null = null
 
   for (let iteration = 0; iteration < maxIterations; iteration++) {
+    throwIfAborted(signal)
     const screenshotHtml = await buildScreenshotHtml({
       sectionHtml: html,
       label,
@@ -126,10 +136,12 @@ export async function runVisualReviewLoop(
       SCREENSHOT_VIEWPORTS.map((vp) =>
         deps.screenshotRenderer.screenshot(
           screenshotHtml,
-          { width: vp.width, height: vp.height }
+          { width: vp.width, height: vp.height },
+          { signal },
         )
       )
     )
+    throwIfAborted(signal)
     const screenshotParts: ContentPart[] = []
     for (let i = 0; i < SCREENSHOT_VIEWPORTS.length; i++) {
       const vp = SCREENSHOT_VIEWPORTS[i]
@@ -181,6 +193,7 @@ export async function runVisualReviewLoop(
       maxTokens: 16384,
       temperature,
       timeoutMs,
+      signal,
       log: {
         taskType: "visual-review",
         pageId,

--- a/packages/pipeline/src/web-rendering.ts
+++ b/packages/pipeline/src/web-rendering.ts
@@ -102,6 +102,10 @@ export interface RenderPageInput {
   userPrompt?: string
 }
 
+export interface RenderExecutionOptions {
+  signal?: AbortSignal
+}
+
 export type ResolveLLMModel = LLMModel | ((modelId: string) => LLMModel)
 
 function getLLMModel(
@@ -111,6 +115,11 @@ function getLLMModel(
   return typeof resolver === "function"
     ? resolver(modelId)
     : resolver
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (!signal?.aborted) return
+  throw signal.reason instanceof Error ? signal.reason : new Error("Operation aborted")
 }
 
 /**
@@ -222,10 +231,13 @@ export async function renderPage(
   llmModel: ResolveLLMModel,
   templateEngine?: TemplateEngine,
   visualRefinement?: VisualRefinementDeps,
+  options: RenderExecutionOptions = {},
 ): Promise<WebRenderingOutput> {
   const sections: SectionRendering[] = []
 
   for (let i = 0; i < input.sectioning.sections.length; i++) {
+    throwIfAborted(options.signal)
+
     const section = input.sectioning.sections[i]
 
     // Skip pruned sections
@@ -271,9 +283,11 @@ export async function renderPage(
         config,
         getLLMModel(llmModel, config.modelId),
         visualRefinement,
+        options,
       )
     }
 
+    throwIfAborted(options.signal)
     sections.push(rendering)
   }
 

--- a/packages/storage/src/book-storage.ts
+++ b/packages/storage/src/book-storage.ts
@@ -321,7 +321,15 @@ export function createBookStorage(label: string, booksRoot: string): Storage {
       )
     },
 
-    markStepCompleted(step: string): void {
+    markStepCompleted(step: string, message?: string): void {
+      if (message !== undefined) {
+        db.run(
+          `INSERT INTO step_runs (step, status, completed_at, message) VALUES (?, 'done', ?, ?)
+           ON CONFLICT (step) DO UPDATE SET status='done', completed_at=excluded.completed_at, message=excluded.message`,
+          [step, new Date().toISOString(), message]
+        )
+        return
+      }
       db.run(
         `INSERT INTO step_runs (step, status, completed_at) VALUES (?, 'done', ?)
          ON CONFLICT (step) DO UPDATE SET status='done', completed_at=excluded.completed_at`,
@@ -363,6 +371,10 @@ export function createBookStorage(label: string, booksRoot: string): Storage {
       if (steps.length === 0) return
       const placeholders = steps.map(() => "?").join(", ")
       db.run(`DELETE FROM step_runs WHERE step IN (${placeholders})`, steps)
+    },
+
+    clearRunningStepRuns(): void {
+      db.run("DELETE FROM step_runs WHERE status = 'running'")
     },
 
     getLatestNodeData(node: string, itemId: string): NodeDataRow | null {

--- a/packages/storage/src/storage.ts
+++ b/packages/storage/src/storage.ts
@@ -96,8 +96,9 @@ export interface Storage {
 
   /** Mark a pipeline step as started (running). */
   markStepStarted(step: string): void
-  /** Mark a pipeline step as completed successfully. */
-  markStepCompleted(step: string): void
+  /** Mark a pipeline step as completed successfully. Optionally persist a
+   *  completion message (e.g. "Completed — 2 page(s) skipped"). */
+  markStepCompleted(step: string, message?: string): void
   /** Mark a pipeline step as skipped. */
   markStepSkipped(step: string): void
   /** Record a step error. Can be called multiple times (last error wins). */
@@ -108,6 +109,9 @@ export interface Storage {
   getStepRuns(): Array<{ step: string; status: string; error: string | null; message: string | null }>
   /** Clear step run records for specific steps (used when clearing downstream data). */
   clearStepRuns(steps: string[]): void
+  /** Delete step run records still marked 'running'. Used when a run is
+   *  cancelled: in-flight steps return to idle rather than showing as errored. */
+  clearRunningStepRuns(): void
 
   /** Get a compact fingerprint of all entity versions for cache invalidation. */
   getNodeVersionFingerprint(excludeNodes?: string[]): Array<{ node: string; itemId: string; version: number }>

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -96,6 +96,13 @@ export { PartRange, PartManifest, ExportedPartEntry, PartsLedger } from "./part.
 export { ProgressEvent } from "./progress.js"
 
 export {
+  PageErrorPolicy,
+  PageErrorAction,
+  PendingDecision,
+  DecisionBody,
+} from "./page-error.js"
+
+export {
   TaskKind,
   TaskStatus,
   TaskEvent,

--- a/packages/types/src/page-error.ts
+++ b/packages/types/src/page-error.ts
@@ -1,0 +1,32 @@
+import { z } from "zod"
+
+/** How a run reacts when a page fails inside a per-page step.
+ *  - "stop" (default): accumulate failures and fail the step at the end
+ *    (the historical behavior — safe for headless/CLI clients).
+ *  - "ask": pause and ask the user to skip the page or stop the step. */
+export const PageErrorPolicy = z.enum(["ask", "stop"])
+export type PageErrorPolicy = z.infer<typeof PageErrorPolicy>
+
+/** What to do with a single failed page once the user (or a fallback) decides. */
+export const PageErrorAction = z.enum(["skip", "stop"])
+export type PageErrorAction = z.infer<typeof PageErrorAction>
+
+/** A page failure awaiting the user's decision. Surfaced both via the ephemeral
+ *  `decision-required` SSE event and the polled step-status response. */
+export const PendingDecision = z.object({
+  decisionId: z.string(),
+  step: z.string(),
+  pageId: z.string(),
+  error: z.string(),
+})
+export type PendingDecision = z.infer<typeof PendingDecision>
+
+/** Body of POST /books/:label/stages/decision. */
+export const DecisionBody = z
+  .object({
+    decisionId: z.string(),
+    action: PageErrorAction,
+    applyToAll: z.boolean().optional(),
+  })
+  .strict()
+export type DecisionBody = z.infer<typeof DecisionBody>

--- a/packages/types/src/progress.ts
+++ b/packages/types/src/progress.ts
@@ -16,6 +16,7 @@ export const ProgressEvent = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("step-complete"),
     step: StepName,
+    message: z.string().optional(),
   }),
   z.object({
     type: z.literal("step-skip"),


### PR DESCRIPTION
Pipeline cancellation and sidebar status controls.

### Changes

- Makes Storyboard cancellation more responsive by propagating `AbortSignal` into page rendering, LLM rendering, visual review, and screenshot capture.
- Preserves queued stage runs when cancelling the currently running stage, so cancelling the active step no longer drops later queued steps.
- Adds a contextual cancel control in the sidebar: when a step is running, hovering over its icon shows a red cancel button.
- Shows a toast with the step name when cancellation is requested, e.g. `Cancelling Storyboard step`.
- Updates sidebar error UI:
  - error state uses a red corner badge similar to the yellow warning badge;
  - removes the previous red ring around the step icon;
  - removes duplicate sidebar border when the page panel is open.
- Updates i18n catalogs for all supported locales.

## Tests

Automated checks run:

- `pnpm exec vitest run apps/api/src/services/stage-service.test.ts`
- `pnpm exec vitest run apps/api/src/services/stage-runner.test.ts`
- `pnpm exec vitest run packages/pipeline/src/__tests__/web-rendering.test.ts`
- `pnpm exec vitest run apps/studio/src/components/pipeline/StageSidebar.test.tsx`
- `pnpm --filter @adt/studio extract`
- `pnpm typecheck`

Manual test checklist:

- Start a step and cancel it from the sidebar cancel button.
- Start a step and cancel it from the existing task indicator cancel button.
- Start many steps, cancel the first running step, and verify the queued steps continue afterward.
- Start Image Captions, queue Glossary, cancel Image Captions, and verify Glossary still starts.
- Start Storyboard, cancel during web rendering, and verify cancellation completes quickly.
- Start Storyboard with visual refinement enabled, cancel during screenshot/visual review, and verify it does not hang.
- Hover a running step icon in the sidebar and verify the icon changes to a red cancel button.
- Click the sidebar cancel button and verify the toast includes the step name.
