### PR TITLE
feat(studio): warn when Easy Read / Language used with Fixed Layout

### DIFF
--- a/apps/studio/src/components/pipeline/components/FixedLayoutWarning.tsx
+++ b/apps/studio/src/components/pipeline/components/FixedLayoutWarning.tsx
@@ -1,0 +1,35 @@
+import { Trans } from "@lingui/react/macro"
+import { LandingPageWarning } from "./LandingPageWarning"
+
+/**
+ * Shared copy for stages whose feature does not support the fixed-layout
+ * rendering mode. Kept in one place so the inline banner and the pre-run
+ * confirmation modal stay in sync (and translate once).
+ */
+export function FixedLayoutWarningTitle() {
+  return <Trans>Not compatible with Fixed Layout</Trans>
+}
+
+export function FixedLayoutWarningDescription() {
+  return (
+    <Trans>
+      This feature is not compatible with Fixed Layout. If you proceed, you may
+      get undesirable results.
+    </Trans>
+  )
+}
+
+/**
+ * Inline warning banner shown on a stage landing page when the book renders in
+ * fixed-layout mode. Renders nothing unless `show` is true.
+ */
+export function FixedLayoutWarningBanner({ show }: { show: boolean }) {
+  return (
+    <LandingPageWarning
+      show={show}
+      variant="prereq"
+      title={<FixedLayoutWarningTitle />}
+      description={<FixedLayoutWarningDescription />}
+    />
+  )
+}

--- a/apps/studio/src/components/pipeline/components/FixedLayoutWarning.tsx
+++ b/apps/studio/src/components/pipeline/components/FixedLayoutWarning.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react"
 import { Trans } from "@lingui/react/macro"
 import { LandingPageWarning } from "./LandingPageWarning"
 
@@ -20,16 +21,39 @@ export function FixedLayoutWarningDescription() {
 }
 
 /**
- * Inline warning banner shown on a stage landing page when the book renders in
- * fixed-layout mode. Renders nothing unless `show` is true.
+ * Language-specific copy: on fixed-layout books, translating the original into
+ * additional languages is unsupported — running translation with only the
+ * original language is fine.
  */
