### PR TITLE
chore(kids): remove dev-only onboarding replay affordances

### DIFF
--- a/apps/adt-runtime/src/features/kids/components/KidsChrome.tsx
+++ b/apps/adt-runtime/src/features/kids/components/KidsChrome.tsx
@@ -1,39 +1,16 @@
-import { useAtomValue, useSetAtom } from "jotai"
-import { useEffect } from "react"
+import { useAtomValue } from "jotai"
 import { KidsBuddy } from "@/features/kids/components/KidsBuddy"
 import { KidsOnboarding } from "@/features/kids/components/KidsOnboarding"
 import { KidsPageArrows } from "@/features/kids/components/KidsPageArrows"
 import { KidsSpeechBubble } from "@/features/kids/components/KidsSpeechBubble"
-import { isKidsPreviewContext } from "@/features/kids/lib/kids-preview"
 import {
   kidsModeActiveAtom,
   kidsOnboardingDoneAtom,
 } from "@/features/kids/state/kids.atoms"
 
-// DEV/AUTHORING ONLY — replay onboarding once per browser tab so it is easy to
-// review while building. Fires in the same dev/authoring preview context
-// used for the kids-mode preview override (see kids-preview.ts):
-// NODE_ENV=development or any iframed runtime (the Studio preview always
-// runs in an iframe). A shipped book runs standalone (window.parent ===
-// window) in production, so this never fires for real readers.
-// Guarded by sessionStorage so page turns (each reloads the runtime) don't
-// re-trigger it; reopen the tab to see it again.
-// Remove before shipping kids mode.
-const DEV_ONBOARDING_RESET_KEY = "kidsDevOnboardingReset"
-
 export function KidsChrome() {
   const kidsModeActive = useAtomValue(kidsModeActiveAtom)
   const kidsOnboardingDone = useAtomValue(kidsOnboardingDoneAtom)
-  const setKidsOnboardingDone = useSetAtom(kidsOnboardingDoneAtom)
-
-  useEffect(() => {
-    if (!isKidsPreviewContext()) return
-    if (typeof sessionStorage === "undefined") return
-    if (sessionStorage.getItem(DEV_ONBOARDING_RESET_KEY)) return
-    sessionStorage.setItem(DEV_ONBOARDING_RESET_KEY, "1")
-    setKidsOnboardingDone(false)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [setKidsOnboardingDone])
 
   return (
     <div
@@ -48,18 +25,6 @@ export function KidsChrome() {
           <KidsPageArrows />
           <KidsSpeechBubble />
           <KidsBuddy />
-          {/* TEMP — quick way to replay onboarding while building. Dev/preview
-              only (never in a shipped book). Remove before shipping. */}
-          {isKidsPreviewContext() ? (
-            <button
-              type="button"
-              data-testid="kids-redo-onboarding"
-              onClick={() => setKidsOnboardingDone(false)}
-              className="pointer-events-auto fixed left-4 top-4 z-[60] rounded-full bg-slate-900/80 px-4 py-2 text-sm font-bold text-white shadow-lg ring-1 ring-white/20 transition hover:bg-slate-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
-            >
-              ↻ Redo intro
-            </button>
-          ) : null}
         </>
       ) : null}
     </div>

--- a/apps/adt-runtime/src/features/kids/lib/kids-preview.test.ts
+++ b/apps/adt-runtime/src/features/kids/lib/kids-preview.test.ts
@@ -27,17 +27,12 @@ afterEach(() => {
 })
 
 describe("isKidsPreviewContext", () => {
-  it("is false outside dev/iframe/onboarding-preview contexts", () => {
+  it("is false outside dev/iframe contexts (standalone shipped book)", () => {
     expect(isKidsPreviewContext()).toBe(false)
   })
 
-  it("is true when the runtime is iframed", () => {
+  it("is true when the runtime is iframed (Studio preview)", () => {
     enterIframeContext()
-    expect(isKidsPreviewContext()).toBe(true)
-  })
-
-  it("is true when the URL carries ?kidsOnboarding=preview, even standalone", () => {
-    setSearch("?kidsOnboarding=preview")
     expect(isKidsPreviewContext()).toBe(true)
   })
 })

--- a/apps/adt-runtime/src/features/kids/lib/kids-preview.ts
+++ b/apps/adt-runtime/src/features/kids/lib/kids-preview.ts
@@ -38,19 +38,8 @@ export function isKidsPreviewContext(): boolean {
   if (typeof window === "undefined") return false
   if (process.env.NODE_ENV === "development") return true
   try {
-    // Studio's preview tags the iframe URL with this param on first load…
-    if (
-      new URLSearchParams(window.location.search).get("kidsOnboarding") ===
-      "preview"
-    ) {
-      return true
-    }
-  } catch {
-    // ignore — fall through to the iframe check
-  }
-  try {
-    // …and, since in-preview navigation can drop the query string, treat any
-    // iframed runtime as a preview context. A shipped book runs standalone
+    // Any iframed runtime is a preview context — Studio's preview always runs
+    // the book in an iframe. A shipped book runs standalone
     // (window.parent === window), so this never fires for real readers.
     if (window.parent !== window) return true
   } catch {

--- a/apps/api/src/routes/books.ts
+++ b/apps/api/src/routes/books.ts
@@ -903,8 +903,8 @@ export function createBookRoutes(
         throw new HTTPException(404, { message: "ADT has no pages" })
       }
       // Preserve the version segment and the query string in the redirect —
-      // the Studio preview rides params on the root URL (kidsOnboarding,
-      // kidsMode) that the runtime must see on the first real page load.
+      // the Studio preview rides the `kidsMode` param on the root URL that the
+      // runtime must see on the first real page load.
       const versionMatch = reqPath.match(/\/adt\/(v-[^/]+)/)
       const versionPrefix = versionMatch ? `${versionMatch[1]}/` : ""
       const query = new URL(c.req.url).search

--- a/apps/studio/src/components/pipeline/stages/PreviewView.tsx
+++ b/apps/studio/src/components/pipeline/stages/PreviewView.tsx
@@ -397,10 +397,7 @@ export function PreviewView({ bookLabel }: { bookLabel: string }) {
         <div style={sizerStyle}>
           <iframe
             ref={iframeRef}
-            // `?kidsOnboarding=preview` lets the runtime replay kids onboarding
-            // in the Studio preview (dev/authoring only). No effect unless kids
-            // mode is on; shipped books never carry this param.
-            src={`${getAdtUrl(bookLabel)}/v-${version}/?kidsOnboarding=preview${kidsParam ? `&kidsMode=${kidsParam}` : ""}`}
+            src={`${getAdtUrl(bookLabel)}/v-${version}/${kidsParam ? `?kidsMode=${kidsParam}` : ""}`}
             className="border-0"
             style={iframeStyle}
             title="ADT Preview"

--- a/docs/KIDS_MODE.md
+++ b/docs/KIDS_MODE.md
@@ -85,9 +85,9 @@ FAB bottom-right (idle bob, reduce-motion aware; expression swaps standing/happy
 
 Sky-blue gradient world with drifting CSS clouds; white chunky cards with 3px borders and **hard offset shadows** (`0 4px 0 <edge>`) pressed down via transform+box-shadow only; sunny-yellow primary CTA (`#FFC800` face / `#DFA000` edge); selection = **full sky-500 fill + white checkmark**; Lucide icons; ≥44px targets; visible focus rings; `reduceMotionAtom` + OS `prefers-reduced-motion` respected throughout. Note the Tailwind v4 trap: custom classes in `@layer utilities` get **no variant support** — the kids animation classes are used unprefixed and gated in JS via `usePrefersReducedMotion`.
 
-### Dev/preview affordances (remove before shipping)
+### Studio preview override
 
-Two `KidsChrome` conveniences fire only on the dev server (`NODE_ENV=development`) or in an iframed runtime (the Studio preview): a once-per-tab onboarding replay, and a "↻ Redo intro" button. A shipped standalone book never sees either. Note: the esbuild runtime build defines only `process.env.NODE_ENV` — `import.meta.env` is undefined and **reading it throws**.
+The Studio preview lets an author flip the book between the KIDS and REGULAR chrome without touching the packed decision. The preview iframe tags its URL with `?kidsMode=on|off`; the runtime honors it (persisted per-tab in sessionStorage so it survives page turns) **only in the preview context** — `isKidsPreviewContext()` = the dev server (`NODE_ENV=development`) or any iframed runtime (`window.parent !== window`). A shipped standalone book runs top-level, so a stray `?kidsMode=` is ignored. Note: the esbuild runtime build defines only `process.env.NODE_ENV` — `import.meta.env` is undefined and **reading it throws**. Onboarding replay for authors lives in the buddy panel ("Meet my buddy again"), not a dev-only button.
 
 ## Feature ↔ research mapping
 


### PR DESCRIPTION
Removes the dev-only kids-mode scaffolding flagged for removal before shipping (pre-merge checklist item 2). **Stacked on `eliezir/kids-mode`** (base of this PR), part of getting #568 merge-ready.

### Removed
- `KidsChrome` once-per-tab onboarding auto-reset (the `kidsDevOnboardingReset` effect).
- The "↻ Redo intro" dev button.
- The now-vestigial `?kidsOnboarding=preview` URL param (PreviewView no longer sends it; `isKidsPreviewContext` no longer reads it).

### Kept / unaffected
- The Studio preview **kids/regular toggle** — still works via preview-context detection (`window.parent !== window` for the iframed preview, or `NODE_ENV=development`).
- Author onboarding replay — the shipped **"Meet my buddy again"** action in the buddy panel.

### Verified (browser E2E, packaged raven)
- Standalone default → kids chrome (packed on). ✓
- Standalone `?kidsMode=off` → **ignored**, kids still shown (a shipped book can't be flipped by a stray param). ✓
- Iframed `?kidsMode=off` (preview) → override honored, kids hidden. ✓
- `pnpm tsc --build` clean · runtime 191/191 · studio 161/161 · eslint clean.
