### PR TITLE
Version picker for TOC (book-style compare) [#582]

### DIFF
--- a/apps/api/src/routes/toc.ts
+++ b/apps/api/src/routes/toc.ts
@@ -4,7 +4,7 @@ import { Hono } from "hono"
 import { HTTPException } from "hono/http-exception"
 import { TocGenerationOutput, WebRenderingOutput, parseBookLabel } from "@adt/types"
 import type { ContentNodeData } from "@adt/types"
-import { openBookDb, createBookStorage } from "@adt/storage"
+import { openBookDb, createBookStorage, readCurrentNodeRow } from "@adt/storage"
 import { getRenderSectioning } from "@adt/pipeline"
 
 function safeParseLabel(label: string): string {
@@ -38,18 +38,15 @@ export function createTocRoutes(booksDir: string): Hono {
 
     const db = openBookDb(dbPath)
     try {
-      const rows = db.all(
-        "SELECT data, version FROM node_data WHERE node = ? AND item_id = ? ORDER BY version DESC LIMIT 1",
-        ["toc-generation", "book"],
-      ) as Array<{ data: string; version: number }>
+      const row = readCurrentNodeRow(db, "toc-generation", "book")
 
-      if (rows.length === 0) {
+      if (!row) {
         return c.json(null)
       }
 
       let parsed: unknown
       try {
-        parsed = JSON.parse(rows[0].data)
+        parsed = JSON.parse(row.data)
       } catch {
         throw new HTTPException(500, {
           message: `Stored TOC data is corrupted for book: ${safeLabel}`,
@@ -63,7 +60,7 @@ export function createTocRoutes(booksDir: string): Hono {
         })
       }
 
-      return c.json({ ...validated.data, version: rows[0].version })
+      return c.json({ ...validated.data, version: row.version })
     } finally {
       db.close()
     }

--- a/apps/studio/src/components/pipeline/stages/toc/TocView.tsx
+++ b/apps/studio/src/components/pipeline/stages/toc/TocView.tsx
@@ -213,9 +213,23 @@ export function TocView({ bookLabel }: { bookLabel: string }) {
           bookLabel={bookLabel}
           pendingLabel={pendingLabel}
           pendingLabelKey={pendingLabelKey}
-          onPreview={(d) => setPending(d as TocData)}
+          onRestored={() => setPending(null)}
           onSave={() => saveRef.current()}
           onDiscard={() => setPending(null)}
+          diff={{
+            items: (d) => (d as TocData | null)?.entries ?? [],
+            keyOf: (it) => (it as TocEntry).id,
+            isEqual: (a, b) => JSON.stringify(a) === JSON.stringify(b),
+            renderItem: (it) => {
+              const entry = it as TocEntry
+              const indent = Math.max(0, Math.min(entry.level ?? 1, 3) - 1) * 12
+              return (
+                <span style={{ paddingLeft: indent }} className="block">
+                  {entry.title || <span className="text-muted-foreground">{t`(untitled)`}</span>}
+                </span>
+              )
+            },
+          }}
         />
       </div>,
     )


### PR DESCRIPTION
Rolls the version picker + rollback out to the **Table of Contents** stage.

**Stacked on #589** (issue-582), which introduces the shared version-picker infrastructure (current-version pointer, restore endpoint, book-style compare dialog). Base is `issue-582`; retarget to `develop` once #589 merges.

## Changes
- `toc-generation` GET route reads the current-version pointer via `readCurrentNodeRow`, so a rollback is reflected.
- `TocView` opts into the `diff` descriptor: the picker shows a per-version **change count** vs current and a **Compare** button → side-by-side dialog (entries indented by level, colored add/edit/remove). Picking a version rolls back (no new version).

## Tests
Typecheck + lint clean. (No pre-existing TOC route test; behavior mirrors the glossary pilot which has storage + route tests in #589.)

🤖 Draft.