### PR TITLE
Improve standalone quiz interactions and fixed-layout exports

### DIFF
--- a/apps/adt-runtime/src/activities-entry.tsx
+++ b/apps/adt-runtime/src/activities-entry.tsx
@@ -33,7 +33,7 @@ import {
   currentSectionIdAtom,
   pagesAtom,
 } from "@/features/navigation/state/nav.atoms"
-import { activityModeAtom, isActivityPageAtom } from "@/features/activity/state/activity.atoms"
+import { activityModeAtom, isActivityPageAtom, submitStateAtom } from "@/features/activity/state/activity.atoms"
 import { initializeQuizActivity } from "@/features/activity/runtime/activity-quiz"
 import { initializeMultiSelectActivity } from "@/features/activity/runtime/activity-multi-select"
 import { initializeFillInTheBlankActivity } from "@/features/activity/runtime/activity-fill-in-the-blank"
@@ -51,7 +51,12 @@ const store = getDefaultStore()
  */
 function ActivityControls() {
   const activityMode = useAtomValue(activityModeAtom)
+  const submitState = useAtomValue(submitStateAtom)
   if (!activityMode) return null
+  // Host readers (EPUB in Apple Books/Thorium, WebPub) have their own page
+  // navigation, so we don't surface the post-answer "Next" button the full web
+  // reader shows — only the "Submit" control that activities need to validate.
+  if (submitState === "next") return null
   return (
     <div
       style={{

--- a/apps/adt-runtime/src/features/activity/components/ActivityDock.tsx
+++ b/apps/adt-runtime/src/features/activity/components/ActivityDock.tsx
@@ -2,7 +2,11 @@ import { DockActivityActions } from "./DockActivityActions";
 import { cn } from "@/shared/lib/utils";
 import { useTranslation } from "@/features/language/hooks/useTranslation";
 import { useAtomValue } from "jotai";
-import { activityModeAtom, submitStateAtom } from "@/features/activity/state/activity.atoms";
+import {
+  activityModeAtom,
+  submitStateAtom,
+  submitVisibleAtom,
+} from "@/features/activity/state/activity.atoms";
 import { useDockContext } from "@/features/dock/context/dock-context";
 import { embedModeAtom } from "@/shared/state/ui.atoms";
 
@@ -12,12 +16,18 @@ export function ActivityDock() {
   const activityMode = useAtomValue(activityModeAtom);
   const embed = useAtomValue(embedModeAtom);
   const submitState = useAtomValue(submitStateAtom);
+  const submitVisible = useAtomValue(submitVisibleAtom);
   // In embed mode the BottomDock is hidden, so sit flush near the edge
   // instead of leaving room above the (absent) reader dock.
   const topClassname = embed ? "top-3" : isCompact ? "top-21" : "top-18";
   const bottomClassname = embed ? "bottom-3" : isCompact ? "bottom-21" : "bottom-18";
 
   if (!activityMode) return null;
+
+  // The dock only hosts the Submit/Next button. Standalone quizzes hide that
+  // button (they validate on click), so drop the whole pill rather than leave
+  // an empty floating container.
+  if (!submitVisible) return null;
 
   // Storyboard preview (`?embed=1`): once the activity is answered correctly the
   // button would flip to a navigating "Next", but advancing only swaps the

--- a/apps/adt-runtime/src/features/activity/components/DockActivityActions.tsx
+++ b/apps/adt-runtime/src/features/activity/components/DockActivityActions.tsx
@@ -5,6 +5,7 @@ import {
   submitEnabledAtom,
   submitLabelAtom,
   submitStateAtom,
+  submitVisibleAtom,
   validateHandlerAtom,
 } from "@/features/activity/state/activity.atoms";
 import { useTranslation } from "@/features/language/hooks/useTranslation";
@@ -12,10 +13,14 @@ import { cn } from "@/shared/lib/utils";
 
 export function DockActivityActions() {
   const submitEnabled = useAtomValue(submitEnabledAtom);
+  const submitVisible = useAtomValue(submitVisibleAtom);
   const validate = useAtomValue(validateHandlerAtom);
   const submitState = useAtomValue(submitStateAtom);
   const submitLabelOverride = useAtomValue(submitLabelAtom);
   const { t } = useTranslation();
+
+  // Standalone quizzes validate on click and hide this button entirely.
+  if (!submitVisible) return null;
 
   const defaultLabel =
     submitState === "next"

--- a/apps/adt-runtime/src/features/activity/runtime/activity-quiz.test.ts
+++ b/apps/adt-runtime/src/features/activity/runtime/activity-quiz.test.ts
@@ -1,16 +1,30 @@
 // @vitest-environment jsdom
-import { beforeEach, describe, expect, it } from "vitest"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import { getDefaultStore } from "jotai"
 import { initializeQuizActivity } from "./activity-quiz"
 import {
+  confettiTriggerAtom,
   skipEnabledAtom,
   submitEnabledAtom,
   submitStateAtom,
+  submitVisibleAtom,
   validateHandlerAtom,
 } from "../state/activity.atoms"
 import { pagesAtom, currentSectionIdAtom } from "../../navigation/state/nav.atoms"
+import { dockMenuValueAtom, sidebarOpenAtom } from "../../../shared/state/ui.atoms"
 
 const store = getDefaultStore()
+
+// initializeQuizActivity registers a document-level keydown listener (for the
+// number-key shortcuts) that outlives DOM replacement. Capture the teardown so
+// each test starts from a clean slate — matching the real lifecycle, which runs
+// this cleanup on page unmount.
+let cleanup: (() => void) | null = null
+
+afterEach(() => {
+  cleanup?.()
+  cleanup = null
+})
 
 function setupStandaloneQuiz(): void {
   document.body.innerHTML = `
@@ -59,6 +73,10 @@ beforeEach(() => {
   store.set(submitEnabledAtom, false)
   store.set(skipEnabledAtom, false)
   store.set(submitStateAtom, "submit")
+  store.set(submitVisibleAtom, true)
+  store.set(confettiTriggerAtom, 0)
+  store.set(sidebarOpenAtom, false)
+  store.set(dockMenuValueAtom, "")
   store.set(validateHandlerAtom, () => null)
 })
 
@@ -73,33 +91,140 @@ describe("initializeQuizActivity — standalone activity_quiz", () => {
     store.set(currentSectionIdAtom, "qz001")
   })
 
-  it("validates the selected option against data-correct-answers", () => {
+  it("hides the submit button (quizzes validate on click)", () => {
     setupStandaloneQuiz()
-    initializeQuizActivity()
-
-    const option = document.querySelector<HTMLElement>(
-      ".activity-option[data-activity-item='item-1']",
-    )!
-    option.click()
-    expect(store.get(submitEnabledAtom)).toBe(true)
-
-    store.get(validateHandlerAtom)?.()
-    expect(store.get(submitStateAtom)).toBe("next")
-    expect(store.get(submitEnabledAtom)).toBe(true) // next page exists
+    cleanup = initializeQuizActivity()
+    expect(store.get(submitVisibleAtom)).toBe(false)
   })
 
-  it("disables next when this is the last page", () => {
+  it("validates immediately on click — no submit needed", () => {
+    setupStandaloneQuiz()
+    cleanup = initializeQuizActivity()
+
+    const correct = document.querySelector<HTMLElement>(
+      ".activity-option[data-activity-item='item-1']",
+    )!
+    correct.click()
+
+    // Verdict is applied straight away, without a second (submit) click.
+    expect(correct.classList.contains("bg-green-50")).toBe(true)
+    expect(correct.getAttribute("aria-invalid")).toBe("false")
+    // A correct answer celebrates.
+    expect(store.get(confettiTriggerAtom)).toBe(1)
+    // …and reveals the Next button (a next page exists in the manifest above).
+    expect(store.get(submitVisibleAtom)).toBe(true)
+    expect(store.get(submitStateAtom)).toBe("next")
+    expect(store.get(submitEnabledAtom)).toBe(true)
+  })
+
+  it("marks a wrong pick as incorrect immediately (no confetti, no Next)", () => {
+    setupStandaloneQuiz()
+    cleanup = initializeQuizActivity()
+
+    const wrong = document.querySelector<HTMLElement>(
+      ".activity-option[data-activity-item='item-2']",
+    )!
+    wrong.click()
+
+    expect(wrong.classList.contains("bg-red-50")).toBe(true)
+    expect(wrong.getAttribute("aria-invalid")).toBe("true")
+    expect(store.get(confettiTriggerAtom)).toBe(0)
+    // No button on a wrong pick — the reader just picks again.
+    expect(store.get(submitVisibleAtom)).toBe(false)
+    expect(store.get(submitStateAtom)).toBe("submit")
+  })
+
+  it("shows a disabled Next after a correct answer on the last page", () => {
     store.set(currentSectionIdAtom, "qz002") // last page
     setupStandaloneQuiz()
     document.querySelector("section")!.setAttribute("data-section-id", "qz002")
-    initializeQuizActivity()
+    cleanup = initializeQuizActivity()
 
     document
       .querySelector<HTMLElement>(".activity-option[data-activity-item='item-1']")!
       .click()
-    store.get(validateHandlerAtom)?.()
+
+    expect(store.get(submitVisibleAtom)).toBe(true)
     expect(store.get(submitStateAtom)).toBe("next")
-    expect(store.get(submitEnabledAtom)).toBe(false)
+    expect(store.get(submitEnabledAtom)).toBe(false) // nowhere to advance
+  })
+
+  it("lets the reader change their answer, updating the verdict and the Next button", () => {
+    setupStandaloneQuiz()
+    cleanup = initializeQuizActivity()
+
+    const wrong = document.querySelector<HTMLElement>(
+      ".activity-option[data-activity-item='item-2']",
+    )!
+    const correct = document.querySelector<HTMLElement>(
+      ".activity-option[data-activity-item='item-1']",
+    )!
+    wrong.click()
+    expect(wrong.classList.contains("bg-red-50")).toBe(true)
+    expect(store.get(submitVisibleAtom)).toBe(false)
+
+    correct.click()
+    // The wrong option's verdict is cleared; the new pick is marked correct and
+    // the Next button appears.
+    expect(wrong.classList.contains("bg-red-50")).toBe(false)
+    expect(correct.classList.contains("bg-green-50")).toBe(true)
+    expect(store.get(submitVisibleAtom)).toBe(true)
+    expect(store.get(submitStateAtom)).toBe("next")
+
+    // Switching back to a wrong answer retracts the Next button.
+    wrong.click()
+    expect(correct.classList.contains("bg-green-50")).toBe(false)
+    expect(wrong.classList.contains("bg-red-50")).toBe(true)
+    expect(store.get(submitVisibleAtom)).toBe(false)
+    expect(store.get(submitStateAtom)).toBe("submit")
+  })
+
+  it("answers via the number keys (1 → first option, 2 → second)", () => {
+    setupStandaloneQuiz()
+    cleanup = initializeQuizActivity()
+
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "2", bubbles: true }),
+    )
+    const second = document.querySelector<HTMLElement>(
+      ".activity-option[data-activity-item='item-2']",
+    )!
+    expect(second.classList.contains("bg-red-50")).toBe(true)
+    expect(store.get(submitVisibleAtom)).toBe(false)
+
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "1", bubbles: true }),
+    )
+    const first = document.querySelector<HTMLElement>(
+      ".activity-option[data-activity-item='item-1']",
+    )!
+    expect(first.classList.contains("bg-green-50")).toBe(true)
+    expect(store.get(confettiTriggerAtom)).toBe(1)
+    expect(store.get(submitVisibleAtom)).toBe(true)
+  })
+
+  it("ignores number keys while a modal/popover overlays the quiz", () => {
+    setupStandaloneQuiz()
+    cleanup = initializeQuizActivity()
+
+    // Simulate an open dialog (dock menu, settings, glossary popover, …).
+    const modal = document.createElement("div")
+    modal.setAttribute("role", "dialog")
+    modal.setAttribute("data-state", "open")
+    document.body.appendChild(modal)
+
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "1", bubbles: true }),
+    )
+
+    const first = document.querySelector<HTMLElement>(
+      ".activity-option[data-activity-item='item-1']",
+    )!
+    // The key was swallowed by the overlay guard — no answer registered.
+    expect(first.classList.contains("bg-green-50")).toBe(false)
+    expect(store.get(confettiTriggerAtom)).toBe(0)
+
+    modal.remove()
   })
 })
 
@@ -114,7 +239,7 @@ describe("initializeQuizActivity — embedded activity_multiple_choice", () => {
 
   it("reads correct answers from window.correctAnswers", () => {
     setupMultipleChoice()
-    initializeQuizActivity()
+    cleanup = initializeQuizActivity()
 
     document
       .querySelector<HTMLInputElement>("input[data-activity-item='item-1']")!
@@ -126,7 +251,7 @@ describe("initializeQuizActivity — embedded activity_multiple_choice", () => {
 
   it("treats a wrong pick as incorrect and stays in submit state", () => {
     setupMultipleChoice()
-    initializeQuizActivity()
+    cleanup = initializeQuizActivity()
 
     document
       .querySelector<HTMLInputElement>("input[data-activity-item='item-2']")!
@@ -138,7 +263,7 @@ describe("initializeQuizActivity — embedded activity_multiple_choice", () => {
 
   it("post-correct, submit enables for the next sequential page (not the next quiz)", () => {
     setupMultipleChoice()
-    initializeQuizActivity()
+    cleanup = initializeQuizActivity()
 
     document
       .querySelector<HTMLInputElement>("input[data-activity-item='item-1']")!
@@ -152,7 +277,7 @@ describe("initializeQuizActivity — embedded activity_multiple_choice", () => {
 
   it("applies a visible selection highlight on the picked option label", () => {
     setupMultipleChoice()
-    initializeQuizActivity()
+    cleanup = initializeQuizActivity()
 
     const opt1 = document
       .querySelector<HTMLInputElement>("input[data-activity-item='item-1']")!
@@ -171,7 +296,7 @@ describe("initializeQuizActivity — embedded activity_multiple_choice", () => {
 
   it("strips the selection highlight on validation and applies the correct/incorrect state class", () => {
     setupMultipleChoice()
-    initializeQuizActivity()
+    cleanup = initializeQuizActivity()
 
     const opt = document
       .querySelector<HTMLInputElement>("input[data-activity-item='item-1']")!
@@ -184,7 +309,7 @@ describe("initializeQuizActivity — embedded activity_multiple_choice", () => {
 
   it("injects a status badge for correct/incorrect verdicts (non-color cue)", () => {
     setupMultipleChoice()
-    initializeQuizActivity()
+    cleanup = initializeQuizActivity()
 
     const correctOpt = document
       .querySelector<HTMLInputElement>("input[data-activity-item='item-1']")!
@@ -199,7 +324,7 @@ describe("initializeQuizActivity — embedded activity_multiple_choice", () => {
 
   it("syncs selection state when the inner radio fires `change` (arrow-key navigation)", () => {
     setupMultipleChoice()
-    initializeQuizActivity()
+    cleanup = initializeQuizActivity()
 
     const radio2 = document.querySelector<HTMLInputElement>(
       "input[data-activity-item='item-2']",
@@ -235,7 +360,7 @@ describe("initializeQuizActivity — embedded activity_multiple_choice", () => {
       </section>
     `
     window.correctAnswers = { "item-1": true, "item-2": false }
-    initializeQuizActivity()
+    cleanup = initializeQuizActivity()
 
     const correctImgOpt = document
       .querySelector<HTMLInputElement>("input[data-activity-item='item-1']")!
@@ -293,7 +418,7 @@ describe("initializeQuizActivity — embedded activity_multiple_choice", () => {
       "item-3": false,
       "item-4": true,
     }
-    initializeQuizActivity()
+    cleanup = initializeQuizActivity()
 
     const q1a = document
       .querySelector<HTMLInputElement>("input[data-activity-item='item-1']")!
@@ -334,7 +459,7 @@ describe("initializeQuizActivity — embedded activity_multiple_choice", () => {
       </section>
     `
     window.correctAnswers = { "item-1": true, "item-2": false }
-    initializeQuizActivity()
+    cleanup = initializeQuizActivity()
 
     // Answer q1 correctly, leave q2 unanswered — should stay in submit.
     document
@@ -374,7 +499,7 @@ describe("initializeQuizActivity — embedded activity_multiple_choice", () => {
       </section>
     `
     window.correctAnswers = { "item-1": false, "item-2": true }
-    initializeQuizActivity()
+    cleanup = initializeQuizActivity()
 
     // Click on the image inside the label — should still register selection
     // on the parent .activity-option via event bubbling.
@@ -405,7 +530,7 @@ describe("initializeQuizActivity — embedded activity_multiple_choice", () => {
       </section>
     `
     window.correctAnswers = { "item-1": false, "item-2": true }
-    initializeQuizActivity()
+    cleanup = initializeQuizActivity()
 
     const winner = document
       .querySelector<HTMLInputElement>("input[data-activity-item='item-2']")!

--- a/apps/adt-runtime/src/features/activity/runtime/activity-quiz.test.ts
+++ b/apps/adt-runtime/src/features/activity/runtime/activity-quiz.test.ts
@@ -117,6 +117,42 @@ describe("initializeQuizActivity — standalone activity_quiz", () => {
     expect(store.get(submitEnabledAtom)).toBe(true)
   })
 
+  it("uses blue for focus, then green or red for the answer verdict", () => {
+    setupStandaloneQuiz()
+    cleanup = initializeQuizActivity()
+
+    const correct = document.querySelector<HTMLElement>(
+      ".activity-option[data-activity-item='item-1']",
+    )!
+    correct.focus()
+    expect(correct.style.outline).toContain("rgb(37, 99, 235)")
+
+    correct.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "Enter",
+        bubbles: true,
+        cancelable: true,
+      }),
+    )
+    expect(correct.style.borderColor).toBe("rgb(22, 163, 74)")
+    expect(correct.style.outline).toContain("rgb(22, 163, 74)")
+
+    const wrong = document.querySelector<HTMLElement>(
+      ".activity-option[data-activity-item='item-2']",
+    )!
+    wrong.focus()
+    expect(wrong.style.outline).toContain("rgb(37, 99, 235)")
+    wrong.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "Enter",
+        bubbles: true,
+        cancelable: true,
+      }),
+    )
+    expect(wrong.style.borderColor).toBe("rgb(220, 38, 38)")
+    expect(wrong.style.outline).toContain("rgb(220, 38, 38)")
+  })
+
   it("marks a wrong pick as incorrect immediately (no confetti, no Next)", () => {
     setupStandaloneQuiz()
     cleanup = initializeQuizActivity()
@@ -339,6 +375,28 @@ describe("initializeQuizActivity — embedded activity_multiple_choice", () => {
     // Validation runs against the keyboard-selected option.
     store.get(validateHandlerAtom)?.()
     expect(store.get(submitStateAtom)).toBe("submit") // item-2 is the wrong answer
+  })
+
+  it("keeps option labels tabbable without consuming the reader's arrow keys", () => {
+    setupMultipleChoice()
+    cleanup = initializeQuizActivity()
+
+    const radio = document.querySelector<HTMLInputElement>(
+      "input[data-activity-item='item-1']",
+    )!
+    const option = radio.closest<HTMLElement>(".activity-option")!
+
+    expect(option.tabIndex).toBe(0)
+    expect(radio.tabIndex).toBe(-1)
+
+    option.focus()
+    const arrow = new KeyboardEvent("keydown", {
+      key: "ArrowRight",
+      bubbles: true,
+      cancelable: true,
+    })
+    option.dispatchEvent(arrow)
+    expect(arrow.defaultPrevented).toBe(false)
   })
 
   it("handles image-only option labels (no inner text)", () => {

--- a/apps/adt-runtime/src/features/activity/runtime/activity-quiz.ts
+++ b/apps/adt-runtime/src/features/activity/runtime/activity-quiz.ts
@@ -8,10 +8,13 @@ import {
   submitEnabledAtom,
   submitLabelAtom,
   submitStateAtom,
+  submitVisibleAtom,
   validateHandlerAtom,
 } from "@/features/activity/state/activity.atoms"
 import { playActivitySound } from "@/features/activity/runtime/sounds"
 import { showActivityProgressToast } from "@/features/activity/lib/progress-toast"
+import { isAnyModalOpen } from "@/features/navigation/lib/modal-state"
+import { dockMenuValueAtom, sidebarOpenAtom } from "@/shared/state/ui.atoms"
 
 /**
  * Quiz (standalone `activity_quiz` page) and in-page `activity_multiple_choice`
@@ -413,6 +416,12 @@ export function initializeQuizActivity(): (() => void) | null {
   const isStandaloneQuiz = sectionType === "activity_quiz"
   const findPostCorrectHref = findNextPageHref
 
+  // Standalone quizzes validate the instant an option is picked — no Submit
+  // button, and the number keys (1/2/3…) pick-and-check too. Embedded
+  // multiple-choice keeps the pick-then-Submit model because a single page can
+  // host several question groups that must all be answered before checking.
+  const immediateValidation = isStandaloneQuiz
+
   const groups = buildGroups(section)
   const hasNextPage = findNextPageHref() !== null
   const hasPostCorrectTarget = findPostCorrectHref() !== null
@@ -430,11 +439,58 @@ export function initializeQuizActivity(): (() => void) | null {
     store.set(submitLabelAtom, null)
     store.set(submitEnabledAtom, false)
     store.set(skipEnabledAtom, hasNextPage)
+    // Immediate-validation quizzes have no button to show.
+    store.set(submitVisibleAtom, !immediateValidation)
+  }
+
+  const validateImmediately = (option: HTMLElement, group: QuestionGroup) => {
+    // Re-clicking the option that's already marked is a no-op so we don't
+    // re-fire confetti / sounds on every repeat click.
+    if (group.validated && group.selected === option) return
+    clearGroupStyles(group, isStandaloneQuiz)
+    const input = option.querySelector<HTMLInputElement>('input[type="radio"]')
+    if (input) input.checked = true
+    option.setAttribute("aria-checked", "true")
+    group.selected = option
+
+    const itemId = getOptionItemId(option)
+    const isCorrect = itemId ? Boolean(correctAnswers[itemId]) : false
+    applyValidationStyle(option, isCorrect, isStandaloneQuiz)
+    showFeedback(option, isCorrect, isStandaloneQuiz)
+    group.validated = true
+    playActivitySound(isCorrect ? "success" : "error")
+
+    if (isCorrect) {
+      store.set(confettiTriggerAtom, store.get(confettiTriggerAtom) + 1)
+      // Reveal the Next button so the reader can advance — parity with the
+      // Submit→Next flow multiple-choice uses. `handleValidate` (the button's
+      // handler) navigates when the state is "next". Enabled only when a next
+      // page actually exists (disabled on the final page).
+      store.set(submitStateAtom, "next")
+      store.set(submitLabelAtom, null)
+      store.set(submitEnabledAtom, hasPostCorrectTarget)
+      store.set(submitVisibleAtom, true)
+    } else {
+      // Wrong pick — keep the button hidden; the reader simply picks again.
+      store.set(submitStateAtom, "submit")
+      store.set(submitLabelAtom, null)
+      store.set(submitEnabledAtom, false)
+      store.set(submitVisibleAtom, false)
+    }
   }
 
   const handleSelect = (option: HTMLElement) => {
     const group = findGroupForOption(groups, option)
     if (!group) return
+    // Land focus on the option label, never the native radio. A focused native
+    // radio arrow-navigates its group and swallows the reader's arrow-key page
+    // turn (e.g. Thorium in the JS EPUB); the label doesn't, so arrow keys pass
+    // through. Selection stays keyboard-accessible via Enter/Space + number keys.
+    if (option !== document.activeElement) option.focus()
+    if (immediateValidation) {
+      validateImmediately(option, group)
+      return
+    }
     if (group.validated) clearGroupStyles(group, isStandaloneQuiz)
     markSelection(option, group, isStandaloneQuiz)
     playActivitySound("drop")
@@ -530,7 +586,7 @@ export function initializeQuizActivity(): (() => void) | null {
 
   const listeners: Array<() => void> = []
   for (const group of groups) {
-    for (const option of group.options) {
+    group.options.forEach((option) => {
       const onClick = () => handleSelect(option)
       const onKey = (e: KeyboardEvent) => {
         if (e.key === "Enter" || e.key === " ") {
@@ -550,6 +606,11 @@ export function initializeQuizActivity(): (() => void) | null {
         'input[type="radio"]',
       )
       if (innerRadio) {
+        // Keep native radios out of the tab order so keyboard focus lands on the
+        // option label (which doesn't arrow-navigate), leaving the reader's
+        // arrow-key page turn free. Selection is still driven by Enter/Space and
+        // the number keys.
+        innerRadio.setAttribute("tabindex", "-1")
         const onChange = () => {
           if (innerRadio.checked) handleSelect(option)
         }
@@ -563,7 +624,47 @@ export function initializeQuizActivity(): (() => void) | null {
         option.removeEventListener("click", onClick)
         option.removeEventListener("keydown", onKey)
       })
+    })
+  }
+
+  // Standalone quiz: pressing a number key picks-and-checks the matching option
+  // (1 → first option, 2 → second, …). Scoped to the single-group quiz page;
+  // multiple-choice keeps arrow-key radio navigation since its number mapping
+  // would be ambiguous across question groups.
+  if (immediateValidation) {
+    const onNumberKey = (e: KeyboardEvent) => {
+      if (e.defaultPrevented) return
+      if (e.altKey || e.ctrlKey || e.metaKey) return
+      // Defer to whatever surface owns the keyboard: an open sidebar, dock
+      // menu, or modal/popover overlays the quiz, so the digit shouldn't reach
+      // it. (Mirrors the guards in useKeyboardPageNav; all no-ops in the WebPub
+      // bundle, which ships none of that chrome.)
+      if (store.get(sidebarOpenAtom) || store.get(dockMenuValueAtom) !== "") {
+        return
+      }
+      if (isAnyModalOpen()) return
+      const active = document.activeElement as HTMLElement | null
+      // Don't hijack digits typed into a real text field. A focused quiz radio
+      // is fine — that's the reader answering, which is exactly what we want.
+      if (
+        active &&
+        (active.isContentEditable ||
+          active.tagName === "TEXTAREA" ||
+          active.tagName === "SELECT" ||
+          (active.tagName === "INPUT" &&
+            (active as HTMLInputElement).type !== "radio"))
+      ) {
+        return
+      }
+      const index = Number.parseInt(e.key, 10) - 1
+      if (!Number.isInteger(index) || index < 0) return
+      const option = groups[0]?.options[index]
+      if (!option) return
+      e.preventDefault()
+      handleSelect(option)
     }
+    document.addEventListener("keydown", onNumberKey)
+    listeners.push(() => document.removeEventListener("keydown", onNumberKey))
   }
 
   store.set(validateHandlerAtom, () => handleValidate)
@@ -595,5 +696,6 @@ export function initializeQuizActivity(): (() => void) | null {
     store.set(skipHandlerAtom, () => null)
     store.set(submitEnabledAtom, false)
     store.set(skipEnabledAtom, false)
+    store.set(submitVisibleAtom, true)
   }
 }

--- a/apps/adt-runtime/src/features/activity/runtime/activity-quiz.ts
+++ b/apps/adt-runtime/src/features/activity/runtime/activity-quiz.ts
@@ -123,6 +123,8 @@ const MC_OUTLINE_COLORS = {
   incorrect: "rgb(220, 38, 38)", // red-600
 } as const
 
+const QUIZ_FOCUS_OUTLINE = `3px solid ${MC_OUTLINE_COLORS.selected}`
+
 // Only correct/incorrect get a faint wash; selected gets outline only so the
 // option's own background (often supplied by the LLM via a `bg-*` class) is
 // preserved and the user doesn't see a flash to transparent when picking.
@@ -302,7 +304,11 @@ function clearOptionState(option: HTMLElement, isStandaloneQuiz: boolean): void 
   option.setAttribute("aria-checked", "false")
   const input = option.querySelector<HTMLInputElement>('input[type="radio"]')
   if (input) input.checked = false
-  if (!isStandaloneQuiz) {
+  if (isStandaloneQuiz) {
+    option.style.borderColor = ""
+    option.style.outline = ""
+    option.style.outlineOffset = ""
+  } else {
     clearMcOutline(option)
     clearMcBadge(option)
   }
@@ -346,6 +352,12 @@ function applyValidationStyle(
     // Strip the blue selection ring so it doesn't fight the green/red verdict.
     option.classList.remove("selected-option", ...SELECTION_HIGHLIGHT_CLASSES)
     option.classList.add(isCorrect ? "bg-green-50" : "bg-red-50")
+    const verdictColor = isCorrect
+      ? MC_OUTLINE_COLORS.correct
+      : MC_OUTLINE_COLORS.incorrect
+    option.style.borderColor = verdictColor
+    option.style.outline = `3px solid ${verdictColor}`
+    option.style.outlineOffset = "2px"
   } else {
     // Keep the outline (now green/red) so the badge has something to dock on
     // and the verdict is visible from across the page.
@@ -594,10 +606,36 @@ export function initializeQuizActivity(): (() => void) | null {
           handleSelect(option)
         }
       }
+      const onFocus = () => {
+        if (
+          option.hasAttribute("aria-invalid") ||
+          option.hasAttribute(MC_STYLE_FLAG_ATTR)
+        ) {
+          return
+        }
+        option.style.outline = QUIZ_FOCUS_OUTLINE
+        option.style.outlineOffset = "2px"
+      }
+      const onBlur = () => {
+        if (
+          option.hasAttribute("aria-invalid") ||
+          option.hasAttribute(MC_STYLE_FLAG_ATTR)
+        ) {
+          return
+        }
+        option.style.outline = ""
+        option.style.outlineOffset = ""
+      }
       option.addEventListener("click", onClick)
       option.addEventListener("keydown", onKey)
+      option.addEventListener("focus", onFocus)
+      option.addEventListener("blur", onBlur)
       option.setAttribute("role", "radio")
       option.setAttribute("aria-checked", "false")
+      // Focus the label instead of the native radio: Tab can still reach every
+      // answer and Enter/Space selects it, while ArrowLeft/ArrowRight remain
+      // available to host readers such as Apple Books for page navigation.
+      option.setAttribute("tabindex", "0")
 
       // Arrow-key navigation between native radios fires `change` on the new
       // radio without firing `click` on its label. Listen here too so keyboard
@@ -623,6 +661,8 @@ export function initializeQuizActivity(): (() => void) | null {
       listeners.push(() => {
         option.removeEventListener("click", onClick)
         option.removeEventListener("keydown", onKey)
+        option.removeEventListener("focus", onFocus)
+        option.removeEventListener("blur", onBlur)
       })
     })
   }

--- a/apps/adt-runtime/src/features/activity/state/activity.atoms.ts
+++ b/apps/adt-runtime/src/features/activity/state/activity.atoms.ts
@@ -10,6 +10,11 @@ export const activityModeAtom = ephemeralAtom(false)
 export const submitEnabledAtom = ephemeralAtom(false)
 export const skipEnabledAtom = ephemeralAtom(false)
 
+// Whether the Submit/Next button (and the dock that hosts it) should render at
+// all. Standalone quizzes validate on the first click and hide the button
+// entirely; every other activity keeps the pick-then-submit flow.
+export const submitVisibleAtom = ephemeralAtom(true)
+
 export const validateHandlerAtom = ephemeralAtom<ValidateHandler | null>(null)
 export const skipHandlerAtom = ephemeralAtom<SkipHandler | null>(null)
 

--- a/apps/adt-runtime/src/features/navigation/lib/typing-target.test.ts
+++ b/apps/adt-runtime/src/features/navigation/lib/typing-target.test.ts
@@ -37,6 +37,22 @@ describe("isTypingTarget", () => {
     document.body.removeChild(wrapper)
   })
 
+  it("returns false for focused quiz labels so arrows keep turning pages", () => {
+    const option = makeEl("label", {
+      class: "activity-option",
+      role: "radio",
+      "data-activity-item": "item-1",
+    })
+    const inner = makeEl("span")
+    option.appendChild(inner)
+    document.body.appendChild(option)
+
+    expect(isTypingTarget(option)).toBe(false)
+    expect(isTypingTarget(inner)).toBe(false)
+
+    option.remove()
+  })
+
   it("returns false for plain non-interactive elements", () => {
     expect(isTypingTarget(makeEl("div"))).toBe(false)
     expect(isTypingTarget(makeEl("p"))).toBe(false)

--- a/apps/adt-runtime/src/features/navigation/lib/typing-target.ts
+++ b/apps/adt-runtime/src/features/navigation/lib/typing-target.ts
@@ -2,15 +2,18 @@
  * Returns true when an event target represents an element that is currently
  * receiving user typing input — used to suppress global keyboard shortcuts
  * (e.g. ArrowLeft/Right for page nav) while the user is editing text or
- * navigating a focused radio-group activity option.
+ * navigating a focused form control.
  */
 export function isTypingTarget(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) return false
   const tag = target.tagName
   if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true
   if (target.isContentEditable) return true
-  // Quiz options listen to arrow keys for radio-group navigation in the
-  // legacy a11y pattern; let them keep the keystroke when focused.
+  // Quiz option labels intentionally handle only Enter/Space. Their native
+  // radios are removed from the tab order so ArrowLeft/ArrowRight can keep
+  // turning pages in the reader while an answer remains focused.
+  if (target.closest(".activity-option[role='radio']")) return false
+  // Other activity items may own richer keyboard interactions.
   if (target.closest("[data-activity-item]")) return true
   return false
 }

--- a/apps/api/src/services/stage-runner.ts
+++ b/apps/api/src/services/stage-runner.ts
@@ -39,6 +39,7 @@ import {
   buildQuizGenerationConfig,
   // Master step imports
   getRenderSectioning,
+  getSemanticSectioning,
   buildTextCatalog,
   buildEasyReadConfig,
   buildEasyReadSourceBlocks,
@@ -1579,19 +1580,39 @@ async function runQuizzesStep(
 
     progress.emit({ type: "step-start", step: "quiz-generation" })
 
-    // Gather page data for quiz generation
+    // Gather page data for quiz generation. A page is eligible only when it has
+    // BOTH a web-rendering and a render-sectioning node — the quiz LLM reads
+    // rendered text, and batching counts sectioned content pages.
     const pages = storage.getPages()
     const quizPages: QuizPageInput[] = []
+    let missingRendering = 0
+    let missingSectioning = 0
     for (const page of pages) {
       const renderingRow = storage.getLatestNodeData("web-rendering", page.pageId)
-      const sectioning = getRenderSectioning(storage, page.pageId)
-      if (!renderingRow || !sectioning) continue
+      // Filter by the SEMANTIC sectioning (real types like `text_and_single_image`),
+      // not the render sectioning — in fixed-layout the render tree is positioned
+      // and its only section type is `fixed-layout-page`, which never matches
+      // `quiz_section_types`, so no page would qualify and no quiz would generate.
+      const sectioning = getSemanticSectioning(storage, page.pageId)
+      if (!renderingRow) {
+        missingRendering++
+        continue
+      }
+      if (!sectioning) {
+        missingSectioning++
+        continue
+      }
       quizPages.push({
         pageId: page.pageId,
         rendering: renderingRow.data as WebRenderingOutput,
         sectioning,
       })
     }
+    console.log(
+      `[stage-run] ${label}: quiz input — ${quizPages.length}/${pages.length} pages ready ` +
+        `(missing web-rendering: ${missingRendering}, missing sectioning: ${missingSectioning}); ` +
+        `pages_per_quiz=${quizConfig.pagesPerQuiz}`
+    )
 
     if (quizPages.length > 0) {
       const quizResult = await generateAllQuizzes(quizPages, quizConfig, quizModel, {
@@ -1607,10 +1628,26 @@ async function runQuizzesStep(
         },
       })
       storage.putNodeData("quiz-generation", "book", quizResult)
+      console.log(
+        `[stage-run] ${label}: generated ${quizResult.quizzes.length} quiz(zes) from ${quizPages.length} page(s)`
+      )
       progress.emit({
         type: "step-progress",
         step: "quiz-generation",
         message: `${quizResult.quizzes.length} quizzes from ${quizPages.length} pages`,
+      })
+    } else {
+      // Nothing to generate. This is the silent "finished instantly, no quizzes"
+      // case — surface it loudly instead of completing green with no output.
+      console.warn(
+        `[stage-run] ${label}: quiz-generation produced NOTHING — 0 of ${pages.length} pages ` +
+          `had both web-rendering and render-sectioning. Re-run the Storyboard stage first ` +
+          `(fixed-layout writes both there), then Quizzes.`
+      )
+      progress.emit({
+        type: "step-progress",
+        step: "quiz-generation",
+        message: `No quizzes: 0/${pages.length} pages had rendering + sectioning`,
       })
     }
 

--- a/packages/pipeline/src/__tests__/package-web.test.ts
+++ b/packages/pipeline/src/__tests__/package-web.test.ts
@@ -413,6 +413,8 @@ describe("renderQuizHtml", () => {
     // Options are a fixed width so they don't resize when feedback appears.
     expect(html).toContain("w-[34rem]")
     expect(html).not.toContain("w-full max-w-xl")
+    expect(html).toContain("outline: 3px solid #2563eb")
+    expect(html).not.toContain("focus:ring-green-300")
   })
 
   it("themes the quiz as a callout when a style is given, preserving the interactive contract", () => {
@@ -433,6 +435,7 @@ describe("renderQuizHtml", () => {
     expect(html).toContain('data-correct-answers=')
     expect(html).toContain('data-activity-item="qz001_o0"')
     expect(html).toContain('class="option-text block adt-body"')
+    expect(html).toContain("outline: 3px solid #2563eb")
   })
 })
 

--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -334,6 +334,7 @@ export { processFixedLayoutPages, isFixedLayoutBook } from "./fixed-layout-rende
 export {
   getRenderSectioning,
   getRenderSectioningRow,
+  getSemanticSectioning,
   FIXED_LAYOUT_SECTIONING_NODE,
   PAGE_SECTIONING_NODE,
 } from "./render-sectioning.js"

--- a/packages/pipeline/src/packaging/epub.ts
+++ b/packages/pipeline/src/packaging/epub.ts
@@ -122,14 +122,48 @@ export function packageEpub(
   // ------------------------------------------------------------------
   const pagesJsonPath = path.join(oebpsDir, "content", "pages.json")
   const rawPages = JSON.parse(fs.readFileSync(pagesJsonPath, "utf-8")) as PageEntry[]
+  // Quizzes run via the standalone activities bundle (the JS runtime), which
+  // works across EPUB readers (Apple Books, Thorium). Quiz pages are authored as
+  // reflowable HTML (device-width viewport, flow layout); in a fixed-layout book
+  // that leaves them uncentered and jarring across page turns, so give them the
+  // book's fixed viewport to render as proper pre-paginated pages — same layout
+  // type, size, and centering as every other page. `refViewport` is the most
+  // common fixed viewport across the book's content pages.
+  const refViewport = options.fixedLayout
+    ? findReferenceViewport(oebpsDir, rawPages)
+    : null
+  // Quiz pages carry the activities bundle, so they also need the OPF `scripted`
+  // property for the reading system to enable scripting.
+  const scriptedHrefs = new Set<string>()
   for (const page of rawPages) {
     if (!page.href.endsWith(".html")) continue
     const htmlPath = path.join(oebpsDir, page.href)
     if (!fs.existsSync(htmlPath)) continue
 
-    const html = fs.readFileSync(htmlPath, "utf-8")
+    const rawHtml = fs.readFileSync(htmlPath, "utf-8")
+    const isQuizPage = rawHtml.includes('data-section-type="activity_quiz"')
+    let html = rawHtml
+    // Fixed-layout: swap the quiz page's responsive viewport for the book's fixed
+    // one so the reader lays it out (and centers it) like its pre-paginated
+    // neighbours instead of floating.
+    if (isQuizPage && refViewport) {
+      html = html.replace(
+        /(<meta name="viewport" content=")width=device-width[^"]*(")/,
+        `$1width=${refViewport.width}, height=${refViewport.height}$2`,
+      )
+    }
     let xhtml = convertPageToXhtml(html)
     const xhtmlHref = page.href.replace(/\.html$/, ".xhtml")
+
+    if (isQuizPage) {
+      // Ship the activities bundle so the reader runs the interactive quiz, and
+      // mark the page scripted in the OPF.
+      xhtml = xhtml.replace(
+        "</body>",
+        `    <script src="./assets/activities.bundle.local.js"></script>\n</body>`,
+      )
+      scriptedHrefs.add(xhtmlHref)
+    }
 
     if (glossaryEntries.length > 0) {
       const result = wrapGlossaryTerms(xhtml, glossaryEntries)
@@ -253,6 +287,7 @@ export function packageEpub(
       allFiles,
       coverHref,
       fixedLayout: options.fixedLayout,
+      scriptedHrefs,
       smilEntries,
       glossaryHref,
     }),
@@ -417,6 +452,42 @@ function parseParagraphs(xhtml: string): Array<{ paragraphId: string; wordIds: s
   return out
 }
 
+/**
+ * The most common fixed viewport (`width=W, height=H`) declared across the
+ * book's pages. Fixed-layout content pages carry an explicit pixel viewport;
+ * quiz pages (authored reflowable) ship `width=device-width` and are ignored.
+ * Returns null when no page declares a fixed viewport.
+ */
+function findReferenceViewport(
+  oebpsDir: string,
+  pages: PageEntry[],
+): { width: number; height: number } | null {
+  const counts = new Map<string, number>()
+  for (const page of pages) {
+    if (!page.href.endsWith(".html")) continue
+    const p = path.join(oebpsDir, page.href)
+    if (!fs.existsSync(p)) continue
+    const m = fs
+      .readFileSync(p, "utf-8")
+      .match(/content="width=(\d+), height=(\d+)"/)
+    if (m) {
+      const key = `${m[1]}x${m[2]}`
+      counts.set(key, (counts.get(key) ?? 0) + 1)
+    }
+  }
+  let best: string | null = null
+  let bestN = 0
+  for (const [key, n] of counts) {
+    if (n > bestN) {
+      bestN = n
+      best = key
+    }
+  }
+  if (!best) return null
+  const [w, h] = best.split("x").map(Number)
+  return { width: w, height: h }
+}
+
 function buildOpf(opts: {
   title: string
   authors: string[]
@@ -426,10 +497,12 @@ function buildOpf(opts: {
   allFiles: Array<{ href: string; mediaType: string }>
   coverHref?: string
   fixedLayout?: boolean
+  /** Page hrefs that carry scripts (JS-quiz pages) → need the `scripted` property. */
+  scriptedHrefs?: Set<string>
   smilEntries?: SmilEntry[]
   glossaryHref?: string
 }): string {
-  const { title, authors, publisher, language, pageList, allFiles, coverHref, fixedLayout, smilEntries, glossaryHref } = opts
+  const { title, authors, publisher, language, pageList, allFiles, coverHref, fixedLayout, scriptedHrefs, smilEntries, glossaryHref } = opts
   const smilByPage = new Map<string, SmilEntry>()
   for (const e of smilEntries ?? []) smilByPage.set(e.pageHref, e)
   const now = new Date().toISOString().replace(/\.\d{3}Z$/, "Z")
@@ -514,7 +587,15 @@ function buildOpf(opts: {
 
     const props: string[] = []
     if (file.href === coverHref) props.push("cover-image")
-    if (!fixedLayout && pageHrefs.has(file.href)) props.push("scripted")
+    // Reflowable page docs are `scripted` by default; JS-quiz pages are scripted
+    // regardless of the book's layout (fixed-layout books opt these pages back to
+    // reflowable + scripted so the runtime bundle can run).
+    if (
+      (!fixedLayout && pageHrefs.has(file.href)) ||
+      scriptedHrefs?.has(file.href)
+    ) {
+      props.push("scripted")
+    }
     const propsAttr = props.length > 0 ? ` properties="${props.join(" ")}"` : ""
     const overlayId = pageHrefToOverlayId.get(file.href)
     const overlayAttr = overlayId ? ` media-overlay="${escapeXml(overlayId)}"` : ""

--- a/packages/pipeline/src/packaging/web.ts
+++ b/packages/pipeline/src/packaging/web.ts
@@ -1347,6 +1347,12 @@ function bookQuizTheme(palette: QuizPalette): QuizTheme {
         color: var(--quiz-option-text);
         box-shadow: 0 6px 0 0 rgba(0, 0, 0, 0.10);
     }
+    /* Quiz options read larger than body copy — the adt-body scale bottoms
+       out at 16px, which is too small for a tappable answer. Floor at 20px. */
+    #simple-main .activity-option,
+    #simple-main .activity-option .option-text {
+        font-size: 20px;
+    }
     #simple-main .activity-option:hover {
         transform: translateY(-2px);
         box-shadow: 0 8px 0 0 rgba(0, 0, 0, 0.12);

--- a/packages/pipeline/src/packaging/web.ts
+++ b/packages/pipeline/src/packaging/web.ts
@@ -1295,6 +1295,12 @@ interface QuizTheme {
 
 const LEGACY_QUIZ_THEME: QuizTheme = {
   styleBlock: `<style>
+    .activity-option:focus,
+    .activity-option:focus-within {
+        outline: 3px solid #2563eb;
+        outline-offset: 2px;
+    }
+
     .activity-option.selected-option {
         border-color: #1d4ed8;
         border-width: 4px;
@@ -1314,7 +1320,7 @@ const LEGACY_QUIZ_THEME: QuizTheme = {
   bodyClose: "",
   questionClass: "text-3xl font-bold text-gray-900 tracking-tight",
   optionLabelClass:
-    "activity-option w-[34rem] max-w-full cursor-pointer rounded-2xl border-2 border-gray-900 bg-[#FFFAF5] px-8 py-6 text-center text-xl font-medium text-gray-900 shadow-[0_6px_0_0_rgba(0,0,0,0.65)] transition-all duration-200 focus:outline-none focus:ring-4 focus:ring-green-300 hover:translate-y-[-2px] hover:shadow-[0_8px_0_0_rgba(0,0,0,0.55)]",
+    "activity-option w-[34rem] max-w-full cursor-pointer rounded-2xl border-2 border-gray-900 bg-[#FFFAF5] px-8 py-6 text-center text-xl font-medium text-gray-900 shadow-[0_6px_0_0_rgba(0,0,0,0.65)] transition-all duration-200 hover:translate-y-[-2px] hover:shadow-[0_8px_0_0_rgba(0,0,0,0.55)]",
   optionTextClass: "option-text block text-lg md:text-2xl text-gray-900",
   feedbackClass:
     "feedback-container hidden w-full rounded-md border border-transparent bg-transparent px-3 py-2 text-gray-700",
@@ -1359,7 +1365,7 @@ function bookQuizTheme(palette: QuizPalette): QuizTheme {
     }
     #simple-main .activity-option:focus,
     #simple-main .activity-option:focus-within {
-        outline: 3px solid var(--quiz-accent);
+        outline: 3px solid #2563eb;
         outline-offset: 2px;
     }
     #simple-main .activity-option.selected-option {

--- a/packages/pipeline/src/pipeline-dag.ts
+++ b/packages/pipeline/src/pipeline-dag.ts
@@ -66,7 +66,7 @@ import {
 } from "./speech.js"
 import { packageAdtWeb } from "./packaging/web.js"
 import { processFixedLayoutPages, isFixedLayoutBook } from "./fixed-layout-rendering.js"
-import { getRenderSectioning } from "./render-sectioning.js"
+import { getRenderSectioning, getSemanticSectioning } from "./render-sectioning.js"
 import { runAccessibilityAssessment } from "./accessibility-assessment.js"
 import { loadBookConfig } from "./config.js"
 import { nullProgress, type Progress } from "./progress.js"
@@ -639,7 +639,12 @@ export async function runFullPipeline(
       const quizPages: QuizPageInput[] = []
       for (const page of pages) {
         const renderingRow = storage.getLatestNodeData("web-rendering", page.pageId)
-        const sectioning = getRenderSectioning(storage, page.pageId)
+        // Filter by the SEMANTIC sectioning (real section types like
+        // `text_and_single_image`), not the render sectioning — in fixed-layout
+        // the latter is the positioned tree whose only type is
+        // `fixed-layout-page`, which never matches `quiz_section_types`, so no
+        // quizzes would ever generate.
+        const sectioning = getSemanticSectioning(storage, page.pageId)
         if (!renderingRow || !sectioning) continue
         quizPages.push({
           pageId: page.pageId,


### PR DESCRIPTION
Standalone quizzes now validate immediately, support number-key answers, preserve reader navigation, and hide submit controls until Next is relevant.

Quiz generation now uses semantic sectioning for fixed-layout books and reports missing inputs and output counts.

EPUB exports ship quiz scripts with fixed-layout viewport metadata, while WebPub quiz options receive a larger text floor.

Validation: 114 runtime tests and 179 quiz/DAG/WebPub/EPUB tests pass; existing target-branch atom type errors, a missing local ESLint binary, and an unrelated speech-test Whisper expectation remain.