### PR TITLE
i18n(studio): translate Kids Mode strings (es, pt-BR, fr, sq)

### DIFF
--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -68,6 +68,12 @@ msgstr "(p.{0})"
 msgid "(template)"
 msgstr "(template)"
 
+#. placeholder {0}: buddies.length
+#. placeholder {1}: KIDS_BUDDIES.length
+#. placeholder {2}: KIDS_BUDDIES.length
+msgid "{0, plural, one {# of {1} shipping} other {# of {2} shipping}}"
+msgstr "{0, plural, one {# of {1} shipping} other {# of {2} shipping}}"
+
 #. placeholder {0}: preview.addedPageNumbers.length
 #. placeholder {0}: result.addedPages
 msgid "{0, plural, one {# page added} other {# pages added}}"
@@ -234,6 +240,10 @@ msgstr "{0} sections"
 msgid "{0} selected images are no longer in the storyboard."
 msgstr "{0} selected images are no longer in the storyboard."
 
+#. placeholder {0}: selectedBuddy.defaultNameFallback
+msgid "{0} ships with this book"
+msgstr "{0} ships with this book"
+
 #. placeholder {0}: String(visibleCount)
 msgid "{0} terms"
 msgstr "{0} terms"
@@ -245,6 +255,10 @@ msgstr "{0} texts"
 #. placeholder {0}: outputLanguages.length
 msgid "{0} translations"
 msgstr "{0} translations"
+
+#. placeholder {0}: selectedBuddy.defaultNameFallback
+msgid "{0}'s voice pack"
+msgstr "{0}'s voice pack"
 
 #. placeholder {0}: String(generatedAudioCount)
 #. placeholder {1}: String(speakableEntries.length)
@@ -288,6 +302,9 @@ msgstr "{0}m ago"
 #. placeholder {0}: String(Math.floor(diff / 1000))
 msgid "{0}s ago"
 msgstr "{0}s ago"
+
+msgid "{buddyCount, plural, one {# buddy} other {# buddies}}"
+msgstr "{buddyCount, plural, one {# buddy} other {# buddies}}"
 
 msgid "{count} {count, plural, one {issue} other {issues}}"
 msgstr "{count} {count, plural, one {issue} other {issues}}"
@@ -351,8 +368,14 @@ msgstr "{missingForCurrentStage} entry/entries are missing audio. Re-run to gene
 msgid "{missingForCurrentStage} entry/entries are missing translations. Re-run to fill the missing items."
 msgstr "{missingForCurrentStage} entry/entries are missing translations. Re-run to fill the missing items."
 
+msgid "{name}'s expressions"
+msgstr "{name}'s expressions"
+
 msgid "{needsChanges} flagged"
 msgstr "{needsChanges} flagged"
+
+msgid "{packCount, plural, one {# voice pack} other {# voice packs}}"
+msgstr "{packCount, plural, one {# voice pack} other {# voice packs}}"
 
 msgid "{pageCount} {pageCount, plural, one {page} other {pages}}"
 msgstr "{pageCount} {pageCount, plural, one {page} other {pages}}"
@@ -517,6 +540,9 @@ msgstr "A figure of speech that describes one thing as if it were another to dra
 
 msgid "A fill-in-the-blank activity."
 msgstr "A fill-in-the-blank activity."
+
+msgid "A friendly character fronts every reading tool, from text-to-speech to font size."
+msgstr "A friendly character fronts every reading tool, from text-to-speech to font size."
 
 msgid "A glossary term with this word already exists."
 msgstr "A glossary term with this word already exists."
@@ -843,6 +869,9 @@ msgstr "Add language"
 msgid "Add Language"
 msgstr "Add Language"
 
+msgid "Add languages to the book to generate voice packs."
+msgstr "Add languages to the book to generate voice packs."
+
 msgid "Add languages to translate the book content into."
 msgstr "Add languages to translate the book content into."
 
@@ -896,6 +925,15 @@ msgstr "Add your first book"
 
 msgid "Add your first term"
 msgstr "Add your first term"
+
+msgid "Add your OpenAI key in Settings to generate voices."
+msgstr "Add your OpenAI key in Settings to generate voices."
+
+msgid "Add your OpenAI key in Settings to generate."
+msgstr "Add your OpenAI key in Settings to generate."
+
+msgid "Add your own buddy"
+msgstr "Add your own buddy"
 
 msgid "added"
 msgstr "added"
@@ -1050,6 +1088,9 @@ msgstr "All categories"
 msgid "All Categories"
 msgstr "All Categories"
 
+msgid "All expressions"
+msgstr "All expressions"
+
 msgid "All issues and manual review items"
 msgstr "All issues and manual review items"
 
@@ -1180,6 +1221,9 @@ msgstr "Appears on pages {0}"
 msgid "Application Programming Interface — a set of rules that allows programs to communicate."
 msgstr "Application Programming Interface — a set of rules that allows programs to communicate."
 
+msgid "Applies to the live preview and every exported format — readers can't turn it off."
+msgstr "Applies to the live preview and every exported format — readers can't turn it off."
+
 msgid "Apply"
 msgstr "Apply"
 
@@ -1265,6 +1309,12 @@ msgstr "Audio narration (largest impact on file size)"
 msgid "Audio Player"
 msgstr "Audio Player"
 
+msgid "Audition"
+msgstr "Audition"
+
+msgid "Audition language"
+msgstr "Audition language"
+
 msgid "Author"
 msgstr "Author"
 
@@ -1319,14 +1369,23 @@ msgstr "Back"
 msgid "Back Cover"
 msgstr "Back Cover"
 
+msgid "Back to book"
+msgstr "Back to book"
+
 msgid "Back to books"
 msgstr "Back to books"
 
 msgid "Back to Editor"
 msgstr "Back to Editor"
 
+msgid "Back to kids UI"
+msgstr "Back to kids UI"
+
 msgid "Back to preview"
 msgstr "Back to preview"
+
+msgid "Back to regular UI"
+msgstr "Back to regular UI"
 
 msgid "Back to Speech overview"
 msgstr "Back to Speech overview"
@@ -1340,6 +1399,9 @@ msgstr "Background"
 #. placeholder {0}: section.backgroundColor
 msgid "Background: {0}"
 msgstr "Background: {0}"
+
+msgid "Baked into the book"
+msgstr "Baked into the book"
 
 msgid "base"
 msgstr "base"
@@ -1482,6 +1544,15 @@ msgstr "Browse and edit Liquid templates used for template-based rendering strat
 
 msgid "Browse every Storyboard section and upload, replace, or remove its sign-language video."
 msgstr "Browse every Storyboard section and upload, replace, or remove its sign-language video."
+
+msgid "Buddies"
+msgstr "Buddies"
+
+msgid "Buddy stage view"
+msgstr "Buddy stage view"
+
+msgid "Buddy-guided interface"
+msgstr "Buddy-guided interface"
 
 msgid "Build"
 msgstr "Build"
@@ -1653,11 +1724,17 @@ msgstr "Chapter books with images"
 msgid "Chapter One"
 msgstr "Chapter One"
 
+msgid "Character art"
+msgstr "Character art"
+
 msgid "Chart / Graph"
 msgstr "Chart / Graph"
 
 #~ msgid "Check for updates"
 #~ msgstr "Check for updates"
+
+msgid "Check plan"
+msgstr "Check plan"
 
 msgid "Checked"
 msgstr "Checked"
@@ -2095,6 +2172,9 @@ msgstr "Current Preview Page"
 msgid "Custom"
 msgstr "Custom"
 
+msgid "Custom buddies are coming soon"
+msgstr "Custom buddies are coming soon"
+
 msgid "Custom Instructions"
 msgstr "Custom Instructions"
 
@@ -2360,6 +2440,12 @@ msgstr "Done"
 msgid "DONE"
 msgstr "DONE"
 
+#. placeholder {0}: lastRun.total
+#. placeholder {1}: lastRun.generated
+#. placeholder {2}: lastRun.cachedHits
+msgid "Done: {0} clips ready — {1} newly generated, {2} from cache."
+msgstr "Done: {0} clips ready — {1} newly generated, {2} from cache."
+
 msgid "Download a full backup of this project"
 msgstr "Download a full backup of this project"
 
@@ -2483,6 +2569,9 @@ msgstr "e.g., Make the background brighter, add more trees..."
 msgid "Each block was simplified by AI. Edit any Easy Read text to refine it against the original, then Save. Changes are stored as a new version, so you can always roll back or regenerate."
 msgstr "Each block was simplified by AI. Edit any Easy Read text to refine it against the original, then Save. Changes are stored as a new version, so you can always roll back or regenerate."
 
+msgid "Each buddy talks in the reader's language, generated once per language and cached for offline use."
+msgstr "Each buddy talks in the reader's language, generated once per language and cached for offline use."
+
 msgid "Each iteration is one LLM call. Lower values are faster and cheaper; higher values give the reviewer more chances to fix problems."
 msgstr "Each iteration is one LLM call. Lower values are faster and cheaper; higher values give the reviewer more chances to fix problems."
 
@@ -2565,6 +2654,9 @@ msgstr "Editable per block"
 msgid "edited"
 msgstr "edited"
 
+msgid "Edited"
+msgstr "Edited"
+
 msgid "Edited in"
 msgstr "Edited in"
 
@@ -2573,6 +2665,9 @@ msgstr "Edited manually"
 
 msgid "Editing"
 msgstr "Editing"
+
+msgid "Editing character art is coming soon"
+msgstr "Editing character art is coming soon"
 
 msgid "Editing is disabled while the storyboard is running"
 msgstr "Editing is disabled while the storyboard is running"
@@ -2635,6 +2730,9 @@ msgstr "Enabled"
 
 msgid "Enabled axe tags"
 msgstr "Enabled axe tags"
+
+msgid "Encouraging"
+msgstr "Encouraging"
 
 msgid "End"
 msgstr "End"
@@ -2743,6 +2841,9 @@ msgstr "Every Storyboard section has a sign-language video assigned. You can swi
 
 msgid "Example Books"
 msgstr "Example Books"
+
+msgid "Excited"
+msgstr "Excited"
 
 msgid "Exclude from read-aloud"
 msgstr "Exclude from read-aloud"
@@ -3108,6 +3209,12 @@ msgstr "Generate a simplified, easier-to-read version of every text block in the
 msgid "Generate a single quiz from specific pages and place it at a chosen location."
 msgstr "Generate a single quiz from specific pages and place it at a chosen location."
 
+msgid "Generate all buddy voices"
+msgstr "Generate all buddy voices"
+
+msgid "Generate all languages"
+msgstr "Generate all languages"
+
 msgid "Generate and customize the table of contents for the book navigation."
 msgstr "Generate and customize the table of contents for the book navigation."
 
@@ -3147,6 +3254,9 @@ msgstr "Generate quiz"
 msgid "Generate Styleguide from Pages"
 msgstr "Generate Styleguide from Pages"
 
+msgid "Generate voices to preview lines"
+msgstr "Generate voices to preview lines"
+
 msgid "Generate with AI"
 msgstr "Generate with AI"
 
@@ -3173,6 +3283,9 @@ msgstr "Generates comprehension questions and activities from the book."
 
 msgid "Generates descriptive alt-text for images so screen readers can describe them."
 msgstr "Generates descriptive alt-text for images so screen readers can describe them."
+
+msgid "Generates every shipped buddy in every book language."
+msgstr "Generates every shipped buddy in every book language."
 
 msgid "Generates the interactive HTML for this activity type."
 msgstr "Generates the interactive HTML for this activity type."
@@ -3284,6 +3397,9 @@ msgstr "Hand out page-range parts and merge them back later."
 #~ msgid "Handwriting"
 #~ msgstr "Handwriting"
 
+msgid "Happy"
+msgstr "Happy"
+
 msgid "Header"
 msgstr "Header"
 
@@ -3316,6 +3432,9 @@ msgstr "Hide AI edit history"
 
 msgid "Hide error details"
 msgstr "Hide error details"
+
+msgid "Hide Kids Mode details"
+msgstr "Hide Kids Mode details"
 
 msgid "High"
 msgstr "High"
@@ -3713,6 +3832,12 @@ msgstr "Key must start with sk-"
 msgid "Keyboard & navigation"
 msgstr "Keyboard & navigation"
 
+msgid "Kids Mode"
+msgstr "Kids Mode"
+
+msgid "Kids Mode swaps the standard reading menus for a friendly, buddy-guided experience: the reader picks a reading buddy that fronts every accessibility feature. It's an authoring decision baked into the live preview and every export — readers can't turn it off or change buddies themselves."
+msgstr "Kids Mode swaps the standard reading menus for a friendly, buddy-guided experience: the reader picks a reading buddy that fronts every accessibility feature. It's an authoring decision baked into the live preview and every export — readers can't turn it off or change buddies themselves."
+
 #. placeholder {0}: afterPage.pageNumber
 msgid "Knowledge check generated from the source pages, after page {0}."
 msgstr "Knowledge check generated from the source pages, after page {0}."
@@ -3819,6 +3944,9 @@ msgstr "Lila wandered between the tall pines, her flashlight catching glimmers o
 
 msgid "lines"
 msgstr "lines"
+
+msgid "Lines"
+msgstr "Lines"
 
 msgid "Língua Portuguesa - 3° Ano"
 msgstr "Língua Portuguesa - 3° Ano"
@@ -4014,6 +4142,9 @@ msgstr "Lower values produce more consistent styling across pages."
 
 msgid "Make sure you're uploading a .zip file exported from ADT Studio."
 msgstr "Make sure you're uploading a .zip file exported from ADT Studio."
+
+msgid "Make this a kids book: pick the reading buddies and generate their voices."
+msgstr "Make this a kids book: pick the reading buddies and generate their voices."
 
 msgid "Manage all sections"
 msgstr "Manage all sections"
@@ -4378,6 +4509,9 @@ msgstr "No audio for this page"
 msgid "No books match your search"
 msgstr "No books match your search"
 
+msgid "No buddy voices generated yet — check the plan to see cost before generating."
+msgstr "No buddy voices generated yet — check the plan to see cost before generating."
+
 msgid "No captioned images yet. Run the image-captioning step first."
 msgstr "No captioned images yet. Run the image-captioning step first."
 
@@ -4690,8 +4824,14 @@ msgstr "of"
 msgid "Off"
 msgstr "Off"
 
+msgid "Off by default"
+msgstr "Off by default"
+
 msgid "On"
 msgstr "On"
+
+msgid "On for this book"
+msgstr "On for this book"
 
 msgid "One Column"
 msgstr "One Column"
@@ -5209,6 +5349,9 @@ msgstr "Pick the languages you want to translate to. The book's original languag
 msgid "Pick which voice each language uses for narration, including regional accents."
 msgstr "Pick which voice each language uses for narration, including regional accents."
 
+msgid "Picking phrases"
+msgstr "Picking phrases"
+
 msgid "Picture books and early readers"
 msgstr "Picture books and early readers"
 
@@ -5233,11 +5376,23 @@ msgstr "Pipeline Stages"
 msgid "Pixel Art"
 msgstr "Pixel Art"
 
+#. placeholder {0}: lastRun.total
+#. placeholder {1}: lastRun.languages.length
+#. placeholder {2}: lastRun.characters.length
+#. placeholder {3}: lastRun.cachedHits
+#. placeholder {4}: lastRun.total - lastRun.cachedHits
+#. placeholder {5}: lastRun.model
+msgid "Plan: {0} clips across {1} language(s) × {2} buddies — {3} already cached, {4} would call the API (model {5})."
+msgstr "Plan: {0} clips across {1} language(s) × {2} buddies — {3} already cached, {4} would call the API (model {5})."
+
 msgid "Plants create sugar via <0>photosynthesis</0>, divide by <1>mitosis</1>, and absorb water by <2>osmosis</2>."
 msgstr "Plants create sugar via <0>photosynthesis</0>, divide by <1>mitosis</1>, and absorb water by <2>osmosis</2>."
 
 msgid "Play"
 msgstr "Play"
