### PR TITLE
fix(site): release detail link 404s under GitHub Pages base path

### DIFF
--- a/apps/site/src/components/sections/ReleasesScene.tsx
+++ b/apps/site/src/components/sections/ReleasesScene.tsx
@@ -2,6 +2,7 @@ import { Trans, useLingui } from "@lingui/react/macro";
 import { ArrowRight, ArrowUpRight, Sparkles, Tag } from "lucide-react";
 import { SectionEyebrow } from "@/components/SectionEyebrow";
 import { cn } from "@/lib/cn";
+import { withBase } from "@/lib/href";
 import {
   firstImageFromBody,
   firstParagraphFromBody,
@@ -103,7 +104,7 @@ function HeroSpotlight({ release }: { release: GithubRelease }) {
   const cover = firstImageFromBody(release.body);
   const excerpt = firstParagraphFromBody(release.body, 240);
   const sections = summarizeSections(release.body).slice(0, 4);
-  const detailHref = `/releases/${encodeURIComponent(release.tag_name)}`;
+  const detailHref = withBase(`/releases/${encodeURIComponent(release.tag_name)}`);
 
   return (
     <article


### PR DESCRIPTION
## Problem

Opening a release detail URL like `https://unicef.github.io/releases/v0.7.4` returns a **404**.

The site is a GitHub Pages *project* site served under `/adt-studio/`. The latest-release hero card in `ReleasesScene` built its detail link as a raw app-absolute anchor:

```tsx
const detailHref = `/releases/${encodeURIComponent(release.tag_name)}`;
<a href={detailHref} ... />
```

A raw `/releases/...` path ignores the router basepath, so clicking it navigates the browser to `unicef.github.io/releases/<tag>` — dropping `/adt-studio/` — which is a hard 404 (nothing exists at the org root).

## Fix

Route the link through the existing `withBase()` helper (`apps/site/src/lib/href.ts`), exactly as the sibling `ReleasesPage` already does. The link now points to `/adt-studio/releases/<tag>`, which resolves via the SPA `404.html` fallback → router matches `/releases/$tag` → renders the release page.

## Verification

- `pnpm --filter @adt/site types:check` passes.
- Confirmed live status codes: `/adt-studio/releases/` → 200, `/releases/v0.7.4` (old link) → hard 404, `/adt-studio/releases/<tag>` → served via SPA fallback.