### PR TITLE
Improve read-aloud panel behavior during page navigation

### DIFF
--- a/apps/adt-runtime/src/features/dock/components/DockMenu.tsx
+++ b/apps/adt-runtime/src/features/dock/components/DockMenu.tsx
@@ -173,7 +173,6 @@ function TTSDockButton() {
         onClose={() => setValue("")}
         anchor={btnRef}
         side={side}
-        staysOpen
       >
         <AudioContent />
       </DockPanel>

--- a/apps/adt-runtime/src/features/dock/components/DockPanel.tsx
+++ b/apps/adt-runtime/src/features/dock/components/DockPanel.tsx
@@ -5,12 +5,6 @@ interface DockPanelProps {
   onClose: () => void
   anchor?: React.RefObject<HTMLElement | null>
   side?: "top" | "bottom"
-  /**
-   * When true, the popover ignores outside-click and escape dismissal. The
-   * only ways to close it are programmatic (e.g. clicking Stop in the
-   * panel) or re-clicking the dock trigger button.
-   */
-  staysOpen?: boolean
   children: React.ReactNode
 }
 
@@ -19,7 +13,6 @@ function DockPanel({
   onClose,
   anchor,
   side = "top",
-  staysOpen,
   children,
 }: DockPanelProps) {
   return (
@@ -27,6 +20,10 @@ function DockPanel({
       open={open}
       onOpenChange={(next, eventDetails) => {
         if (next) return
+        // Clicks on a dock trigger button (prev/next page, panel toggles)
+        // are handled by the button's own onClick — don't also treat them as
+        // an outside-press dismissal, or the panel would flicker/toggle. Any
+        // other outside-press (a click in the book) closes the panel.
         if (
           eventDetails.reason === "outside-press" &&
           eventDetails.event &&
@@ -36,17 +33,11 @@ function DockPanel({
         ) {
           return
         }
-        if (
-          staysOpen &&
-          (eventDetails.reason === "outside-press" ||
-            eventDetails.reason === "escape-key")
-        ) {
-          return
-        }
         onClose()
       }}
     >
       <PopoverContent
+        data-dock-panel=""
         side={side}
         align="center"
         sideOffset={12}

--- a/apps/adt-runtime/src/features/navigation/components/PageNav.tsx
+++ b/apps/adt-runtime/src/features/navigation/components/PageNav.tsx
@@ -1,4 +1,4 @@
-import { useAtomValue } from "jotai";
+import { useAtomValue, useSetAtom } from "jotai";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import {
   currentPageNumberAtom,
@@ -6,6 +6,7 @@ import {
   pagesAtom,
   type PageEntry,
 } from "@/features/navigation/state/nav.atoms";
+import { dockMenuValueAtom } from "@/shared/state/ui.atoms";
 import { useTranslation } from "@/features/language/hooks/useTranslation";
 import { DockIconButton } from "@/features/dock/components/DockIconButton";
 
@@ -48,6 +49,8 @@ export function PageNav() {
   const pages = useAtomValue(pagesAtom);
   const currentSectionId = useAtomValue(currentSectionIdAtom);
   const currentPageFromMeta = useAtomValue(currentPageNumberAtom);
+  const dockMenuValue = useAtomValue(dockMenuValueAtom);
+  const setDockMenuValue = useSetAtom(dockMenuValueAtom);
   const { t } = useTranslation();
 
   const idx = pages.findIndex((p) => p.section_id === currentSectionId);
@@ -62,6 +65,11 @@ export function PageNav() {
 
   const go = (href: string | undefined) => {
     if (!href) return;
+    // Turning the page dismisses the read-aloud panel. `dockMenuValue` is
+    // persisted, so clearing it keeps the panel closed on the next document
+    // rather than re-opening. Playback resumes independently via the
+    // persisted `isPlaying` flag, so audio keeps reading the new page.
+    if (dockMenuValue === "audio") setDockMenuValue("");
     window.location.href = href;
   };
 

--- a/apps/adt-runtime/src/features/navigation/hooks/useKeyboardPageNav.ts
+++ b/apps/adt-runtime/src/features/navigation/hooks/useKeyboardPageNav.ts
@@ -12,7 +12,7 @@
  * (SC 2.1.1) without trapping focus (SC 2.1.2) — the listener is only
  * active outside text-input contexts and modal surfaces.
  */
-import { useAtomValue } from "jotai"
+import { useAtomValue, useSetAtom } from "jotai"
 import { useEffect } from "react"
 import { appConfigAtom } from "@/shared/state/config.atoms"
 import {
@@ -22,18 +22,7 @@ import {
 } from "@/features/navigation/state/nav.atoms"
 import { dockMenuValueAtom, sidebarOpenAtom } from "@/shared/state/ui.atoms"
 import { isTypingTarget } from "@/features/navigation/lib/typing-target"
-
-function isAnyModalOpen(): boolean {
-  if (typeof document === "undefined") return false
-  // Radix / base-ui popovers and dialogs set `data-state="open"` on their
-  // root portals. The dock menu popovers, sidebar, notepad, eli5, admin,
-  // and tutorial overlays all share that convention.
-  return Boolean(
-    document.querySelector(
-      '[role="dialog"][data-state="open"], [data-radix-popper-content-wrapper], [data-base-ui-popper-content-wrapper]',
-    ),
-  )
-}
+import { isAnyModalOpen } from "@/features/navigation/lib/modal-state"
 
 function findIndex(pages: PageEntry[], sectionId: string | null): number {
   if (!sectionId) return -1
@@ -44,6 +33,7 @@ export function useKeyboardPageNav(): void {
   const pages = useAtomValue(pagesAtom)
   const currentSectionId = useAtomValue(currentSectionIdAtom)
   const dockMenuValue = useAtomValue(dockMenuValueAtom)
+  const setDockMenuValue = useSetAtom(dockMenuValueAtom)
   const sidebarOpen = useAtomValue(sidebarOpenAtom)
   const features = useAtomValue(appConfigAtom).features
 
@@ -55,7 +45,12 @@ export function useKeyboardPageNav(): void {
       if (event.defaultPrevented) return
       if (event.altKey || event.ctrlKey || event.metaKey) return
       if (isTypingTarget(event.target)) return
-      if (sidebarOpen || dockMenuValue !== "") return
+      // The read-aloud (audio) panel is the one dock surface with no
+      // arrow-key controls of its own, and users page through the book while
+      // listening — so keep global page nav live while it's open. Every other
+      // panel (toc/glossary/language/settings) owns its arrow keys.
+      if (sidebarOpen) return
+      if (dockMenuValue !== "" && dockMenuValue !== "audio") return
       if (isAnyModalOpen()) return
 
       const idx = findIndex(pages, currentSectionId)
@@ -82,10 +77,15 @@ export function useKeyboardPageNav(): void {
 
       if (!target) return
       event.preventDefault()
+      // Turning the page dismisses the read-aloud panel. `dockMenuValue` is
+      // persisted, so clearing it here keeps it closed on the next document
+      // instead of re-opening. Playback itself resumes independently (the
+      // persisted `isPlaying` flag), so audio keeps reading the new page.
+      if (dockMenuValue === "audio") setDockMenuValue("")
       window.location.href = target.href
     }
 
     document.addEventListener("keydown", onKeyDown)
     return () => document.removeEventListener("keydown", onKeyDown)
-  }, [pages, currentSectionId, dockMenuValue, sidebarOpen, features.showNavigationControls])
+  }, [pages, currentSectionId, dockMenuValue, setDockMenuValue, sidebarOpen, features.showNavigationControls])
 }

--- a/apps/adt-runtime/src/features/navigation/lib/modal-state.test.ts
+++ b/apps/adt-runtime/src/features/navigation/lib/modal-state.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from "vitest"
+import { isAnyModalOpen } from "./modal-state"
+
+function appendOpenPopup(
+  role: "dialog" | "menu",
+  attrs: Record<string, string> = {},
+): HTMLElement {
+  const popup = document.createElement("div")
+  popup.setAttribute("role", role)
+  popup.setAttribute("data-open", "")
+  for (const [key, value] of Object.entries(attrs)) {
+    popup.setAttribute(key, value)
+  }
+  document.body.appendChild(popup)
+  return popup
+}
+
+describe("isAnyModalOpen", () => {
+  beforeEach(() => document.body.replaceChildren())
+
+  it("ignores the outer dock panel popup", () => {
+    appendOpenPopup("dialog", { "data-dock-panel": "" })
+
+    expect(isAnyModalOpen()).toBe(false)
+  })
+
+  it.each(["dialog", "menu"] as const)(
+    "detects a nested Base UI %s popup while the dock panel is open",
+    (role) => {
+      appendOpenPopup("dialog", { "data-dock-panel": "" })
+      appendOpenPopup(role)
+
+      expect(isAnyModalOpen()).toBe(true)
+    },
+  )
+
+  it("continues to detect Radix dialogs and poppers", () => {
+    const dialog = document.createElement("div")
+    dialog.setAttribute("role", "dialog")
+    dialog.setAttribute("data-state", "open")
+    document.body.appendChild(dialog)
+    expect(isAnyModalOpen()).toBe(true)
+
+    dialog.remove()
+    const popper = document.createElement("div")
+    popper.setAttribute("data-radix-popper-content-wrapper", "")
+    document.body.appendChild(popper)
+    expect(isAnyModalOpen()).toBe(true)
+  })
+})

--- a/apps/adt-runtime/src/features/navigation/lib/modal-state.ts
+++ b/apps/adt-runtime/src/features/navigation/lib/modal-state.ts
@@ -1,0 +1,17 @@
+const OPEN_MODAL_SELECTOR = [
+  // Radix dialogs and poppers.
+  '[role="dialog"][data-state="open"]',
+  "[data-radix-popper-content-wrapper]",
+  // Current Base UI popups use `data-open`. Dock panels are handled by
+  // `dockMenuValueAtom`; excluding their outer popup lets the audio panel
+  // keep page navigation enabled while still blocking its nested controls.
+  '[role="dialog"][data-open]:not([data-dock-panel])',
+  '[role="menu"][data-open]',
+  // Compatibility with older Base UI popper markup.
+  "[data-base-ui-popper-content-wrapper]",
+].join(", ")
+
+export function isAnyModalOpen(): boolean {
+  if (typeof document === "undefined") return false
+  return Boolean(document.querySelector(OPEN_MODAL_SELECTOR))
+}


### PR DESCRIPTION
## Summary
- Let readers use page-navigation shortcuts while the read-aloud panel is open.
- Dismiss the panel on page changes, outside clicks, and Escape while preserving playback across pages.
- Keep nested speed and volume popups from leaking navigation keystrokes, with regression coverage.

## Testing
- `pnpm --filter @adt/runtime test` (109 passed)
- `pnpm --filter @adt/runtime build`

Typecheck remains blocked by pre-existing errors in `lifecycle.ts` and fill-in-the-blank code.