+
+msgid "Play this line"
+msgstr "Play this line"
 
 msgid "Play video"
 msgstr "Play video"
@@ -5300,11 +5455,17 @@ msgstr "Preview"
 #~ msgid "Preview & split pages"
 #~ msgstr "Preview & split pages"
 
+msgid "Preview kids UI"
+msgstr "Preview kids UI"
+
 msgid "Preview linked page"
 msgstr "Preview linked page"
 
 msgid "Preview of the HTML/CSS patterns used for LLM-generated pages."
 msgstr "Preview of the HTML/CSS patterns used for LLM-generated pages."
+
+msgid "Preview regular UI"
+msgstr "Preview regular UI"
 
 msgid "Preview: per-sentence"
 msgstr "Preview: per-sentence"
@@ -5585,6 +5746,9 @@ msgstr "Readium-compatible digital book"
 msgid "Reads in"
 msgstr "Reads in"
 
+msgid "Ready"
+msgstr "Ready"
+
 msgid "Real books processed with this preset — before and after."
 msgstr "Real books processed with this preset — before and after."
 
@@ -5778,6 +5942,9 @@ msgstr "Reset fonts"
 
 msgid "Reset fonts to default?"
 msgstr "Reset fonts to default?"
+
+msgid "Reset to default"
+msgstr "Reset to default"
 
 msgid "Reset to defaults"
 msgstr "Reset to defaults"
@@ -6101,6 +6268,9 @@ msgstr "Save selection"
 
 msgid "Save settings"
 msgstr "Save settings"
+
+msgid "Save voice"
+msgstr "Save voice"
 
 msgid "Save your work first if you want to keep these changes."
 msgstr "Save your work first if you want to keep these changes."
@@ -6446,6 +6616,9 @@ msgstr "Shadow"
 msgid "Ship"
 msgstr "Ship"
 
+msgid "Ships with this book"
+msgstr "Ships with this book"
+
 msgid "Short, simple sentences for kindergarten through 5th grade."
 msgstr "Short, simple sentences for kindergarten through 5th grade."
 
@@ -6473,6 +6646,9 @@ msgstr "Show error details"
 
 msgid "Show fewer"
 msgstr "Show fewer"
+
+msgid "Show Kids Mode details"
+msgstr "Show Kids Mode details"
 
 msgid "Show only the terms you added manually"
 msgstr "Show only the terms you added manually"
@@ -6512,6 +6688,9 @@ msgstr "Sign language video overlays for each page"
 
 msgid "Sign language videos provide access for deaf and hard of hearing readers who may not be fluent in written language."
 msgstr "Sign language videos provide access for deaf and hard of hearing readers who may not be fluent in written language."
+
+msgid "Signature"
+msgstr "Signature"
 
 msgid "Simplified Easy Read text variants."
 msgstr "Simplified Easy Read text variants."
@@ -6689,6 +6868,9 @@ msgstr "Split preview"
 msgid "Split segments"
 msgstr "Split segments"
 
+msgid "Spoken buddy voices"
+msgstr "Spoken buddy voices"
+
 msgid "Spread"
 msgstr "Spread"
 
@@ -6712,6 +6894,9 @@ msgstr "Standard e-book for readers & libraries"
 
 msgid "Standard EPUB 3 file for e-readers, reading apps, and accessibility tools. Interactive features (quizzes, TTS) work in readers that support JavaScript."
 msgstr "Standard EPUB 3 file for e-readers, reading apps, and accessibility tools. Interactive features (quizzes, TTS) work in readers that support JavaScript."
+
+msgid "Standing"
+msgstr "Standing"
 
 msgid "Start"
 msgstr "Start"
@@ -6819,6 +7004,9 @@ msgstr "Style guide"
 msgid "Style Guide"
 msgstr "Style Guide"
 
+msgid "Style instructions"
+msgstr "Style instructions"
+
 msgid "Style reference"
 msgstr "Style reference"
 
@@ -6860,6 +7048,9 @@ msgstr "Summary Prompt"
 
 msgid "Sun"
 msgstr "Sun"
+
+msgid "Surprised"
+msgstr "Surprised"
 
 msgid "SW"
 msgstr "SW"
@@ -7034,6 +7225,10 @@ msgstr "The default TTS instruction applied to every language unless overridden 
 msgid "The entire page is treated as a single section - all text and images stay together as one unit. Best for storybooks, reference books, and any content where each page is self-contained."
 msgstr "The entire page is treated as a single section - all text and images stay together as one unit. Best for storybooks, reference books, and any content where each page is self-contained."
 
+#. placeholder {0}: selectedBuddy.defaultNameFallback
+msgid "The expression set {0} uses across the reading experience"
+msgstr "The expression set {0} uses across the reading experience"
+
 msgid "The file may be damaged or incomplete. Try downloading it again from the source."
 msgstr "The file may be damaged or incomplete. Try downloading it again from the source."
 
@@ -7166,6 +7361,12 @@ msgstr "They produce flowers to attract pollinators."
 msgid "They release oxygen directly into the air."
 msgstr "They release oxygen directly into the air."
 
+msgid "Things {name} says"
+msgstr "Things {name} says"
+
+msgid "Thinking"
+msgstr "Thinking"
+
 msgid "This archive can't be opened safely"
 msgstr "This archive can't be opened safely"
 
@@ -7221,6 +7422,9 @@ msgstr "This image is marked decorative — click to un-mark"
 
 msgid "This is <0>ADT Studio</0>."
 msgstr "This is <0>ADT Studio</0>."
+
+msgid "This is a kids book"
+msgstr "This is a kids book"
 
 msgid "This is a preview of the options you have selected for your book, each option affects the preview in a different way."
 msgstr "This is a preview of the options you have selected for your book, each option affects the preview in a different way."
@@ -7521,6 +7725,9 @@ msgstr "Tune how text is simplified in the Easy Read Prompt settings. After runn
 
 msgid "Turn any PDF into a fully accessible book — audio, translations, structured HTML layouts — all generated from your source file, <0>all editable</0>, <1>all yours</1>."
 msgstr "Turn any PDF into a fully accessible book — audio, translations, structured HTML layouts — all generated from your source file, <0>all editable</0>, <1>all yours</1>."
+
+msgid "Turn on kids mode to configure buddies and voices."
+msgstr "Turn on kids mode to configure buddies and voices."
 
 msgid "Turn this on to show the Validation review card in Preview and the Reviewer Validation tab in the Validation step."
 msgstr "Turn this on to show the Validation review card in Preview and the Reviewer Validation tab in the Validation step."
@@ -7833,6 +8040,9 @@ msgstr "Voice"
 
 msgid "Voice Mappings"
 msgstr "Voice Mappings"
+
+msgid "Voice preset"
+msgstr "Voice preset"
 
 msgid "Voices"
 msgstr "Voices"

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -68,6 +68,12 @@ msgstr "(p.{0})"
 msgid "(template)"
 msgstr "(plantilla)"
 
+#. placeholder {0}: buddies.length
+#. placeholder {1}: KIDS_BUDDIES.length
+#. placeholder {2}: KIDS_BUDDIES.length
+msgid "{0, plural, one {# of {1} shipping} other {# of {2} shipping}}"
+msgstr "{0, plural, one {# de {1} incluido} other {# de {2} incluidos}}"
+
 #. placeholder {0}: preview.addedPageNumbers.length
 #. placeholder {0}: result.addedPages
 msgid "{0, plural, one {# page added} other {# pages added}}"
@@ -234,6 +240,10 @@ msgstr "{0} secciones"
 msgid "{0} selected images are no longer in the storyboard."
 msgstr "{0} imágenes seleccionadas ya no están en el guion gráfico."
 
+#. placeholder {0}: selectedBuddy.defaultNameFallback
+msgid "{0} ships with this book"
+msgstr "{0} se incluye con este libro"
+
 #. placeholder {0}: String(visibleCount)
 msgid "{0} terms"
 msgstr "{0} términos"
@@ -245,6 +255,10 @@ msgstr "{0} textos"
 #. placeholder {0}: outputLanguages.length
 msgid "{0} translations"
 msgstr "{0} traducciones"
+
+#. placeholder {0}: selectedBuddy.defaultNameFallback
+msgid "{0}'s voice pack"
+msgstr "Paquete de voz de {0}"
 
 #. placeholder {0}: String(generatedAudioCount)
 #. placeholder {1}: String(speakableEntries.length)
@@ -288,6 +302,9 @@ msgstr "Hace {0}min"
 #. placeholder {0}: String(Math.floor(diff / 1000))
 msgid "{0}s ago"
 msgstr "Hace {0}s"
+
+msgid "{buddyCount, plural, one {# buddy} other {# buddies}}"
+msgstr "{buddyCount, plural, one {# compañero} other {# compañeros}}"
 
 msgid "{count} {count, plural, one {issue} other {issues}}"
 msgstr "{count} {count, plural, one {problema} other {problemas}}"
@@ -351,8 +368,14 @@ msgstr "{missingForCurrentStage} entrada(s) sin audio. Vuelve a ejecutar para ge
 msgid "{missingForCurrentStage} entry/entries are missing translations. Re-run to fill the missing items."
 msgstr "{missingForCurrentStage} entrada(s) sin traducción. Vuelve a ejecutar para completar los elementos faltantes."
 
+msgid "{name}'s expressions"
+msgstr "Expresiones de {name}"
+
 msgid "{needsChanges} flagged"
 msgstr "{needsChanges} marcados"
+
+msgid "{packCount, plural, one {# voice pack} other {# voice packs}}"
+msgstr "{packCount, plural, one {# paquete de voz} other {# paquetes de voz}}"
 
 msgid "{pageCount} {pageCount, plural, one {page} other {pages}}"
 msgstr "{pageCount} {pageCount, plural, one {página} other {páginas}}"
@@ -517,6 +540,9 @@ msgstr "Una figura retórica que describe una cosa como si fuera otra para hacer
 
 msgid "A fill-in-the-blank activity."
 msgstr "Una actividad de completar espacios en blanco."
+
+msgid "A friendly character fronts every reading tool, from text-to-speech to font size."
+msgstr "Un personaje amigable es la cara de cada herramienta de lectura, desde la conversión de texto a voz hasta el tamaño de fuente."
 
 msgid "A glossary term with this word already exists."
 msgstr "Ya existe un término del glosario con esta palabra."
@@ -843,6 +869,9 @@ msgstr "Agregar idioma"
 msgid "Add Language"
 msgstr "Agregar idioma"
 
+msgid "Add languages to the book to generate voice packs."
+msgstr "Agrega idiomas al libro para generar paquetes de voz."
+
 msgid "Add languages to translate the book content into."
 msgstr "Agrega idiomas para traducir el contenido del libro."
 
@@ -896,6 +925,15 @@ msgstr "Agrega tu primer libro"
 
 msgid "Add your first term"
 msgstr "Añade tu primer término"
+
+msgid "Add your OpenAI key in Settings to generate voices."
+msgstr "Añade tu clave de OpenAI en Configuración para generar voces."
+
+msgid "Add your OpenAI key in Settings to generate."
+msgstr "Añade tu clave de OpenAI en Configuración para generar."
+
+msgid "Add your own buddy"
+msgstr "Agrega tu propio compañero"
 
 msgid "added"
 msgstr "añadido"
@@ -1050,6 +1088,9 @@ msgstr "Todas las categorías"
 msgid "All Categories"
 msgstr "All Categories"
 
+msgid "All expressions"
+msgstr "Todas las expresiones"
+
 msgid "All issues and manual review items"
 msgstr "Todos los problemas y elementos de revisión manual"
 
@@ -1180,6 +1221,9 @@ msgstr "Aparece en las páginas {0}"
 msgid "Application Programming Interface — a set of rules that allows programs to communicate."
 msgstr "Interfaz de programación de aplicaciones (API): conjunto de reglas que permite que los programas se comuniquen."
 
+msgid "Applies to the live preview and every exported format — readers can't turn it off."
+msgstr "Se aplica a la vista previa en vivo y a todos los formatos exportados — los lectores no pueden desactivarlo."
+
 msgid "Apply"
 msgstr "Aplicar"
 
@@ -1265,6 +1309,12 @@ msgstr "Narración de audio (mayor impacto en el tamaño del archivo)"
 msgid "Audio Player"
 msgstr "Reproductor de Audio"
 
+msgid "Audition"
+msgstr "Vista previa"
+
+msgid "Audition language"
+msgstr "Idioma de vista previa"
+
 msgid "Author"
 msgstr "Autor"
 
@@ -1319,14 +1369,23 @@ msgstr "Atrás"
 msgid "Back Cover"
 msgstr "Contraportada"
 
+msgid "Back to book"
+msgstr "Volver al libro"
+
 msgid "Back to books"
 msgstr "Volver a los libros"
 
 msgid "Back to Editor"
 msgstr "Volver al editor"
 
+msgid "Back to kids UI"
+msgstr "Volver a la interfaz infantil"
+
 msgid "Back to preview"
 msgstr "Volver a vista previa"
+
+msgid "Back to regular UI"
+msgstr "Volver a la interfaz normal"
 
 msgid "Back to Speech overview"
 msgstr "Volver a la vista general de Voz"
@@ -1340,6 +1399,9 @@ msgstr "Fondo"
 #. placeholder {0}: section.backgroundColor
 msgid "Background: {0}"
 msgstr "Fondo: {0}"
+
+msgid "Baked into the book"
+msgstr "Integrado en el libro"
 
 msgid "base"
 msgstr "base"
@@ -1482,6 +1544,15 @@ msgstr "Navega y edita plantillas Liquid usadas para estrategias de renderizaci�
 
 msgid "Browse every Storyboard section and upload, replace, or remove its sign-language video."
 msgstr "Explora cada sección del Storyboard y sube, reemplaza o elimina su video de lenguaje de señas."
+
+msgid "Buddies"
+msgstr "Compañeros"
+
+msgid "Buddy stage view"
+msgstr "Vista del escenario del compañero"
+
+msgid "Buddy-guided interface"
+msgstr "Interfaz guiada por un compañero"
 
 msgid "Build"
 msgstr "Compilación"
@@ -1653,11 +1724,17 @@ msgstr "Libros de capítulos con imágenes"
 msgid "Chapter One"
 msgstr "Capítulo Uno"
 
+msgid "Character art"
+msgstr "Arte del personaje"
+
 msgid "Chart / Graph"
 msgstr "Gráfico / Tabla"
 
 #~ msgid "Check for updates"
 #~ msgstr "Buscar actualizaciones"
+
+msgid "Check plan"
+msgstr "Consultar plan"
 
 msgid "Checked"
 msgstr "Checked"
@@ -2095,6 +2172,9 @@ msgstr "Current Preview Page"
 msgid "Custom"
 msgstr "Personalizado"
 
+msgid "Custom buddies are coming soon"
+msgstr "Los compañeros personalizados llegarán pronto"
+
 msgid "Custom Instructions"
 msgstr "Instrucciones Personalizadas"
 
@@ -2360,6 +2440,12 @@ msgstr "Hecho"
 msgid "DONE"
 msgstr "HECHO"
 
+#. placeholder {0}: lastRun.total
+#. placeholder {1}: lastRun.generated
+#. placeholder {2}: lastRun.cachedHits
+msgid "Done: {0} clips ready — {1} newly generated, {2} from cache."
+msgstr "Listo: {0} clips listos — {1} recién generados, {2} desde caché."
+
 msgid "Download a full backup of this project"
 msgstr "Descargar una copia de seguridad completa de este proyecto"
 
@@ -2483,6 +2569,9 @@ msgstr "ej., Haz el fondo más brillante, añade más árboles..."
 msgid "Each block was simplified by AI. Edit any Easy Read text to refine it against the original, then Save. Changes are stored as a new version, so you can always roll back or regenerate."
 msgstr "Cada bloque fue simplificado por IA. Edita cualquier texto de Lectura Fácil para refinarlo con el original, luego guarda. Los cambios se guardan como una nueva versión, por lo que siempre puedes revertir o regenerar."
 
