### PR TITLE
fix(pipeline): fit fixed-layout pages in web reader to match storyboard

### DIFF
--- a/apps/adt-runtime/src/features/dock/components/Dock.tsx
+++ b/apps/adt-runtime/src/features/dock/components/Dock.tsx
@@ -50,8 +50,12 @@ export function Dock({ children }: DockProps) {
     const el = dockRef.current;
     if (!el) return;
     const update = () => {
-      const w = el.getBoundingClientRect().width;
-      document.documentElement.style.setProperty("--dock-width", `${w}px`);
+      const rect = el.getBoundingClientRect();
+      document.documentElement.style.setProperty("--dock-width", `${rect.width}px`);
+      // --dock-height + event let fixed-layout pages reserve the dock band and
+      // re-fit (the fit script runs before the dock mounts; see package-web.ts).
+      document.documentElement.style.setProperty("--dock-height", `${rect.height}px`);
+      window.dispatchEvent(new Event("adt:dock-resize"));
     };
     update();
     const ro = new ResizeObserver(update);
@@ -59,6 +63,7 @@ export function Dock({ children }: DockProps) {
     return () => {
       ro.disconnect();
       document.documentElement.style.removeProperty("--dock-width");
+      document.documentElement.style.removeProperty("--dock-height");
     };
   }, []);
 

--- a/apps/studio/src/components/pipeline/stages/PreviewView.tsx
+++ b/apps/studio/src/components/pipeline/stages/PreviewView.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback, useMemo, type CSSProperties } from "react"
+import { useState, useEffect, useRef, useCallback, useMemo } from "react"
 import type { AccessibilityFinding } from "@adt/types"
 import { Trans } from "@lingui/react/macro"
 import { StageBlockedState } from "@/components/pipeline/components/StageBlockedState"
@@ -35,20 +35,7 @@ export function PreviewView({ bookLabel }: { bookLabel: string }) {
   const storyboardDone = stageState("storyboard") === "done"
   const { allPruned, isLoading: prunedLoading } = useAllPagesPruned(bookLabel)
   const iframeRef = useRef<HTMLIFrameElement>(null)
-  const wrapperRef = useRef<HTMLDivElement>(null)
   const ranRef = useRef(false)
-  // Fixed-layout pages render at their native pixel viewport (e.g.
-  // 1587×1224) which usually exceeds the studio preview pane. Detect the
-  // page's intrinsic size from the iframe body's inline width/height and
-  // CSS-scale the iframe to fit, mirroring the storyboard preview.
-  // null = reflowable (no scaling).
-  // `referenceWidth` is the book-wide widest page (a full spread in spread
-  // mode), read from `#content`'s `data-fl-reference-width`. Scaling off it —
-  // not this page's own width — keeps every page at one uniform scale, so a
-  // single cover/end page renders centered at half-width rather than upscaled
-  // to fill the pane. Falls back to the page's own width when absent.
-  const [fixedLayoutSize, setFixedLayoutSize] = useState<{ height: number; referenceWidth: number } | null>(null)
-  const [availableWidth, setAvailableWidth] = useState(0)
   const { panelOpen } = useDebugPanelState()
   const [isSubmittingPackage, setIsSubmittingPackage] = useState(false)
   const [pendingTaskId, setPendingTaskId] = useState<string | null>(null)
@@ -135,58 +122,11 @@ export function PreviewView({ bookLabel }: { bookLabel: string }) {
       const signLanguageEnabled =
         iframe.contentDocument.querySelector("#sl-quick-toggle-button, #sign-language-video") !== null
 
-      // Detect fixed-layout pages — `package-web.ts` emits inline
-      // `style="...width:Wpx;height:Hpx..."` on `<body>` for fixed-layout
-      // page HTML. Parse those values; null otherwise. The book-wide
-      // reference width lives on `#content`'s `data-fl-reference-width`.
-      const body = iframe.contentDocument.body
-      const w = parsePxStyle(body?.style.width)
-      const h = parsePxStyle(body?.style.height)
-      const contentEl = iframe.contentDocument.getElementById("content")
-      const refRaw = contentEl?.getAttribute("data-fl-reference-width")
-      const ref = refRaw ? parseFloat(refRaw) : NaN
-      if (w !== null && h !== null && body) {
-        // The iframe is laid out at the book's reference (spread) width so the
-        // reader's full-width bottom dock — fixed to the iframe viewport —
-        // stays one constant width on every page (see iframeStyle). Center this
-        // page's (possibly narrower) body within that viewport so a single
-        // cover/end page sits in the middle with the dock spanning the whole
-        // panel beneath it. Overrides the produced page's inline `margin:0`.
-        body.style.marginLeft = "auto"
-        body.style.marginRight = "auto"
-        setFixedLayoutSize({ height: h, referenceWidth: Number.isFinite(ref) && ref > 0 ? ref : w })
-      } else {
-        setFixedLayoutSize(null)
-      }
-
       setCurrentPreviewPage({ sectionId, href, title, hasImages, hasActivity, signLanguageEnabled })
     } catch {
-      setFixedLayoutSize(null)
       setCurrentPreviewPage({ sectionId: null, href: null, title: null, hasImages: false, hasActivity: false, signLanguageEnabled: false })
     }
   }, [])
