### PR TITLE
fix(tts): stop fixed-layout text jumping during read-aloud

### DIFF
--- a/apps/adt-runtime/src/features/audio/lib/word-highlight.ts
+++ b/apps/adt-runtime/src/features/audio/lib/word-highlight.ts
@@ -93,6 +93,23 @@ function wrapWordsFromSegments(element: HTMLElement, segments: Segment[]): boole
     return out
   }
 
+  // Largest segment `font-size` (px) overlapping [start, end), or undefined
+  // when none declares one. Used to size each word wrapper's paint box.
+  const maxSegFontSize = (start: number, end: number): number | undefined => {
+    let max = 0
+    for (let i = 0; i < segments.length; i++) {
+      const segStart = segOffsets[i]
+      const segEnd = segStart + segments[i].text.length
+      if (segEnd <= start) continue
+      if (segStart >= end) break
+      const fsRaw = segments[i].style?.["font-size"]
+      if (!fsRaw) continue
+      const fs = parseFloat(fsRaw)
+      if (Number.isFinite(fs) && fs > max) max = fs
+    }
+    return max > 0 ? max : undefined
+  }
+
   const fragment = doc.createDocumentFragment()
   let charCursor = 0
   for (const seg of plan) {
@@ -116,6 +133,19 @@ function wrapWordsFromSegments(element: HTMLElement, segments: Segment[]): boole
     const end = start + seg.text.length
     const wrap = doc.createElement("span")
     wrap.setAttribute("data-word-index", String(seg.wordIndex))
+    // The word highlight (`.bg-yellow-300`) paints this wrapper's inline
+    // background box, whose height is the wrapper's own font content-area.
+    // Fixed-layout font-size lives only on the inner per-segment pieces, so
+    // an unsized wrapper inherits the page default (~16px) and the yellow bar
+    // renders as a thin sliver behind a large word. Mirror the word's largest
+    // segment size onto the wrapper so the highlight covers the whole word —
+    // same fix as wrapBySegments in packaging/epub.ts. The wrapper holds no
+    // text of its own (the glyphs live in the pieces), so width/advance is
+    // unchanged; emitted inline so auto-fit shrinks it in lockstep.
+    const wordFontSize = maxSegFontSize(start, end)
+    if (wordFontSize !== undefined) {
+      wrap.setAttribute("style", `font-size:${wordFontSize}px`)
+    }
     for (const piece of buildPieces(start, end)) wrap.appendChild(piece)
     fragment.appendChild(wrap)
     charCursor = end

--- a/apps/adt-runtime/src/features/audio/lib/word-highlight.ts
+++ b/apps/adt-runtime/src/features/audio/lib/word-highlight.ts
@@ -93,23 +93,6 @@ function wrapWordsFromSegments(element: HTMLElement, segments: Segment[]): boole
     return out
   }
 
