### PR TITLE
feat(studio): select & style a blank group in the storyboard (#341)

### DIFF
--- a/apps/studio/src/components/pipeline/stages/storyboard/components/BookPreviewFrame.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/BookPreviewFrame.tsx
@@ -72,6 +72,14 @@ export interface BookPreviewFrameHandle {
    *  place the selection toolbar when selection is driven from outside the
    *  preview (e.g. clicking a node in the section tree). */
   getElementRect: (dataId: string) => DOMRect | null
+  /** Locate a container element by the nearest common ancestor of its descendant
+   *  leaves (which carry data-ids), assigning it a transient data-id if needed.
+   *  Groups aren't tagged with their tree nodeId in the rendered HTML, so this is
+   *  how the section tree selects a pre-existing group for styling. Returns the
+   *  resolved data-id, rect and tag, or null when no descendant leaf is present. */
+  selectContainerByDescendants: (
+    leafDataIds: string[]
+  ) => { dataId: string; rect: DOMRect; tagName: string } | null
   /** Regenerate Tailwind CSS including the given extra HTML, then inject into iframe.
    *  Use after AI edits introduce new Tailwind classes not yet in the DB. */
   refreshCss: (extraHtml: string) => Promise<void>
@@ -168,6 +176,53 @@ export const BookPreviewFrame = forwardRef<BookPreviewFrameHandle, BookPreviewFr
       if (!doc) return null
       const el = doc.querySelector(`[data-id="${CSS.escape(dataId)}"]`) as HTMLElement | null
       return el?.getBoundingClientRect() ?? null
+    },
+    selectContainerByDescendants: (leafDataIds: string[]) => {
+      const doc = iframeRef.current?.contentDocument
+      if (!doc) return null
+      const els = leafDataIds
+        .map((id) => doc.querySelector(`[data-id="${CSS.escape(id)}"]`) as HTMLElement | null)
+        .filter((e): e is HTMLElement => e != null)
+      if (els.length === 0) return null
+
+      // Nearest common ancestor of all present leaves.
+      const chain = (n: HTMLElement | null) => {
+        const out: HTMLElement[] = []
+        while (n) { out.push(n); n = n.parentElement }
+        return out
+      }
+      const firstChain = new Set(chain(els[0]))
+      let ancestor: HTMLElement | null = els[0]
+      for (let i = 1; i < els.length; i++) {
+        let n: HTMLElement | null = els[i]
+        while (n && !firstChain.has(n)) n = n.parentElement
+        ancestor = n
+        if (!ancestor) return null
+      }
+      // For a single leaf the "common ancestor" is the leaf itself — climb to its
+      // parent so we target the wrapping container, not the leaf.
+      if (ancestor && els.includes(ancestor)) ancestor = ancestor.parentElement
+
+      const content = doc.getElementById("content")
+      if (
+        !ancestor ||
+        ancestor === doc.body ||
+        ancestor === content ||
+        ancestor.getAttribute("data-section-id") != null
+      ) {
+        return null
+      }
+
+      let dataId = ancestor.getAttribute("data-id")
+      if (!dataId) {
+        // Transient id (stripped on save, like preview-click container selection).
+        const nums = Array.from(doc.querySelectorAll('[data-id^="_el"]'))
+          .map((e) => parseInt((e.getAttribute("data-id") ?? "").slice(3), 10))
+          .filter((n) => !Number.isNaN(n))
+        dataId = `_el${(nums.length ? Math.max(...nums) : 0) + 1}`
+        ancestor.setAttribute("data-id", dataId)
+      }
+      return { dataId, rect: ancestor.getBoundingClientRect(), tagName: ancestor.tagName.toLowerCase() }
     },
     refreshCss: async (extraHtml: string) => {
       const id = ++refreshIdRef.current

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/BookPreviewFrame.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/BookPreviewFrame.tsx
@@ -67,6 +67,11 @@ const FL_MAX_SCALE = 2
 export interface BookPreviewFrameHandle {
   /** Get the iframe element's bounding rect in the viewport */
   getIframeRect: () => DOMRect | null
+  /** Get an element's bounding rect (in the iframe's own coordinate space) by
+   *  data-id. Returns null when the element isn't in the iframe yet. Used to
+   *  place the selection toolbar when selection is driven from outside the
+   *  preview (e.g. clicking a node in the section tree). */
+  getElementRect: (dataId: string) => DOMRect | null
   /** Regenerate Tailwind CSS including the given extra HTML, then inject into iframe.
    *  Use after AI edits introduce new Tailwind classes not yet in the DB. */
   refreshCss: (extraHtml: string) => Promise<void>
@@ -158,6 +163,12 @@ export const BookPreviewFrame = forwardRef<BookPreviewFrameHandle, BookPreviewFr
 
   useImperativeHandle(ref, () => ({
     getIframeRect: () => iframeRef.current?.getBoundingClientRect() ?? null,
+    getElementRect: (dataId: string): DOMRect | null => {
+      const doc = iframeRef.current?.contentDocument
+      if (!doc) return null
+      const el = doc.querySelector(`[data-id="${CSS.escape(dataId)}"]`) as HTMLElement | null
+      return el?.getBoundingClientRect() ?? null
+    },
     refreshCss: async (extraHtml: string) => {
       const id = ++refreshIdRef.current
       const doc = iframeRef.current?.contentDocument

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/SectionEditPanel.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/SectionEditPanel.tsx
@@ -45,6 +45,9 @@ interface SectionEditPanelProps {
   onLeafTextEdited: (nodeId: string, text: string) => void
   onLeafDuplicated: (sourceNodeId: string, newNodeId: string) => void
   onLeafDeleted: (nodeId: string) => void
+  onLeafAdded: (nodeId: string, parentNodeId: string | null) => void
+  onContainerAdded: (nodeId: string, parentNodeId: string | null) => void
+  onSelectNode: (nodeId: string, tagName?: string) => void
   onStructuralChange: () => void
   onMergeSection: (dir: "prev" | "next") => void
   onMergeCrossPage?: (dir: "prev" | "next") => void
@@ -84,6 +87,9 @@ export function SectionEditPanel({
   onLeafTextEdited,
   onLeafDuplicated,
   onLeafDeleted,
+  onLeafAdded,
+  onContainerAdded,
+  onSelectNode,
   onStructuralChange,
   onMergeSection,
   onMergeCrossPage,
@@ -282,6 +288,9 @@ export function SectionEditPanel({
           onLeafTextEdited={onLeafTextEdited}
           onLeafDuplicated={onLeafDuplicated}
           onLeafDeleted={onLeafDeleted}
+          onLeafAdded={onLeafAdded}
+          onContainerAdded={onContainerAdded}
+          onSelectNode={onSelectNode}
           onStructuralChange={onStructuralChange}
         />
 

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/SectionEditPanel.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/SectionEditPanel.tsx
@@ -48,6 +48,7 @@ interface SectionEditPanelProps {
   onLeafAdded: (nodeId: string, parentNodeId: string | null) => void
   onContainerAdded: (nodeId: string, parentNodeId: string | null) => void
   onSelectNode: (nodeId: string, tagName?: string) => void
+  renderedDataIds: Set<string>
   onStructuralChange: () => void
   onMergeSection: (dir: "prev" | "next") => void
   onMergeCrossPage?: (dir: "prev" | "next") => void
@@ -90,6 +91,7 @@ export function SectionEditPanel({
   onLeafAdded,
   onContainerAdded,
   onSelectNode,
+  renderedDataIds,
   onStructuralChange,
   onMergeSection,
   onMergeCrossPage,
@@ -291,6 +293,7 @@ export function SectionEditPanel({
           onLeafAdded={onLeafAdded}
           onContainerAdded={onContainerAdded}
           onSelectNode={onSelectNode}
+          renderedDataIds={renderedDataIds}
           onStructuralChange={onStructuralChange}
         />
 

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
@@ -762,7 +762,13 @@ export function StoryboardSectionDetail({
           sectionIndex,
           editedHtml
         )
-        if (updatedSectioning !== sBase) {
+        // Persist sectioning when there are pending structural changes (e.g. a
+        // blank group/text the user just added) OR when text back-propagation
+        // changed it. Saving a rendering edit also injects a new node into
+        // `pendingSectioning`; without saving it here that node lives only in
+        // the rendering and disappears from the tree on reload, leaving
+        // sectioning a version behind (the version-mismatch users saw).
+        if (pendingSectioning != null || updatedSectioning !== sBase) {
           await api.updateSectioning(bookLabel, pageId, updatedSectioning)
         }
       }

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
@@ -126,12 +126,16 @@ type RenderingData = NonNullable<PageDetail["rendering"]>
 
 // `_el#` data-ids are assigned by the iframe at runtime to give the inspector
 // a stable handle on container elements; they must not be persisted.
+// `data-adt-placeholder` is an edit-mode-only hint on blank elements — also
+// stripped so it never leaks into saved/packaged HTML.
 function stripTransientIds(rendering: RenderingData): RenderingData {
   return {
     ...rendering,
     sections: rendering.sections.map((s) => ({
       ...s,
-      html: s.html.replace(/\s+data-id="_el\d+"/g, ""),
+      html: s.html
+        .replace(/\s+data-id="_el\d+"/g, "")
+        .replace(/\s+data-adt-placeholder="[^"]*"/g, ""),
     })),
   }
 }
@@ -220,6 +224,20 @@ function buildEditInstructions(savedHtml: string, pendingHtml: string): string {
     const dataId = pendingEl.getAttribute("data-id")
     if (!dataId) return
     const savedEl = savedDoc.querySelector(`[data-id="${dataId}"]`)
+
+    // Added elements (present in pending but not saved — e.g. a blank group/text
+    // the user inserted). Describe the new element so the LLM keeps it, even when
+    // it is empty and has no classes (which the class/text branches would skip).
+    if (!savedEl) {
+      const tag = pendingEl.tagName.toLowerCase()
+      const cls = (pendingEl.getAttribute("class") ?? "").trim()
+      const txt = pendingEl.tagName !== "IMG" ? (pendingEl.textContent?.trim() ?? "") : ""
+      let line = `- Add a new <${tag} data-id="${dataId}"> element the user inserted — keep it`
+      if (cls) line += ` with these Tailwind classes: "${cls}"`
+      if (txt) line += ` containing the text: "${txt}"`
+      lines.push(line)
+      return
+    }
 
     // Class changes
     const pendingClasses = pendingEl.getAttribute("class") ?? ""
@@ -1050,6 +1068,69 @@ export function StoryboardSectionDetail({
     [pendingRendering, page.rendering, sectionIndex, markPending]
   )
 
+  // Inject a brand-new blank element (a text <p> or a container <div>) into the
+  // rendered HTML so a node added in the tree editor is immediately present in
+  // the preview with a real data-id — selectable and stylable without an LLM
+  // re-render. `placeholder` is shown (edit-mode only, via CSS) while the
+  // element is empty. Returns the new full HTML, or null if nothing was inserted.
+  const insertBlankElementInRendering = useCallback(
+    (
+      nodeId: string,
+      kind: "text" | "container",
+      afterNodeId?: string | null,
+      placeholder?: string
+    ): string | null => {
+      const rBase = pendingRendering ?? page.rendering
+      if (!rBase) return null
+      const currentSection = getRenderedSectionByIndex(rBase, sectionIndex)
+      if (!currentSection?.html) return null
+
+      const parser = new DOMParser()
+      const doc = parser.parseFromString(currentSection.html, "text/html")
+
+      const el = doc.createElement(kind === "text" ? "p" : "div")
+      el.setAttribute("data-id", nodeId)
+      if (placeholder) el.setAttribute("data-adt-placeholder", placeholder)
+
+      // Insert after the anchor node's block-level target when provided, so the
+      // new element lands where the tree appended it; otherwise append to the
+      // section's content wrapper (or body as a last resort).
+      let inserted = false
+      if (afterNodeId) {
+        const anchor = doc.querySelector(`[data-id="${afterNodeId}"]`)
+        if (anchor) {
+          const blockParent = anchor.closest("div, p, figure, li, tr")
+          const target =
+            blockParent && !blockParent.getAttribute("data-section-id")
+              ? blockParent
+              : anchor
+          target.parentNode?.insertBefore(el, target.nextSibling)
+          inserted = true
+        }
+      }
+      if (!inserted) {
+        const wrapper =
+          doc.getElementById("content") ??
+          doc.querySelector("section[data-section-id]") ??
+          doc.body
+        wrapper.appendChild(el)
+      }
+
+      const newHtml = doc.body.innerHTML
+      const updated: RenderingData = {
+        ...rBase,
+        sections: rBase.sections.map((s) => {
+          if (s.sectionIndex !== sectionIndex) return s
+          return { ...s, html: newHtml }
+        }),
+      }
+      setPendingRendering(updated)
+      markPending("elements")
+      return newHtml
+    },
+    [pendingRendering, page.rendering, sectionIndex, markPending]
+  )
+
   // Replace textContent of a single [data-id="..."] element in the rendered HTML.
   const updateElementTextInRendering = useCallback(
     (dataId: string, newText: string) => {
@@ -1250,6 +1331,52 @@ export function StoryboardSectionDetail({
     // Snapshot element classes once at selection time (not during render)
     setSelectedElementClasses(previewFrameRef.current?.getElementClasses(dataId) ?? null)
   }, [])
+
+  // Select an element that lives in the preview but wasn't clicked there (e.g.
+  // just inserted, or chosen from the section tree). The iframe re-injects the
+  // pending HTML asynchronously, so wait a frame for the element's rect, with a
+  // single fallback retry if it isn't laid out yet.
+  const selectByDataId = useCallback(
+    (dataId: string, tagName?: string) => {
+      let tries = 0
+      const attempt = () => {
+        const rect = previewFrameRef.current?.getElementRect(dataId)
+        if (rect) {
+          handleSelectElement(dataId, rect, tagName)
+        } else if (tries++ < 1) {
+          requestAnimationFrame(attempt)
+        }
+      }
+      requestAnimationFrame(attempt)
+    },
+    [handleSelectElement]
+  )
+
+  // Open the style pane for a node chosen in the section tree.
+  const handleTreeNodeSelected = useCallback(
+    (nodeId: string, tagName?: string) => {
+      selectByDataId(nodeId, tagName)
+    },
+    [selectByDataId]
+  )
+
+  // SectionTreeEditor add callbacks — inject a real element into the rendered
+  // HTML (no LLM re-render) and auto-select it so the user can style it.
+  const handleLeafAdded = useCallback(
+    (nodeId: string, parentNodeId: string | null) => {
+      insertBlankElementInRendering(nodeId, "text", parentNodeId, t`Empty text`)
+      selectByDataId(nodeId, "p")
+    },
+    [insertBlankElementInRendering, selectByDataId, t]
+  )
+
+  const handleContainerAdded = useCallback(
+    (nodeId: string, parentNodeId: string | null) => {
+      insertBlankElementInRendering(nodeId, "container", parentNodeId, t`Empty group`)
+      selectByDataId(nodeId, "div")
+    },
+    [insertBlankElementInRendering, selectByDataId, t]
+  )
 
   const handleClassesChange = useCallback(
     (dataId: string, classes: string[]) => {
@@ -2282,6 +2409,9 @@ export function StoryboardSectionDetail({
         onLeafTextEdited={handleLeafTextEdited}
         onLeafDuplicated={handleLeafDuplicated}
         onLeafDeleted={handleLeafDeleted}
+        onLeafAdded={handleLeafAdded}
+        onContainerAdded={handleContainerAdded}
+        onSelectNode={handleTreeNodeSelected}
         onStructuralChange={handleStructuralChange}
         onMergeSection={handleMergeSection}
         onMergeCrossPage={handleMergeCrossPage}

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
@@ -31,6 +31,7 @@ import type {
 } from "@adt/types"
 import {
   addImageLeaf,
+  collectLeafIdsInSubtree,
   collectLeafNodes,
   collectPrunedLeafIds,
   deleteNode,
@@ -1358,12 +1359,31 @@ export function StoryboardSectionDetail({
     [handleSelectElement]
   )
 
-  // Open the style pane for a node chosen in the section tree.
+  // Open the style pane for a node chosen in the section tree. Leaves (and blank
+  // elements we injected) carry their nodeId as a data-id, so we select them
+  // directly. Containers aren't tagged with their nodeId in the rendered HTML, so
+  // we locate their wrapping element via the common ancestor of their descendant
+  // leaves instead.
   const handleTreeNodeSelected = useCallback(
     (nodeId: string, tagName?: string) => {
+      const direct = previewFrameRef.current?.getElementRect(nodeId)
+      if (direct) {
+        handleSelectElement(nodeId, direct, tagName)
+        return
+      }
+      const node = section ? findNode(section.nodes, nodeId) : null
+      if (node && !node.role) {
+        const leafIds = collectLeafIdsInSubtree(node)
+        const hit = previewFrameRef.current?.selectContainerByDescendants(leafIds)
+        if (hit) {
+          handleSelectElement(hit.dataId, hit.rect, hit.tagName)
+          return
+        }
+      }
+      // Freshly injected element may not be in the iframe yet — retry next frame.
       selectByDataId(nodeId, tagName)
     },
-    [selectByDataId]
+    [handleSelectElement, section, selectByDataId]
   )
 
   // SectionTreeEditor add callbacks — inject a real element into the rendered
@@ -1943,6 +1963,16 @@ export function StoryboardSectionDetail({
   // Compute pruned data-ids for optimistic preview feedback
   const prunedDataIds = useMemo(() => collectPrunedLeafIds(nodes), [nodes])
 
+  // data-ids present in the current section's rendered HTML. Used to gate the
+  // tree's "Edit styles" button: a node is stylable only when its element (or,
+  // for a container, at least one descendant leaf) exists in the preview.
+  const renderedDataIds = useMemo(() => {
+    const ids = new Set<string>()
+    const html = renderedSection?.html ?? ""
+    for (const m of html.matchAll(/data-id="([^"]+)"/g)) ids.add(m[1])
+    return ids
+  }, [renderedSection?.html])
+
   // Compute changed elements by diffing pending vs saved state
   const changedElements = useMemo(() => {
     if (!pendingRendering && !pendingSectioning) return []
@@ -2418,6 +2448,7 @@ export function StoryboardSectionDetail({
         onLeafAdded={handleLeafAdded}
         onContainerAdded={handleContainerAdded}
         onSelectNode={handleTreeNodeSelected}
+        renderedDataIds={renderedDataIds}
         onStructuralChange={handleStructuralChange}
         onMergeSection={handleMergeSection}
         onMergeCrossPage={handleMergeCrossPage}

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/iframe-interactive.ts
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/iframe-interactive.ts
@@ -71,9 +71,15 @@ export const INTERACTIVE_SCRIPT = `<script>
     }, '*');
   }
 
+  // Container tags are styled, not text-edited — selecting them must not make
+  // them contentEditable (a blank <div> group carries a real data-id but is a
+  // container, so it would otherwise wrongly enter text-edit mode).
+  var CONTAINER_TAGS = { DIV: 1, SECTION: 1, FIGURE: 1, UL: 1, OL: 1, TABLE: 1, TR: 1, TBODY: 1, THEAD: 1 };
+
   function startEditing(el) {
     if (editing === el) return;
     if (el.tagName === 'IMG') return;
+    if (CONTAINER_TAGS[el.tagName]) return;
     editing = el;
     // Save the current MathML display before swapping to LaTeX
     savedDisplayHtml = el.innerHTML;
@@ -217,5 +223,21 @@ export const INTERACTIVE_STYLES = `body[data-editable="true"] *:hover:not(:has(*
       cursor: pointer;
     }
     body[data-editable="true"] img[data-id] { position: relative; z-index: 1; }
+    /* Empty blanks (freshly added text/div) collapse to zero size and can't be
+       hovered/clicked — give them a hittable box and a placeholder in edit mode
+       so they're selectable. Cleared automatically once they gain content. */
+    body[data-editable="true"] [data-id]:empty {
+      display: block;
+      min-height: 1.5rem;
+      min-width: 2rem;
+      outline: 1px dashed rgba(124, 58, 237, 0.5);
+      outline-offset: 2px;
+    }
+    body[data-editable="true"] [data-id]:empty::before {
+      content: attr(data-adt-placeholder);
+      color: rgba(124, 58, 237, 0.6);
+      font-size: 0.75rem;
+      font-style: italic;
+    }
     [data-adt-selected] { outline: 2px solid rgb(124, 58, 237) !important; outline-offset: 2px !important; }
     [data-adt-editing] { outline: 2px solid rgb(91, 33, 182) !important; outline-offset: 2px !important; }`

--- a/apps/studio/src/components/section-tree-editor/SectionTreeEditor.tsx
+++ b/apps/studio/src/components/section-tree-editor/SectionTreeEditor.tsx
@@ -34,6 +34,12 @@ export interface SectionTreeEditorProps {
   onLeafDuplicated?: (sourceNodeId: string, newNodeId: string) => void
   /** Called after a leaf is deleted. Parent can remove the preview DOM element. */
   onLeafDeleted?: (nodeId: string) => void
+  /** Called after a blank text leaf is added. Parent injects it into preview HTML. */
+  onLeafAdded?: (nodeId: string, parentNodeId: string | null) => void
+  /** Called after a blank container is added. Parent injects it into preview HTML. */
+  onContainerAdded?: (nodeId: string, parentNodeId: string | null) => void
+  /** Called when a node is selected for styling. Parent opens the style pane. */
+  onSelectNode?: (nodeId: string, tagName?: string) => void
   /** Called whenever a change happens that needs a re-render (structural change). */
   onStructuralChange?: () => void
 }
@@ -55,6 +61,9 @@ export function SectionTreeEditor({
   onLeafTextEdited,
   onLeafDuplicated,
   onLeafDeleted,
+  onLeafAdded,
+  onContainerAdded,
+  onSelectNode,
   onStructuralChange,
 }: SectionTreeEditorProps) {
   const { t } = useLingui()
@@ -166,43 +175,52 @@ export function SectionTreeEditor({
     [section.nodes, applyNodes, onStructuralChange]
   )
 
+  // Wrap idFactory so we can capture the id it mints — addLeaf/addContainer
+  // don't return the new node's id. Mirrors the trick used in handleDuplicate.
+  const captureNewId = useCallback(
+    (mint: (idFactory: IdFactory) => void): string | null => {
+      let newId: string | null = null
+      const wrappedFactory: IdFactory = () => {
+        const id = idFactory()
+        if (newId == null) newId = id
+        return id
+      }
+      mint(wrappedFactory)
+      return newId
+    },
+    [idFactory]
+  )
+
   const handleAddContainerAtRoot = useCallback(() => {
     const structure =
       (containerStructures && Object.keys(containerStructures)[0]) ?? "group"
-    applyNodes(
-      addContainer(section.nodes, null, {
-        structure,
-        idFactory,
-      })
+    const newId = captureNewId((factory) =>
+      applyNodes(addContainer(section.nodes, null, { structure, idFactory: factory }))
     )
-    onStructuralChange?.()
-  }, [section.nodes, applyNodes, containerStructures, idFactory, onStructuralChange])
+    if (newId) onContainerAdded?.(newId, null)
+    else onStructuralChange?.()
+  }, [section.nodes, applyNodes, containerStructures, captureNewId, onContainerAdded, onStructuralChange])
 
   const handleAddChildLeaf = useCallback(
     (parentNodeId: string | null, role: string) => {
-      applyNodes(
-        addLeaf(section.nodes, parentNodeId, {
-          role,
-          text: "",
-          idFactory,
-        })
+      const newId = captureNewId((factory) =>
+        applyNodes(addLeaf(section.nodes, parentNodeId, { role, text: "", idFactory: factory }))
       )
-      onStructuralChange?.()
+      if (newId) onLeafAdded?.(newId, parentNodeId)
+      else onStructuralChange?.()
     },
-    [section.nodes, applyNodes, idFactory, onStructuralChange]
+    [section.nodes, applyNodes, captureNewId, onLeafAdded, onStructuralChange]
   )
 
   const handleAddChildContainer = useCallback(
     (parentNodeId: string | null, structure: string) => {
-      applyNodes(
-        addContainer(section.nodes, parentNodeId, {
-          structure,
-          idFactory,
-        })
+      const newId = captureNewId((factory) =>
+        applyNodes(addContainer(section.nodes, parentNodeId, { structure, idFactory: factory }))
       )
-      onStructuralChange?.()
+      if (newId) onContainerAdded?.(newId, parentNodeId)
+      else onStructuralChange?.()
     },
-    [section.nodes, applyNodes, idFactory, onStructuralChange]
+    [section.nodes, applyNodes, captureNewId, onContainerAdded, onStructuralChange]
   )
 
   const handleDrop = useCallback(
@@ -271,6 +289,7 @@ export function SectionTreeEditor({
             onAddChildLeaf={handleAddChildLeaf}
             onAddChildContainer={handleAddChildContainer}
             onDrop={handleDrop}
+            onSelectNode={onSelectNode}
             defaultTextRole={defaultTextRole}
             defaultStructure={defaultStructure}
           />

--- a/apps/studio/src/components/section-tree-editor/SectionTreeEditor.tsx
+++ b/apps/studio/src/components/section-tree-editor/SectionTreeEditor.tsx
@@ -40,6 +40,9 @@ export interface SectionTreeEditorProps {
   onContainerAdded?: (nodeId: string, parentNodeId: string | null) => void
   /** Called when a node is selected for styling. Parent opens the style pane. */
   onSelectNode?: (nodeId: string, tagName?: string) => void
+  /** data-ids present in the rendered HTML — gates the per-node "Edit styles"
+   *  button so it only shows for nodes that can actually be located & styled. */
+  renderedDataIds?: Set<string>
   /** Called whenever a change happens that needs a re-render (structural change). */
   onStructuralChange?: () => void
 }
@@ -64,6 +67,7 @@ export function SectionTreeEditor({
   onLeafAdded,
   onContainerAdded,
   onSelectNode,
+  renderedDataIds,
   onStructuralChange,
 }: SectionTreeEditorProps) {
   const { t } = useLingui()
@@ -290,6 +294,7 @@ export function SectionTreeEditor({
             onAddChildContainer={handleAddChildContainer}
             onDrop={handleDrop}
             onSelectNode={onSelectNode}
+            renderedDataIds={renderedDataIds}
             defaultTextRole={defaultTextRole}
             defaultStructure={defaultStructure}
           />

--- a/apps/studio/src/components/section-tree-editor/TreeNode.tsx
+++ b/apps/studio/src/components/section-tree-editor/TreeNode.tsx
@@ -16,6 +16,7 @@ import {
   Link2,
   MessageCircle,
   MoreHorizontal,
+  Palette,
   PanelTop,
   PenLine,
   Puzzle,
@@ -161,6 +162,8 @@ export interface TreeNodeProps {
   onAddChildLeaf: (parentNodeId: string | null, role: string) => void
   onAddChildContainer: (parentNodeId: string | null, structure: string) => void
   onDrop: (sourceNodeId: string, target: DropIntent) => void
+  /** Select this node for styling — opens the style pane for its preview element. */
+  onSelectNode?: (nodeId: string, tagName?: string) => void
   defaultTextRole: string
   defaultStructure: string
 }
@@ -213,6 +216,37 @@ function DragHandle({
     >
       <GripVertical className="h-3.5 w-3.5 text-muted-foreground pointer-events-none" />
     </div>
+  )
+}
+
+// ── Select-for-styling button ────────────────────────────────────
+
+function StyleButton({
+  nodeId,
+  tagName,
+  onSelectNode,
+  disabled,
+}: {
+  nodeId: string
+  tagName?: string
+  onSelectNode?: (nodeId: string, tagName?: string) => void
+  disabled?: boolean
+}) {
+  const { t } = useLingui()
+  if (!onSelectNode) return null
+  return (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.stopPropagation()
+        onSelectNode(nodeId, tagName)
+      }}
+      disabled={disabled}
+      className="p-0.5 rounded hover:bg-accent transition-colors cursor-pointer disabled:opacity-30"
+      title={t`Edit styles`}
+    >
+      <Palette className="h-3 w-3 text-muted-foreground" />
+    </button>
   )
 }
 
@@ -347,6 +381,7 @@ function ContainerNode(props: TreeNodeProps) {
     onAddChildLeaf,
     onAddChildContainer,
     onDrop,
+    onSelectNode,
     defaultTextRole,
     defaultStructure,
     parentNodeId,
@@ -465,6 +500,12 @@ function ContainerNode(props: TreeNodeProps) {
           )}
         </button>
         <div className="ml-auto flex items-center gap-0.5 opacity-0 group-hover/head:opacity-100 transition-opacity">
+          <StyleButton
+            nodeId={node.nodeId}
+            tagName="div"
+            onSelectNode={onSelectNode}
+            disabled={disabled}
+          />
           <button
             type="button"
             onClick={() => onTogglePruned(node.nodeId)}
@@ -571,6 +612,7 @@ function ContainerNode(props: TreeNodeProps) {
                 onAddChildLeaf={onAddChildLeaf}
                 onAddChildContainer={onAddChildContainer}
                 onDrop={onDrop}
+                onSelectNode={onSelectNode}
                 defaultTextRole={defaultTextRole}
                 defaultStructure={defaultStructure}
               />
@@ -603,6 +645,7 @@ function TextLeaf(props: TreeNodeProps) {
     onDuplicate,
     onNest,
     onUnnest,
+    onSelectNode,
     parentNodeId,
     defaultStructure,
   } = props
@@ -678,6 +721,12 @@ function TextLeaf(props: TreeNodeProps) {
         disabled={disabled}
       />
       <div className="shrink-0 flex items-center gap-0.5 self-center ml-auto opacity-0 group-hover/row:opacity-100 transition-opacity">
+        <StyleButton
+          nodeId={node.nodeId}
+          tagName="p"
+          onSelectNode={onSelectNode}
+          disabled={disabled}
+        />
         <button
           type="button"
           onClick={() => onTogglePruned(node.nodeId)}

--- a/apps/studio/src/components/section-tree-editor/TreeNode.tsx
+++ b/apps/studio/src/components/section-tree-editor/TreeNode.tsx
@@ -164,8 +164,22 @@ export interface TreeNodeProps {
   onDrop: (sourceNodeId: string, target: DropIntent) => void
   /** Select this node for styling — opens the style pane for its preview element. */
   onSelectNode?: (nodeId: string, tagName?: string) => void
+  /** data-ids present in the rendered HTML — gates the "Edit styles" button. */
+  renderedDataIds?: Set<string>
   defaultTextRole: string
   defaultStructure: string
+}
+
+// A node is stylable when its own element is in the rendered HTML, or (for a
+// container) at least one descendant leaf is — enough for the parent to locate
+// its wrapping element via the common ancestor of those leaves.
+function nodeHasRenderTarget(node: ContentNodeData, ids: Set<string> | undefined): boolean {
+  if (!ids) return false
+  if (ids.has(node.nodeId)) return true
+  for (const child of node.children ?? []) {
+    if (nodeHasRenderTarget(child, ids)) return true
+  }
+  return false
 }
 
 export function TreeNode(props: TreeNodeProps) {
@@ -382,6 +396,7 @@ function ContainerNode(props: TreeNodeProps) {
     onAddChildContainer,
     onDrop,
     onSelectNode,
+    renderedDataIds,
     defaultTextRole,
     defaultStructure,
     parentNodeId,
@@ -500,12 +515,14 @@ function ContainerNode(props: TreeNodeProps) {
           )}
         </button>
         <div className="ml-auto flex items-center gap-0.5 opacity-0 group-hover/head:opacity-100 transition-opacity">
-          <StyleButton
-            nodeId={node.nodeId}
-            tagName="div"
-            onSelectNode={onSelectNode}
-            disabled={disabled}
-          />
+          {nodeHasRenderTarget(node, renderedDataIds) && (
+            <StyleButton
+              nodeId={node.nodeId}
+              tagName="div"
+              onSelectNode={onSelectNode}
+              disabled={disabled}
+            />
+          )}
           <button
             type="button"
             onClick={() => onTogglePruned(node.nodeId)}
@@ -613,6 +630,7 @@ function ContainerNode(props: TreeNodeProps) {
                 onAddChildContainer={onAddChildContainer}
                 onDrop={onDrop}
                 onSelectNode={onSelectNode}
+                renderedDataIds={renderedDataIds}
                 defaultTextRole={defaultTextRole}
                 defaultStructure={defaultStructure}
               />
@@ -646,6 +664,7 @@ function TextLeaf(props: TreeNodeProps) {
     onNest,
     onUnnest,
     onSelectNode,
+    renderedDataIds,
     parentNodeId,
     defaultStructure,
   } = props
@@ -721,12 +740,14 @@ function TextLeaf(props: TreeNodeProps) {
         disabled={disabled}
       />
       <div className="shrink-0 flex items-center gap-0.5 self-center ml-auto opacity-0 group-hover/row:opacity-100 transition-opacity">
-        <StyleButton
-          nodeId={node.nodeId}
-          tagName="p"
-          onSelectNode={onSelectNode}
-          disabled={disabled}
-        />
+        {nodeHasRenderTarget(node, renderedDataIds) && (
+          <StyleButton
+            nodeId={node.nodeId}
+            tagName="p"
+            onSelectNode={onSelectNode}
+            disabled={disabled}
+          />
+        )}
         <button
           type="button"
           onClick={() => onTogglePruned(node.nodeId)}

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -2547,6 +2547,9 @@ msgstr "Edit Prompt"
 msgid "Edit Prompts"
 msgstr "Edit Prompts"
 
+msgid "Edit styles"
+msgstr "Edit styles"
+
 #~ msgid "Edit the Liquid/HTML template below. Changes are saved when you click Save & Rerun."
 #~ msgstr "Edit the Liquid/HTML template below. Changes are saved when you click Save & Rerun."
 
@@ -2604,11 +2607,17 @@ msgstr "Empty"
 msgid "Empty container"
 msgstr "Empty container"
 
+msgid "Empty group"
+msgstr "Empty group"
+
 msgid "Empty section"
 msgstr "Empty section"
 
 msgid "Empty section — add a container below to start"
 msgstr "Empty section — add a container below to start"
+
+msgid "Empty text"
+msgstr "Empty text"
 
 msgid "en"
 msgstr "en"

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -2547,6 +2547,9 @@ msgstr "Prompt de edición"
 msgid "Edit Prompts"
 msgstr "Editar prompts"
 
+msgid "Edit styles"
+msgstr "Editar estilos"
+
 #~ msgid "Edit the Liquid/HTML template below. Changes are saved when you click Save & Rerun."
 #~ msgstr "Edita la plantilla Liquid/HTML a continuación. Los cambios se guardan cuando haces clic en Guardar y reejecutar."
 
@@ -2604,11 +2607,17 @@ msgstr "Vacío"
 msgid "Empty container"
 msgstr "Contenedor vacío"
 
+msgid "Empty group"
+msgstr "Grupo vacío"
+
 msgid "Empty section"
 msgstr "Sección vacía"
 
 msgid "Empty section — add a container below to start"
 msgstr "Sección vacía — añade un contenedor abajo para empezar"
+
+msgid "Empty text"
+msgstr "Texto vacío"
 
 msgid "en"
 msgstr "en"

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -2549,6 +2549,9 @@ msgstr "Modifier Invite"
 msgid "Edit Prompts"
 msgstr "Modifier Invites"
 
+msgid "Edit styles"
+msgstr "Modifier les styles"
+
 #~ msgid "Edit the Liquid/HTML template below. Changes are saved when you click Save & Rerun."
 #~ msgstr "Modifiez le modèle Liquid/HTML ci-dessous. Les modifications sont enregistrées lorsque vous cliquez sur Enregistrer et relancer."
 
@@ -2606,11 +2609,17 @@ msgstr "Vide"
 msgid "Empty container"
 msgstr "Conteneur vide"
 
+msgid "Empty group"
+msgstr "Groupe vide"
+
 msgid "Empty section"
 msgstr "Section vide"
 
 msgid "Empty section — add a container below to start"
 msgstr "Section vide — ajouter un conteneur ci-dessous pour commencer"
+
+msgid "Empty text"
+msgstr "Texte vide"
 
 msgid "en"
 msgstr "en"

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -2547,6 +2547,9 @@ msgstr "Prompt de edição"
 msgid "Edit Prompts"
 msgstr "Editar prompts"
 
+msgid "Edit styles"
+msgstr "Editar estilos"
+
 #~ msgid "Edit the Liquid/HTML template below. Changes are saved when you click Save & Rerun."
 #~ msgstr "Edite o template Liquid/HTML abaixo. As alterações são salvas quando você clica em Salvar e reexecutar."
 
@@ -2604,11 +2607,17 @@ msgstr "Vazio"
 msgid "Empty container"
 msgstr "Contêiner vazio"
 
+msgid "Empty group"
+msgstr "Grupo vazio"
+
 msgid "Empty section"
 msgstr "Seção vazia"
 
 msgid "Empty section — add a container below to start"
 msgstr "Seção vazia — adicione um contêiner abaixo para começar"
+
+msgid "Empty text"
+msgstr "Texto vazio"
 
 msgid "en"
 msgstr "en"

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -2548,6 +2548,9 @@ msgstr "Redakto Prompt-in"
 msgid "Edit Prompts"
 msgstr "Redakto Prompt-et"
 
+msgid "Edit styles"
+msgstr "Redakto stilet"
+
 #~ msgid "Edit the Liquid/HTML template below. Changes are saved when you click Save & Rerun."
 #~ msgstr "Redaktoni shabllonin Liquid/HTML më poshtë. Ndryshimet ruhen kur klikoni Ruaj dhe Riekzekuto."
 
@@ -2605,11 +2608,17 @@ msgstr "Bosh"
 msgid "Empty container"
 msgstr "Kontejner bosh"
 
+msgid "Empty group"
+msgstr "Grup bosh"
+
 msgid "Empty section"
 msgstr "Seksion bosh"
 
 msgid "Empty section — add a container below to start"
 msgstr "Seksion bosh — shtoni një kontejner më poshtë për të filluar"
+
+msgid "Empty text"
+msgstr "Tekst bosh"
 
 msgid "en"
 msgstr "en"


### PR DESCRIPTION
## Summary

Closes #341.

Lets users add a blank **group** (or blank text) in the storyboard and give it a deterministic look by styling it — no LLM required.

Previously, the tree editor's *Add group* / add-node actions only flagged an LLM re-render and injected nothing into the preview, so the new element had no `data-id` in the iframe and couldn't be selected or styled. This PR:

- **Injects the element into the rendered section HTML immediately** on add (reusing the existing `duplicateElementsInRendering` DOM-mirroring pattern) — deterministic, no LLM call.
- **Adds a selection path from both the tree and the preview**: a per-node *Edit styles* (palette) button opens the style pane for that element (and it auto-opens right after adding); empty elements get a clickable dashed placeholder box in the preview so they aren't zero-size.
- **Guards inline editing**: blank `<div>` containers are selected but not made `contentEditable`.
- **Preserves blanks across a later LLM re-render** via a `buildEditInstructions` "added element" branch.
- **Persists added sectioning nodes on save**: when a rendering edit also adds a tree node, `saveRendering` now saves the sectioning too, so sectioning and rendering version together (fixes a v1/v2 mismatch where the group vanished from the tree after reload).

No new "blank div/text" UI or terminology — reuses the existing *Add group* / add-node affordances. No `@adt/types` schema changes.

## Test plan

- [x] Add a group → dashed placeholder appears and style pane auto-opens; adding Tailwind classes applies live.
- [x] Deselect, click the group's tree node's *Edit styles* button → style pane re-opens.
- [x] Save → sectioning and rendering both bump to v2; group persists in the tree after full reload; no `data-adt-*` leak into saved HTML.
- [x] `pnpm --filter @adt/studio` typecheck + lint clean; i18n catalogs extracted and fully translated (en/pt-BR/es/fr/sq).

## Verification

Driven end-to-end with Playwright against a real book (storyboard stage): add-group injects `<div data-id>` (data-id count 18→19), auto-selects it, opens the **Container** style pane; save cycle confirmed `sectioning 1→2` / `rendering 1→2` with the node present in both and persisting across reload.