+msgid "Each buddy talks in the reader's language, generated once per language and cached for offline use."
+msgstr "Cada compañero habla en el idioma del lector, generado una vez por idioma y almacenado en caché para uso sin conexión."
+
 msgid "Each iteration is one LLM call. Lower values are faster and cheaper; higher values give the reviewer more chances to fix problems."
 msgstr "Cada iteración es una llamada LLM. Valores más bajos son más rápidos y baratos; valores más altos dan al revisor más oportunidades de corregir problemas."
 
@@ -2565,6 +2654,9 @@ msgstr "Editable por bloque"
 msgid "edited"
 msgstr "editado"
 
+msgid "Edited"
+msgstr "Editado"
+
 msgid "Edited in"
 msgstr "Editado en"
 
@@ -2573,6 +2665,9 @@ msgstr "Editado manualmente"
 
 msgid "Editing"
 msgstr "Editando"
+
+msgid "Editing character art is coming soon"
+msgstr "La edición del arte del personaje llegará pronto"
 
 msgid "Editing is disabled while the storyboard is running"
 msgstr "La edición está deshabilitada mientras el storyboard se está ejecutando"
@@ -2635,6 +2730,9 @@ msgstr "Enabled"
 
 msgid "Enabled axe tags"
 msgstr "Enabled axe tags"
+
+msgid "Encouraging"
+msgstr "Alentador"
 
 msgid "End"
 msgstr "Fin"
@@ -2743,6 +2841,9 @@ msgstr "Cada sección del Storyboard tiene un video de lenguaje de señas asigna
 
 msgid "Example Books"
 msgstr "Libros de Ejemplo"
+
+msgid "Excited"
+msgstr "Emocionado"
 
 msgid "Exclude from read-aloud"
 msgstr "Excluir de la lectura en voz alta"
@@ -3108,6 +3209,12 @@ msgstr "Genera una versión simplificada y más fácil de leer de cada bloque de
 msgid "Generate a single quiz from specific pages and place it at a chosen location."
 msgstr "Genera un único cuestionario a partir de páginas específicas y colócalo en una ubicación elegida."
 
+msgid "Generate all buddy voices"
+msgstr "Generar todas las voces de los compañeros"
+
+msgid "Generate all languages"
+msgstr "Generar todos los idiomas"
+
 msgid "Generate and customize the table of contents for the book navigation."
 msgstr "Genera y personaliza la tabla de contenidos para la navegación del libro."
 
@@ -3147,6 +3254,9 @@ msgstr "Generar cuestionario"
 msgid "Generate Styleguide from Pages"
 msgstr "Generar guía de estilo desde páginas"
 
+msgid "Generate voices to preview lines"
+msgstr "Genera voces para previsualizar las frases"
+
 msgid "Generate with AI"
 msgstr "Generar con IA"
 
@@ -3173,6 +3283,9 @@ msgstr "Genera preguntas de comprensión y actividades del libro."
 
 msgid "Generates descriptive alt-text for images so screen readers can describe them."
 msgstr "Genera texto alternativo descriptivo para imágenes para que los lectores de pantalla puedan describirlas."
+
+msgid "Generates every shipped buddy in every book language."
+msgstr "Genera todos los compañeros incluidos en todos los idiomas del libro."
 
 msgid "Generates the interactive HTML for this activity type."
 msgstr "Genera el HTML interactivo para este tipo de actividad."
@@ -3284,6 +3397,9 @@ msgstr "Reparte partes por rango de páginas y combínalas más tarde."
 #~ msgid "Handwriting"
 #~ msgstr "Manuscrita"
 
+msgid "Happy"
+msgstr "Feliz"
+
 msgid "Header"
 msgstr "Encabezado"
 
@@ -3316,6 +3432,9 @@ msgstr "Ocultar historial de edición con IA"
 
 msgid "Hide error details"
 msgstr "Ocultar detalles del error"
+
+msgid "Hide Kids Mode details"
+msgstr "Ocultar detalles del Modo Niños"
 
 msgid "High"
 msgstr "Alto"
@@ -3713,6 +3832,12 @@ msgstr "La clave debe empezar con sk-"
 msgid "Keyboard & navigation"
 msgstr "Keyboard & navigation"
 
+msgid "Kids Mode"
+msgstr "Modo Niños"
+
+msgid "Kids Mode swaps the standard reading menus for a friendly, buddy-guided experience: the reader picks a reading buddy that fronts every accessibility feature. It's an authoring decision baked into the live preview and every export — readers can't turn it off or change buddies themselves."
+msgstr "El Modo Niños reemplaza los menús de lectura estándar por una experiencia amigable guiada por un compañero: el lector elige un compañero de lectura que representa cada función de accesibilidad. Es una decisión de autoría integrada en la vista previa en vivo y en cada exportación — los lectores no pueden desactivarla ni cambiar de compañero por su cuenta."
+
 #. placeholder {0}: afterPage.pageNumber
 msgid "Knowledge check generated from the source pages, after page {0}."
 msgstr "Comprobación de conocimientos generada a partir de las páginas de origen, después de la página {0}."
@@ -3819,6 +3944,9 @@ msgstr "Lila deambulaba entre los altos pinos, su linterna capturando destellos 
 
 msgid "lines"
 msgstr "líneas"
+
+msgid "Lines"
+msgstr "Frases"
 
 msgid "Língua Portuguesa - 3° Ano"
 msgstr "Lengua Portuguesa - 3° Año"
@@ -4014,6 +4142,9 @@ msgstr "Valores más bajos producen estilos más consistentes entre páginas."
 
 msgid "Make sure you're uploading a .zip file exported from ADT Studio."
 msgstr "Asegúrese de subir un archivo .zip exportado desde ADT Studio."
+
+msgid "Make this a kids book: pick the reading buddies and generate their voices."
+msgstr "Convierte esto en un libro infantil: elige los compañeros de lectura y genera sus voces."
 
 msgid "Manage all sections"
 msgstr "Gestionar todas las secciones"
@@ -4378,6 +4509,9 @@ msgstr "No hay audio para esta página"
 msgid "No books match your search"
 msgstr "Ningún libro coincide con tu búsqueda"
 
+msgid "No buddy voices generated yet — check the plan to see cost before generating."
+msgstr "Aún no se generaron voces de compañeros — consulta el plan para ver el costo antes de generar."
+
 msgid "No captioned images yet. Run the image-captioning step first."
 msgstr "Aún no hay imágenes con subtítulo. Ejecuta primero el paso de generación de subtítulos."
 
@@ -4690,8 +4824,14 @@ msgstr "of"
 msgid "Off"
 msgstr "Apagado"
 
+msgid "Off by default"
+msgstr "Desactivado por defecto"
+
 msgid "On"
 msgstr "Encendido"
+
+msgid "On for this book"
+msgstr "Activado para este libro"
 
 msgid "One Column"
 msgstr "Una Columna"
@@ -5209,6 +5349,9 @@ msgstr "Elige los idiomas a los que deseas traducir. El idioma original del libr
 msgid "Pick which voice each language uses for narration, including regional accents."
 msgstr "Elige qué voz usa cada idioma para la narración, incluidos los acentos regionales."
 
+msgid "Picking phrases"
+msgstr "Frases para elegir"
+
 msgid "Picture books and early readers"
 msgstr "Libros ilustrados y primeros lectores"
 
@@ -5233,11 +5376,23 @@ msgstr "Etapas del pipeline"
 msgid "Pixel Art"
 msgstr "Pixel Art"
 
+#. placeholder {0}: lastRun.total
+#. placeholder {1}: lastRun.languages.length
+#. placeholder {2}: lastRun.characters.length
+#. placeholder {3}: lastRun.cachedHits
+#. placeholder {4}: lastRun.total - lastRun.cachedHits
+#. placeholder {5}: lastRun.model
+msgid "Plan: {0} clips across {1} language(s) × {2} buddies — {3} already cached, {4} would call the API (model {5})."
+msgstr "Plan: {0} clips en {1} idioma(s) × {2} compañeros — {3} ya en caché, {4} llamarían a la API (modelo {5})."
+
 msgid "Plants create sugar via <0>photosynthesis</0>, divide by <1>mitosis</1>, and absorb water by <2>osmosis</2>."
 msgstr "Las plantas crean azúcar mediante <0>fotosíntesis</0>, se dividen por <1>mitosis</1>, y absorben agua por <2>ósmosis</2>."
 
 msgid "Play"
 msgstr "Reproducir"
+
+msgid "Play this line"
+msgstr "Reproducir esta frase"
 
 msgid "Play video"
 msgstr "Reproducir video"
@@ -5300,11 +5455,17 @@ msgstr "Previsualización"
 #~ msgid "Preview & split pages"
 #~ msgstr "Previsualizar y dividir páginas"
 
+msgid "Preview kids UI"
+msgstr "Vista previa de la interfaz infantil"
+
 msgid "Preview linked page"
 msgstr "Vista previa de la página vinculada"
 
 msgid "Preview of the HTML/CSS patterns used for LLM-generated pages."
 msgstr "Vista previa de los patrones HTML/CSS usados para páginas generadas por LLM."
+
+msgid "Preview regular UI"
+msgstr "Vista previa de la interfaz normal"
 
 msgid "Preview: per-sentence"
 msgstr "Vista previa: por oración"
@@ -5585,6 +5746,9 @@ msgstr "Libro digital compatible con Readium"
 msgid "Reads in"
 msgstr "Lee en"
 
+msgid "Ready"
+msgstr "Listo"
+
 msgid "Real books processed with this preset — before and after."
 msgstr "Libros reales procesados con este preajuste — antes y después."
 
@@ -5778,6 +5942,9 @@ msgstr "Restablecer fuentes"
 
 msgid "Reset fonts to default?"
 msgstr "¿Restablecer las fuentes predeterminadas?"
+
+msgid "Reset to default"
+msgstr "Restablecer al valor predeterminado"
 
 msgid "Reset to defaults"
 msgstr "Reset to defaults"
@@ -6101,6 +6268,9 @@ msgstr "Guardar selección"
 
 msgid "Save settings"
 msgstr "Save settings"
+
+msgid "Save voice"
+msgstr "Guardar voz"
 
 msgid "Save your work first if you want to keep these changes."
 msgstr "Guarda tu trabajo primero si quieres conservar estos cambios."
@@ -6446,6 +6616,9 @@ msgstr "Sombra"
 msgid "Ship"
 msgstr "Enviar"
 
+msgid "Ships with this book"
+msgstr "Se incluye con este libro"
+
 msgid "Short, simple sentences for kindergarten through 5th grade."
 msgstr "Oraciones cortas y simples para jardín de infancia hasta 5º grado."
 
@@ -6473,6 +6646,9 @@ msgstr "Mostrar detalles del error"
 
 msgid "Show fewer"
 msgstr "Show fewer"
+
+msgid "Show Kids Mode details"
+msgstr "Mostrar detalles del Modo Niños"
 
 msgid "Show only the terms you added manually"
 msgstr "Mostrar solo los términos que agregaste manualmente"
@@ -6512,6 +6688,9 @@ msgstr "Superposiciones de video en lengua de señas para cada página"
 
 msgid "Sign language videos provide access for deaf and hard of hearing readers who may not be fluent in written language."
 msgstr "Los videos en lenguaje de señas brindan acceso a lectores sordos y con dificultades auditivas que pueden no ser fluidos en el lenguaje escrito."
+
+msgid "Signature"
+msgstr "Distintiva"
 
 msgid "Simplified Easy Read text variants."
 msgstr "Variantes de texto simplificadas de Lectura Fácil."
@@ -6689,6 +6868,9 @@ msgstr "Previsualización de división"
 msgid "Split segments"
 msgstr "Segmentos divididos"
 
+msgid "Spoken buddy voices"
+msgstr "Voces habladas del compañero"
+
 msgid "Spread"
 msgstr "Extensión"
 
@@ -6712,6 +6894,9 @@ msgstr "Libro electrónico estándar para lectores y bibliotecas"
 
 msgid "Standard EPUB 3 file for e-readers, reading apps, and accessibility tools. Interactive features (quizzes, TTS) work in readers that support JavaScript."
 msgstr "Archivo EPUB 3 estándar para lectores electrónicos, aplicaciones de lectura y herramientas de accesibilidad. Las funciones interactivas (cuestionarios, TTS) funcionan en lectores que admiten JavaScript."
+
+msgid "Standing"
+msgstr "De pie"
 
 msgid "Start"
 msgstr "Inicio"
@@ -6819,6 +7004,9 @@ msgstr "Guía de estilo"
 msgid "Style Guide"
 msgstr "Guía de Estilo"
 
+msgid "Style instructions"
+msgstr "Instrucciones de estilo"
+
 msgid "Style reference"
 msgstr "Referencia de estilo"
 
@@ -6860,6 +7048,9 @@ msgstr "Indicación de resumen"
 
 msgid "Sun"
 msgstr "Sol"
+
+msgid "Surprised"
+msgstr "Sorprendido"
 
 msgid "SW"
 msgstr "SW"
@@ -7034,6 +7225,10 @@ msgstr "La instrucción de TTS predeterminada que se aplica a todos los idiomas,
 msgid "The entire page is treated as a single section - all text and images stay together as one unit. Best for storybooks, reference books, and any content where each page is self-contained."
 msgstr "Toda la página se trata como una sola sección - todo el texto e imágenes permanecen juntos como una unidad. Mejor para libros de cuentos, libros de referencia y cualquier contenido donde cada página sea autónoma."
 
+#. placeholder {0}: selectedBuddy.defaultNameFallback
+msgid "The expression set {0} uses across the reading experience"
+msgstr "El conjunto de expresiones que usa {0} en la experiencia de lectura"
+
 msgid "The file may be damaged or incomplete. Try downloading it again from the source."
 msgstr "El archivo puede estar dañado o incompleto. Intenta descargarlo nuevamente desde la fuente."
 
@@ -7166,6 +7361,12 @@ msgstr "Producen flores para atraer polinizadores."
 msgid "They release oxygen directly into the air."
 msgstr "Liberan oxígeno directamente al aire."
 
+msgid "Things {name} says"
+msgstr "Cosas que dice {name}"
+
+msgid "Thinking"
+msgstr "Pensativo"
+
 msgid "This archive can't be opened safely"
 msgstr "Este archivo no se puede abrir de forma segura"
 
@@ -7221,6 +7422,9 @@ msgstr "Esta imagen está marcada como decorativa — haz clic para desmarcar"
 
 msgid "This is <0>ADT Studio</0>."
 msgstr "Esto es <0>ADT Studio</0>."
+
+msgid "This is a kids book"
+msgstr "Este es un libro infantil"
 
 msgid "This is a preview of the options you have selected for your book, each option affects the preview in a different way."
 msgstr "Esta es una vista previa de las opciones que has seleccionado para tu libro, cada opción afecta la vista previa de una manera diferente."
@@ -7521,6 +7725,9 @@ msgstr "Ajusta cómo se simplifica el texto en la configuración del Prompt de L
 
 msgid "Turn any PDF into a fully accessible book — audio, translations, structured HTML layouts — all generated from your source file, <0>all editable</0>, <1>all yours</1>."
 msgstr "Convierte cualquier PDF en un libro totalmente accesible — audio, traducciones, diseños HTML estructurados — todo generado a partir de tu archivo fuente, <0>todo editable</0>, <1>todo tuyo</1>."
+
+msgid "Turn on kids mode to configure buddies and voices."
+msgstr "Activa el modo niños para configurar los compañeros y las voces."
 
 msgid "Turn this on to show the Validation review card in Preview and the Reviewer Validation tab in the Validation step."
 msgstr "Turn this on to show the Validation review card in Preview and the Reviewer Validation tab in the Validation step."
@@ -7833,6 +8040,9 @@ msgstr "Voz"
 
 msgid "Voice Mappings"
 msgstr "Asignaciones de voz"
+
+msgid "Voice preset"
+msgstr "Preajuste de voz"
 
 msgid "Voices"
 msgstr "Voces"

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -70,6 +70,12 @@ msgstr "(p.{0})"
 msgid "(template)"
 msgstr "(modèle)"
 