-  // Largest segment `font-size` (px) overlapping [start, end), or undefined
-  // when none declares one. Used to size each word wrapper's paint box.
-  const maxSegFontSize = (start: number, end: number): number | undefined => {
-    let max = 0
-    for (let i = 0; i < segments.length; i++) {
-      const segStart = segOffsets[i]
-      const segEnd = segStart + segments[i].text.length
-      if (segEnd <= start) continue
-      if (segStart >= end) break
-      const fsRaw = segments[i].style?.["font-size"]
-      if (!fsRaw) continue
-      const fs = parseFloat(fsRaw)
-      if (Number.isFinite(fs) && fs > max) max = fs
-    }
-    return max > 0 ? max : undefined
-  }
-
   const fragment = doc.createDocumentFragment()
   let charCursor = 0
   for (const seg of plan) {
@@ -133,19 +116,15 @@ function wrapWordsFromSegments(element: HTMLElement, segments: Segment[]): boole
     const end = start + seg.text.length
     const wrap = doc.createElement("span")
     wrap.setAttribute("data-word-index", String(seg.wordIndex))
-    // The word highlight (`.bg-yellow-300`) paints this wrapper's inline
-    // background box, whose height is the wrapper's own font content-area.
-    // Fixed-layout font-size lives only on the inner per-segment pieces, so
-    // an unsized wrapper inherits the page default (~16px) and the yellow bar
-    // renders as a thin sliver behind a large word. Mirror the word's largest
-    // segment size onto the wrapper so the highlight covers the whole word —
-    // same fix as wrapBySegments in packaging/epub.ts. The wrapper holds no
-    // text of its own (the glyphs live in the pieces), so width/advance is
-    // unchanged; emitted inline so auto-fit shrinks it in lockstep.
-    const wordFontSize = maxSegFontSize(start, end)
-    if (wordFontSize !== undefined) {
-      wrap.setAttribute("style", `font-size:${wordFontSize}px`)
-    }
+    // The wrapper carries NO font-size on purpose. The highlight is painted on
+    // the wrapper AND its inner pieces (see the .bg-yellow-300 rule), and the
+    // pieces already carry the word's real font-size/family — so the yellow
+    // covers the full word height without the wrapper needing a size. Sizing
+    // the wrapper (as we used to) inserts an extra inline box in the page's
+    // default font, whose metrics differ from the text's font and shift the
+    // line's baseline while read-aloud is active — the text "bobs". An unsized
+    // wrapper inherits the small page default (smaller than the text), so it
+    // contributes nothing to the line box and the baseline stays put.
     for (const piece of buildPieces(start, end)) wrap.appendChild(piece)
     fragment.appendChild(wrap)
     charCursor = end

--- a/apps/adt-runtime/src/features/audio/lib/word-highlight.ts
+++ b/apps/adt-runtime/src/features/audio/lib/word-highlight.ts
@@ -28,6 +28,30 @@ import { parseSegments, styleToInline, type Segment } from "@/shared/lib/fl-segm
 const ORIGINAL_HTML_ATTR = "data-tts-original-html"
 const WORD_HIGHLIGHT_CLASS = "bg-yellow-300"
 const BLOCK_HIGHLIGHT_CLASS = "tts-active-block"
+const FIT_ATTR = "data-adt-fit"
+
+/**
+ * Re-run the fixed-layout auto-fit pass (`assets/adt/auto-fit.js`, exposed as
+ * `window.__adtRunAutoFit`) after we rebuild a paragraph's innerHTML for word
+ * wrapping.
+ *
+ * On fixed-layout pages the auto-fit script shrinks each paragraph's inline
+ * `font-size` / `letter-spacing` so the text fits its absolutely-positioned
+ * block box. Wrapping words rebuilds the innerHTML from the original
+ * `data-segments` (and drops the per-span `data-adt-fs` cache), which
+ * reinstates the pre-fit sizes — so without this the text grows and reflows
+ * ("jumps around") the instant read-aloud starts, then snaps back on teardown
+ * when the stashed fitted HTML is restored. Re-fitting the freshly-wrapped
+ * spans keeps the layout stable. Guarded on `data-adt-fit`, so it's a no-op
+ * for reflowable pages (which have no fit targets). The translation-swap path
+ * in `i18n.ts` re-fits the same way after rebuilding segment spans.
+ */
+function refitFixedLayout(element: HTMLElement): void {
+  if (!element.hasAttribute(FIT_ATTR)) return
+  const runAutoFit = (window as Window & { __adtRunAutoFit?: () => void })
+    .__adtRunAutoFit
+  if (typeof runAutoFit === "function") runAutoFit()
+}
 
 /**
  * Fixed-layout word wrap: tokenise across the concatenated `data-segments`
@@ -73,7 +97,18 @@ function wrapWordsFromSegments(element: HTMLElement, segments: Segment[]): boole
   let charCursor = 0
   for (const seg of plan) {
     if (seg.type === "separator") {
-      if (seg.text.length > 0) fragment.appendChild(doc.createTextNode(seg.text))
+      // Separators stay OUTSIDE the word-index wrapper (so the highlight box
+      // hugs the word), but must still carry the surrounding segment's style:
+      // in fixed-layout the font-size lives only on the per-segment span and
+      // the paragraph itself has none, so a bare text node would inherit the
+      // page default (~16px) and change the spacing between words on play.
+      // Route the whitespace run through buildPieces so it keeps the segment's
+      // font metrics — mirrors wrapBySegments in packaging/epub.ts.
+      if (seg.text.length > 0) {
+        for (const piece of buildPieces(charCursor, charCursor + seg.text.length)) {
+          fragment.appendChild(piece)
+        }
+      }
       charCursor += seg.text.length
       continue
     }
@@ -102,7 +137,10 @@ export function wrapWordsForElement(element: HTMLElement, text: string): void {
 
   const segments = parseSegments(element.getAttribute("data-segments"))
   if (segments && segments.length > 0) {
-    if (wrapWordsFromSegments(element, segments)) return
+    if (wrapWordsFromSegments(element, segments)) {
+      refitFixedLayout(element)
+      return
+    }
     element.removeAttribute(ORIGINAL_HTML_ATTR)
     return
   }
@@ -127,6 +165,7 @@ export function wrapWordsForElement(element: HTMLElement, text: string): void {
     }
   }
   element.replaceChildren(fragment)
+  refitFixedLayout(element)
 }
 
 export function unwrapWordsForElement(element: HTMLElement): void {

--- a/apps/adt-runtime/src/styles/globals.css
+++ b/apps/adt-runtime/src/styles/globals.css
@@ -154,19 +154,26 @@ section[data-section-type="activity_open_ended_answer"] textarea {
  * legible regardless of the surrounding text color (the page may render in
  * white, orange, or any other foreground).
  *
+ * Painted on BOTH the word wrapper and its inner pieces:
+ *   - Reflowable pages hold the text directly in the wrapper, so the wrapper
+ *     selector paints it at the paragraph's font-size.
+ *   - Fixed-layout pages hold the text in inner styled <span> pieces that carry
+ *     the real (e.g. 48px) font-size, so the piece selector covers the full
+ *     word height. The wrapper itself is intentionally unsized (see
+ *     word-highlight.ts), so we must reach the pieces to get the height.
+ *
  * PAINT-ONLY ON PURPOSE — only background-color, color and border-radius, and
  * no transition. Never box-model properties (padding / margin / border /
  * font-size). In fixed layout the words are absolutely positioned at
  * fractional, auto-fit sizes; toggling ANY layout-affecting property (even a
- * net-zero padding+negative-margin pair) forces the browser to re-lay-out that
- * line fragment and re-snap its baseline to the device-pixel grid, which nudges
- * the glyphs a fraction of a pixel and reads as the word "jumping" up and down.
- * Background/color/border-radius are pure paint — they can't change the box or
- * the glyph position — so the text stays fixed while the highlight moves across
- * it. The full-word height comes from the wrapper's font-size, set once at wrap
- * time in word-highlight.ts, not from this rule.
+ * net-zero padding+negative-margin pair) forces the browser to re-lay-out the
+ * line and re-snap its baseline to the device-pixel grid, which nudges the
+ * glyphs and reads as the word "jumping". Background/color/border-radius are
+ * pure paint — they can't change the box or the glyph position — so the text
+ * stays fixed while the highlight moves across it.
  */
-span[data-word-index].bg-yellow-300 {
+span[data-word-index].bg-yellow-300,
+span[data-word-index].bg-yellow-300 span {
   background-color: #fde047 !important;
   color: #000 !important;
   border-radius: 3px;

--- a/apps/adt-runtime/src/styles/globals.css
+++ b/apps/adt-runtime/src/styles/globals.css
@@ -152,8 +152,15 @@ section[data-section-type="activity_open_ended_answer"] textarea {
 /*
  * Word-by-word TTS highlight. Forced yellow/black so the active word stays
  * legible regardless of the surrounding text color (the page may render in
- * white, orange, or any other foreground). `transition` smooths the swap
- * between adjacent words.
+ * white, orange, or any other foreground).
+ *
+ * Deliberately NO transition: animating background-color/color over the text
+ * re-rasterizes the glyphs every frame (antialiasing/subpixel rendering shifts
+ * as the background changes), which reads as a subtle vertical shimmer now that
+ * the highlight box covers the whole word in fixed layout. An instant swap
+ * keeps each word fixed in place — matching the EPUB media-overlay highlight
+ * and the reduced-motion path. Horizontal padding/negative-margin net to zero
+ * so the box paint grows without nudging neighbouring words.
  */
 span[data-word-index].bg-yellow-300 {
   background-color: #fde047 !important;
@@ -161,7 +168,6 @@ span[data-word-index].bg-yellow-300 {
   border-radius: 3px;
   padding: 0 1px;
   margin: 0 -1px;
-  transition: background-color 120ms ease, color 120ms ease;
 }
 
 /*

--- a/apps/adt-runtime/src/styles/globals.css
+++ b/apps/adt-runtime/src/styles/globals.css
@@ -154,20 +154,22 @@ section[data-section-type="activity_open_ended_answer"] textarea {
  * legible regardless of the surrounding text color (the page may render in
  * white, orange, or any other foreground).
  *
- * Deliberately NO transition: animating background-color/color over the text
- * re-rasterizes the glyphs every frame (antialiasing/subpixel rendering shifts
- * as the background changes), which reads as a subtle vertical shimmer now that
- * the highlight box covers the whole word in fixed layout. An instant swap
- * keeps each word fixed in place — matching the EPUB media-overlay highlight
- * and the reduced-motion path. Horizontal padding/negative-margin net to zero
- * so the box paint grows without nudging neighbouring words.
+ * PAINT-ONLY ON PURPOSE — only background-color, color and border-radius, and
+ * no transition. Never box-model properties (padding / margin / border /
+ * font-size). In fixed layout the words are absolutely positioned at
+ * fractional, auto-fit sizes; toggling ANY layout-affecting property (even a
+ * net-zero padding+negative-margin pair) forces the browser to re-lay-out that
+ * line fragment and re-snap its baseline to the device-pixel grid, which nudges
+ * the glyphs a fraction of a pixel and reads as the word "jumping" up and down.
+ * Background/color/border-radius are pure paint — they can't change the box or
+ * the glyph position — so the text stays fixed while the highlight moves across
+ * it. The full-word height comes from the wrapper's font-size, set once at wrap
+ * time in word-highlight.ts, not from this rule.
  */
 span[data-word-index].bg-yellow-300 {
   background-color: #fde047 !important;
   color: #000 !important;
   border-radius: 3px;
-  padding: 0 1px;
-  margin: 0 -1px;
 }
 
 /*

--- a/assets/adt/tailwind_css.css
+++ b/assets/adt/tailwind_css.css
@@ -154,19 +154,26 @@ section[data-section-type="activity_open_ended_answer"] textarea {
  * legible regardless of the surrounding text color (the page may render in
  * white, orange, or any other foreground).
  *
+ * Painted on BOTH the word wrapper and its inner pieces:
+ *   - Reflowable pages hold the text directly in the wrapper, so the wrapper
+ *     selector paints it at the paragraph's font-size.
+ *   - Fixed-layout pages hold the text in inner styled <span> pieces that carry
+ *     the real (e.g. 48px) font-size, so the piece selector covers the full
+ *     word height. The wrapper itself is intentionally unsized (see
+ *     word-highlight.ts), so we must reach the pieces to get the height.
+ *
  * PAINT-ONLY ON PURPOSE — only background-color, color and border-radius, and
  * no transition. Never box-model properties (padding / margin / border /
  * font-size). In fixed layout the words are absolutely positioned at
  * fractional, auto-fit sizes; toggling ANY layout-affecting property (even a
- * net-zero padding+negative-margin pair) forces the browser to re-lay-out that
- * line fragment and re-snap its baseline to the device-pixel grid, which nudges
- * the glyphs a fraction of a pixel and reads as the word "jumping" up and down.
- * Background/color/border-radius are pure paint — they can't change the box or
- * the glyph position — so the text stays fixed while the highlight moves across
- * it. The full-word height comes from the wrapper's font-size, set once at wrap
- * time in word-highlight.ts, not from this rule.
+ * net-zero padding+negative-margin pair) forces the browser to re-lay-out the
+ * line and re-snap its baseline to the device-pixel grid, which nudges the
+ * glyphs and reads as the word "jumping". Background/color/border-radius are
+ * pure paint — they can't change the box or the glyph position — so the text
+ * stays fixed while the highlight moves across it.
  */
-span[data-word-index].bg-yellow-300 {
+span[data-word-index].bg-yellow-300,
+span[data-word-index].bg-yellow-300 span {
   background-color: #fde047 !important;
   color: #000 !important;
   border-radius: 3px;

--- a/assets/adt/tailwind_css.css
+++ b/assets/adt/tailwind_css.css
@@ -152,8 +152,15 @@ section[data-section-type="activity_open_ended_answer"] textarea {
 /*
  * Word-by-word TTS highlight. Forced yellow/black so the active word stays
  * legible regardless of the surrounding text color (the page may render in
- * white, orange, or any other foreground). `transition` smooths the swap
- * between adjacent words.
+ * white, orange, or any other foreground).
+ *
+ * Deliberately NO transition: animating background-color/color over the text
+ * re-rasterizes the glyphs every frame (antialiasing/subpixel rendering shifts
+ * as the background changes), which reads as a subtle vertical shimmer now that
+ * the highlight box covers the whole word in fixed layout. An instant swap
+ * keeps each word fixed in place — matching the EPUB media-overlay highlight
+ * and the reduced-motion path. Horizontal padding/negative-margin net to zero
+ * so the box paint grows without nudging neighbouring words.
  */
 span[data-word-index].bg-yellow-300 {
   background-color: #fde047 !important;
@@ -161,7 +168,6 @@ span[data-word-index].bg-yellow-300 {
   border-radius: 3px;
   padding: 0 1px;
   margin: 0 -1px;
-  transition: background-color 120ms ease, color 120ms ease;
 }
 
 /*

--- a/assets/adt/tailwind_css.css
+++ b/assets/adt/tailwind_css.css
@@ -154,20 +154,22 @@ section[data-section-type="activity_open_ended_answer"] textarea {
  * legible regardless of the surrounding text color (the page may render in
  * white, orange, or any other foreground).
  *
- * Deliberately NO transition: animating background-color/color over the text
- * re-rasterizes the glyphs every frame (antialiasing/subpixel rendering shifts
- * as the background changes), which reads as a subtle vertical shimmer now that
- * the highlight box covers the whole word in fixed layout. An instant swap
- * keeps each word fixed in place — matching the EPUB media-overlay highlight
- * and the reduced-motion path. Horizontal padding/negative-margin net to zero
- * so the box paint grows without nudging neighbouring words.
+ * PAINT-ONLY ON PURPOSE — only background-color, color and border-radius, and
+ * no transition. Never box-model properties (padding / margin / border /
+ * font-size). In fixed layout the words are absolutely positioned at
+ * fractional, auto-fit sizes; toggling ANY layout-affecting property (even a
+ * net-zero padding+negative-margin pair) forces the browser to re-lay-out that
+ * line fragment and re-snap its baseline to the device-pixel grid, which nudges
+ * the glyphs a fraction of a pixel and reads as the word "jumping" up and down.
+ * Background/color/border-radius are pure paint — they can't change the box or
+ * the glyph position — so the text stays fixed while the highlight moves across
+ * it. The full-word height comes from the wrapper's font-size, set once at wrap
+ * time in word-highlight.ts, not from this rule.
  */
 span[data-word-index].bg-yellow-300 {
   background-color: #fde047 !important;
   color: #000 !important;
   border-radius: 3px;
-  padding: 0 1px;
-  margin: 0 -1px;
 }
 
 /*

--- a/config/speech_instructions.yaml
+++ b/config/speech_instructions.yaml
@@ -87,3 +87,4 @@ ne: |-
   Use pronunciation influence only, not vocabulary or grammar changes.
 
   Speak in a cheerful and positive tone.
+fr: Speak it an a French Benin accent. Use the pronunciation and intonation typical of Benin. Maintain a calm, conversational tone. Speak in a cheerful positive tone.


### PR DESCRIPTION
Fixes fixed-layout read-aloud in the web reader: text no longer jumps or re-spaces when TTS starts. Word-wrapping a paragraph on play rebuilt its innerHTML from the raw `data-segments`, which reverted the auto-fit font-size/letter-spacing shrink and dropped inter-word whitespace to the inherited page font-size. This re-runs the auto-fit pass after wrapping (mirroring the `i18n.ts` translation-swap path) and routes word separators through `buildPieces` so whitespace keeps the segment's font metrics (mirroring `wrapBySegments` in `packaging/epub.ts`); reflowable books are unaffected since both paths are no-ops without `data-segments`/`data-adt-fit`. Also adds a French (Benin accent) entry to `config/speech_instructions.yaml`.