### PR TITLE
fix(wizard): prune header/footer by default with correct role keys

### DIFF
--- a/apps/studio/src/components/wizard/constants.ts
+++ b/apps/studio/src/components/wizard/constants.ts
@@ -326,7 +326,10 @@ export const PRESETS: PresetConfig[] = [
         activity_sorting: "activity_sorting",
         activity_open_ended_answer: "activity_open_ended_answer",
       },
-      pruned_role_types: ["header_text", "footer_text", "page_number"],
+      // Role keys must match the actual `role_types` the sectioning LLM assigns
+      // (config.yaml uses bare `header`/`footer`/`page_number`). The `_text`
+      // suffixed variants never match, so header/footer would leak in unpruned.
+      pruned_role_types: ["header", "footer", "page_number"],
       pruned_section_types: ["back_cover", "credits", "inside_cover"],
       image_filters: { min_stddev: 2 },
     },
@@ -400,7 +403,11 @@ export const PRESETS: PresetConfig[] = [
         },
       },
       section_render_strategies: {},
-      pruned_role_types: ["header_text", "footer_text", "page_number"],
+      // Role keys must match the actual `role_types` the sectioning LLM assigns
+      // (config.yaml uses bare `header`/`footer`/`page_number`). The `_text`
+      // suffixed variants never match, so header/footer would leak into the
+      // two-column-story layout unpruned.
+      pruned_role_types: ["header", "footer", "page_number"],
       pruned_section_types: [
         "back_cover",
         "credits",
@@ -487,7 +494,10 @@ export const PRESETS: PresetConfig[] = [
         },
       },
       section_render_strategies: {},
-      pruned_role_types: ["header_text", "footer_text", "page_number"],
+      // Role keys must match the actual `role_types` the sectioning LLM assigns
+      // (config.yaml uses bare `header`/`footer`/`page_number`). The `_text`
+      // suffixed variants never match, so header/footer would leak in unpruned.
+      pruned_role_types: ["header", "footer", "page_number"],
       pruned_section_types: [
         "back_cover",
         "credits",


### PR DESCRIPTION
## Summary

All non-custom wizard presets (Textbook, Storybook, Reference) were pruning `header_text`/`footer_text`, which are not real role keys — the sectioning LLM assigns the bare `header`/`footer`/`page_number` roles defined in `config.yaml`, so header and footer text leaked into rendered output (and showed as un-pruned in the Sectioning settings) despite being intended as pruned defaults. This changes each preset's `pruned_role_types` to the correct keys so header and footer are genuinely pruned by default.

## Notes

The `custom` preset is intentionally left untouched (no `baseConfig` — full user control). No i18n/`.po` changes needed since these are config arrays, not user-visible strings.