+#. placeholder {0}: buddies.length
+#. placeholder {1}: KIDS_BUDDIES.length
+#. placeholder {2}: KIDS_BUDDIES.length
+msgid "{0, plural, one {# of {1} shipping} other {# of {2} shipping}}"
+msgstr "{0, plural, one {# sur {1} inclus} other {# sur {2} inclus}}"
+
 #. placeholder {0}: preview.addedPageNumbers.length
 #. placeholder {0}: result.addedPages
 msgid "{0, plural, one {# page added} other {# pages added}}"
@@ -236,6 +242,10 @@ msgstr "{0} sections"
 msgid "{0} selected images are no longer in the storyboard."
 msgstr "{0} images sélectionnées ne figurent plus dans le storyboard."
 
+#. placeholder {0}: selectedBuddy.defaultNameFallback
+msgid "{0} ships with this book"
+msgstr "{0} est inclus avec ce livre"
+
 #. placeholder {0}: String(visibleCount)
 msgid "{0} terms"
 msgstr "{0} termes"
@@ -247,6 +257,10 @@ msgstr "{0} textes"
 #. placeholder {0}: outputLanguages.length
 msgid "{0} translations"
 msgstr "{0} traductions"
+
+#. placeholder {0}: selectedBuddy.defaultNameFallback
+msgid "{0}'s voice pack"
+msgstr "Pack de voix de {0}"
 
 #. placeholder {0}: String(generatedAudioCount)
 #. placeholder {1}: String(speakableEntries.length)
@@ -290,6 +304,9 @@ msgstr "il y a {0} min"
 #. placeholder {0}: String(Math.floor(diff / 1000))
 msgid "{0}s ago"
 msgstr "il y a {0} s"
+
+msgid "{buddyCount, plural, one {# buddy} other {# buddies}}"
+msgstr "{buddyCount, plural, one {# compagnon} other {# compagnons}}"
 
 msgid "{count} {count, plural, one {issue} other {issues}}"
 msgstr "{count} {count, plural, one {problème} other {problèmes}}"
@@ -353,8 +370,14 @@ msgstr "{missingForCurrentStage} entrée(s) sans audio. Relancez pour générer 
 msgid "{missingForCurrentStage} entry/entries are missing translations. Re-run to fill the missing items."
 msgstr "{missingForCurrentStage} entrée(s) sans traduction. Relancez pour compléter les éléments manquants."
 
+msgid "{name}'s expressions"
+msgstr "Expressions de {name}"
+
 msgid "{needsChanges} flagged"
 msgstr "{needsChanges} signalés"
+
+msgid "{packCount, plural, one {# voice pack} other {# voice packs}}"
+msgstr "{packCount, plural, one {# pack de voix} other {# packs de voix}}"
 
 msgid "{pageCount} {pageCount, plural, one {page} other {pages}}"
 msgstr "{pageCount} {pageCount, plural, one {page} other {pages}}"
@@ -519,6 +542,9 @@ msgstr "Une figure de style qui décrit une chose comme si c'était une autre po
 
 msgid "A fill-in-the-blank activity."
 msgstr "Une activité à compléter."
+
+msgid "A friendly character fronts every reading tool, from text-to-speech to font size."
+msgstr "Un personnage sympathique incarne chaque outil de lecture, de la synthèse vocale à la taille de la police."
 
 msgid "A glossary term with this word already exists."
 msgstr "Un terme du glossaire avec ce mot existe déjà."
@@ -845,6 +871,9 @@ msgstr "Ajouter langue"
 msgid "Add Language"
 msgstr "Ajouter une langue"
 
+msgid "Add languages to the book to generate voice packs."
+msgstr "Ajoutez des langues au livre pour générer des packs de voix."
+
 msgid "Add languages to translate the book content into."
 msgstr "Ajoutez des langues pour traduire le contenu du livre."
 
@@ -898,6 +927,15 @@ msgstr "Ajoutez votre premier livre"
 
 msgid "Add your first term"
 msgstr "Ajoutez votre premier terme"
+
+msgid "Add your OpenAI key in Settings to generate voices."
+msgstr "Ajoutez votre clé OpenAI dans Paramètres pour générer des voix."
+
+msgid "Add your OpenAI key in Settings to generate."
+msgstr "Ajoutez votre clé OpenAI dans Paramètres pour générer."
+
+msgid "Add your own buddy"
+msgstr "Ajoutez votre propre compagnon"
 
 msgid "added"
 msgstr "ajouté"
@@ -1052,6 +1090,9 @@ msgstr "Toutes les catégories"
 msgid "All Categories"
 msgstr "Toutes les catégories"
 
+msgid "All expressions"
+msgstr "Toutes les expressions"
+
 msgid "All issues and manual review items"
 msgstr "Tous les problèmes et éléments de révision manuelle"
 
@@ -1182,6 +1223,9 @@ msgstr "Apparaît sur les pages {0}"
 msgid "Application Programming Interface — a set of rules that allows programs to communicate."
 msgstr "Interface de programmation d'applications — un ensemble de règles permettant aux programmes de communiquer."
 
+msgid "Applies to the live preview and every exported format — readers can't turn it off."
+msgstr "S'applique à l'aperçu en direct et à tous les formats exportés — les lecteurs ne peuvent pas le désactiver."
+
 msgid "Apply"
 msgstr "Appliquer"
 
@@ -1267,6 +1311,12 @@ msgstr "Narration audio (impact majeur sur la taille du fichier)"
 msgid "Audio Player"
 msgstr "Lecteur audio"
 
+msgid "Audition"
+msgstr "Aperçu"
+
+msgid "Audition language"
+msgstr "Langue de l'aperçu"
+
 msgid "Author"
 msgstr "Auteur"
 
@@ -1321,14 +1371,23 @@ msgstr "Retour"
 msgid "Back Cover"
 msgstr "Quatrième de couverture"
 
+msgid "Back to book"
+msgstr "Retour au livre"
+
 msgid "Back to books"
 msgstr "Retour aux livres"
 
 msgid "Back to Editor"
 msgstr "Retour à l'éditeur"
 
+msgid "Back to kids UI"
+msgstr "Retour à l'interface enfants"
+
 msgid "Back to preview"
 msgstr "Retour à l'aperçu"
+
+msgid "Back to regular UI"
+msgstr "Retour à l'interface normale"
 
 msgid "Back to Speech overview"
 msgstr "Retour à l'aperçu de la parole"
@@ -1342,6 +1401,9 @@ msgstr "Arrière-plan"
 #. placeholder {0}: section.backgroundColor
 msgid "Background: {0}"
 msgstr "Background: {0}"
+
+msgid "Baked into the book"
+msgstr "Intégré au livre"
 
 msgid "base"
 msgstr "base"
@@ -1484,6 +1546,15 @@ msgstr "Parcourez et modifiez les modèles Liquid utilisés pour les stratégies
 
 msgid "Browse every Storyboard section and upload, replace, or remove its sign-language video."
 msgstr "Parcourez chaque section du Storyboard et téléchargez, remplacez ou supprimez sa vidéo en langue des signes."
+
+msgid "Buddies"
+msgstr "Compagnons"
+
+msgid "Buddy stage view"
+msgstr "Vue de la scène du compagnon"
+
+msgid "Buddy-guided interface"
+msgstr "Interface guidée par un compagnon"
 
 msgid "Build"
 msgstr "Build"
@@ -1655,11 +1726,17 @@ msgstr "Livres à chapitres avec images"
 msgid "Chapter One"
 msgstr "Chapitre un"
 
+msgid "Character art"
+msgstr "Illustration du personnage"
+
 msgid "Chart / Graph"
 msgstr "Graphique / Diagramme"
 
 #~ msgid "Check for updates"
 #~ msgstr "Vérifier les mises à jour"
+
+msgid "Check plan"
+msgstr "Vérifier le plan"
 
 msgid "Checked"
 msgstr "Vérifié"
@@ -2097,6 +2174,9 @@ msgstr "Page d'aperçu actuelle"
 msgid "Custom"
 msgstr "Personnalisé"
 
+msgid "Custom buddies are coming soon"
+msgstr "Les compagnons personnalisés arrivent bientôt"
+
 msgid "Custom Instructions"
 msgstr "Instructions personnalisées"
 
@@ -2362,6 +2442,12 @@ msgstr "Terminé"
 msgid "DONE"
 msgstr "TERMINÉ"
 
+#. placeholder {0}: lastRun.total
+#. placeholder {1}: lastRun.generated
+#. placeholder {2}: lastRun.cachedHits
+msgid "Done: {0} clips ready — {1} newly generated, {2} from cache."
+msgstr "Terminé : {0} clips prêts — {1} nouvellement générés, {2} depuis le cache."
+
 msgid "Download a full backup of this project"
 msgstr "Télécharger une sauvegarde complète de ce projet"
 
@@ -2485,6 +2571,9 @@ msgstr "ex., Rendre l'arrière-plan plus lumineux, ajouter plus d'arbres..."
 msgid "Each block was simplified by AI. Edit any Easy Read text to refine it against the original, then Save. Changes are stored as a new version, so you can always roll back or regenerate."
 msgstr "Chaque bloc a été simplifié par l'IA. Modifiez tout texte en lecture facile pour le peaufiner par rapport à l'original, puis enregistrez. Les modifications sont enregistrées comme une nouvelle version, vous pouvez donc toujours revenir en arrière ou régénérer."
 
+msgid "Each buddy talks in the reader's language, generated once per language and cached for offline use."
+msgstr "Chaque compagnon parle dans la langue du lecteur, généré une fois par langue et mis en cache pour une utilisation hors ligne."
+
 msgid "Each iteration is one LLM call. Lower values are faster and cheaper; higher values give the reviewer more chances to fix problems."
 msgstr "Chaque itération est un appel LLM. Des valeurs plus basses sont plus rapides et moins chères ; des valeurs plus élevées donnent au réviseur plus de chances de corriger les problèmes."
 
@@ -2567,6 +2656,9 @@ msgstr "Modifiable par bloc"
 msgid "edited"
 msgstr "modifié"
 
+msgid "Edited"
+msgstr "Modifié"
+
 msgid "Edited in"
 msgstr "Modifié dans"
 
@@ -2575,6 +2667,9 @@ msgstr "Modifié manuellement"
 
 msgid "Editing"
 msgstr "Modification"
+
+msgid "Editing character art is coming soon"
+msgstr "La modification de l'illustration du personnage arrive bientôt"
 
 msgid "Editing is disabled while the storyboard is running"
 msgstr "La modification est désactivée pendant l'exécution du scénarimage"
@@ -2637,6 +2732,9 @@ msgstr "Activé"
 
 msgid "Enabled axe tags"
 msgstr "Tags axe activés"
+
+msgid "Encouraging"
+msgstr "Encourageant"
 
 msgid "End"
 msgstr "Fin"
@@ -2745,6 +2843,9 @@ msgstr "Chaque section du Storyboard a une vidéo en langue des signes assignée
 
 msgid "Example Books"
 msgstr "Exemple Livres"
+
+msgid "Excited"
+msgstr "Excité"
 
 msgid "Exclude from read-aloud"
 msgstr "Exclure de la lecture à voix haute"
@@ -3110,6 +3211,12 @@ msgstr "Générez une version simplifiée et plus facile à lire de chaque bloc 
 msgid "Generate a single quiz from specific pages and place it at a chosen location."
 msgstr "Générez un seul quiz à partir de pages spécifiques et placez-le à l'endroit de votre choix."
 
+msgid "Generate all buddy voices"
+msgstr "Générer toutes les voix des compagnons"
+
+msgid "Generate all languages"
+msgstr "Générer toutes les langues"
+
 msgid "Generate and customize the table of contents for the book navigation."
 msgstr "Générez et personnalisez la table des matières pour la navigation du livre."
 
@@ -3149,6 +3256,9 @@ msgstr "Générer le quiz"
 msgid "Generate Styleguide from Pages"
 msgstr "Générer un guide de style à partir des pages"
 
+msgid "Generate voices to preview lines"
+msgstr "Générez des voix pour prévisualiser les répliques"
+
 msgid "Generate with AI"
 msgstr "Générer avec l'IA"
 
@@ -3175,6 +3285,9 @@ msgstr "Génère des questions de compréhension et des activités à partir du 
 
 msgid "Generates descriptive alt-text for images so screen readers can describe them."
 msgstr "Génère du texte alternatif descriptif pour les images afin que les lecteurs d'écran puissent les décrire."
+
+msgid "Generates every shipped buddy in every book language."
+msgstr "Génère chaque compagnon inclus dans chaque langue du livre."
 
 msgid "Generates the interactive HTML for this activity type."
 msgstr "Génère le HTML interactif pour ce type d'activité."
@@ -3286,6 +3399,9 @@ msgstr "Distribuez des parties par plage de pages et fusionnez-les plus tard."
 #~ msgid "Handwriting"
 #~ msgstr "Manuscrite"
 
+msgid "Happy"
+msgstr "Content"
+
 msgid "Header"
 msgstr "En-tête"
 
@@ -3318,6 +3434,9 @@ msgstr "Masquer l'historique des modifications IA"
 
 msgid "Hide error details"
 msgstr "Masquer les détails de l'erreur"
+
+msgid "Hide Kids Mode details"
+msgstr "Masquer les détails du Mode Enfants"
 
 msgid "High"
 msgstr "Élevé"
@@ -3715,6 +3834,12 @@ msgstr "La clé doit commencer par sk-"
 msgid "Keyboard & navigation"
 msgstr "Clavier et navigation"
 
+msgid "Kids Mode"
+msgstr "Mode Enfants"
+
+msgid "Kids Mode swaps the standard reading menus for a friendly, buddy-guided experience: the reader picks a reading buddy that fronts every accessibility feature. It's an authoring decision baked into the live preview and every export — readers can't turn it off or change buddies themselves."
+msgstr "Le Mode Enfants remplace les menus de lecture standards par une expérience conviviale guidée par un compagnon : le lecteur choisit un compagnon de lecture qui incarne chaque fonctionnalité d'accessibilité. C'est une décision d'auteur intégrée à l'aperçu en direct et à chaque export — les lecteurs ne peuvent ni la désactiver ni changer de compagnon eux-mêmes."
+
 #. placeholder {0}: afterPage.pageNumber
 msgid "Knowledge check generated from the source pages, after page {0}."
 msgstr "Vérification des connaissances générée à partir des pages source, après la page {0}."
@@ -3821,6 +3946,9 @@ msgstr "Lila errait entre les grands pins, sa lampe de poche captant des éclats
 
 msgid "lines"
 msgstr "lignes"
+
+msgid "Lines"
+msgstr "Répliques"
 
 msgid "Língua Portuguesa - 3° Ano"
 msgstr "Língua Portuguesa - 3° Ano"
@@ -4016,6 +4144,9 @@ msgstr "Les valeurs plus basses produisent un style plus cohérent entre les pag
 
 msgid "Make sure you're uploading a .zip file exported from ADT Studio."
 msgstr "Assurez-vous de télécharger un fichier .zip exporté depuis ADT Studio."
+
+msgid "Make this a kids book: pick the reading buddies and generate their voices."
+msgstr "Faites-en un livre pour enfants : choisissez les compagnons de lecture et générez leurs voix."
 
 msgid "Manage all sections"
 msgstr "Gérer toutes les sections"
@@ -4380,6 +4511,9 @@ msgstr "Pas de son pour cette page"
 msgid "No books match your search"
 msgstr "Aucun livre ne correspond à votre recherche"
 
+msgid "No buddy voices generated yet — check the plan to see cost before generating."
+msgstr "Aucune voix de compagnon générée pour l'instant — consultez le plan pour connaître le coût avant de générer."
+
 msgid "No captioned images yet. Run the image-captioning step first."
 msgstr "Aucune image légendée pour le moment. Exécutez d'abord l'étape de légendage des images."
 
