### PR TITLE
Multi-Provider Selection & Model Resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ Thumbs.db
 
 # AI agent local config
 .claude/
+.kiro/
 
 # AI agent rule files
 CLAUDE.md

--- a/apps/api/src/routes/glossary.ts
+++ b/apps/api/src/routes/glossary.ts
@@ -122,9 +122,13 @@ export function createGlossaryRoutes(
     const { label } = c.req.param()
     const safeLabel = safeParseLabel(label)
 
-    const apiKey = c.req.header("X-OpenAI-Key")
-    if (!apiKey) {
-      throw new HTTPException(400, { message: "Missing X-OpenAI-Key header" })
+    const apiKey = c.req.header("X-OpenAI-Key") || undefined
+    const anthropicApiKey = c.req.header("X-Anthropic-API-Key") || undefined
+    const googleApiKey = c.req.header("X-Google-API-Key") || undefined
+    const customBaseUrl = c.req.header("X-Custom-Base-URL") || undefined
+    const customApiKey = c.req.header("X-Custom-API-Key") || undefined
+    if (!apiKey && !anthropicApiKey && !googleApiKey && !customBaseUrl) {
+      throw new HTTPException(400, { message: "At least one LLM provider API key is required." })
     }
 
     const body = await c.req.json()
@@ -157,6 +161,10 @@ export function createGlossaryRoutes(
         onLog: (entry) => storage.appendLlmLog(entry),
         credentials: {
           openaiApiKey: apiKey,
+          anthropicApiKey,
+          googleApiKey,
+          customBaseUrl,
+          customApiKey,
         },
       })
 

--- a/apps/api/src/routes/pages.ts
+++ b/apps/api/src/routes/pages.ts
@@ -1151,10 +1151,13 @@ export function createPageRoutes(
     }
     const { sectionIndex } = queryParsed.data
 
-    const apiKey = c.req.header("X-OpenAI-Key")
-    if (!apiKey) {
+    const apiKey = c.req.header("X-OpenAI-Key") || undefined
+    const anthropicApiKey = c.req.header("X-Anthropic-API-Key") || undefined
+    const googleApiKey = c.req.header("X-Google-API-Key") || undefined
+    const customBaseUrl = c.req.header("X-Custom-Base-URL") || undefined
+    if (!apiKey && !anthropicApiKey && !googleApiKey && !customBaseUrl) {
       throw new HTTPException(400, {
-        message: "Missing X-OpenAI-Key header",
+        message: "At least one LLM provider API key is required.",
       })
     }
 
@@ -1218,7 +1221,11 @@ export function createPageRoutes(
             promptsDir,
             webAssetsDir,
             configPath,
-            apiKey,
+            apiKey: apiKey ?? "",
+            anthropicApiKey,
+            googleApiKey,
+            customBaseUrl,
+            defaultModelId: c.req.header("X-Default-LLM-Model") || undefined,
           })
         },
         { pageId, url: `/books/${safeLabel}/storyboard/${pageId}` }
@@ -1236,7 +1243,11 @@ export function createPageRoutes(
       promptsDir,
       webAssetsDir,
       configPath,
-      apiKey,
+      apiKey: apiKey ?? "",
+      anthropicApiKey,
+      googleApiKey,
+      customBaseUrl,
+      defaultModelId: c.req.header("X-Default-LLM-Model") || undefined,
     })
 
     return c.json(result)
@@ -1252,9 +1263,12 @@ export function createPageRoutes(
       throw new HTTPException(400, { message: "Invalid section index" })
     }
 
-    const apiKey = c.req.header("X-OpenAI-Key")
-    if (!apiKey) {
-      throw new HTTPException(400, { message: "Missing X-OpenAI-Key header" })
+    const apiKey = c.req.header("X-OpenAI-Key") || undefined
+    const anthropicApiKey = c.req.header("X-Anthropic-API-Key") || undefined
+    const googleApiKey = c.req.header("X-Google-API-Key") || undefined
+    const customBaseUrl = c.req.header("X-Custom-Base-URL") || undefined
+    if (!apiKey && !anthropicApiKey && !googleApiKey && !customBaseUrl) {
+      throw new HTTPException(400, { message: "At least one LLM provider API key is required." })
     }
 
     const body = await c.req.json()
@@ -1281,7 +1295,11 @@ export function createPageRoutes(
             promptsDir,
             webAssetsDir,
             configPath,
-            apiKey,
+            apiKey: apiKey ?? "",
+            anthropicApiKey,
+            googleApiKey,
+            customBaseUrl,
+            defaultModelId: c.req.header("X-Default-LLM-Model") || undefined,
           })
 
           // Save the edited HTML as a new rendering version
@@ -1319,7 +1337,11 @@ export function createPageRoutes(
       promptsDir,
       webAssetsDir,
       configPath,
-      apiKey,
+      apiKey: apiKey ?? "",
+      anthropicApiKey,
+      googleApiKey,
+      customBaseUrl,
+      defaultModelId: c.req.header("X-Default-LLM-Model") || undefined,
     })
 
     return c.json(result)
@@ -1947,9 +1969,12 @@ export function createPageRoutes(
         return c.json({ error: `Book not found: ${safeLabel}` }, 404)
       }
 