-
-  // Track wrapper width so the scale recomputes when the panel resizes
-  // (debug panel toggle, window resize, sidebar collapse, etc.). Depends
-  // on `ready` because the wrapper only renders once packaging is done —
-  // without that dep the effect runs once on mount when the wrapper
-  // doesn't exist yet, ref is null, and the observer never attaches.
-  useEffect(() => {
-    if (!ready) return
-    const el = wrapperRef.current
-    if (!el) return
-    setAvailableWidth(el.getBoundingClientRect().width)
-    const ro = new ResizeObserver((entries) => {
-      const entry = entries[0]
-      if (entry) setAvailableWidth(entry.contentRect.width)
-    })
-    ro.observe(el)
-    return () => ro.disconnect()
-  }, [ready])
-
-  const scale = fixedLayoutSize && availableWidth > 0
-    ? Math.min(1, availableWidth / fixedLayoutSize.referenceWidth)
-    : 1
 
   const packaging = !ready && (isSubmittingPackage || isTaskRunning("package-adt"))
 
@@ -335,46 +275,17 @@ export function PreviewView({ bookLabel }: { bookLabel: string }) {
   }
 
   if (ready) {
-    // Fixed-layout: lay the iframe out at the book's reference (spread) width —
-    // not this page's own width — and CSS-scale it via transform to fit the
-    // pane. Using the constant reference width keeps the reader's bottom dock
-    // (fixed to the iframe viewport, full-width) one consistent width on every
-    // page; a single page's narrower body is centered within that viewport
-    // (see syncCurrentPreviewPage), so the cover sits in the middle with the
-    // dock spanning the whole panel. The sizing div takes the *scaled*
-    // dimensions (the iframe's layout box stays at native size despite the
-    // transform, so we wrap it to keep page layout honest).
-    // Reflowable: iframe fills the wrapper as before.
-    const iframeStyle: CSSProperties = fixedLayoutSize
-      ? {
-          width: fixedLayoutSize.referenceWidth,
-          height: fixedLayoutSize.height,
-          transform: `scale(${scale})`,
-          transformOrigin: "0 0",
-        }
-      : { width: "100%", height: "100%" }
-    const sizerStyle: CSSProperties = fixedLayoutSize
-      ? {
-          width: fixedLayoutSize.referenceWidth * scale,
-          height: fixedLayoutSize.height * scale,
-          overflow: "hidden",
-          // Center the reader within the pane when it's narrower than the pane
-          // (large screens, scale capped at 1×).
-          margin: "0 auto",
-        }
-      : { width: "100%", height: "100%" }
+    // The iframe fills the pane; fixed-layout pages scale themselves to fit
+    // (see renderPageHtml's fit script in package-web.ts).
     return (
-      <div ref={wrapperRef} className="relative h-full w-full bg-muted/20 overflow-auto">
-        <div style={sizerStyle}>
-          <iframe
-            ref={iframeRef}
-            src={`${getAdtUrl(bookLabel)}/v-${version}/`}
-            className="border-0"
-            style={iframeStyle}
-            title="ADT Preview"
-            onLoad={syncCurrentPreviewPage}
-          />
-        </div>
+      <div className="relative h-full w-full bg-muted/20 overflow-hidden">
+        <iframe
+          ref={iframeRef}
+          src={`${getAdtUrl(bookLabel)}/v-${version}/`}
+          className="h-full w-full border-0"
+          title="ADT Preview"
+          onLoad={syncCurrentPreviewPage}
+        />
 
         <PreviewAccessibilityCard
           label={bookLabel}
@@ -419,13 +330,6 @@ export function PreviewView({ bookLabel }: { bookLabel: string }) {
   }
 
   return null
-}
-
-/** Parse a pixel value (e.g. "1587px") to a number, or null for missing/non-px values. */
-function parsePxStyle(value: string | undefined): number | null {
-  if (!value) return null
-  const match = /^(\d+(?:\.\d+)?)px$/.exec(value.trim())
-  return match ? parseFloat(match[1]) : null
 }
 
 function deriveReviewPageId(sectionId: string | null, href: string | null): string | null {

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/BookPreviewFrame.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/BookPreviewFrame.tsx
@@ -23,7 +23,7 @@ import {
   weightToToken,
 } from "./iframe-computed-styles"
 import { INTERACTIVE_SCRIPT, INTERACTIVE_STYLES } from "./iframe-interactive"
-import { primaryFontFamily, googleFontsCss2Url } from "@adt/types"
+import { primaryFontFamily, googleFontsCss2Url, FIXED_LAYOUT_MAX_SCALE } from "@adt/types"
 
 export type { ComputedTypographyStyles }
 
@@ -58,11 +58,6 @@ function parsePxStyle(value: string | undefined): number | null {
   const match = /^(\d+(?:\.\d+)?)px$/.exec(value.trim())
   return match ? parseFloat(match[1]) : null
 }
-
-// Upper bound for upscaling fixed-layout pages so small-page PDFs fill the
-// preview panel instead of rendering boxed. 2× keeps rasterised assets from
-// getting unacceptably soft while still filling the panel for typical books.
-const FL_MAX_SCALE = 2
 
 export interface BookPreviewFrameHandle {
   /** Get the iframe element's bounding rect in the viewport */
@@ -760,12 +755,14 @@ ${selectors}:hover {
   // page shares one scale — a full spread fills the panel, a single cover/end
   // page renders centered at its natural fraction (e.g. half) of the panel
   // rather than being upscaled to fill it. Small books (reference width below
-  // the panel) still upscale up to FL_MAX_SCALE so they don't render boxed.
+  // the panel) still upscale up to FIXED_LAYOUT_MAX_SCALE so they don't render
+  // boxed — the same cap the packaged reader's fit script uses, so the preview
+  // reads at the size edited here.
   // Reflowable: fit to the device-frame base width, desktop capped at 1× and
   // mobile/tablet grown up to a target visible width for legibility.
   useEffect(() => {
     if (fixedLayoutSize) {
-      setScale(Math.min(FL_MAX_SCALE, availableWidth / fixedLayoutSize.referenceWidth))
+      setScale(Math.min(FIXED_LAYOUT_MAX_SCALE, availableWidth / fixedLayoutSize.referenceWidth))
       return
     }
     const fitScale = Math.max(0, availableWidth / baseWidth)

--- a/packages/pipeline/src/package-web.ts
+++ b/packages/pipeline/src/package-web.ts
@@ -31,7 +31,7 @@ import type {
   Quiz,
   ImageCaptioningOutput,
 } from "@adt/types"
-import { WebRenderingOutput as WebRenderingOutputSchema, isTtsExcluded } from "@adt/types"
+import { WebRenderingOutput as WebRenderingOutputSchema, isTtsExcluded, FIXED_LAYOUT_MAX_SCALE } from "@adt/types"
 import {
   GOOGLE_FONTS,
   googleFontsReferencedIn,
@@ -156,6 +156,11 @@ function buildRuntimeTimecodeMap(
   return map
 }
 
+// Folded into the packaging cache hash so already-packaged books regenerate
+// when renderPageHtml's output format changes (which book inputs don't capture).
+// Bump on any such change.
+const PACKAGING_FORMAT_VERSION = 4
+
 export interface ComputePackagingInputHashOptions {
   storage: Storage
   bookDir: string
@@ -185,6 +190,7 @@ export function computePackagingInputHash(options: ComputePackagingInputHashOpti
 
   // 2. Packaging options that affect output
   hash.update(JSON.stringify({
+    formatVersion: PACKAGING_FORMAT_VERSION,
     label: options.label,
     language: options.language,
     outputLanguages: options.outputLanguages,
@@ -1014,9 +1020,16 @@ body {
   max-width: none !important;
 }
 
-/* Content wrapper: preserve position:relative and explicit dimensions */
+/* Content wrapper: native size, no injected scale/centering — Readium/EPUB
+   readers size pre-paginated pages themselves, so neutralize the browser
+   reader's viewport-fit transform (renderPageHtml's fixed-layout fit script). */
 #content {
   opacity: 1 !important;
+  visibility: visible !important;
+  position: relative !important;
+  left: auto !important;
+  top: auto !important;
+  transform: none !important;
   margin: 0 !important;
 }
 
@@ -1036,6 +1049,57 @@ body {
   border-radius: 0.15em;
 }
 </style>`
+
+/**
+ * Fit script for fixed-layout pages in the browser web reader (studio preview +
+ * standalone). Scales `#content` to the viewport from first paint — no iframe
+ * transform, so no native-size flash and the reader's fixed dock stays at the
+ * pane bottom. `#content` starts hidden and is revealed once positioned
+ * (`<noscript>` reveals it without JS). The dock band is read from the
+ * `--dock-height` CSS var (published by `Dock.tsx`), with `dockReserveFallbackPx`
+ * for the first paint before the dock mounts. Neutralized for WebPub/Readium by
+ * FIXED_LAYOUT_OVERRIDE_CSS.
+ */
+function fixedLayoutWebFit(dockReserveFallbackPx: number): { headStyle: string; bodyScript: string } {
+  const headStyle = `    <style>
+      html { width: 100%; height: 100%; }
+      #content { visibility: hidden; }
+    </style>
+    <noscript><style>#content { visibility: visible !important; }</style></noscript>`
+  const bodyScript = `    <script>
+      (function () {
+        var c = document.getElementById("content");
+        if (!c) return;
+        var W = parseFloat(c.style.width) || c.offsetWidth || 1;
+        var H = parseFloat(c.style.height) || c.offsetHeight || 1;
+        var ref = parseFloat(c.getAttribute("data-fl-reference-width"));
+        var refW = ref > 0 ? ref : W;
+        var FALLBACK = ${dockReserveFallbackPx};
+        function dock() {
+          var v = parseFloat(getComputedStyle(document.documentElement).getPropertyValue("--dock-height"));
+          return v > 0 ? v : FALLBACK;
+        }
+        function fit() {
+          var DOCK = dock();
+          var byW = window.innerWidth / refW;
+          var byH = (window.innerHeight - DOCK) / H;
+          var s = Math.min(${FIXED_LAYOUT_MAX_SCALE}, byW, byH > 0 ? byH : byW);
+          c.style.position = "absolute";
+          c.style.left = "50%";
+          c.style.top = "calc((100% - " + DOCK + "px) / 2)";
+          c.style.margin = "0";
+          c.style.transformOrigin = "center center";
+          c.style.transform = "translate(-50%, -50%) scale(" + s + ")";
+          c.style.visibility = "visible";
+        }
+        fit();
+        window.addEventListener("resize", fit);
+        window.addEventListener("load", fit);
+        window.addEventListener("adt:dock-resize", fit);
+      })();
+    </script>`
+  return { headStyle, bodyScript }
+}
 
 export interface InjectWebpubStylesOptions {
   fixedLayout?: boolean
@@ -1272,6 +1336,9 @@ ${fallbackHeadingHtml}${contentBlock}
     <link href="${escapeAttr(googleFontsUrl)}" rel="stylesheet">`
     : ""
 
+  // 96 is the first-paint dock-band fallback; 0 in embed mode (dock hidden).
+  const flFit = opts.fixedViewport ? fixedLayoutWebFit(opts.embed ? 0 : 96) : null
+
   return `<!DOCTYPE html>
 <html lang="${escapeAttr(opts.language)}">
 
@@ -1284,11 +1351,11 @@ ${fallbackHeadingHtml}${contentBlock}
     <link href="./content/tailwind_output.css" rel="stylesheet">
     <link href="./assets/libs/fontawesome/css/all.min.css" rel="stylesheet">
     <link href="./assets/fonts.css" rel="stylesheet">${googleFontsLinks}
-${mathScript}${embedStyles}${bodyFontStyle}</head>
+${mathScript}${embedStyles}${bodyFontStyle}${flFit ? `${flFit.headStyle}\n` : ""}</head>
 
-<body${opts.fixedViewport ? ` style="margin:0;overflow:hidden;width:${opts.fixedViewport.width}px;height:${opts.fixedViewport.height}px"` : ` class="min-h-screen flex items-center justify-center"${bodyStyle}`}>
+<body${opts.fixedViewport ? ` style="margin:0;overflow:hidden;width:100%;height:100%"` : ` class="min-h-screen flex items-center justify-center"${bodyStyle}`}>
 ${mainBlock}
-${answersScript}
+${flFit ? `${flFit.bodyScript}\n` : ""}${answersScript}
     <div class="relative z-50" id="interface-container"></div>
     <div class="relative z-50" id="nav-container"></div>
 ${opts.embed

--- a/packages/types/src/google-fonts.ts
+++ b/packages/types/src/google-fonts.ts
@@ -199,11 +199,18 @@ export function googleFontsCss2Url(families: string[]): string | null {
 export function googleFontsReferencedIn(text: string): string[] {
   if (!text) return []
   const found = new Set<string>()
+  // Decode `&apos;` first: fixed-layout spans emit `font-family:&apos;Noto
+  // Sans&apos;`, and the `;` inside the entity would cut the value capture short.
+  // (data-segments JSON stays skipped: decoding leaves `font-family":`, which the
+  // `font-family\s*:` anchor never matches.)
+  const decoded = text
+    .replace(/&apos;|&#39;/g, "'")
+    .replace(/&quot;|&#34;/g, '"')
   // Scan font-family declaration values only (inline styles + CSS rules), then
   // exact-match each comma-separated family token. Exact (not substring)
   // matching avoids body-text false positives AND prefix collisions — e.g. a
   // page using "Noto Sans Mono" must not also pull "Noto Sans".
-  for (const m of text.matchAll(/font-family\s*:\s*([^;"}<]+)/gi)) {
+  for (const m of decoded.matchAll(/font-family\s*:\s*([^;"}<]+)/gi)) {
     for (const tokenRaw of m[1].split(",")) {
       const token = tokenRaw.trim().replace(/^['"]+|['"]+$/g, "")
       const entry = GOOGLE_FONTS.find((f) => f.family === token)

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -202,6 +202,7 @@ export { BookSummaryOutput } from "./book-summary.js"
 export { ExtractionWarning } from "./extraction-warning.js"
 
 export {
+  FIXED_LAYOUT_MAX_SCALE,
   SectionRendering,
   WebRenderingOutput,
   webRenderingLLMSchema,

--- a/packages/types/src/web-rendering.ts
+++ b/packages/types/src/web-rendering.ts
@@ -1,5 +1,13 @@
 import { z } from "zod"
 
+/**
+ * Max upscale for a fixed-layout page filling its viewport. Shared by the
+ * storyboard editor (`BookPreviewFrame`) and the packaged reader's fit script
+ * (`renderPageHtml`) so the preview/export matches the size the user edits at.
+ * 2× keeps rasterised art from getting too soft.
+ */
+export const FIXED_LAYOUT_MAX_SCALE = 2
+
 export const SectionRendering = z.object({
   sectionIndex: z.number().int(),
   sectionType: z.string(),


### PR DESCRIPTION
## What & why

Fixed-layout pages now scale to fit the viewport **inside the packaged HTML itself**, so the web reader — both the Studio preview and the standalone/exported reader — renders them the way the **storyboard editor** already does. Previously only the Studio preview scaled the page, by transforming the iframe from the React side; the exported reader and the preview could disagree, and the preview didn't match the size you edit at.

**Goal: the web reader should replicate the storyboard view** — same fit, same upscale cap, same centering.

## Before → After

| | Before | After |
|---|---|---|
| **Who scales the page** | Studio React wrapper transformed the iframe | The packaged page scales itself (inline fit script) |
| **Standalone / exported reader** | No fit — rendered at native pixel size | Same fit as the preview |
| **Upscale cap** | Preview capped at 1× (width only) | Shared `FIXED_LAYOUT_MAX_SCALE` = 2×, fits by width **and** height — same as storyboard |
| **First paint** | Native-size flash before the transform applied | `#content` hidden until positioned — no flash |
| **Dock band** | Not reserved | Reserved via `--dock-height` var + `adt:dock-resize` event |
| **Small fixed-layout books** | Rendered boxed in the pane | Upscale to fill (up to 2×), matching the editor |
| **Google Fonts on FL pages** | `font-family:&apos;Noto Sans&apos;` → font **not bundled** | Entities decoded before matching → font bundled |

## How

- New inline `fixedLayoutWebFit` script scales `#content` to the viewport from first paint; `<noscript>` reveals content when JS is off.
- EPUB/Readium output neutralizes the fit transform via `FIXED_LAYOUT_OVERRIDE_CSS` (readers paginate pre-paginated pages themselves).
- `FIXED_LAYOUT_MAX_SCALE` shared between `@adt/types`, the storyboard editor, and the reader.
- `PACKAGING_FORMAT_VERSION` bumped so already-packaged books regenerate.
- `PreviewView` simplified — React-side iframe scaling removed (~118 lines).
- google-fonts scan decodes `&apos;`/`&quot;` before matching `font-family`.

## Testing

- 136 tests pass (`package-web`, `fixed-layout-rendering`, `google-fonts`).
- `tsc` clean on studio and pipeline. (Pre-existing `@adt/runtime` type errors in `lifecycle.ts` / `activity-fill-in-the-blank.ts` are unrelated to this branch.)