@@ -4692,8 +4826,14 @@ msgstr "sur"
 msgid "Off"
 msgstr "Désactivé"
 
+msgid "Off by default"
+msgstr "Désactivé par défaut"
+
 msgid "On"
 msgstr "Activé"
+
+msgid "On for this book"
+msgstr "Activé pour ce livre"
 
 msgid "One Column"
 msgstr "Une colonne"
@@ -5211,6 +5351,9 @@ msgstr "Choisissez les langues vers lesquelles vous souhaitez traduire. La langu
 msgid "Pick which voice each language uses for narration, including regional accents."
 msgstr "Choisissez quelle voix chaque langue utilise pour la narration, y compris les accents régionaux."
 
+msgid "Picking phrases"
+msgstr "Phrases de choix"
+
 msgid "Picture books and early readers"
 msgstr "Albums illustrés et premières lectures"
 
@@ -5235,11 +5378,23 @@ msgstr "Étapes du pipeline"
 msgid "Pixel Art"
 msgstr "Pixel Art"
 
+#. placeholder {0}: lastRun.total
+#. placeholder {1}: lastRun.languages.length
+#. placeholder {2}: lastRun.characters.length
+#. placeholder {3}: lastRun.cachedHits
+#. placeholder {4}: lastRun.total - lastRun.cachedHits
+#. placeholder {5}: lastRun.model
+msgid "Plan: {0} clips across {1} language(s) × {2} buddies — {3} already cached, {4} would call the API (model {5})."
+msgstr "Plan : {0} clips sur {1} langue(s) × {2} compagnons — {3} déjà en cache, {4} appelleraient l'API (modèle {5})."
+
 msgid "Plants create sugar via <0>photosynthesis</0>, divide by <1>mitosis</1>, and absorb water by <2>osmosis</2>."
 msgstr "Les plantes fabriquent du sucre par <0>photosynthèse</0>, se divisent par <1>mitose</1>, et absorbent l'eau par <2>osmose</2>."
 
 msgid "Play"
 msgstr "Lire"
+
+msgid "Play this line"
+msgstr "Lire cette réplique"
 
 msgid "Play video"
 msgstr "Lire la vidéo"
@@ -5302,11 +5457,17 @@ msgstr "Aperçu"
 #~ msgid "Preview & split pages"
 #~ msgstr "Aperçu et division des pages"
 
+msgid "Preview kids UI"
+msgstr "Aperçu de l'interface enfants"
+
 msgid "Preview linked page"
 msgstr "Aperçu de la page liée"
 
 msgid "Preview of the HTML/CSS patterns used for LLM-generated pages."
 msgstr "Aperçu des modèles HTML/CSS utilisés pour les pages générées par le LLM."
+
+msgid "Preview regular UI"
+msgstr "Aperçu de l'interface normale"
 
 msgid "Preview: per-sentence"
 msgstr "Aperçu : par phrase"
@@ -5587,6 +5748,9 @@ msgstr "Livre numérique compatible Readium"
 msgid "Reads in"
 msgstr "Lit en"
 
+msgid "Ready"
+msgstr "Prêt"
+
 msgid "Real books processed with this preset — before and after."
 msgstr "De vrais livres traités avec ce préréglage — avant et après."
 
@@ -5780,6 +5944,9 @@ msgstr "Réinitialiser les polices"
 
 msgid "Reset fonts to default?"
 msgstr "Réinitialiser les polices par défaut ?"
+
+msgid "Reset to default"
+msgstr "Réinitialiser à la valeur par défaut"
 
 msgid "Reset to defaults"
 msgstr "Réinitialiser aux valeurs par défaut"
@@ -6103,6 +6270,9 @@ msgstr "Enregistrer la sélection"
 
 msgid "Save settings"
 msgstr "Enregistrer les paramètres"
+
+msgid "Save voice"
+msgstr "Enregistrer la voix"
 
 msgid "Save your work first if you want to keep these changes."
 msgstr "Enregistrez d'abord votre travail si vous souhaitez conserver ces modifications."
@@ -6448,6 +6618,9 @@ msgstr "Ombre"
 msgid "Ship"
 msgstr "Livrer"
 
+msgid "Ships with this book"
+msgstr "Inclus avec ce livre"
+
 msgid "Short, simple sentences for kindergarten through 5th grade."
 msgstr "Phrases courtes et simples pour la maternelle jusqu'à la 5e année."
 
@@ -6475,6 +6648,9 @@ msgstr "Afficher les détails de l'erreur"
 
 msgid "Show fewer"
 msgstr "Afficher moins"
+
+msgid "Show Kids Mode details"
+msgstr "Afficher les détails du Mode Enfants"
 
 msgid "Show only the terms you added manually"
 msgstr "Afficher uniquement les termes que vous avez ajoutés manuellement"
@@ -6514,6 +6690,9 @@ msgstr "Superpositions vidéo en langue des signes pour chaque page"
 
 msgid "Sign language videos provide access for deaf and hard of hearing readers who may not be fluent in written language."
 msgstr "Les vidéos en langue des signes offrent un accès aux lecteurs sourds et malentendants qui peuvent ne pas être à l'aise avec la langue écrite."
+
+msgid "Signature"
+msgstr "Signature"
 
 msgid "Simplified Easy Read text variants."
 msgstr "Variantes de texte simplifiées en Lecture Facile."
@@ -6691,6 +6870,9 @@ msgstr "Aperçu de la division"
 msgid "Split segments"
 msgstr "Diviser segments"
 
+msgid "Spoken buddy voices"
+msgstr "Voix parlées du compagnon"
+
 msgid "Spread"
 msgstr "Double page"
 
@@ -6714,6 +6896,9 @@ msgstr "Livre électronique standard pour liseuses et bibliothèques"
 
 msgid "Standard EPUB 3 file for e-readers, reading apps, and accessibility tools. Interactive features (quizzes, TTS) work in readers that support JavaScript."
 msgstr "Fichier EPUB 3 standard pour liseuses, applications de lecture et outils d'accessibilité. Les fonctions interactives (quiz, TTS) fonctionnent dans les lecteurs qui prennent en charge JavaScript."
+
+msgid "Standing"
+msgstr "Debout"
 
 msgid "Start"
 msgstr "Démarrer"
@@ -6821,6 +7006,9 @@ msgstr "Guide de style"
 msgid "Style Guide"
 msgstr "Guide de style"
 
+msgid "Style instructions"
+msgstr "Instructions de style"
+
 msgid "Style reference"
 msgstr "Référence de style"
 
@@ -6862,6 +7050,9 @@ msgstr "Résumé Invite"
 
 msgid "Sun"
 msgstr "Sun"
+
+msgid "Surprised"
+msgstr "Surpris"
 
 msgid "SW"
 msgstr "SW"
@@ -7036,6 +7227,10 @@ msgstr "L'instruction TTS par défaut appliquée à toutes les langues, sauf si 
 msgid "The entire page is treated as a single section - all text and images stay together as one unit. Best for storybooks, reference books, and any content where each page is self-contained."
 msgstr "La page entière est traitée comme une seule section — tout le texte et les images restent ensemble en une seule unité. Idéal pour les livres d'histoires, les ouvrages de référence et tout contenu où chaque page est autonome."
 
+#. placeholder {0}: selectedBuddy.defaultNameFallback
+msgid "The expression set {0} uses across the reading experience"
+msgstr "L'ensemble d'expressions que {0} utilise dans l'expérience de lecture"
+
 msgid "The file may be damaged or incomplete. Try downloading it again from the source."
 msgstr "Le fichier peut être endommagé ou incomplet. Essayez de le télécharger à nouveau depuis la source."
 
@@ -7168,6 +7363,12 @@ msgstr "Elles produisent des fleurs pour attirer les pollinisateurs."
 msgid "They release oxygen directly into the air."
 msgstr "Elles libèrent de l'oxygène directement dans l'air."
 
+msgid "Things {name} says"
+msgstr "Ce que dit {name}"
+
+msgid "Thinking"
+msgstr "Pensif"
+
 msgid "This archive can't be opened safely"
 msgstr "Cette archive ne peut pas être ouverte en toute sécurité"
 
@@ -7223,6 +7424,9 @@ msgstr "Cette image est marquée comme décorative — cliquez pour désélectio
 
 msgid "This is <0>ADT Studio</0>."
 msgstr "Voici <0>ADT Studio</0>."
+
+msgid "This is a kids book"
+msgstr "Ceci est un livre pour enfants"
 
 msgid "This is a preview of the options you have selected for your book, each option affects the preview in a different way."
 msgstr "Ceci est un aperçu des options que vous avez sélectionnées pour votre livre. Chaque option affecte l'aperçu de manière différente."
@@ -7523,6 +7727,9 @@ msgstr "Ajustez la façon dont le texte est simplifié dans les paramètres de l
 
 msgid "Turn any PDF into a fully accessible book — audio, translations, structured HTML layouts — all generated from your source file, <0>all editable</0>, <1>all yours</1>."
 msgstr "Transformez n'importe quel PDF en livre entièrement accessible — audio, traductions, mises en page HTML structurées — le tout généré à partir de votre fichier source, <0>tout modifiable</0>, <1>tout à vous</1>."
+
+msgid "Turn on kids mode to configure buddies and voices."
+msgstr "Activez le mode enfants pour configurer les compagnons et les voix."
 
 msgid "Turn this on to show the Validation review card in Preview and the Reviewer Validation tab in the Validation step."
 msgstr "Activez cette option pour afficher la carte de révision Validation dans l'Aperçu et l'onglet Validation du réviseur dans l'étape Validation."
@@ -7835,6 +8042,9 @@ msgstr "Voix"
 
 msgid "Voice Mappings"
 msgstr "Correspondances de voix"
+
+msgid "Voice preset"
+msgstr "Préréglage de voix"
 
 msgid "Voices"
 msgstr "Voix"

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -68,6 +68,12 @@ msgstr "(p.{0})"
 msgid "(template)"
 msgstr "(template)"
 
+#. placeholder {0}: buddies.length
+#. placeholder {1}: KIDS_BUDDIES.length
+#. placeholder {2}: KIDS_BUDDIES.length
+msgid "{0, plural, one {# of {1} shipping} other {# of {2} shipping}}"
+msgstr "{0, plural, one {# de {1} incluído} other {# de {2} incluídos}}"
+
 #. placeholder {0}: preview.addedPageNumbers.length
 #. placeholder {0}: result.addedPages
 msgid "{0, plural, one {# page added} other {# pages added}}"
@@ -234,6 +240,10 @@ msgstr "{0} seções"
 msgid "{0} selected images are no longer in the storyboard."
 msgstr "{0} imagens selecionadas não estão mais no storyboard."
 
+#. placeholder {0}: selectedBuddy.defaultNameFallback
+msgid "{0} ships with this book"
+msgstr "{0} está incluído neste livro"
+
 #. placeholder {0}: String(visibleCount)
 msgid "{0} terms"
 msgstr "{0} termos"
@@ -245,6 +255,10 @@ msgstr "{0} textos"
 #. placeholder {0}: outputLanguages.length
 msgid "{0} translations"
 msgstr "{0} traduções"
+
+#. placeholder {0}: selectedBuddy.defaultNameFallback
+msgid "{0}'s voice pack"
+msgstr "Pacote de voz de {0}"
 
 #. placeholder {0}: String(generatedAudioCount)
 #. placeholder {1}: String(speakableEntries.length)
@@ -288,6 +302,9 @@ msgstr "Há {0}min"
 #. placeholder {0}: String(Math.floor(diff / 1000))
 msgid "{0}s ago"
 msgstr "Há {0}s"
+
+msgid "{buddyCount, plural, one {# buddy} other {# buddies}}"
+msgstr "{buddyCount, plural, one {# amigo} other {# amigos}}"
 
 msgid "{count} {count, plural, one {issue} other {issues}}"
 msgstr "{count} {count, plural, one {problema} other {problemas}}"
@@ -351,8 +368,14 @@ msgstr "{missingForCurrentStage} entrada(s) sem áudio. Execute novamente para g
 msgid "{missingForCurrentStage} entry/entries are missing translations. Re-run to fill the missing items."
 msgstr "{missingForCurrentStage} entrada(s) sem tradução. Execute novamente para preencher os itens faltantes."
 
+msgid "{name}'s expressions"
+msgstr "Expressões de {name}"
+
 msgid "{needsChanges} flagged"
 msgstr "{needsChanges} sinalizados"
+
+msgid "{packCount, plural, one {# voice pack} other {# voice packs}}"
+msgstr "{packCount, plural, one {# pacote de voz} other {# pacotes de voz}}"
 
 msgid "{pageCount} {pageCount, plural, one {page} other {pages}}"
 msgstr "{pageCount} {pageCount, plural, one {página} other {páginas}}"
@@ -517,6 +540,9 @@ msgstr "Uma figura de linguagem que descreve uma coisa como se fosse outra para 
 
 msgid "A fill-in-the-blank activity."
 msgstr "Uma atividade de preencher lacunas."
+
+msgid "A friendly character fronts every reading tool, from text-to-speech to font size."
+msgstr "Um personagem amigável representa cada ferramenta de leitura, da conversão de texto em fala ao tamanho da fonte."
 
 msgid "A glossary term with this word already exists."
 msgstr "Já existe um termo de glossário com esta palavra."
@@ -843,6 +869,9 @@ msgstr "Adicionar idioma"
 msgid "Add Language"
 msgstr "Adicionar idioma"
 
+msgid "Add languages to the book to generate voice packs."
+msgstr "Adicione idiomas ao livro para gerar pacotes de voz."
+
 msgid "Add languages to translate the book content into."
 msgstr "Adicione idiomas para traduzir o conteúdo do livro."
 
@@ -896,6 +925,15 @@ msgstr "Adicione seu primeiro livro"
 
 msgid "Add your first term"
 msgstr "Adicione seu primeiro termo"
+
+msgid "Add your OpenAI key in Settings to generate voices."
+msgstr "Adicione sua chave da OpenAI em Configurações para gerar vozes."
+
+msgid "Add your OpenAI key in Settings to generate."
+msgstr "Adicione sua chave da OpenAI em Configurações para gerar."
+
+msgid "Add your own buddy"
+msgstr "Adicione seu próprio amigo"
 
 msgid "added"
 msgstr "adicionado"
@@ -1050,6 +1088,9 @@ msgstr "Todas as categorias"
 msgid "All Categories"
 msgstr "All Categories"
 
+msgid "All expressions"
+msgstr "Todas as expressões"
+
 msgid "All issues and manual review items"
 msgstr "Todos os problemas e itens de revisão manual"
 
@@ -1180,6 +1221,9 @@ msgstr "Aparece nas páginas {0}"
 msgid "Application Programming Interface — a set of rules that allows programs to communicate."
 msgstr "Interface de programação de aplicativos (API) — conjunto de regras que permite que programas se comuniquem."
 
+msgid "Applies to the live preview and every exported format — readers can't turn it off."
+msgstr "Aplica-se à pré-visualização ao vivo e a todos os formatos exportados — os leitores não podem desativá-lo."
+
 msgid "Apply"
 msgstr "Aplicar"
 
@@ -1265,6 +1309,12 @@ msgstr "Narração de áudio (maior impacto no tamanho do arquivo)"
 msgid "Audio Player"
 msgstr "Reprodutor de Áudio"
 
+msgid "Audition"
+msgstr "Prévia"
+
+msgid "Audition language"
+msgstr "Idioma da prévia"
+
 msgid "Author"
 msgstr "Autor"
 
@@ -1319,14 +1369,23 @@ msgstr "Voltar"
 msgid "Back Cover"
 msgstr "Contracapa"
 
+msgid "Back to book"
+msgstr "Voltar ao livro"
+
 msgid "Back to books"
 msgstr "Voltar aos livros"
 
 msgid "Back to Editor"
 msgstr "Voltar ao editor"
 
+msgid "Back to kids UI"
+msgstr "Voltar à interface infantil"
+
 msgid "Back to preview"
 msgstr "Voltar para pré-visualização"
