### PR TITLE
fix(storyboard): avoid vertical clipping in scaled preview

### DIFF
--- a/apps/studio/src/components/pipeline/stages/storyboard/components/BookPreviewFrame.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/BookPreviewFrame.tsx
@@ -850,7 +850,8 @@ ${selectors}:hover {
       className={className}
       style={{
         height: visibleHeight,
-        overflow: "hidden",
+        overflowX: "hidden",
+        overflowY: "visible",
         display: "flex",
         justifyContent: "center",
       }}


### PR DESCRIPTION
## Summary
- avoid clipping Storyboard preview content on the vertical axis
- keep horizontal clipping to prevent scaled iframe overflow
- preserve existing scaling behavior while matching Preview/Export visibility better

## Change
- `BookPreviewFrame` wrapper style changed from `overflow: hidden` to:
  - `overflowX: "hidden"`
  - `overflowY: "visible"`

## Why
Storyboard renders scaled iframe content. With full `overflow: hidden`, some layouts could be visually cut in Storyboard while still rendering correctly in Preview/Export.

## Validation
- `pnpm typecheck` ✅
- `pnpm lint` ❌ (`eslint` command not available in local environment)
- `pnpm test` ❌ (pre-existing failing tests unrelated to this change)

## Issue
Closes #585