### PR TITLE
fix(studio): show run feedback immediately when a stage starts

### DIFF
--- a/apps/studio/src/components/pipeline/components/StageRunCard.tsx
+++ b/apps/studio/src/components/pipeline/components/StageRunCard.tsx
@@ -97,6 +97,20 @@ export function StageRunCard({
     })
     .find((item) => item !== null)
 
+  // The run has been kicked off but no step has reported yet — the server is
+  // still in its synchronous stage startup (for Extract: reading and parsing
+  // the PDF, seconds on a large book). Spin the first pending sub-step so the
+  // card body doesn't sit inert and grey while the header already says
+  // "Running". Resolves into the real step state on the first step-start.
+  const anyStepRunning = subSteps.some(({ key }) => stepState(key) === "running")
+  const startingStepKey =
+    isRunning && !anyStepRunning
+      ? subSteps.find(({ key }) => {
+          const state = stepState(key)
+          return state !== "done" && state !== "skipped"
+        })?.key
+      : undefined
+
   return (
     <Card className={cn("overflow-hidden max-w-xl shadow-none", borderColor)}>
       {/* Colored header */}
@@ -132,7 +146,7 @@ export function StageRunCard({
               const numericProgressLabel = hasPages ? `${progress.page}/${progress.totalPages}` : null
               const messageProgressLabel = progress?.message?.trim()
               const progressLabel = messageProgressLabel || numericProgressLabel
-              const isSubRunning = state === "running"
+              const isSubRunning = state === "running" || key === startingStepKey
               const showInlineProgress = Boolean(
                 isSubRunning &&
                 progressLabel &&

--- a/apps/studio/src/components/pipeline/components/StageSidebar.tsx
+++ b/apps/studio/src/components/pipeline/components/StageSidebar.tsx
@@ -38,7 +38,7 @@ import {
 import { useSettingsDialog } from "@/routes/__root"
 import type { TaskInfoResponse } from "@/api/client"
 import { getStageLabelI18n, getStepLabelI18n, getStageStatusLabelI18n } from "../pipeline-i18n"
-import { ALL_STEP_NAMES } from "@adt/types"
+import { ALL_STEP_NAMES, STAGE_ORDER } from "@adt/types"
 
 const STAGE_GROUP_LABELS: Record<StageGroup, MessageDescriptor> = {
   convert: msg`Core Pipeline`,
@@ -439,7 +439,7 @@ export function StageSidebar({
 function TaskIndicator({ bookLabel }: { bookLabel: string }) {
   const { i18n } = useLingui()
   const { runningTasks, runningCount } = useBookTasks(bookLabel)
-  const { stepState, stepProgress, isCancelling, cancelRun } = useBookRun()
+  const { stepState, stageState, stepProgress, isCancelling, cancelRun } = useBookRun()
 
   // Running steps with visible progress (pages, entries, batches, etc.)
   const stageProgressRows: { step: string; label: string; progressLabel: string }[] = []
@@ -462,9 +462,27 @@ function TaskIndicator({ bookLabel }: { bookLabel: string }) {
     }
   }
 
-  const totalCount = runningCount + stageProgressRows.length + activeSteps.length
+  // Stages that have been kicked off but whose first step hasn't reported yet.
+  // A run is queued the moment the button is clicked (optimistically) and stays
+  // that way through the server's synchronous stage startup — for Extract that
+  // window is seconds (PDF read + WASM parse). Keying the indicator purely off
+  // running *steps* left it hidden for that whole gap, so a click looked like
+  // it had done nothing. Only shown while no step is reporting yet, so a
+  // running stage doesn't get counted twice.
+  const startingStages: { key: string; label: string }[] = []
+  if (stageProgressRows.length + activeSteps.length === 0) {
+    for (const stage of STAGE_ORDER) {
+      const state = stageState(stage)
+      if (state === "queued" || state === "running") {
+        startingStages.push({ key: stage, label: getStageLabelI18n(stage) })
+      }
+    }
+  }
+
+  const pipelineRowCount = stageProgressRows.length + activeSteps.length + startingStages.length
+  const totalCount = runningCount + pipelineRowCount
   // A pipeline stage run (not just ad-hoc tasks) is active — offer to cancel it.
-  const pipelineActive = stageProgressRows.length + activeSteps.length > 0
+  const pipelineActive = pipelineRowCount > 0
 
   if (totalCount === 0) return null
 
@@ -489,6 +507,17 @@ function TaskIndicator({ bookLabel }: { bookLabel: string }) {
             <p className="flex-1 min-w-0 text-xs font-medium truncate">
               {row.label}
             </p>
+          </div>
+        ))}
+        {startingStages.map((row) => (
+          <div key={row.key} className="flex items-center gap-2 px-1 py-1">
+            <Loader2 className="w-3 h-3 animate-spin text-violet-500 shrink-0" />
+            <p className="flex-1 min-w-0 text-xs font-medium truncate">
+              {row.label}
+            </p>
+            <span className="text-[10px] text-muted-foreground shrink-0">
+              {i18n._(msg`Starting…`)}
+            </span>
           </div>
         ))}
         {runningTasks.map((task) => (

--- a/apps/studio/src/components/wizard/BookCreationWizard.tsx
+++ b/apps/studio/src/components/wizard/BookCreationWizard.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect, useRef, type CSSProperties } from "react"
 import { Trans, useLingui } from "@lingui/react/macro"
 import { Eye, ArrowLeft, ArrowRight, Zap, Loader2 } from "lucide-react"
 import { useStore } from "@tanstack/react-form"
+import { useQueryClient } from "@tanstack/react-query"
 import { useNavigate } from "@tanstack/react-router"
 import { Button } from "@/components/ui/button"
 import { api } from "@/api/client"
@@ -203,6 +204,7 @@ function PreviewContainer({
 export function BookCreationWizard() {
   const { t, i18n } = useLingui()
   const navigate = useNavigate()
+  const queryClient = useQueryClient()
   const { phase, currentStep, setCurrentStep, stepDirection, previewFocus } = useWizard()
   const form = useWizardForm()
   const createMutation = useCreateBook()
@@ -307,6 +309,16 @@ export function BookCreationWizard() {
       // so extracting the full book on this machine would be the very cost the
       // split feature avoids.
       if (values.scope !== "split" && hasApiKey) {
+        // Seed the run status the book page reads, so it paints "Extract
+        // queued" on first render. Without this the page mounts with a cold
+        // cache and shows an idle pipeline until its own step-status fetch
+        // round-trips — several seconds while the server is busy opening the
+        // PDF, which reads as "the run never started".
+        queryClient.setQueryData(["books", book.label, "step-status"], {
+          stages: { extract: "queued" },
+          steps: {},
+          error: null,
+        })
         try {
           await api.runStages(
             book.label,
@@ -323,6 +335,8 @@ export function BookCreationWizard() {
           )
         } catch (pipelineError) {
           console.error("[wizard] extract kickoff failed:", pipelineError)
+          // Roll the seeded status back — nothing is running.
+          queryClient.removeQueries({ queryKey: ["books", book.label, "step-status"] })
         }
       }
 

--- a/apps/studio/src/hooks/use-book-run.ts
+++ b/apps/studio/src/hooks/use-book-run.ts
@@ -600,10 +600,14 @@ export function useBookRunStatus(label: string): BookRunContextValue {
       // Optimistically mark target stage(s) as queued and clear downstream
       const stagesToClear = new Set(getStageClearOrder(fromStage as StageName))
       queryClient.setQueryData<StepStatusResponse>(stepStatusKey(label), (old) => {
-        if (!old) return old
-        const stages = { ...old.stages }
-        const steps = { ...old.steps }
-        const stepMessages = old.stepMessages ? { ...old.stepMessages } : null
+        // Seed a base when the initial step-status fetch hasn't resolved yet
+        // (e.g. a run kicked off right after landing on the book). Bailing out
+        // on a cold cache would drop the optimistic "queued" state entirely and
+        // leave the UI idle until the first poll lands.
+        const base: StepStatusResponse = old ?? { stages: {}, steps: {}, error: null }
+        const stages = { ...base.stages }
+        const steps = { ...base.steps }
+        const stepMessages = base.stepMessages ? { ...base.stepMessages } : null
 
         for (const stage of stagesToClear) {
           const stageDef = PIPELINE.find((s) => s.name === stage)

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -7429,6 +7429,9 @@ msgstr "Start typing to see words from the book…"
 msgid "Start with a PDF"
 msgstr "Start with a PDF"
 
+msgid "Starting…"
+msgstr "Starting…"
+
 msgid "Stats"
 msgstr "Stats"
 

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -7429,6 +7429,9 @@ msgstr "Empieza a escribir para ver palabras del libro…"
 msgid "Start with a PDF"
 msgstr "Empezar con un PDF"
 
+msgid "Starting…"
+msgstr "Iniciando…"
+
 msgid "Stats"
 msgstr "Estadísticas"
 

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -7431,6 +7431,9 @@ msgstr "Commencez à taper pour voir les mots du livre…"
 msgid "Start with a PDF"
 msgstr "Commencer avec un PDF"
 
+msgid "Starting…"
+msgstr "Démarrage…"
+
 msgid "Stats"
 msgstr "Statistiques"
 

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -7429,6 +7429,9 @@ msgstr "Comece a digitar para ver palavras do livro…"
 msgid "Start with a PDF"
 msgstr "Selecione um PDF"
 
+msgid "Starting…"
+msgstr "Iniciando…"
+
 msgid "Stats"
 msgstr "Estatísticas"
 

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -7430,6 +7430,9 @@ msgstr "Fillo të shkruash për të parë fjalë nga libri…"
 msgid "Start with a PDF"
 msgstr "Fillo me një PDF"
 
+msgid "Starting…"
+msgstr "Po fillon…"
+
 msgid "Stats"
 msgstr "Statistika"
 

--- a/packages/pipeline/src/pdf-extraction.ts
+++ b/packages/pipeline/src/pdf-extraction.ts
@@ -38,6 +38,18 @@ export async function extractPDF(
 
   progress.emit({ type: "step-start", step: "extract" })
 
+  // Let the event loop turn once so `step-start` (already written to step_runs
+  // and queued on the SSE stream) can reach the client before the synchronous
+  // setup below — readFileSync of the whole PDF, then mupdf WASM open/metadata/
+  // page-count — blocks it. setImmediate rather than setTimeout: resuming from
+  // the check phase means the poll phase in between has serviced pending socket
+  // reads. Measured on a 5.7MB book this cuts the first GET /step-status from
+  // ~640ms to ~380ms (warm) and ~2.2s to ~1.9s (cold); it does not close the
+  // gap on its own, since extraction keeps the loop busy afterwards. The
+  // client-side optimistic "queued" state is what actually makes the UI
+  // immediate — this just gets the authoritative status out sooner.
+  await new Promise((resolve) => setImmediate(resolve))
+
   try {
     if (fontsCacheDir) {
       progress.emit({ type: "step-progress", step: "extract", message: "Caching book fonts..." })


### PR DESCRIPTION
Starting Extract left the UI looking idle for ~5s: measured on a 5.7MB PDF, the book page painted an idle "Run Extract" button ~600-900ms after navigation and the violet task indicator did not appear until ~6.0s. Two causes — the book page mounted with a cold TanStack cache (the creation wizard navigated without seeding `step-status`, and that fetch then sat 0.4-2.3s behind `extractPDF`'s synchronous `readFileSync` + mupdf WASM startup), and `TaskIndicator` keyed purely off a *step* being `running` while ignoring a queued *stage*.

The wizard now seeds `step-status` before navigating (rolling back if the kickoff throws), `queueRun` no longer drops its optimistic update on a cold cache via `if (!old) return old`, `TaskIndicator` and `StageRunCard` render a "Starting…" state for a queued stage with no reporting step yet, and `extractPDF` yields via `setImmediate` after `step-start` so the status write and SSE frame escape before the sync work blocks the loop.

Verified in a real browser: all feedback now lands at 147ms after click (first sample interval), versus a 123ms baseline on the already-warm click path, which was never the broken one; typecheck, lint, and 1903/1903 tests pass with all 5 locales translated.

Two caveats — the wizard→landing path is verified by construction rather than end-to-end (Playwright could not get past the "Visual Layout" wizard step; the mechanism is identical to the click path that *was* verified end-to-end, but it mounts a fresh `BookRunProvider`, so a manual check is worthwhile), and the `setImmediate` yield is a partial improvement only (634→375ms, 2198→1810ms, 2349→1960ms in paired trials) since extraction keeps the loop busy afterwards — the optimistic client state is what actually makes the UI immediate.