+
+msgid "Back to regular UI"
+msgstr "Voltar à interface normal"
 
 msgid "Back to Speech overview"
 msgstr "Voltar para visão geral de Fala"
@@ -1340,6 +1399,9 @@ msgstr "Fundo"
 #. placeholder {0}: section.backgroundColor
 msgid "Background: {0}"
 msgstr "Fundo: {0}"
+
+msgid "Baked into the book"
+msgstr "Incorporado ao livro"
 
 msgid "base"
 msgstr "base"
@@ -1482,6 +1544,15 @@ msgstr "Navegue e edite templates Liquid usados para estratégias de renderizaç
 
 msgid "Browse every Storyboard section and upload, replace, or remove its sign-language video."
 msgstr "Navegue por cada seção do Storyboard e faça upload, substitua ou remova seu vídeo em linguagem de sinais."
+
+msgid "Buddies"
+msgstr "Amigos"
+
+msgid "Buddy stage view"
+msgstr "Visualização do palco do amigo"
+
+msgid "Buddy-guided interface"
+msgstr "Interface guiada pelo amigo"
 
 msgid "Build"
 msgstr "Compilação"
@@ -1653,11 +1724,17 @@ msgstr "Livros de capítulos com imagens"
 msgid "Chapter One"
 msgstr "Capítulo Um"
 
+msgid "Character art"
+msgstr "Arte do personagem"
+
 msgid "Chart / Graph"
 msgstr "Gráfico / Tabela"
 
 #~ msgid "Check for updates"
 #~ msgstr "Verificar atualizações"
+
+msgid "Check plan"
+msgstr "Verificar plano"
 
 msgid "Checked"
 msgstr "Checked"
@@ -2095,6 +2172,9 @@ msgstr "Current Preview Page"
 msgid "Custom"
 msgstr "Personalizado"
 
+msgid "Custom buddies are coming soon"
+msgstr "Amigos personalizados em breve"
+
 msgid "Custom Instructions"
 msgstr "Instruções Personalizadas"
 
@@ -2360,6 +2440,12 @@ msgstr "Concluído"
 msgid "DONE"
 msgstr "CONCLUÍDO"
 
+#. placeholder {0}: lastRun.total
+#. placeholder {1}: lastRun.generated
+#. placeholder {2}: lastRun.cachedHits
+msgid "Done: {0} clips ready — {1} newly generated, {2} from cache."
+msgstr "Concluído: {0} clipes prontos — {1} recém-gerados, {2} do cache."
+
 msgid "Download a full backup of this project"
 msgstr "Baixar um backup completo deste projeto"
 
@@ -2483,6 +2569,9 @@ msgstr "ex.: Deixe o fundo mais claro, adicione mais árvores..."
 msgid "Each block was simplified by AI. Edit any Easy Read text to refine it against the original, then Save. Changes are stored as a new version, so you can always roll back or regenerate."
 msgstr "Cada bloco foi simplificado por IA. Edite qualquer texto de Leitura Fácil para refiná-lo em relação ao original e depois Salve. As alterações são armazenadas como uma nova versão, para que você sempre possa reverter ou regenerar."
 
+msgid "Each buddy talks in the reader's language, generated once per language and cached for offline use."
+msgstr "Cada amigo fala no idioma do leitor, gerado uma vez por idioma e armazenado em cache para uso off-line."
+
 msgid "Each iteration is one LLM call. Lower values are faster and cheaper; higher values give the reviewer more chances to fix problems."
 msgstr "Cada iteração é uma chamada LLM. Valores menores são mais rápidos e baratos; valores maiores dão ao revisor mais chances de corrigir problemas."
 
@@ -2565,6 +2654,9 @@ msgstr "Editável por bloco"
 msgid "edited"
 msgstr "editado"
 
+msgid "Edited"
+msgstr "Editado"
+
 msgid "Edited in"
 msgstr "Editado em"
 
@@ -2573,6 +2665,9 @@ msgstr "Editado manualmente"
 
 msgid "Editing"
 msgstr "Editando"
+
+msgid "Editing character art is coming soon"
+msgstr "A edição da arte do personagem chega em breve"
 
 msgid "Editing is disabled while the storyboard is running"
 msgstr "A edição está desabilitada enquanto o storyboard está em execução"
@@ -2635,6 +2730,9 @@ msgstr "Enabled"
 
 msgid "Enabled axe tags"
 msgstr "Enabled axe tags"
+
+msgid "Encouraging"
+msgstr "Encorajador"
 
 msgid "End"
 msgstr "Fim"
@@ -2743,6 +2841,9 @@ msgstr "Cada seção do Storyboard tem um vídeo em linguagem de sinais atribuí
 
 msgid "Example Books"
 msgstr "Livros de Exemplo"
+
+msgid "Excited"
+msgstr "Animado"
 
 msgid "Exclude from read-aloud"
 msgstr "Excluir da leitura em voz alta"
@@ -3108,6 +3209,12 @@ msgstr "Gere uma versão simplificada e mais fácil de ler de cada bloco de text
 msgid "Generate a single quiz from specific pages and place it at a chosen location."
 msgstr "Gere um único questionário a partir de páginas específicas e posicione-o em um local escolhido."
 
+msgid "Generate all buddy voices"
+msgstr "Gerar todas as vozes dos amigos"
+
+msgid "Generate all languages"
+msgstr "Gerar todos os idiomas"
+
 msgid "Generate and customize the table of contents for the book navigation."
 msgstr "Gere e personalize o sumário para a navegação do livro."
 
@@ -3147,6 +3254,9 @@ msgstr "Gerar questionário"
 msgid "Generate Styleguide from Pages"
 msgstr "Gerar guia de estilo a partir das páginas"
 
+msgid "Generate voices to preview lines"
+msgstr "Gere vozes para pré-visualizar as falas"
+
 msgid "Generate with AI"
 msgstr "Gerar com IA"
 
@@ -3173,6 +3283,9 @@ msgstr "Gera perguntas de compreensão e atividades a partir do livro."
 
 msgid "Generates descriptive alt-text for images so screen readers can describe them."
 msgstr "Gera texto alternativo descritivo para imagens para que leitores de tela possam descrevê-las."
+
+msgid "Generates every shipped buddy in every book language."
+msgstr "Gera todos os amigos incluídos em todos os idiomas do livro."
 
 msgid "Generates the interactive HTML for this activity type."
 msgstr "Gera o HTML interativo para este tipo de atividade."
@@ -3284,6 +3397,9 @@ msgstr "Distribua partes por intervalo de páginas e mescle-as mais tarde."
 #~ msgid "Handwriting"
 #~ msgstr "Manuscrita"
 
+msgid "Happy"
+msgstr "Feliz"
+
 msgid "Header"
 msgstr "Cabeçalho"
 
@@ -3316,6 +3432,9 @@ msgstr "Ocultar histórico de edições com IA"
 
 msgid "Hide error details"
 msgstr "Ocultar detalhes do erro"
+
+msgid "Hide Kids Mode details"
+msgstr "Ocultar detalhes do Modo Infantil"
 
 msgid "High"
 msgstr "Alto"
@@ -3713,6 +3832,12 @@ msgstr "A chave deve começar com sk-"
 msgid "Keyboard & navigation"
 msgstr "Keyboard & navigation"
 
+msgid "Kids Mode"
+msgstr "Modo Infantil"
+
+msgid "Kids Mode swaps the standard reading menus for a friendly, buddy-guided experience: the reader picks a reading buddy that fronts every accessibility feature. It's an authoring decision baked into the live preview and every export — readers can't turn it off or change buddies themselves."
+msgstr "O Modo Infantil substitui os menus de leitura padrão por uma experiência amigável guiada por um amigo: o leitor escolhe um amigo de leitura que representa cada recurso de acessibilidade. É uma decisão de autoria incorporada à pré-visualização ao vivo e a cada exportação — os leitores não podem desativá-la nem trocar de amigo por conta própria."
+
 #. placeholder {0}: afterPage.pageNumber
 msgid "Knowledge check generated from the source pages, after page {0}."
 msgstr "Verificação de conhecimento gerada a partir das páginas de origem, após a página {0}."
@@ -3819,6 +3944,9 @@ msgstr "Lila vagava entre os altos pinheiros, sua lanterna captando brilhos de o
 
 msgid "lines"
 msgstr "linhas"
+
+msgid "Lines"
+msgstr "Falas"
 
 msgid "Língua Portuguesa - 3° Ano"
 msgstr "Língua Portuguesa - 3° Ano"
@@ -4014,6 +4142,9 @@ msgstr "Valores mais baixos produzem estilização mais consistente entre as pá
 
 msgid "Make sure you're uploading a .zip file exported from ADT Studio."
 msgstr "Certifique-se de enviar um arquivo .zip exportado do ADT Studio."
+
+msgid "Make this a kids book: pick the reading buddies and generate their voices."
+msgstr "Transforme isto em um livro infantil: escolha os amigos de leitura e gere suas vozes."
 
 msgid "Manage all sections"
 msgstr "Gerenciar todas as seções"
@@ -4378,6 +4509,9 @@ msgstr "Sem áudio para esta página"
 msgid "No books match your search"
 msgstr "Nenhum livro corresponde à sua busca"
 
+msgid "No buddy voices generated yet — check the plan to see cost before generating."
+msgstr "Nenhuma voz de amigo gerada ainda — verifique o plano para ver o custo antes de gerar."
+
 msgid "No captioned images yet. Run the image-captioning step first."
 msgstr "Ainda não há imagens com legenda. Execute primeiro a etapa de geração de legendas."
 
@@ -4690,8 +4824,14 @@ msgstr "of"
 msgid "Off"
 msgstr "Desligado"
 
+msgid "Off by default"
+msgstr "Desativado por padrão"
+
 msgid "On"
 msgstr "Ligado"
+
+msgid "On for this book"
+msgstr "Ativado para este livro"
 
 msgid "One Column"
 msgstr "Uma Coluna"
@@ -5209,6 +5349,9 @@ msgstr "Escolha os idiomas para os quais deseja traduzir. O idioma original do l
 msgid "Pick which voice each language uses for narration, including regional accents."
 msgstr "Escolha qual voz cada idioma usa para narração, incluindo sotaques regionais."
 
+msgid "Picking phrases"
+msgstr "Frases de escolha"
+
 msgid "Picture books and early readers"
 msgstr "Livros ilustrados e leitores iniciantes"
 
@@ -5233,11 +5376,23 @@ msgstr "Etapas do pipeline"
 msgid "Pixel Art"
 msgstr "Pixel Art"
 
+#. placeholder {0}: lastRun.total
+#. placeholder {1}: lastRun.languages.length
+#. placeholder {2}: lastRun.characters.length
+#. placeholder {3}: lastRun.cachedHits
+#. placeholder {4}: lastRun.total - lastRun.cachedHits
+#. placeholder {5}: lastRun.model
+msgid "Plan: {0} clips across {1} language(s) × {2} buddies — {3} already cached, {4} would call the API (model {5})."
+msgstr "Plano: {0} clipes em {1} idioma(s) × {2} amigos — {3} já em cache, {4} chamariam a API (modelo {5})."
+
 msgid "Plants create sugar via <0>photosynthesis</0>, divide by <1>mitosis</1>, and absorb water by <2>osmosis</2>."
 msgstr "As plantas criam açúcar pela <0>fotossíntese</0>, dividem-se por <1>mitose</1>, e absorvem água por <2>osmose</2>."
 
 msgid "Play"
 msgstr "Reproduzir"
+
+msgid "Play this line"
+msgstr "Reproduzir esta fala"
 
 msgid "Play video"
 msgstr "Reproduzir vídeo"
@@ -5300,11 +5455,17 @@ msgstr "Pré-visualização"
 #~ msgid "Preview & split pages"
 #~ msgstr "Pré-visualizar e dividir páginas"
 
+msgid "Preview kids UI"
+msgstr "Pré-visualizar interface infantil"
+
 msgid "Preview linked page"
 msgstr "Visualizar página vinculada"
 
 msgid "Preview of the HTML/CSS patterns used for LLM-generated pages."
 msgstr "Pré-visualização dos padrões HTML/CSS usados para páginas geradas por LLM."
+
+msgid "Preview regular UI"
+msgstr "Pré-visualizar interface normal"
 
 msgid "Preview: per-sentence"
 msgstr "Pré-visualização: por frase"
@@ -5585,6 +5746,9 @@ msgstr "Livro digital compatível com Readium"
 msgid "Reads in"
 msgstr "Lê em"
 
+msgid "Ready"
+msgstr "Pronto"
+
 msgid "Real books processed with this preset — before and after."
 msgstr "Livros reais processados com este predefinido — antes e depois."
 
@@ -5778,6 +5942,9 @@ msgstr "Redefinir fontes"
 
 msgid "Reset fonts to default?"
 msgstr "Redefinir as fontes para o padrão?"
+
+msgid "Reset to default"
+msgstr "Redefinir para o padrão"
 
 msgid "Reset to defaults"
 msgstr "Reset to defaults"
@@ -6101,6 +6268,9 @@ msgstr "Salvar seleção"
 
 msgid "Save settings"
 msgstr "Save settings"
+
+msgid "Save voice"
+msgstr "Salvar voz"
 
 msgid "Save your work first if you want to keep these changes."
 msgstr "Salve seu trabalho primeiro se quiser manter estas alterações."
@@ -6446,6 +6616,9 @@ msgstr "Sombra"
 msgid "Ship"
 msgstr "Entregar"
 
+msgid "Ships with this book"
+msgstr "Incluído neste livro"
+
 msgid "Short, simple sentences for kindergarten through 5th grade."
 msgstr "Frases curtas e simples para jardim de infância até o 5º ano."
 
@@ -6473,6 +6646,9 @@ msgstr "Mostrar detalhes do erro"
 
 msgid "Show fewer"
 msgstr "Show fewer"
+
+msgid "Show Kids Mode details"
+msgstr "Mostrar detalhes do Modo Infantil"
 
 msgid "Show only the terms you added manually"
 msgstr "Mostrar apenas os termos que você adicionou manualmente"
@@ -6512,6 +6688,9 @@ msgstr "Sobreposições de vídeo em língua de sinais para cada página"
 
 msgid "Sign language videos provide access for deaf and hard of hearing readers who may not be fluent in written language."
 msgstr "Vídeos em língua de sinais oferecem acesso para leitores surdos e com deficiência auditiva que podem não ser fluentes em linguagem escrita."
+
+msgid "Signature"
+msgstr "Marcante"
 
 msgid "Simplified Easy Read text variants."
 msgstr "Variantes de texto simplificadas de Leitura Fácil."
@@ -6689,6 +6868,9 @@ msgstr "Pré-visualização da divisão"
 msgid "Split segments"
 msgstr "Segmentos divididos"
 
+msgid "Spoken buddy voices"
+msgstr "Vozes faladas do amigo"
+
 msgid "Spread"
 msgstr "Dupla"
 
@@ -6712,6 +6894,9 @@ msgstr "E-book padrão para leitores e bibliotecas"
 
 msgid "Standard EPUB 3 file for e-readers, reading apps, and accessibility tools. Interactive features (quizzes, TTS) work in readers that support JavaScript."
 msgstr "Arquivo EPUB 3 padrão para leitores eletrônicos, aplicativos de leitura e ferramentas de acessibilidade. Recursos interativos (questionários, TTS) funcionam em leitores que suportam JavaScript."
+
+msgid "Standing"
+msgstr "Em pé"
 
 msgid "Start"
 msgstr "Início"
@@ -6819,6 +7004,9 @@ msgstr "Guia de estilo"
 msgid "Style Guide"
 msgstr "Guia de Estilo"
 
+msgid "Style instructions"
+msgstr "Instruções de estilo"
+
 msgid "Style reference"
 msgstr "Referência de estilo"
 
@@ -6860,6 +7048,9 @@ msgstr "Prompt de resumo"
 
 msgid "Sun"
 msgstr "Sol"
+
+msgid "Surprised"
+msgstr "Surpreso"
 
 msgid "SW"
 msgstr "SW"
