### PR TITLE
feat(speech): add Jamaican English (en-jm) accent

### DIFF
--- a/config/speech_instructions.yaml
+++ b/config/speech_instructions.yaml
@@ -1,5 +1,8 @@
 default: Speak in a cheerful and positive tone.
 en: Speak in a cheerful and positive tone.
+en-jm: |-
+  Speak it in a Jamaican English accent. Use the pronunciation and
+  intonation typical of Jamaica. Maintain a calm, conversational and positive tone.
 sq: |
   Style: Warm, natural, child-friendly conversational cadence at a calm, measured pace.
   Accent: Speak in an authentic Albanian accent native to Pristina, Kosovo. Use Gheg


### PR DESCRIPTION
Adds a Jamaican English accent as a new `en-jm` entry in `config/speech_instructions.yaml`:

```yaml
en-jm: |-
  Speak it in a Jamaican English accent. Use the pronunciation and
  intonation typical of Jamaica. Maintain a calm, conversational and positive tone.
```

The generic `en` prompt is unchanged — this only applies to books that route an output language to `en-jm`, mirroring the existing regional entries (`en-tz`, `es-uy`, …). Config-only, +3 lines.
