### PR TITLE
Version picker for Quizzes (book-style compare) [#582]

### DIFF
--- a/apps/api/src/routes/quizzes.ts
+++ b/apps/api/src/routes/quizzes.ts
@@ -9,7 +9,7 @@ import {
   type Quiz,
   type WebRenderingOutput,
 } from "@adt/types"
-import { openBookDb, createBookStorage } from "@adt/storage"
+import { openBookDb, createBookStorage, readCurrentNodeRow } from "@adt/storage"
 import {
   buildQuizGenerationConfig,
   generateQuiz,
@@ -55,18 +55,15 @@ export function createQuizRoutes(
 
     const db = openBookDb(dbPath)
     try {
-      const rows = db.all(
-        "SELECT version, data FROM node_data WHERE node = ? AND item_id = ? ORDER BY version DESC LIMIT 1",
-        ["quiz-generation", "book"]
-      ) as Array<{ version: number; data: string }>
+      const row = readCurrentNodeRow(db, "quiz-generation", "book")
 
-      if (rows.length === 0) {
+      if (!row) {
         return c.json({ quizzes: null, version: null })
       }
 
       let parsed: unknown
       try {
-        parsed = JSON.parse(rows[0].data)
+        parsed = JSON.parse(row.data)
       } catch {
         throw new HTTPException(500, {
           message: `Stored quiz data is corrupted for book: ${safeLabel}`,
@@ -82,7 +79,7 @@ export function createQuizRoutes(
 
       return c.json({
         quizzes: validated.data,
-        version: rows[0].version,
+        version: row.version,
       })
     } finally {
       db.close()

--- a/apps/studio/src/components/pipeline/stages/quizzes/QuizzesView.tsx
+++ b/apps/studio/src/components/pipeline/stages/quizzes/QuizzesView.tsx
@@ -11,7 +11,7 @@ import {
 } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { api } from "@/api/client";
-import type { QuizGenerationOutput } from "@/api/client";
+import type { QuizGenerationOutput, QuizItem } from "@/api/client";
 import { useQuizzes } from "@/hooks/use-quizzes";
 import { usePageImage, usePages } from "@/hooks/use-pages";
 import { formatPageNumbers } from "./lib/format-page-numbers";
@@ -308,9 +308,26 @@ export function QuizzesView({
           bookLabel={bookLabel}
           pendingLabel={pendingLabel}
           pendingLabelKey={pendingLabelKey}
-          onPreview={(d) => setPending(d as QuizData)}
+          onRestored={() => setPending(null)}
           onSave={() => saveRef.current()}
           onDiscard={() => setPending(null)}
+          diff={{
+            items: (d) => (d as QuizData | null)?.quizzes ?? [],
+            keyOf: (it) => String((it as QuizItem).quizIndex),
+            isEqual: (a, b) => JSON.stringify(a) === JSON.stringify(b),
+            renderItem: (it) => {
+              const q = it as QuizItem;
+              const correct = q.options?.[q.answerIndex]?.text;
+              return (
+                <span>
+                  <span className="font-medium text-foreground">{q.question}</span>
+                  {correct ? (
+                    <span className="mt-0.5 block text-emerald-700">✓ {correct}</span>
+                  ) : null}
+                </span>
+              );
+            },
+          }}
         />
       </div>,
     );


### PR DESCRIPTION
Rolls the version picker + rollback out to the **Quizzes** stage.

**Stacked on #589** (issue-582). Base is `issue-582`; retarget to `develop` once #589 merges.

## Changes
- `quiz-generation` GET route reads the current-version pointer via `readCurrentNodeRow`.
- `QuizzesView` opts into the `diff` descriptor: per-version **change count** vs current + **Compare** dialog (side-by-side, showing each quiz's question and correct answer). Rollback on pick.

Typecheck + lint clean.

🤖 Draft.