-export function FixedLayoutWarningBanner({ show }: { show: boolean }) {
+export function FixedLayoutExtraLanguagesDescription() {
+  return (
+    <Trans>
+      Adding languages beyond the original is not compatible with Fixed Layout.
+      If you proceed, you may get undesirable results.
+    </Trans>
+  )
+}
+
+/**
+ * Inline warning banner shown when the book renders in fixed-layout mode.
+ * Defaults to the generic feature-incompatibility copy; pass `title` /
+ * `description` to override. Renders nothing unless `show` is true.
+ */
+export function FixedLayoutWarningBanner({
+  show,
+  title = <FixedLayoutWarningTitle />,
+  description = <FixedLayoutWarningDescription />,
+}: {
+  show: boolean
+  title?: ReactNode
+  description?: ReactNode
+}) {
   return (
     <LandingPageWarning
       show={show}
       variant="prereq"
-      title={<FixedLayoutWarningTitle />}
-      description={<FixedLayoutWarningDescription />}
+      title={title}
+      description={description}
     />
   )
 }

--- a/apps/studio/src/components/pipeline/components/LandingPageShell.tsx
+++ b/apps/studio/src/components/pipeline/components/LandingPageShell.tsx
@@ -17,6 +17,7 @@ import { BOOK_LEVEL_STAGES, type StageName } from "@adt/types"
 import { PartialMergeNotice } from "@/components/parts/PartialMergeNotice"
 import { getStageLabelI18n } from "../pipeline-i18n"
 import { CascadeResetDialog } from "./CascadeResetDialog"
+import { RunWarningDialog } from "./RunWarningDialog"
 
 export function LandingPageShell({
   bookLabel,
@@ -38,6 +39,7 @@ export function LandingPageShell({
   previewBodyClassName,
   onRun,
   preview,
+  runWarning,
   hideRunButton = false,
   hideAdvancedSettings = false,
   hideFooter = false,
@@ -62,12 +64,19 @@ export function LandingPageShell({
   previewBodyClassName?: string
   onRun: () => void
   preview: ReactNode
+  /**
+   * When set, pressing Run first shows an advisory warning modal (e.g. the
+   * feature is incompatible with the book's fixed-layout mode). The user can
+   * cancel or proceed. Omit/leave null when there's nothing to warn about.
+   */
+  runWarning?: { title: ReactNode; description: ReactNode } | null
   hideRunButton?: boolean
   hideAdvancedSettings?: boolean
   hideFooter?: boolean
   children: ReactNode
 }) {
   const [confirmOpen, setConfirmOpen] = useState(false)
+  const [warnOpen, setWarnOpen] = useState(false)
   const downstreamAffected = useDownstreamWithOutput(stageSlug)
   const needsConfirmation = isCompleted && downstreamAffected.length > 0
   const { isCancelling, cancelRun } = useBookRun()
@@ -84,12 +93,27 @@ export function LandingPageShell({
   const isDisabled = isRunning || !canRun || extraDisabled
   const showTooltip = isDisabled && !isRunning && !!disabledReason
 
-  const handleRunClick = () => {
+  // Run gates, applied outermost-first: fixed-layout (or other) warning, then
+  // the cascade-reset confirmation, then the run itself.
+  const proceedRun = () => {
     if (needsConfirmation) {
       setConfirmOpen(true)
     } else {
       onRun()
     }
+  }
+
+  const handleRunClick = () => {
+    if (runWarning) {
+      setWarnOpen(true)
+    } else {
+      proceedRun()
+    }
+  }
+
+  const handleWarnConfirm = () => {
+    setWarnOpen(false)
+    proceedRun()
   }
 
   const handleConfirm = () => {
@@ -219,6 +243,17 @@ export function LandingPageShell({
         confirmColorClass={hasError ? errorColorClass : colorClass}
         onConfirm={handleConfirm}
       />
+
+      {runWarning && (
+        <RunWarningDialog
+          open={warnOpen}
+          onOpenChange={setWarnOpen}
+          title={runWarning.title}
+          description={runWarning.description}
+          confirmColorClass={hasError ? errorColorClass : colorClass}
+          onConfirm={handleWarnConfirm}
+        />
+      )}
     </div>
   )
 }

--- a/apps/studio/src/components/pipeline/components/RunWarningDialog.tsx
+++ b/apps/studio/src/components/pipeline/components/RunWarningDialog.tsx
@@ -1,0 +1,80 @@
+import type { ReactNode } from "react"
+import { Play, TriangleAlert } from "lucide-react"
+import { Trans } from "@lingui/react/macro"
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+
+/**
+ * Confirmation modal shown before running a stage when the current settings are
+ * likely to produce poor results (e.g. running a feature that doesn't support
+ * the book's fixed-layout rendering mode). Purely advisory — the user can
+ * always proceed. The caller supplies the warning copy; the confirm button
+ * reuses the stage accent color so it reads as "run this stage anyway".
+ */
+export function RunWarningDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmColorClass,
+  onConfirm,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  title: ReactNode
+  description: ReactNode
+  confirmColorClass: string
+  onConfirm: () => void
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="gap-5 p-6 sm:max-w-md">
+        <DialogHeader className="flex-row items-start gap-3.5 space-y-0 text-left">
+          <span
+            className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-amber-100 shadow-sm"
+            aria-hidden
+          >
+            <TriangleAlert className="h-5 w-5 text-amber-600" strokeWidth={2} />
+          </span>
+          <div className="flex min-w-0 flex-col gap-1 pt-0.5">
+            <DialogTitle className="text-[16px] font-semibold leading-tight tracking-tight text-[#0a0a0a]">
+              {title}
+            </DialogTitle>
+            <DialogDescription className="text-[13px] leading-snug text-[#525252]">
+              {description}
+            </DialogDescription>
+          </div>
+        </DialogHeader>
+
+        <div className="-mx-6 border-t border-[#f1f1f1]" aria-hidden />
+        <DialogFooter className="-mt-1 gap-2">
+          <Button
+            variant="ghost"
+            onClick={() => onOpenChange(false)}
+            className="h-10 px-4 font-medium text-[#525252] hover:text-[#0a0a0a]"
+          >
+            <Trans>Cancel</Trans>
+          </Button>
+          <Button
+            onClick={onConfirm}
+            className={cn(
+              "h-10 px-5 font-medium text-white border-0 shadow-sm",
+              confirmColorClass,
+            )}
+          >
+            <Play className="w-4 h-4 mr-2" />
+            <Trans>Run anyway</Trans>
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/studio/src/components/pipeline/stages/easy-read/EasyReadLandingPage.tsx
+++ b/apps/studio/src/components/pipeline/stages/easy-read/EasyReadLandingPage.tsx
@@ -2,7 +2,13 @@ import { ArrowDown, PencilLine, ToggleRight, History } from "lucide-react"
 import { Trans, useLingui } from "@lingui/react/macro"
 import { LandingPageShell } from "@/components/pipeline/components/LandingPageShell"
 import { PrereqGuard } from "@/components/pipeline/components/PrereqGuard"
+import {
+  FixedLayoutWarningBanner,
+  FixedLayoutWarningTitle,
+  FixedLayoutWarningDescription,
+} from "@/components/pipeline/components/FixedLayoutWarning"
 import { useStageStatus } from "@/hooks/use-stage-status"
+import { useIsFixedLayout } from "@/hooks/use-fixed-layout"
 import { useRunEasyRead } from "./use-run-easy-read"
 
 export function EasyReadLandingPage({ bookLabel }: { bookLabel: string }) {
@@ -10,6 +16,7 @@ export function EasyReadLandingPage({ bookLabel }: { bookLabel: string }) {
   const { runEasyRead, hasApiKey } = useRunEasyRead(bookLabel)
   const status = useStageStatus("easy-read")
   const storyboardReady = useStageStatus("storyboard").isCompleted
+  const isFixedLayout = useIsFixedLayout(bookLabel)
 
   const disabledReason = !hasApiKey ? (
     <Trans>Add an API key in Book settings to generate Easy Read content.</Trans>
@@ -36,7 +43,17 @@ export function EasyReadLandingPage({ bookLabel }: { bookLabel: string }) {
       previewLabel={t`Easy Read Preview`}
       onRun={() => void runEasyRead()}
       preview={<EasyReadPreview />}
+      runWarning={
+        isFixedLayout
+          ? {
+              title: <FixedLayoutWarningTitle />,
+              description: <FixedLayoutWarningDescription />,
+            }
+          : null
+      }
     >
+      <FixedLayoutWarningBanner show={isFixedLayout} />
+
       <div className="flex flex-col gap-2">
         <h1 className="text-[26px] font-semibold leading-tight tracking-tight text-[#0a0a0a]">
           <Trans>Easy Read</Trans>

--- a/apps/studio/src/components/pipeline/stages/languages/LanguageLandingPage.tsx
+++ b/apps/studio/src/components/pipeline/stages/languages/LanguageLandingPage.tsx
@@ -8,7 +8,7 @@ import { PrereqGuard } from "@/components/pipeline/components/PrereqGuard"
 import {
   FixedLayoutWarningBanner,
   FixedLayoutWarningTitle,
-  FixedLayoutWarningDescription,
+  FixedLayoutExtraLanguagesDescription,
 } from "@/components/pipeline/components/FixedLayoutWarning"
 import {
   SettingsCard,
@@ -158,6 +158,11 @@ export function LanguageLandingPage({ bookLabel }: { bookLabel: string }) {
   }
 
   const hasLanguages = outputLanguages.size > 0
+  // Fixed layout only breaks when translating the original into *additional*
+  // languages — running translation with just the original language is fine.
+  const hasAdditionalLanguages = Array.from(outputLanguages).some(
+    (code) => normalizeLocale(code) !== baseLanguage,
+  )
 
   const disabledReason = !hasApiKey ? (
     <Trans>Add an API key in Book settings to run translation.</Trans>
@@ -193,16 +198,14 @@ export function LanguageLandingPage({ bookLabel }: { bookLabel: string }) {
         />
       }
       runWarning={
-        isFixedLayout
+        isFixedLayout && hasAdditionalLanguages
           ? {
               title: <FixedLayoutWarningTitle />,
-              description: <FixedLayoutWarningDescription />,
+              description: <FixedLayoutExtraLanguagesDescription />,
             }
           : null
       }
     >
-      <FixedLayoutWarningBanner show={isFixedLayout} />
-
       <div className="flex flex-col gap-2">
         <h1 className="text-[26px] font-semibold leading-tight tracking-tight text-[#0a0a0a]">
           <Trans>Language</Trans>
@@ -266,6 +269,10 @@ export function LanguageLandingPage({ bookLabel }: { bookLabel: string }) {
               multiple
               renderBadges={false}
               label={t`Add language`}
+            />
+            <FixedLayoutWarningBanner
+              show={isFixedLayout}
+              description={<FixedLayoutExtraLanguagesDescription />}
             />
           </div>
         </SettingsField>

--- a/apps/studio/src/components/pipeline/stages/languages/LanguageLandingPage.tsx
+++ b/apps/studio/src/components/pipeline/stages/languages/LanguageLandingPage.tsx
@@ -6,11 +6,17 @@ import { Trans, useLingui } from "@lingui/react/macro"
 import { LandingPageShell } from "@/components/pipeline/components/LandingPageShell"
 import { PrereqGuard } from "@/components/pipeline/components/PrereqGuard"
 import {
+  FixedLayoutWarningBanner,
+  FixedLayoutWarningTitle,
+  FixedLayoutWarningDescription,
+} from "@/components/pipeline/components/FixedLayoutWarning"
+import {
   SettingsCard,
   SettingsField,
 } from "@/components/pipeline/components/SettingsCard"
 import { LanguagePicker } from "@/components/LanguagePicker"
 import { useActiveConfig } from "@/hooks/use-debug"
+import { useIsFixedLayout } from "@/hooks/use-fixed-layout"
 import { useStageStatus } from "@/hooks/use-stage-status"
 import { useBookRun } from "@/hooks/use-book-run"
 import { useApiKey } from "@/hooks/use-api-key"
@@ -39,6 +45,7 @@ export function LanguageLandingPage({ bookLabel }: { bookLabel: string }) {
   const storyboardReady = storyboardStatus.isCompleted
   const captionsStatus = useStageStatus("captions")
   const captionsReady = captionsStatus.isCompleted
+  const isFixedLayout = useIsFixedLayout(bookLabel)
 
   const [outputLanguages, setOutputLanguages] = useState<Set<string>>(new Set())
   const [selectedImageIds, setSelectedImageIds] = useState<string[]>([])
@@ -185,7 +192,17 @@ export function LanguageLandingPage({ bookLabel }: { bookLabel: string }) {
           imageCount={selectedImageIds.length}
         />
       }
+      runWarning={
+        isFixedLayout
+          ? {
+              title: <FixedLayoutWarningTitle />,
+              description: <FixedLayoutWarningDescription />,
+            }
+          : null
+      }
     >
+      <FixedLayoutWarningBanner show={isFixedLayout} />
+
       <div className="flex flex-col gap-2">
         <h1 className="text-[26px] font-semibold leading-tight tracking-tight text-[#0a0a0a]">
           <Trans>Language</Trans>

--- a/apps/studio/src/hooks/use-fixed-layout.ts
+++ b/apps/studio/src/hooks/use-fixed-layout.ts
@@ -1,0 +1,12 @@
+import { useActiveConfig } from "@/hooks/use-debug"
+import { isFixedLayoutConfig } from "@/lib/render-strategy"
+
+/**
+ * Whether the book renders in fixed-layout mode, derived from the merged
+ * config. Returns `false` until the config has loaded, so callers never flash a
+ * false-positive warning. See {@link isFixedLayoutConfig} for the predicate.
+ */
+export function useIsFixedLayout(label: string): boolean {
+  const { data } = useActiveConfig(label)
+  return isFixedLayoutConfig(data?.merged)
+}

--- a/apps/studio/src/lib/render-strategy.test.ts
+++ b/apps/studio/src/lib/render-strategy.test.ts
@@ -59,6 +59,38 @@ describe("isFixedLayoutConfig", () => {
     expect(isFixedLayoutConfig(null)).toBe(false)
   })
 
+  it("is false for every non-fixed book type (the fixed_layout entry is only an available option)", () => {
+    // A real book's render_strategies map always lists fixed_layout as an
+    // available option — but the warning must only fire when it is the SELECTED
+    // strategy. Every other book type must resolve to false.
+    const fullStrategies = {
+      single_column: { render_type: "template" },
+      llm: { render_type: "llm" },
+      "llm-overlay": { render_type: "llm" },
+      two_column: { render_type: "template" },
+      two_column_story: { render_type: "template" },
+      fixed_layout: { render_type: "fixed_layout" },
+    }
+    for (const selected of [
+      "single_column",
+      "llm",
+      "llm-overlay",
+      "two_column",
+      "two_column_story",
+      "dynamic", // legacy sentinel
+      "", // unset
+    ]) {
+      expect(
+        isFixedLayoutConfig({
+          default_render_strategy: selected,
+          render_strategies: fullStrategies,
+        })
+      ).toBe(false)
+    }
+    // Config with no strategy fields at all.
+    expect(isFixedLayoutConfig({})).toBe(false)
+  })
+
   it("is true when the book-wide default resolves to fixed_layout", () => {
     expect(
       isFixedLayoutConfig({

--- a/apps/studio/src/lib/render-strategy.test.ts
+++ b/apps/studio/src/lib/render-strategy.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 import {
+  isFixedLayoutConfig,
   listDefaultRenderStrategies,
   listSelectableRenderStrategies,
   normalizeDefaultRenderStrategy,
@@ -43,6 +44,56 @@ describe("listDefaultRenderStrategies", () => {
       "two_column",
       "fixed_layout",
     ])
+  })
+})
+
+describe("isFixedLayoutConfig", () => {
+  const strategies = {
+    llm: { render_type: "llm" },
+    two_column: { render_type: "template" },
+    fixed_layout: { render_type: "fixed_layout" },
+  }
+
+  it("returns false for nullish config", () => {
+    expect(isFixedLayoutConfig(undefined)).toBe(false)
+    expect(isFixedLayoutConfig(null)).toBe(false)
+  })
+
+  it("is true when the book-wide default resolves to fixed_layout", () => {
+    expect(
+      isFixedLayoutConfig({
+        default_render_strategy: "fixed_layout",
+        render_strategies: strategies,
+      })
+    ).toBe(true)
+  })
+
+  it("is false when the default resolves to a reflowable strategy", () => {
+    expect(
+      isFixedLayoutConfig({
+        default_render_strategy: "two_column",
+        render_strategies: strategies,
+      })
+    ).toBe(false)
+  })
+
+  it("is true when any per-section strategy is fixed_layout", () => {
+    expect(
+      isFixedLayoutConfig({
+        default_render_strategy: "two_column",
+        render_strategies: strategies,
+        section_render_strategies: { chapter: "two_column", cover: "fixed_layout" },
+      })
+    ).toBe(true)
+  })
+
+  it("is false when a fixed_layout strategy exists but nothing references it", () => {
+    expect(
+      isFixedLayoutConfig({
+        default_render_strategy: "two_column",
+        render_strategies: strategies,
+      })
+    ).toBe(false)
   })
 })
 

--- a/apps/studio/src/lib/render-strategy.ts
+++ b/apps/studio/src/lib/render-strategy.ts
@@ -39,6 +39,39 @@ export function chooseDefaultRenderStrategyFallback(
   return selectable[0] ?? ""
 }
 
+/**
+ * Whether the book renders in fixed-layout mode. Mirrors the server-side
+ * `isFixedLayoutBook` (packages/pipeline/src/fixed-layout-rendering.ts): a book
+ * is fixed-layout if its book-wide default OR any per-section strategy resolves
+ * to a `fixed_layout`-typed render strategy. The frontend can't import the
+ * pipeline package (layer rule), so this replicates the same predicate over the
+ * merged config record from `useActiveConfig`.
+ */
+export function isFixedLayoutConfig(
+  merged: Record<string, unknown> | undefined | null
+): boolean {
+  if (!merged) return false
+  const strategies = (
+    merged.render_strategies && typeof merged.render_strategies === "object"
+      ? merged.render_strategies
+      : {}
+  ) as RenderStrategyMap
+  const names = new Set<string>()
+  if (typeof merged.default_render_strategy === "string") {
+    names.add(merged.default_render_strategy)
+  }
+  const sectionStrategies = merged.section_render_strategies
+  if (sectionStrategies && typeof sectionStrategies === "object") {
+    for (const name of Object.values(sectionStrategies as Record<string, unknown>)) {
+      if (typeof name === "string") names.add(name)
+    }
+  }
+  for (const name of names) {
+    if (strategies[name]?.render_type === "fixed_layout") return true
+  }
+  return false
+}
+
 export function normalizeDefaultRenderStrategy(
   requested: string | null | undefined,
   strategies: RenderStrategyMap

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -963,6 +963,9 @@ msgstr "Added"
 msgid "Added manually"
 msgstr "Added manually"
 
+msgid "Adding languages beyond the original is not compatible with Fixed Layout. If you proceed, you may get undesirable results."
+msgstr "Adding languages beyond the original is not compatible with Fixed Layout. If you proceed, you may get undesirable results."
+
 msgid "Additional Languages"
 msgstr "Additional Languages"
 

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -4953,6 +4953,9 @@ msgstr "noise"
 msgid "None"
 msgstr "None"
 
+msgid "Not compatible with Fixed Layout"
+msgstr "Not compatible with Fixed Layout"
+
 msgid "Not detected"
 msgstr "Not detected"
 
@@ -6324,6 +6327,9 @@ msgstr "Run {stageLabel}"
 
 msgid "Run {upstreamLabel} first"
 msgstr "Run {upstreamLabel} first"
+
+msgid "Run anyway"
+msgstr "Run anyway"
 
 msgid "Run cancelled"
 msgstr "Run cancelled"
@@ -7744,6 +7750,9 @@ msgstr "This book isn't fully assembled yet — pages <0>{0}</0> haven't been me
 
 msgid "This book renders fixed-layout, so it keeps the original PDF fonts. Attached fonts still guide the AI for activities and generated pages."
 msgstr "This book renders fixed-layout, so it keeps the original PDF fonts. Attached fonts still guide the AI for activities and generated pages."
+
+msgid "This feature is not compatible with Fixed Layout. If you proceed, you may get undesirable results."
+msgstr "This feature is not compatible with Fixed Layout. If you proceed, you may get undesirable results."
 
 msgid "This file couldn't be read as a ZIP archive"
 msgstr "This file couldn't be read as a ZIP archive"

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -963,6 +963,9 @@ msgstr "Añadida"
 msgid "Added manually"
 msgstr "Agregado manualmente"
 
+msgid "Adding languages beyond the original is not compatible with Fixed Layout. If you proceed, you may get undesirable results."
+msgstr "Agregar idiomas además del original no es compatible con Diseño Fijo. Si continúas, podrías obtener resultados no deseados."
+
 msgid "Additional Languages"
 msgstr "Idiomas adicionales"
 

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -4953,6 +4953,9 @@ msgstr "ruido"
 msgid "None"
 msgstr "Ninguno"
 
+msgid "Not compatible with Fixed Layout"
+msgstr "No compatible con Diseño Fijo"
+
 msgid "Not detected"
 msgstr "No detectado"
 
@@ -6324,6 +6327,9 @@ msgstr "Ejecutar {0}"
 
 msgid "Run {upstreamLabel} first"
 msgstr "Ejecuta {upstreamLabel} primero"
+
+msgid "Run anyway"
+msgstr "Ejecutar de todos modos"
 
 msgid "Run cancelled"
 msgstr "Ejecución cancelada"
@@ -7744,6 +7750,9 @@ msgstr "Este libro aún no está completo — las páginas <0>{0}</0> no se han 
 
 msgid "This book renders fixed-layout, so it keeps the original PDF fonts. Attached fonts still guide the AI for activities and generated pages."
 msgstr "Este libro se renderiza con diseño fijo, por lo que mantiene las fuentes originales del PDF. Las fuentes adjuntas igualmente guían a la IA en actividades y páginas generadas."
+
+msgid "This feature is not compatible with Fixed Layout. If you proceed, you may get undesirable results."
+msgstr "Esta función no es compatible con Diseño Fijo. Si continúas, podrías obtener resultados no deseados."
 
 msgid "This file couldn't be read as a ZIP archive"
 msgstr "Este archivo no pudo leerse como un archivo ZIP"

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -4955,6 +4955,9 @@ msgstr "bruit"
 msgid "None"
 msgstr "Aucun"
 
+msgid "Not compatible with Fixed Layout"
+msgstr "Incompatible avec la mise en page fixe"
+
 msgid "Not detected"
 msgstr "Non détecté"
 
@@ -6326,6 +6329,9 @@ msgstr "Exécuter {stageLabel}"
 
 msgid "Run {upstreamLabel} first"
 msgstr "Exécutez d'abord {upstreamLabel}"
+
+msgid "Run anyway"
+msgstr "Exécuter quand même"
 
 msgid "Run cancelled"
 msgstr "Exécution annulée"
@@ -7746,6 +7752,9 @@ msgstr "Ce livre n'est pas encore complet — les pages <0>{0}</0> n'ont pas ét
 
 msgid "This book renders fixed-layout, so it keeps the original PDF fonts. Attached fonts still guide the AI for activities and generated pages."
 msgstr "Ce livre est rendu en mise en page fixe, il conserve donc les polices d'origine du PDF. Les polices jointes guident tout de même l'IA pour les activités et les pages générées."
+
+msgid "This feature is not compatible with Fixed Layout. If you proceed, you may get undesirable results."
+msgstr "Cette fonctionnalité n'est pas compatible avec la mise en page fixe. Si vous continuez, vous pourriez obtenir des résultats indésirables."
 
 msgid "This file couldn't be read as a ZIP archive"
 msgstr "Ce fichier n'a pas pu être lu comme une archive ZIP"

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -965,6 +965,9 @@ msgstr "Ajoutée"
 msgid "Added manually"
 msgstr "Ajouté manuellement"
 
+msgid "Adding languages beyond the original is not compatible with Fixed Layout. If you proceed, you may get undesirable results."
+msgstr "Ajouter des langues en plus de l'original n'est pas compatible avec la mise en page fixe. Si vous continuez, vous pourriez obtenir des résultats indésirables."
+
 msgid "Additional Languages"
 msgstr "Langues supplémentaires"
 

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -963,6 +963,9 @@ msgstr "Adicionada"
 msgid "Added manually"
 msgstr "Adicionado manualmente"
 
+msgid "Adding languages beyond the original is not compatible with Fixed Layout. If you proceed, you may get undesirable results."
+msgstr "Adicionar idiomas além do original não é compatível com Layout Fixo. Se você continuar, poderá obter resultados indesejados."
+
 msgid "Additional Languages"
 msgstr "Idiomas adicionais"
 

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -4953,6 +4953,9 @@ msgstr "ruído"
 msgid "None"
 msgstr "Nenhum"
 
+msgid "Not compatible with Fixed Layout"
+msgstr "Não compatível com Layout Fixo"
+
 msgid "Not detected"
 msgstr "Não detectado"
 
@@ -6324,6 +6327,9 @@ msgstr "Executar {0}"
 
 msgid "Run {upstreamLabel} first"
 msgstr "Execute {upstreamLabel} primeiro"
+
+msgid "Run anyway"
+msgstr "Executar mesmo assim"
 
 msgid "Run cancelled"
 msgstr "Execução cancelada"
@@ -7744,6 +7750,9 @@ msgstr "Este livro ainda não está completo — as páginas <0>{0}</0> não for
 
 msgid "This book renders fixed-layout, so it keeps the original PDF fonts. Attached fonts still guide the AI for activities and generated pages."
 msgstr "Este livro é renderizado em layout fixo, então mantém as fontes originais do PDF. Fontes anexadas ainda orientam a IA em atividades e páginas geradas."
+
+msgid "This feature is not compatible with Fixed Layout. If you proceed, you may get undesirable results."
+msgstr "Este recurso não é compatível com Layout Fixo. Se você continuar, poderá obter resultados indesejados."
 
 msgid "This file couldn't be read as a ZIP archive"
 msgstr "Este arquivo não pôde ser lido como um arquivo ZIP"

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -4954,6 +4954,9 @@ msgstr "zhurmë"
 msgid "None"
 msgstr "Asnjë"
 
+msgid "Not compatible with Fixed Layout"
+msgstr "I papajtueshëm me Paraqitjen e fiksuar"
+
 msgid "Not detected"
 msgstr "Nuk u zbulua"
 
@@ -6325,6 +6328,9 @@ msgstr "Ekzekuto {stageLabel}"
 
 msgid "Run {upstreamLabel} first"
 msgstr "Ekzekuto {upstreamLabel} së pari"
+
+msgid "Run anyway"
+msgstr "Ekzekuto gjithsesi"
 
 msgid "Run cancelled"
 msgstr "Ekzekutimi u anulua"
@@ -7745,6 +7751,9 @@ msgstr "Ky libër ende nuk është plotësuar — faqet <0>{0}</0> nuk janë bas
 
 msgid "This book renders fixed-layout, so it keeps the original PDF fonts. Attached fonts still guide the AI for activities and generated pages."
 msgstr "Ky libër shfaqet me strukturë fikse, kështu që ruan fontet origjinale të PDF-së. Fontet e bashkëngjitura gjithsesi udhëzojnë IA-në për aktivitetet dhe faqet e gjeneruara."
+
+msgid "This feature is not compatible with Fixed Layout. If you proceed, you may get undesirable results."
+msgstr "Kjo veçori nuk është e pajtueshme me Paraqitjen e fiksuar. Nëse vazhdoni, mund të merrni rezultate të padëshiruara."
 
 msgid "This file couldn't be read as a ZIP archive"
 msgstr "Ky skedar nuk mund të lexohej si arkiv ZIP"

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -964,6 +964,9 @@ msgstr "E shtuar"
 msgid "Added manually"
 msgstr "Shtuar manualisht"
 
+msgid "Adding languages beyond the original is not compatible with Fixed Layout. If you proceed, you may get undesirable results."
+msgstr "Shtimi i gjuhëve përtej origjinalit nuk është i pajtueshëm me Paraqitjen e fiksuar. Nëse vazhdoni, mund të merrni rezultate të padëshiruara."
+
 msgid "Additional Languages"
 msgstr "Gjuhë Shtesë"
 


### PR DESCRIPTION
Fixed-layout books don't support the Easy Read and translation features, so this adds two warning surfaces to both steps' landing pages: an inline banner shown whenever the book renders in fixed-layout mode, and a pre-run confirmation modal (Cancel / Run anyway) that appears when the user presses Run. Fixed-layout detection is done via a new `useIsFixedLayout` hook backed by an `isFixedLayoutConfig` predicate that mirrors the server-side `isFixedLayoutBook` over the merged config (the frontend can't import `@adt/pipeline`). The warning gate lives in `LandingPageShell` via a new optional `runWarning` prop and is applied outermost-first (warning → cascade-reset confirmation → run), with shared copy centralized in `FixedLayoutWarning.tsx` and a reusable `RunWarningDialog`. Includes unit tests for the new predicate and full translations of the three new strings across all locales (es, fr, pt-BR, sq).