### PR TITLE
fix(storyboard): preserve intentional reading order

### DIFF
--- a/apps/api/src/routes/pages.ts
+++ b/apps/api/src/routes/pages.ts
@@ -1160,11 +1160,16 @@ export function createPageRoutes(
 
     // Optional prompt for LLM guidance during re-render
     let prompt: string | undefined
+    let intentionalReadingOrder = false
     try {
       const body = await c.req.json()
-      const parsed = z.object({ prompt: z.string().optional() }).safeParse(body)
+      const parsed = z.object({
+        prompt: z.string().optional(),
+        intentionalReadingOrder: z.boolean().optional(),
+      }).safeParse(body)
       if (parsed.success) {
         prompt = parsed.data.prompt
+        intentionalReadingOrder = parsed.data.intentionalReadingOrder ?? false
       }
     } catch {
       // No body or not JSON — that's fine, prompt is optional
@@ -1214,6 +1219,7 @@ export function createPageRoutes(
             pageId,
             sectionIndex,
             prompt,
+            intentionalReadingOrder,
             booksDir,
             promptsDir,
             webAssetsDir,
@@ -1232,6 +1238,7 @@ export function createPageRoutes(
       pageId,
       sectionIndex,
       prompt,
+      intentionalReadingOrder,
       booksDir,
       promptsDir,
       webAssetsDir,

--- a/apps/api/src/services/page-edit-service.test.ts
+++ b/apps/api/src/services/page-edit-service.test.ts
@@ -219,6 +219,7 @@ describe("page-edit-service", () => {
         label,
         pageId,
         sectionIndex: 1,
+        intentionalReadingOrder: true,
         booksDir: tmpDir,
         promptsDir: tmpDir,
         configPath: path.resolve(process.cwd(), "config.yaml"),

--- a/apps/api/src/services/page-edit-service.ts
+++ b/apps/api/src/services/page-edit-service.ts
@@ -14,6 +14,8 @@ export interface ReRenderOptions {
   sectionIndex?: number
   /** Optional user prompt/instructions to guide the LLM during re-render */
   prompt?: string
+  /** The user intentionally changed the source PDF's reading order. */
+  intentionalReadingOrder?: boolean
   booksDir: string
   promptsDir: string
   webAssetsDir?: string
@@ -48,7 +50,7 @@ export interface AiEditSectionResult {
 export async function reRenderPage(
   options: ReRenderOptions
 ): Promise<ReRenderResult> {
-  const { label, pageId, sectionIndex, prompt, booksDir, promptsDir, webAssetsDir, configPath, apiKey } = options
+  const { label, pageId, sectionIndex, prompt, intentionalReadingOrder, booksDir, promptsDir, webAssetsDir, configPath, apiKey } = options
 
   // Set API key
   const previousKey = process.env.OPENAI_API_KEY
@@ -176,6 +178,7 @@ export async function reRenderPage(
         styleguide: styleguideContent,
         bookFonts: buildBookFontsPromptContext(storage),
         userPrompt: prompt,
+        intentionalReadingOrder,
       },
       resolveRenderConfig,
       resolveRenderModel,

--- a/apps/studio/src/api/client.ts
+++ b/apps/studio/src/api/client.ts
@@ -966,13 +966,22 @@ export const api = {
       method: "DELETE",
     }),
 
-  reRenderPage: (label: string, pageId: string, apiKey: string, sectionIndex?: number, prompt?: string) =>
+  reRenderPage: (
+    label: string,
+    pageId: string,
+    apiKey: string,
+    sectionIndex?: number,
+    prompt?: string,
+    intentionalReadingOrder?: boolean,
+  ) =>
     request<{ taskId?: string; status?: string; version?: number; rendering?: { sections: SectionRendering[] } }>(
       `/books/${label}/pages/${pageId}/re-render${sectionIndex !== undefined ? `?sectionIndex=${sectionIndex}` : ""}`,
       {
         method: "POST",
         headers: { "X-OpenAI-Key": apiKey },
-        ...(prompt ? { body: JSON.stringify({ prompt }) } : {}),
+        ...(prompt || intentionalReadingOrder
+          ? { body: JSON.stringify({ prompt, intentionalReadingOrder }) }
+          : {}),
         signal: AbortSignal.timeout(30_000), // Just submitting a task now
       }
     ),

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/SectionEditPanel.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/SectionEditPanel.tsx
@@ -45,7 +45,7 @@ interface SectionEditPanelProps {
   onLeafTextEdited: (nodeId: string, text: string) => void
   onLeafDuplicated: (sourceNodeId: string, newNodeId: string) => void
   onLeafDeleted: (nodeId: string) => void
-  onStructuralChange: () => void
+  onStructuralChange: (kind?: "reorder") => void
   onMergeSection: (dir: "prev" | "next") => void
   onMergeCrossPage?: (dir: "prev" | "next") => void
   hasPrevPage?: boolean

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
@@ -416,6 +416,10 @@ export function StoryboardSectionDetail({
   // Tracks whether pending sectioning changes require LLM re-render on save.
   // Pure prune/delete can be resolved locally; unprune/type change/reorder need LLM.
   const needsRerenderRef = useRef(false)
+  // A user-directed reorder intentionally changes the PDF's reading order. The
+  // re-render must follow the edited tree without a visual reviewer undoing it
+  // merely because it no longer matches the original page.
+  const intentionalReadingOrderRef = useRef(false)
 
   // Inline editing state
   const [selectedElement, setSelectedElement] = useState<{
@@ -612,6 +616,7 @@ export function StoryboardSectionDetail({
     setSaving(false)
     setActivityPreviewMode(false)
     needsRerenderRef.current = false
+    intentionalReadingOrderRef.current = false
   }, [pageId, sectionIndex])
 
   // Reset scroll position when page or section changes
@@ -660,6 +665,7 @@ export function StoryboardSectionDetail({
     setSaving(true)
     setPanelOpen(false)
     const shouldRerender = needsRerenderRef.current
+    const intentionalReadingOrder = intentionalReadingOrderRef.current
     try {
       const minDelay = new Promise((r) => setTimeout(r, 400))
 
@@ -689,6 +695,7 @@ export function StoryboardSectionDetail({
       setPendingRendering(null)
       setPendingCategories(new Set())
       needsRerenderRef.current = false
+      intentionalReadingOrderRef.current = false
       await queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "pages", pageId] })
       await queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "pages"] })
       invalidateStoryboardDependents(queryClient, bookLabel)
@@ -697,7 +704,14 @@ export function StoryboardSectionDetail({
       // Only re-render when changes require LLM (e.g., unprune, type change, reorder)
       // Skip for pure prune/delete — those are already handled by local HTML removal
       if (shouldRerender && hasApiKey) {
-        api.reRenderPage(bookLabel, pageId, apiKey, sectionIndex).catch(() => {})
+        api.reRenderPage(
+          bookLabel,
+          pageId,
+          apiKey,
+          sectionIndex,
+          undefined,
+          intentionalReadingOrder,
+        ).catch(() => {})
       }
     } catch (err) {
       setAiError(err instanceof Error ? err.message : t`Save failed`)
@@ -718,6 +732,7 @@ export function StoryboardSectionDetail({
     pendingHtmlRef.current = null
     setHasUnflushedEdits(false)
     needsRerenderRef.current = false
+    intentionalReadingOrderRef.current = false
     previewFrameRef.current?.resetContent()
   }
 
@@ -1209,8 +1224,9 @@ export function StoryboardSectionDetail({
     [removeElementsFromRendering]
   )
 
-  const handleStructuralChange = useCallback(() => {
+  const handleStructuralChange = useCallback((kind?: "reorder") => {
     needsRerenderRef.current = true
+    if (kind === "reorder") intentionalReadingOrderRef.current = true
   }, [])
 
   // Handle inline text edit from BookPreviewFrame

--- a/apps/studio/src/components/section-tree-editor/SectionTreeEditor.tsx
+++ b/apps/studio/src/components/section-tree-editor/SectionTreeEditor.tsx
@@ -35,7 +35,7 @@ export interface SectionTreeEditorProps {
   /** Called after a leaf is deleted. Parent can remove the preview DOM element. */
   onLeafDeleted?: (nodeId: string) => void
   /** Called whenever a change happens that needs a re-render (structural change). */
-  onStructuralChange?: () => void
+  onStructuralChange?: (kind?: "reorder") => void
 }
 
 const DEFAULT_ID_PREFIX = "user_node"
@@ -220,7 +220,7 @@ export function SectionTreeEditor({
       })
       if (next !== section.nodes) {
         applyNodes(next)
-        onStructuralChange?.()
+        onStructuralChange?.("reorder")
       }
     },
     [section.nodes, applyNodes, onStructuralChange]

--- a/packages/pipeline/src/__tests__/visual-review.test.ts
+++ b/packages/pipeline/src/__tests__/visual-review.test.ts
@@ -1,8 +1,23 @@
 import { describe, expect, it } from "vitest"
-import type { GenerateObjectResult, LLMModel } from "@adt/llm"
+import path from "node:path"
+import { createPromptEngine, type GenerateObjectResult, type LLMModel } from "@adt/llm"
 import { runVisualReviewLoop } from "../visual-review.js"
 
 describe("runVisualReviewLoop", () => {
+  it("treats a user-directed storyboard order as authoritative", async () => {
+    const engine = createPromptEngine(path.resolve(process.cwd(), "prompts"))
+    const messages = await engine.renderPrompt("visual_review", {
+      viewports: [],
+      intentional_reading_order: true,
+    })
+    const system = messages.find((message) => message.role === "system")
+    const content = typeof system?.content === "string" ? system.content : ""
+
+    expect(content).toContain("Treat the order in the current HTML as authoritative")
+    expect(content).toContain("the user intentionally chose the current order")
+    expect(content).not.toContain("completely wrong ordering")
+  })
+
   it("applies a validated revision and returns approved result", async () => {
     let call = 0
     const fakeModel: LLMModel = {

--- a/packages/pipeline/src/__tests__/web-rendering-prompts.test.ts
+++ b/packages/pipeline/src/__tests__/web-rendering-prompts.test.ts
@@ -1,0 +1,44 @@
+import path from "node:path"
+import { describe, expect, it } from "vitest"
+import { createPromptEngine } from "@adt/llm"
+
+describe("web-rendering prompts", () => {
+  const engine = createPromptEngine(path.resolve(process.cwd(), "prompts"))
+  const context = {
+    page_image_base64: "",
+    section_id: "section-1",
+    section_type: "content",
+    nodes: [],
+    images: [],
+    styleguide: "",
+    book_fonts: [],
+    viewports: [],
+    user_instructions: "",
+    intentional_reading_order: true,
+  }
+
+  it.each(["web_generation_html", "web_generation_html_overlay"])(
+    "%s makes the user-chosen tree order authoritative",
+    async (promptName) => {
+      const messages = await engine.renderPrompt(promptName, context)
+      const rendered = messages
+        .map((message) => typeof message.content === "string" ? message.content : "")
+        .join("\n")
+
+      expect(rendered).toContain("USER-CHOSEN READING ORDER")
+      expect(rendered).toContain("content tree order is authoritative")
+      expect(rendered).toContain("even when that differs from the original page image")
+    },
+  )
+
+  it("does not tell overlay rendering to restore original positions", async () => {
+    const messages = await engine.renderPrompt("web_generation_html_overlay", context)
+    const rendered = messages
+      .map((message) => typeof message.content === "string" ? message.content : "")
+      .join("\n")
+
+    expect(rendered).toContain("position text overlays in the user-chosen sequence")
+    expect(rendered).not.toContain("overlay text groups in their original locations")
+    expect(rendered).not.toContain("use this to determine EXACT positions")
+  })
+})

--- a/packages/pipeline/src/render-llm.ts
+++ b/packages/pipeline/src/render-llm.ts
@@ -48,6 +48,7 @@ export async function renderSectionLlm(
     viewports: getViewportBreakpoints(),
     _isActivity: isActivity,
     user_instructions: input.userPrompt ?? "",
+    intentional_reading_order: input.intentionalReadingOrder ?? false,
   }
 
   const result = await llmModel.generateObject<{
@@ -103,6 +104,7 @@ export async function renderSectionLlm(
         current_html: generatedHtml,
         nodes: renderContext.nodes,
         leaf_texts: renderContext.leaf_texts,
+        intentional_reading_order: input.intentionalReadingOrder ?? false,
       },
       originalImageIntroText: "Here is the original page image (this is what the rendered page should resemble):",
       firstIterationScreenshotsText: "\nHere are screenshots of the current rendered HTML at three viewport sizes:\n",

--- a/packages/pipeline/src/web-rendering.ts
+++ b/packages/pipeline/src/web-rendering.ts
@@ -88,6 +88,8 @@ export interface RenderSectionInput {
   bookFonts?: BookFontPromptEntry[]
   /** Optional user instructions appended to the LLM prompt during re-render */
   userPrompt?: string
+  /** The user intentionally changed the source PDF's reading order. */
+  intentionalReadingOrder?: boolean
 }
 
 export interface RenderPageInput {
@@ -100,6 +102,8 @@ export interface RenderPageInput {
   bookFonts?: BookFontPromptEntry[]
   /** Optional user instructions appended to the LLM prompt during re-render */
   userPrompt?: string
+  /** The user intentionally changed the source PDF's reading order. */
+  intentionalReadingOrder?: boolean
 }
 
 export type ResolveLLMModel = LLMModel | ((modelId: string) => LLMModel)
@@ -248,6 +252,7 @@ export async function renderPage(
       styleguide: input.styleguide,
       bookFonts: input.bookFonts,
       userPrompt: input.userPrompt,
+      intentionalReadingOrder: input.intentionalReadingOrder,
     }
 
     let rendering: SectionRendering

--- a/prompts/visual_review.liquid
+++ b/prompts/visual_review.liquid
@@ -6,6 +6,9 @@ You are a visual quality reviewer for HTML textbook pages. Your job is to compar
 2. The rendering should keep the SPIRIT of the original — same general layout, visual hierarchy, and content flow — but does NOT need to be pixel-identical
 3. Prioritize: readability, attractive appearance, no overlapping text/elements, and responsive behavior across all three viewport sizes
 4. If the rendering looks good, approve it. If there are real problems, provide corrected HTML
+{% if intentional_reading_order %}
+5. The user intentionally changed the content order in the storyboard. Treat the order in the current HTML as authoritative. Do NOT reject or revise it for differing from the original page's reading order.
+{% endif %}
 
 ## IMPORTANT: SECTION SCOPE
 The screenshots show a **single section**, which is typically only a SUBSET of the original page — not the whole page. A page is usually composed of multiple sections (a header, a body paragraph, an image with caption, a sidebar, etc.), and you are only reviewing ONE of them at a time.
@@ -30,7 +33,7 @@ The screenshots show a **single section**, which is typically only a SUBSET of t
 - Text that is unreadably small or excessively large
 - Images that are missing, broken, wildly misplaced, or stretched beyond their natural size (use `max-w-full` not `w-full` to prevent upscaling)
 - Text alignment that differs from the original — body text and headings that are left-aligned in the original should NOT be centered (and vice versa)
-- Layout that fundamentally differs from the original (e.g., wrong number of columns, completely wrong ordering)
+- Layout that fundamentally differs from the original (e.g., wrong number of columns{% unless intentional_reading_order %}, completely wrong ordering{% endunless %})
 - Content that doesn't reflow at smaller viewports (overflowing, horizontal scroll)
 
 ## WHAT IS ACCEPTABLE (do NOT reject for these)
@@ -41,6 +44,7 @@ The screenshots show a **single section**, which is typically only a SUBSET of t
 - Color or background differences that maintain the overall feel
 - Subtle styling improvements that enhance the appearance
 - Text that is not included on purpose (page numbers, other metadata)
+{% if intentional_reading_order %}- Content order that differs from the original page — the user intentionally chose the current order in the storyboard{% endif %}
 
 ## VIEWPORT SIZES & TAILWIND BREAKPOINTS (DESKTOP-FIRST)
 Screenshots are taken at these exact viewport widths, which correspond to Tailwind CSS breakpoints:

--- a/prompts/web_generation_html.liquid
+++ b/prompts/web_generation_html.liquid
@@ -22,6 +22,9 @@ You are an expert frontend engineer. Generate a beautiful, kid-friendly HTML pag
 13. Preserve the original text alignment — most body text and headings are LEFT-ALIGNED. Do NOT center text unless it is clearly centered in the original page image. When in doubt, default to left alignment.
 14. Output natural-language text as literal Unicode characters. Do NOT encode letters as numeric or hex HTML entities (for example, avoid `&#...;` and `&#x...;`). Only use standard HTML escaping where required for markup syntax (for example `&amp;`, `&lt;`, `&gt;`, and quotes in attributes).
 15. Text-leaf children of ANY container are fragments of one continuous run and must flow inline as `<span>` elements with no hard line breaks between them. Never wrap a leaf in its own `<p>`, and never emit `<br>` between sibling leaves. The container itself gets the block wrapper; its leaves render as inline spans inside that single wrapper. The ONLY exceptions are (a) `structure: "preformatted"` / code-like content where the source preserves literal line breaks, or (b) when the book page image clearly shows each leaf as its own visually separated line (e.g. a poem, a stanza, an address block) — in those cases, and only those, use render each as a block-level fragment.
+{% if intentional_reading_order %}
+16. **USER-CHOSEN READING ORDER:** The user intentionally reordered the storyboard. The content tree order is authoritative for both DOM order and visual sequence. Render every sibling in exactly the order supplied by the tree, even when that differs from the original page image. Do not infer, restore, or prefer the PDF's original order; use the PDF only as a visual style and layout reference.
+{% endif %}
 ## RESPONSIVE DESIGN (DESKTOP-FIRST)
 Your HTML will be tested at these viewport widths. Use ONLY these Tailwind responsive prefixes:
 {% for vp in viewports %}- **{{ vp.label }}** ({{ vp.width }}px){% if vp.tailwind_prefix != "" %}: `{{ vp.tailwind_prefix }}` prefix{% else %}: default (no prefix — base/desktop styles){% endif %}
@@ -58,7 +61,7 @@ Image ID: {{ image.image_id }}
 {% image image.image_base64 %}
 {% endfor %}
 
-Content tree (indentation shows hierarchy):
+Content tree (indentation shows hierarchy{% if intentional_reading_order %}; its order is the user's required reading and visual order{% endif %}):
 {% include "_render_node", nodes: nodes, depth: 0 %}
 {% if user_instructions != "" %}
 

--- a/prompts/web_generation_html_overlay.liquid
+++ b/prompts/web_generation_html_overlay.liquid
@@ -1,11 +1,11 @@
 {% chat role: "system" %}
-You are an expert frontend engineer creating HTML pages that faithfully recreate textbook pages by overlaying text on top of background images using Tailwind CSS.
+You are an expert frontend engineer creating HTML textbook pages by overlaying text on top of background images using Tailwind CSS.
 
 ## CORE OBJECTIVE
-Recreate the original textbook page as closely as possible by using the page image(s) as background and positioning text elements as overlays in their exact original locations. The result should look like the original page but with selectable, accessible text.
+{% if intentional_reading_order %}Recreate the original textbook page's visual character while honoring the user's reordered content tree. Use the page image(s) as a background, but position text overlays in the user-chosen sequence rather than their old locations when the two conflict. The result should look related to the original page while using the requested selectable, accessible reading order.{% else %}Recreate the original textbook page as closely as possible by using the page image(s) as background and positioning text elements as overlays in their exact original locations. The result should look like the original page but with selectable, accessible text.{% endif %}
 
 ## INPUTS
-1. Original textbook page image (layout reference — use to determine exact text positions)
+1. Original textbook page image ({% if intentional_reading_order %}visual reference — do not use it to restore the old content sequence{% else %}layout reference — use to determine exact text positions{% endif %})
 2. A content tree for the section (indentation shows hierarchy) — containers (paragraph, group, list, activity, image_group, …) wrap leaves in reading order
 3. Images with their IDs
 4. Section type
@@ -23,18 +23,21 @@ Recreate the original textbook page as closely as possible by using the page ima
 10. Do NOT use any `data-id` values other than the ones provided
 11. Text color must be readable against the background — add bg overlays or text shadows as needed
 12. Output natural-language text as literal Unicode characters. Do NOT encode letters as numeric or hex HTML entities (for example, avoid `&#...;` and `&#x...;`). Only use standard HTML escaping where required for markup syntax (for example `&amp;`, `&lt;`, `&gt;`, and quotes in attributes).
+{% if intentional_reading_order %}
+13. **USER-CHOSEN READING ORDER:** The user intentionally reordered the storyboard. The content tree order is authoritative for both DOM order and visual sequence. Render every sibling in exactly the order supplied by the tree, even when that differs from the original page image. Do not infer, restore, or prefer the PDF's original order. In an overlay layout, assign positions so the reordered groups appear in the tree's sequence; use the PDF only as a reference for visual style, sizing, and general composition.
+{% endif %}
 
 ## LAYOUT STRATEGY
 
 Choose the layout based on whether images are provided:
 
 ### When images ARE provided → OVERLAY LAYOUT
-Use the overlay approach: position the background image on the page and overlay text groups in their original locations.
+Use the overlay approach: position the background image on the page and overlay text groups {% if intentional_reading_order %}in the content tree's user-chosen sequence{% else %}in their original locations{% endif %}.
 
 How it works:
 1. **Background image fills the container** — The main image acts as the full page background
 2. **Text groups are absolutely positioned** — Position ONE overlay `div` per text group, then place all text elements from that group inside it as normal flow (no individual absolute positioning per sentence)
-3. **Reference the original page image** — Study the original textbook page image carefully to determine where each group should be positioned
+3. **Reference the original page image** — {% if intentional_reading_order %}Study its visual style and composition, then position groups in the content tree's sequence{% else %}Study the original textbook page image carefully to determine where each group should be positioned{% endif %}
 4. **Maintain readability** — Add subtle backgrounds, text shadows, or semi-transparent overlays behind text when needed for contrast
 
 ### When NO images are provided → TEXT-ONLY LAYOUT
@@ -98,10 +101,10 @@ Images must NEVER obscure text. Ensure correct stacking:
 - This ensures paragraphs flow naturally as a block, not as scattered individual lines
 
 ### Positioning guidelines:
-- **Use the original page image as your primary reference** — carefully match each group's position to where that text visually appears on the page
-- **Content is provided in document flow order** (top-to-bottom). Use this ordering to resolve ambiguity: the first group is near the top, the last group is near the bottom
+- **Use the original page image as your primary visual reference** — carefully match the page's style and general composition{% unless intentional_reading_order %}, including where each text group appears{% endunless %}
+- **Content is provided in document flow order** (top-to-bottom). The first group belongs before the last group.{% if intentional_reading_order %} This user-chosen sequence overrides positions inferred from the original page image.{% else %} Use this ordering to resolve positional ambiguity: the first group is near the top, the last group is near the bottom.{% endif %}
 - If an image appears between two text groups in the flow order, the first group is above/beside the image and the second is below/beside it
-- Use `top-[Y%]` and `left-[X%]` with percentage values matching where the group appears on the original page
+- Use `top-[Y%]` and `left-[X%]` with percentage values {% if intentional_reading_order %}that place groups in the content tree's visual sequence; do not reuse an old vertical position when it would restore the PDF order{% else %}matching where the group appears on the original page{% endif %}
 - Use `max-w-[W%]` to constrain the group width proportionally to the image — match the width of the text block as it appears in the original
 - For groups near the right edge, use `right-[X%]` instead of `left`
 - For groups near the bottom, use `bottom-[Y%]` instead of `top`
@@ -272,7 +275,7 @@ Return JSON:
 {% endchat %}
 
 {% chat role: "user" %}
-Page image for context (use this to determine EXACT positions for each text group):
+Page image for context ({% if intentional_reading_order %}use for visual style and general composition; do not recover the old reading order from it{% else %}use this to determine EXACT positions for each text group{% endif %}):
 {% image page_image_base64 %}
 
 Section ID: {{ section_id }}
@@ -283,8 +286,8 @@ Image ID: {{ image.image_id }}
 {% image image.image_base64 %}
 {% endfor %}
 
-Page content in DOCUMENT FLOW ORDER (top-to-bottom as they appear on the page).
-Use this ordering plus the page image to determine the vertical position of each group.
+Page content in DOCUMENT FLOW ORDER ({% if intentional_reading_order %}the user's required top-to-bottom sequence{% else %}top-to-bottom as they appear on the page{% endif %}).
+{% if intentional_reading_order %}Use this ordering to determine the vertical sequence of each group. It overrides the original page image when they conflict.{% else %}Use this ordering plus the page image to determine the vertical position of each group.{% endif %}
 
 Content tree (indentation shows hierarchy):
 {% include "_render_node", nodes: nodes, depth: 0 %}


### PR DESCRIPTION
## Summary

Storyboard users can reorder paragraphs, images, and containers in the edit pane, but the subsequent web-rendering pass could silently restore the source PDF order. The overlay prompt was especially restrictive: it described the tree as the original top-to-bottom page order and instructed the model to recover exact positions from the PDF.

This PR makes an intentional storyboard reorder authoritative throughout rendering and review.

## What changed

- Marks drag-and-drop tree changes as an intentional reading-order edit.
- Carries that intent through the Studio API client, page re-render route, page-edit service, and pipeline render inputs.
- Provides the intent to both the initial web-generation prompt and the visual-review prompt.
- Updates standard web generation so sibling DOM order and visual sequence follow the edited content tree.
- Updates overlay generation so reordered groups receive positions consistent with the user-selected sequence instead of being restored to their previous PDF positions.
- Keeps the original PDF as a reference for styling, sizing, and general composition when an intentional reorder exists.
- Tells visual review not to reject or rewrite the user-selected order while continuing to review overlap, clipping, responsiveness, readability, broken images, and other visual defects.
- Leaves normal rendering unchanged when no intentional reorder was made.

## Resulting behavior

When a user reorders storyboard objects and saves:

1. The saved section tree remains the source of truth.
2. Web rendering emits elements in that tree order.
3. Overlay rendering visually positions groups in that same sequence.
4. Visual review accepts the order difference as intentional but still evaluates all other quality rules.

## Validation

- Focused Vitest suite passed: 5 test files and 66 tests.
- Added prompt regression coverage for standard generation, overlay generation, and intentional-order visual review.
- The overlay prompt regression specifically verifies that original-position restoration instructions are absent when user-selected order is active.
- Diff whitespace validation passes.

Fixes #250