### PR TITLE
Re-enable site docs

### DIFF
--- a/apps/site/src/lib/flags.ts
+++ b/apps/site/src/lib/flags.ts
@@ -1,9 +1,7 @@
 /**
  * Build/runtime feature flags for the site.
  *
- * `DOCS_ENABLED` gates the entire `/docs` section (routes, nav/footer links,
- * home Docs scene, search) while the documentation is still being written and
- * translated. Flip this to `true` — no other changes required — to publish the
- * docs once the content is ready.
+ * `DOCS_ENABLED` gates the entire `/docs` section: routes, nav/footer links,
+ * the home Docs scene, search, and prerender entries.
  */
-export const DOCS_ENABLED = false;
+export const DOCS_ENABLED = true;


### PR DESCRIPTION
## Summary

- Enables the public `/docs` surface by flipping `DOCS_ENABLED` to `true`.
- Updates landing/footer/docs-overview links that pointed at temporarily planned docs slugs so they now point at existing pages.
- Fixes the quizzes docs icon name so the docs build no longer warns about an unknown lucide icon.

## Verification

- `pnpm --filter @adt/site types:check`
- `pnpm --filter @adt/site build`

## Notes

This PR targets `landing-page` because PR #528 was merged into `landing-page`, not `develop`. A PR against `develop` would include the full landing-page diff until the landing-page branch is merged there.
