### PR TITLE
Fix(desktop): make SKIP_NOTARIZE accept per-platform targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,6 +169,8 @@ jobs:
       contents: read
     env:
       APP_VERSION: ${{ needs.prepare.outputs.version }}
+      # SKIP_NOTARIZE accepts ALL, MAC, WIN, LINUX (comma/space separated).
+      # "true" is treated as ALL for backward compatibility.
       SKIP_NOTARIZE: ${{ vars.SKIP_NOTARIZE }}
     steps:
       - uses: actions/checkout@v4
@@ -211,8 +213,20 @@ jobs:
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
+      - name: Resolve Windows signing skip
+        id: skip
+        if: matrix.os == 'windows-latest'
+        shell: bash
+        run: |
+          tokens=" $(echo "${SKIP_NOTARIZE:-}" | tr '[:lower:]' '[:upper:]' | tr ',' ' ') "
+          skip=false
+          case "$tokens" in
+            *" ALL "*|*" TRUE "*|*" WIN "*) skip=true ;;
+          esac
+          echo "win=$skip" >> "$GITHUB_OUTPUT"
+
       - name: Acquire Azure code signing token
-        if: matrix.os == 'windows-latest' && env.SKIP_NOTARIZE != 'true'
+        if: matrix.os == 'windows-latest' && steps.skip.outputs.win != 'true'
         shell: bash
         env:
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -125,6 +125,8 @@ jobs:
       contents: read
     env:
       APP_VERSION: ${{ needs.stage.outputs.version }}
+      # SKIP_NOTARIZE accepts ALL, MAC, WIN, LINUX (comma/space separated).
+      # "true" is treated as ALL for backward compatibility.
       SKIP_NOTARIZE: ${{ vars.SKIP_NOTARIZE }}
     steps:
       - uses: actions/checkout@v4
@@ -163,8 +165,20 @@ jobs:
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
+      - name: Resolve Windows signing skip
+        id: skip
+        if: matrix.os == 'windows-latest'
+        shell: bash
+        run: |
+          tokens=" $(echo "${SKIP_NOTARIZE:-}" | tr '[:lower:]' '[:upper:]' | tr ',' ' ') "
+          skip=false
+          case "$tokens" in
+            *" ALL "*|*" TRUE "*|*" WIN "*) skip=true ;;
+          esac
+          echo "win=$skip" >> "$GITHUB_OUTPUT"
+
       - name: Acquire Azure code signing token
-        if: matrix.os == 'windows-latest' && env.SKIP_NOTARIZE != 'true'
+        if: matrix.os == 'windows-latest' && steps.skip.outputs.win != 'true'
         shell: bash
         env:
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -81,11 +81,27 @@ apps/desktop/release/
   - `CSC_LINK` and `CSC_KEY_PASSWORD` for the Developer ID certificate
   - `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, `APPLE_TEAM_ID` for notarytool
 
-To skip signing in CI or local tests:
+To skip signing in CI or local tests, use the single `SKIP_NOTARIZE` variable.
+It accepts one or more targets — `ALL`, `MAC`, `WIN`, `LINUX` — separated by
+commas or spaces (case-insensitive). `true` is treated as `ALL`.
 
 ```bash
