### PR TITLE
fix(i18n): persist UI locale and auto-detect OS language in Electron

### DIFF
--- a/apps/desktop/src/main/ipc/app-info.ts
+++ b/apps/desktop/src/main/ipc/app-info.ts
@@ -12,4 +12,11 @@ export function registerAppInfoIpc(): void {
   ipcMain.on("app:version", (event) => {
     event.returnValue = app.getVersion();
   });
+
+  // OS languages in the user's preference order (e.g. ["pt-BR", "en-US"]).
+  // Used by the renderer to pick a default UI locale on first launch.
+  ipcMain.on("app:system-locales", (event) => {
+    const preferred = app.getPreferredSystemLanguages();
+    event.returnValue = preferred.length > 0 ? preferred : [app.getLocale()];
+  });
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -82,6 +82,9 @@ const api = {
   get version(): string {
     return ipcRenderer.sendSync('app:version') as string
   },
+  get systemLocales(): string[] {
+    return ipcRenderer.sendSync('app:system-locales') as string[]
+  },
   windowControls,
   updates,
 }

--- a/apps/studio/src/i18n/locales.ts
+++ b/apps/studio/src/i18n/locales.ts
@@ -19,6 +19,28 @@ export type AppLocale = (typeof LOCALES)[number]
 export const LOCALE_STORAGE_KEY = "adt:locale"
 
 /**
+ * Resolve arbitrary BCP-47 locale tag(s) — e.g. from the OS — to a supported
+ * AppLocale. Candidates are tried in order (the list expresses preference);
+ * for each, an exact match wins, otherwise a language-only match (so `es-MX`
+ * → `es`, `pt` → `pt-BR`). Returns `null` when nothing matches.
+ */
+export function matchSupportedLocale(
+  candidates: string | readonly string[],
+): AppLocale | null {
+  const list = typeof candidates === "string" ? [candidates] : candidates
+  for (const raw of list) {
+    if (!raw) continue
+    const exact = LOCALES.find((l) => l.toLowerCase() === raw.toLowerCase())
+    if (exact) return exact
+    const lang = raw.split("-")[0]?.toLowerCase()
+    if (!lang) continue
+    const byLang = LOCALES.find((l) => l.split("-")[0].toLowerCase() === lang)
+    if (byLang) return byLang
+  }
+  return null
+}
+
+/**
  * Read the persisted UI locale, if any. Returns `null` when nothing valid is
  * stored (first launch, cleared storage, or an unsupported value).
  */

--- a/apps/studio/src/i18n/locales.ts
+++ b/apps/studio/src/i18n/locales.ts
@@ -15,18 +15,47 @@ import { i18n } from "@lingui/core"
 export const LOCALES = ["en", "pt-BR", "es", "fr", "sq"] as const
 export type AppLocale = (typeof LOCALES)[number]
 
+/** localStorage key under which the user's chosen UI locale is persisted. */
+export const LOCALE_STORAGE_KEY = "adt:locale"
+
 /**
- * Activate a locale AND reflect it on `<html lang>`.
+ * Read the persisted UI locale, if any. Returns `null` when nothing valid is
+ * stored (first launch, cleared storage, or an unsupported value).
+ */
+export function getStoredLocale(): AppLocale | null {
+  if (typeof localStorage === "undefined") return null
+  try {
+    const stored = localStorage.getItem(LOCALE_STORAGE_KEY)
+    return stored && LOCALES.includes(stored as AppLocale) ? (stored as AppLocale) : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Activate a locale, persist it, AND reflect it on `<html lang>`.
  *
  * Always use this instead of calling `i18n.activate()` directly: screen readers
  * pick their pronunciation voice from the document language, so a stale `lang`
  * attribute makes Spanish/French/Portuguese content be read with an English
  * voice (WCAG 3.1.1 / 3.1.2). BCP-47 codes like "pt-BR" are valid `lang` values.
+ *
+ * The chosen locale is saved to localStorage so it survives app restarts.
  */
 export function activateLocale(locale: AppLocale): void {
+  const changed = i18n.locale !== locale
   i18n.activate(locale)
   if (typeof document !== "undefined") {
     document.documentElement.lang = locale
+  }
+  // Only touch storage on a real change: the router re-activates the current
+  // locale on every navigation, and we don't want a write per route change.
+  if (changed && typeof localStorage !== "undefined") {
+    try {
+      localStorage.setItem(LOCALE_STORAGE_KEY, locale)
+    } catch {
+      // Persisting is best-effort; ignore quota/privacy-mode failures.
+    }
   }
 }
 

--- a/apps/studio/src/main.tsx
+++ b/apps/studio/src/main.tsx
@@ -15,14 +15,14 @@ import { messages as frMessages } from "./locales/fr.po"
 import { messages as sqMessages } from "./locales/sq.po"
 import { routeTree } from "./routeTree.gen"
 import "./styles/globals.css"
-import { LOCALES, activateLocale } from "./i18n/locales"
+import { LOCALES, activateLocale, getStoredLocale } from "./i18n/locales"
 import type { AppLocale } from "./i18n/locales"
 export { LOCALES, type AppLocale } from "./i18n/locales"
 
 function detectLocale(): AppLocale {
   const urlLang = new URLSearchParams(window.location.search).get("lang")
   if (urlLang && LOCALES.includes(urlLang as AppLocale)) return urlLang as AppLocale
-  return "en"
+  return getStoredLocale() ?? "en"
 }
 
 i18n.load({ en: enMessages, "pt-BR": ptBRMessages, es: esMessages, fr: frMessages, sq: sqMessages })

--- a/apps/studio/src/main.tsx
+++ b/apps/studio/src/main.tsx
@@ -15,14 +15,23 @@ import { messages as frMessages } from "./locales/fr.po"
 import { messages as sqMessages } from "./locales/sq.po"
 import { routeTree } from "./routeTree.gen"
 import "./styles/globals.css"
-import { LOCALES, activateLocale, getStoredLocale } from "./i18n/locales"
+import { LOCALES, activateLocale, getStoredLocale, matchSupportedLocale } from "./i18n/locales"
 import type { AppLocale } from "./i18n/locales"
 export { LOCALES, type AppLocale } from "./i18n/locales"
 
+// In Electron, match the OS languages against our supported locales for a
+// sensible first-launch default. Returns null on the web (no `systemLocales`).
+function detectOsLocale(): AppLocale | null {
+  const osLocales = window.api?.systemLocales
+  if (!osLocales || osLocales.length === 0) return null
+  return matchSupportedLocale(osLocales)
+}
+
+// Priority: web ?lang override → stored preference → OS language → English.
 function detectLocale(): AppLocale {
   const urlLang = new URLSearchParams(window.location.search).get("lang")
   if (urlLang && LOCALES.includes(urlLang as AppLocale)) return urlLang as AppLocale
-  return getStoredLocale() ?? "en"
+  return getStoredLocale() ?? detectOsLocale() ?? "en"
 }
 
 i18n.load({ en: enMessages, "pt-BR": ptBRMessages, es: esMessages, fr: frMessages, sq: sqMessages })

--- a/apps/studio/src/vite-env.d.ts
+++ b/apps/studio/src/vite-env.d.ts
@@ -118,6 +118,8 @@ interface Window {
     platform?: ElectronPlatform
     /** Application version from the Electron main process. Undefined in the web build. */
     version?: string
+    /** OS languages in preference order (e.g. `["pt-BR", "en-US"]`). Undefined in the web build. */
+    systemLocales?: string[]
     /** IPC bridge for custom title bar controls. Undefined in the web build. */
     windowControls?: ElectronWindowControls
     /** IPC bridge for desktop auto-updater. Undefined in the web build. */


### PR DESCRIPTION
## Summary

Fixes two related desktop i18n gaps so the UI language behaves correctly
across launches instead of always starting in English.

Closes #599
Closes #287

## What changed

### Persist the selected UI locale (#599)
The locale lived only in the `?lang` URL param and in-memory Lingui state,
so a fresh Electron launch (no `?lang`) always reset to English.

- `activateLocale()` now writes the chosen locale to `localStorage`
  (`adt:locale`) — it's the single choke-point every locale change flows
  through (startup, the router's `?lang` rewrite, and the header switcher).
- The write is guarded to fire only on an actual change, not on every
  router navigation.
- `detectLocale()` reads the stored value as a fallback.

### Auto-detect OS language on first launch (#287)
On a fresh install (no stored preference) the Electron app now picks a
default UI locale from the OS instead of always starting in English.

- The main process exposes `app.getPreferredSystemLanguages()` over sync
  IPC (`app:system-locales`).
- The renderer matches them against supported locales — exact first, then
  language-only, so `es-MX → es` and `pt → pt-BR`.

### Resulting precedence
```
web ?lang override  →  stored preference  →  OS language  →  en
```

A manual pick in the switcher is persisted and therefore always wins over
OS detection on subsequent launches. The web build is unaffected (no
`systemLocales` bridge → falls back to `en` as before).

## Testing
- Desktop (`pnpm dev:desktop`): switch language → quit → relaunch → choice
  persists.
- Clear `localStorage.adt:locale` → relaunch → app opens in the OS language
  (verified `adt:locale` persistence in the Electron LevelDB during dev).
- Typecheck passes for both `@adt/studio` and `@adt/desktop`.

## Notes / follow-ups (out of scope)
- The splash screen has its own independent OS-language detection
  (`navigator.language`) and already shows the right language. It does not
  yet honor a *manual* override (separate origin, can't read `adt:locale`)
  and lacks an Albanian (`sq`) catalog — tracked separately.