-      const apiKey = c.req.header("X-OpenAI-Key")
-      if (!apiKey) {
-        return c.json({ error: "Missing X-OpenAI-Key header" }, 400)
+      const apiKey = c.req.header("X-OpenAI-Key") || undefined
+      const anthropicApiKey = c.req.header("X-Anthropic-API-Key") || undefined
+      const googleApiKey = c.req.header("X-Google-API-Key") || undefined
+      const customBaseUrl = c.req.header("X-Custom-Base-URL") || undefined
+      if (!apiKey && !anthropicApiKey && !googleApiKey && !customBaseUrl) {
+        return c.json({ error: "At least one LLM provider API key is required." }, 400)
       }
 
       const pageId = c.req.query("pageId")
@@ -2005,7 +2030,7 @@ export function createPageRoutes(
           desc,
           async () => {
             return await executeAiImageGeneration({
-              safeLabel, bookDir, dbPath, apiKey, pageId,
+              safeLabel, bookDir, dbPath, apiKey: apiKey ?? "", pageId,
               prompt, referenceImageId, targetImageId,
               style, imageType, styleImageId, promptsDir,
               sectionIndex, mode, booksDir,
@@ -2018,7 +2043,7 @@ export function createPageRoutes(
 
       // Fallback: run synchronously
       const result = await executeAiImageGeneration({
-        safeLabel, bookDir, dbPath, apiKey, pageId,
+        safeLabel, bookDir, dbPath, apiKey: apiKey ?? "", pageId,
         prompt, referenceImageId, targetImageId,
         style, imageType, styleImageId, promptsDir,
         sectionIndex, mode, booksDir,
@@ -2225,13 +2250,16 @@ export function createPageRoutes(
     }
     validateImageId(pageId)
 
-    const apiKey = c.req.header("X-OpenAI-Key")
-    if (!apiKey) {
-      return c.json({ error: "Missing X-OpenAI-Key header" }, 400)
+    const apiKey = c.req.header("X-OpenAI-Key") || undefined
+    const anthropicApiKey = c.req.header("X-Anthropic-API-Key") || undefined
+    const googleApiKey = c.req.header("X-Google-API-Key") || undefined
+    const customBaseUrl = c.req.header("X-Custom-Base-URL") || undefined
+    if (!apiKey && !anthropicApiKey && !googleApiKey && !customBaseUrl) {
+      return c.json({ error: "At least one LLM provider API key is required." }, 400)
     }
 
     const previousKey = process.env.OPENAI_API_KEY
-    process.env.OPENAI_API_KEY = apiKey
+    process.env.OPENAI_API_KEY = apiKey ?? ""
 
     const storage = createBookStorage(safeLabel, booksDir)
     try {
@@ -2403,9 +2431,12 @@ export function createPageRoutes(
     const { label } = c.req.param()
     const safeLabel = parseBookLabel(label)
 
-    const apiKey = c.req.header("X-OpenAI-Key")
-    if (!apiKey) {
-      throw new HTTPException(400, { message: "Missing X-OpenAI-Key header" })
+    const apiKey = c.req.header("X-OpenAI-Key") || undefined
+    const anthropicApiKey = c.req.header("X-Anthropic-API-Key") || undefined
+    const googleApiKey = c.req.header("X-Google-API-Key") || undefined
+    const customBaseUrl = c.req.header("X-Custom-Base-URL") || undefined
+    if (!apiKey && !anthropicApiKey && !googleApiKey && !customBaseUrl) {
+      throw new HTTPException(400, { message: "At least one LLM provider API key is required." })
     }
 
     const body = await c.req.json()
@@ -2453,7 +2484,7 @@ export function createPageRoutes(
 
     // Set API key for LLM
     const previousKey = process.env.OPENAI_API_KEY
-    process.env.OPENAI_API_KEY = apiKey
+    process.env.OPENAI_API_KEY = apiKey ?? ""
 
     try {
       const bookPromptsDir = path.join(bookDir, "prompts")

--- a/apps/api/src/routes/quizzes.ts
+++ b/apps/api/src/routes/quizzes.ts
@@ -132,16 +132,20 @@ export function createQuizRoutes(
     const { label } = c.req.param()
     const safeLabel = safeParseLabel(label)
 
-    const apiKey = c.req.header("X-OpenAI-Key")
-    if (!apiKey) {
-      throw new HTTPException(400, { message: "Missing X-OpenAI-Key header" })
+    const apiKey = c.req.header("X-OpenAI-Key") || undefined
+    const anthropicApiKey = c.req.header("X-Anthropic-API-Key") || undefined
+    const googleApiKey = c.req.header("X-Google-API-Key") || undefined
+    const customBaseUrl = c.req.header("X-Custom-Base-URL") || undefined
+    const customApiKey = c.req.header("X-Custom-API-Key") || undefined
+    if (!apiKey && !anthropicApiKey && !googleApiKey && !customBaseUrl) {
+      throw new HTTPException(400, { message: "At least one LLM provider API key is required." })
     }
     const credentials = {
       openaiApiKey: apiKey,
-      anthropicApiKey: c.req.header("X-Anthropic-API-Key") || undefined,
-      googleApiKey: c.req.header("X-Google-API-Key") || undefined,
-      customBaseUrl: c.req.header("X-Custom-Base-URL") || undefined,
-      customApiKey: c.req.header("X-Custom-API-Key") || undefined,
+      anthropicApiKey,
+      googleApiKey,
+      customBaseUrl,
+      customApiKey,
     }
 
     const body = await c.req.json()

--- a/apps/api/src/routes/stages.ts
+++ b/apps/api/src/routes/stages.ts
@@ -76,12 +76,16 @@ export function createStageRoutes(
     const customApiKey = c.req.header("X-Custom-API-Key") || undefined
     const defaultModelId = c.req.header("X-Default-LLM-Model") || undefined
     const rawExplicitModels = c.req.header("X-Step-Model-Overrides")
-    let explicitModelIds: string[] | undefined
+    let explicitModelIds: Record<string, string> | undefined
     if (rawExplicitModels) {
       try {
         const parsedModels: unknown = JSON.parse(rawExplicitModels)
-        if (Array.isArray(parsedModels)) {
-          explicitModelIds = parsedModels.filter((model): model is string => typeof model === "string")
+        if (parsedModels && typeof parsedModels === "object" && !Array.isArray(parsedModels)) {
+          const obj: Record<string, string> = {}
+          for (const [key, val] of Object.entries(parsedModels as Record<string, unknown>)) {
+            if (typeof val === "string") obj[key] = val
+          }
+          if (Object.keys(obj).length > 0) explicitModelIds = obj
         }
       } catch {
         throw new HTTPException(400, { message: "Invalid step model overrides header." })

--- a/apps/api/src/routes/stages.ts
+++ b/apps/api/src/routes/stages.ts
@@ -69,11 +69,28 @@ export function createStageRoutes(
   // POST /books/:label/stages/run — Start or queue a stage-scoped run
   app.post("/books/:label/stages/run", async (c) => {
     const { label } = c.req.param()
-    const apiKey = c.req.header("X-OpenAI-Key")
+    const apiKey = c.req.header("X-OpenAI-Key") || undefined
+    const anthropicApiKey = c.req.header("X-Anthropic-API-Key") || undefined
+    const googleApiKey = c.req.header("X-Google-API-Key") || undefined
+    const customBaseUrl = c.req.header("X-Custom-Base-URL") || undefined
+    const customApiKey = c.req.header("X-Custom-API-Key") || undefined
+    const defaultModelId = c.req.header("X-Default-LLM-Model") || undefined
+    const rawExplicitModels = c.req.header("X-Step-Model-Overrides")
+    let explicitModelIds: string[] | undefined
+    if (rawExplicitModels) {
+      try {
+        const parsedModels: unknown = JSON.parse(rawExplicitModels)
+        if (Array.isArray(parsedModels)) {
+          explicitModelIds = parsedModels.filter((model): model is string => typeof model === "string")
+        }
+      } catch {
+        throw new HTTPException(400, { message: "Invalid step model overrides header." })
+      }
+    }
 
-    if (!apiKey) {
+    if (!apiKey && !anthropicApiKey && !googleApiKey && !customBaseUrl) {
       throw new HTTPException(400, {
-        message: "API key required. Set X-OpenAI-Key header.",
+        message: "At least one LLM provider API key is required.",
       })
     }
 
@@ -93,10 +110,6 @@ export function createStageRoutes(
 
     const { fromStage, toStage, renderOnly } = parsed.data
 
-    const anthropicApiKey = c.req.header("X-Anthropic-API-Key") || undefined
-    const googleApiKey = c.req.header("X-Google-API-Key") || undefined
-    const customBaseUrl = c.req.header("X-Custom-Base-URL") || undefined
-    const customApiKey = c.req.header("X-Custom-API-Key") || undefined
     const azureSpeechKey = c.req.header("X-Azure-Speech-Key") || undefined
     const azureSpeechRegion = c.req.header("X-Azure-Speech-Region") || undefined
     const geminiApiKey = c.req.header("X-Gemini-API-Key") || undefined
@@ -107,11 +120,13 @@ export function createStageRoutes(
 
     const result = stageService.startStageRun(label, {
       booksDir,
-      apiKey,
+      apiKey: apiKey ?? "",
       anthropicApiKey,
       googleApiKey,
       customBaseUrl,
       customApiKey,
+      defaultModelId,
+      explicitModelIds,
       promptsDir,
       webAssetsDir,
       configPath,

--- a/apps/api/src/services/page-edit-service.ts
+++ b/apps/api/src/services/page-edit-service.ts
@@ -19,6 +19,11 @@ export interface ReRenderOptions {
   webAssetsDir?: string
   configPath?: string
   apiKey: string
+  anthropicApiKey?: string
+  googleApiKey?: string
+  customBaseUrl?: string
+  customApiKey?: string
+  defaultModelId?: string
 }
 
 export interface ReRenderResult {
@@ -38,6 +43,11 @@ export interface AiEditSectionOptions {
   webAssetsDir?: string
   configPath?: string
   apiKey: string
+  anthropicApiKey?: string
+  googleApiKey?: string
+  customBaseUrl?: string
+  customApiKey?: string
+  defaultModelId?: string
 }
 
 export interface AiEditSectionResult {
@@ -48,11 +58,11 @@ export interface AiEditSectionResult {
 export async function reRenderPage(
   options: ReRenderOptions
 ): Promise<ReRenderResult> {
-  const { label, pageId, sectionIndex, prompt, booksDir, promptsDir, webAssetsDir, configPath, apiKey } = options
+  const { label, pageId, sectionIndex, prompt, booksDir, promptsDir, webAssetsDir, configPath, apiKey, anthropicApiKey, googleApiKey, customBaseUrl, customApiKey, defaultModelId } = options
 
-  // Set API key
+  // Set API key for legacy global provider fallback
   const previousKey = process.env.OPENAI_API_KEY
-  process.env.OPENAI_API_KEY = apiKey
+  if (apiKey) process.env.OPENAI_API_KEY = apiKey
 
   const storage = createBookStorage(label, booksDir)
   let visualRefinement: VisualRefinementDeps | undefined
@@ -123,6 +133,14 @@ export async function reRenderPage(
         cacheDir,
         promptEngine,
         onLog: (entry) => storage.appendLlmLog(entry),
+        credentials: {
+          openaiApiKey: apiKey || undefined,
+          anthropicApiKey,
+          googleApiKey,
+          customBaseUrl,
+          customApiKey,
+          defaultModelId,
+        },
       })
       renderModels.set(modelId, model)
       return model
@@ -250,10 +268,10 @@ export async function reRenderPage(
 export async function aiEditSection(
   options: AiEditSectionOptions
 ): Promise<AiEditSectionResult> {
-  const { label, pageId, sectionIndex, instruction, currentHtml: providedHtml, booksDir, promptsDir, webAssetsDir, configPath, apiKey } = options
+  const { label, pageId, sectionIndex, instruction, currentHtml: providedHtml, booksDir, promptsDir, webAssetsDir, configPath, apiKey, anthropicApiKey, googleApiKey, customBaseUrl, customApiKey, defaultModelId } = options
 
   const previousKey = process.env.OPENAI_API_KEY
-  process.env.OPENAI_API_KEY = apiKey
+  if (apiKey) process.env.OPENAI_API_KEY = apiKey
 
   const storage = createBookStorage(label, booksDir)
 
@@ -293,6 +311,14 @@ export async function aiEditSection(
       cacheDir,
       promptEngine,
       onLog: (entry) => storage.appendLlmLog(entry),
+      credentials: {
+        openaiApiKey: apiKey || undefined,
+        anthropicApiKey,
+        googleApiKey,
+        customBaseUrl,
+        customApiKey,
+        defaultModelId,
+      },
     })
 
     // Gather the imageIds referenced in the HTML so screenshots render their

--- a/apps/api/src/services/stage-runner.ts
+++ b/apps/api/src/services/stage-runner.ts
@@ -551,6 +551,8 @@ function buildLLMCredentials(options: StageRunOptions) {
     googleApiKey: options.googleApiKey,
     customBaseUrl: options.customBaseUrl,
     customApiKey: options.customApiKey,
+    defaultModelId: options.defaultModelId,
+    explicitModelIds: options.explicitModelIds,
   }
 }
 

--- a/apps/api/src/services/stage-service.ts
+++ b/apps/api/src/services/stage-service.ts
@@ -46,7 +46,7 @@ export interface StageRunOptions {
   customBaseUrl?: string
   customApiKey?: string
   defaultModelId?: string
-  explicitModelIds?: string[]
+  explicitModelIds?: Record<string, string>
   azureSpeechKey?: string
   azureSpeechRegion?: string
   geminiApiKey?: string

--- a/apps/api/src/services/stage-service.ts
+++ b/apps/api/src/services/stage-service.ts
@@ -45,6 +45,8 @@ export interface StageRunOptions {
   googleApiKey?: string
   customBaseUrl?: string
   customApiKey?: string
+  defaultModelId?: string
+  explicitModelIds?: string[]
   azureSpeechKey?: string
   azureSpeechRegion?: string
   geminiApiKey?: string

--- a/apps/studio/src/api/client.ts
+++ b/apps/studio/src/api/client.ts
@@ -199,7 +199,7 @@ export interface StageRunProviderCredentials {
   azure?: AzureCredentials
   geminiApiKey?: string
   defaultModelId?: string
-  explicitModelIds?: string[]
+  explicitModelIds?: Record<string, string>
 }
 
 export interface RunStagesOptions {
@@ -238,7 +238,7 @@ function buildApiHeaders(
     headers["X-Gemini-API-Key"] = providerCredentials.geminiApiKey
   }
   if (providerCredentials?.defaultModelId) headers["X-Default-LLM-Model"] = providerCredentials.defaultModelId
-  if (providerCredentials?.explicitModelIds?.length) {
+  if (providerCredentials?.explicitModelIds && Object.keys(providerCredentials.explicitModelIds).length > 0) {
     headers["X-Step-Model-Overrides"] = JSON.stringify(providerCredentials.explicitModelIds)
   }
   return headers

--- a/apps/studio/src/api/client.ts
+++ b/apps/studio/src/api/client.ts
@@ -198,6 +198,8 @@ export interface StageRunProviderCredentials {
   customApiKey?: string
   azure?: AzureCredentials
   geminiApiKey?: string
+  defaultModelId?: string
+  explicitModelIds?: string[]
 }
 
 export interface RunStagesOptions {
@@ -211,7 +213,9 @@ function buildApiHeaders(
   apiKey: string,
   providerCredentials?: StageRunProviderCredentials
 ): Record<string, string> {
-  const headers: Record<string, string> = { "X-OpenAI-Key": apiKey }
+  const headers: Record<string, string> = {}
+  const openaiApiKey = apiKey.trim()
+  if (openaiApiKey.startsWith("sk-")) headers["X-OpenAI-Key"] = openaiApiKey
   if (providerCredentials?.anthropicApiKey) {
     headers["X-Anthropic-API-Key"] = providerCredentials.anthropicApiKey
   }
@@ -232,6 +236,10 @@ function buildApiHeaders(
   }
   if (providerCredentials?.geminiApiKey) {
     headers["X-Gemini-API-Key"] = providerCredentials.geminiApiKey
+  }
+  if (providerCredentials?.defaultModelId) headers["X-Default-LLM-Model"] = providerCredentials.defaultModelId
+  if (providerCredentials?.explicitModelIds?.length) {
+    headers["X-Step-Model-Overrides"] = JSON.stringify(providerCredentials.explicitModelIds)
   }
   return headers
 }

--- a/apps/studio/src/components/StudioTopBar.tsx
+++ b/apps/studio/src/components/StudioTopBar.tsx
@@ -4,7 +4,7 @@ import { Home, HelpCircle, Settings, Download } from "lucide-react";
 import { useLingui } from "@lingui/react/macro";
 import { Button } from "@/components/ui/button";
 import { LocaleSwitcher } from "@/components/LocaleSwitcher";
-import { useSettingsDialog } from "@/routes/__root";
+import { useSettingsDialog } from "@/hooks/use-settings-dialog";
 import { useUpdateDialog } from "@/components/updates";
 import { usePlatform } from "@/hooks/use-platform";
 import { useAppVersion } from "@/hooks/use-app-version";

--- a/apps/studio/src/components/pipeline/StageSidebar.test.tsx
+++ b/apps/studio/src/components/pipeline/StageSidebar.test.tsx
@@ -45,6 +45,7 @@ vi.mock("@lingui/react", () => ({
       },
     },
   }),
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }))
 
 vi.mock("@tanstack/react-router", () => ({
@@ -57,6 +58,51 @@ vi.mock("@tanstack/react-router", () => ({
 
 vi.mock("@lingui/react/macro", () => ({
   Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useLingui: () => ({
+    t: (strings: TemplateStringsArray, ...values: unknown[]) => {
+      let text = ""
+      for (let index = 0; index < strings.length; index += 1) {
+        text += strings[index]
+        if (index < values.length) text += String(values[index])
+      }
+      return text
+    },
+  }),
+}))
+
+vi.mock("./pipeline-i18n", () => {
+  const stageLabels: Record<string, string> = {
+    book: "Book",
+    extract: "Extract",
+    sectioning: "Sectioning",
+    storyboard: "Storyboard",
+    quizzes: "Quizzes",
+    captions: "Image Captions",
+    glossary: "Glossary",
+    toc: "Table of Contents",
+    "easy-read": "Easy Read",
+    translate: "Language",
+    speech: "Speech",
+    "sign-language": "Sign Language",
+    validation: "Validation",
+    preview: "Preview",
+    export: "Export",
+  }
+  return {
+    getStageLabelI18n: (slug: string) => stageLabels[slug] ?? slug,
+    getStepLabelI18n: (slug: string) => slug,
+    getStageStatusLabelI18n: (status: string) => status,
+  }
+})
+
+vi.mock("./settings-tabs", () => ({
+  getSettingsTabs: (slug: string) => {
+    if (slug !== "validation") return null
+    return [
+      { key: "accessibility", label: "Accessibility" },
+      { key: "reviewer-checklist", label: "Reviewer Checklist" },
+    ]
+  },
 }))
 
 vi.mock("@/hooks/use-book-run", () => ({
@@ -67,7 +113,24 @@ vi.mock("@/hooks/use-book-run", () => ({
   }),
 }))
 
+vi.mock("@/hooks/use-api-key", () => ({
+  useApiKey: () => ({
+    defaultModel: "anthropic:claude-sonnet-4-6",
+    hasOpenAIKey: false,
+    hasAnthropicKey: true,
+    hasGoogleKey: false,
+    hasCustomProvider: false,
+    providerDefaultModels: {
+      openai: "openai:gpt-5.4",
+      anthropic: "anthropic:claude-sonnet-4-6",
+      google: "google:gemini-2.5-pro",
+      custom: "custom:your-model-name",
+    },
+  }),
+}))
+
 vi.mock("@/hooks/use-debug", () => ({
+  useActiveConfig: () => ({ data: { merged: {} } }),
   useAccessibilityAssessment: () => ({
     data: {
       assessment: {
@@ -121,6 +184,25 @@ afterEach(() => {
 })
 
 describe("StageSidebar", () => {
+  it("shows the selected model below the file name and above the steps", async () => {
+    const { StageSidebar } = await import("./components/StageSidebar")
+    render(
+      <StageSidebar
+        bookLabel="demo-book"
+        activeStep="extract"
+      />,
+    )
+
+    const fileName = screen.getByText("DemoBook")
+    const selectedModel = screen.getByTestId("selected-model-card")
+    const extractStep = document.querySelector("[data-stage-slug='extract']")
+
+    expect(extractStep).toBeTruthy()
+
+    expect(fileName.compareDocumentPosition(selectedModel) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(selectedModel.compareDocumentPosition(extractStep!) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+
   it("shows Validation before Preview and exposes Validation settings tabs", async () => {
     const { StageSidebar } = await import("./components/StageSidebar")
     const { container } = render(
@@ -134,7 +216,7 @@ describe("StageSidebar", () => {
     const previewLink = screen.getByTitle("Preview")
     expect(validationLink.compareDocumentPosition(previewLink) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
 
-    expect(screen.getByTitle("Validation Settings")).toBeTruthy()
+    expect(screen.getAllByTitle(/^Validation/).some((element) => element.getAttribute("to") === "/books/$label/$step/settings")).toBe(true)
     expect(screen.getByText("Accessibility")).toBeTruthy()
     expect(screen.getByText("Reviewer Checklist")).toBeTruthy()
     expect(container.textContent).toContain("Validation")

--- a/apps/studio/src/components/pipeline/components/LandingPageShell.tsx
+++ b/apps/studio/src/components/pipeline/components/LandingPageShell.tsx
@@ -150,31 +150,33 @@ export function LandingPageShell({
               <span />
             )}
 
-            <div
-              className={cn(
-                "transition-all duration-200 ease-out",
-                hideRunButton
-                  ? "pointer-events-none translate-y-1 opacity-0"
-                  : "translate-y-0 opacity-100",
-              )}
-              inert={hideRunButton || undefined}
-            >
-              {showTooltip ? (
-                <TooltipProvider delayDuration={150}>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <span tabIndex={0} className="inline-flex cursor-help">
-                        <span className="pointer-events-none">{runButton}</span>
-                      </span>
-                    </TooltipTrigger>
-                    <TooltipContent side="top" align="end" className="max-w-[260px] text-center">
-                      {disabledReason}
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
-              ) : (
-                runButton
-              )}
+            <div className="flex items-center gap-3">
+              <div
+                className={cn(
+                  "transition-all duration-200 ease-out",
+                  hideRunButton
+                    ? "pointer-events-none translate-y-1 opacity-0"
+                    : "translate-y-0 opacity-100",
+                )}
+                inert={hideRunButton || undefined}
+              >
+                {showTooltip ? (
+                  <TooltipProvider delayDuration={150}>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span tabIndex={0} className="inline-flex cursor-help">
+                          <span className="pointer-events-none">{runButton}</span>
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent side="top" align="end" className="max-w-[260px] text-center">
+                        {disabledReason}
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
+                ) : (
+                  runButton
+                )}
+              </div>
             </div>
           </div>
         )}

--- a/apps/studio/src/components/pipeline/components/ModelSelect.tsx
+++ b/apps/studio/src/components/pipeline/components/ModelSelect.tsx
@@ -19,6 +19,8 @@ interface ModelSelectProps {
   inputClassName?: string
   /** When true (default), selected values are prefixed as "provider:model". When false, only the bare model name is emitted. */
   prefixProvider?: boolean
+  /** Providers whose models remain visible but cannot be selected. */
+  disabledProviders?: string[]
 }
 
 export function ModelSelect({
@@ -29,6 +31,7 @@ export function ModelSelect({
   className,
   inputClassName,
   prefixProvider = true,
+  disabledProviders = [],
 }: ModelSelectProps) {
   const { t } = useLingui()
   const [open, setOpen] = useState(false)
@@ -92,6 +95,7 @@ export function ModelSelect({
     if (!trimmed) { closeDropdown(); return }
     // If it exactly matches a dropdown item, use formatModelId for consistency
     for (const g of groups) {
+      if (disabledProviders.includes(g.provider)) continue
       for (const m of g.models) {
         const full = `${g.provider}:${m}`
         if (trimmed === full || trimmed === m) {
@@ -183,18 +187,26 @@ export function ModelSelect({
             <div key={group.provider}>
               <div className="px-3 py-1.5 text-xs font-semibold text-muted-foreground uppercase tracking-wider">
                 {group.provider}
+                {disabledProviders.includes(group.provider) && (
+                  <span className="ml-2 rounded-full border border-muted-foreground/30 px-1.5 py-0.5 text-[9px] font-medium normal-case tracking-normal">
+                    {t`Not configured`}
+                  </span>
+                )}
               </div>
               {group.models.map((model) => {
                 const fullId = formatModelId(group.provider, model)
                 const isSelected = value === fullId
+                const isDisabled = disabledProviders.includes(group.provider)
                 return (
                   <button
                     key={`${group.provider}:${model}`}
                     type="button"
                     onClick={() => selectModel(group.provider, model)}
+                    disabled={isDisabled}
                     className={cn(
                       "flex w-full items-center px-3 py-1.5 text-sm cursor-pointer hover:bg-accent hover:text-accent-foreground",
-                      isSelected && "bg-accent text-accent-foreground"
+                      isSelected && "bg-accent text-accent-foreground",
+                      isDisabled && "cursor-not-allowed opacity-40 hover:bg-transparent hover:text-inherit"
                     )}
                   >
                     {prefixProvider && <span className="text-muted-foreground mr-1">{group.provider}:</span>}

--- a/apps/studio/src/components/pipeline/components/PromptViewer.tsx
+++ b/apps/studio/src/components/pipeline/components/PromptViewer.tsx
@@ -6,6 +6,7 @@ import { DEFAULT_LLM_MAX_RETRIES } from "@adt/types"
 import { api } from "@/api/client"
 import { Trans, useLingui } from "@lingui/react/macro"
 import { ModelSelect, LLM_MODEL_GROUPS, type ModelGroup } from "./ModelSelect"
+import { useApiKey } from "@/hooks/use-api-key"
 
 interface PromptViewerBaseProps {
   /** Prompt template name to fetch (e.g. "page_sectioning") */
@@ -62,13 +63,23 @@ export function PromptViewer({
   onContentChange,
   maxRetries,
   onMaxRetriesChange,
-  modelPlaceholder = "openai:gpt-5.4",
+  modelPlaceholder,
   modelGroups = LLM_MODEL_GROUPS,
   enabled = true,
   hideModel = false,
   readOnly = false,
 }: PromptViewerProps) {
   const { t } = useLingui()
+  const { defaultModel, hasOpenAIKey, hasAnthropicKey, hasGoogleKey, hasCustomProvider } = useApiKey()
+  const disabledProviders = modelGroups
+    .filter((group) =>
+      group.provider === "openai" ? !hasOpenAIKey
+        : group.provider === "anthropic" ? !hasAnthropicKey
+          : group.provider === "google" ? !hasGoogleKey
+            : group.provider === "custom" ? !hasCustomProvider
+              : false
+    )
+    .map((group) => group.provider)
 
   const { data: promptData, isLoading } = useQuery({
     queryKey: ["prompts", promptName, bookLabel],
@@ -123,8 +134,9 @@ export function PromptViewer({
             <ModelSelect
               value={model ?? ""}
               onChange={(v) => onModelChange?.(v)}
-              placeholder={modelPlaceholder}
+              placeholder={modelPlaceholder ?? defaultModel ?? ""}
               groups={modelGroups}
+              disabledProviders={disabledProviders}
               className="mt-1"
               inputClassName="text-xs"
             />

--- a/apps/studio/src/components/pipeline/components/ProviderSelector.tsx
+++ b/apps/studio/src/components/pipeline/components/ProviderSelector.tsx
@@ -1,0 +1,178 @@
+import { useState, useRef, useEffect } from "react"
+import { Trans, useLingui } from "@lingui/react/macro"
+import { ChevronDown, Settings } from "lucide-react"
+import { cn } from "@/lib/utils"
+import {
+  useActiveProvider,
+  PROVIDER_PRIORITY,
+  type ProviderType,
+} from "@/hooks/use-active-provider"
+import { useSettingsDialog } from "@/hooks/use-settings-dialog"
+
+/**
+ * ProviderSelector — displays the active LLM provider and allows switching
+ * when multiple providers are configured.
+ *
+ * - No providers configured → inline message with link to Settings
+ * - Single provider configured → static provider name + model (no dropdown)
+ * - Multiple providers configured → custom dropdown listing all 4 providers
+ *
+ * Uses a custom dropdown instead of radix Select so that disabled/unconfigured
+ * providers remain clickable (opening the Settings dialog for credential entry).
+ */
+export function ProviderSelector() {
+  const { t } = useLingui()
+  const {
+    activeProvider,
+    allProviders,
+    configuredProviders,
+    setActiveProvider,
+    hasMultipleProviders,
+  } = useActiveProvider()
+  const { openSettings } = useSettingsDialog()
+
+  const [open, setOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener("mousedown", handler)
+    return () => document.removeEventListener("mousedown", handler)
+  }, [open])
+
+  // Close on escape
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setOpen(false)
+      }
+    }
+    document.addEventListener("keydown", handler)
+    return () => document.removeEventListener("keydown", handler)
+  }, [open])
+
+  // No providers configured — show message with link to Settings
+  if (configuredProviders.length === 0) {
+    return (
+      <button
+        type="button"
+        onClick={openSettings}
+        className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+        aria-label={t`Configure provider credentials`}
+      >
+        <Settings className="w-3.5 h-3.5" />
+        <span>
+          <Trans>Configure a provider to run</Trans>
+        </span>
+      </button>
+    )
+  }
+
+  // Single provider configured — static display, no dropdown
+  if (!hasMultipleProviders && activeProvider) {
+    return (
+      <div
+        className="flex items-center gap-2 text-sm text-muted-foreground"
+        aria-label={t`Active provider: ${activeProvider.label}`}
+      >
+        <span className="font-medium text-foreground">
+          {activeProvider.label}
+        </span>
+        <span className="text-xs text-muted-foreground truncate max-w-[140px]">
+          {activeProvider.model}
+        </span>
+      </div>
+    )
+  }
+
+  // Multiple providers configured — custom dropdown
+  const handleSelect = (type: ProviderType, configured: boolean) => {
+    if (!configured) {
+      // Unconfigured provider → open Settings dialog
+      openSettings()
+      setOpen(false)
+      return
+    }
+    setActiveProvider(type)
+    setOpen(false)
+  }
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className={cn(
+          "flex h-8 items-center gap-2 rounded-md border border-input bg-background px-3 text-sm",
+          "ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+          "hover:bg-accent/50 transition-colors"
+        )}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-label={t`Select LLM provider`}
+      >
+        {activeProvider && (
+          <span className="flex items-center gap-2 truncate">
+            <span className="font-medium">{activeProvider.label}</span>
+            <span className="text-xs text-muted-foreground truncate max-w-[120px]">
+              {activeProvider.model}
+            </span>
+          </span>
+        )}
+        <ChevronDown className={cn("h-3.5 w-3.5 opacity-50 transition-transform", open && "rotate-180")} />
+      </button>
+
+      {open && (
+        <div
+          role="listbox"
+          aria-label={t`LLM providers`}
+          className="absolute z-50 mt-1 min-w-[200px] rounded-md border bg-popover text-popover-foreground shadow-md"
+        >
+          {PROVIDER_PRIORITY.map((type) => {
+            const provider = allProviders.find((p) => p.type === type)
+            if (!provider) return null
+            const isActive = activeProvider?.type === type
+            const isDisabled = !provider.configured
+            return (
+              <button
+                key={type}
+                type="button"
+                role="option"
+                aria-selected={isActive}
+                aria-disabled={isDisabled}
+                onClick={() => handleSelect(type, provider.configured)}
+                className={cn(
+                  "flex w-full items-center justify-between px-3 py-2 text-sm cursor-pointer",
+                  "hover:bg-accent hover:text-accent-foreground transition-colors",
+                  isActive && "bg-accent/50",
+                  isDisabled && "opacity-60"
+                )}
+              >
+                <span className="flex items-center gap-2">
+                  <span className={cn(isDisabled && "text-muted-foreground")}>
+                    {provider.label}
+                  </span>
+                  {isDisabled && (
+                    <span className="text-xs text-muted-foreground italic">
+                      <Trans>credentials needed</Trans>
+                    </span>
+                  )}
+                </span>
+                {isActive && (
+                  <span className="h-2 w-2 rounded-full bg-foreground" />
+                )}
+              </button>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/studio/src/components/pipeline/components/StageRunCard.tsx
+++ b/apps/studio/src/components/pipeline/components/StageRunCard.tsx
@@ -67,7 +67,7 @@ export function StageRunCard({
 }: StageRunCardProps) {
   const { t } = useLingui()
   const stage = STAGES.find((s) => s.slug === stageSlug) ?? STAGES[0]
-  const { stageState, stepState, stepProgress, stepError, error } = useBookRun()
+  const { stageState, stepState, stepProgress, stepError, error, runProvider } = useBookRun()
   const stageStatus = stageState(stageSlug)
   const subSteps = STAGE_SUB_STEPS[stageSlug as StageName] ?? []
   const Icon = stage.icon
@@ -109,6 +109,11 @@ export function StageRunCard({
             ? getStageRunningLabelI18n(stageSlug)
             : stageLabel}
         </CardTitle>
+        {runProvider && (isRunning || isCompleted || hasError) && (
+          <span className="ml-auto text-[11px] font-normal opacity-80">
+            {t`Provider: ${runProvider.providerName}`}
+          </span>
+        )}
       </CardHeader>
 
       {/* Main row: sub-steps | button | description */}

--- a/apps/studio/src/components/pipeline/components/StageSidebar.tsx
+++ b/apps/studio/src/components/pipeline/components/StageSidebar.tsx
@@ -6,6 +6,7 @@ import {
   Loader2,
   RotateCcw,
   Settings,
+  Sparkles,
   TriangleAlert,
 } from "lucide-react"
 import { useVirtualizer } from "@tanstack/react-virtual"
@@ -15,7 +16,8 @@ import { msg } from "@lingui/core/macro"
 import type { MessageDescriptor } from "@lingui/core"
 import { Button } from "@/components/ui/button"
 import { useBookRun } from "@/hooks/use-book-run"
-import { useAccessibilityAssessment } from "@/hooks/use-debug"
+import { useAccessibilityAssessment, useActiveConfig } from "@/hooks/use-debug"
+import { useApiKey } from "@/hooks/use-api-key"
 import { useBookTasks } from "@/hooks/use-book-tasks"
 import { useStageMissingCounts } from "@/hooks/use-stage-missing-counts"
 import { useDirtyTabsForStage } from "@/hooks/use-settings-dirty-tabs"
@@ -24,6 +26,7 @@ import { usePackageAdtStatus } from "@/hooks/use-books"
 import { useSignLanguageVideos } from "@/hooks/use-sign-language-videos"
 import { StepProgressRing } from "./StepProgressRing"
 import { StoryboardIndex } from "./StoryboardIndex"
+import { ProviderSelector } from "./ProviderSelector"
 import { useSectionNav } from "@/routes/books.$label"
 import { usePages, usePageImage } from "@/hooks/use-pages"
 import {
@@ -32,7 +35,7 @@ import {
   toCamelLabel,
   type StageGroup,
 } from "../stage-config"
-import { useSettingsDialog } from "@/routes/__root"
+import { useSettingsDialog } from "@/hooks/use-settings-dialog"
 import type { TaskInfoResponse } from "@/api/client"
 import { getStageLabelI18n, getStepLabelI18n, getStageStatusLabelI18n } from "../pipeline-i18n"
 import { ALL_STEP_NAMES } from "@adt/types"
@@ -55,6 +58,17 @@ const TASK_KIND_LABELS: Record<string, MessageDescriptor> = {
   "font-assignment": msg`Font Analysis`,
 }
 
+const STAGE_MODEL_CONFIG: Record<string, string> = {
+  extract: "metadata",
+  sectioning: "page_sectioning",
+  captions: "image_captioning",
+  glossary: "glossary",
+  quizzes: "quiz_generation",
+  toc: "toc_generation",
+  "easy-read": "easy_read",
+  translate: "translation",
+}
+
 
 export function StageSidebar({
   bookLabel,
@@ -74,6 +88,7 @@ export function StageSidebar({
   const { i18n } = useLingui()
   const matchRoute = useMatchRoute()
   const search = useSearch({ strict: false }) as { tab?: string }
+  const activeTab = search.tab ?? "general"
   const { stageState } = useBookRun()
   const { data: accessibilityAssessment } = useAccessibilityAssessment(bookLabel)
   const { data: signLanguageData } = useSignLanguageVideos(bookLabel)
@@ -85,6 +100,46 @@ export function StageSidebar({
   const speechNeedsRerun = stageMissing.speech > 0
   const activeDirtyTabs = useDirtyTabsForStage(activeStep)
   const { data: sidebarPages } = usePages(bookLabel, { enabled: false })
+  const { defaultModel, hasOpenAIKey, hasAnthropicKey, hasGoogleKey, hasCustomProvider } = useApiKey()
+  const { data: activeConfig } = useActiveConfig(bookLabel)
+  const activeModelConfigKey = activeStep === "extract"
+    ? activeTab === "meaningfulness-prompt"
+      ? "image_meaningfulness"
+      : activeTab === "cropping-prompt"
+        ? "image_cropping"
+        : activeTab === "segmentation-prompt"
+          ? "image_segmentation"
+          : "metadata"
+    : STAGE_MODEL_CONFIG[activeStep]
+  const activeModelConfig = activeModelConfigKey
+    ? (activeConfig?.merged as Record<string, unknown> | undefined)?.[activeModelConfigKey]
+    : undefined
+  const mergedConfig = activeConfig?.merged as Record<string, unknown> | undefined
+  const storyboardStrategy = activeStep === "storyboard" && typeof mergedConfig?.default_render_strategy === "string"
+    ? (mergedConfig.render_strategies as Record<string, { config?: { model?: string; model_override?: boolean } }> | undefined)?.[mergedConfig.default_render_strategy]
+    : undefined
+  const activeStepModel = storyboardStrategy?.config?.model ?? (activeModelConfig && typeof activeModelConfig === "object"
+    ? (activeModelConfig as Record<string, unknown>).model
+    : undefined)
+  const hasActiveStepOverride = storyboardStrategy
+    ? storyboardStrategy.config?.model_override === true
+    : activeModelConfig && typeof activeModelConfig === "object"
+      ? (activeModelConfig as Record<string, unknown>).model_override === true
+      : false
+  const activeProvider = typeof activeStepModel === "string" && activeStepModel.includes(":")
+    ? activeStepModel.slice(0, activeStepModel.indexOf(":"))
+    : "openai"
+  const activeProviderAvailable =
+    (activeProvider === "openai" && hasOpenAIKey) ||
+    (activeProvider === "anthropic" && hasAnthropicKey) ||
+    (activeProvider === "google" && hasGoogleKey) ||
+    (activeProvider === "custom" && hasCustomProvider)
+  const effectiveStepModel = hasActiveStepOverride && typeof activeStepModel === "string" && activeProviderAvailable
+    ? activeStepModel
+    : defaultModel
+  const stepModelOverride = effectiveStepModel && effectiveStepModel !== defaultModel
+    ? effectiveStepModel
+    : null
   const hasNoTextLayer = (sidebarPages ?? []).some((p) => p.extractionWarning)
   const noTextLayerLabel = i18n._(
     msg`Some pages have no embedded text layer — text was recovered from the page image. Prefer a text-based PDF.`
@@ -103,7 +158,6 @@ export function StageSidebar({
     to: "/books/$label/$step/settings",
     params: { label: bookLabel, step: activeStep },
   })
-  const activeTab = search.tab ?? "general"
 
   // The rail collapses (icon-only, hover to expand) only when pages are showing
   // and we're not in settings. Otherwise it's always expanded with labels visible.
@@ -117,6 +171,31 @@ export function StageSidebar({
     showFlex:  "flex",
     flex1:     "flex-1",
   }
+  const selectedModelItem = (
+    <div
+      key="selected-model"
+      data-testid="selected-model-card"
+      className="mb-1 ml-[42px] mr-2 flex min-h-10 items-center gap-2 overflow-hidden rounded-lg border bg-muted/40 px-2 py-1.5"
+    >
+      <Sparkles className="h-4 w-4 shrink-0 text-primary" aria-hidden />
+      <div className={cn(
+        "min-w-0 whitespace-nowrap transition-opacity duration-150",
+        railCollapsed ? "opacity-0 delay-150 group-hover/rail:opacity-100" : "opacity-100",
+      )}>
+        <div className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+          <Trans>Selected model</Trans>
+        </div>
+        <div className="mt-1 min-w-0">
+          <ProviderSelector />
+        </div>
+        {stepModelOverride && (
+          <div className="mt-0.5 truncate text-[10px] text-amber-700 dark:text-amber-400" title={stepModelOverride}>
+            <Trans>This step uses</Trans> <span className="font-mono">{stepModelOverride}</span>
+          </div>
+        )}
+      </div>
+    </div>
+  )
 
   const validationCompleted = Boolean(accessibilityAssessment?.assessment)
   const signLanguageCompleted = signLanguageData?.videos?.some((v) => v.sectionId !== null) ?? false
@@ -204,6 +283,7 @@ export function StageSidebar({
 
         {/* Step row */}
         <div
+          data-stage-slug={step.slug}
           className={cn(
             "group/row flex items-center py-2 text-sm transition-colors overflow-hidden",
             x.gap,
@@ -337,6 +417,10 @@ export function StageSidebar({
         )}
       </div>
     )
+
+    if (step.slug === "book" && selectedModelItem) {
+      stageItems.push(selectedModelItem)
+    }
   })
 
   return (

--- a/apps/studio/src/components/pipeline/components/StageSidebar.tsx
+++ b/apps/studio/src/components/pipeline/components/StageSidebar.tsx
@@ -26,7 +26,6 @@ import { usePackageAdtStatus } from "@/hooks/use-books"
 import { useSignLanguageVideos } from "@/hooks/use-sign-language-videos"
 import { StepProgressRing } from "./StepProgressRing"
 import { StoryboardIndex } from "./StoryboardIndex"
-import { ProviderSelector } from "./ProviderSelector"
 import { useSectionNav } from "@/routes/books.$label"
 import { usePages, usePageImage } from "@/hooks/use-pages"
 import {
@@ -175,22 +174,22 @@ export function StageSidebar({
     <div
       key="selected-model"
       data-testid="selected-model-card"
-      className="mb-1 ml-[42px] mr-2 flex min-h-10 items-center gap-2 overflow-hidden rounded-lg border bg-muted/40 px-2 py-1.5"
+      className="mb-1 mx-2 flex min-h-8 items-start gap-2 overflow-hidden rounded-md border border-border/60 bg-muted/30 px-2.5 py-1.5"
     >
-      <Sparkles className="h-4 w-4 shrink-0 text-primary" aria-hidden />
+      <Sparkles className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden />
       <div className={cn(
-        "min-w-0 whitespace-nowrap transition-opacity duration-150",
-        railCollapsed ? "opacity-0 delay-150 group-hover/rail:opacity-100" : "opacity-100",
-      )}>
-        <div className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-          <Trans>Selected model</Trans>
+        "min-w-0 flex-1 whitespace-nowrap transition-opacity duration-150",
+        railCollapsed ? "opacity-0 pointer-events-none delay-150 group-hover/rail:opacity-100 group-hover/rail:pointer-events-auto" : "opacity-100",
+      )} inert={railCollapsed || undefined}>
+        <div className="text-[10px] font-medium text-muted-foreground">
+          {activeProvider.charAt(0).toUpperCase() + activeProvider.slice(1)}
         </div>
-        <div className="mt-1 min-w-0">
-          <ProviderSelector />
+        <div className="truncate text-xs font-mono text-foreground/80">
+          {effectiveStepModel ?? defaultModel}
         </div>
         {stepModelOverride && (
-          <div className="mt-0.5 truncate text-[10px] text-amber-700 dark:text-amber-400" title={stepModelOverride}>
-            <Trans>This step uses</Trans> <span className="font-mono">{stepModelOverride}</span>
+          <div className="mt-0.5 truncate text-[10px] text-amber-600 dark:text-amber-400" title={stepModelOverride}>
+            <Trans>Step override: {stepModelOverride}</Trans>
           </div>
         )}
       </div>

--- a/apps/studio/src/components/pipeline/stages/BookView.tsx
+++ b/apps/studio/src/components/pipeline/stages/BookView.tsx
@@ -759,4 +759,3 @@ function BookOverviewCard({ bookLabel }: { bookLabel: string }) {
     </section>
   )
 }
-

--- a/apps/studio/src/components/pipeline/stages/languages/LanguageSettings.tsx
+++ b/apps/studio/src/components/pipeline/stages/languages/LanguageSettings.tsx
@@ -27,6 +27,7 @@ import { SelectImagesDialog } from "./components/SelectImagesDialog"
 import { WordHighlightPreview } from "./components/WordHighlightPreview"
 import { useLingui } from "@lingui/react/macro"
 import { displayLang } from "./lib/display-lang"
+import { useApiKey } from "@/hooks/use-api-key"
 
 export function LanguageSettings({ bookLabel, tab = "general", stageSlug = "translate" }: { bookLabel: string; headerTarget?: HTMLDivElement | null; tab?: string; stageSlug?: string }) {
   const isSpeechStage = stageSlug === "speech"
@@ -36,6 +37,7 @@ export function LanguageSettings({ bookLabel, tab = "general", stageSlug = "tran
     enabled: !isSpeechStage,
   })
   const { t } = useLingui()
+  const { hasOpenAIKey } = useApiKey()
   const { data: book } = useBook(bookLabel)
   const { data: bookConfigData } = useBookConfig(bookLabel)
   const { data: activeConfigData } = useActiveConfig(bookLabel)
@@ -76,7 +78,6 @@ export function LanguageSettings({ bookLabel, tab = "general", stageSlug = "tran
 
   const merged = activeConfigData?.merged as Record<string, unknown> | undefined
   const translation = useStepConfig(merged, "translation", markDirty)
-  const imageTranslation = useStepConfig(merged, "image_translation", markDirty)
 
   const configuredEditingLanguage = merged?.editing_language as string | undefined
   const bookLanguage = book?.languageCode ?? book?.metadata?.language_code ?? null
@@ -147,7 +148,6 @@ export function LanguageSettings({ bookLabel, tab = "general", stageSlug = "tran
       const existing = (bookConfigData?.config?.image_translation ?? {}) as Record<string, unknown>
       overrides.image_translation = {
         ...existing,
-        ...imageTranslation.configOverrides,
         enabled: imageTranslationEnabled,
         image_model: imageModel.trim() || undefined,
         selected_image_ids: selectedImageIds.length > 0 ? selectedImageIds : undefined,
@@ -358,6 +358,7 @@ export function LanguageSettings({ bookLabel, tab = "general", stageSlug = "tran
               onChange={(v) => { setImageModel(v); markDirty("image_translation") }}
               placeholder="openai:gpt-image-2"
               groups={IMAGE_MODEL_GROUPS}
+              disabledProviders={hasOpenAIKey ? [] : ["openai"]}
               prefixProvider
               className="max-w-md"
               inputClassName="h-9 text-sm"
@@ -437,10 +438,7 @@ export function LanguageSettings({ bookLabel, tab = "general", stageSlug = "tran
               bookLabel={bookLabel}
               title={t`Image translation prompt`}
               description={t`The prompt sent to the image model alongside each selected image.`}
-              model={imageTranslation.model}
-              onModelChange={imageTranslation.onModelChange}
-              maxRetries={imageTranslation.maxRetries}
-              onMaxRetriesChange={imageTranslation.onMaxRetriesChange}
+              hideModel
               onContentChange={setImagePromptDraft}
               enabled={tab === "image-translation"}
             />
@@ -523,7 +521,8 @@ function ReadAloudContentSection({
 /* ---------- Speech per-language cards ---------- */
 
 // eslint-disable-next-line lingui/no-unlocalized-strings -- brand names
-const PROVIDER_LABELS: Record<string, string> = { openai: "OpenAI", azure: "Azure", gemini: "Gemini" }
+const PROVIDER_LABELS: Record<string, string> = { openai: "OpenAI", anthropic: "Anthropic", azure: "Azure", gemini: "Gemini" }
+const SPEECH_PROVIDER_OPTIONS = ["openai", "anthropic", "azure", "gemini"] as const
 
 const MODEL_GROUPS_BY_PROVIDER: Record<string, typeof OPENAI_TTS_MODELS> = {
   openai: OPENAI_TTS_MODELS,
@@ -648,7 +647,7 @@ function SpeechLanguageCards({
   // Route a language to a different provider
   const routeLanguageTo = (lang: string, newProvider: string) => {
     // Remove from all providers' language lists
-    for (const p of ["openai", "azure", "gemini"]) {
+    for (const p of SPEECH_PROVIDER_OPTIONS) {
       const current = getProviderLanguages(p)
       const langs = current.split(",").map((s) => s.trim()).filter(Boolean)
       const filtered = langs.filter((l) => normalizeLocale(l) !== normalizeLocale(lang))
@@ -682,9 +681,15 @@ function SpeechLanguageCards({
               className="flex h-8 w-40 rounded-md border border-input bg-background px-3 py-1 text-xs shadow-sm"
             >
               <option value="openai">{t`OpenAI`}</option>
+              <option value="anthropic" disabled>{t`Anthropic`}</option>
               <option value="azure">{t`Azure`}</option>
               <option value="gemini">{t`Gemini`}</option>
             </select>
+            {defaultProvider === "anthropic" && (
+              <p className="max-w-40 text-[10px] text-muted-foreground">
+                {t`Anthropic is available for text models, but not speech synthesis.`}
+              </p>
+            )}
           </div>
           <div className="space-y-1.5">
             <Label className="text-xs">{t`Format`}</Label>
@@ -762,12 +767,17 @@ function SpeechLanguageCards({
                     onChange={(e) => routeLanguageTo(lang, e.target.value)}
                     className="flex h-8 w-36 rounded-md border border-input bg-background px-2 py-1 text-xs shadow-sm"
                   >
-                    {["openai", "azure", "gemini"].map((p) => (
-                      <option key={p} value={p}>
+                    {SPEECH_PROVIDER_OPTIONS.map((p) => (
+                      <option key={p} value={p} disabled={p === "anthropic"}>
                         {PROVIDER_LABELS[p]}{p === defaultProvider ? ` (${t`default`})` : ""}
                       </option>
                     ))}
                   </select>
+                  {provider === "anthropic" && (
+                    <p className="text-[10px] text-muted-foreground">
+                      {t`Anthropic is available for text models, but not speech synthesis.`}
+                    </p>
+                  )}
                 </div>
                 <div className="space-y-1 flex-1 min-w-[200px]">
                   <Label className="text-[10px] text-muted-foreground">{t`Model`}</Label>

--- a/apps/studio/src/components/pipeline/stages/speech/SpeechLandingPage.tsx
+++ b/apps/studio/src/components/pipeline/stages/speech/SpeechLandingPage.tsx
@@ -16,20 +16,22 @@ import { useActiveConfig } from "@/hooks/use-debug"
 import { useStageStatus } from "@/hooks/use-stage-status"
 import { useBookRun } from "@/hooks/use-book-run"
 import { useApiKey } from "@/hooks/use-api-key"
-import { useBookConfig } from "@/hooks/use-book-config"
+import { useBookConfig, useUpdateBookConfig } from "@/hooks/use-book-config"
 import { usePersistConfig } from "@/hooks/use-persist-config"
 import { SpeechPreview } from "./components/SpeechPreview"
 
-type ProviderKey = "openai" | "azure" | "gemini"
+type ProviderKey = "openai" | "anthropic" | "azure" | "gemini"
 
 const PROVIDER_LABELS: Record<ProviderKey, MessageDescriptor> = {
   openai: msg`OpenAI`,
+  anthropic: msg`Anthropic`,
   azure: msg`Azure`,
   gemini: msg`Gemini`,
 }
 
 const PROVIDER_HINTS: Record<ProviderKey, MessageDescriptor> = {
   openai: msg`Natural, expressive voices. Best general-purpose default.`,
+  anthropic: msg`Anthropic is available for text models, but not speech synthesis.`,
   azure: msg`Wide multilingual coverage with neural voices for many locales.`,
   gemini: msg`Google's voices with strong intonation for narrative content.`,
 }
@@ -43,7 +45,8 @@ export function SpeechLandingPage({ bookLabel }: { bookLabel: string }) {
   const { data: bookConfigData } = useBookConfig(bookLabel)
   const { data: activeConfigData } = useActiveConfig(bookLabel)
   const persist = usePersistConfig(bookLabel)
-  const { apiKey, hasApiKey, hasAzureKey, hasGeminiKey } = useApiKey()
+  const updateConfig = useUpdateBookConfig()
+  const { apiKey, hasOpenAIKey, hasAzureKey, hasGeminiKey } = useApiKey()
   const { queueRun } = useBookRun()
   const status = useStageStatus("speech")
   const translateStatus = useStageStatus("translate")
@@ -51,6 +54,14 @@ export function SpeechLandingPage({ bookLabel }: { bookLabel: string }) {
 
   const [wordHighlighting, setWordHighlighting] = useState(false)
   const [provider, setProvider] = useState<ProviderKey>("openai")
+  const providerKeyAvailable: Record<ProviderKey, boolean> = {
+    openai: hasOpenAIKey,
+    anthropic: false,
+    azure: hasAzureKey,
+    gemini: hasGeminiKey,
+  }
+  const firstAvailableSpeechProvider: ProviderKey =
+    hasOpenAIKey ? "openai" : hasAzureKey ? "azure" : hasGeminiKey ? "gemini" : "openai"
 
   useEffect(() => {
     if (!activeConfigData) return
@@ -61,12 +72,15 @@ export function SpeechLandingPage({ bookLabel }: { bookLabel: string }) {
     }
     if (
       speech.default_provider === "openai" ||
+      speech.default_provider === "anthropic" ||
       speech.default_provider === "azure" ||
       speech.default_provider === "gemini"
     ) {
       setProvider(speech.default_provider)
+    } else {
+      setProvider(firstAvailableSpeechProvider)
     }
-  }, [activeConfigData])
+  }, [activeConfigData, firstAvailableSpeechProvider])
 
   const persistSpeech = (patch: Record<string, unknown>) => {
     const existing = (bookConfigData?.config?.speech ?? {}) as Record<
@@ -86,26 +100,41 @@ export function SpeechLandingPage({ bookLabel }: { bookLabel: string }) {
     persistSpeech({ default_provider: value })
   }
 
-  const handleRun = () => {
-    if (!hasApiKey || !translateReady || status.isRunning) return
+  const handleRun = async () => {
+    if (!providerKeyAvailable[provider] || !translateReady || status.isRunning) return
+    const base = bookConfigData?.config ?? {}
+    const existingSpeech = (base.speech ?? {}) as Record<string, unknown>
+    if (existingSpeech.default_provider !== provider) {
+      await updateConfig.mutateAsync({
+        label: bookLabel,
+        config: {
+          ...base,
+          speech: {
+            ...existingSpeech,
+            default_provider: provider,
+          },
+        },
+      })
+    }
     queueRun({ fromStage: "speech", toStage: "speech", apiKey, viewAfter: true })
-  }
-
-  const providerKeyAvailable: Record<ProviderKey, boolean> = {
-    openai: hasApiKey,
-    azure: hasAzureKey,
-    gemini: hasGeminiKey,
   }
 
   const providerOptions = useMemo(
     () => {
       const disabledHint = t`Add this provider's API key in Book settings.`
+      const unsupportedHint = t`Anthropic is available for text models, but not speech synthesis.`
       return [
         {
           value: "openai" as const,
           label: linguiI18n._(PROVIDER_LABELS.openai),
-          disabled: !hasApiKey,
+          disabled: !hasOpenAIKey,
           disabledHint,
+        },
+        {
+          value: "anthropic" as const,
+          label: linguiI18n._(PROVIDER_LABELS.anthropic),
+          disabled: true,
+          disabledHint: unsupportedHint,
         },
         {
           value: "azure" as const,
@@ -121,15 +150,16 @@ export function SpeechLandingPage({ bookLabel }: { bookLabel: string }) {
         },
       ]
     },
-    [t, hasApiKey, hasAzureKey, hasGeminiKey],
+    [t, hasOpenAIKey, hasAzureKey, hasGeminiKey],
   )
 
   const selectedProviderKeyMissing = !providerKeyAvailable[provider]
+  const selectedProviderUnsupported = provider === "anthropic"
 
   const disabledProviderLabels = useMemo(
     () =>
       providerOptions
-        .filter((o) => o.disabled)
+        .filter((o) => o.disabled && o.value !== "anthropic")
         .map((o) => o.label),
     [providerOptions],
   )
@@ -151,8 +181,11 @@ export function SpeechLandingPage({ bookLabel }: { bookLabel: string }) {
     [t],
   )
 
-  const disabledReason = !hasApiKey ? (
-    <Trans>Add an API key in Book settings to run speech.</Trans>
+  const hasSpeechProviderKey = hasOpenAIKey || hasAzureKey || hasGeminiKey
+  const disabledReason = selectedProviderUnsupported ? (
+    <Trans>Anthropic is available for text models, but not speech synthesis.</Trans>
+  ) : !hasSpeechProviderKey ? (
+    <Trans>Add a speech provider API key in Book settings to run speech.</Trans>
   ) : selectedProviderKeyMissing ? (
     <Trans>Add the selected provider's API key in Book settings to run speech.</Trans>
   ) : !translateReady ? (
@@ -171,7 +204,7 @@ export function SpeechLandingPage({ bookLabel }: { bookLabel: string }) {
       isCompleted={status.isCompleted}
       hasError={status.hasError}
       canRun={true}
-      extraDisabled={!hasApiKey || selectedProviderKeyMissing || !translateReady}
+      extraDisabled={!hasSpeechProviderKey || selectedProviderKeyMissing || !translateReady}
       disabledReason={disabledReason}
       runLabel={<Trans>Run Speech</Trans>}
       rerunLabel={<Trans>Re-run</Trans>}
@@ -207,7 +240,9 @@ export function SpeechLandingPage({ bookLabel }: { bookLabel: string }) {
         <SettingsField
           label={<Trans>Provider</Trans>}
           hint={
-            selectedProviderKeyMissing ? (
+            selectedProviderUnsupported ? (
+              linguiI18n._(PROVIDER_HINTS.anthropic)
+            ) : selectedProviderKeyMissing ? (
               <Trans>
                 No API key for {linguiI18n._(PROVIDER_LABELS[provider])} yet.
                 Add one in Book settings to enable this provider.
@@ -242,6 +277,20 @@ export function SpeechLandingPage({ bookLabel }: { bookLabel: string }) {
                       in Book settings to enable them.
                     </Trans>
                   )}
+                </span>
+              </div>
+            )}
+            {!hasSpeechProviderKey && (
+              <div className="flex items-start gap-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-[11.5px] text-blue-800">
+                <AlertCircle
+                  className="mt-0.5 h-3.5 w-3.5 shrink-0 text-blue-600"
+                  strokeWidth={2}
+                  aria-hidden
+                />
+                <span>
+                  <Trans>
+                    Anthropic does not offer a text-to-speech API. Add an OpenAI, Gemini, or Azure key to generate audio narration.
+                  </Trans>
                 </span>
               </div>
             )}

--- a/apps/studio/src/components/pipeline/stages/speech/SpeechLandingPage.tsx
+++ b/apps/studio/src/components/pipeline/stages/speech/SpeechLandingPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from "react"
+import { useState, useEffect, useMemo, useRef } from "react"
 import { AlertCircle, Pencil, Settings2 } from "lucide-react"
 import { Link } from "@tanstack/react-router"
 import { Trans, useLingui } from "@lingui/react/macro"
@@ -63,6 +63,8 @@ export function SpeechLandingPage({ bookLabel }: { bookLabel: string }) {
   const firstAvailableSpeechProvider: ProviderKey =
     hasOpenAIKey ? "openai" : hasAzureKey ? "azure" : hasGeminiKey ? "gemini" : "openai"
 
+  const providerInitRef = useRef(false)
+
   useEffect(() => {
     if (!activeConfigData) return
     const m = activeConfigData.merged as Record<string, unknown>
@@ -77,8 +79,10 @@ export function SpeechLandingPage({ bookLabel }: { bookLabel: string }) {
       speech.default_provider === "gemini"
     ) {
       setProvider(speech.default_provider)
-    } else {
+      providerInitRef.current = true
+    } else if (!providerInitRef.current) {
       setProvider(firstAvailableSpeechProvider)
+      providerInitRef.current = true
     }
   }, [activeConfigData, firstAvailableSpeechProvider])
 
@@ -101,20 +105,24 @@ export function SpeechLandingPage({ bookLabel }: { bookLabel: string }) {
   }
 
   const handleRun = async () => {
-    if (!providerKeyAvailable[provider] || !translateReady || status.isRunning) return
+    if (!providerKeyAvailable[provider] || !translateReady || status.isRunning || updateConfig.isPending) return
     const base = bookConfigData?.config ?? {}
     const existingSpeech = (base.speech ?? {}) as Record<string, unknown>
     if (existingSpeech.default_provider !== provider) {
-      await updateConfig.mutateAsync({
-        label: bookLabel,
-        config: {
-          ...base,
-          speech: {
-            ...existingSpeech,
-            default_provider: provider,
+      try {
+        await updateConfig.mutateAsync({
+          label: bookLabel,
+          config: {
+            ...base,
+            speech: {
+              ...existingSpeech,
+              default_provider: provider,
+            },
           },
-        },
-      })
+        })
+      } catch {
+        return
+      }
     }
     queueRun({ fromStage: "speech", toStage: "speech", apiKey, viewAfter: true })
   }

--- a/apps/studio/src/components/pipeline/stages/storyboard/StoryboardSettings.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/StoryboardSettings.tsx
@@ -136,7 +136,17 @@ export function StoryboardSettings({ bookLabel, tab = "general" }: { bookLabel: 
   const { data: bookConfigData } = useBookConfig(bookLabel)
   const { data: activeConfigData } = useActiveConfig(bookLabel)
   const updateConfig = useUpdateBookConfig()
-  const { apiKey, hasApiKey } = useApiKey()
+  const { apiKey, hasApiKey, defaultModel, hasOpenAIKey, hasAnthropicKey, hasGoogleKey, hasCustomProvider } = useApiKey()
+  const effectiveModel = (configuredModel?: string, isOverride = false) => {
+    if (!configuredModel || !isOverride) return defaultModel ?? configuredModel ?? ""
+    const provider = configuredModel.includes(":") ? configuredModel.slice(0, configuredModel.indexOf(":")) : "openai"
+    const available =
+      (provider === "openai" && hasOpenAIKey) ||
+      (provider === "anthropic" && hasAnthropicKey) ||
+      (provider === "google" && hasGoogleKey) ||
+      (provider === "custom" && hasCustomProvider)
+    return available ? configuredModel : (defaultModel ?? configuredModel)
+  }
 
   // Form state
   const [defaultRenderStrategy, setDefaultRenderStrategy] = useState("")
@@ -166,17 +176,18 @@ export function StoryboardSettings({ bookLabel, tab = "general" }: { bookLabel: 
 
   // Derive activity strategies directly from merged config (synchronous)
   const activityStrategies = useMemo(() => {
-    if (!activeConfigData) return {} as Record<string, { prompt: string; answer_prompt?: string; model?: string; max_retries?: number }>
+    if (!activeConfigData) return {} as Record<string, { prompt: string; answer_prompt?: string; model?: string; model_override?: boolean; max_retries?: number }>
     const merged = activeConfigData.merged as Record<string, unknown>
-    const strategies = merged.render_strategies as Record<string, { render_type?: string; config?: { prompt?: string; answer_prompt?: string; model?: string; max_retries?: number } }> | undefined
-    if (!strategies || typeof strategies !== "object") return {} as Record<string, { prompt: string; answer_prompt?: string; model?: string; max_retries?: number }>
-    const activityMap: Record<string, { prompt: string; answer_prompt?: string; model?: string; max_retries?: number }> = {}
+    const strategies = merged.render_strategies as Record<string, { render_type?: string; config?: { prompt?: string; answer_prompt?: string; model?: string; model_override?: boolean; max_retries?: number } }> | undefined
+    if (!strategies || typeof strategies !== "object") return {} as Record<string, { prompt: string; answer_prompt?: string; model?: string; model_override?: boolean; max_retries?: number }>
+    const activityMap: Record<string, { prompt: string; answer_prompt?: string; model?: string; model_override?: boolean; max_retries?: number }> = {}
     for (const [name, strat] of Object.entries(strategies)) {
       if (strat.render_type === "activity" && strat.config?.prompt) {
         activityMap[name] = {
           prompt: strat.config.prompt,
           answer_prompt: strat.config.answer_prompt,
           model: strat.config.model,
+          model_override: strat.config.model_override,
           max_retries: strat.config.max_retries,
         }
       }
@@ -265,7 +276,7 @@ export function StoryboardSettings({ bookLabel, tab = "general" }: { bookLabel: 
       merged.render_strategies && typeof merged.render_strategies === "object"
         ? merged.render_strategies
         : {}
-    ) as Record<string, { render_type?: string; config?: { prompt?: string; answer_prompt?: string; model?: string; template?: string; temperature?: number; max_retries?: number } }>
+    ) as Record<string, { render_type?: string; config?: { prompt?: string; answer_prompt?: string; model?: string; model_override?: boolean; template?: string; temperature?: number; max_retries?: number } }>
     const normalizedDefaultRenderStrategy = normalizeDefaultRenderStrategy(
       typeof merged.default_render_strategy === "string"
         ? String(merged.default_render_strategy)
@@ -286,8 +297,9 @@ export function StoryboardSettings({ bookLabel, tab = "general" }: { bookLabel: 
       : undefined
     if (defaultStrategy?.render_type) setRenderingRenderType(defaultStrategy.render_type)
     else setRenderingRenderType("")
-    if (defaultStrategy?.config?.model) setRenderingModel(String(defaultStrategy.config.model))
-    else setRenderingModel("")
+    if (defaultStrategy?.config?.model) {
+      setRenderingModel(effectiveModel(String(defaultStrategy.config.model), defaultStrategy.config.model_override === true))
+    } else setRenderingModel(defaultModel ?? "")
     if (defaultStrategy?.config?.prompt) setRenderingPromptName(String(defaultStrategy.config.prompt))
     else setRenderingPromptName("")
     if (defaultStrategy?.config?.template) {
@@ -306,7 +318,7 @@ export function StoryboardSettings({ bookLabel, tab = "general" }: { bookLabel: 
     setVisualReviewMaxIterations(
       typeof merged.visual_review_max_iterations === "number" ? String(merged.visual_review_max_iterations) : ""
     )
-  }, [activeConfigData])
+  }, [activeConfigData, defaultModel, hasOpenAIKey, hasAnthropicKey, hasGoogleKey, hasCustomProvider])
 
   // Helper: only write a field if the user changed it or the book config already had it
   const shouldWrite = (field: string) =>
@@ -347,11 +359,15 @@ export function StoryboardSettings({ bookLabel, tab = "general" }: { bookLabel: 
         : undefined
     }
     // Write rendering temperature / retries into the default render strategy config
-    if ((shouldWrite("rendering_temperature") || shouldWrite("rendering_retries")) && defaultRenderStrategy) {
+    if ((shouldWrite("rendering_model") || shouldWrite("rendering_temperature") || shouldWrite("rendering_retries")) && defaultRenderStrategy) {
       const existingStrategies = (overrides.render_strategies ?? merged?.render_strategies ?? {}) as Record<string, Record<string, unknown>>
       const stratCopy = JSON.parse(JSON.stringify(existingStrategies)) as Record<string, Record<string, unknown>>
       if (stratCopy[defaultRenderStrategy]) {
         const cfg = (stratCopy[defaultRenderStrategy].config ?? {}) as Record<string, unknown>
+        if (shouldWrite("rendering_model")) {
+          cfg.model = renderingModel.trim() || undefined
+          cfg.model_override = true
+        }
         if (shouldWrite("rendering_temperature")) cfg.temperature = renderingTemperature.trim() ? Number(renderingTemperature) : undefined
         if (shouldWrite("rendering_retries")) cfg.max_retries = renderingRetries.trim() ? Number(renderingRetries) : undefined
         stratCopy[defaultRenderStrategy].config = cfg
@@ -366,7 +382,10 @@ export function StoryboardSettings({ bookLabel, tab = "general" }: { bookLabel: 
       const stratCopy = overrides.render_strategies as Record<string, Record<string, unknown>>
       if (stratCopy[activityStrategyName]) {
         const cfg = (stratCopy[activityStrategyName].config ?? {}) as Record<string, unknown>
-        if (shouldWrite("activity_model")) cfg.model = activityModel.trim() || undefined
+        if (shouldWrite("activity_model")) {
+          cfg.model = activityModel.trim() || undefined
+          cfg.model_override = true
+        }
         if (shouldWrite("activity_retries")) cfg.max_retries = activityRetries.trim() ? Number(activityRetries) : undefined
         stratCopy[activityStrategyName].config = cfg
       }
@@ -435,7 +454,10 @@ export function StoryboardSettings({ bookLabel, tab = "general" }: { bookLabel: 
               if (strat) {
                 if (strat.render_type) setRenderingRenderType(strat.render_type)
                 if (strat.config?.prompt) setRenderingPromptName(strat.config.prompt)
-                if (strat.config?.model) setRenderingModel(strat.config.model)
+                if (strat.config?.model) {
+                  const cfg = strat.config as { model?: string; model_override?: boolean }
+                  setRenderingModel(effectiveModel(cfg.model, cfg.model_override === true))
+                }
                 if (strat.config?.template) {
                   setRenderingTemplateName(strat.config.template)
                   setTemplateTabName(strat.config.template)
@@ -691,7 +713,7 @@ export function StoryboardSettings({ bookLabel, tab = "general" }: { bookLabel: 
                 setActivityStrategyName(name)
                 setActivityPromptDraft(null)
                 setActivityAnswerDraft(null)
-                setActivityModel(name ? (activityStrategies[name]?.model ?? "") : "")
+                setActivityModel(name ? effectiveModel(activityStrategies[name]?.model, activityStrategies[name]?.model_override === true) : "")
                 setActivityRetries(name && activityStrategies[name]?.max_retries != null ? String(activityStrategies[name].max_retries) : "")
               }}
             >

--- a/apps/studio/src/components/settings/ApiKeyDialog.tsx
+++ b/apps/studio/src/components/settings/ApiKeyDialog.tsx
@@ -14,8 +14,10 @@ import { Label } from "@/components/ui/label"
 import { cn } from "@/lib/utils"
 import { Trans } from "@lingui/react/macro"
 import { useLingui } from "@lingui/react/macro"
+import { ModelSelect, LLM_MODEL_GROUPS } from "@/components/pipeline/components/ModelSelect"
 
 type TabKey = "openai" | "anthropic" | "google" | "custom" | "azure"
+type TextProviderKey = "openai" | "anthropic" | "google" | "custom"
 
 interface ApiKeyDialogProps {
   open: boolean
@@ -34,11 +36,15 @@ interface ApiKeyDialogProps {
   onSaveAzureKey: (key: string) => void
   azureRegion: string
   onSaveAzureRegion: (region: string) => void
+  providerDefaultModels: Record<TextProviderKey, string>
+  onSaveProviderDefaultModel: (provider: TextProviderKey, model: string) => void
 }
 
 function isValidOpenAIKey(key: string): boolean {
   return key.trim().length > 0 && key.trim().startsWith("sk-")
 }
+
+const TEXT_PROVIDER_ORDER: TextProviderKey[] = ["openai", "anthropic", "google", "custom"]
 
 export function ApiKeyDialog({
   open,
@@ -57,6 +63,8 @@ export function ApiKeyDialog({
   onSaveAzureKey,
   azureRegion,
   onSaveAzureRegion,
+  providerDefaultModels,
+  onSaveProviderDefaultModel,
 }: ApiKeyDialogProps) {
   const { t } = useLingui()
   const [tab, setTab] = useState<TabKey>("openai")
@@ -68,6 +76,14 @@ export function ApiKeyDialog({
   const [azureKeyDraft, setAzureKeyDraft] = useState(azureKey)
   const [azureRegionDraft, setAzureRegionDraft] = useState(azureRegion)
   const [showKey, setShowKey] = useState(false)
+  const [defaultModelDrafts, setDefaultModelDrafts] = useState(providerDefaultModels)
+  const [activeProviderDraft, setActiveProviderDraft] = useState(() => {
+    try {
+      return localStorage.getItem("adt-studio-active-provider") ?? ""
+    } catch {
+      return ""
+    }
+  })
   const prevOpenRef = useRef(false)
 
   const tabs = [
@@ -89,9 +105,28 @@ export function ApiKeyDialog({
       setAzureKeyDraft(azureKey)
       setAzureRegionDraft(azureRegion)
       setShowKey(false)
+      setDefaultModelDrafts(providerDefaultModels)
+      try {
+        setActiveProviderDraft(localStorage.getItem("adt-studio-active-provider") ?? "")
+      } catch {
+        setActiveProviderDraft("")
+      }
     }
     prevOpenRef.current = open
   }, [open, apiKey, anthropicKey, googleKey, customBaseUrl, customApiKey, azureKey, azureRegion])
+
+  const draftConfiguredProviders: Record<TextProviderKey, boolean> = {
+    openai: isValidOpenAIKey(openaiDraft),
+    anthropic: anthropicDraft.trim().length > 0,
+    google: googleDraft.trim().length > 0,
+    custom: customBaseUrlDraft.trim().length > 0,
+  }
+
+  // Count only the current drafts. If a user clears OpenAI, it should stop
+  // acting configured immediately instead of falling back to the saved prop.
+  const configuredProviderCount = TEXT_PROVIDER_ORDER
+    .filter((provider) => draftConfiguredProviders[provider])
+    .length
 
   function handleSave() {
     // Save all tabs — not just the active one
@@ -104,11 +139,36 @@ export function ApiKeyDialog({
     onSaveCustomApiKey(customApiKeyDraft.trim())
     onSaveAzureKey(azureKeyDraft.trim())
     onSaveAzureRegion(azureRegionDraft.trim())
+    for (const provider of TEXT_PROVIDER_ORDER) {
+      onSaveProviderDefaultModel(provider, defaultModelDrafts[provider].trim())
+    }
+
+    // Save the active provider preference only if that provider is configured.
+    // Otherwise fall back to the first configured provider in the same order
+    // used by the rest of the app.
+    const resolvedActiveProvider =
+      activeProviderDraft && draftConfiguredProviders[activeProviderDraft as TextProviderKey]
+        ? activeProviderDraft
+        : (TEXT_PROVIDER_ORDER.find((provider) => draftConfiguredProviders[provider]) ?? "")
+
+    try {
+      if (resolvedActiveProvider) {
+        localStorage.setItem("adt-studio-active-provider", resolvedActiveProvider)
+      } else {
+        localStorage.removeItem("adt-studio-active-provider")
+      }
+      window.dispatchEvent(new CustomEvent("adt:api-setting-changed", {
+        detail: { key: "adt-studio-active-provider", value: resolvedActiveProvider },
+      }))
+    } catch {
+      // localStorage unavailable
+    }
 
     onOpenChange(false)
   }
 
   // Check if there are any meaningful changes to save
+  const savedActiveProvider = (() => { try { return localStorage.getItem("adt-studio-active-provider") ?? "" } catch { return "" } })()
   const hasChanges =
     openaiDraft.trim() !== apiKey.trim() ||
     anthropicDraft.trim() !== anthropicKey.trim() ||
@@ -117,6 +177,8 @@ export function ApiKeyDialog({
     customApiKeyDraft.trim() !== customApiKey.trim() ||
     azureKeyDraft.trim() !== azureKey.trim() ||
     azureRegionDraft.trim() !== azureRegion.trim()
+    || Object.entries(defaultModelDrafts).some(([provider, model]) => model.trim() !== providerDefaultModels[provider as keyof typeof providerDefaultModels].trim())
+    || activeProviderDraft !== savedActiveProvider
 
   // Validate the OpenAI key if it was changed to a non-empty value
   const openaiValid = openaiDraft.trim() === "" || openaiDraft.trim() === apiKey.trim() || isValidOpenAIKey(openaiDraft)
@@ -140,6 +202,11 @@ export function ApiKeyDialog({
                   : item.key === "google" ? googleKey.length > 0
                     : item.key === "custom" ? customBaseUrl.length > 0
                       : azureKey.length > 0
+            const isDefault =
+              item.key !== "azure" &&
+              draftConfiguredProviders[item.key] &&
+              activeProviderDraft === item.key &&
+              configuredProviderCount > 1
             return (
               <button
                 key={item.key}
@@ -153,6 +220,9 @@ export function ApiKeyDialog({
               >
                 {item.label}
                 {isSaved && <Check className="h-3 w-3 text-green-500" />}
+                {isDefault && (
+                  <span className="rounded bg-green-100 px-1 py-px text-[10px] font-medium text-green-700">✦</span>
+                )}
               </button>
             )
           })}
@@ -160,9 +230,27 @@ export function ApiKeyDialog({
 
         {tab === "openai" && (
           <div className="space-y-2">
-            <Label htmlFor="openai-key-input">
-              <Trans>OpenAI API Key</Trans>
-            </Label>
+            <div className="flex items-center justify-between">
+              <Label htmlFor="openai-key-input">
+                <Trans>OpenAI API Key</Trans>
+              </Label>
+              {configuredProviderCount > 1 && (
+                activeProviderDraft === "openai" ? (
+                  <span className="inline-flex items-center gap-1 rounded bg-green-100 px-1.5 py-0.5 text-[11px] font-medium text-green-700">
+                    <Check className="h-3 w-3" />
+                    <Trans>default</Trans>
+                  </span>
+                ) : draftConfiguredProviders.openai ? (
+                  <button
+                    type="button"
+                    onClick={() => setActiveProviderDraft("openai")}
+                    className="rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors"
+                  >
+                    <Trans>Mark as default</Trans>
+                  </button>
+                ) : null
+              )}
+            </div>
             <div className="relative">
               <Input
                 id="openai-key-input"
@@ -194,9 +282,27 @@ export function ApiKeyDialog({
 
         {tab === "anthropic" && (
           <div className="space-y-2">
-            <Label htmlFor="anthropic-key-input">
-              <Trans>Anthropic API Key</Trans>
-            </Label>
+            <div className="flex items-center justify-between">
+              <Label htmlFor="anthropic-key-input">
+                <Trans>Anthropic API Key</Trans>
+              </Label>
+              {configuredProviderCount > 1 && (
+                activeProviderDraft === "anthropic" ? (
+                  <span className="inline-flex items-center gap-1 rounded bg-green-100 px-1.5 py-0.5 text-[11px] font-medium text-green-700">
+                    <Check className="h-3 w-3" />
+                    <Trans>default</Trans>
+                  </span>
+                ) : draftConfiguredProviders.anthropic ? (
+                  <button
+                    type="button"
+                    onClick={() => setActiveProviderDraft("anthropic")}
+                    className="rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors"
+                  >
+                    <Trans>Mark as default</Trans>
+                  </button>
+                ) : null
+              )}
+            </div>
             <div className="relative">
               <Input
                 id="anthropic-key-input"
@@ -228,9 +334,27 @@ export function ApiKeyDialog({
 
         {tab === "google" && (
           <div className="space-y-2">
-            <Label htmlFor="google-key-input">
-              <Trans>Google AI API Key</Trans>
-            </Label>
+            <div className="flex items-center justify-between">
+              <Label htmlFor="google-key-input">
+                <Trans>Google AI API Key</Trans>
+              </Label>
+              {configuredProviderCount > 1 && (
+                activeProviderDraft === "google" ? (
+                  <span className="inline-flex items-center gap-1 rounded bg-green-100 px-1.5 py-0.5 text-[11px] font-medium text-green-700">
+                    <Check className="h-3 w-3" />
+                    <Trans>default</Trans>
+                  </span>
+                ) : draftConfiguredProviders.google ? (
+                  <button
+                    type="button"
+                    onClick={() => setActiveProviderDraft("google")}
+                    className="rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors"
+                  >
+                    <Trans>Mark as default</Trans>
+                  </button>
+                ) : null
+              )}
+            </div>
             <div className="relative">
               <Input
                 id="google-key-input"
@@ -263,9 +387,27 @@ export function ApiKeyDialog({
         {tab === "custom" && (
           <div className="space-y-3">
             <div className="space-y-2">
-              <Label htmlFor="custom-base-url-input">
-                <Trans>Base URL</Trans>
-              </Label>
+              <div className="flex items-center justify-between">
+                <Label htmlFor="custom-base-url-input">
+                  <Trans>Base URL</Trans>
+                </Label>
+                {configuredProviderCount > 1 && (
+                  activeProviderDraft === "custom" ? (
+                    <span className="inline-flex items-center gap-1 rounded bg-green-100 px-1.5 py-0.5 text-[11px] font-medium text-green-700">
+                      <Check className="h-3 w-3" />
+                      <Trans>default</Trans>
+                    </span>
+                  ) : draftConfiguredProviders.custom ? (
+                    <button
+                      type="button"
+                      onClick={() => setActiveProviderDraft("custom")}
+                      className="rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors"
+                    >
+                      <Trans>Mark as default</Trans>
+                    </button>
+                  ) : null
+                )}
+              </div>
               <Input
                 id="custom-base-url-input"
                 placeholder={t`e.g. http://localhost:11434/v1`}
@@ -353,6 +495,19 @@ export function ApiKeyDialog({
             </p>
           </div>
         )}
+
+        {tab !== "azure" && tab !== "custom" && <div className="space-y-2 rounded-md border p-3">
+          <Label><Trans>Default AI model</Trans></Label>
+          <ModelSelect
+            value={defaultModelDrafts[tab]}
+            onChange={(model) => setDefaultModelDrafts((current) => ({ ...current, [tab]: model }))}
+            groups={LLM_MODEL_GROUPS.filter((group) => group.provider === tab)}
+            placeholder={t`Provider default model`}
+          />
+          <p className="text-xs text-muted-foreground">
+            <Trans>Used by default when this provider's API key is selected.</Trans>
+          </p>
+        </div>}
 
         <DialogFooter>
           <Button variant="outline" onClick={() => onOpenChange(false)}>

--- a/apps/studio/src/components/settings/ApiKeyDialog.tsx
+++ b/apps/studio/src/components/settings/ApiKeyDialog.tsx
@@ -496,7 +496,7 @@ export function ApiKeyDialog({
           </div>
         )}
 
-        {tab !== "azure" && tab !== "custom" && <div className="space-y-2 rounded-md border p-3">
+        {tab !== "azure" && <div className="space-y-2 rounded-md border p-3">
           <Label><Trans>Default AI model</Trans></Label>
           <ModelSelect
             value={defaultModelDrafts[tab]}

--- a/apps/studio/src/hooks/use-active-provider.ts
+++ b/apps/studio/src/hooks/use-active-provider.ts
@@ -1,0 +1,206 @@
+import { useState, useCallback, useEffect, useMemo } from "react"
+import { msg } from "@lingui/core/macro"
+import type { MessageDescriptor } from "@lingui/core"
+import { useLingui } from "@lingui/react"
+import { useApiKey } from "./use-api-key"
+
+// --- Types ---
+
+export type ProviderType = "openai" | "anthropic" | "google" | "custom"
+
+export interface ProviderInfo {
+  type: ProviderType
+  label: string
+  model: string
+  configured: boolean
+}
+
+export interface ActiveProviderState {
+  /** The currently active provider (null if none configured) */
+  activeProvider: ProviderInfo | null
+  /** All known providers with their configuration status */
+  allProviders: ProviderInfo[]
+  /** Only providers with valid credentials */
+  configuredProviders: ProviderInfo[]
+  /** Set the active provider (persists to localStorage) */
+  setActiveProvider: (type: ProviderType) => void
+  /** Whether multiple providers are configured (controls dropdown vs static display) */
+  hasMultipleProviders: boolean
+}
+
+// --- Constants ---
+
+export const PROVIDER_PRIORITY: ProviderType[] = ["openai", "anthropic", "google", "custom"]
+
+export const PROVIDER_LABELS: Record<ProviderType, MessageDescriptor> = {
+  openai: msg`OpenAI`,
+  anthropic: msg`Anthropic`,
+  google: msg`Google`,
+  custom: msg`Custom`,
+}
+
+// --- Pure Resolution Function ---
+
+const STORAGE_KEY = "adt-studio-active-provider"
+const API_SETTING_CHANGED_EVENT = "adt:api-setting-changed"
+
+function readPersistedProvider(): ProviderType | "" {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored && PROVIDER_PRIORITY.includes(stored as ProviderType)) {
+      return stored as ProviderType
+    }
+    return ""
+  } catch {
+    return ""
+  }
+}
+
+/**
+ * Pure function that resolves the active provider given persisted choice,
+ * the set of currently configured providers, and the priority order.
+ *
+ * Algorithm:
+ * 1. If persisted is non-empty AND in configuredSet → return persisted
+ * 2. If persisted is non-empty AND NOT in configuredSet → return first in priority that is configured
+ * 3. For each provider in priority order: if configured → return it
+ * 4. Return null (no providers configured)
+ */
+export function resolveActiveProvider(
+  persisted: ProviderType | "" | null,
+  configuredSet: Set<ProviderType>,
+  priority: ProviderType[]
+): ProviderType | null {
+  // If persisted value is valid and still configured, use it
+  if (persisted && configuredSet.has(persisted)) {
+    return persisted
+  }
+
+  // Fall back to first configured provider in priority order
+  for (const provider of priority) {
+    if (configuredSet.has(provider)) {
+      return provider
+    }
+  }
+
+  // No providers configured
+  return null
+}
+
+// --- Hook ---
+
+export function useActiveProvider(): ActiveProviderState {
+  const { i18n } = useLingui()
+  const {
+    hasOpenAIKey,
+    hasAnthropicKey,
+    hasGoogleKey,
+    hasCustomProvider,
+    providerDefaultModels,
+  } = useApiKey()
+
+  // Read persisted value from localStorage
+  const [persisted, setPersistedState] = useState<ProviderType | "">(readPersistedProvider)
+
+  // Persist to localStorage
+  const setPersisted = useCallback((value: ProviderType | "") => {
+    setPersistedState(value)
+    try {
+      if (value) {
+        localStorage.setItem(STORAGE_KEY, value)
+      } else {
+        localStorage.removeItem(STORAGE_KEY)
+      }
+      window.dispatchEvent(new CustomEvent(API_SETTING_CHANGED_EVENT, {
+        detail: { key: STORAGE_KEY, value },
+      }))
+    } catch {
+      // localStorage unavailable — graceful degradation
+    }
+  }, [])
+
+  // Listen for credential changes via the adt:api-setting-changed event
+  // This forces a re-read of localStorage persisted value when credentials change
+  useEffect(() => {
+    const onSettingChanged = () => {
+      setPersistedState(readPersistedProvider())
+    }
+    window.addEventListener(API_SETTING_CHANGED_EVENT, onSettingChanged)
+    window.addEventListener("storage", onSettingChanged)
+    return () => {
+      window.removeEventListener(API_SETTING_CHANGED_EVENT, onSettingChanged)
+      window.removeEventListener("storage", onSettingChanged)
+    }
+  }, [])
+
+  // Build the configured set from useApiKey state
+  const configuredSet = useMemo(() => {
+    const set = new Set<ProviderType>()
+    if (hasOpenAIKey) set.add("openai")
+    if (hasAnthropicKey) set.add("anthropic")
+    if (hasGoogleKey) set.add("google")
+    if (hasCustomProvider) set.add("custom")
+    return set
+  }, [hasOpenAIKey, hasAnthropicKey, hasGoogleKey, hasCustomProvider])
+
+  // Resolve the active provider
+  const resolvedType = useMemo(
+    () => resolveActiveProvider(persisted, configuredSet, PROVIDER_PRIORITY),
+    [persisted, configuredSet]
+  )
+
+  // Property 3: If persisted value references an unconfigured provider, clear it
+  // and update to the resolved default
+  useEffect(() => {
+    if (persisted && !configuredSet.has(persisted)) {
+      // Persisted provider is no longer configured — clear stale value
+      setPersisted(resolvedType ?? "")
+    }
+  }, [persisted, configuredSet, resolvedType, setPersisted])
+
+  // Build allProviders list
+  const allProviders: ProviderInfo[] = useMemo(
+    () =>
+      PROVIDER_PRIORITY.map((type) => ({
+        type,
+        label: i18n._(PROVIDER_LABELS[type]),
+        model: providerDefaultModels[type],
+        configured: configuredSet.has(type),
+      })),
+    [configuredSet, i18n, providerDefaultModels]
+  )
+
+  // Build configuredProviders list
+  const configuredProviders = useMemo(
+    () => allProviders.filter((p) => p.configured),
+    [allProviders]
+  )
+
+  // Active provider info object
+  const activeProvider: ProviderInfo | null = useMemo(() => {
+    if (!resolvedType) return null
+    return allProviders.find((p) => p.type === resolvedType) ?? null
+  }, [resolvedType, allProviders])
+
+  // Property 4: Selection guard — reject unconfigured providers
+  const setActiveProvider = useCallback(
+    (type: ProviderType) => {
+      if (!configuredSet.has(type)) {
+        // Reject: provider is not configured
+        return
+      }
+      setPersisted(type)
+    },
+    [configuredSet, setPersisted]
+  )
+
+  const hasMultipleProviders = configuredProviders.length > 1
+
+  return {
+    activeProvider,
+    allProviders,
+    configuredProviders,
+    setActiveProvider,
+    hasMultipleProviders,
+  }
+}

--- a/apps/studio/src/hooks/use-active-provider.ts
+++ b/apps/studio/src/hooks/use-active-provider.ts
@@ -149,15 +149,6 @@ export function useActiveProvider(): ActiveProviderState {
     [persisted, configuredSet]
   )
 
-  // Property 3: If persisted value references an unconfigured provider, clear it
-  // and update to the resolved default
-  useEffect(() => {
-    if (persisted && !configuredSet.has(persisted)) {
-      // Persisted provider is no longer configured — clear stale value
-      setPersisted(resolvedType ?? "")
-    }
-  }, [persisted, configuredSet, resolvedType, setPersisted])
-
   // Build allProviders list
   const allProviders: ProviderInfo[] = useMemo(
     () =>

--- a/apps/studio/src/hooks/use-api-key.ts
+++ b/apps/studio/src/hooks/use-api-key.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react"
+import { useState, useCallback, useEffect } from "react"
 
 const STORAGE_KEY_OPENAI = "adt-studio-openai-key"
 const STORAGE_KEY_ANTHROPIC = "adt-studio-anthropic-key"
@@ -8,6 +8,21 @@ const STORAGE_KEY_CUSTOM_API_KEY = "adt-studio-custom-api-key"
 const STORAGE_KEY_AZURE = "adt-studio-azure-key"
 const STORAGE_KEY_AZURE_REGION = "adt-studio-azure-region"
 const STORAGE_KEY_GEMINI = "adt-studio-gemini-key"
+const STORAGE_KEY_OPENAI_MODEL = "adt-studio-openai-default-model"
+const STORAGE_KEY_ANTHROPIC_MODEL = "adt-studio-anthropic-default-model"
+const STORAGE_KEY_GOOGLE_MODEL = "adt-studio-google-default-model"
+const STORAGE_KEY_CUSTOM_MODEL = "adt-studio-custom-default-model"
+const API_SETTING_CHANGED_EVENT = "adt:api-setting-changed"
+const ACTIVE_PROVIDER_STORAGE_KEY = "adt-studio-active-provider"
+
+function hasValue(value: string): boolean {
+  return value.trim().length > 0
+}
+
+function isConfiguredOpenAIKey(value: string): boolean {
+  const trimmed = value.trim()
+  return trimmed.length > 0 && trimmed.startsWith("sk-")
+}
 
 function useLocalStorageState(key: string) {
   const [value, setValueState] = useState<string>(() => {
@@ -27,9 +42,31 @@ function useLocalStorageState(key: string) {
       } catch {
         // localStorage unavailable
       }
+      if (typeof window !== "undefined") {
+        window.dispatchEvent(new CustomEvent(API_SETTING_CHANGED_EVENT, {
+          detail: { key, value: v },
+        }))
+      }
     },
     [key]
   )
+
+  useEffect(() => {
+    const syncValue = (nextValue: string | null) => setValueState(nextValue ?? "")
+    const onStorage = (event: StorageEvent) => {
+      if (event.key === key) syncValue(event.newValue)
+    }
+    const onLocalChange = (event: Event) => {
+      const detail = (event as CustomEvent<{ key?: string; value?: string }>).detail
+      if (detail?.key === key) syncValue(detail.value ?? null)
+    }
+    window.addEventListener("storage", onStorage)
+    window.addEventListener(API_SETTING_CHANGED_EVENT, onLocalChange)
+    return () => {
+      window.removeEventListener("storage", onStorage)
+      window.removeEventListener(API_SETTING_CHANGED_EVENT, onLocalChange)
+    }
+  }, [key])
 
   return [value, setValue] as const
 }
@@ -46,22 +83,74 @@ export function useApiKey() {
   const [azureKey, setAzureKey] = useLocalStorageState(STORAGE_KEY_AZURE)
   const [azureRegion, setAzureRegion] = useLocalStorageState(STORAGE_KEY_AZURE_REGION)
   const [geminiKey, setGeminiKey] = useLocalStorageState(STORAGE_KEY_GEMINI)
+  const [openaiDefaultModel, setOpenaiDefaultModel] = useLocalStorageState(STORAGE_KEY_OPENAI_MODEL)
+  const [anthropicDefaultModel, setAnthropicDefaultModel] = useLocalStorageState(STORAGE_KEY_ANTHROPIC_MODEL)
+  const [googleDefaultModel, setGoogleDefaultModel] = useLocalStorageState(STORAGE_KEY_GOOGLE_MODEL)
+  const [customDefaultModel, setCustomDefaultModel] = useLocalStorageState(STORAGE_KEY_CUSTOM_MODEL)
+
+  const hasOpenAIKey = isConfiguredOpenAIKey(apiKey)
+  const hasAnthropicKey = hasValue(anthropicKey)
+  const hasGoogleKey = hasValue(googleKey)
+  const hasCustomProvider = hasValue(customBaseUrl)
+  const hasApiKey = hasOpenAIKey || hasAnthropicKey || hasGoogleKey || hasCustomProvider
+
+  // Read the user's active provider choice reactively
+  const [activeProviderChoice] = useLocalStorageState(ACTIVE_PROVIDER_STORAGE_KEY)
+
+  // Resolve default model: prefer the active provider's model, then fall back to priority order
+  const defaultModel = (() => {
+    const models: Record<string, string> = {
+      openai: openaiDefaultModel || "openai:gpt-5.4",
+      anthropic: anthropicDefaultModel || "anthropic:claude-sonnet-4-6",
+      google: googleDefaultModel || "google:gemini-2.5-pro",
+      custom: customDefaultModel || "custom:your-model-name",
+    }
+    const configured: Record<string, boolean> = {
+      openai: hasOpenAIKey,
+      anthropic: hasAnthropicKey,
+      google: hasGoogleKey,
+      custom: hasCustomProvider,
+    }
+    // If user explicitly chose a provider and it's still configured, use its model
+    if (activeProviderChoice && configured[activeProviderChoice]) {
+      return models[activeProviderChoice]
+    }
+    // Fall back to priority order
+    for (const p of ["openai", "anthropic", "google", "custom"]) {
+      if (configured[p]) return models[p]
+    }
+    return null
+  })()
 
   return {
     apiKey,
     setApiKey,
-    hasApiKey: apiKey.length > 0,
+    hasApiKey,
+    hasOpenAIKey,
+    defaultModel,
+    providerDefaultModels: {
+      openai: openaiDefaultModel || "openai:gpt-5.4",
+      anthropic: anthropicDefaultModel || "anthropic:claude-sonnet-4-6",
+      google: googleDefaultModel || "google:gemini-2.5-pro",
+      custom: customDefaultModel || "custom:your-model-name",
+    },
+    setProviderDefaultModel: (provider: "openai" | "anthropic" | "google" | "custom", model: string) => {
+      if (provider === "openai") setOpenaiDefaultModel(model)
+      else if (provider === "anthropic") setAnthropicDefaultModel(model)
+      else if (provider === "google") setGoogleDefaultModel(model)
+      else setCustomDefaultModel(model)
+    },
     anthropicKey,
     setAnthropicKey,
-    hasAnthropicKey: anthropicKey.length > 0,
+    hasAnthropicKey,
     googleKey,
     setGoogleKey,
-    hasGoogleKey: googleKey.length > 0,
+    hasGoogleKey,
     customBaseUrl,
     setCustomBaseUrl,
     customApiKey,
     setCustomApiKey,
-    hasCustomProvider: customBaseUrl.length > 0,
+    hasCustomProvider,
     azureKey,
     setAzureKey,
     hasAzureKey: azureKey.length > 0,

--- a/apps/studio/src/hooks/use-book-run.ts
+++ b/apps/studio/src/hooks/use-book-run.ts
@@ -23,24 +23,18 @@ import { useApiKey } from "./use-api-key"
 import { useBookConfig } from "./use-book-config"
 import { useActiveProvider, type ProviderType } from "./use-active-provider"
 
-function collectExplicitModelIds(value: unknown): string[] {
-  const models = new Set<string>()
-  const visit = (current: unknown) => {
-    if (!current || typeof current !== "object") return
-    if (Array.isArray(current)) {
-      current.forEach(visit)
-      return
-    }
-    const record = current as Record<string, unknown>
+function collectExplicitModelIds(value: unknown): Record<string, string> {
+  const models: Record<string, string> = {}
+  if (!value || typeof value !== "object" || Array.isArray(value)) return models
+  const root = value as Record<string, unknown>
+  for (const [key, section] of Object.entries(root)) {
+    if (!section || typeof section !== "object" || Array.isArray(section)) continue
+    const record = section as Record<string, unknown>
     if (record.model_override === true && typeof record.model === "string") {
-      models.add(record.model)
-    }
-    for (const child of Object.values(record)) {
-      visit(child)
+      models[key] = record.model
     }
   }
-  visit(value)
-  return [...models]
+  return models
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/studio/src/hooks/use-book-run.ts
+++ b/apps/studio/src/hooks/use-book-run.ts
@@ -20,6 +20,28 @@ import { getStageLabelI18n, getStageRunningLabelI18n } from "@/components/pipeli
 import { bookTasksKey } from "./use-book-tasks"
 import { invalidateStoryboardDependents } from "./use-page-mutations"
 import { useApiKey } from "./use-api-key"
+import { useBookConfig } from "./use-book-config"
+import { useActiveProvider, type ProviderType } from "./use-active-provider"
+
+function collectExplicitModelIds(value: unknown): string[] {
+  const models = new Set<string>()
+  const visit = (current: unknown) => {
+    if (!current || typeof current !== "object") return
+    if (Array.isArray(current)) {
+      current.forEach(visit)
+      return
+    }
+    const record = current as Record<string, unknown>
+    if (record.model_override === true && typeof record.model === "string") {
+      models.add(record.model)
+    }
+    for (const child of Object.values(record)) {
+      visit(child)
+    }
+  }
+  visit(value)
+  return [...models]
+}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -32,6 +54,13 @@ export interface StepProgress {
   page?: number
   totalPages?: number
   message?: string
+}
+
+/** Provider info captured at stage run initiation time for status display. */
+export interface RunProviderCapture {
+  providerName: string
+  providerType: ProviderType
+  modelId: string
 }
 
 export interface QueueRunOptions {
@@ -79,6 +108,8 @@ export interface BookRunContextValue {
   isStatusLoading: boolean
   /** Queue a stage run */
   queueRun(options: QueueRunOptions): void
+  /** Provider info captured at the most recent stage run initiation */
+  runProvider: RunProviderCapture | null
 }
 
 const BookRunContext = createContext<BookRunContextValue | null>(null)
@@ -102,7 +133,13 @@ const stepStatusKey = (label: string) => ["books", label, "step-status"] as cons
 
 export function useBookRunStatus(label: string): BookRunContextValue {
   const queryClient = useQueryClient()
-  const { anthropicKey, googleKey, customBaseUrl, customApiKey, azureKey, azureRegion, geminiKey } = useApiKey()
+  const { anthropicKey, googleKey, customBaseUrl, customApiKey, azureKey, azureRegion, geminiKey, defaultModel } = useApiKey()
+  const { activeProvider } = useActiveProvider()
+  const { data: bookConfigData } = useBookConfig(label)
+  const explicitModelIds = collectExplicitModelIds(bookConfigData?.config)
+
+  // Capture the active provider at run initiation time for stage run status display
+  const [runProvider, setRunProvider] = useState<RunProviderCapture | null>(null)
 
   // Screen-reader announcements for long-running jobs. Held in a ref so the
   // always-on SSE effect (keyed on [label, queryClient]) can announce without
@@ -435,6 +472,19 @@ export function useBookRunStatus(label: string): BookRunContextValue {
   const queueRun = useCallback(
     (options: QueueRunOptions) => {
       const { fromStage, toStage, apiKey, renderOnly, viewAfter } = options
+
+      // Capture active provider at run initiation time for stage run status display
+      if (activeProvider) {
+        setRunProvider({
+          providerName: activeProvider.label,
+          providerType: activeProvider.type,
+          modelId: activeProvider.model,
+        })
+      }
+
+      // Use the active provider's model as the default model for this run
+      const activeDefaultModelId = activeProvider?.model
+
       const providerCredentials: StageRunProviderCredentials = {
         anthropicApiKey: anthropicKey || undefined,
         googleApiKey: googleKey || undefined,
@@ -442,6 +492,8 @@ export function useBookRunStatus(label: string): BookRunContextValue {
         customApiKey: customApiKey || undefined,
         azure: { key: azureKey, region: azureRegion },
         geminiApiKey: geminiKey || undefined,
+        defaultModelId: activeDefaultModelId || defaultModel || undefined,
+        explicitModelIds,
         ...options.providerCredentials,
       }
 
@@ -554,7 +606,7 @@ export function useBookRunStatus(label: string): BookRunContextValue {
         }
       })
     },
-    [label, navigate, queryClient, anthropicKey, googleKey, customBaseUrl, customApiKey, azureKey, azureRegion, geminiKey]
+    [label, navigate, queryClient, anthropicKey, googleKey, customBaseUrl, customApiKey, azureKey, azureRegion, geminiKey, defaultModel, explicitModelIds, activeProvider]
   )
 
   // ------------------------------------------------------------------
@@ -607,6 +659,7 @@ export function useBookRunStatus(label: string): BookRunContextValue {
     isRunning,
     isStatusLoading: isPending,
     queueRun,
+    runProvider,
   }
 }
 

--- a/apps/studio/src/hooks/use-settings-dialog.ts
+++ b/apps/studio/src/hooks/use-settings-dialog.ts
@@ -1,0 +1,9 @@
+import { createContext, useContext } from "react"
+
+export const SettingsContext = createContext<{ openSettings: () => void }>({
+  openSettings: () => {},
+})
+
+export function useSettingsDialog() {
+  return useContext(SettingsContext)
+}

--- a/apps/studio/src/hooks/use-step-config.test.tsx
+++ b/apps/studio/src/hooks/use-step-config.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { renderHook, waitFor } from "@testing-library/react"
+import { useStepConfig } from "./use-step-config"
+import { useApiKey } from "./use-api-key"
+
+describe("useStepConfig model inheritance", () => {
+  beforeEach(() => localStorage.clear())
+
+  it.each([
+    "image_captioning",
+    "glossary",
+    "translation",
+    "toc_generation",
+  ])("uses the selected provider model for %s when there is no explicit override", async (configKey) => {
+    localStorage.setItem("adt-studio-anthropic-key", "test-key")
+    localStorage.setItem("adt-studio-anthropic-default-model", "anthropic:claude-haiku-4-5")
+
+    const { result } = renderHook(() => useStepConfig({
+      [configKey]: { model: "openai:gpt-5.4" },
+    }, configKey, vi.fn()))
+
+    await waitFor(() => {
+      expect(result.current.model).toBe("anthropic:claude-haiku-4-5")
+    })
+  })
+
+  it("ignores an unconfigured OpenAI key when choosing the default model", async () => {
+    localStorage.setItem("adt-studio-openai-key", "not-a-valid-openai-key")
+    localStorage.setItem("adt-studio-anthropic-key", "test-key")
+    localStorage.setItem("adt-studio-anthropic-default-model", "anthropic:claude-haiku-4-5")
+
+    const { result } = renderHook(() => useStepConfig({
+      glossary: { model: "openai:gpt-5.4" },
+    }, "glossary", vi.fn()))
+
+    await waitFor(() => {
+      expect(result.current.model).toBe("anthropic:claude-haiku-4-5")
+    })
+  })
+
+  it("uses a configured provider explicitly selected by the user", async () => {
+    localStorage.setItem("adt-studio-openai-key", "sk-test")
+    localStorage.setItem("adt-studio-anthropic-key", "test-key")
+    localStorage.setItem("adt-studio-active-provider", "anthropic")
+    localStorage.setItem("adt-studio-anthropic-default-model", "anthropic:claude-haiku-4-5")
+
+    const { result } = renderHook(() => useStepConfig({
+      glossary: { model: "openai:gpt-5.4" },
+    }, "glossary", vi.fn()))
+
+    await waitFor(() => {
+      expect(result.current.model).toBe("anthropic:claude-haiku-4-5")
+    })
+  })
+
+  it("preserves an explicit step override", async () => {
+    localStorage.setItem("adt-studio-anthropic-key", "test-key")
+
+    const { result } = renderHook(() => useStepConfig({
+      glossary: {
+        model: "anthropic:claude-opus-4-6",
+        model_override: true,
+      },
+    }, "glossary", vi.fn()))
+
+    await waitFor(() => {
+      expect(result.current.model).toBe("anthropic:claude-opus-4-6")
+    })
+  })
+
+  it("updates mounted settings when another hook changes the selected model", async () => {
+    localStorage.setItem("adt-studio-anthropic-key", "test-key")
+    const merged = { translation: { model: "openai:gpt-5.4" } }
+    const settings = renderHook(() => useStepConfig(merged, "translation", vi.fn()))
+    const apiSettings = renderHook(() => useApiKey())
+
+    apiSettings.result.current.setProviderDefaultModel(
+      "anthropic",
+      "anthropic:claude-haiku-4-5",
+    )
+
+    await waitFor(() => {
+      expect(settings.result.current.model).toBe("anthropic:claude-haiku-4-5")
+    })
+  })
+
+  it("does not replace a manual selection when merged config refreshes", async () => {
+    localStorage.setItem("adt-studio-anthropic-key", "test-key")
+    const markDirty = vi.fn()
+    const { result, rerender } = renderHook(
+      ({ merged }) => useStepConfig(merged, "glossary", markDirty),
+      { initialProps: { merged: { glossary: { model: "openai:gpt-5.4" } } } },
+    )
+
+    result.current.onModelChange("anthropic:claude-opus-4-6")
+    rerender({ merged: { glossary: { model: "openai:gpt-5.4" } } })
+
+    await waitFor(() => {
+      expect(result.current.model).toBe("anthropic:claude-opus-4-6")
+      expect(result.current.configOverrides.model_override).toBe(true)
+    })
+  })
+})

--- a/apps/studio/src/hooks/use-step-config.ts
+++ b/apps/studio/src/hooks/use-step-config.ts
@@ -1,5 +1,6 @@
-import { useState, useEffect } from "react"
+import { useState, useEffect, useRef } from "react"
 import { DEFAULT_LLM_MAX_RETRIES } from "@adt/types"
+import { useApiKey } from "@/hooks/use-api-key"
 
 const DEFAULT_MAX_RETRIES = String(DEFAULT_LLM_MAX_RETRIES)
 
@@ -18,32 +19,67 @@ export function useStepConfig(
   configKey: string,
   markDirty: (key: string) => void
 ) {
-  const [model, setModel] = useState("")
+  const { defaultModel, hasOpenAIKey, hasAnthropicKey, hasGoogleKey, hasCustomProvider } = useApiKey()
+  const [model, setModel] = useState(() => defaultModel ?? "")
+  const [modelOverride, setModelOverride] = useState(false)
   const [retries, setRetries] = useState("")
+  const modelTouchedRef = useRef(false)
+  const previousConfigKeyRef = useRef(configKey)
 
   useEffect(() => {
+    if (previousConfigKeyRef.current !== configKey) {
+      previousConfigKeyRef.current = configKey
+      modelTouchedRef.current = false
+    }
     // Reset when switching books/presets/keys so values don't bleed across contexts.
-    setModel("")
+    if (!modelTouchedRef.current) setModel(defaultModel ?? "")
+    if (!modelTouchedRef.current) setModelOverride(false)
     setRetries("")
 
     if (!mergedConfig) return
     const cfg = mergedConfig[configKey]
     if (cfg && typeof cfg === "object") {
       const c = cfg as Record<string, unknown>
-      if (c.model) setModel(String(c.model))
+      if (!modelTouchedRef.current) setModelOverride(c.model_override === true)
+      if (c.model) {
+        const configuredModel = String(c.model)
+        const provider = configuredModel.includes(":")
+          ? configuredModel.slice(0, configuredModel.indexOf(":"))
+          : "openai"
+        const providerAvailable =
+          (provider === "openai" && hasOpenAIKey) ||
+          (provider === "anthropic" && hasAnthropicKey) ||
+          (provider === "google" && hasGoogleKey) ||
+          (provider === "custom" && hasCustomProvider)
+        if (!modelTouchedRef.current) {
+          setModel(providerAvailable && c.model_override === true
+            ? configuredModel
+            : (defaultModel ?? configuredModel))
+        }
+      } else if (defaultModel) {
+        if (!modelTouchedRef.current) setModel(defaultModel)
+      }
       if (c.max_retries != null) setRetries(String(c.max_retries))
+    } else if (defaultModel) {
+      if (!modelTouchedRef.current) setModel(defaultModel)
     }
-  }, [mergedConfig, configKey])
+  }, [mergedConfig, configKey, defaultModel, hasOpenAIKey, hasAnthropicKey, hasGoogleKey, hasCustomProvider])
 
   return {
     model,
-    onModelChange: (v: string) => { setModel(v); markDirty(configKey) },
+    onModelChange: (v: string) => {
+      modelTouchedRef.current = true
+      setModel(v)
+      setModelOverride(true)
+      markDirty(configKey)
+    },
     // Show the effective default in the UI when config does not set one.
     maxRetries: retries || DEFAULT_MAX_RETRIES,
     onMaxRetriesChange: (v: string) => { setRetries(v); markDirty(configKey) },
     /** Spread into the config section object in buildOverrides */
     configOverrides: {
       model: model.trim() || undefined,
+      model_override: modelOverride || undefined,
       max_retries: retries.trim() ? Number(retries) : undefined,
     },
   }

--- a/apps/studio/src/hooks/use-step-config.ts
+++ b/apps/studio/src/hooks/use-step-config.ts
@@ -19,22 +19,24 @@ export function useStepConfig(
   configKey: string,
   markDirty: (key: string) => void
 ) {
-  const { defaultModel, hasOpenAIKey, hasAnthropicKey, hasGoogleKey, hasCustomProvider } = useApiKey()
+  const { defaultModel } = useApiKey()
   const [model, setModel] = useState(() => defaultModel ?? "")
   const [modelOverride, setModelOverride] = useState(false)
   const [retries, setRetries] = useState("")
   const modelTouchedRef = useRef(false)
+  const retriesTouchedRef = useRef(false)
   const previousConfigKeyRef = useRef(configKey)
 
   useEffect(() => {
     if (previousConfigKeyRef.current !== configKey) {
       previousConfigKeyRef.current = configKey
       modelTouchedRef.current = false
+      retriesTouchedRef.current = false
     }
     // Reset when switching books/presets/keys so values don't bleed across contexts.
     if (!modelTouchedRef.current) setModel(defaultModel ?? "")
     if (!modelTouchedRef.current) setModelOverride(false)
-    setRetries("")
+    if (!retriesTouchedRef.current) setRetries("")
 
     if (!mergedConfig) return
     const cfg = mergedConfig[configKey]
@@ -43,27 +45,19 @@ export function useStepConfig(
       if (!modelTouchedRef.current) setModelOverride(c.model_override === true)
       if (c.model) {
         const configuredModel = String(c.model)
-        const provider = configuredModel.includes(":")
-          ? configuredModel.slice(0, configuredModel.indexOf(":"))
-          : "openai"
-        const providerAvailable =
-          (provider === "openai" && hasOpenAIKey) ||
-          (provider === "anthropic" && hasAnthropicKey) ||
-          (provider === "google" && hasGoogleKey) ||
-          (provider === "custom" && hasCustomProvider)
         if (!modelTouchedRef.current) {
-          setModel(providerAvailable && c.model_override === true
+          setModel(c.model_override === true
             ? configuredModel
             : (defaultModel ?? configuredModel))
         }
       } else if (defaultModel) {
         if (!modelTouchedRef.current) setModel(defaultModel)
       }
-      if (c.max_retries != null) setRetries(String(c.max_retries))
+      if (c.max_retries != null && !retriesTouchedRef.current) setRetries(String(c.max_retries))
     } else if (defaultModel) {
       if (!modelTouchedRef.current) setModel(defaultModel)
     }
-  }, [mergedConfig, configKey, defaultModel, hasOpenAIKey, hasAnthropicKey, hasGoogleKey, hasCustomProvider])
+  }, [mergedConfig, configKey, defaultModel])
 
   return {
     model,
@@ -75,7 +69,7 @@ export function useStepConfig(
     },
     // Show the effective default in the UI when config does not set one.
     maxRetries: retries || DEFAULT_MAX_RETRIES,
-    onMaxRetriesChange: (v: string) => { setRetries(v); markDirty(configKey) },
+    onMaxRetriesChange: (v: string) => { retriesTouchedRef.current = true; setRetries(v); markDirty(configKey) },
     /** Spread into the config section object in buildOverrides */
     configOverrides: {
       model: model.trim() || undefined,

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -1147,6 +1147,9 @@ msgstr "Anthropic"
 msgid "Anthropic API Key"
 msgstr "Anthropic API Key"
 
+msgid "Anthropic does not offer a text-to-speech API. Add an OpenAI, Gemini, or Azure key to generate audio narration."
+msgstr "Anthropic does not offer a text-to-speech API. Add an OpenAI, Gemini, or Azure key to generate audio narration."
+
 msgid "Anthropic is available for text models, but not speech synthesis."
 msgstr "Anthropic is available for text models, but not speech synthesis."
 

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -662,6 +662,13 @@ msgstr "active item"
 msgid "active items"
 msgstr "active items"
 
+#~ msgid "Active provider requires valid credentials. Please configure your provider in Settings."
+#~ msgstr "Active provider requires valid credentials. Please configure your provider in Settings."
+
+#. placeholder {0}: activeProvider.label
+msgid "Active provider: {0}"
+msgstr "Active provider: {0}"
+
 msgid "Active reviewer session"
 msgstr "Active reviewer session"
 
@@ -753,6 +760,9 @@ msgstr "Add a language to see translations appear here."
 msgid "Add a quiz"
 msgstr "Add a quiz"
 
+msgid "Add a speech provider API key in Book settings to run speech."
+msgstr "Add a speech provider API key in Book settings to run speech."
+
 msgid "Add after"
 msgstr "Add after"
 
@@ -777,8 +787,8 @@ msgstr "Add an API key in Book settings to run extraction."
 msgid "Add an API key in Book settings to run sectioning."
 msgstr "Add an API key in Book settings to run sectioning."
 
-msgid "Add an API key in Book settings to run speech."
-msgstr "Add an API key in Book settings to run speech."
+#~ msgid "Add an API key in Book settings to run speech."
+#~ msgstr "Add an API key in Book settings to run speech."
 
 msgid "Add an API key in Book settings to run storyboard."
 msgstr "Add an API key in Book settings to run storyboard."
@@ -1136,6 +1146,9 @@ msgstr "Anthropic"
 
 msgid "Anthropic API Key"
 msgstr "Anthropic API Key"
+
+msgid "Anthropic is available for text models, but not speech synthesis."
+msgstr "Anthropic is available for text models, but not speech synthesis."
 
 msgid "Any content type"
 msgstr "Any content type"
@@ -1552,6 +1565,9 @@ msgstr "Cancel"
 msgid "Cancel download"
 msgstr "Cancel download"
 
+#~ msgid "Cannot run: active provider has no credentials"
+#~ msgstr "Cannot run: active provider has no credentials"
+
 #. placeholder {0}: String(MAX_ENTRIES)
 msgid "capped at {0}"
 msgstr "capped at {0}"
@@ -1857,6 +1873,9 @@ msgstr "Condensation"
 msgid "Config"
 msgstr "Config"
 
+msgid "Configure a provider to run"
+msgstr "Configure a provider to run"
+
 msgid "Configure activity detection and image processing options for extracted content. Hover any setting to see how it affects the preview."
 msgstr "Configure activity detection and image processing options for extracted content. Hover any setting to see how it affects the preview."
 
@@ -1871,6 +1890,9 @@ msgstr "Configure each stage — extract, storyboard, layout — then let ADT St
 
 msgid "Configure features to include in the export"
 msgstr "Configure features to include in the export"
+
+msgid "Configure provider credentials"
+msgstr "Configure provider credentials"
 
 msgid "Configure voices and accents"
 msgstr "Configure voices and accents"
@@ -2044,6 +2066,9 @@ msgstr "Creates a ZIP archive of the full project — database, source PDF, and 
 msgid "Creating..."
 msgstr "Creating..."
 
+msgid "credentials needed"
+msgstr "credentials needed"
+
 msgid "Credits"
 msgstr "Credits"
 
@@ -2085,6 +2110,9 @@ msgstr "Current effective values"
 
 msgid "Current Preview Page"
 msgstr "Current Preview Page"
+
+#~ msgid "Current step:"
+#~ msgstr "Current step:"
 
 #~ msgid "Current version"
 #~ msgstr "Current version"
@@ -2130,6 +2158,12 @@ msgstr "Default (inherit)"
 
 msgid "Default (no text detected yet)"
 msgstr "Default (no text detected yet)"
+
+msgid "Default AI model"
+msgstr "Default AI model"
+
+#~ msgid "Default AI model:"
+#~ msgstr "Default AI model:"
 
 msgid "Default model"
 msgstr "Default model"
@@ -2960,6 +2994,9 @@ msgstr "Final Page"
 
 #~ msgid "First"
 #~ msgstr "First"
+
+#~ msgid "First available provider"
+#~ msgstr "First available provider"
 
 msgid "First images from the deep-field telescope."
 msgstr "First images from the deep-field telescope."
@@ -3859,6 +3896,9 @@ msgstr "LLM meaningfulness filter"
 msgid "LLM positions text over background images"
 msgstr "LLM positions text over background images"
 
+msgid "LLM providers"
+msgstr "LLM providers"
+
 msgid "LLM segmentation"
 msgstr "LLM segmentation"
 
@@ -4038,6 +4078,9 @@ msgstr "Mark as decorative"
 
 msgid "Mark as decorative (hidden from screen readers)"
 msgstr "Mark as decorative (hidden from screen readers)"
+
+msgid "Mark as default"
+msgstr "Mark as default"
 
 msgid "Match Design"
 msgstr "Match Design"
@@ -4621,6 +4664,9 @@ msgstr "noise"
 msgid "None"
 msgstr "None"
 
+msgid "Not configured"
+msgstr "Not configured"
+
 msgid "Not detected"
 msgstr "Not detected"
 
@@ -4864,6 +4910,9 @@ msgstr "Output Languages"
 
 msgid "Output Tokens"
 msgstr "Output Tokens"
+
+#~ msgid "Overall model"
+#~ msgstr "Overall model"
 
 msgid "Overall page note"
 msgstr "Overall page note"
@@ -5350,6 +5399,13 @@ msgstr "Prompt template not found."
 
 msgid "Provider"
 msgstr "Provider"
+
+msgid "Provider default model"
+msgstr "Provider default model"
+
+#. placeholder {0}: runProvider.providerName
+msgid "Provider: {0}"
+msgstr "Provider: {0}"
 
 msgid "Provides consistent HTML/CSS patterns for LLM-generated pages."
 msgstr "Provides consistent HTML/CSS patterns for LLM-generated pages."
@@ -6328,6 +6384,9 @@ msgstr "Select all"
 msgid "Select images to translate"
 msgstr "Select images to translate"
 
+msgid "Select LLM provider"
+msgstr "Select LLM provider"
+
 msgid "Select node type..."
 msgstr "Select node type..."
 
@@ -6354,6 +6413,9 @@ msgstr "Select up to 5 pages to use as visual references. The LLM will analyze t
 
 msgid "Selected images"
 msgstr "Selected images"
+
+msgid "Selected model"
+msgstr "Selected model"
 
 #. placeholder {0}: fmtRange(w)
 msgid "Selected pages {0}."
@@ -7306,6 +7368,9 @@ msgstr "This section is pruned and isn't rendered."
 msgid "This session is using an older reviewer checklist snapshot. Newer checklist settings will apply only to newly created reviewer sessions."
 msgstr "This session is using an older reviewer checklist snapshot. Newer checklist settings will apply only to newly created reviewer sessions."
 
+msgid "This step uses"
+msgstr "This step uses"
+
 msgid "This text is only perceptible to assistive technologies."
 msgstr "This text is only perceptible to assistive technologies."
 
@@ -7712,6 +7777,9 @@ msgstr "Use this for checks you intentionally want to suppress, such as known fa
 msgid "Use this format to back up the project or move it to another machine."
 msgstr "Use this format to back up the project or move it to another machine."
 
+msgid "Used by default when this provider's API key is selected."
+msgstr "Used by default when this provider's API key is selected."
+
 msgid "Used for"
 msgstr "Used for"
 
@@ -7726,6 +7794,9 @@ msgstr "Used for Gemini models — both LLM (gemini-2.5-pro, etc.) and TTS (gemi
 
 msgid "Used for this quiz"
 msgstr "Used for this quiz"
+
+#~ msgid "Used when a step has no available provider-specific model. Only providers with configured credentials are listed."
+#~ msgstr "Used when a step has no available provider-specific model. Only providers with configured credentials are listed."
 
 msgid "Validation"
 msgstr "Validation"

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -662,6 +662,13 @@ msgstr "active item"
 msgid "active items"
 msgstr "active items"
 
+#~ msgid "Active provider requires valid credentials. Please configure your provider in Settings."
+#~ msgstr "El proveedor activo requiere credenciales válidas. Por favor, configure su proveedor en Configuración."
+
+#. placeholder {0}: activeProvider.label
+msgid "Active provider: {0}"
+msgstr "Proveedor activo: {0}"
+
 msgid "Active reviewer session"
 msgstr "Active reviewer session"
 
@@ -753,6 +760,9 @@ msgstr "Añade un idioma para ver las traducciones aquí."
 msgid "Add a quiz"
 msgstr "Añadir un cuestionario"
 
+msgid "Add a speech provider API key in Book settings to run speech."
+msgstr "Añade una clave de API de un proveedor de voz en los ajustes del libro para ejecutar la voz."
+
 msgid "Add after"
 msgstr "Añadir después"
 
@@ -777,8 +787,8 @@ msgstr "Añade una clave API en la configuración del libro para ejecutar extrac
 msgid "Add an API key in Book settings to run sectioning."
 msgstr "Añade una clave API en la configuración del libro para ejecutar seccionamiento."
 
-msgid "Add an API key in Book settings to run speech."
-msgstr "Añade una clave API en la configuración del libro para ejecutar voz."
+#~ msgid "Add an API key in Book settings to run speech."
+#~ msgstr "Añade una clave API en la configuración del libro para ejecutar voz."
 
 msgid "Add an API key in Book settings to run storyboard."
 msgstr "Añade una clave API en la configuración del libro para ejecutar storyboard."
@@ -1136,6 +1146,9 @@ msgstr "Anthropic"
 
 msgid "Anthropic API Key"
 msgstr "Clave de API de Anthropic"
+
+msgid "Anthropic is available for text models, but not speech synthesis."
+msgstr "Anthropic está disponible para modelos de texto, pero no para síntesis de voz."
 
 msgid "Any content type"
 msgstr "Cualquier tipo de contenido"
@@ -1552,6 +1565,9 @@ msgstr "Cancelar"
 msgid "Cancel download"
 msgstr "Cancelar descarga"
 
+#~ msgid "Cannot run: active provider has no credentials"
+#~ msgstr "No se puede ejecutar: el proveedor activo no tiene credenciales"
+
 #. placeholder {0}: String(MAX_ENTRIES)
 msgid "capped at {0}"
 msgstr "limitado a {0}"
@@ -1857,6 +1873,9 @@ msgstr "Condensación"
 msgid "Config"
 msgstr "Configuración"
 
+msgid "Configure a provider to run"
+msgstr "Configurar un proveedor para ejecutar"
+
 msgid "Configure activity detection and image processing options for extracted content. Hover any setting to see how it affects the preview."
 msgstr "Configura las opciones de detección de actividad y procesamiento de imágenes para el contenido extraído. Pasa el cursor sobre cualquier configuración para ver cómo afecta la vista previa."
 
@@ -1871,6 +1890,9 @@ msgstr "Configura cada etapa — extraer, guión gráfico, diseño — luego dej
 
 msgid "Configure features to include in the export"
 msgstr "Configura las características a incluir en la exportación"
+
+msgid "Configure provider credentials"
+msgstr "Configurar credenciales del proveedor"
 
 msgid "Configure voices and accents"
 msgstr "Configurar voces y acentos"
@@ -2044,6 +2066,9 @@ msgstr "Crea un archivo ZIP del proyecto completo — base de datos, PDF de orig
 msgid "Creating..."
 msgstr "Creando..."
 
+msgid "credentials needed"
+msgstr "credenciales necesarias"
+
 msgid "Credits"
 msgstr "Créditos"
 
@@ -2085,6 +2110,9 @@ msgstr "Current effective values"
 
 msgid "Current Preview Page"
 msgstr "Current Preview Page"
+
+#~ msgid "Current step:"
+#~ msgstr "Paso actual:"
 
 #~ msgid "Current version"
 #~ msgstr "Versión actual"
@@ -2130,6 +2158,12 @@ msgstr "Predeterminado (heredar)"
 
 msgid "Default (no text detected yet)"
 msgstr "Predeterminada (aún no se detectó texto)"
+
+msgid "Default AI model"
+msgstr "Modelo de IA predeterminado"
+
+#~ msgid "Default AI model:"
+#~ msgstr "Modelo de IA predeterminado:"
 
 msgid "Default model"
 msgstr "Modelo predeterminado"
@@ -2960,6 +2994,9 @@ msgstr "Página Final"
 
 #~ msgid "First"
 #~ msgstr "Primera"
+
+#~ msgid "First available provider"
+#~ msgstr "Primer proveedor disponible"
 
 msgid "First images from the deep-field telescope."
 msgstr "Primeras imágenes del telescopio de campo profundo."
@@ -3859,6 +3896,9 @@ msgstr "Filtro de relevancia por LLM"
 msgid "LLM positions text over background images"
 msgstr "El LLM posiciona texto sobre imágenes de fondo"
 
+msgid "LLM providers"
+msgstr "Proveedores LLM"
+
 msgid "LLM segmentation"
 msgstr "Segmentación LLM"
 
@@ -4038,6 +4078,9 @@ msgstr "Marcar como decorativo"
 
 msgid "Mark as decorative (hidden from screen readers)"
 msgstr "Marcar como decorativo (oculto para lectores de pantalla)"
+
+msgid "Mark as default"
+msgstr "Marcar como predeterminado"
 
 msgid "Match Design"
 msgstr "Coincidir con el diseño"
@@ -4621,6 +4664,9 @@ msgstr "ruido"
 msgid "None"
 msgstr "Ninguno"
 
+msgid "Not configured"
+msgstr "No configurado"
+
 msgid "Not detected"
 msgstr "No detectado"
 
@@ -4864,6 +4910,9 @@ msgstr "Idiomas de salida"
 
 msgid "Output Tokens"
 msgstr "Tokens de salida"
+
+#~ msgid "Overall model"
+#~ msgstr "Modelo general"
 
 msgid "Overall page note"
 msgstr "Overall page note"
@@ -5350,6 +5399,13 @@ msgstr "Prompt template not found."
 
 msgid "Provider"
 msgstr "Proveedor"
+
+msgid "Provider default model"
+msgstr "Modelo predeterminado del proveedor"
+
+#. placeholder {0}: runProvider.providerName
+msgid "Provider: {0}"
+msgstr "Proveedor: {0}"
 
 msgid "Provides consistent HTML/CSS patterns for LLM-generated pages."
 msgstr "Proporciona patrones HTML/CSS consistentes para páginas generadas por LLM."
@@ -6328,6 +6384,9 @@ msgstr "Seleccionar todo"
 msgid "Select images to translate"
 msgstr "Seleccionar imágenes para traducir"
 
+msgid "Select LLM provider"
+msgstr "Seleccionar proveedor LLM"
+
 msgid "Select node type..."
 msgstr "Seleccionar tipo de nodo..."
 
@@ -6354,6 +6413,9 @@ msgstr "Selecciona hasta 5 páginas para usar como referencias visuales. El LLM 
 
 msgid "Selected images"
 msgstr "Imágenes seleccionadas"
+
+msgid "Selected model"
+msgstr "Modelo seleccionado"
 
 #. placeholder {0}: fmtRange(w)
 msgid "Selected pages {0}."
@@ -7306,6 +7368,9 @@ msgstr "Esta sección está podada y no se renderiza."
 msgid "This session is using an older reviewer checklist snapshot. Newer checklist settings will apply only to newly created reviewer sessions."
 msgstr "This session is using an older reviewer checklist snapshot. Newer checklist settings will apply only to newly created reviewer sessions."
 
+msgid "This step uses"
+msgstr "Este paso usa"
+
 msgid "This text is only perceptible to assistive technologies."
 msgstr "Este texto solo es perceptible para tecnologías de asistencia."
 
@@ -7712,6 +7777,9 @@ msgstr "Use this for checks you intentionally want to suppress, such as known fa
 msgid "Use this format to back up the project or move it to another machine."
 msgstr "Usa este formato para respaldar el proyecto o moverlo a otra máquina."
 
+msgid "Used by default when this provider's API key is selected."
+msgstr "Se utiliza de forma predeterminada cuando se selecciona la clave API de este proveedor."
+
 msgid "Used for"
 msgstr "Se usa para"
 
@@ -7726,6 +7794,9 @@ msgstr "Utilizada para modelos Gemini — tanto LLM (gemini-2.5-pro, etc.) como 
 
 msgid "Used for this quiz"
 msgstr "Se usa en este cuestionario"
+
+#~ msgid "Used when a step has no available provider-specific model. Only providers with configured credentials are listed."
+#~ msgstr "Se utiliza cuando un paso no tiene disponible un modelo específico del proveedor. Solo se muestran los proveedores con credenciales configuradas."
 
 msgid "Validation"
 msgstr "Validation"

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -1147,6 +1147,9 @@ msgstr "Anthropic"
 msgid "Anthropic API Key"
 msgstr "Clave de API de Anthropic"
 
+msgid "Anthropic does not offer a text-to-speech API. Add an OpenAI, Gemini, or Azure key to generate audio narration."
+msgstr "Anthropic no ofrece una API de texto a voz. Añade una clave de OpenAI, Gemini o Azure para generar narración de audio."
+
 msgid "Anthropic is available for text models, but not speech synthesis."
 msgstr "Anthropic está disponible para modelos de texto, pero no para síntesis de voz."
 

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -664,6 +664,13 @@ msgstr "élément actif"
 msgid "active items"
 msgstr "éléments actifs"
 
+#~ msgid "Active provider requires valid credentials. Please configure your provider in Settings."
+#~ msgstr "Le fournisseur actif nécessite des identifiants valides. Veuillez configurer votre fournisseur dans les Paramètres."
+
+#. placeholder {0}: activeProvider.label
+msgid "Active provider: {0}"
+msgstr "Fournisseur actif : {0}"
+
 msgid "Active reviewer session"
 msgstr "Session de révision active"
 
@@ -755,6 +762,9 @@ msgstr "Ajoutez une langue pour voir les traductions apparaître ici."
 msgid "Add a quiz"
 msgstr "Ajouter un quiz"
 
+msgid "Add a speech provider API key in Book settings to run speech."
+msgstr "Ajoutez une clé d'API d'un fournisseur vocal dans les paramètres du livre pour lancer la voix."
+
 msgid "Add after"
 msgstr "Ajouter à la suite"
 
@@ -779,8 +789,8 @@ msgstr "Ajoutez une clé API dans les paramètres du livre pour exécuter l'extr
 msgid "Add an API key in Book settings to run sectioning."
 msgstr "Ajoutez une clé API dans les paramètres du livre pour exécuter le découpage."
 
-msgid "Add an API key in Book settings to run speech."
-msgstr "Ajoutez une clé API dans les paramètres du livre pour exécuter la parole."
+#~ msgid "Add an API key in Book settings to run speech."
+#~ msgstr "Ajoutez une clé API dans les paramètres du livre pour exécuter la parole."
 
 msgid "Add an API key in Book settings to run storyboard."
 msgstr "Ajoutez une clé API dans les paramètres du livre pour exécuter le storyboard."
@@ -1138,6 +1148,9 @@ msgstr "Anthropic"
 
 msgid "Anthropic API Key"
 msgstr "Anthropic Clé API"
+
+msgid "Anthropic is available for text models, but not speech synthesis."
+msgstr "Anthropic est disponible pour les modèles de texte, mais pas pour la synthèse vocale."
 
 msgid "Any content type"
 msgstr "Tout type de contenu"
@@ -1554,6 +1567,9 @@ msgstr "Annuler"
 msgid "Cancel download"
 msgstr "Annuler le téléchargement"
 
+#~ msgid "Cannot run: active provider has no credentials"
+#~ msgstr "Impossible d'exécuter : le fournisseur actif n'a pas d'identifiants"
+
 #. placeholder {0}: String(MAX_ENTRIES)
 msgid "capped at {0}"
 msgstr "limité à {0}"
@@ -1859,6 +1875,9 @@ msgstr "Condensation"
 msgid "Config"
 msgstr "Config"
 
+msgid "Configure a provider to run"
+msgstr "Configurer un fournisseur pour exécuter"
+
 msgid "Configure activity detection and image processing options for extracted content. Hover any setting to see how it affects the preview."
 msgstr "Configurer les options de détection d'activité et de traitement d'image pour le contenu extrait. Survolez un paramètre pour voir comment il affecte l'aperçu."
 
@@ -1873,6 +1892,9 @@ msgstr "Configurez chaque étape — extraction, storyboard, mise en page — pu
 
 msgid "Configure features to include in the export"
 msgstr "Configurer les fonctionnalités à inclure dans l'exportation"
+
+msgid "Configure provider credentials"
+msgstr "Configurer les identifiants du fournisseur"
 
 msgid "Configure voices and accents"
 msgstr "Configurer les voix et les accents"
@@ -2046,6 +2068,9 @@ msgstr "Crée une archive ZIP du projet complet — base de données, PDF source
 msgid "Creating..."
 msgstr "Création..."
 
+msgid "credentials needed"
+msgstr "identifiants requis"
+
 msgid "Credits"
 msgstr "Crédits"
 
@@ -2087,6 +2112,9 @@ msgstr "Valeurs effectives actuelles"
 
 msgid "Current Preview Page"
 msgstr "Page d'aperçu actuelle"
+
+#~ msgid "Current step:"
+#~ msgstr "Étape actuelle :"
 
 #~ msgid "Current version"
 #~ msgstr "Version actuelle"
@@ -2132,6 +2160,12 @@ msgstr "Par défaut (hériter)"
 
 msgid "Default (no text detected yet)"
 msgstr "Par défaut (aucun texte détecté pour l'instant)"
+
+msgid "Default AI model"
+msgstr "Modèle d’IA par défaut"
+
+#~ msgid "Default AI model:"
+#~ msgstr "Modèle d’IA par défaut :"
 
 msgid "Default model"
 msgstr "Par défaut modèle"
@@ -2962,6 +2996,9 @@ msgstr "Page finale"
 
 #~ msgid "First"
 #~ msgstr "Premier"
+
+#~ msgid "First available provider"
+#~ msgstr "Premier fournisseur disponible"
 
 msgid "First images from the deep-field telescope."
 msgstr "Premières images du télescope à champ profond."
@@ -3861,6 +3898,9 @@ msgstr "Filtre de pertinence LLM"
 msgid "LLM positions text over background images"
 msgstr "Le LLM positionne le texte sur les images d'arrière-plan"
 
+msgid "LLM providers"
+msgstr "Fournisseurs LLM"
+
 msgid "LLM segmentation"
 msgstr "LLM segmentation"
 
@@ -4040,6 +4080,9 @@ msgstr "Marquer comme décoratif"
 
 msgid "Mark as decorative (hidden from screen readers)"
 msgstr "Marquer comme décoratif (caché des lecteurs d'écran)"
+
+msgid "Mark as default"
+msgstr "Marquer comme valeur par défaut"
 
 msgid "Match Design"
 msgstr "Correspondre au design"
@@ -4623,6 +4666,9 @@ msgstr "bruit"
 msgid "None"
 msgstr "Aucun"
 
+msgid "Not configured"
+msgstr "Non configuré"
+
 msgid "Not detected"
 msgstr "Non détecté"
 
@@ -4866,6 +4912,9 @@ msgstr "Langues de sortie"
 
 msgid "Output Tokens"
 msgstr "Jetons de sortie"
+
+#~ msgid "Overall model"
+#~ msgstr "Modèle global"
 
 msgid "Overall page note"
 msgstr "Note globale de la page"
@@ -5352,6 +5401,13 @@ msgstr "Invite modèle non trouvé."
 
 msgid "Provider"
 msgstr "Provider"
+
+msgid "Provider default model"
+msgstr "Modèle par défaut du fournisseur"
+
+#. placeholder {0}: runProvider.providerName
+msgid "Provider: {0}"
+msgstr "Fournisseur : {0}"
 
 msgid "Provides consistent HTML/CSS patterns for LLM-generated pages."
 msgstr "Fournit des modèles HTML/CSS cohérents pour les pages générées par le LLM."
@@ -6330,6 +6386,9 @@ msgstr "Tout sélectionner"
 msgid "Select images to translate"
 msgstr "Sélectionner les images à traduire"
 
+msgid "Select LLM provider"
+msgstr "Sélectionner le fournisseur LLM"
+
 msgid "Select node type..."
 msgstr "Sélectionnez le type de nœud..."
 
@@ -6356,6 +6415,9 @@ msgstr "Sélectionnez jusqu'à 5 pages à utiliser comme références visuelles.
 
 msgid "Selected images"
 msgstr "Images sélectionnées"
+
+msgid "Selected model"
+msgstr "Modèle sélectionné"
 
 #. placeholder {0}: fmtRange(w)
 msgid "Selected pages {0}."
@@ -7308,6 +7370,9 @@ msgstr "Cette section est élaguée et n'est pas rendue."
 msgid "This session is using an older reviewer checklist snapshot. Newer checklist settings will apply only to newly created reviewer sessions."
 msgstr "Cette session utilise un ancien instantané de la liste de contrôle du réviseur. Les nouveaux paramètres de liste de contrôle ne s'appliqueront qu'aux sessions de révision nouvellement créées."
 
+msgid "This step uses"
+msgstr "Cette étape utilise"
+
 msgid "This text is only perceptible to assistive technologies."
 msgstr "Ce texte n'est perceptible que par les technologies d'assistance."
 
@@ -7714,6 +7779,9 @@ msgstr "Utilisez ceci pour les vérifications que vous souhaitez intentionnellem
 msgid "Use this format to back up the project or move it to another machine."
 msgstr "Utilisez ce format pour sauvegarder le projet ou le déplacer vers une autre machine."
 
+msgid "Used by default when this provider's API key is selected."
+msgstr "Utilisé par défaut lorsque la clé API de ce fournisseur est sélectionnée."
+
 msgid "Used for"
 msgstr "Utilisée pour"
 
@@ -7728,6 +7796,9 @@ msgstr "Utilisé pour les modèles Gemini — LLM (gemini-2.5-pro, etc.) et TTS 
 
 msgid "Used for this quiz"
 msgstr "Utilisée pour ce quiz"
+
+#~ msgid "Used when a step has no available provider-specific model. Only providers with configured credentials are listed."
+#~ msgstr "Utilisé lorsqu’une étape ne dispose d’aucun modèle propre à un fournisseur. Seuls les fournisseurs dont les identifiants sont configurés sont affichés."
 
 msgid "Validation"
 msgstr "Validation"

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -1149,6 +1149,9 @@ msgstr "Anthropic"
 msgid "Anthropic API Key"
 msgstr "Anthropic Clé API"
 
+msgid "Anthropic does not offer a text-to-speech API. Add an OpenAI, Gemini, or Azure key to generate audio narration."
+msgstr "Anthropic ne propose pas d'API de synthèse vocale. Ajoutez une clé OpenAI, Gemini ou Azure pour générer la narration audio."
+
 msgid "Anthropic is available for text models, but not speech synthesis."
 msgstr "Anthropic est disponible pour les modèles de texte, mais pas pour la synthèse vocale."
 

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -1147,6 +1147,9 @@ msgstr "Anthropic"
 msgid "Anthropic API Key"
 msgstr "Chave de API da Anthropic"
 
+msgid "Anthropic does not offer a text-to-speech API. Add an OpenAI, Gemini, or Azure key to generate audio narration."
+msgstr "Anthropic não oferece uma API de conversão de texto em fala. Adicione uma chave OpenAI, Gemini ou Azure para gerar narração de áudio."
+
 msgid "Anthropic is available for text models, but not speech synthesis."
 msgstr "A Anthropic está disponível para modelos de texto, mas não para síntese de fala."
 

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -662,6 +662,13 @@ msgstr "active item"
 msgid "active items"
 msgstr "active items"
 
+#~ msgid "Active provider requires valid credentials. Please configure your provider in Settings."
+#~ msgstr "O provedor ativo requer credenciais válidas. Por favor, configure seu provedor em Configurações."
+
+#. placeholder {0}: activeProvider.label
+msgid "Active provider: {0}"
+msgstr "Provedor ativo: {0}"
+
 msgid "Active reviewer session"
 msgstr "Active reviewer session"
 
@@ -753,6 +760,9 @@ msgstr "Adicione um idioma para ver as traduções aparecerem aqui."
 msgid "Add a quiz"
 msgstr "Adicionar um questionário"
 
+msgid "Add a speech provider API key in Book settings to run speech."
+msgstr "Adicione uma chave de API de um provedor de fala nas configurações do livro para executar a fala."
+
 msgid "Add after"
 msgstr "Adicionar depois"
 
@@ -777,8 +787,8 @@ msgstr "Adicione uma chave de API nas configurações do Livro para executar ext
 msgid "Add an API key in Book settings to run sectioning."
 msgstr "Adicione uma chave de API nas configurações do Livro para executar seccionamento."
 
-msgid "Add an API key in Book settings to run speech."
-msgstr "Adicione uma chave de API nas configurações do Livro para executar fala."
+#~ msgid "Add an API key in Book settings to run speech."
+#~ msgstr "Adicione uma chave de API nas configurações do Livro para executar fala."
 
 msgid "Add an API key in Book settings to run storyboard."
 msgstr "Adicione uma chave de API nas configurações do Livro para executar storyboard."
@@ -1136,6 +1146,9 @@ msgstr "Anthropic"
 
 msgid "Anthropic API Key"
 msgstr "Chave de API da Anthropic"
+
+msgid "Anthropic is available for text models, but not speech synthesis."
+msgstr "A Anthropic está disponível para modelos de texto, mas não para síntese de fala."
 
 msgid "Any content type"
 msgstr "Qualquer tipo de conteúdo"
@@ -1552,6 +1565,9 @@ msgstr "Cancelar"
 msgid "Cancel download"
 msgstr "Cancelar download"
 
+#~ msgid "Cannot run: active provider has no credentials"
+#~ msgstr "Não é possível executar: o provedor ativo não possui credenciais"
+
 #. placeholder {0}: String(MAX_ENTRIES)
 msgid "capped at {0}"
 msgstr "limitado a {0}"
@@ -1857,6 +1873,9 @@ msgstr "Condensação"
 msgid "Config"
 msgstr "Configuração"
 
+msgid "Configure a provider to run"
+msgstr "Configurar um provedor para executar"
+
 msgid "Configure activity detection and image processing options for extracted content. Hover any setting to see how it affects the preview."
 msgstr "Configure as opções de detecção de atividade e processamento de imagem para o conteúdo extraído. Passe o mouse sobre qualquer configuração para ver como ela afeta a visualização."
 
@@ -1871,6 +1890,9 @@ msgstr "Configure cada etapa — extração, storyboard, layout — e deixe o AD
 
 msgid "Configure features to include in the export"
 msgstr "Configure as funcionalidades a incluir na exportação"
+
+msgid "Configure provider credentials"
+msgstr "Configurar credenciais do provedor"
 
 msgid "Configure voices and accents"
 msgstr "Configurar vozes e sotaques"
@@ -2044,6 +2066,9 @@ msgstr "Cria um arquivo ZIP do projeto completo — banco de dados, PDF de orige
 msgid "Creating..."
 msgstr "Criando..."
 
+msgid "credentials needed"
+msgstr "credenciais necessárias"
+
 msgid "Credits"
 msgstr "Créditos"
 
@@ -2085,6 +2110,9 @@ msgstr "Current effective values"
 
 msgid "Current Preview Page"
 msgstr "Current Preview Page"
+
+#~ msgid "Current step:"
+#~ msgstr "Etapa atual:"
 
 #~ msgid "Current version"
 #~ msgstr "Versão atual"
@@ -2130,6 +2158,12 @@ msgstr "Padrão (herdar)"
 
 msgid "Default (no text detected yet)"
 msgstr "Padrão (nenhum texto detectado ainda)"
+
+msgid "Default AI model"
+msgstr "Modelo de IA padrão"
+
+#~ msgid "Default AI model:"
+#~ msgstr "Modelo de IA padrão:"
 
 msgid "Default model"
 msgstr "Modelo padrão"
@@ -2960,6 +2994,9 @@ msgstr "Página Final"
 
 #~ msgid "First"
 #~ msgstr "Primeira"
+
+#~ msgid "First available provider"
+#~ msgstr "Primeiro provedor disponível"
 
 msgid "First images from the deep-field telescope."
 msgstr "Primeiras imagens do telescópio de campo profundo."
@@ -3859,6 +3896,9 @@ msgstr "Filtro de relevância por LLM"
 msgid "LLM positions text over background images"
 msgstr "LLM posiciona texto sobre imagens de fundo"
 
+msgid "LLM providers"
+msgstr "Provedores LLM"
+
 msgid "LLM segmentation"
 msgstr "Segmentação LLM"
 
@@ -4038,6 +4078,9 @@ msgstr "Marcar como decorativo"
 
 msgid "Mark as decorative (hidden from screen readers)"
 msgstr "Marcar como decorativo (oculto para leitores de tela)"
+
+msgid "Mark as default"
+msgstr "Marcar como padrão"
 
 msgid "Match Design"
 msgstr "Corresponder ao Design"
@@ -4621,6 +4664,9 @@ msgstr "ruído"
 msgid "None"
 msgstr "Nenhum"
 
+msgid "Not configured"
+msgstr "Não configurado"
+
 msgid "Not detected"
 msgstr "Não detectado"
 
@@ -4864,6 +4910,9 @@ msgstr "Idiomas de saída"
 
 msgid "Output Tokens"
 msgstr "Tokens de saída"
+
+#~ msgid "Overall model"
+#~ msgstr "Modelo geral"
 
 msgid "Overall page note"
 msgstr "Overall page note"
@@ -5350,6 +5399,13 @@ msgstr "Prompt template not found."
 
 msgid "Provider"
 msgstr "Provedor"
+
+msgid "Provider default model"
+msgstr "Modelo padrão do provedor"
+
+#. placeholder {0}: runProvider.providerName
+msgid "Provider: {0}"
+msgstr "Provedor: {0}"
 
 msgid "Provides consistent HTML/CSS patterns for LLM-generated pages."
 msgstr "Fornece padrões HTML/CSS consistentes para páginas geradas por LLM."
@@ -6328,6 +6384,9 @@ msgstr "Selecionar tudo"
 msgid "Select images to translate"
 msgstr "Selecionar imagens para traduzir"
 
+msgid "Select LLM provider"
+msgstr "Selecionar provedor LLM"
+
 msgid "Select node type..."
 msgstr "Selecionar tipo de nó..."
 
@@ -6354,6 +6413,9 @@ msgstr "Selecione até 5 páginas para usar como referências visuais. O LLM ir�
 
 msgid "Selected images"
 msgstr "Imagens selecionadas"
+
+msgid "Selected model"
+msgstr "Modelo selecionado"
 
 #. placeholder {0}: fmtRange(w)
 msgid "Selected pages {0}."
@@ -7306,6 +7368,9 @@ msgstr "Esta seção foi removida e não é renderizada."
 msgid "This session is using an older reviewer checklist snapshot. Newer checklist settings will apply only to newly created reviewer sessions."
 msgstr "This session is using an older reviewer checklist snapshot. Newer checklist settings will apply only to newly created reviewer sessions."
 
+msgid "This step uses"
+msgstr "Esta etapa usa"
+
 msgid "This text is only perceptible to assistive technologies."
 msgstr "Este texto é perceptível apenas para tecnologias assistivas."
 
@@ -7712,6 +7777,9 @@ msgstr "Use this for checks you intentionally want to suppress, such as known fa
 msgid "Use this format to back up the project or move it to another machine."
 msgstr "Use este formato para fazer backup do projeto ou movê-lo para outra máquina."
 
+msgid "Used by default when this provider's API key is selected."
+msgstr "Usado por padrão quando a chave de API deste provedor é selecionada."
+
 msgid "Used for"
 msgstr "Usada para"
 
@@ -7726,6 +7794,9 @@ msgstr "Utilizada para modelos Gemini — tanto LLM (gemini-2.5-pro, etc.) quant
 
 msgid "Used for this quiz"
 msgstr "Usada neste questionário"
+
+#~ msgid "Used when a step has no available provider-specific model. Only providers with configured credentials are listed."
+#~ msgstr "Usado quando uma etapa não tem um modelo específico do provedor disponível. Apenas provedores com credenciais configuradas são exibidos."
 
 msgid "Validation"
 msgstr "Validation"

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -663,6 +663,13 @@ msgstr "element aktiv"
 msgid "active items"
 msgstr "elementë aktivë"
 
+#~ msgid "Active provider requires valid credentials. Please configure your provider in Settings."
+#~ msgstr "Ofruesi aktiv kërkon kredenciale të vlefshme. Ju lutem konfiguroni ofruesin tuaj në Cilësimet."
+
+#. placeholder {0}: activeProvider.label
+msgid "Active provider: {0}"
+msgstr "Ofruesi aktiv: {0}"
+
 msgid "Active reviewer session"
 msgstr "Sesion aktiv i rishikuesit"
 
@@ -754,6 +761,9 @@ msgstr "Shto një gjuhë për të parë përkthimet këtu."
 msgid "Add a quiz"
 msgstr "Shto një kuiz"
 
+msgid "Add a speech provider API key in Book settings to run speech."
+msgstr "Shto një çelës API të një ofruesi të të folurit në cilësimet e Librit për të ekzekutuar të folurin."
+
 msgid "Add after"
 msgstr "Shto pas"
 
@@ -778,8 +788,8 @@ msgstr "Shto një çelës API në cilësimet e Librit për të ekzekutuar nxjerr
 msgid "Add an API key in Book settings to run sectioning."
 msgstr "Shto një çelës API në cilësimet e Librit për të ekzekutuar ndarjen në seksione."
 
-msgid "Add an API key in Book settings to run speech."
-msgstr "Shto një çelës API në cilësimet e Librit për të ekzekutuar të folurit."
+#~ msgid "Add an API key in Book settings to run speech."
+#~ msgstr "Shto një çelës API në cilësimet e Librit për të ekzekutuar të folurit."
 
 msgid "Add an API key in Book settings to run storyboard."
 msgstr "Shto një çelës API në cilësimet e Librit për të ekzekutuar storyboard-in."
@@ -1137,6 +1147,9 @@ msgstr "Anthropic"
 
 msgid "Anthropic API Key"
 msgstr "Çelësi API Anthropic"
+
+msgid "Anthropic is available for text models, but not speech synthesis."
+msgstr "Anthropic është i disponueshëm për modele teksti, por jo për sintezë të të folurit."
 
 msgid "Any content type"
 msgstr "Çdo lloj përmbajtjeje"
@@ -1553,6 +1566,9 @@ msgstr "Anulo"
 msgid "Cancel download"
 msgstr "Anulo shkarkimin"
 
+#~ msgid "Cannot run: active provider has no credentials"
+#~ msgstr "Nuk mund të ekzekutohet: ofruesi aktiv nuk ka kredenciale"
+
 #. placeholder {0}: String(MAX_ENTRIES)
 msgid "capped at {0}"
 msgstr "kufizuar në {0}"
@@ -1858,6 +1874,9 @@ msgstr "Kondensim"
 msgid "Config"
 msgstr "Konfigurim"
 
+msgid "Configure a provider to run"
+msgstr "Konfiguroni një ofrues për të ekzekutuar"
+
 msgid "Configure activity detection and image processing options for extracted content. Hover any setting to see how it affects the preview."
 msgstr "Konfiguroni zbulimin e aktivitetit dhe opsionet e përpunimit të imazheve për përmbajtjen e ekstraktuar. Kaloni kursorin mbi çdo cilësim për të parë si ndikon në pamjen paraprake."
 
@@ -1872,6 +1891,9 @@ msgstr "Konfiguroni çdo fazë — ekstraktim, storyboard, faqosje — pastaj l�
 
 msgid "Configure features to include in the export"
 msgstr "Konfiguroni funksionet për t'i përfshirë në eksportim"
+
+msgid "Configure provider credentials"
+msgstr "Konfiguroni kredencialet e ofruesit"
 
 msgid "Configure voices and accents"
 msgstr "Konfiguroni zërat dhe thekset"
@@ -2045,6 +2067,9 @@ msgstr "Krijon një arkiv ZIP të projektit të plotë — bazën e të dhënave
 msgid "Creating..."
 msgstr "Po krijohet..."
 
+msgid "credentials needed"
+msgstr "nevojiten kredenciale"
+
 msgid "Credits"
 msgstr "Kreditet"
 
@@ -2086,6 +2111,9 @@ msgstr "Vlerat aktuale efektive"
 
 msgid "Current Preview Page"
 msgstr "Faqja aktuale e pamjes paraprake"
+
+#~ msgid "Current step:"
+#~ msgstr "Hapi aktual:"
 
 #~ msgid "Current version"
 #~ msgstr "Versioni aktual"
@@ -2131,6 +2159,12 @@ msgstr "Parazgjedhje (trashëgo)"
 
 msgid "Default (no text detected yet)"
 msgstr "Parazgjedhje (ende nuk u zbulua tekst)"
+
+msgid "Default AI model"
+msgstr "Modeli i parazgjedhur i IA-së"
+
+#~ msgid "Default AI model:"
+#~ msgstr "Modeli i parazgjedhur i IA-së:"
 
 msgid "Default model"
 msgstr "Modeli parazgjedhës"
@@ -2961,6 +2995,9 @@ msgstr "Faqja e fundit"
 
 #~ msgid "First"
 #~ msgstr "E para"
+
+#~ msgid "First available provider"
+#~ msgstr "Ofruesi i parë i disponueshëm"
 
 msgid "First images from the deep-field telescope."
 msgstr "Imazhet e para nga teleskopi i fushës së thellë."
@@ -3860,6 +3897,9 @@ msgstr "Filtër kuptimësie LLM"
 msgid "LLM positions text over background images"
 msgstr "LLM pozicionon tekstin mbi imazhet e sfondit"
 
+msgid "LLM providers"
+msgstr "Ofruesit LLM"
+
 msgid "LLM segmentation"
 msgstr "Segmentim LLM"
 
@@ -4039,6 +4079,9 @@ msgstr "Shëno si dekorativ"
 
 msgid "Mark as decorative (hidden from screen readers)"
 msgstr "Shëno si dekorativ (i fshehur nga lexuesit e ekranit)"
+
+msgid "Mark as default"
+msgstr "Shëno si parazgjedhje"
 
 msgid "Match Design"
 msgstr "Përputhje Dizajni"
@@ -4622,6 +4665,9 @@ msgstr "zhurmë"
 msgid "None"
 msgstr "Asnjë"
 
+msgid "Not configured"
+msgstr "I pakonfiguruar"
+
 msgid "Not detected"
 msgstr "Nuk u zbulua"
 
@@ -4865,6 +4911,9 @@ msgstr "Gjuhët e daljes"
 
 msgid "Output Tokens"
 msgstr "Tokena dalje"
+
+#~ msgid "Overall model"
+#~ msgstr "Modeli i përgjithshëm"
 
 msgid "Overall page note"
 msgstr "Shënim i përgjithshëm i faqes"
@@ -5351,6 +5400,13 @@ msgstr "Shablloni i prompt-it nuk u gjet."
 
 msgid "Provider"
 msgstr "Ofruesi"
+
+msgid "Provider default model"
+msgstr "Modeli i parazgjedhur i ofruesit"
+
+#. placeholder {0}: runProvider.providerName
+msgid "Provider: {0}"
+msgstr "Ofruesi: {0}"
 
 msgid "Provides consistent HTML/CSS patterns for LLM-generated pages."
 msgstr "Siguron modele të qëndrueshme HTML/CSS për faqet e gjeneruara nga LLM."
@@ -6329,6 +6385,9 @@ msgstr "Zgjidhni të gjitha"
 msgid "Select images to translate"
 msgstr "Zgjidhni imazhet për të përkthyer"
 
+msgid "Select LLM provider"
+msgstr "Zgjidhni ofruesin LLM"
+
 msgid "Select node type..."
 msgstr "Zgjidhni llojin e nyjes..."
 
@@ -6355,6 +6414,9 @@ msgstr "Zgjidhni deri në 5 faqe për t'i përdorur si referenca vizuale. LLM do
 
 msgid "Selected images"
 msgstr "Imazhe të zgjedhura"
+
+msgid "Selected model"
+msgstr "Modeli i zgjedhur"
 
 #. placeholder {0}: fmtRange(w)
 msgid "Selected pages {0}."
@@ -7307,6 +7369,9 @@ msgstr "Ky seksion është prerë dhe nuk renderizohet."
 msgid "This session is using an older reviewer checklist snapshot. Newer checklist settings will apply only to newly created reviewer sessions."
 msgstr "Kjo sesion po përdor një fotografi të vjetër të listës së kontrollit të rishikuesit. Cilësimet e reja të listës do të zbatohen vetëm për sesionet e rishikuesit të krijuara rishtazi."
 
+msgid "This step uses"
+msgstr "Ky hap përdor"
+
 msgid "This text is only perceptible to assistive technologies."
 msgstr "Ky tekst perceptohet vetëm nga teknologjitë ndihmëse."
 
@@ -7713,6 +7778,9 @@ msgstr "Përdor këtë për kontrollet që dëshiron t'i fshehësh me qëllim, s
 msgid "Use this format to back up the project or move it to another machine."
 msgstr "Përdor këtë format për të rezervuar projektin ose për ta zhvendosur në një makinë tjetër."
 
+msgid "Used by default when this provider's API key is selected."
+msgstr "Përdoret si parazgjedhje kur zgjidhet çelësi API i këtij ofruesi."
+
 msgid "Used for"
 msgstr "Përdoret për"
 
@@ -7727,6 +7795,9 @@ msgstr "Përdoret për modelet Gemini — si LLM (gemini-2.5-pro, etj.) ashtu ed
 
 msgid "Used for this quiz"
 msgstr "Përdoret për këtë kuiz"
+
+#~ msgid "Used when a step has no available provider-specific model. Only providers with configured credentials are listed."
+#~ msgstr "Përdoret kur një hap nuk ka model të disponueshëm specifik për ofruesin. Shfaqen vetëm ofruesit me kredenciale të konfiguruara."
 
 msgid "Validation"
 msgstr "Vërtetim"

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -1148,6 +1148,9 @@ msgstr "Anthropic"
 msgid "Anthropic API Key"
 msgstr "Çelësi API Anthropic"
 
+msgid "Anthropic does not offer a text-to-speech API. Add an OpenAI, Gemini, or Azure key to generate audio narration."
+msgstr "Anthropic nuk ofron një API tekst-në-të-folur. Shtoni një çelës OpenAI, Gemini ose Azure për të gjeneruar narrativë audio."
+
 msgid "Anthropic is available for text models, but not speech synthesis."
 msgstr "Anthropic është i disponueshëm për modele teksti, por jo për sintezë të të folurit."
 

--- a/apps/studio/src/routes/__root.tsx
+++ b/apps/studio/src/routes/__root.tsx
@@ -1,4 +1,4 @@
-import { useState, createContext, useContext, useCallback, useMemo } from "react"
+import { useState, useCallback, useMemo } from "react"
 import {
   createRootRoute,
   Outlet,
@@ -10,14 +10,9 @@ import { Toaster } from "@/components/ui/sonner"
 import { UpdateDialogProvider } from "@/components/updates"
 import { useApiKey } from "@/hooks/use-api-key"
 import { ErrorScreen } from "@/components/ErrorScreen"
+import { SettingsContext, useSettingsDialog } from "@/hooks/use-settings-dialog"
 
-const SettingsContext = createContext<{ openSettings: () => void }>({
-  openSettings: () => {},
-})
-
-export function useSettingsDialog() {
-  return useContext(SettingsContext)
-}
+export { useSettingsDialog }
 
 function RootErrorComponent({ error, reset }: ErrorComponentProps) {
   return <ErrorScreen variant="app" error={error} reset={reset} />
@@ -46,6 +41,8 @@ function RootLayout() {
     azureRegion,
     setAzureRegion,
     setGeminiKey,
+    providerDefaultModels,
+    setProviderDefaultModel,
   } = useApiKey()
   const pathname = useRouterState({ select: (s) => s.location.pathname })
   const isOnboarding = pathname.startsWith("/onboarding")
@@ -79,6 +76,8 @@ function RootLayout() {
             onSaveAzureKey={setAzureKey}
             azureRegion={azureRegion}
             onSaveAzureRegion={setAzureRegion}
+            providerDefaultModels={providerDefaultModels}
+            onSaveProviderDefaultModel={setProviderDefaultModel}
           />
           <Toaster position="top-center" richColors closeButton />
         </div>

--- a/packages/llm/src/__tests__/client.test.ts
+++ b/packages/llm/src/__tests__/client.test.ts
@@ -141,4 +141,28 @@ describe("createLLMModel credentials", () => {
       expect.objectContaining({ model: googleModel }),
     )
   })
+
+  it("uses tool mode for Anthropic callers that request JSON mode", async () => {
+    const anthropicModel = { provider: "request-anthropic" }
+    createAnthropicMock.mockReturnValue(vi.fn(() => anthropicModel))
+    generateObjectMock.mockResolvedValue({
+      object: { ok: true },
+      usage: { promptTokens: 1, completionTokens: 2 },
+    })
+
+    const llm = createLLMModel({
+      modelId: "anthropic:claude-sonnet-4-6",
+      credentials: { anthropicApiKey: "ak-request" },
+      logLevel: "silent",
+    })
+    await llm.generateObject({
+      schema: z.object({ ok: z.boolean() }),
+      mode: "json",
+      messages: [{ role: "user", content: "hello" }],
+    })
+
+    expect(generateObjectMock).toHaveBeenCalledWith(
+      expect.objectContaining({ model: anthropicModel, mode: "tool" }),
+    )
+  })
 })

--- a/packages/llm/src/__tests__/model-resolution.test.ts
+++ b/packages/llm/src/__tests__/model-resolution.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest"
+import { resolveEffectiveModelId } from "../client.js"
+
+describe("resolveEffectiveModelId", () => {
+  it("keeps a configured model when its provider credential exists", () => {
+    expect(resolveEffectiveModelId("anthropic:claude-opus-4-6", {
+      anthropicApiKey: "anthropic-key",
+    })).toBe("anthropic:claude-opus-4-6")
+  })
+
+  it("falls back to the first configured provider", () => {
+    expect(resolveEffectiveModelId("openai:gpt-5.4", {
+      anthropicApiKey: "anthropic-key",
+      googleApiKey: "google-key",
+    })).toBe("anthropic:claude-sonnet-4-6")
+  })
+
+  it("uses Google when it is the first available provider", () => {
+    expect(resolveEffectiveModelId("openai:gpt-5.4", {
+      googleApiKey: "google-key",
+    })).toBe("google:gemini-2.5-pro")
+  })
+
+  it("honors an available user-selected default model", () => {
+    expect(resolveEffectiveModelId("openai:gpt-5.4", {
+      anthropicApiKey: "anthropic-key",
+      googleApiKey: "google-key",
+      defaultModelId: "google:gemini-2.5-flash",
+    })).toBe("google:gemini-2.5-flash")
+  })
+
+  it("uses the selected default instead of a base-config model", () => {
+    expect(resolveEffectiveModelId("openai:gpt-5.4", {
+      openaiApiKey: "openai-key",
+      defaultModelId: "openai:gpt-4.1",
+    })).toBe("openai:gpt-4.1")
+  })
+
+  it("preserves a model explicitly selected for a step", () => {
+    expect(resolveEffectiveModelId("openai:gpt-5.4", {
+      openaiApiKey: "openai-key",
+      defaultModelId: "openai:gpt-4.1",
+      explicitModelIds: ["openai:gpt-5.4"],
+    })).toBe("openai:gpt-5.4")
+  })
+})

--- a/packages/llm/src/__tests__/model-resolution.test.ts
+++ b/packages/llm/src/__tests__/model-resolution.test.ts
@@ -40,7 +40,7 @@ describe("resolveEffectiveModelId", () => {
     expect(resolveEffectiveModelId("openai:gpt-5.4", {
       openaiApiKey: "openai-key",
       defaultModelId: "openai:gpt-4.1",
-      explicitModelIds: ["openai:gpt-5.4"],
-    })).toBe("openai:gpt-5.4")
+      explicitModelIds: { "glossary": "openai:gpt-5.4" },
+    }, "glossary")).toBe("openai:gpt-5.4")
   })
 })

--- a/packages/llm/src/client.ts
+++ b/packages/llm/src/client.ts
@@ -23,8 +23,8 @@ export interface LLMProviderCredentials {
   customBaseUrl?: string
   customApiKey?: string
   defaultModelId?: string
-  /** Model IDs explicitly selected for individual steps. */
-  explicitModelIds?: string[]
+  /** Model IDs explicitly selected for individual steps (step name → model ID). */
+  explicitModelIds?: Record<string, string>
 }
 
 const FALLBACK_MODELS = {
@@ -38,6 +38,7 @@ const FALLBACK_MODELS = {
 export function resolveEffectiveModelId(
   modelId: string,
   credentials?: LLMProviderCredentials,
+  stepName?: string,
 ): string {
   if (!credentials) return modelId
   const requestedProvider = modelId.includes(":") ? modelId.slice(0, modelId.indexOf(":")) : "openai"
@@ -50,7 +51,7 @@ export function resolveEffectiveModelId(
   if (available.length === 0 || available.includes(requestedProvider as keyof typeof FALLBACK_MODELS)) {
     if (
       credentials.defaultModelId &&
-      !credentials.explicitModelIds?.includes(modelId)
+      !(stepName && credentials.explicitModelIds?.[stepName])
     ) {
       const defaultProvider = credentials.defaultModelId.includes(":")
         ? credentials.defaultModelId.slice(0, credentials.defaultModelId.indexOf(":"))
@@ -79,6 +80,8 @@ export interface CreateLLMModelOptions {
   credentials?: LLMProviderCredentials
   /** Console log level. Defaults to "info" (show all). Use "silent" to suppress. */
   logLevel?: LogLevel
+  /** Step name used to look up explicit model overrides in credentials. */
+  stepName?: string
 }
 
 /**
@@ -92,7 +95,7 @@ export interface CreateLLMModelOptions {
  */
 export function createLLMModel(options: CreateLLMModelOptions): LLMModel {
   const { cacheDir, promptEngine, onLog, rateLimiter, credentials, logLevel } = options
-  const modelId = resolveEffectiveModelId(options.modelId, credentials)
+  const modelId = resolveEffectiveModelId(options.modelId, credentials, options.stepName)
   const log = createLogger(logLevel)
 
   return {

--- a/packages/llm/src/client.ts
+++ b/packages/llm/src/client.ts
@@ -22,6 +22,52 @@ export interface LLMProviderCredentials {
   googleApiKey?: string
   customBaseUrl?: string
   customApiKey?: string
+  defaultModelId?: string
+  /** Model IDs explicitly selected for individual steps. */
+  explicitModelIds?: string[]
+}
+
+const FALLBACK_MODELS = {
+  openai: "gpt-5.4",
+  anthropic: "claude-sonnet-4-6",
+  google: "gemini-2.5-pro",
+  custom: "your-model-name",
+} as const
+
+/** Resolve an unavailable configured provider to the first request-scoped credential. */
+export function resolveEffectiveModelId(
+  modelId: string,
+  credentials?: LLMProviderCredentials,
+): string {
+  if (!credentials) return modelId
+  const requestedProvider = modelId.includes(":") ? modelId.slice(0, modelId.indexOf(":")) : "openai"
+  const available = [
+    credentials.openaiApiKey && "openai",
+    credentials.anthropicApiKey && "anthropic",
+    credentials.googleApiKey && "google",
+    credentials.customBaseUrl && "custom",
+  ].filter(Boolean) as Array<keyof typeof FALLBACK_MODELS>
+  if (available.length === 0 || available.includes(requestedProvider as keyof typeof FALLBACK_MODELS)) {
+    if (
+      credentials.defaultModelId &&
+      !credentials.explicitModelIds?.includes(modelId)
+    ) {
+      const defaultProvider = credentials.defaultModelId.includes(":")
+        ? credentials.defaultModelId.slice(0, credentials.defaultModelId.indexOf(":"))
+        : "openai"
+      if (available.includes(defaultProvider as keyof typeof FALLBACK_MODELS)) {
+        return credentials.defaultModelId
+      }
+    }
+    return modelId
+  }
+  const preferred = credentials.defaultModelId
+  if (preferred) {
+    const preferredProvider = (preferred.includes(":") ? preferred.slice(0, preferred.indexOf(":")) : "openai") as keyof typeof FALLBACK_MODELS
+    if (available.includes(preferredProvider)) return preferred
+  }
+  const provider = available[0]
+  return `${provider}:${FALLBACK_MODELS[provider]}`
 }
 
 export interface CreateLLMModelOptions {
@@ -45,7 +91,8 @@ export interface CreateLLMModelOptions {
  * - Optional prompt rendering (pass promptEngine + use prompt option)
  */
 export function createLLMModel(options: CreateLLMModelOptions): LLMModel {
-  const { modelId, cacheDir, promptEngine, onLog, rateLimiter, credentials, logLevel } = options
+  const { cacheDir, promptEngine, onLog, rateLimiter, credentials, logLevel } = options
+  const modelId = resolveEffectiveModelId(options.modelId, credentials)
   const log = createLogger(logLevel)
 
   return {
@@ -82,6 +129,7 @@ export function createLLMModel(options: CreateLLMModelOptions): LLMModel {
       }
 
       const maxRetries = opts.maxRetries ?? 0
+      const objectMode = resolveObjectMode(modelId, opts.mode)
       const t0 = Date.now()
       const requestId = randomUUID()
 
@@ -93,11 +141,16 @@ export function createLLMModel(options: CreateLLMModelOptions): LLMModel {
       const label = opts.log
         ? `${opts.log.taskType}${opts.log.pageId ? ` ${opts.log.pageId}` : ""}`
         : modelId
+      log.info(
+        `[LLM] ${label} | model=${modelId}` +
+        `${modelId !== options.modelId ? ` | requested=${options.modelId}` : ""}` +
+        ` | mode=${objectMode ?? "auto"} | start`
+      )
 
       for (let attempt = 0; attempt <= maxRetries; attempt++) {
         const hash = computeHash({
           modelId,
-          mode: opts.mode,
+          mode: objectMode,
           system,
           messages: currentMessages,
           schema: opts.schema,
@@ -121,7 +174,8 @@ export function createLLMModel(options: CreateLLMModelOptions): LLMModel {
                 }),
                 opts,
                 system,
-                currentMessages
+                currentMessages,
+                objectMode,
               )
               result = generated.object
               totalUsage.inputTokens += generated.usage.inputTokens
@@ -137,7 +191,8 @@ export function createLLMModel(options: CreateLLMModelOptions): LLMModel {
               }),
               opts,
               system,
-              currentMessages
+              currentMessages,
+              objectMode,
             )
             result = generated.object
             totalUsage.inputTokens += generated.usage.inputTokens
@@ -312,6 +367,18 @@ export function createLLMModel(options: CreateLLMModelOptions): LLMModel {
   }
 }
 
+function resolveObjectMode(
+  modelId: string,
+  requestedMode: GenerateObjectOptions["mode"],
+): GenerateObjectOptions["mode"] {
+  const provider = modelId.includes(":") ? modelId.slice(0, modelId.indexOf(":")) : "openai"
+  // The AI SDK's Anthropic provider does not implement JSON-mode object
+  // generation. Tool mode provides schema-constrained objects for Claude and
+  // also supports the recursive schemas for which callers request JSON mode.
+  if (provider === "anthropic" && requestedMode === "json") return "tool"
+  return requestedMode
+}
+
 function resolveModel(
   modelId: string,
   credentials?: LLMProviderCredentials,
@@ -389,7 +456,8 @@ async function callLLM<T>(
   model: LanguageModel,
   opts: GenerateObjectOptions,
   system: string | undefined,
-  messages: Message[]
+  messages: Message[],
+  mode: GenerateObjectOptions["mode"],
 ): Promise<{ object: T; usage: TokenUsage }> {
   const coreMessages = convertMessages(messages)
   const generateOpts: Record<string, unknown> = {
@@ -400,8 +468,8 @@ async function callLLM<T>(
     maxRetries: 0,
     abortSignal: AbortSignal.timeout(opts.timeoutMs ?? 90_000),
   }
-  if (opts.mode) {
-    generateOpts.mode = opts.mode
+  if (mode) {
+    generateOpts.mode = mode
   }
   if (opts.maxTokens) {
     generateOpts.maxTokens = opts.maxTokens

--- a/packages/llm/src/index.ts
+++ b/packages/llm/src/index.ts
@@ -10,7 +10,7 @@ export type {
   ValidationResult,
 } from "./types.js"
 
-export { createLLMModel, type CreateLLMModelOptions } from "./client.js"
+export { createLLMModel, resolveEffectiveModelId, type CreateLLMModelOptions } from "./client.js"
 
 export {
   generateImageWithCache,

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -14,6 +14,8 @@ export type RateLimitConfig = z.infer<typeof RateLimitConfig>
 export const StepConfig = z.object({
   prompt: z.string().optional(),
   model: z.string().optional(),
+  /** True when the user intentionally overrides the application-wide selected model. */
+  model_override: z.boolean().optional(),
   max_retries: z.number().int().min(0).optional(),
   timeout: z.number().int().min(1).optional(),
   temperature: z.number().min(0).max(2).optional(),
@@ -77,6 +79,7 @@ export const RenderStrategyConfig = z
         // llm / activity render type
         prompt: z.string().optional(),
         model: z.string().optional(),
+        model_override: z.boolean().optional(),
         max_retries: z.number().int().min(0).optional(),
         timeout: z.number().int().min(1).optional(),
         temperature: z.number().min(0).max(2).optional(),


### PR DESCRIPTION

## Problem

When multiple LLM providers are configured (e.g., OpenAI + Anthropic), the system always silently picks the first one in a hardcoded priority order (OpenAI → Anthropic → Google → Custom). Users have no way to control which provider is used for pipeline runs, no way to change the default model per provider, and no visibility into which provider was actually used.

Worse, the app previously required an OpenAI key to function — even if the user only wants to use Anthropic or Google, the pipeline would fail without a valid OpenAI key configured. There was no workaround short of providing an OpenAI key.

Additionally, when the configured model's provider has no key available, the pipeline fails silently rather than falling back to an available provider.

## Solution

**User-facing: Default provider selection in Settings**
- Added a "Mark as default" button next to each provider's API key label in the Settings dialog
- Shows a green "default" badge and ✦ tab indicator for the active default
- Choice persists across sessions (localStorage)
- Only visible when 2+ providers are configured — single-provider setups are unchanged
- If no provider is explicitly selected, the first available configured provider is used automatically instead of failing

**User-facing: Per-provider default model configuration**
- Each provider tab in Settings now includes a "Default AI model" dropdown
- Users can change the model used for each provider (e.g., switch OpenAI from gpt-5.4 to gpt-4.1, or Anthropic from claude-sonnet-4-6 to claude-opus-4-6)
- The selected model is persisted per provider and used whenever that provider is active
- System provides sensible fallbacks if no model is explicitly chosen (e.g., openai:gpt-5.4, anthropic:claude-sonnet-4-6)

**Backend: Model resolution engine**
- New `resolveEffectiveModelId()` function in `packages/llm` that routes models to available providers
- Respects per-step model overrides (`X-Step-Model-Overrides` header)
- Respects the user's default model preference (`X-Default-LLM-Model` header)
- Falls back gracefully when a provider's key is missing — automatically resolves to the first available provider instead of failing
- Handles Anthropic's lack of JSON-mode by automatically switching to tool-mode
- Removed the hard dependency on OpenAI — any single configured provider is now sufficient to run the full pipeline

**Frontend: Unified model source of truth**
- `useApiKey().defaultModel` now respects the active provider choice everywhere (workflow pages, step configs, stage runs)
- `useActiveProvider` hook encapsulates resolution, persistence, and reactivity
- `StageRunCard` shows which provider was used for each run
- Removed the OpenAI-specific key validation that previously blocked non-OpenAI-only setups

**Speech page: Better Anthropic messaging**
- Added visible info banner explaining that Anthropic doesn't offer TTS when no speech-capable provider is configured

### Key Points

- **No breaking changes** — single-provider setups behave identically to before
- **OpenAI is no longer required** — the app now works with any single configured provider (Anthropic, Google, or Custom alone)
- **Graceful fallback** — if no default provider is explicitly selected, the first available configured provider is used instead of failing
- **Per-provider model customization** — users can now choose which specific model each provider uses without editing config files
- **Frontend-only provider selection** — the backend already accepted all provider keys; this just controls which model ID is sent as the default
- **Backend model resolution is new** — enables automatic fallback when a step's configured model isn't available
- **Anthropic JSON→tool mode fix** — the AI SDK's Anthropic provider doesn't support `mode: "json"`, so we automatically switch to `mode: "tool"` which provides equivalent schema-constrained output
- **i18n complete** — all new strings translated to pt-BR, es, fr, sq

### Testing

- All 1661 tests pass (2 pre-existing timeouts in `part-service.test.ts` unrelated to this PR)
- TypeScript strict mode passes clean
- New test files: `model-resolution.test.ts`, `use-step-config.test.tsx`, `StageSidebar.test.tsx`
- Manual testing: verified provider switching, persistence across sessions, model display on workflow pages, stage run execution with non-OpenAI providers