### PR TITLE
fix: reflect sectioning text edits in the storyboard

### DIFF
--- a/apps/api/src/routes/pages.test.ts
+++ b/apps/api/src/routes/pages.test.ts
@@ -297,6 +297,15 @@ describe("Page routes", () => {
         }
       }
 
+      function readRenderingVersion(pageId: string): number {
+        const storage = createBookStorage(label, tmpDir)
+        try {
+          return storage.getLatestNodeData("web-rendering", pageId)?.version ?? 0
+        } finally {
+          storage.close()
+        }
+      }
+
       function putSectioning(text: string, nodes?: unknown) {
         return app.request(
           `/api/books/${label}/pages/${label}_p1/sectioning`,
@@ -340,6 +349,17 @@ describe("Page routes", () => {
         expect(html).not.toContain("Hello world")
         // Surrounding markup survives — we substitute text, not re-render.
         expect(html).toContain('data-section-type="content"')
+      })
+
+      // The Storyboard iframe is cache-busted by the rendering version, so a
+      // propagated edit has to bump it or the user keeps seeing the old page.
+      it("bumps the rendering version so the preview reloads", async () => {
+        seedRendering(`${label}_p1`, "Hello world")
+        const before = readRenderingVersion(`${label}_p1`)
+
+        await putSectioning("Goodbye world")
+
+        expect(readRenderingVersion(`${label}_p1`)).toBeGreaterThan(before)
       })
 
       it("leaves other pages' renderings untouched", async () => {

--- a/apps/api/src/routes/pages.test.ts
+++ b/apps/api/src/routes/pages.test.ts
@@ -390,9 +390,28 @@ describe("Page routes", () => {
         ])
 
         expect(res.status).toBe(200)
-        expect((await res.json()).needsRerender).toBe(true)
+        const body = await res.json()
+        expect(body.needsRerender).toBe(true)
+        // The client re-renders just these sections rather than the whole page.
+        expect(body.rerenderSections).toEqual([0])
         // Half-patching a drifted section would be worse than leaving it stale.
         expect(readRenderingHtml(`${label}_p1`)).toBe(sectionHtml("Hello world"))
+      })
+
+      it("saves successfully even when the rendering node is unreadable", async () => {
+        const storage = createBookStorage(label, tmpDir)
+        try {
+          storage.putNodeData("web-rendering", `${label}_p1`, { bogus: true })
+        } finally {
+          storage.close()
+        }
+
+        const res = await putSectioning("Goodbye world")
+
+        // Propagation is best-effort — the sectioning row is already committed,
+        // so a problem here must never surface as a failed save.
+        expect(res.status).toBe(200)
+        expect((await res.json()).version).toBe(2)
       })
 
       it("skips propagation for fixed-layout pages", async () => {

--- a/apps/api/src/routes/pages.test.ts
+++ b/apps/api/src/routes/pages.test.ts
@@ -260,6 +260,158 @@ describe("Page routes", () => {
 
       expect(res.status).toBe(404)
     })
+
+    // The rendered HTML is a snapshot of the sectioning text, so an edit in the
+    // Sectioning view has to be pushed into it or the Storyboard shows stale copy.
+    describe("storyboard text propagation", () => {
+      const sectionHtml = (text: string) =>
+        `<div class="container content" id="content"><section data-section-type="content" data-section-id="${label}_p1_sec001"><p data-id="${label}_p1_n001">${text}</p></section></div>`
+
+      /** Replace the fixture's placeholder HTML with realistically rendered markup. */
+      function seedRendering(pageId: string, text: string): void {
+        const storage = createBookStorage(label, tmpDir)
+        try {
+          storage.putNodeData("web-rendering", pageId, {
+            sections: [
+              {
+                sectionIndex: 0,
+                sectionType: "content",
+                reasoning: "rendered",
+                html: sectionHtml(text),
+              },
+            ],
+          })
+        } finally {
+          storage.close()
+        }
+      }
+
+      function readRenderingHtml(pageId: string): string {
+        const storage = createBookStorage(label, tmpDir)
+        try {
+          const row = storage.getLatestNodeData("web-rendering", pageId)
+          const data = row?.data as { sections: Array<{ html: string }> }
+          return data.sections[0].html
+        } finally {
+          storage.close()
+        }
+      }
+
+      function putSectioning(text: string, nodes?: unknown) {
+        return app.request(
+          `/api/books/${label}/pages/${label}_p1/sectioning`,
+          {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              reasoning: "edited",
+              sections: [
+                {
+                  sectionId: `${label}_p1_sec001`,
+                  sectionType: "content",
+                  backgroundColor: "#ffffff",
+                  textColor: "#000000",
+                  pageNumber: 1,
+                  isPruned: false,
+                  nodes: nodes ?? [
+                    {
+                      nodeId: `${label}_p1_n001`,
+                      isPruned: false,
+                      role: "text",
+                      text,
+                    },
+                  ],
+                },
+              ],
+            }),
+          }
+        )
+      }
+
+      it("pushes edited text into the stored rendering", async () => {
+        seedRendering(`${label}_p1`, "Hello world")
+
+        const res = await putSectioning("Goodbye world")
+
+        expect(res.status).toBe(200)
+        expect((await res.json()).needsRerender).toBe(false)
+        const html = readRenderingHtml(`${label}_p1`)
+        expect(html).toContain("Goodbye world")
+        expect(html).not.toContain("Hello world")
+        // Surrounding markup survives — we substitute text, not re-render.
+        expect(html).toContain('data-section-type="content"')
+      })
+
+      it("leaves other pages' renderings untouched", async () => {
+        seedRendering(`${label}_p1`, "Hello world")
+        seedRendering(`${label}_p2`, "Page two copy")
+
+        await putSectioning("Goodbye world")
+
+        expect(readRenderingHtml(`${label}_p2`)).toContain("Page two copy")
+      })
+
+      it("reports needsRerender and leaves HTML alone on a structural edit", async () => {
+        seedRendering(`${label}_p1`, "Hello world")
+
+        const res = await putSectioning("", [
+          {
+            nodeId: `${label}_p1_n001`,
+            isPruned: false,
+            role: "text",
+            text: "Hello world",
+          },
+          {
+            nodeId: `${label}_p1_n002`,
+            isPruned: false,
+            role: "text",
+            text: "A newly added paragraph",
+          },
+        ])
+
+        expect(res.status).toBe(200)
+        expect((await res.json()).needsRerender).toBe(true)
+        // Half-patching a drifted section would be worse than leaving it stale.
+        expect(readRenderingHtml(`${label}_p1`)).toBe(sectionHtml("Hello world"))
+      })
+
+      it("skips propagation for fixed-layout pages", async () => {
+        seedRendering(`${label}_p1`, "Hello world")
+        const storage = createBookStorage(label, tmpDir)
+        try {
+          // Fixed-layout pages render from the positioned tree, whose data-ids
+          // are unrelated to the semantic tree being edited here.
+          storage.putNodeData("fixed-layout-sectioning", `${label}_p1`, {
+            reasoning: "positioned",
+            sections: [],
+          })
+        } finally {
+          storage.close()
+        }
+
+        const res = await putSectioning("Goodbye world")
+
+        expect(res.status).toBe(200)
+        expect((await res.json()).needsRerender).toBe(false)
+        expect(readRenderingHtml(`${label}_p1`)).toContain("Hello world")
+      })
+
+      it("saves normally when the page has no rendering yet", async () => {
+        const storage = createBookStorage(label, tmpDir)
+        try {
+          storage.clearNodesByType(["web-rendering"])
+        } finally {
+          storage.close()
+        }
+
+        const res = await putSectioning("Goodbye world")
+
+        expect(res.status).toBe(200)
+        const body = await res.json()
+        expect(body.version).toBe(2)
+        expect(body.needsRerender).toBe(false)
+      })
+    })
   })
 
   describe("PUT /api/books/:label/pages/:pageId/image-filtering", () => {

--- a/apps/api/src/routes/pages.ts
+++ b/apps/api/src/routes/pages.ts
@@ -5,7 +5,7 @@ import { z } from "zod"
 import { Hono } from "hono"
 import { HTTPException } from "hono/http-exception"
 import { parseBookLabel, ImageClassificationOutput, PageSectioningOutput, WebRenderingOutput, ImageCaptioningOutput, ImageSegmentRegion, DEFAULT_LLM_MAX_RETRIES, primaryFontFamily, reflowableFontChain, BookFontRegistry, bookBodyFont, bookFontFamilyChain, splitNodesBefore } from "@adt/types"
-import type { ContentNodeData, ExtractionWarning } from "@adt/types"
+import type { ContentNodeData, ExtractionWarning, PageSectioningOutput as PageSectioningOutputType } from "@adt/types"
 import { classifyExtractionWarning, flattenVisibleSectioningText } from "../services/extraction-warning.js"
 import { openBookDb } from "@adt/storage"
 import { createBookStorage } from "@adt/storage"
@@ -29,6 +29,8 @@ import {
   createScreenshotRenderer,
   SCREENSHOT_VIEWPORTS,
   isFixedLayoutBook,
+  propagateSectioningTextToRendering,
+  FIXED_LAYOUT_SECTIONING_NODE,
   type ScreenshotRenderer,
 } from "@adt/pipeline"
 import { createLLMModel, createPromptEngine, renderLiquidTemplate, generateImageWithCache } from "@adt/llm"
@@ -440,6 +442,47 @@ function saveStoryboardNode(
   const version = storage.putNodeData(node, itemId, data)
   clearCaptionData(storage)
   return version
+}
+
+/**
+ * Push edited sectioning text into the page's already-rendered storyboard HTML.
+ *
+ * The rendered HTML is a snapshot of the sectioning text taken at render time,
+ * so without this the Storyboard keeps showing the old copy after an edit in
+ * the Sectioning view. Only the edited page's node is touched — the book-wide
+ * `clearNodesByType` would discard every other page's rendering for a one-word
+ * change.
+ *
+ * Returns true when a section drifted structurally and needs a re-render.
+ */
+function propagateTextToStoryboard(
+  storage: Storage,
+  label: string,
+  pageId: string,
+  sectioning: PageSectioningOutputType
+): boolean {
+  // Fixed-layout pages render from the positioned tree in
+  // `fixed-layout-sectioning`, built from extraction draw-items rather than
+  // this semantic tree, and their data-ids belong to that tree. There is
+  // nothing here to propagate, and reporting drift would only send the user
+  // to a re-render that cannot help.
+  if (storage.getLatestNodeData(FIXED_LAYOUT_SECTIONING_NODE, pageId)) return false
+
+  const renderingRow = storage.getLatestNodeData("web-rendering", pageId)
+  if (!renderingRow) return false
+
+  const rendering = WebRenderingOutput.safeParse(renderingRow.data)
+  if (!rendering.success) return false
+
+  const result = propagateSectioningTextToRendering(
+    sectioning,
+    rendering.data,
+    label
+  )
+  if (result.changed) {
+    storage.putNodeData("web-rendering", pageId, result.rendering)
+  }
+  return result.needsRerender
 }
 
 /** Renumber sectionIds to the canonical `${pageId}_sec${NNN}` sequence. */
@@ -1189,7 +1232,14 @@ export function createPageRoutes(
       const version = storage.putNodeData("page-sectioning", pageId, parsed.data)
       // Sectioning change cascades to everything downstream
       clearCaptionData(storage)
-      return c.json({ version })
+
+      const needsRerender = propagateTextToStoryboard(
+        storage,
+        safeLabel,
+        pageId,
+        parsed.data
+      )
+      return c.json({ version, needsRerender })
     } finally {
       storage.close()
     }

--- a/apps/api/src/routes/pages.ts
+++ b/apps/api/src/routes/pages.ts
@@ -453,36 +453,51 @@ function saveStoryboardNode(
  * `clearNodesByType` would discard every other page's rendering for a one-word
  * change.
  *
- * Returns true when a section drifted structurally and needs a re-render.
+ * Returns the section indices that could not be synced and need re-rendering.
+ * Best-effort: the sectioning row is already committed by the time this runs,
+ * so a failure here must never turn a successful save into an error.
  */
 function propagateTextToStoryboard(
   storage: Storage,
   label: string,
   pageId: string,
   sectioning: PageSectioningOutputType
-): boolean {
-  // Fixed-layout pages render from the positioned tree in
-  // `fixed-layout-sectioning`, built from extraction draw-items rather than
-  // this semantic tree, and their data-ids belong to that tree. There is
-  // nothing here to propagate, and reporting drift would only send the user
-  // to a re-render that cannot help.
-  if (storage.getLatestNodeData(FIXED_LAYOUT_SECTIONING_NODE, pageId)) return false
+): number[] {
+  try {
+    // Fixed-layout pages render from the positioned tree in
+    // `fixed-layout-sectioning`, built from extraction draw-items rather than
+    // this semantic tree, and their data-ids belong to that tree. There is
+    // nothing here to propagate, and reporting drift would only send the user
+    // to a re-render that cannot help.
+    if (storage.getLatestNodeData(FIXED_LAYOUT_SECTIONING_NODE, pageId)) return []
 
-  const renderingRow = storage.getLatestNodeData("web-rendering", pageId)
-  if (!renderingRow) return false
+    const renderingRow = storage.getLatestNodeData("web-rendering", pageId)
+    if (!renderingRow) return []
 
-  const rendering = WebRenderingOutput.safeParse(renderingRow.data)
-  if (!rendering.success) return false
+    const rendering = WebRenderingOutput.safeParse(renderingRow.data)
+    if (!rendering.success) return []
 
-  const result = propagateSectioningTextToRendering(
-    sectioning,
-    rendering.data,
-    label
-  )
-  if (result.changed) {
-    storage.putNodeData("web-rendering", pageId, result.rendering)
+    const result = propagateSectioningTextToRendering(
+      sectioning,
+      rendering.data,
+      label
+    )
+    if (result.changed) {
+      storage.putNodeData("web-rendering", pageId, result.rendering)
+    }
+    for (const skip of result.skipped) {
+      console.log(
+        `[sectioning-save] ${label}/${pageId}: section ${skip.sectionIndex} not synced (${skip.reason}): ${skip.errors.join("; ")}`
+      )
+    }
+    return result.skipped.map((s) => s.sectionIndex)
+  } catch (err) {
+    console.error(
+      `[sectioning-save] ${label}/${pageId}: text propagation failed`,
+      err
+    )
+    return []
   }
-  return result.needsRerender
 }
 
 /** Renumber sectionIds to the canonical `${pageId}_sec${NNN}` sequence. */
@@ -1233,13 +1248,17 @@ export function createPageRoutes(
       // Sectioning change cascades to everything downstream
       clearCaptionData(storage)
 
-      const needsRerender = propagateTextToStoryboard(
+      const rerenderSections = propagateTextToStoryboard(
         storage,
         safeLabel,
         pageId,
         parsed.data
       )
-      return c.json({ version, needsRerender })
+      return c.json({
+        version,
+        needsRerender: rerenderSections.length > 0,
+        rerenderSections,
+      })
     } finally {
       storage.close()
     }

--- a/apps/studio/src/api/client.ts
+++ b/apps/studio/src/api/client.ts
@@ -958,8 +958,10 @@ export const api = {
       body: JSON.stringify(data),
     }),
 
+  // `needsRerender` is set when the edit changed the section's structure, which
+  // can't be reflected in the existing rendered HTML by substituting text.
   updateSectioning: (label: string, pageId: string, data: unknown) =>
-    request<{ version: number }>(`/books/${label}/pages/${pageId}/sectioning`, {
+    request<{ version: number; needsRerender: boolean }>(`/books/${label}/pages/${pageId}/sectioning`, {
       method: "PUT",
       body: JSON.stringify(data),
     }),

--- a/apps/studio/src/api/client.ts
+++ b/apps/studio/src/api/client.ts
@@ -958,10 +958,11 @@ export const api = {
       body: JSON.stringify(data),
     }),
 
-  // `needsRerender` is set when the edit changed the section's structure, which
-  // can't be reflected in the existing rendered HTML by substituting text.
+  // Text edits are pushed into the rendered HTML server-side. `rerenderSections`
+  // lists the sections that couldn't be synced that way (their structure changed,
+  // or their stored HTML was unpatchable) and need re-rendering to catch up.
   updateSectioning: (label: string, pageId: string, data: unknown) =>
-    request<{ version: number; needsRerender: boolean }>(`/books/${label}/pages/${pageId}/sectioning`, {
+    request<{ version: number; needsRerender: boolean; rerenderSections: number[] }>(`/books/${label}/pages/${pageId}/sectioning`, {
       method: "PUT",
       body: JSON.stringify(data),
     }),

--- a/apps/studio/src/components/pipeline/stages/sectioning/SectioningPageDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/sectioning/SectioningPageDetail.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react"
 import { createPortal } from "react-dom"
 import { Eye } from "lucide-react"
 import { Trans, useLingui } from "@lingui/react/macro"
@@ -7,6 +7,7 @@ import type { PageSectioningOutput, PageSectioningSection } from "@adt/types"
 import { api, type PageDetail } from "@/api/client"
 import { usePageImage } from "@/hooks/use-pages"
 import { useApiKey } from "@/hooks/use-api-key"
+import { useBookTasks, bookTasksKey } from "@/hooks/use-book-tasks"
 import { invalidateStoryboardDependents } from "@/hooks/use-page-mutations"
 import { cn } from "@/lib/utils"
 import { SectionTreeEditor } from "@/components/section-tree-editor/SectionTreeEditor"
@@ -88,8 +89,8 @@ export function SectioningPageDetail({
   >({})
   const [saving, setSaving] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
-  const [needsRerender, setNeedsRerender] = useState(false)
-  const [rerendering, setRerendering] = useState(false)
+  // Sections the server couldn't bring in sync by substituting text.
+  const [rerenderSections, setRerenderSections] = useState<number[]>([])
   const [structuralBusy, setStructuralBusy] = useState(false)
   const [confirmMerge, setConfirmMerge] = useState<{
     action: () => void
@@ -101,10 +102,38 @@ export function SectioningPageDetail({
   useEffect(() => {
     setPendingBySectionId({})
     setSaveError(null)
-    setNeedsRerender(false)
+    setRerenderSections([])
     setConfirmMerge(null)
     setConfirmDelete(null)
   }, [pageId])
+
+  // Re-render runs as a background task, so derive progress from the task list
+  // rather than from the submit call — which returns as soon as it's queued.
+  // This also reconnects to a run still in flight after navigating away.
+  const { tasks: bookTasks } = useBookTasks(bookLabel)
+  const rerendering = useMemo(
+    () =>
+      bookTasks.some(
+        (t) => t.kind === "re-render" && t.pageId === pageId && t.status === "running"
+      ),
+    [bookTasks, pageId]
+  )
+
+  // Clear the notice only once the render we were waiting on has finished, and
+  // pull in the HTML it produced.
+  const wasRerenderingRef = useRef(false)
+  useEffect(() => {
+    if (wasRerenderingRef.current && !rerendering) {
+      setRerenderSections([])
+      void queryClient.invalidateQueries({
+        queryKey: ["books", bookLabel, "pages", pageId],
+      })
+      invalidateStoryboardDependents(queryClient, bookLabel)
+    }
+    wasRerenderingRef.current = rerendering
+  }, [rerendering, bookLabel, pageId, queryClient])
+
+  const needsRerender = rerenderSections.length > 0
 
   const sectionsFromServer = page.sectioningTree?.sections ?? []
   const mergedSections: PageSectioningSection[] = useMemo(
@@ -134,16 +163,16 @@ export function SectioningPageDetail({
         reasoning: page.sectioningTree?.reasoning ?? "",
         sections: mergedSections,
       }
-      const { needsRerender } = await api.updateSectioning(
+      const { rerenderSections } = await api.updateSectioning(
         bookLabel,
         pageId,
         payload
       )
       setPendingBySectionId({})
       // Text edits are pushed straight into the rendered HTML by the server.
-      // A structural change can't be, so offer a re-render rather than firing
-      // one off silently — it costs an LLM call and replaces the section's layout.
-      setNeedsRerender(needsRerender)
+      // Anything it couldn't sync needs a re-render, which we offer rather than
+      // fire off silently — it costs an LLM call and replaces the layout.
+      setRerenderSections(rerenderSections)
       await queryClient.invalidateQueries({
         queryKey: ["books", bookLabel, "pages", pageId],
       })
@@ -168,22 +197,30 @@ export function SectioningPageDetail({
   ])
 
   const handleRerender = useCallback(async () => {
-    if (rerendering || !hasApiKey) return
-    setRerendering(true)
+    if (rerendering || !hasApiKey || rerenderSections.length === 0) return
     setSaveError(null)
     try {
-      await api.reRenderPage(bookLabel, pageId, apiKey)
-      setNeedsRerender(false)
-      await queryClient.invalidateQueries({
-        queryKey: ["books", bookLabel, "pages", pageId],
-      })
-      invalidateStoryboardDependents(queryClient, bookLabel)
+      // Re-render only the sections that fell out of sync — a whole-page render
+      // would also discard the layout of every section that is already correct.
+      for (const sectionIndex of rerenderSections) {
+        await api.reRenderPage(bookLabel, pageId, apiKey, sectionIndex)
+      }
+      // Pick up the queued tasks so `rerendering` turns on without waiting for
+      // the next poll.
+      await queryClient.invalidateQueries({ queryKey: bookTasksKey(bookLabel) })
     } catch (err) {
       setSaveError(err instanceof Error ? err.message : t`Re-render failed`)
-    } finally {
-      setRerendering(false)
     }
-  }, [rerendering, hasApiKey, bookLabel, pageId, apiKey, queryClient, t])
+  }, [
+    rerendering,
+    hasApiKey,
+    rerenderSections,
+    bookLabel,
+    pageId,
+    apiKey,
+    queryClient,
+    t,
+  ])
 
   // Server-side structural ops (merge/split/clone/delete) rewrite sectionIds,
   // so they are blocked while there are unsaved local edits.

--- a/apps/studio/src/components/pipeline/stages/sectioning/SectioningPageDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/sectioning/SectioningPageDetail.tsx
@@ -6,6 +6,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query"
 import type { PageSectioningOutput, PageSectioningSection } from "@adt/types"
 import { api, type PageDetail } from "@/api/client"
 import { usePageImage } from "@/hooks/use-pages"
+import { useApiKey } from "@/hooks/use-api-key"
 import { invalidateStoryboardDependents } from "@/hooks/use-page-mutations"
 import { cn } from "@/lib/utils"
 import { SectionTreeEditor } from "@/components/section-tree-editor/SectionTreeEditor"
@@ -50,6 +51,7 @@ export function SectioningPageDetail({
 }) {
   const { t } = useLingui()
   const queryClient = useQueryClient()
+  const { apiKey, hasApiKey } = useApiKey()
   const { headerSlotEl } = useStepHeader()
   const { data: imageData } = usePageImage(bookLabel, pageId)
 
@@ -86,6 +88,8 @@ export function SectioningPageDetail({
   >({})
   const [saving, setSaving] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
+  const [needsRerender, setNeedsRerender] = useState(false)
+  const [rerendering, setRerendering] = useState(false)
   const [structuralBusy, setStructuralBusy] = useState(false)
   const [confirmMerge, setConfirmMerge] = useState<{
     action: () => void
@@ -97,6 +101,7 @@ export function SectioningPageDetail({
   useEffect(() => {
     setPendingBySectionId({})
     setSaveError(null)
+    setNeedsRerender(false)
     setConfirmMerge(null)
     setConfirmDelete(null)
   }, [pageId])
@@ -129,8 +134,16 @@ export function SectioningPageDetail({
         reasoning: page.sectioningTree?.reasoning ?? "",
         sections: mergedSections,
       }
-      await api.updateSectioning(bookLabel, pageId, payload)
+      const { needsRerender } = await api.updateSectioning(
+        bookLabel,
+        pageId,
+        payload
+      )
       setPendingBySectionId({})
+      // Text edits are pushed straight into the rendered HTML by the server.
+      // A structural change can't be, so offer a re-render rather than firing
+      // one off silently — it costs an LLM call and replaces the section's layout.
+      setNeedsRerender(needsRerender)
       await queryClient.invalidateQueries({
         queryKey: ["books", bookLabel, "pages", pageId],
       })
@@ -153,6 +166,24 @@ export function SectioningPageDetail({
     queryClient,
     t,
   ])
+
+  const handleRerender = useCallback(async () => {
+    if (rerendering || !hasApiKey) return
+    setRerendering(true)
+    setSaveError(null)
+    try {
+      await api.reRenderPage(bookLabel, pageId, apiKey)
+      setNeedsRerender(false)
+      await queryClient.invalidateQueries({
+        queryKey: ["books", bookLabel, "pages", pageId],
+      })
+      invalidateStoryboardDependents(queryClient, bookLabel)
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : t`Re-render failed`)
+    } finally {
+      setRerendering(false)
+    }
+  }, [rerendering, hasApiKey, bookLabel, pageId, apiKey, queryClient, t])
 
   // Server-side structural ops (merge/split/clone/delete) rewrite sectionIds,
   // so they are blocked while there are unsaved local edits.
@@ -247,6 +278,31 @@ export function SectioningPageDetail({
       {saveError ? (
         <span className="text-xs text-destructive">{saveError}</span>
       ) : null}
+      {needsRerender && !dirty ? (
+        <div className="ml-auto flex items-center gap-2">
+          <span className="text-xs text-white/70">
+            <Trans>Storyboard is out of date</Trans>
+          </span>
+          <button
+            type="button"
+            onClick={handleRerender}
+            disabled={rerendering || !hasApiKey}
+            title={hasApiKey ? undefined : t`Add an API key to re-render`}
+            className={cn(
+              "text-xs px-2.5 py-1 rounded transition-colors",
+              rerendering || !hasApiKey
+                ? "bg-secondary/60 text-secondary-foreground/70 cursor-default"
+                : "bg-secondary text-secondary-foreground hover:bg-secondary/80 cursor-pointer"
+            )}
+          >
+            {rerendering ? (
+              <Trans>Re-rendering…</Trans>
+            ) : (
+              <Trans>Re-render</Trans>
+            )}
+          </button>
+        </div>
+      ) : null}
       {dirty ? (
         <div className="ml-auto flex items-center gap-2">
           <button
@@ -277,7 +333,9 @@ export function SectioningPageDetail({
           </button>
         </div>
       ) : null}
-      <div className={cn("flex gap-1", dirty ? "" : "ml-auto")}>{navigationArrows}</div>
+      <div className={cn("flex gap-1", dirty || needsRerender ? "" : "ml-auto")}>
+        {navigationArrows}
+      </div>
     </div>
   )
 

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -828,6 +828,9 @@ msgstr "Add an API key in Book settings to run TOC generation."
 msgid "Add an API key in Book settings to run translation."
 msgstr "Add an API key in Book settings to run translation."
 
+msgid "Add an API key to re-render"
+msgstr "Add an API key to re-render"
+
 msgid "Add an API key to re-run"
 msgstr "Add an API key to re-run"
 
@@ -5695,6 +5698,9 @@ msgstr "Re-render this section"
 msgid "Re-rendering..."
 msgstr "Re-rendering..."
 
+msgid "Re-rendering…"
+msgstr "Re-rendering…"
+
 msgid "Re-run"
 msgstr "Re-run"
 
@@ -7012,6 +7018,9 @@ msgstr "Storyboard"
 
 msgid "Storyboard has already been run. Changes made here will not take effect until storyboard is re-run."
 msgstr "Storyboard has already been run. Changes made here will not take effect until storyboard is re-run."
+
+msgid "Storyboard is out of date"
+msgstr "Storyboard is out of date"
 
 msgid "Storyboard not ready"
 msgstr "Storyboard not ready"

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -829,7 +829,7 @@ msgid "Add an API key in Book settings to run translation."
 msgstr "Añade una clave API en la configuración del libro para ejecutar traducción."
 
 msgid "Add an API key to re-render"
-msgstr ""
+msgstr "Agrega una clave de API para volver a renderizar"
 
 msgid "Add an API key to re-run"
 msgstr "Agrega una clave de API para re-ejecutar"
@@ -5699,7 +5699,7 @@ msgid "Re-rendering..."
 msgstr "Volviendo a renderizar..."
 
 msgid "Re-rendering…"
-msgstr ""
+msgstr "Volviendo a renderizar…"
 
 msgid "Re-run"
 msgstr "Re-ejecutar"
@@ -7020,7 +7020,7 @@ msgid "Storyboard has already been run. Changes made here will not take effect u
 msgstr "El storyboard ya se ejecutó. Los cambios realizados aquí no tendrán efecto hasta que se vuelva a ejecutar el storyboard."
 
 msgid "Storyboard is out of date"
-msgstr ""
+msgstr "El storyboard está desactualizado"
 
 msgid "Storyboard not ready"
 msgstr "Storyboard no está listo"

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -828,6 +828,9 @@ msgstr "Añade una clave API en la configuración del libro para ejecutar la gen
 msgid "Add an API key in Book settings to run translation."
 msgstr "Añade una clave API en la configuración del libro para ejecutar traducción."
 
+msgid "Add an API key to re-render"
+msgstr ""
+
 msgid "Add an API key to re-run"
 msgstr "Agrega una clave de API para re-ejecutar"
 
@@ -5695,6 +5698,9 @@ msgstr "Re-renderizar esta sección"
 msgid "Re-rendering..."
 msgstr "Volviendo a renderizar..."
 
+msgid "Re-rendering…"
+msgstr ""
+
 msgid "Re-run"
 msgstr "Re-ejecutar"
 
@@ -7012,6 +7018,9 @@ msgstr "Storyboard"
 
 msgid "Storyboard has already been run. Changes made here will not take effect until storyboard is re-run."
 msgstr "El storyboard ya se ejecutó. Los cambios realizados aquí no tendrán efecto hasta que se vuelva a ejecutar el storyboard."
+
+msgid "Storyboard is out of date"
+msgstr ""
 
 msgid "Storyboard not ready"
 msgstr "Storyboard no está listo"

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -831,7 +831,7 @@ msgid "Add an API key in Book settings to run translation."
 msgstr "Ajoutez une clé API dans les paramètres du livre pour exécuter la traduction."
 
 msgid "Add an API key to re-render"
-msgstr ""
+msgstr "Ajoutez une clé API pour relancer le rendu"
 
 msgid "Add an API key to re-run"
 msgstr "Ajoutez une clé API pour relancer"
@@ -5701,7 +5701,7 @@ msgid "Re-rendering..."
 msgstr "Re-rendu en cours..."
 
 msgid "Re-rendering…"
-msgstr ""
+msgstr "Re-rendu en cours…"
 
 msgid "Re-run"
 msgstr "Relancer"
@@ -7022,7 +7022,7 @@ msgid "Storyboard has already been run. Changes made here will not take effect u
 msgstr "Le scénarimage a déjà été exécuté. Les modifications effectuées ici ne prendront effet que lorsque le scénarimage sera relancé."
 
 msgid "Storyboard is out of date"
-msgstr ""
+msgstr "Le scénarimage n'est plus à jour"
 
 msgid "Storyboard not ready"
 msgstr "Storyboard non prêt"

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -830,6 +830,9 @@ msgstr "Ajoutez une clé API dans les paramètres du livre pour exécuter la gé
 msgid "Add an API key in Book settings to run translation."
 msgstr "Ajoutez une clé API dans les paramètres du livre pour exécuter la traduction."
 
+msgid "Add an API key to re-render"
+msgstr ""
+
 msgid "Add an API key to re-run"
 msgstr "Ajoutez une clé API pour relancer"
 
@@ -5697,6 +5700,9 @@ msgstr "Re-rendre cette section"
 msgid "Re-rendering..."
 msgstr "Re-rendu en cours..."
 
+msgid "Re-rendering…"
+msgstr ""
+
 msgid "Re-run"
 msgstr "Relancer"
 
@@ -7014,6 +7020,9 @@ msgstr "Scénarimage"
 
 msgid "Storyboard has already been run. Changes made here will not take effect until storyboard is re-run."
 msgstr "Le scénarimage a déjà été exécuté. Les modifications effectuées ici ne prendront effet que lorsque le scénarimage sera relancé."
+
+msgid "Storyboard is out of date"
+msgstr ""
 
 msgid "Storyboard not ready"
 msgstr "Storyboard non prêt"

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -829,7 +829,7 @@ msgid "Add an API key in Book settings to run translation."
 msgstr "Adicione uma chave de API nas configurações do Livro para executar tradução."
 
 msgid "Add an API key to re-render"
-msgstr ""
+msgstr "Adicione uma chave de API para renderizar novamente"
 
 msgid "Add an API key to re-run"
 msgstr "Adicione uma chave de API para reexecutar"
@@ -5699,7 +5699,7 @@ msgid "Re-rendering..."
 msgstr "Renderizando novamente..."
 
 msgid "Re-rendering…"
-msgstr ""
+msgstr "Renderizando novamente…"
 
 msgid "Re-run"
 msgstr "Reexecutar"
@@ -7020,7 +7020,7 @@ msgid "Storyboard has already been run. Changes made here will not take effect u
 msgstr "O storyboard já foi executado. As alterações feitas aqui não terão efeito até que o storyboard seja executado novamente."
 
 msgid "Storyboard is out of date"
-msgstr ""
+msgstr "O storyboard está desatualizado"
 
 msgid "Storyboard not ready"
 msgstr "Storyboard não está pronto"

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -828,6 +828,9 @@ msgstr "Adicione uma chave de API nas configurações do Livro para executar a g
 msgid "Add an API key in Book settings to run translation."
 msgstr "Adicione uma chave de API nas configurações do Livro para executar tradução."
 
+msgid "Add an API key to re-render"
+msgstr ""
+
 msgid "Add an API key to re-run"
 msgstr "Adicione uma chave de API para reexecutar"
 
@@ -5695,6 +5698,9 @@ msgstr "Rerenderizar esta seção"
 msgid "Re-rendering..."
 msgstr "Renderizando novamente..."
 
+msgid "Re-rendering…"
+msgstr ""
+
 msgid "Re-run"
 msgstr "Reexecutar"
 
@@ -7012,6 +7018,9 @@ msgstr "Storyboard"
 
 msgid "Storyboard has already been run. Changes made here will not take effect until storyboard is re-run."
 msgstr "O storyboard já foi executado. As alterações feitas aqui não terão efeito até que o storyboard seja executado novamente."
+
+msgid "Storyboard is out of date"
+msgstr ""
 
 msgid "Storyboard not ready"
 msgstr "Storyboard não está pronto"

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -830,7 +830,7 @@ msgid "Add an API key in Book settings to run translation."
 msgstr "Shto një çelës API në cilësimet e Librit për të ekzekutuar përkthimin."
 
 msgid "Add an API key to re-render"
-msgstr ""
+msgstr "Shto një çelës API për të ri-renderizuar"
 
 msgid "Add an API key to re-run"
 msgstr "Shto një çelës API për të ri-ekzekutuar"
@@ -5700,7 +5700,7 @@ msgid "Re-rendering..."
 msgstr "Po ri-renderizohet..."
 
 msgid "Re-rendering…"
-msgstr ""
+msgstr "Po ri-renderizohet…"
 
 msgid "Re-run"
 msgstr "Ri-ekzekuto"
@@ -7021,7 +7021,7 @@ msgid "Storyboard has already been run. Changes made here will not take effect u
 msgstr "Storyboard-i është ekzekutuar tashmë. Ndryshimet e bëra këtu nuk do të hyjnë në fuqi derisa storyboard-i të ri-ekzekutohet."
 
 msgid "Storyboard is out of date"
-msgstr ""
+msgstr "Storyboard-i nuk është i përditësuar"
 
 msgid "Storyboard not ready"
 msgstr "Storyboard-i nuk është gati"

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -829,6 +829,9 @@ msgstr "Shto një çelës API në cilësimet e Librit për të ekzekutuar gjener
 msgid "Add an API key in Book settings to run translation."
 msgstr "Shto një çelës API në cilësimet e Librit për të ekzekutuar përkthimin."
 
+msgid "Add an API key to re-render"
+msgstr ""
+
 msgid "Add an API key to re-run"
 msgstr "Shto një çelës API për të ri-ekzekutuar"
 
@@ -5696,6 +5699,9 @@ msgstr "Ri-renderizo këtë seksion"
 msgid "Re-rendering..."
 msgstr "Po ri-renderizohet..."
 
+msgid "Re-rendering…"
+msgstr ""
+
 msgid "Re-run"
 msgstr "Ri-ekzekuto"
 
@@ -7013,6 +7019,9 @@ msgstr "Storyboard"
 
 msgid "Storyboard has already been run. Changes made here will not take effect until storyboard is re-run."
 msgstr "Storyboard-i është ekzekutuar tashmë. Ndryshimet e bëra këtu nuk do të hyjnë në fuqi derisa storyboard-i të ri-ekzekutohet."
+
+msgid "Storyboard is out of date"
+msgstr ""
 
 msgid "Storyboard not ready"
 msgstr "Storyboard-i nuk është gati"

--- a/packages/pipeline/src/__tests__/propagate-sectioning-text.test.ts
+++ b/packages/pipeline/src/__tests__/propagate-sectioning-text.test.ts
@@ -309,13 +309,62 @@ describe("propagateSectioningTextToRendering", () => {
     expect(result.rendering.sections[1].html).toBe(stored.sections[1].html)
   })
 
-  it("handles an empty rendering without error", () => {
+  it("flags a section that has content but was never rendered", () => {
+    const sectioning: PageSectioningOutput = {
+      reasoning: "",
+      sections: [
+        section("pg001_sec001", [leaf("pg001_tx001", "Rendered")]),
+        section("pg001_sec002", [leaf("pg001_tx002", "Never rendered")]),
+      ],
+    }
+    const stored = rendering([
+      { sectionIndex: 0, html: html(`<p data-id="pg001_tx001">Rendered</p>`) },
+    ])
+
+    const result = propagateSectioningTextToRendering(sectioning, stored, LABEL)
+
+    expect(result.needsRerender).toBe(true)
+    expect(result.skipped.map((s) => s.sectionIndex)).toContain(1)
+  })
+
+  it("ignores an empty section the renderer skips by design", () => {
+    const sectioning: PageSectioningOutput = {
+      reasoning: "",
+      sections: [
+        section("pg001_sec001", [leaf("pg001_tx001", "Rendered")]),
+        section("pg001_sec002", []),
+      ],
+    }
+    const stored = rendering([
+      { sectionIndex: 0, html: html(`<p data-id="pg001_tx001">Rendered</p>`) },
+    ])
+
+    const result = propagateSectioningTextToRendering(sectioning, stored, LABEL)
+
+    expect(result.needsRerender).toBe(false)
+    expect(result.skipped).toEqual([])
+  })
+
+  // A rendering node that exists but has no sections is drift. The separate
+  // "page was never rendered" case is short-circuited by the caller.
+  it("reports drift when the rendering has no sections at all", () => {
     const sectioning: PageSectioningOutput = {
       reasoning: "",
       sections: [section("pg001_sec001", [leaf("pg001_tx001", "Text")])],
     }
     const result = propagateSectioningTextToRendering(
       sectioning,
+      { sections: [] },
+      LABEL
+    )
+
+    expect(result.changed).toBe(false)
+    expect(result.needsRerender).toBe(true)
+  })
+
+  it("stays quiet when neither side has content", () => {
+    const result = propagateSectioningTextToRendering(
+      { reasoning: "", sections: [] },
       { sections: [] },
       LABEL
     )

--- a/packages/pipeline/src/__tests__/propagate-sectioning-text.test.ts
+++ b/packages/pipeline/src/__tests__/propagate-sectioning-text.test.ts
@@ -362,6 +362,25 @@ describe("propagateSectioningTextToRendering", () => {
     expect(result.needsRerender).toBe(true)
   })
 
+  // A section whose stored HTML can't be parsed as a section is stale after an
+  // edit just like a structurally drifted one, and a re-render fixes both.
+  it("reports drift for HTML it cannot patch, rather than failing silently", () => {
+    const sectioning: PageSectioningOutput = {
+      reasoning: "",
+      sections: [section("pg001_sec001", [leaf("pg001_tx001", "Edited")])],
+    }
+    const stored = rendering([
+      { sectionIndex: 0, html: "<div>Legacy markup with no section</div>" },
+    ])
+
+    const result = propagateSectioningTextToRendering(sectioning, stored, LABEL)
+
+    expect(result.changed).toBe(false)
+    expect(result.needsRerender).toBe(true)
+    expect(result.skipped[0].reason).toBe("invalid")
+    expect(result.rendering.sections[0].html).toBe(stored.sections[0].html)
+  })
+
   it("stays quiet when neither side has content", () => {
     const result = propagateSectioningTextToRendering(
       { reasoning: "", sections: [] },

--- a/packages/pipeline/src/__tests__/propagate-sectioning-text.test.ts
+++ b/packages/pipeline/src/__tests__/propagate-sectioning-text.test.ts
@@ -1,0 +1,326 @@
+import { describe, it, expect } from "vitest"
+import type {
+  PageSectioningOutput,
+  PageSectioningSection,
+  WebRenderingOutput,
+} from "@adt/types"
+import { propagateSectioningTextToRendering } from "../propagate-sectioning-text.js"
+
+const LABEL = "test-book"
+
+function leaf(nodeId: string, text: string, role = "paragraph") {
+  return { nodeId, isPruned: false, role, text }
+}
+
+function section(
+  sectionId: string,
+  nodes: PageSectioningSection["nodes"]
+): PageSectioningSection {
+  return {
+    sectionId,
+    sectionType: "text",
+    backgroundColor: "#fff",
+    textColor: "#000",
+    pageNumber: 1,
+    isPruned: false,
+    nodes,
+  }
+}
+
+function html(body: string, sectionId = "pg001_sec001"): string {
+  return `<div class="container content" id="content"><section data-section-type="text" data-section-id="${sectionId}" class="space-y-6">${body}</section></div>`
+}
+
+function rendering(sections: Array<{ sectionIndex: number; html: string }>): WebRenderingOutput {
+  return {
+    sections: sections.map((s) => ({
+      sectionIndex: s.sectionIndex,
+      sectionType: "text",
+      reasoning: "",
+      html: s.html,
+    })),
+  }
+}
+
+describe("propagateSectioningTextToRendering", () => {
+  it("rewrites rendered text to match an edited section tree", () => {
+    const sectioning: PageSectioningOutput = {
+      reasoning: "",
+      sections: [
+        section("pg001_sec001", [
+          leaf("pg001_tx001", "Heading"),
+          leaf("pg001_tx002", "The user rewrote this sentence entirely."),
+        ]),
+      ],
+    }
+    const stored = rendering([
+      {
+        sectionIndex: 0,
+        html: html(
+          `<h1 data-id="pg001_tx001">Heading</h1><p data-id="pg001_tx002">Original body text.</p>`
+        ),
+      },
+    ])
+
+    const result = propagateSectioningTextToRendering(sectioning, stored, LABEL)
+
+    expect(result.changed).toBe(true)
+    expect(result.needsRerender).toBe(false)
+    expect(result.updatedSectionIndices).toEqual([0])
+    expect(result.rendering.sections[0].html).toContain(
+      "The user rewrote this sentence entirely."
+    )
+    expect(result.rendering.sections[0].html).not.toContain("Original body text.")
+  })
+
+  it("preserves surrounding markup, classes, and attributes", () => {
+    const sectioning: PageSectioningOutput = {
+      reasoning: "",
+      sections: [section("pg001_sec001", [leaf("pg001_tx001", "New copy")])],
+    }
+    const stored = rendering([
+      {
+        sectionIndex: 0,
+        html: html(
+          `<p class="text-lg leading-relaxed text-gray-800" data-id="pg001_tx001">Old copy</p>`
+        ),
+      },
+    ])
+
+    const result = propagateSectioningTextToRendering(sectioning, stored, LABEL)
+
+    const out = result.rendering.sections[0].html
+    expect(out).toContain('class="text-lg leading-relaxed text-gray-800"')
+    expect(out).toContain('data-section-type="text"')
+    expect(out).toContain('id="content"')
+    expect(out).toContain("New copy")
+  })
+
+  it("is a no-op when no text changed", () => {
+    const sectioning: PageSectioningOutput = {
+      reasoning: "",
+      sections: [section("pg001_sec001", [leaf("pg001_tx001", "Unchanged")])],
+    }
+    const stored = rendering([
+      { sectionIndex: 0, html: html(`<p data-id="pg001_tx001">Unchanged</p>`) },
+    ])
+
+    const result = propagateSectioningTextToRendering(sectioning, stored, LABEL)
+
+    expect(result.changed).toBe(false)
+    expect(result.updatedSectionIndices).toEqual([])
+    expect(result.skipped).toEqual([])
+    // Same object identity — callers can skip the write entirely.
+    expect(result.rendering).toBe(stored)
+  })
+
+  it("is idempotent", () => {
+    const sectioning: PageSectioningOutput = {
+      reasoning: "",
+      sections: [section("pg001_sec001", [leaf("pg001_tx001", "Edited")])],
+    }
+    const stored = rendering([
+      { sectionIndex: 0, html: html(`<p data-id="pg001_tx001">Original</p>`) },
+    ])
+
+    const first = propagateSectioningTextToRendering(sectioning, stored, LABEL)
+    const second = propagateSectioningTextToRendering(
+      sectioning,
+      first.rendering,
+      LABEL
+    )
+
+    expect(first.changed).toBe(true)
+    expect(second.changed).toBe(false)
+    expect(second.rendering.sections[0].html).toBe(
+      first.rendering.sections[0].html
+    )
+  })
+
+  it("flags a leaf added to the tree but absent from the HTML", () => {
+    const sectioning: PageSectioningOutput = {
+      reasoning: "",
+      sections: [
+        section("pg001_sec001", [
+          leaf("pg001_tx001", "Existing"),
+          leaf("pg001_tx002", "Newly added paragraph"),
+        ]),
+      ],
+    }
+    const stored = rendering([
+      { sectionIndex: 0, html: html(`<p data-id="pg001_tx001">Existing</p>`) },
+    ])
+
+    const result = propagateSectioningTextToRendering(sectioning, stored, LABEL)
+
+    expect(result.needsRerender).toBe(true)
+    expect(result.changed).toBe(false)
+    expect(result.skipped[0].reason).toBe("structural")
+    // The stale section is left exactly as it was rather than half-patched.
+    expect(result.rendering.sections[0].html).toBe(stored.sections[0].html)
+  })
+
+  it("flags a leaf removed from the tree but still in the HTML", () => {
+    const sectioning: PageSectioningOutput = {
+      reasoning: "",
+      sections: [section("pg001_sec001", [leaf("pg001_tx001", "Kept")])],
+    }
+    const stored = rendering([
+      {
+        sectionIndex: 0,
+        html: html(
+          `<p data-id="pg001_tx001">Kept</p><p data-id="pg001_tx002">Deleted</p>`
+        ),
+      },
+    ])
+
+    const result = propagateSectioningTextToRendering(sectioning, stored, LABEL)
+
+    expect(result.needsRerender).toBe(true)
+    expect(result.skipped[0].reason).toBe("structural")
+  })
+
+  it("treats a pruned node as structural drift", () => {
+    const sectioning: PageSectioningOutput = {
+      reasoning: "",
+      sections: [
+        section("pg001_sec001", [
+          leaf("pg001_tx001", "Kept"),
+          { nodeId: "pg001_tx002", isPruned: true, role: "paragraph", text: "Hidden" },
+        ]),
+      ],
+    }
+    const stored = rendering([
+      {
+        sectionIndex: 0,
+        html: html(
+          `<p data-id="pg001_tx001">Kept</p><p data-id="pg001_tx002">Hidden</p>`
+        ),
+      },
+    ])
+
+    const result = propagateSectioningTextToRendering(sectioning, stored, LABEL)
+
+    expect(result.needsRerender).toBe(true)
+  })
+
+  it("matches sections by sectionIndex, not array position", () => {
+    // The renderer skips sections with no renderable content, so rendering
+    // .sections is sparse: here only index 1 was rendered.
+    const sectioning: PageSectioningOutput = {
+      reasoning: "",
+      sections: [
+        section("pg001_sec001", []),
+        section("pg001_sec002", [leaf("pg001_tx002", "Second section, edited")]),
+      ],
+    }
+    const stored = rendering([
+      {
+        sectionIndex: 1,
+        html: html(`<p data-id="pg001_tx002">Second section</p>`, "pg001_sec002"),
+      },
+    ])
+
+    const result = propagateSectioningTextToRendering(sectioning, stored, LABEL)
+
+    expect(result.changed).toBe(true)
+    expect(result.updatedSectionIndices).toEqual([1])
+    expect(result.rendering.sections[0].html).toContain("Second section, edited")
+  })
+
+  it("updates only the edited section and leaves siblings untouched", () => {
+    const sectioning: PageSectioningOutput = {
+      reasoning: "",
+      sections: [
+        section("pg001_sec001", [leaf("pg001_tx001", "Untouched")]),
+        section("pg001_sec002", [leaf("pg001_tx002", "Changed")]),
+      ],
+    }
+    const stored = rendering([
+      { sectionIndex: 0, html: html(`<p data-id="pg001_tx001">Untouched</p>`) },
+      {
+        sectionIndex: 1,
+        html: html(`<p data-id="pg001_tx002">Before</p>`, "pg001_sec002"),
+      },
+    ])
+
+    const result = propagateSectioningTextToRendering(sectioning, stored, LABEL)
+
+    expect(result.updatedSectionIndices).toEqual([1])
+    expect(result.rendering.sections[0].html).toBe(stored.sections[0].html)
+    expect(result.rendering.sections[1].html).toContain("Changed")
+  })
+
+  it("does not treat image nodes as text", () => {
+    const sectioning: PageSectioningOutput = {
+      reasoning: "",
+      sections: [
+        section("pg001_sec001", [
+          { nodeId: "pg001_im001", isPruned: false, role: "image" },
+          leaf("pg001_tx001", "Caption-adjacent copy, edited"),
+        ]),
+      ],
+    }
+    const stored = rendering([
+      {
+        sectionIndex: 0,
+        html: html(
+          `<img data-id="pg001_im001" src="/api/books/test-book/images/pg001_im001" alt="" /><p data-id="pg001_tx001">Original</p>`
+        ),
+      },
+    ])
+
+    const result = propagateSectioningTextToRendering(sectioning, stored, LABEL)
+
+    expect(result.needsRerender).toBe(false)
+    expect(result.changed).toBe(true)
+    const out = result.rendering.sections[0].html
+    expect(out).toContain("Caption-adjacent copy, edited")
+    // The <img> keeps its original src — we pass no imageUrlPrefix, so the
+    // validator's src-rewriting pass never runs.
+    expect(out).toContain('src="/api/books/test-book/images/pg001_im001"')
+  })
+
+  it("leaves structurally sound sections alone when a sibling drifts", () => {
+    const sectioning: PageSectioningOutput = {
+      reasoning: "",
+      sections: [
+        section("pg001_sec001", [leaf("pg001_tx001", "Edited fine")]),
+        section("pg001_sec002", [
+          leaf("pg001_tx002", "Kept"),
+          leaf("pg001_tx003", "Added"),
+        ]),
+      ],
+    }
+    const stored = rendering([
+      { sectionIndex: 0, html: html(`<p data-id="pg001_tx001">Before</p>`) },
+      {
+        sectionIndex: 1,
+        html: html(`<p data-id="pg001_tx002">Kept</p>`, "pg001_sec002"),
+      },
+    ])
+
+    const result = propagateSectioningTextToRendering(sectioning, stored, LABEL)
+
+    expect(result.changed).toBe(true)
+    expect(result.needsRerender).toBe(true)
+    expect(result.updatedSectionIndices).toEqual([0])
+    expect(result.rendering.sections[0].html).toContain("Edited fine")
+    expect(result.rendering.sections[1].html).toBe(stored.sections[1].html)
+  })
+
+  it("handles an empty rendering without error", () => {
+    const sectioning: PageSectioningOutput = {
+      reasoning: "",
+      sections: [section("pg001_sec001", [leaf("pg001_tx001", "Text")])],
+    }
+    const result = propagateSectioningTextToRendering(
+      sectioning,
+      { sections: [] },
+      LABEL
+    )
+
+    expect(result.changed).toBe(false)
+    expect(result.needsRerender).toBe(false)
+  })
+})

--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -149,6 +149,12 @@ export {
 } from "./toc-generation.js"
 export { validateSectionHtml } from "./validate-html.js"
 export {
+  propagateSectioningTextToRendering,
+  type PropagateResult,
+  type SkippedSection,
+  type SectionSkipReason,
+} from "./propagate-sectioning-text.js"
+export {
   generateQuiz,
   generateAllQuizzes,
   buildQuizGenerationConfig,

--- a/packages/pipeline/src/propagate-sectioning-text.ts
+++ b/packages/pipeline/src/propagate-sectioning-text.ts
@@ -172,6 +172,21 @@ export function propagateSectioningTextToRendering(
     return { ...stored, html: outcome.html }
   })
 
+  // A section the renderer never produced HTML for is drift too. Empty sections
+  // are skipped at render time by design, so only flag ones that would actually
+  // have rendered something.
+  const renderedIndices = new Set(rendering.sections.map((s) => s.sectionIndex))
+  sectioning.sections.forEach((section, index) => {
+    if (renderedIndices.has(index)) return
+    const context = buildRenderContext(section, new Map(), label)
+    if (context.leaf_texts.length === 0 && context.image_refs.length === 0) return
+    skipped.push({
+      sectionIndex: index,
+      reason: "structural",
+      errors: [`No rendered section at index ${index}`],
+    })
+  })
+
   return {
     rendering: changed ? { ...rendering, sections: nextSections } : rendering,
     changed,

--- a/packages/pipeline/src/propagate-sectioning-text.ts
+++ b/packages/pipeline/src/propagate-sectioning-text.ts
@@ -34,7 +34,12 @@ export interface PropagateResult {
   updatedSectionIndices: number[]
   /** Sections that could not be updated, with the reason. */
   skipped: SkippedSection[]
-  /** True when any section drifted structurally and needs a re-render to resync. */
+  /**
+   * True when any section could not be brought in sync by substituting text.
+   * Covers both reasons: a re-render regenerates the section's HTML from the
+   * current tree, which resolves structural drift and replaces HTML that was
+   * too malformed to patch.
+   */
   needsRerender: boolean
 }
 
@@ -192,6 +197,9 @@ export function propagateSectioningTextToRendering(
     changed,
     updatedSectionIndices,
     skipped,
-    needsRerender: skipped.some((s) => s.reason === "structural"),
+    // Any skip leaves that section stale. Reporting only structural drift would
+    // let a section with unpatchable HTML fail silently — the user's edit saves,
+    // the storyboard keeps the old copy, and nothing says so.
+    needsRerender: skipped.length > 0,
   }
 }

--- a/packages/pipeline/src/propagate-sectioning-text.ts
+++ b/packages/pipeline/src/propagate-sectioning-text.ts
@@ -1,0 +1,182 @@
+import type {
+  PageSectioningOutput,
+  PageSectioningSection,
+  SectionRendering,
+  WebRenderingOutput,
+} from "@adt/types"
+import { buildRenderContext } from "./web-rendering.js"
+import { collectOptionalTextIds } from "./render-llm.js"
+import { validateSectionHtml } from "./validate-html.js"
+
+/**
+ * Why a section could not have its text propagated.
+ *
+ * - `structural`: the section tree and the rendered HTML no longer describe the
+ *   same set of leaves (a node was added, deleted, pruned, or re-roled). Text
+ *   substitution cannot express that — the section must be re-rendered.
+ * - `invalid`: the stored HTML has a problem unrelated to our edit. We leave it
+ *   untouched rather than write over a section we don't understand.
+ */
+export type SectionSkipReason = "structural" | "invalid"
+
+export interface SkippedSection {
+  sectionIndex: number
+  reason: SectionSkipReason
+  errors: string[]
+}
+
+export interface PropagateResult {
+  /** Rendering with updated text. Same object identity as the input when nothing changed. */
+  rendering: WebRenderingOutput
+  /** True when at least one section's HTML was rewritten. */
+  changed: boolean
+  /** Section indices whose HTML now carries the edited text. */
+  updatedSectionIndices: number[]
+  /** Sections that could not be updated, with the reason. */
+  skipped: SkippedSection[]
+  /** True when any section drifted structurally and needs a re-render to resync. */
+  needsRerender: boolean
+}
+
+/**
+ * Errors that mean "the rendered text differs from the source text".
+ *
+ * This is the expected, benign case here: the user just changed the source
+ * text, so of course the stored HTML no longer matches it. The validator
+ * reports the mismatch *and* substitutes the correct text anyway, which is
+ * precisely the behaviour we want.
+ */
+const TEXT_MISMATCH_PREFIX = "Text mismatch for data-id"
+
+/**
+ * Errors that mean the tree and the HTML disagree about which leaves exist.
+ * Substituting text cannot reconcile this; only a re-render can.
+ */
+const STRUCTURAL_PREFIXES = [
+  "Missing required text data-id",
+  "Unknown data-id",
+]
+
+function classify(errors: string[]): SectionSkipReason | null {
+  let structural = false
+  for (const err of errors) {
+    if (err.startsWith(TEXT_MISMATCH_PREFIX)) continue
+    if (STRUCTURAL_PREFIXES.some((p) => err.startsWith(p))) {
+      structural = true
+      continue
+    }
+    // Anything else is a pre-existing defect in the stored HTML.
+    return "invalid"
+  }
+  return structural ? "structural" : null
+}
+
+/**
+ * Rewrite one stored section's HTML so its text matches the section tree.
+ * Returns null when the section cannot be safely updated.
+ */
+function propagateSection(
+  section: PageSectioningSection,
+  stored: SectionRendering,
+  label: string
+): { html: string } | { skip: SectionSkipReason; errors: string[] } {
+  // Images only contribute their ids here — the base64/dimension payload is
+  // irrelevant because we never re-render, and passing no prefix leaves the
+  // stored <img src> attributes untouched.
+  const context = buildRenderContext(section, new Map(), label)
+
+  const result = validateSectionHtml(
+    stored.html,
+    context.leaf_texts.map((t) => t.text_id),
+    context.image_refs.map((i) => i.image_id),
+    undefined,
+    {
+      // We are patching HTML that was already accepted at render time, not
+      // gating new content. Allowing `activity_gen_*` ids keeps activity
+      // sections from being misread as structural drift; it cannot admit bad
+      // markup, because nothing new is being introduced here.
+      allowActivityGeneratedIds: true,
+      allowedContainerIds: context.group_ids,
+      expectedTexts: new Map(
+        context.leaf_texts.map((t) => [t.text_id, t.text])
+      ),
+      optionalTextIds: collectOptionalTextIds(context.leaf_texts),
+      // Deliberately no expectedSectionType/expectedSectionId: we already know
+      // which section this is (matched by sectionIndex), and asserting them
+      // would fail on books whose sectionIds were renumbered by a split/merge.
+    }
+  )
+
+  const skip = classify(result.errors)
+  if (skip) return { skip, errors: result.errors }
+  if (!result.sectionHtml) {
+    return { skip: "invalid", errors: ["Validator returned no HTML"] }
+  }
+  return { html: result.sectionHtml }
+}
+
+/**
+ * Propagate edited sectioning text into an already-rendered storyboard.
+ *
+ * The rendered HTML stored in `web-rendering` is a snapshot of the sectioning
+ * text taken at render time, with each leaf's `nodeId` emitted as a `data-id`
+ * attribute. Editing text in the Sectioning stage therefore leaves the
+ * storyboard showing stale copy until the page is re-rendered.
+ *
+ * Rather than re-render (an LLM call that also discards the layout the renderer
+ * produced), we reuse the substitution pass the renderer already applies to
+ * fresh LLM output: `validateSectionHtml` rewrites each `[data-id]` element's
+ * text to match the source tree. Running it over stored HTML is idempotent, so
+ * sections whose text did not change come back byte-identical.
+ *
+ * Sections that drifted structurally cannot be reconciled this way and are
+ * reported via `needsRerender` instead.
+ */
+export function propagateSectioningTextToRendering(
+  sectioning: PageSectioningOutput,
+  rendering: WebRenderingOutput,
+  label: string
+): PropagateResult {
+  const updatedSectionIndices: number[] = []
+  const skipped: SkippedSection[] = []
+  let changed = false
+
+  const nextSections = rendering.sections.map((stored) => {
+    // `sectionIndex` indexes into sectioning.sections, but rendering.sections
+    // is sparse — the renderer skips sections with no renderable content — so
+    // match on the value rather than array position.
+    const section = sectioning.sections[stored.sectionIndex]
+    if (!section) {
+      skipped.push({
+        sectionIndex: stored.sectionIndex,
+        reason: "structural",
+        errors: [`No sectioning section at index ${stored.sectionIndex}`],
+      })
+      return stored
+    }
+
+    const outcome = propagateSection(section, stored, label)
+    if ("skip" in outcome) {
+      skipped.push({
+        sectionIndex: stored.sectionIndex,
+        reason: outcome.skip,
+        errors: outcome.errors,
+      })
+      return stored
+    }
+
+    if (outcome.html === stored.html) return stored
+
+    changed = true
+    updatedSectionIndices.push(stored.sectionIndex)
+    return { ...stored, html: outcome.html }
+  })
+
+  return {
+    rendering: changed ? { ...rendering, sections: nextSections } : rendering,
+    changed,
+    updatedSectionIndices,
+    skipped,
+    needsRerender: skipped.some((s) => s.reason === "structural"),
+  }
+}


### PR DESCRIPTION
Closes #515.

Text edited in the Sectioning stage never reached the Storyboard. `SectionRendering.html` is a frozen snapshot of the sectioning text taken at render time, with each leaf's `nodeId` emitted as a `data-id`, and the storyboard preview reads only that snapshot — nothing re-reads `ContentNodeData.text`.

`PUT /books/:label/pages/:pageId/sectioning` wrote the new tree and called `clearCaptionData`, whose comment claims the change "cascades to everything downstream", but its node list doesn't include `web-rendering`. The result was visibly inconsistent rather than merely stale: the storyboard's sidebar previews are computed live from the tree server-side, so the sidebar updated while the rendered preview didn't.

## Approach

Rather than re-render — an LLM call that also discards the layout the renderer produced — this reuses the substitution pass the renderer already applies to fresh LLM output. `validateSectionHtml` rewrites each `[data-id]` element's text to match the source tree; the sectioning editor was simply the one write path that never invoked it.

Running that pass over stored HTML turns out to be idempotent, so untouched sections come back byte-identical and sections we didn't mean to touch can't be corrupted. It also inherits the existing edge-case handling for free: fill-in-the-blank markers, textbook placeholders, container ids with nested children, entity repair.

Structural edits (a leaf added, deleted, pruned, or re-roled) can't be expressed as a text substitution. Those sections are left alone, and the UI offers a re-render of just the affected sections.

## Changes

- `packages/pipeline/src/propagate-sectioning-text.ts` — new pure function that walks a page's stored sections and rewrites their text to match the tree, classifying anything it can't reconcile.
- `apps/api/src/routes/pages.ts` — wired into the sectioning save. Page-scoped: `clearNodesByType` is book-wide and would discard every other page's rendering over a one-word edit. Propagation is best-effort and wrapped so it can never turn an already-committed save into an error, and every skipped section is logged.
- `apps/studio/.../SectioningPageDetail.tsx` — "Storyboard is out of date" notice with a targeted re-render, driven by the task list so it reflects when the render actually finishes rather than when it was queued.

## Notes for review

Fixed-layout pages are skipped deliberately. They render from `fixed-layout-sectioning`, a positioned tree built from extraction draw-items, so the semantic tree's node ids never appear in their HTML and a re-render wouldn't help either. That gap is written up as [4] in #580.

Sections whose stored HTML can't be parsed are reported rather than silently skipped. An earlier iteration skipped them without a signal, which reproduced the original bug invisibly.

The remaining scope — surfacing drift on page load, the duplicate `web-rendering` write on the storyboard save path, and the book-wide `clearCaptionData` blast radius — is split out into #580.

## Testing

- 15 unit tests covering propagation, idempotency, structural drift in both directions, pruning, sparse `sectionIndex` matching, image leaves, and unpatchable HTML.
- 7 API integration tests against real SQLite storage, covering the propagation itself, per-page blast radius, the rendering version bump that busts the preview iframe cache, fixed-layout skipping, and that an unreadable rendering node still saves cleanly.
- Full suite shows no regressions against develop. The PDF-extraction, accessibility-assessment and studio-settings failures present on this branch are pre-existing and flaky — develop fails the same set, and counts vary run to run.

Not yet verified against a real rendered book — there's no book data in my checkout, so everything is synthetic fixtures plus API-level integration. Worth a manual pass on a book with activity sections in particular, since those carry `activity_gen_*` ids the propagation treats permissively.