@@ -7034,6 +7225,10 @@ msgstr "A instrução de TTS padrão aplicada a todos os idiomas, a menos que se
 msgid "The entire page is treated as a single section - all text and images stay together as one unit. Best for storybooks, reference books, and any content where each page is self-contained."
 msgstr "A página inteira é tratada como uma única seção - todo o texto e imagens permanecem juntos como uma unidade. Melhor para livros de histórias, livros de referência e qualquer conteúdo onde cada página é autossuficiente."
 
+#. placeholder {0}: selectedBuddy.defaultNameFallback
+msgid "The expression set {0} uses across the reading experience"
+msgstr "O conjunto de expressões que {0} usa na experiência de leitura"
+
 msgid "The file may be damaged or incomplete. Try downloading it again from the source."
 msgstr "O arquivo pode estar danificado ou incompleto. Tente baixá-lo novamente da fonte."
 
@@ -7166,6 +7361,12 @@ msgstr "Produzem flores para atrair polinizadores."
 msgid "They release oxygen directly into the air."
 msgstr "Liberam oxigênio diretamente no ar."
 
+msgid "Things {name} says"
+msgstr "Coisas que {name} diz"
+
+msgid "Thinking"
+msgstr "Pensativo"
+
 msgid "This archive can't be opened safely"
 msgstr "Este arquivo não pode ser aberto com segurança"
 
@@ -7221,6 +7422,9 @@ msgstr "Esta imagem está marcada como decorativa — clique para desmarcar"
 
 msgid "This is <0>ADT Studio</0>."
 msgstr "Isto é o <0>ADT Studio</0>."
+
+msgid "This is a kids book"
+msgstr "Este é um livro infantil"
 
 msgid "This is a preview of the options you have selected for your book, each option affects the preview in a different way."
 msgstr "Esta é uma pré-visualização das opções que você selecionou para o seu livro, cada opção afeta a pré-visualização de uma maneira diferente."
@@ -7521,6 +7725,9 @@ msgstr "Ajuste como o texto é simplificado nas configurações do Prompt de Lei
 
 msgid "Turn any PDF into a fully accessible book — audio, translations, structured HTML layouts — all generated from your source file, <0>all editable</0>, <1>all yours</1>."
 msgstr "Transforme qualquer PDF em um livro totalmente acessível — áudio, traduções, layouts HTML estruturados — tudo gerado a partir do seu arquivo fonte, <0>tudo editável</0>, <1>tudo seu</1>."
+
+msgid "Turn on kids mode to configure buddies and voices."
+msgstr "Ative o modo infantil para configurar os amigos e as vozes."
 
 msgid "Turn this on to show the Validation review card in Preview and the Reviewer Validation tab in the Validation step."
 msgstr "Turn this on to show the Validation review card in Preview and the Reviewer Validation tab in the Validation step."
@@ -7833,6 +8040,9 @@ msgstr "Voz"
 
 msgid "Voice Mappings"
 msgstr "Mapeamentos de voz"
+
+msgid "Voice preset"
+msgstr "Predefinição de voz"
 
 msgid "Voices"
 msgstr "Vozes"

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -69,6 +69,12 @@ msgstr "(f.{0})"
 msgid "(template)"
 msgstr "(shabllon)"
 
+#. placeholder {0}: buddies.length
+#. placeholder {1}: KIDS_BUDDIES.length
+#. placeholder {2}: KIDS_BUDDIES.length
+msgid "{0, plural, one {# of {1} shipping} other {# of {2} shipping}}"
+msgstr "{0, plural, one {# nga {1} i përfshirë} other {# nga {2} të përfshirë}}"
+
 #. placeholder {0}: preview.addedPageNumbers.length
 #. placeholder {0}: result.addedPages
 msgid "{0, plural, one {# page added} other {# pages added}}"
@@ -235,6 +241,10 @@ msgstr "{0} seksione"
 msgid "{0} selected images are no longer in the storyboard."
 msgstr "{0} imazhe të zgjedhura nuk janë më në storyboard."
 
+#. placeholder {0}: selectedBuddy.defaultNameFallback
+msgid "{0} ships with this book"
+msgstr "{0} përfshihet me këtë libër"
+
 #. placeholder {0}: String(visibleCount)
 msgid "{0} terms"
 msgstr "{0} terma"
@@ -246,6 +256,10 @@ msgstr "{0} tekste"
 #. placeholder {0}: outputLanguages.length
 msgid "{0} translations"
 msgstr "{0} përkthime"
+
+#. placeholder {0}: selectedBuddy.defaultNameFallback
+msgid "{0}'s voice pack"
+msgstr "Paketa e zërit të {0}"
 
 #. placeholder {0}: String(generatedAudioCount)
 #. placeholder {1}: String(speakableEntries.length)
@@ -289,6 +303,9 @@ msgstr "{0}m më parë"
 #. placeholder {0}: String(Math.floor(diff / 1000))
 msgid "{0}s ago"
 msgstr "{0}s më parë"
+
+msgid "{buddyCount, plural, one {# buddy} other {# buddies}}"
+msgstr "{buddyCount, plural, one {# shok} other {# shokë}}"
 
 msgid "{count} {count, plural, one {issue} other {issues}}"
 msgstr "{count} {count, plural, one {problem} other {probleme}}"
@@ -352,8 +369,14 @@ msgstr "{missingForCurrentStage} hyrje/hyrjet mungojnë audio. Ekzekutoni përs�
 msgid "{missingForCurrentStage} entry/entries are missing translations. Re-run to fill the missing items."
 msgstr "{missingForCurrentStage} hyrje/hyrjet mungojnë përkthime. Ekzekutoni përsëri për të plotësuar elementet që mungojnë."
 
+msgid "{name}'s expressions"
+msgstr "Shprehjet e {name}"
+
 msgid "{needsChanges} flagged"
 msgstr "{needsChanges} të shënuara"
+
+msgid "{packCount, plural, one {# voice pack} other {# voice packs}}"
+msgstr "{packCount, plural, one {# paketë zëri} other {# paketa zëri}}"
 
 msgid "{pageCount} {pageCount, plural, one {page} other {pages}}"
 msgstr "{pageCount} {pageCount, plural, one {faqe} other {faqe}}"
@@ -518,6 +541,9 @@ msgstr "Një figurë stilistike që përshkruan diçka sikur të ishte tjetër g
 
 msgid "A fill-in-the-blank activity."
 msgstr "Një aktivitet me plotësim boshllëqesh."
+
+msgid "A friendly character fronts every reading tool, from text-to-speech to font size."
+msgstr "Një personazh miqësor përfaqëson çdo mjet leximi, nga tekst-në-fjalim deri te madhësia e shkronjave."
 
 msgid "A glossary term with this word already exists."
 msgstr "Një term glosari me këtë fjalë ekziston tashmë."
@@ -844,6 +870,9 @@ msgstr "Shto gjuhë"
 msgid "Add Language"
 msgstr "Shto Gjuhë"
 
+msgid "Add languages to the book to generate voice packs."
+msgstr "Shto gjuhë në libër për të gjeneruar paketa zëri."
+
 msgid "Add languages to translate the book content into."
 msgstr "Shto gjuhë për të përkthyer përmbajtjen e librit."
 
@@ -897,6 +926,15 @@ msgstr "Shto librin tuaj të parë"
 
 msgid "Add your first term"
 msgstr "Shto termin tuaj të parë"
+
+msgid "Add your OpenAI key in Settings to generate voices."
+msgstr "Shto çelësin tënd të OpenAI te Cilësimet për të gjeneruar zëra."
+
+msgid "Add your OpenAI key in Settings to generate."
+msgstr "Shto çelësin tënd të OpenAI te Cilësimet për të gjeneruar."
+
+msgid "Add your own buddy"
+msgstr "Shto shokun tënd"
 
 msgid "added"
 msgstr "shtuar"
@@ -1051,6 +1089,9 @@ msgstr "Të gjitha kategoritë"
 msgid "All Categories"
 msgstr "Të Gjitha Kategoritë"
 
+msgid "All expressions"
+msgstr "Të gjitha shprehjet"
+
 msgid "All issues and manual review items"
 msgstr "Të gjitha problemet dhe elementet e rishikimit manual"
 
@@ -1181,6 +1222,9 @@ msgstr "Shfaqet në faqet {0}"
 msgid "Application Programming Interface — a set of rules that allows programs to communicate."
 msgstr "Ndërfaqe Programimi Aplikacioni — një grup rregullash që lejon programet të komunikojnë."
 
+msgid "Applies to the live preview and every exported format — readers can't turn it off."
+msgstr "Zbatohet në pamjen paraprake të drejtpërdrejtë dhe në çdo format të eksportuar — lexuesit nuk mund ta çaktivizojnë."
+
 msgid "Apply"
 msgstr "Apliko"
 
@@ -1266,6 +1310,12 @@ msgstr "Tregim audio (ndikimi më i madh në madhësinë e skedarit)"
 msgid "Audio Player"
 msgstr "Luajtës audio"
 
+msgid "Audition"
+msgstr "Shikim paraprak"
+
+msgid "Audition language"
+msgstr "Gjuha e shikimit paraprak"
+
 msgid "Author"
 msgstr "Autor"
 
@@ -1320,14 +1370,23 @@ msgstr "Kthehu"
 msgid "Back Cover"
 msgstr "Kapaku i pasëm"
 
+msgid "Back to book"
+msgstr "Kthehu te libri"
+
 msgid "Back to books"
 msgstr "Kthehu te librat"
 
 msgid "Back to Editor"
 msgstr "Kthehu te redaktori"
 
+msgid "Back to kids UI"
+msgstr "Kthehu te ndërfaqja për fëmijë"
+
 msgid "Back to preview"
 msgstr "Kthehu te pamja paraprake"
+
+msgid "Back to regular UI"
+msgstr "Kthehu te ndërfaqja normale"
 
 msgid "Back to Speech overview"
 msgstr "Kthehu te përmbledhja e të folurit"
@@ -1341,6 +1400,9 @@ msgstr "Sfond"
 #. placeholder {0}: section.backgroundColor
 msgid "Background: {0}"
 msgstr "Sfond: {0}"
+
+msgid "Baked into the book"
+msgstr "I integruar në libër"
 
 msgid "base"
 msgstr "bazë"
@@ -1483,6 +1545,15 @@ msgstr "Shfleto dhe redakto shabllonët Liquid të përdorur për strategjitë e
 
 msgid "Browse every Storyboard section and upload, replace, or remove its sign-language video."
 msgstr "Shfleto çdo seksion të Storyboard-it dhe ngarko, zëvendëso ose hiq videon e gjuhës së shenjave."
+
+msgid "Buddies"
+msgstr "Shokët"
+
+msgid "Buddy stage view"
+msgstr "Pamja e skenës së shokut"
+
+msgid "Buddy-guided interface"
+msgstr "Ndërfaqe e udhëhequr nga shoku"
 
 msgid "Build"
 msgstr "Ndërtim"
@@ -1654,11 +1725,17 @@ msgstr "Libra me kapituj dhe imazhe"
 msgid "Chapter One"
 msgstr "Kapitulli i Parë"
 
+msgid "Character art"
+msgstr "Arti i personazhit"
+
 msgid "Chart / Graph"
 msgstr "Tabelë / Grafik"
 
 #~ msgid "Check for updates"
 #~ msgstr "Kontrollo për përditësime"
+
+msgid "Check plan"
+msgstr "Kontrollo planin"
 
 msgid "Checked"
 msgstr "Kontrolluar"
@@ -2096,6 +2173,9 @@ msgstr "Faqja aktuale e pamjes paraprake"
 msgid "Custom"
 msgstr "I personalizuar"
 
+msgid "Custom buddies are coming soon"
+msgstr "Shokët e personalizuar së shpejti"
+
 msgid "Custom Instructions"
 msgstr "Udhëzime të personalizuara"
 
@@ -2361,6 +2441,12 @@ msgstr "U krye"
 msgid "DONE"
 msgstr "KRYER"
 
+#. placeholder {0}: lastRun.total
+#. placeholder {1}: lastRun.generated
+#. placeholder {2}: lastRun.cachedHits
+msgid "Done: {0} clips ready — {1} newly generated, {2} from cache."
+msgstr "Përfunduar: {0} klipe gati — {1} të sapogjeneruara, {2} nga cache."
+
 msgid "Download a full backup of this project"
 msgstr "Shkarko një kopje rezervë të plotë të këtij projekti"
 
@@ -2484,6 +2570,9 @@ msgstr "p.sh., Bëje sfondin më të ndritshëm, shto më shumë pemë..."
 msgid "Each block was simplified by AI. Edit any Easy Read text to refine it against the original, then Save. Changes are stored as a new version, so you can always roll back or regenerate."
 msgstr "Çdo bllok u thjeshtua nga AI. Redakto çdo tekst Easy Read për ta rafinuar ndaj origjinalit, pastaj Ruaje. Ndryshimet ruhen si version i ri, kështu që mund të kthehesh gjithmonë ose të rigjenerohet."
 
+msgid "Each buddy talks in the reader's language, generated once per language and cached for offline use."
+msgstr "Çdo shok flet në gjuhën e lexuesit, i gjeneruar një herë për çdo gjuhë dhe i ruajtur në cache për përdorim jashtë linje."
+
 msgid "Each iteration is one LLM call. Lower values are faster and cheaper; higher values give the reviewer more chances to fix problems."
 msgstr "Çdo iteracion është një thirrje LLM. Vlerat e ulëta janë më të shpejta dhe më të lira; vlerat e larta i japin rishikuesit më shumë mundësi për të korrigjuar problemet."
 
@@ -2566,6 +2655,9 @@ msgstr "I redaktueshëm për çdo bllok"
 msgid "edited"
 msgstr "redaktuar"
 
+msgid "Edited"
+msgstr "Ndryshuar"
+
 msgid "Edited in"
 msgstr "Redaktuar në"
 
@@ -2574,6 +2666,9 @@ msgstr "Redaktuar manualisht"
 
 msgid "Editing"
 msgstr "Duke redaktuar"
+
+msgid "Editing character art is coming soon"
+msgstr "Redaktimi i artit të personazhit vjen së shpejti"
 
 msgid "Editing is disabled while the storyboard is running"
 msgstr "Redaktimi është i çaktivizuar ndërsa storyboard-i është duke u ekzekutuar"
@@ -2636,6 +2731,9 @@ msgstr "Aktivizuar"
 
 msgid "Enabled axe tags"
 msgstr "Etiketat axe të aktivizuara"
+
+msgid "Encouraging"
+msgstr "Inkurajues"
 
 msgid "End"
 msgstr "Fundi"
@@ -2744,6 +2842,9 @@ msgstr "Çdo seksion i Storyboard-it ka një video të gjuhës së shenjave të 
 
 msgid "Example Books"
 msgstr "Libra shembull"
+
+msgid "Excited"
+msgstr "I emocionuar"
 
 msgid "Exclude from read-aloud"
 msgstr "Përjashto nga leximi me zë"
@@ -3109,6 +3210,12 @@ msgstr "Gjenero një version të thjeshtësuar, më të lehtë për t'u lexuar t
 msgid "Generate a single quiz from specific pages and place it at a chosen location."
 msgstr "Gjenero një kuiz të vetëm nga faqe specifike dhe vendoseni në një vend të zgjedhur."
 
+msgid "Generate all buddy voices"
+msgstr "Gjenero të gjithë zërat e shokëve"
+
+msgid "Generate all languages"
+msgstr "Gjenero të gjitha gjuhët"
+
 msgid "Generate and customize the table of contents for the book navigation."
 msgstr "Gjenero dhe personalizo tabelën e përmbajtjes për navigimin e librit."
 
@@ -3148,6 +3255,9 @@ msgstr "Gjenero kuiz"
 msgid "Generate Styleguide from Pages"
 msgstr "Gjenero Udhëzuesin e Stilit nga Faqet"
 