-SKIP_NOTARIZE=true pnpm --filter @adt/desktop build:win
+# Skip signing for every platform
+SKIP_NOTARIZE=ALL pnpm --filter @adt/desktop build:win
+
+# Skip a single platform, leaving the others signed
+SKIP_NOTARIZE=WIN pnpm --filter @adt/desktop build:win   # Azure code signing
+SKIP_NOTARIZE=MAC pnpm --filter @adt/desktop build:mac   # Developer ID + notarization
+
+# Skip more than one
+SKIP_NOTARIZE="MAC,WIN" pnpm --filter @adt/desktop build
 ```
+
+In CI this is read from a repository/environment **variable** (`vars.SKIP_NOTARIZE`),
+so setting it to `WIN` lets a release build Windows unsigned (e.g. while the
+Azure signing credentials are unavailable) while macOS still signs and
+notarizes. Linux builds are never signed, so `LINUX` is accepted but has no
+effect.
 
 ### Sign and release mac version
 

--- a/apps/desktop/electron-builder.js
+++ b/apps/desktop/electron-builder.js
@@ -37,7 +37,15 @@ const extraResources = [
 
 const version = process.env.APP_VERSION || require("./package.json").version;
 
-const skipNotarize = process.env.SKIP_NOTARIZE === "true";
+const skipTargets = new Set(
+  (process.env.SKIP_NOTARIZE || "")
+    .toUpperCase()
+    .split(/[\s,]+/)
+    .filter(Boolean),
+);
+const shouldSkip = (target) =>
+  skipTargets.has("ALL") || skipTargets.has("TRUE") || skipTargets.has(target);
+const skipMac = shouldSkip("MAC");
 
 const isBeta = version.includes("-beta");
 const appId = isBeta ? "com.nees.adt-studio.beta" : "com.nees.adt-studio";
@@ -102,8 +110,8 @@ const config = {
     gatekeeperAssess: false,
     entitlements: "build/entitlements.mac.plist",
     entitlementsInherit: "build/entitlements.mac.plist",
-    identity: skipNotarize ? null : "Developer ID Application",
-    ...(skipNotarize ? { notarize: false } : {}),
+    identity: skipMac ? null : "Developer ID Application",
+    ...(skipMac ? { notarize: false } : {}),
     extraResources,
     extendInfo: {
       NSCameraUsageDescription:

--- a/apps/desktop/scripts/sign-windows.js
+++ b/apps/desktop/scripts/sign-windows.js
@@ -6,8 +6,18 @@ const TRUSTED_SIGNING_KEYSTORE = "eus.codesigning.azure.net";
 const TRUSTED_SIGNING_ALIAS = "NEES/neespnld";
 
 module.exports = async function (configuration) {
-  if (process.env.SKIP_NOTARIZE === "true") {
-    console.warn(`SKIP_NOTARIZE=true → skipping signature for ${configuration.path}`);
+  const skipTargets = new Set(
+    (process.env.SKIP_NOTARIZE || "")
+      .toUpperCase()
+      .split(/[\s,]+/)
+      .filter(Boolean),
+  );
+  if (
+    skipTargets.has("ALL") ||
+    skipTargets.has("TRUE") ||
+    skipTargets.has("WIN")
+  ) {
+    console.warn(`Windows signing skipped for ${configuration.path}`);
     return;
   }
 


### PR DESCRIPTION
## What's changed

Make the `SKIP_NOTARIZE` build variable accept per-platform targets instead of being an all-or-nothing switch.

`SKIP_NOTARIZE` now accepts one or more targets — `ALL`, `MAC`, `WIN`, `LINUX` — separated by commas or spaces (case-insensitive). `true` still maps to `ALL` for backward compatibility.

| Value | Effect |
|-------|--------|
| `ALL` / `true` | Skip signing on every platform |
| `MAC` | Skip Developer ID + notarization (macOS) |
| `WIN` | Skip Azure code signing (Windows) |
| `LINUX` | Accepted but no-op (Linux is never signed) |
| `MAC,WIN` | Combine targets |

## Why

Previously a single `SKIP_NOTARIZE=true` disabled signing on **all** platforms at once — there was no way to skip just one. With the Azure code-signing credentials expired, we couldn't cut a release: we needed Windows to build unsigned while macOS still signed and notarized.

Setting `SKIP_NOTARIZE=WIN` now unblocks releases in exactly this situation.

## Changes

- `apps/desktop/electron-builder.js` — parse `SKIP_NOTARIZE` into a set of tokens; gate the macOS signing/notarization block on it.
- `apps/desktop/scripts/sign-windows.js` — same parsing; skip Windows signing when `WIN`/`ALL` is present.
- `.github/workflows/release.yml` & `.github/workflows/staging.yml` — drop the single-value gate; add a small step that resolves whether Windows signing is skipped and gates the "Acquire Azure code signing token" step accordingly.
- `apps/desktop/README.md` — document the new per-target usage.

## How to use (Azure expired)

Set the repository/environment variable `SKIP_NOTARIZE=WIN`, then run the Release workflow. Windows builds unsigned; macOS still signs + notarizes; Linux is unaffected. Clear the variable once Azure credentials are renewed.

## Testing

- [ ] Release/staging run with `SKIP_NOTARIZE=WIN` produces an unsigned Windows build and a signed + notarized macOS build.