+msgid "Generate voices to preview lines"
+msgstr "Gjenero zëra për të shikuar paraprakisht replikat"
+
 msgid "Generate with AI"
 msgstr "Gjenero me AI"
 
@@ -3174,6 +3284,9 @@ msgstr "Gjeneron pyetje kuptimi dhe aktivitete nga libri."
 
 msgid "Generates descriptive alt-text for images so screen readers can describe them."
 msgstr "Gjeneron tekst alternativ përshkrues për imazhet që lexuesit e ekranit mund t'i përshkruajnë."
+
+msgid "Generates every shipped buddy in every book language."
+msgstr "Gjeneron çdo shok të përfshirë në çdo gjuhë të librit."
 
 msgid "Generates the interactive HTML for this activity type."
 msgstr "Gjeneron HTML interaktiv për këtë lloj aktiviteti."
@@ -3285,6 +3398,9 @@ msgstr "Shpërndani pjesë sipas intervalit të faqeve dhe bashkojini më vonë.
 #~ msgid "Handwriting"
 #~ msgstr "Shkrim dore"
 
+msgid "Happy"
+msgstr "I lumtur"
+
 msgid "Header"
 msgstr "Titull"
 
@@ -3317,6 +3433,9 @@ msgstr "Fshih historikun e editimeve të AI"
 
 msgid "Hide error details"
 msgstr "Fshih detajet e gabimit"
+
+msgid "Hide Kids Mode details"
+msgstr "Fshih detajet e Modalitetit për Fëmijë"
 
 msgid "High"
 msgstr "I lartë"
@@ -3714,6 +3833,12 @@ msgstr "Çelësi duhet të fillojë me sk-"
 msgid "Keyboard & navigation"
 msgstr "Tastierë dhe navigim"
 
+msgid "Kids Mode"
+msgstr "Modaliteti për Fëmijë"
+
+msgid "Kids Mode swaps the standard reading menus for a friendly, buddy-guided experience: the reader picks a reading buddy that fronts every accessibility feature. It's an authoring decision baked into the live preview and every export — readers can't turn it off or change buddies themselves."
+msgstr "Modaliteti për Fëmijë zëvendëson menytë standarde të leximit me një përvojë miqësore të udhëhequr nga një shok: lexuesi zgjedh një shok leximi që përfaqëson çdo veçori aksesueshmërie. Është një vendim autorial i integruar në pamjen paraprake të drejtpërdrejtë dhe në çdo eksportim — lexuesit nuk mund ta çaktivizojnë apo të ndryshojnë shokun vetë."
+
 #. placeholder {0}: afterPage.pageNumber
 msgid "Knowledge check generated from the source pages, after page {0}."
 msgstr "Kontroll njohurish gjeneruar nga faqet burimore, pas faqes {0}."
@@ -3820,6 +3945,9 @@ msgstr "Lila endej midis pishave të larta, elektriku i saj duke kapur shkëlqim
 
 msgid "lines"
 msgstr "rreshta"
+
+msgid "Lines"
+msgstr "Replika"
 
 msgid "Língua Portuguesa - 3° Ano"
 msgstr "Língua Portuguesa - 3° Ano"
@@ -4015,6 +4143,9 @@ msgstr "Vlerat më të ulëta prodhojnë stil më konsistent nëpër faqe."
 
 msgid "Make sure you're uploading a .zip file exported from ADT Studio."
 msgstr "Sigurohuni që po ngarkoni një skedar .zip të eksportuar nga ADT Studio."
+
+msgid "Make this a kids book: pick the reading buddies and generate their voices."
+msgstr "Bëje këtë një libër për fëmijë: zgjidh shokët e leximit dhe gjenero zërat e tyre."
 
 msgid "Manage all sections"
 msgstr "Menaxho të gjitha seksionet"
@@ -4379,6 +4510,9 @@ msgstr "Nuk ka audio për këtë faqe"
 msgid "No books match your search"
 msgstr "Asnjë libër nuk përputhet me kërkimin tuaj"
 
+msgid "No buddy voices generated yet — check the plan to see cost before generating."
+msgstr "Ende nuk janë gjeneruar zëra shokësh — kontrollo planin për të parë koston para se të gjenerosh."
+
 msgid "No captioned images yet. Run the image-captioning step first."
 msgstr "Nuk ka ende imazhe me tituj. Ekzekuto fillimisht hapin e titullimit të imazheve."
 
@@ -4691,8 +4825,14 @@ msgstr "nga"
 msgid "Off"
 msgstr "Joaktiv"
 
+msgid "Off by default"
+msgstr "Çaktivizuar si parazgjedhje"
+
 msgid "On"
 msgstr "Aktiv"
+
+msgid "On for this book"
+msgstr "Aktivizuar për këtë libër"
 
 msgid "One Column"
 msgstr "Një kolonë"
@@ -5210,6 +5350,9 @@ msgstr "Zgjidhni gjuhët në të cilat dëshironi të përktheni. Gjuha origjina
 msgid "Pick which voice each language uses for narration, including regional accents."
 msgstr "Zgjidhni cilën zë përdor secila gjuhë për tregimin, duke përfshirë thekset rajonale."
 
+msgid "Picking phrases"
+msgstr "Fjali zgjedhjeje"
+
 msgid "Picture books and early readers"
 msgstr "Libra me ilustrime dhe lexues fillestarë"
 
@@ -5234,11 +5377,23 @@ msgstr "Fazat e Pipeline"
 msgid "Pixel Art"
 msgstr "Pixel Art"
 
+#. placeholder {0}: lastRun.total
+#. placeholder {1}: lastRun.languages.length
+#. placeholder {2}: lastRun.characters.length
+#. placeholder {3}: lastRun.cachedHits
+#. placeholder {4}: lastRun.total - lastRun.cachedHits
+#. placeholder {5}: lastRun.model
+msgid "Plan: {0} clips across {1} language(s) × {2} buddies — {3} already cached, {4} would call the API (model {5})."
+msgstr "Plani: {0} klipe në {1} gjuhë × {2} shokë — {3} tashmë në cache, {4} do të thërrisnin API-në (modeli {5})."
+
 msgid "Plants create sugar via <0>photosynthesis</0>, divide by <1>mitosis</1>, and absorb water by <2>osmosis</2>."
 msgstr "Bimët krijojnë sheqer nëpërmjet <0>fotosintezës</0>, ndahen me <1>mitozë</1>, dhe thithin ujë me <2>osmozë</2>."
 
 msgid "Play"
 msgstr "Luaj"
+
+msgid "Play this line"
+msgstr "Luaj këtë replikë"
 
 msgid "Play video"
 msgstr "Luaj videon"
@@ -5301,11 +5456,17 @@ msgstr "Pamje paraprake"
 #~ msgid "Preview & split pages"
 #~ msgstr "Parashiko dhe ndaj faqet"
 
+msgid "Preview kids UI"
+msgstr "Shiko ndërfaqen për fëmijë"
+
 msgid "Preview linked page"
 msgstr "Shiko faqen e lidhur"
 
 msgid "Preview of the HTML/CSS patterns used for LLM-generated pages."
 msgstr "Pamje paraprake e modeleve HTML/CSS të përdorura për faqet e gjeneruara nga LLM."
+
+msgid "Preview regular UI"
+msgstr "Shiko ndërfaqen normale"
 
 msgid "Preview: per-sentence"
 msgstr "Pamje paraprake: për-fjali"
@@ -5586,6 +5747,9 @@ msgstr "Libër dixhital i pajtueshëm me Readium"
 msgid "Reads in"
 msgstr "Lexohet në"
 
+msgid "Ready"
+msgstr "Gati"
+
 msgid "Real books processed with this preset — before and after."
 msgstr "Libra të vërtetë të procesuar me këtë paracaktim — para dhe pas."
 
@@ -5779,6 +5943,9 @@ msgstr "Rivendos fontet"
 
 msgid "Reset fonts to default?"
 msgstr "Të rivendosen fontet në parazgjedhje?"
+
+msgid "Reset to default"
+msgstr "Rivendos në paracaktim"
 
 msgid "Reset to defaults"
 msgstr "Rivendos në paracaktimet"
@@ -6102,6 +6269,9 @@ msgstr "Ruaj zgjedhjen"
 
 msgid "Save settings"
 msgstr "Ruaj cilësimet"
+
+msgid "Save voice"
+msgstr "Ruaj zërin"
 
 msgid "Save your work first if you want to keep these changes."
 msgstr "Ruaje punën tënde më parë nëse dëshiron t'i mbash këto ndryshime."
@@ -6447,6 +6617,9 @@ msgstr "Hije"
 msgid "Ship"
 msgstr "Dërgo"
 
+msgid "Ships with this book"
+msgstr "Përfshihet me këtë libër"
+
 msgid "Short, simple sentences for kindergarten through 5th grade."
 msgstr "Fjali të shkurtra dhe të thjeshta për klasën e parë deri në të pestën."
 
@@ -6474,6 +6647,9 @@ msgstr "Shfaq detajet e gabimit"
 
 msgid "Show fewer"
 msgstr "Shfaq më pak"
+
+msgid "Show Kids Mode details"
+msgstr "Shfaq detajet e Modalitetit për Fëmijë"
 
 msgid "Show only the terms you added manually"
 msgstr "Shfaq vetëm termat që shtuat manualisht"
@@ -6513,6 +6689,9 @@ msgstr "Mbivendosje videosh të gjuhës së shenjave për çdo faqe"
 
 msgid "Sign language videos provide access for deaf and hard of hearing readers who may not be fluent in written language."
 msgstr "Videot e gjuhës së shenjave ofrojnë qasje për lexuesit shurdhamutë dhe me dëgjim të kufizuar, të cilët mund të mos jenë të rrjedhshëm në gjuhën e shkruar."
+
+msgid "Signature"
+msgstr "Dalluese"
 
 msgid "Simplified Easy Read text variants."
 msgstr "Variante të thjeshtuara të tekstit Easy Read."
@@ -6690,6 +6869,9 @@ msgstr "Pamja paraprake e ndarjes"
 msgid "Split segments"
 msgstr "Ndaj segmentet"
 
+msgid "Spoken buddy voices"
+msgstr "Zërat e folur të shokut"
+
 msgid "Spread"
 msgstr "Shpërndarje"
 
@@ -6713,6 +6895,9 @@ msgstr "E-book standard për lexues dhe biblioteka"
 
 msgid "Standard EPUB 3 file for e-readers, reading apps, and accessibility tools. Interactive features (quizzes, TTS) work in readers that support JavaScript."
 msgstr "Skedar standard EPUB 3 për lexues elektronikë, aplikacione leximi dhe mjete aksesueshmërie. Veçoritë interaktive (quiz-e, TTS) funksionojnë në lexues që mbështesin JavaScript."
+
+msgid "Standing"
+msgstr "Në këmbë"
 
 msgid "Start"
 msgstr "Fillo"
@@ -6820,6 +7005,9 @@ msgstr "Udhëzues stili"
 msgid "Style Guide"
 msgstr "Udhëzues Stili"
 
+msgid "Style instructions"
+msgstr "Udhëzime stili"
+
 msgid "Style reference"
 msgstr "Referencë stili"
 
@@ -6861,6 +7049,9 @@ msgstr "Prompt Përmbledhjeje"
 
 msgid "Sun"
 msgstr "Diell"
+
+msgid "Surprised"
+msgstr "I habitur"
 
 msgid "SW"
 msgstr "JP"
@@ -7035,6 +7226,10 @@ msgstr "Udhëzimi i parazgjedhur i TTS që zbatohet për çdo gjuhë, përveçse
 msgid "The entire page is treated as a single section - all text and images stay together as one unit. Best for storybooks, reference books, and any content where each page is self-contained."
 msgstr "I gjithë faqja trajtohet si një seksion i vetëm — i gjithë teksti dhe imazhet qëndrojnë bashkë si një njësi. Më e mirë për libra me tregime, libra referencë dhe çdo përmbajtje ku çdo faqe është e vetëmjaftueshme."
 
+#. placeholder {0}: selectedBuddy.defaultNameFallback
+msgid "The expression set {0} uses across the reading experience"
+msgstr "Grupi i shprehjeve që përdor {0} në përvojën e leximit"
+
 msgid "The file may be damaged or incomplete. Try downloading it again from the source."
 msgstr "Skedari mund të jetë i dëmtuar ose i paplotë. Provo ta shkarkosh sërish nga burimi."
 
@@ -7167,6 +7362,12 @@ msgstr "Ato prodhojnë lule për të tërhequr polenizuesit."
 msgid "They release oxygen directly into the air."
 msgstr "Ato lëshojnë oksigjen drejtpërdrejt në ajër."
 
+msgid "Things {name} says"
+msgstr "Gjëra që thotë {name}"
+
+msgid "Thinking"
+msgstr "Duke menduar"
+
 msgid "This archive can't be opened safely"
 msgstr "Ky arkiv nuk mund të hapet në mënyrë të sigurt"
 
@@ -7222,6 +7423,9 @@ msgstr "Ky imazh është shënuar si dekorativ — kliko për ta hequr shënimin
 
 msgid "This is <0>ADT Studio</0>."
 msgstr "Ky është <0>ADT Studio</0>."
+
+msgid "This is a kids book"
+msgstr "Ky është një libër për fëmijë"
 
 msgid "This is a preview of the options you have selected for your book, each option affects the preview in a different way."
 msgstr "Ky është një paraparim i opsioneve të zgjedhura për librin tuaj, çdo opsion ndikon paraparimimin në mënyra të ndryshme."
@@ -7522,6 +7726,9 @@ msgstr "Rregullo se si thjeshtohet teksti në cilësimet e Udhëzimit Easy Read.
 
 msgid "Turn any PDF into a fully accessible book — audio, translations, structured HTML layouts — all generated from your source file, <0>all editable</0>, <1>all yours</1>."
 msgstr "Ktheje çdo PDF në një libër plotësisht të aksesueshëm — audio, përkthime, paraqitje HTML të strukturuara — të gjitha të gjeneruara nga skedari juaj burim, <0>të gjitha të redaktueshme</0>, <1>të gjitha tuajat</1>."
+
+msgid "Turn on kids mode to configure buddies and voices."
+msgstr "Aktivizo modalitetin për fëmijë për të konfiguruar shokët dhe zërat."
 
 msgid "Turn this on to show the Validation review card in Preview and the Reviewer Validation tab in the Validation step."
 msgstr "Aktivizo këtë për të shfaqur kartën e rishikimit të Validimit në Paraparimim dhe skedën e Validimit të Rishikuesit në hapin e Validimit."
@@ -7834,6 +8041,9 @@ msgstr "Zë"
 
 msgid "Voice Mappings"
 msgstr "Hartëzime zërash"
+
+msgid "Voice preset"
+msgstr "Paracaktim zëri"
 
 msgid "Voices"
 msgstr "Zëra"


### PR DESCRIPTION
Fills the Studio i18n catalogs for the Kids Mode feature (pre-merge checklist item 1, Studio half). **Stacked on `eliezir/kids-mode`.**

- `pnpm --filter @adt/studio extract` surfaced 65 new strings (Kids Mode UI + a few generic ones like "Lines", "Ready", "Edited").
- Translated all 65 into **es, pt-BR, fr, sq** (260 strings) in a professional authoring-UI register, matching existing catalog terminology; ICU placeholders/plurals/markup preserved; `en` left as source. Buddy names stay as-is.
- **CI i18n job replicated green:** extract idempotent (0 unextracted), `compile --strict` passes, no empty `msgstr` in the 4 non-en locales, lingui `no-unlocalized-strings` clean.

### Scope note — runtime i18n handled separately
This covers only **Studio** (authoring UI, 5 locales, CI-gated). The **runtime** kids strings use inline English fallbacks via `tk()` across 69 chrome catalogs that are already partially translated by the localization process (en=194 keys, many locales ~126). Machine-translating 52 kids keys × 68 languages of *child-facing accessibility content* unreviewed isn't appropriate for a UNICEF product, so runtime localization is deferred to the translation workstream (a follow-up will add the EN source keys). Runtime degrades gracefully to English today.
