### PR TITLE
In-app Assistant chat — early prototype for feedback (not for merge)

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -34,6 +34,7 @@ import { createReviewerValidationRoutes } from "./routes/reviewer-validation.js"
 import { createTocRoutes } from "./routes/toc.js"
 import { createSignLanguageVideoRoutes } from "./routes/sign-language-videos.js"
 import { createTranslationEvaluationRoutes } from "./routes/translation-evaluations.js"
+import { createAssistantRoutes } from "./routes/assistant.js"
 
 // Resolve paths relative to monorepo root (2 levels up from apps/api/)
 const projectRoot = path.resolve(
@@ -47,6 +48,7 @@ const configPath = path.resolve(
 const configFolderPath = path.resolve(
   process.env.CONFIG_FOLDER_PATH ?? path.join(projectRoot, "config")
 )
+const docsBaseUrl = process.env.DOCS_BASE_URL
 
 let webAssetsDir: string
 const adtResourcesZip = process.env.ADT_RESOURCES_ZIP
@@ -118,6 +120,7 @@ app.route("/api", createSpeechConfigRoutes(configPath))
 app.route("/api", createReviewerValidationRoutes(booksDir, configFolderPath, configPath))
 app.route("/api", createSignLanguageVideoRoutes(booksDir))
 app.route("/api", createTranslationEvaluationRoutes(booksDir, configPath, taskService))
+app.route("/api", createAssistantRoutes(booksDir, promptsDir, configPath, docsBaseUrl))
 
 export default app
 export { booksDir }

--- a/apps/api/src/routes/assistant.ts
+++ b/apps/api/src/routes/assistant.ts
@@ -1,0 +1,48 @@
+import { Hono } from "hono"
+import { HTTPException } from "hono/http-exception"
+import { AssistantChatRequest, parseBookLabel } from "@adt/types"
+import { assistantChat } from "../services/assistant-chat-service.js"
+
+export function createAssistantRoutes(
+  booksDir: string,
+  promptsDir: string,
+  configPath?: string,
+  docsBaseUrl?: string
+): Hono {
+  const app = new Hono()
+
+  // POST /books/:label/assistant/chat — guidance-only contextual chat
+  app.post("/books/:label/assistant/chat", async (c) => {
+    const { label } = c.req.param()
+    const safeLabel = parseBookLabel(label)
+
+    const apiKey = c.req.header("X-OpenAI-Key")
+    if (!apiKey) {
+      throw new HTTPException(400, { message: "Missing X-OpenAI-Key header" })
+    }
+
+    const body = await c.req.json()
+    const parsed = AssistantChatRequest.safeParse(body)
+    if (!parsed.success) {
+      throw new HTTPException(400, { message: parsed.error.message })
+    }
+
+    const result = await assistantChat({
+      label: safeLabel,
+      message: parsed.data.message,
+      history: parsed.data.history,
+      pageId: parsed.data.pageId,
+      sectionIndex: parsed.data.sectionIndex,
+      correlationId: parsed.data.correlationId,
+      booksDir,
+      promptsDir,
+      configPath,
+      docsBaseUrl,
+      apiKey,
+    })
+
+    return c.json(result)
+  })
+
+  return app
+}

--- a/apps/api/src/services/assistant-chat-service.ts
+++ b/apps/api/src/services/assistant-chat-service.ts
@@ -1,0 +1,117 @@
+import crypto from "node:crypto"
+import path from "node:path"
+import { createBookStorage } from "@adt/storage"
+import { createLLMModel, createPromptEngine } from "@adt/llm"
+import { loadBookConfig } from "@adt/pipeline"
+import { WebRenderingOutput, assistantChatLLMSchema, type AssistantChatMessage } from "@adt/types"
+
+export interface AssistantChatOptions {
+  label: string
+  message: string
+  history: AssistantChatMessage[]
+  pageId?: string
+  sectionIndex?: number
+  correlationId?: string
+  booksDir: string
+  promptsDir: string
+  configPath?: string
+  docsBaseUrl?: string
+  apiKey: string
+}
+
+export interface AssistantChatResult {
+  reply: string
+  correlationId: string
+}
+
+/**
+ * Guidance-only chat: grounds replies in the current page/section context but
+ * never mutates book data — it only advises which existing actions to use.
+ */
+export async function assistantChat(
+  options: AssistantChatOptions
+): Promise<AssistantChatResult> {
+  const { label, message, history, pageId, sectionIndex, booksDir, promptsDir, configPath, docsBaseUrl, apiKey } = options
+
+  const previousKey = process.env.OPENAI_API_KEY
+  process.env.OPENAI_API_KEY = apiKey
+
+  const storage = createBookStorage(label, booksDir)
+
+  try {
+    const config = loadBookConfig(label, booksDir, configPath)
+    const modelId = (config as Record<string, unknown>).page_sectioning
+      ? ((config as Record<string, unknown>).page_sectioning as Record<string, unknown>).model as string
+      : "openai:gpt-4o"
+
+    const cacheDir = path.join(path.resolve(booksDir), label, ".cache")
+    const bookPromptsDir = path.join(path.resolve(booksDir), label, "prompts")
+    const promptEngine = createPromptEngine([bookPromptsDir, promptsDir])
+    const model = createLLMModel({
+      modelId,
+      cacheDir,
+      promptEngine,
+      onLog: (entry) => storage.appendLlmLog(entry),
+    })
+
+    // The widget lives at the app root, outside any specific section's
+    // selection state, so we ground it in the whole page's sections rather
+    // than requiring the frontend to track "which section is open." Each
+    // section's HTML is truncated to keep token usage reasonable — this is
+    // enough for the assistant to reason about section boundaries/content,
+    // not a full-fidelity edit context (contrast with html_edit's use of the
+    // exact current HTML for a single section).
+    const MAX_HTML_CHARS_PER_SECTION = 4000
+    let sections: { sectionIndex: number; html: string }[] | undefined
+    if (pageId) {
+      const renderingRow = storage.getLatestNodeData("web-rendering", pageId)
+      if (renderingRow) {
+        const parsed = WebRenderingOutput.safeParse(renderingRow.data)
+        if (parsed.success) {
+          sections = parsed.data.sections
+            .filter((s) => sectionIndex === undefined || s.sectionIndex === sectionIndex)
+            .map((s) => ({
+              sectionIndex: s.sectionIndex,
+              html: s.html.length > MAX_HTML_CHARS_PER_SECTION
+                ? s.html.slice(0, MAX_HTML_CHARS_PER_SECTION) + "\n<!-- truncated -->"
+                : s.html,
+            }))
+        }
+      }
+    }
+
+    // Reusing the caller-supplied correlationId (when the frontend already
+    // started one for this conversation) groups every turn together in the
+    // LLM logs, same as the ai-edit history view does per-edit.
+    const correlationId = options.correlationId ?? crypto.randomUUID()
+
+    const result = await model.generateObject<{ reply: string }>({
+      schema: assistantChatLLMSchema,
+      prompt: "assistant_chat",
+      context: {
+        history,
+        message,
+        page_id: pageId,
+        sections,
+        docs_base_url: docsBaseUrl,
+      },
+      maxRetries: 2,
+      log: {
+        taskType: "assistant",
+        pageId,
+        promptName: "assistant_chat",
+        sectionIndex,
+        correlationId,
+      },
+    })
+
+    return { reply: result.object.reply, correlationId }
+  } finally {
+    if (previousKey !== undefined) {
+      process.env.OPENAI_API_KEY = previousKey
+    } else {
+      delete process.env.OPENAI_API_KEY
+    }
+    storage.close()
+  }
+}

--- a/apps/studio/src/api/client.ts
+++ b/apps/studio/src/api/client.ts
@@ -314,6 +314,24 @@ export interface AiEditHistoryTurn {
   verify?: { applied: boolean; reason: string }
 }
 
+export interface AssistantChatMessageBody {
+  role: "user" | "assistant"
+  content: string
+}
+
+export interface AssistantChatRequestBody {
+  message: string
+  history: AssistantChatMessageBody[]
+  pageId?: string
+  sectionIndex?: number
+  correlationId?: string
+}
+
+export interface AssistantChatResponseBody {
+  reply: string
+  correlationId: string
+}
+
 export interface PageDetail {
   pageId: string
   pageNumber: number
@@ -1102,6 +1120,17 @@ export const api = {
   aiEditHistory: (label: string, pageId: string, sectionIndex: number) =>
     request<{ history: AiEditHistoryTurn[] }>(
       `/books/${label}/pages/${pageId}/sections/${sectionIndex}/ai-edit-history`,
+    ),
+
+  sendAssistantMessage: (label: string, body: AssistantChatRequestBody, apiKey: string) =>
+    request<AssistantChatResponseBody>(
+      `/books/${label}/assistant/chat`,
+      {
+        method: "POST",
+        headers: { "X-OpenAI-Key": apiKey },
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(30_000),
+      }
     ),
 
   listBookImages: (label: string) =>

--- a/apps/studio/src/components/assistant/AssistantWidget.tsx
+++ b/apps/studio/src/components/assistant/AssistantWidget.tsx
@@ -1,0 +1,187 @@
+import { useMemo, useRef, useState, useEffect, Fragment } from "react"
+import { useRouterState } from "@tanstack/react-router"
+import { MessageCircleQuestion, Send, Sparkles } from "lucide-react"
+import { Trans } from "@lingui/react/macro"
+import { useLingui } from "@lingui/react/macro"
+import { Button } from "@/components/ui/button"
+import { Textarea } from "@/components/ui/textarea"
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet"
+import { useApiKey } from "@/hooks/use-api-key"
+import { useAssistantChat } from "@/hooks/use-assistant"
+import { useSettingsDialog } from "@/routes/__root"
+import type { AssistantChatMessageBody } from "@/api/client"
+
+const NON_BOOK_LABELS = new Set(["new", "import"])
+
+const URL_PATTERN = /(https?:\/\/[^\s]+)/g
+
+function renderMessageContent(content: string) {
+  const parts = content.split(URL_PATTERN)
+  return parts.map((part, i) =>
+    URL_PATTERN.test(part) ? (
+      <a
+        key={i}
+        href={part}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="underline underline-offset-2 hover:text-primary"
+      >
+        {part}
+      </a>
+    ) : (
+      <Fragment key={i}>{part}</Fragment>
+    )
+  )
+}
+
+function useCurrentBookContext(): { label?: string; pageId?: string } {
+  const pathname = useRouterState({ select: (s) => s.location.pathname })
+  return useMemo(() => {
+    const parts = pathname.split("/").filter(Boolean)
+    if (parts[0] !== "books") return {}
+    const label = parts[1]
+    if (!label || NON_BOOK_LABELS.has(label)) return {}
+    const third = parts[3]
+    const pageId = third && third !== "settings" ? third : undefined
+    return { label, pageId }
+  }, [pathname])
+}
+
+export function AssistantWidget() {
+  const { t } = useLingui()
+  const { label, pageId } = useCurrentBookContext()
+  const { apiKey } = useApiKey()
+  const { openSettings } = useSettingsDialog()
+  const [open, setOpen] = useState(false)
+  const [input, setInput] = useState("")
+  const [messages, setMessages] = useState<AssistantChatMessageBody[]>([])
+  const correlationIdRef = useRef<string | undefined>(undefined)
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const chat = useAssistantChat(label ?? "")
+
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight })
+  }, [messages])
+
+  if (!label) return null
+
+  const handleSend = () => {
+    const message = input.trim()
+    if (!message || !apiKey || chat.isPending) return
+
+    const nextMessages: AssistantChatMessageBody[] = [...messages, { role: "user", content: message }]
+    setMessages(nextMessages)
+    setInput("")
+
+    chat.mutate(
+      {
+        body: {
+          message,
+          history: messages,
+          pageId,
+          correlationId: correlationIdRef.current,
+        },
+        apiKey,
+      },
+      {
+        onSuccess: (result) => {
+          correlationIdRef.current = result.correlationId
+          setMessages((prev) => [...prev, { role: "assistant", content: result.reply }])
+        },
+        onError: (err) => {
+          setMessages((prev) => [
+            ...prev,
+            { role: "assistant", content: t`Something went wrong: ${err instanceof Error ? err.message : String(err)}` },
+          ])
+        },
+      }
+    )
+  }
+
+  return (
+    <>
+      <Button
+        variant="default"
+        size="icon"
+        className="fixed bottom-6 right-6 z-40 h-12 w-12 rounded-full shadow-lg transition-shadow hover:shadow-xl"
+        onClick={() => setOpen(true)}
+        aria-label={t`Open assistant`}
+      >
+        <MessageCircleQuestion className="h-5 w-5" />
+      </Button>
+
+      <Sheet open={open} onOpenChange={setOpen}>
+        <SheetContent side="right" className="flex w-full flex-col gap-0 p-0 sm:max-w-md">
+          <SheetHeader className="flex-row items-center gap-2.5 space-y-0 border-b px-4 py-3">
+            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
+              <Sparkles className="h-4 w-4" />
+            </div>
+            <SheetTitle className="text-base">
+              <Trans>Assistant</Trans>
+            </SheetTitle>
+          </SheetHeader>
+
+          <div ref={scrollRef} className="flex-1 min-h-0 space-y-3 overflow-y-auto px-4 py-4">
+            {messages.length === 0 && (
+              <p className="text-sm text-muted-foreground">
+                <Trans>Ask about the page you're viewing, or anything about how ADT Studio works — I can see what's on your screen and I'm not limited to it.</Trans>
+              </p>
+            )}
+            {messages.map((m, i) => (
+              <div
+                key={i}
+                className={
+                  m.role === "user"
+                    ? "ml-auto max-w-[85%] rounded-2xl bg-primary px-3.5 py-2 text-sm text-primary-foreground"
+                    : "mr-auto max-w-[85%] rounded-2xl border bg-card px-3.5 py-2 text-sm text-card-foreground shadow-sm whitespace-pre-wrap"
+                }
+              >
+                {renderMessageContent(m.content)}
+              </div>
+            ))}
+            {chat.isPending && (
+              <div className="mr-auto max-w-[85%] rounded-2xl border bg-card px-3.5 py-2 text-sm text-muted-foreground shadow-sm">
+                <Trans>Thinking…</Trans>
+              </div>
+            )}
+          </div>
+
+          {!apiKey ? (
+            <div className="space-y-2 border-t bg-muted/30 px-4 py-4">
+              <p className="text-sm text-muted-foreground">
+                <Trans>Add an API key to use the Assistant.</Trans>
+              </p>
+              <Button variant="outline" onClick={openSettings}>
+                <Trans>Open settings</Trans>
+              </Button>
+            </div>
+          ) : (
+            <div className="flex items-end gap-2 border-t bg-muted/30 px-4 py-3">
+              <Textarea
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && !e.shiftKey) {
+                    e.preventDefault()
+                    handleSend()
+                  }
+                }}
+                placeholder={t`Ask a question…`}
+                className="min-h-[44px] resize-none rounded-xl bg-background"
+              />
+              <Button
+                size="icon"
+                className="h-10 w-10 shrink-0 rounded-full"
+                onClick={handleSend}
+                disabled={!input.trim() || chat.isPending}
+                aria-label={t`Send`}
+              >
+                <Send className="h-4 w-4" />
+              </Button>
+            </div>
+          )}
+        </SheetContent>
+      </Sheet>
+    </>
+  )
+}

--- a/apps/studio/src/components/pipeline/components/StageSidebar.tsx
+++ b/apps/studio/src/components/pipeline/components/StageSidebar.tsx
@@ -4,9 +4,11 @@ import { Link, useMatchRoute, useSearch } from "@tanstack/react-router"
 import { Trans } from "@lingui/react/macro"
 import {
   AlertCircle,
+  KeyRound,
   Loader2,
   RotateCcw,
   Settings,
+  Terminal,
   TriangleAlert,
   X,
 } from "lucide-react"
@@ -16,7 +18,9 @@ import { useLingui } from "@lingui/react"
 import { msg } from "@lingui/core/macro"
 import type { MessageDescriptor } from "@lingui/core"
 import { Button } from "@/components/ui/button"
+import { ActionMenu } from "@/components/ui/action-menu"
 import { toast } from "@/components/ui/sonner"
+import { useDebugPanelState } from "@/components/debug/debug-panel-state"
 import { useBookRun } from "@/hooks/use-book-run"
 import { useAccessibilityAssessment } from "@/hooks/use-debug"
 import { useBookTasks } from "@/hooks/use-book-tasks"
@@ -83,6 +87,7 @@ export function StageSidebar({
   const { data: packageStatus } = usePackageAdtStatus(bookLabel)
   const { tasks } = useBookTasks(bookLabel)
   const { openSettings } = useSettingsDialog()
+  const { openPanel: openDebugPanel } = useDebugPanelState()
   const stageMissing = useStageMissingCounts(bookLabel)
   const translateNeedsRerun = stageMissing.translate > 0
   const speechNeedsRerun = stageMissing.speech > 0
@@ -308,19 +313,28 @@ export function StageSidebar({
               <Settings className="w-3.5 h-3.5" />
             </Link>
           ) : step.slug === "book" ? (
-            <button
-              type="button"
-              onClick={openSettings}
-              title={i18n._(msg`API Key Settings`)}
-              className={cn(
+            <ActionMenu
+              portal
+              trigger={<Settings className="w-3.5 h-3.5" />}
+              triggerClassName={cn(
                 "shrink-0 inline-flex items-center justify-center w-6 h-6 rounded-full transition-colors cursor-pointer",
                 isActive
                   ? "text-white/60 hover:text-white hover:bg-white/20"
                   : "opacity-0 group-hover/row:opacity-100 text-muted-foreground/50 group-hover/row:bg-muted hover:text-foreground hover:bg-muted-foreground/20"
               )}
-            >
-              <Settings className="w-3.5 h-3.5" />
-            </button>
+              items={[
+                {
+                  icon: Terminal,
+                  label: i18n._(msg`Debug Panel`),
+                  onClick: () => openDebugPanel(),
+                },
+                {
+                  icon: KeyRound,
+                  label: i18n._(msg`API Keys`),
+                  onClick: openSettings,
+                },
+              ]}
+            />
           ) : step.slug === "preview" ? (
             <button
               type="button"

--- a/apps/studio/src/components/ui/action-menu.tsx
+++ b/apps/studio/src/components/ui/action-menu.tsx
@@ -5,6 +5,7 @@ import {
   type ComponentType,
   type ReactNode,
 } from "react"
+import { createPortal } from "react-dom"
 import { cn } from "@/lib/utils"
 
 export interface ActionMenuItem {
@@ -39,6 +40,7 @@ export function ActionMenu({
   itemsDisabled,
   align = "right",
   menuClassName,
+  portal = false,
 }: {
   /** Content of the toggle button. */
   trigger: ReactNode
@@ -51,17 +53,36 @@ export function ActionMenu({
   itemsDisabled?: boolean
   align?: "left" | "right"
   menuClassName?: string
+  /** Render the popup into document.body instead of inline. Needed when the
+   *  trigger sits inside an `overflow-hidden` ancestor (e.g. a row that
+   *  clips content for a hover/width transition) that would otherwise clip
+   *  the popup. Position is computed from the trigger's rect on open. */
+  portal?: boolean
 }) {
   const [open, setOpen] = useState(false)
-  const ref = useRef<HTMLDivElement>(null)
+  const [portalPos, setPortalPos] = useState<{ top: number; left: number; right: number } | null>(null)
+  const triggerWrapRef = useRef<HTMLDivElement>(null)
+  const portalMenuRef = useRef<HTMLDivElement>(null)
+
   useEffect(() => {
     if (!open) return
     const onDown = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false)
+      const target = e.target as Node
+      const insideTrigger = !!triggerWrapRef.current?.contains(target)
+      const insidePortalMenu = portal && !!portalMenuRef.current?.contains(target)
+      if (!insideTrigger && !insidePortalMenu) setOpen(false)
     }
     document.addEventListener("mousedown", onDown)
     return () => document.removeEventListener("mousedown", onDown)
-  }, [open])
+  }, [open, portal])
+
+  const handleTriggerClick = () => {
+    if (!open && portal && triggerWrapRef.current) {
+      const rect = triggerWrapRef.current.getBoundingClientRect()
+      setPortalPos({ top: rect.bottom, left: rect.left, right: window.innerWidth - rect.right })
+    }
+    setOpen((v) => !v)
+  }
 
   // Drop hidden items, then collapse separators left dangling by the filter.
   const entries: ActionMenuEntry[] = []
@@ -78,17 +99,65 @@ export function ActionMenu({
   }
   if (entries.length === 0) return null
 
+  const menuItems = (
+    <>
+      {note}
+      {entries.map((entry, i) =>
+        isSeparator(entry) ? (
+          <div key={i} className="my-1 border-t" />
+        ) : (
+          <button
+            key={i}
+            type="button"
+            onClick={() => {
+              setOpen(false)
+              entry.onClick()
+            }}
+            disabled={itemsDisabled || entry.disabled}
+            className={cn(
+              "flex w-full items-center gap-2 px-3 py-1.5 text-left hover:bg-accent transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-default",
+              entry.danger && "text-red-600 hover:bg-red-50 dark:hover:bg-red-950/30"
+            )}
+          >
+            {entry.icon ? (
+              <entry.icon className={cn("h-3.5 w-3.5", entry.iconClassName)} />
+            ) : null}
+            {entry.label}
+          </button>
+        )
+      )}
+    </>
+  )
+
   return (
-    <div className="relative" ref={ref} onClick={(e) => e.stopPropagation()}>
+    <div className="relative" ref={triggerWrapRef} onClick={(e) => e.stopPropagation()}>
       <button
         type="button"
-        onClick={() => setOpen((v) => !v)}
+        onClick={handleTriggerClick}
         disabled={triggerDisabled}
         className={triggerClassName}
       >
         {trigger}
       </button>
-      {open && (
+      {open && portal && portalPos &&
+        createPortal(
+          <div
+            ref={portalMenuRef}
+            style={{
+              position: "fixed",
+              top: portalPos.top + 4,
+              ...(align === "right" ? { right: portalPos.right } : { left: portalPos.left }),
+            }}
+            className={cn(
+              "z-50 min-w-[160px] rounded-md border bg-popover py-1 text-xs shadow-md",
+              menuClassName
+            )}
+          >
+            {menuItems}
+          </div>,
+          document.body
+        )}
+      {open && !portal && (
         <div
           className={cn(
             "absolute top-full z-50 mt-1 min-w-[160px] rounded-md border bg-popover py-1 text-xs shadow-md",
@@ -96,31 +165,7 @@ export function ActionMenu({
             menuClassName
           )}
         >
-          {note}
-          {entries.map((entry, i) =>
-            isSeparator(entry) ? (
-              <div key={i} className="my-1 border-t" />
-            ) : (
-              <button
-                key={i}
-                type="button"
-                onClick={() => {
-                  setOpen(false)
-                  entry.onClick()
-                }}
-                disabled={itemsDisabled || entry.disabled}
-                className={cn(
-                  "flex w-full items-center gap-2 px-3 py-1.5 text-left hover:bg-accent transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-default",
-                  entry.danger && "text-red-600 hover:bg-red-50 dark:hover:bg-red-950/30"
-                )}
-              >
-                {entry.icon ? (
-                  <entry.icon className={cn("h-3.5 w-3.5", entry.iconClassName)} />
-                ) : null}
-                {entry.label}
-              </button>
-            )
-          )}
+          {menuItems}
         </div>
       )}
     </div>

--- a/apps/studio/src/hooks/use-assistant.ts
+++ b/apps/studio/src/hooks/use-assistant.ts
@@ -1,0 +1,10 @@
+import { useMutation } from "@tanstack/react-query"
+import { api } from "@/api/client"
+import type { AssistantChatRequestBody } from "@/api/client"
+
+export function useAssistantChat(label: string) {
+  return useMutation({
+    mutationFn: ({ body, apiKey }: { body: AssistantChatRequestBody; apiKey: string }) =>
+      api.sendAssistantMessage(label, body, apiKey),
+  })
+}

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -859,6 +859,9 @@ msgstr "Add an API key in Book settings to run translation."
 msgid "Add an API key to re-run"
 msgstr "Add an API key to re-run"
 
+msgid "Add an API key to use the Assistant."
+msgstr "Add an API key to use the Assistant."
+
 msgid "Add at least one output language to run translation."
 msgstr "Add at least one output language to run translation."
 
@@ -1338,6 +1341,18 @@ msgstr "Article"
 msgid "Aside"
 msgstr "Aside"
 
+#~ msgid "Ask a question about this page…"
+#~ msgstr "Ask a question about this page…"
+
+msgid "Ask a question…"
+msgstr "Ask a question…"
+
+#~ msgid "Ask about the page you're currently viewing — I can see what's on it."
+#~ msgstr "Ask about the page you're currently viewing — I can see what's on it."
+
+msgid "Ask about the page you're viewing, or anything about how ADT Studio works — I can see what's on your screen and I'm not limited to it."
+msgstr "Ask about the page you're viewing, or anything about how ADT Studio works — I can see what's on your screen and I'm not limited to it."
+
 msgid "Ask AI to edit..."
 msgstr "Ask AI to edit..."
 
@@ -1352,6 +1367,9 @@ msgstr "Asset"
 
 msgid "Assign..."
 msgstr "Assign..."
+
+msgid "Assistant"
+msgstr "Assistant"
 
 msgid "At the river's edge"
 msgstr "At the river's edge"
@@ -2365,6 +2383,12 @@ msgstr "Cut a region out of any page"
 
 msgid "Debug mode is not enabled."
 msgstr "Debug mode is not enabled."
+
+msgid "Debug Panel"
+msgstr "Debug Panel"
+
+msgid "Debug Panel (Cmd+Shift+D)"
+msgstr "Debug Panel (Cmd+Shift+D)"
 
 msgid "Decorative"
 msgstr "Decorative"
@@ -5308,6 +5332,9 @@ msgstr "Open a page to review"
 msgid "Open a page to see page-level findings"
 msgstr "Open a page to see page-level findings"
 
+msgid "Open assistant"
+msgstr "Open assistant"
+
 #. placeholder {0}: source.buildCommit.sha.slice(0, 7)
 #. placeholder {0}: source.changeCommit.sha.slice(0, 7)
 msgid "Open commit {0}"
@@ -5340,6 +5367,9 @@ msgstr "Open Preview"
 #. placeholder {0}: pullRequest.number
 msgid "Open pull request {0}"
 msgstr "Open pull request {0}"
+
+msgid "Open settings"
+msgstr "Open settings"
 
 msgid "Open source PDF in a new tab"
 msgstr "Open source PDF in a new tab"
@@ -7156,6 +7186,9 @@ msgstr "Selecting \"None\" lets the LLM choose its own styling for each page."
 msgid "Self-contained ADT web app"
 msgstr "Self-contained ADT web app"
 
+msgid "Send"
+msgstr "Send"
+
 msgid "Send this project archive back to the coordinator to merge into the source book."
 msgstr "Send this project archive back to the coordinator to merge into the source book."
 
@@ -7379,6 +7412,10 @@ msgstr "Some pages have no embedded text layer — text was recovered from the p
 
 msgid "Something went wrong"
 msgstr "Something went wrong"
+
+#. placeholder {0}: err instanceof Error ? err.message : String(err)
+msgid "Something went wrong: {0}"
+msgstr "Something went wrong: {0}"
 
 msgid "Sort"
 msgstr "Sort"
@@ -8049,6 +8086,9 @@ msgstr "They produce flowers to attract pollinators."
 
 msgid "They release oxygen directly into the air."
 msgstr "They release oxygen directly into the air."
+
+msgid "Thinking…"
+msgstr "Thinking…"
 
 msgid "This archive can't be opened safely"
 msgstr "This archive can't be opened safely"

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -859,6 +859,9 @@ msgstr "Añade una clave API en la configuración del libro para ejecutar traduc
 msgid "Add an API key to re-run"
 msgstr "Agrega una clave de API para re-ejecutar"
 
+msgid "Add an API key to use the Assistant."
+msgstr "Agrega una clave de API para usar el Asistente."
+
 msgid "Add at least one output language to run translation."
 msgstr "Añade al menos un idioma de salida para ejecutar traducción."
 
@@ -1338,6 +1341,18 @@ msgstr "Artículo"
 msgid "Aside"
 msgstr "Aparte"
 
+#~ msgid "Ask a question about this page…"
+#~ msgstr "Haz una pregunta sobre esta página…"
+
+msgid "Ask a question…"
+msgstr "Haz una pregunta…"
+
+#~ msgid "Ask about the page you're currently viewing — I can see what's on it."
+#~ msgstr "Pregunta sobre la página que estás viendo ahora — puedo ver lo que hay en ella."
+
+msgid "Ask about the page you're viewing, or anything about how ADT Studio works — I can see what's on your screen and I'm not limited to it."
+msgstr "Pregunta sobre la página que estás viendo, o sobre cualquier aspecto de cómo funciona ADT Studio — puedo ver lo que hay en tu pantalla, pero no me limito a eso."
+
 msgid "Ask AI to edit..."
 msgstr "Pide a la IA que edite..."
 
@@ -1352,6 +1367,9 @@ msgstr "Recurso"
 
 msgid "Assign..."
 msgstr "Asignar..."
+
+msgid "Assistant"
+msgstr "Asistente"
 
 msgid "At the river's edge"
 msgstr "A la orilla del río"
@@ -2365,6 +2383,12 @@ msgstr "Recorta una región de cualquier página"
 
 msgid "Debug mode is not enabled."
 msgstr "El modo de depuración no está habilitado."
+
+msgid "Debug Panel"
+msgstr "Panel de depuración"
+
+msgid "Debug Panel (Cmd+Shift+D)"
+msgstr "Panel de depuración (Cmd+Shift+D)"
 
 msgid "Decorative"
 msgstr "Decorativa"
@@ -5308,6 +5332,9 @@ msgstr "Open a page to review"
 msgid "Open a page to see page-level findings"
 msgstr "Open a page to see page-level findings"
 
+msgid "Open assistant"
+msgstr "Abrir asistente"
+
 #. placeholder {0}: source.buildCommit.sha.slice(0, 7)
 #. placeholder {0}: source.changeCommit.sha.slice(0, 7)
 msgid "Open commit {0}"
@@ -5340,6 +5367,9 @@ msgstr "Open Preview"
 #. placeholder {0}: pullRequest.number
 msgid "Open pull request {0}"
 msgstr "Abrir solicitud de cambios {0}"
+
+msgid "Open settings"
+msgstr "Abrir configuración"
 
 msgid "Open source PDF in a new tab"
 msgstr "Abrir el PDF de origen en una nueva pestaña"
@@ -7156,6 +7186,9 @@ msgstr "Seleccionar \\\"Ninguno\\\" permite al LLM elegir su propio estilo para 
 msgid "Self-contained ADT web app"
 msgstr "Aplicación web ADT autónoma"
 
+msgid "Send"
+msgstr "Enviar"
+
 msgid "Send this project archive back to the coordinator to merge into the source book."
 msgstr "Envía este archivo de proyecto al coordinador para combinarlo en el libro de origen."
 
@@ -7379,6 +7412,10 @@ msgstr "Algunas páginas no tienen capa de texto incrustado — el texto se recu
 
 msgid "Something went wrong"
 msgstr "Algo salió mal"
+
+#. placeholder {0}: err instanceof Error ? err.message : String(err)
+msgid "Something went wrong: {0}"
+msgstr "Algo salió mal: {0}"
 
 msgid "Sort"
 msgstr "Ordenar"
@@ -8049,6 +8086,9 @@ msgstr "Producen flores para atraer polinizadores."
 
 msgid "They release oxygen directly into the air."
 msgstr "Liberan oxígeno directamente al aire."
+
+msgid "Thinking…"
+msgstr "Pensando…"
 
 msgid "This archive can't be opened safely"
 msgstr "Este archivo no se puede abrir de forma segura"

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -861,6 +861,9 @@ msgstr "Ajoutez une clé API dans les paramètres du livre pour exécuter la tra
 msgid "Add an API key to re-run"
 msgstr "Ajoutez une clé API pour relancer"
 
+msgid "Add an API key to use the Assistant."
+msgstr "Ajoutez une clé API pour utiliser l'Assistant."
+
 msgid "Add at least one output language to run translation."
 msgstr "Ajoutez au moins une langue de sortie pour exécuter la traduction."
 
@@ -1340,6 +1343,18 @@ msgstr "Article"
 msgid "Aside"
 msgstr "Aparté"
 
+#~ msgid "Ask a question about this page…"
+#~ msgstr "Posez une question sur cette page…"
+
+msgid "Ask a question…"
+msgstr "Posez une question…"
+
+#~ msgid "Ask about the page you're currently viewing — I can see what's on it."
+#~ msgstr "Posez des questions sur la page que vous consultez actuellement — je peux voir ce qu'elle contient."
+
+msgid "Ask about the page you're viewing, or anything about how ADT Studio works — I can see what's on your screen and I'm not limited to it."
+msgstr "Posez une question sur la page que vous consultez, ou sur le fonctionnement d'ADT Studio en général — je vois ce qui est affiché à l'écran, mais je ne m'y limite pas."
+
 msgid "Ask AI to edit..."
 msgstr "Demander à l'IA de modifier..."
 
@@ -1354,6 +1369,9 @@ msgstr "Ressource"
 
 msgid "Assign..."
 msgstr "Attribuer..."
+
+msgid "Assistant"
+msgstr "Assistant"
 
 msgid "At the river's edge"
 msgstr "Au bord de la rivière"
@@ -2367,6 +2385,12 @@ msgstr "Découpez une région de n'importe quelle page"
 
 msgid "Debug mode is not enabled."
 msgstr "Le mode débogage n'est pas activé."
+
+msgid "Debug Panel"
+msgstr "Panneau de débogage"
+
+msgid "Debug Panel (Cmd+Shift+D)"
+msgstr "Panneau de débogage (Cmd+Shift+D)"
 
 msgid "Decorative"
 msgstr "Décorative"
@@ -5310,6 +5334,9 @@ msgstr "Ouvrir une page à réviser"
 msgid "Open a page to see page-level findings"
 msgstr "Ouvrir une page pour voir les résultats au niveau de la page"
 
+msgid "Open assistant"
+msgstr "Ouvrir l'assistant"
+
 #. placeholder {0}: source.buildCommit.sha.slice(0, 7)
 #. placeholder {0}: source.changeCommit.sha.slice(0, 7)
 msgid "Open commit {0}"
@@ -5342,6 +5369,9 @@ msgstr "Ouvrir l'aperçu"
 #. placeholder {0}: pullRequest.number
 msgid "Open pull request {0}"
 msgstr "Ouvrir la demande de tirage {0}"
+
+msgid "Open settings"
+msgstr "Ouvrir les paramètres"
 
 msgid "Open source PDF in a new tab"
 msgstr "Ouvrir le PDF source dans un nouvel onglet"
@@ -7158,6 +7188,9 @@ msgstr "Sélectionner \\\"Aucun\\\" laisse le LLM choisir son propre style pour 
 msgid "Self-contained ADT web app"
 msgstr "Application web ADT autonome"
 
+msgid "Send"
+msgstr "Envoyer"
+
 msgid "Send this project archive back to the coordinator to merge into the source book."
 msgstr "Renvoyez cette archive de projet au coordinateur pour la fusionner dans le livre source."
 
@@ -7381,6 +7414,10 @@ msgstr "Certaines pages n'ont pas de couche de texte intégrée — le texte a �
 
 msgid "Something went wrong"
 msgstr "Quelque chose s'est mal passé"
+
+#. placeholder {0}: err instanceof Error ? err.message : String(err)
+msgid "Something went wrong: {0}"
+msgstr "Une erreur s'est produite : {0}"
 
 msgid "Sort"
 msgstr "Trier"
@@ -8051,6 +8088,9 @@ msgstr "Elles produisent des fleurs pour attirer les pollinisateurs."
 
 msgid "They release oxygen directly into the air."
 msgstr "Elles libèrent de l'oxygène directement dans l'air."
+
+msgid "Thinking…"
+msgstr "Réflexion en cours…"
 
 msgid "This archive can't be opened safely"
 msgstr "Cette archive ne peut pas être ouverte en toute sécurité"

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -859,6 +859,9 @@ msgstr "Adicione uma chave de API nas configurações do Livro para executar tra
 msgid "Add an API key to re-run"
 msgstr "Adicione uma chave de API para reexecutar"
 
+msgid "Add an API key to use the Assistant."
+msgstr "Adicione uma chave de API para usar o Assistente."
+
 msgid "Add at least one output language to run translation."
 msgstr "Adicione pelo menos um idioma de saída para executar tradução."
 
@@ -1338,6 +1341,18 @@ msgstr "Artigo"
 msgid "Aside"
 msgstr "Aparte"
 
+#~ msgid "Ask a question about this page…"
+#~ msgstr "Faça uma pergunta sobre esta página…"
+
+msgid "Ask a question…"
+msgstr "Faça uma pergunta…"
+
+#~ msgid "Ask about the page you're currently viewing — I can see what's on it."
+#~ msgstr "Pergunte sobre a página que você está vendo agora — consigo ver o que há nela."
+
+msgid "Ask about the page you're viewing, or anything about how ADT Studio works — I can see what's on your screen and I'm not limited to it."
+msgstr "Pergunte sobre a página que você está vendo, ou sobre qualquer aspecto de como o ADT Studio funciona — consigo ver o que há na sua tela, mas não me limito a isso."
+
 msgid "Ask AI to edit..."
 msgstr "Peça para a IA editar..."
 
@@ -1352,6 +1367,9 @@ msgstr "Recurso"
 
 msgid "Assign..."
 msgstr "Atribuir..."
+
+msgid "Assistant"
+msgstr "Assistente"
 
 msgid "At the river's edge"
 msgstr "Na beira do rio"
@@ -2365,6 +2383,12 @@ msgstr "Recorte uma região de qualquer página"
 
 msgid "Debug mode is not enabled."
 msgstr "Modo de depuração não está ativado."
+
+msgid "Debug Panel"
+msgstr "Painel de depuração"
+
+msgid "Debug Panel (Cmd+Shift+D)"
+msgstr "Painel de depuração (Cmd+Shift+D)"
 
 msgid "Decorative"
 msgstr "Decorativa"
@@ -5308,6 +5332,9 @@ msgstr "Open a page to review"
 msgid "Open a page to see page-level findings"
 msgstr "Open a page to see page-level findings"
 
+msgid "Open assistant"
+msgstr "Abrir assistente"
+
 #. placeholder {0}: source.buildCommit.sha.slice(0, 7)
 #. placeholder {0}: source.changeCommit.sha.slice(0, 7)
 msgid "Open commit {0}"
@@ -5340,6 +5367,9 @@ msgstr "Open Preview"
 #. placeholder {0}: pullRequest.number
 msgid "Open pull request {0}"
 msgstr "Abrir pull request {0}"
+
+msgid "Open settings"
+msgstr "Abrir configurações"
 
 msgid "Open source PDF in a new tab"
 msgstr "Abrir o PDF de origem em uma nova aba"
@@ -7156,6 +7186,9 @@ msgstr "Selecionar \\\"Nenhum\\\" permite que o LLM escolha seu próprio estilo 
 msgid "Self-contained ADT web app"
 msgstr "Aplicativo web ADT autônomo"
 
+msgid "Send"
+msgstr "Enviar"
+
 msgid "Send this project archive back to the coordinator to merge into the source book."
 msgstr "Envie este arquivo de projeto de volta ao coordenador para mesclá-lo no livro de origem."
 
@@ -7379,6 +7412,10 @@ msgstr "Algumas páginas não têm camada de texto incorporada — o texto foi r
 
 msgid "Something went wrong"
 msgstr "Algo deu errado"
+
+#. placeholder {0}: err instanceof Error ? err.message : String(err)
+msgid "Something went wrong: {0}"
+msgstr "Algo deu errado: {0}"
 
 msgid "Sort"
 msgstr "Ordenar"
@@ -8049,6 +8086,9 @@ msgstr "Produzem flores para atrair polinizadores."
 
 msgid "They release oxygen directly into the air."
 msgstr "Liberam oxigênio diretamente no ar."
+
+msgid "Thinking…"
+msgstr "Pensando…"
 
 msgid "This archive can't be opened safely"
 msgstr "Este arquivo não pode ser aberto com segurança"

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -860,6 +860,9 @@ msgstr "Shto një çelës API në cilësimet e Librit për të ekzekutuar përkt
 msgid "Add an API key to re-run"
 msgstr "Shto një çelës API për të ri-ekzekutuar"
 
+msgid "Add an API key to use the Assistant."
+msgstr "Shtoni një çelës API për të përdorur Asistentin."
+
 msgid "Add at least one output language to run translation."
 msgstr "Shto të paktën një gjuhë dalëse për të ekzekutuar përkthimin."
 
@@ -1339,6 +1342,18 @@ msgstr "Artikull"
 msgid "Aside"
 msgstr "Shënim anësor"
 
+#~ msgid "Ask a question about this page…"
+#~ msgstr "Bëni një pyetje rreth kësaj faqeje…"
+
+msgid "Ask a question…"
+msgstr "Bëni një pyetje…"
+
+#~ msgid "Ask about the page you're currently viewing — I can see what's on it."
+#~ msgstr "Pyisni për faqen që po shikoni aktualisht — mund ta shoh çfarë ka në të."
+
+msgid "Ask about the page you're viewing, or anything about how ADT Studio works — I can see what's on your screen and I'm not limited to it."
+msgstr "Pyisni për faqen që po shikoni, ose për çdo gjë rreth mënyrës se si funksionon ADT Studio — mund ta shoh çfarë ka në ekranin tuaj, por nuk kufizohem vetëm tek kjo."
+
 msgid "Ask AI to edit..."
 msgstr "Kërko nga AI të redaktojë..."
 
@@ -1353,6 +1368,9 @@ msgstr "Burim"
 
 msgid "Assign..."
 msgstr "Cakto..."
+
+msgid "Assistant"
+msgstr "Asistenti"
 
 msgid "At the river's edge"
 msgstr "Në buzë të lumit"
@@ -2366,6 +2384,12 @@ msgstr "Prit një zonë nga çdo faqe"
 
 msgid "Debug mode is not enabled."
 msgstr "Modaliteti i korrigjimit nuk është aktivizuar."
+
+msgid "Debug Panel"
+msgstr "Paneli i korrigjimit"
+
+msgid "Debug Panel (Cmd+Shift+D)"
+msgstr "Paneli i korrigjimit (Cmd+Shift+D)"
 
 msgid "Decorative"
 msgstr "Dekorativ"
@@ -5309,6 +5333,9 @@ msgstr "Hapni një faqe për rishikim"
 msgid "Open a page to see page-level findings"
 msgstr "Hapni një faqe për të parë gjetjet në nivel faqeje"
 
+msgid "Open assistant"
+msgstr "Hap asistentin"
+
 #. placeholder {0}: source.buildCommit.sha.slice(0, 7)
 #. placeholder {0}: source.changeCommit.sha.slice(0, 7)
 msgid "Open commit {0}"
@@ -5341,6 +5368,9 @@ msgstr "Hapni Pamjen Paraprake"
 #. placeholder {0}: pullRequest.number
 msgid "Open pull request {0}"
 msgstr "Hap pull request-in {0}"
+
+msgid "Open settings"
+msgstr "Hap cilësimet"
 
 msgid "Open source PDF in a new tab"
 msgstr "Hapni PDF-in burimor në një skedë të re"
@@ -7157,6 +7187,9 @@ msgstr "Zgjedhja e \"Asnjë\" i lejon LLM-it të zgjedhë stilin e tij për çdo
 msgid "Self-contained ADT web app"
 msgstr "Aplikacion web ADT i pavarur"
 
+msgid "Send"
+msgstr "Dërgo"
+
 msgid "Send this project archive back to the coordinator to merge into the source book."
 msgstr "Dërgojeni këtë arkiv projekti te koordinatori për ta bashkuar në librin burim."
 
@@ -7380,6 +7413,10 @@ msgstr "Disa faqe nuk kanë shtresë teksti të integruar — teksti u rikuperua
 
 msgid "Something went wrong"
 msgstr "Diçka shkoi keq"
+
+#. placeholder {0}: err instanceof Error ? err.message : String(err)
+msgid "Something went wrong: {0}"
+msgstr "Diçka shkoi keq: {0}"
 
 msgid "Sort"
 msgstr "Rendit"
@@ -8050,6 +8087,9 @@ msgstr "Ato prodhojnë lule për të tërhequr polenizuesit."
 
 msgid "They release oxygen directly into the air."
 msgstr "Ato lëshojnë oksigjen drejtpërdrejt në ajër."
+
+msgid "Thinking…"
+msgstr "Duke menduar…"
 
 msgid "This archive can't be opened safely"
 msgstr "Ky arkiv nuk mund të hapet në mënyrë të sigurt"

--- a/apps/studio/src/routes/__root.tsx
+++ b/apps/studio/src/routes/__root.tsx
@@ -6,6 +6,7 @@ import {
   type ErrorComponentProps,
 } from "@tanstack/react-router"
 import { ApiKeyDialog } from "@/components/settings/ApiKeyDialog"
+import { AssistantWidget } from "@/components/assistant/AssistantWidget"
 import { Toaster } from "@/components/ui/sonner"
 import { UpdateDialogProvider } from "@/components/updates"
 import { useApiKey } from "@/hooks/use-api-key"
@@ -81,6 +82,7 @@ function RootLayout() {
             onSaveAzureRegion={setAzureRegion}
           />
           <Toaster position="top-center" richColors closeButton />
+          <AssistantWidget />
         </div>
       </UpdateDialogProvider>
     </SettingsContext>

--- a/apps/studio/src/routes/books.$label.tsx
+++ b/apps/studio/src/routes/books.$label.tsx
@@ -8,8 +8,7 @@ import {
   useMatchRoute,
   type ErrorComponentProps,
 } from "@tanstack/react-router"
-import { Home, Terminal } from "lucide-react"
-import { Button } from "@/components/ui/button"
+import { Home } from "lucide-react"
 import { DebugPanel } from "@/components/debug/DebugPanel"
 import { DebugPanelStateProvider, type DebugTabValue } from "@/components/debug/debug-panel-state"
 import { StageSidebar } from "@/components/pipeline/components/StageSidebar"
@@ -198,18 +197,6 @@ function BookLayoutInner({ label, isRunning }: { label: string; isRunning: boole
               />
             )}
           </div>
-
-          {!debugOpen && !isDebugRoute && (
-            <Button
-              variant="outline"
-              size="icon"
-              className="fixed bottom-16 right-4 z-50 h-8 w-8 rounded-full shadow-md opacity-60 hover:opacity-100"
-              onClick={() => openDebugPanel()}
-              title="Debug Panel (Cmd+Shift+D)"
-            >
-              <Terminal className="h-4 w-4" />
-            </Button>
-          )}
         </SectionNavCtx.Provider>
         </SettingsDirtyTabsProvider>
       </FloatingSaveProvider>

--- a/docs/ASSISTANT.md
+++ b/docs/ASSISTANT.md
@@ -1,0 +1,162 @@
+# Assistant — In-App Chat Widget
+
+The Assistant is a persistent chat panel available from anywhere in the Studio
+app. It answers questions about whatever book page the user is currently
+looking at, and — in this first version — **advises only**: it never calls a
+mutating endpoint on the user's behalf. It tells the user which existing UI
+action to use (Duplicate, Merge, Delete, edit a section's text/image nodes,
+etc.) and walks them through it, but it does not perform the action itself.
+
+## Why it exists
+
+There's no dedicated "split a section" action in the product today. When the
+AI extraction pipeline merges two distinct activities into one section, a
+user's only path to fixing it is a manual workaround (duplicate the section,
+then edit each copy down to one activity). The Assistant exists to surface
+that kind of guidance in place, without requiring the user to already know
+the workaround or dig through documentation.
+
+## Tone
+
+The system prompt ([`prompts/assistant_chat.liquid`](../prompts/assistant_chat.liquid))
+enforces one hard rule: never phrase an answer as an apology or a
+consolation ("I can't do that, but here's a workaround..."). Instead it states
+the steps directly, as if they're simply the answer — the user cares about
+solving their problem, not about whether a one-click action exists. This is a
+deliberate contrast with assistants that lead with their own limitations.
+
+## Scope: not just the current page
+
+The Assistant is grounded in the current page's content when relevant, but
+it is explicitly **not limited to it**. The system prompt tells the model to
+judge each incoming message on its own terms: a question about the current
+page uses that page's section HTML as context; a broader "how does ADT
+Studio work" or conceptual question (stages vs. steps, what caching means,
+where a setting lives) gets answered directly, without forcing it back to
+page content it doesn't need. The widget's own gating (`if (!label) return
+null`) still limits *where the bubble appears* (book pages only, since that's
+where "the page you're currently viewing" has meaning) — but once it's open,
+what you can ask it is broader than that page.
+
+## Guardrail: confidence is not license to fabricate
+
+Broadening the scope beyond page content exposed a real failure mode during
+manual testing: asked "can my coworker help me?" (i.e. is there a
+collaboration/sharing feature), the model invented a plausible but entirely
+fictional "Members / Share" settings flow — confidently, because the tone
+rule tells it to never hedge. Confident wording does not make a fabricated
+menu less dangerous; if anything it's worse, since the user will go looking
+for something that was never there.
+
+The fix is a **Facts about ADT Studio** section in the system prompt —
+concrete, verifiable statements pulled from this repo's own principles
+(single-user/no-accounts, book-level storage, versioning, caching, LLM-call
+transparency, the real list of section actions) — plus an explicit rule
+that confidence describes *how* the model says true things, never license
+to invent untrue ones. When a question falls outside both the current page
+and these facts, the prompt tells it to say plainly what it does and
+doesn't know rather than improvising UI.
+
+**This is the load-bearing lesson for anyone extending this prompt further:
+every time the Assistant's scope grows, whatever it's now expected to
+answer needs to be backed by real facts in the prompt, not just tone
+instructions.** Tone rules alone make wrong answers more convincing, not
+more correct.
+
+## Linking to documentation
+
+When a `DOCS_BASE_URL` environment variable is set (same pattern as
+`BOOKS_DIR`/`PROMPTS_DIR` in `apps/api/src/app.ts`), the system prompt tells
+the model it may point users to the docs site for deeper explanations by
+including that link in its reply. The frontend renders any `http(s)://` URL
+in a reply as a clickable link (`renderMessageContent` in
+`AssistantWidget.tsx` — a plain-text URL split/wrap, not `dangerouslySetInnerHTML`).
+
+**Deliberately scoped to the docs *home page* only, not deep links to
+specific pages.** The model has no index of the docs site's internal page
+structure, and the prompt explicitly forbids it from inventing a sub-page
+path — a fabricated URL is worse than no link. Building an actual page
+index (title + path per doc page, fed into the prompt so the model can pick
+an accurate specific page) is a natural v2 once the docs site
+(`apps/site`, which lives on a separate branch from this one — see the
+root `CLAUDE.md`) is far enough along to be worth indexing.
+
+## Request flow
+
+```
+AssistantWidget.tsx (floating bubble + Sheet, mounted in __root.tsx)
+  → useAssistantChat() (apps/studio/src/hooks/use-assistant.ts, TanStack Query mutation)
+    → api.sendAssistantMessage() (apps/studio/src/api/client.ts)
+      → POST /books/:label/assistant/chat   [X-OpenAI-Key header, never logged/queried]
+        → createAssistantRoutes (apps/api/src/routes/assistant.ts)
+          → assistantChat() (apps/api/src/services/assistant-chat-service.ts)
+            → createLLMModel + createPromptEngine (@adt/llm)  — same client every
+              other AI feature uses (page edits, sectioning, etc.)
+              → renders prompts/assistant_chat.liquid with page context
+              → OpenAI, response validated against assistantChatLLMSchema (Zod)
+            → every call appended to the book's own llm_log via storage.appendLlmLog()
+              (taskType: "assistant") — visible in Debug → LLM Logs like any other call
+```
+
+Nothing here is a new integration: it's the same LLM client, the same prompt
+templating engine, and the same per-book SQLite log that every existing
+AI-driven pipeline step uses. The Assistant is a new **caller** of that
+machinery, not a new code path alongside it.
+
+## What context the model sees
+
+The widget only appears on `/books/:label/...` routes (`AssistantWidget.tsx`
+returns `null` off a book page — there's nothing for it to be contextual
+*about* elsewhere). When the user has a page open, the service reads that
+page's latest `web-rendering` output and sends the model the HTML of every
+section on the page (each truncated to 4,000 characters to keep token usage
+reasonable), tagged with its section index. This is deliberately *not* the
+full-fidelity single-section HTML that `aiEditSection` (the existing AI-edit
+feature) uses — the Assistant needs to reason about section boundaries and
+rough content across a whole page, not make a precise edit to one section.
+
+Conversation history is passed back on every turn from the frontend's local
+React state (not persisted server-side); a `correlationId` is generated on
+the first turn and reused on later ones so all turns of one conversation
+group together in the LLM logs, the same way `aiEditHistory` groups edit
+turns.
+
+## Data contract
+
+Defined in [`packages/types/src/assistant.ts`](../packages/types/src/assistant.ts)
+— the single source of truth per the repo's Zod-schemas-only rule:
+
+- `AssistantChatRequest` — `message`, `history` (`AssistantChatMessage[]`),
+  optional `pageId` / `sectionIndex` / `correlationId`.
+- `AssistantChatResponse` — `reply`, `correlationId`.
+- `assistantChatLLMSchema` — the shape the LLM's structured output is
+  validated against (`{ reply: string }`); intentionally narrower than the
+  full response type since the server derives `correlationId` itself.
+
+## Where it doesn't touch anything
+
+- **No new dependencies.** Built entirely from existing pieces: Hono routing,
+  the shared `@adt/llm` client, the existing prompt engine, TanStack Query.
+- **No mutation.** The route is read-only — it never calls a book-storage
+  write path other than the LLM log append every AI call already makes.
+- **No new storage.** Conversation history lives in the browser tab's React
+  state; nothing new is persisted to disk beyond the standard LLM log row.
+- **i18n:** every user-visible string in `AssistantWidget.tsx` is wrapped in
+  Lingui macros per the repo's i18n rules; catalogs still need `pnpm --filter
+  @adt/studio extract` run and translated before merging (see Known gaps).
+
+## Known gaps / not yet done
+
+- Only tested against a synthetic book label with no real book data and a
+  placeholder API key — the actual reply content/tone has not yet been
+  checked against a real OpenAI key.
+- **No automated tests.** `assistant-chat-service.ts` and the route have no
+  `*.test.ts` counterpart, unlike sibling AI-feature services. This is a
+  known, deliberate gap in this PR — left for a developer to pick up
+  post-merge rather than blocking the first PR on it.
+- `DOCS_BASE_URL` has no value configured anywhere yet (no `.env`, no
+  `docker-compose.yml` entry, no deploy config) — the linking capability is
+  wired end-to-end but inert until that's set.
+- v1 is guidance-only by design; whether to add action-capability (letting
+  the Assistant actually invoke Duplicate/Merge/Delete) or build a real
+  "split" endpoint is an open decision for a v2, not part of this PR.

--- a/packages/types/src/assistant.ts
+++ b/packages/types/src/assistant.ts
@@ -1,0 +1,26 @@
+import { z } from "zod"
+
+export const AssistantChatMessage = z.object({
+  role: z.enum(["user", "assistant"]),
+  content: z.string(),
+})
+export type AssistantChatMessage = z.infer<typeof AssistantChatMessage>
+
+export const AssistantChatRequest = z.object({
+  message: z.string().min(1),
+  history: z.array(AssistantChatMessage).default([]),
+  pageId: z.string().optional(),
+  sectionIndex: z.number().int().optional(),
+  correlationId: z.string().optional(),
+})
+export type AssistantChatRequest = z.infer<typeof AssistantChatRequest>
+
+export const AssistantChatResponse = z.object({
+  reply: z.string(),
+  correlationId: z.string(),
+})
+export type AssistantChatResponse = z.infer<typeof AssistantChatResponse>
+
+export const assistantChatLLMSchema = z.object({
+  reply: z.string(),
+})

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -274,6 +274,13 @@ export {
 } from "./toc.js"
 
 export {
+  AssistantChatMessage,
+  AssistantChatRequest,
+  AssistantChatResponse,
+  assistantChatLLMSchema,
+} from "./assistant.js"
+
+export {
   AccessibilityNodeResult,
   AccessibilityFinding,
   AccessibilityPageResult,

--- a/prompts/assistant_chat.liquid
+++ b/prompts/assistant_chat.liquid
@@ -1,0 +1,71 @@
+{% chat role: "system" %}
+You are the in-app assistant for ADT Studio, a tool that converts activity books (PDFs) into interactive digital books through an AI pipeline. You are shown to users as a persistent chat panel they can open from anywhere in the app.
+
+## Your job
+
+Help the user get unstuck — whether that's something specific to the page they're currently viewing, or a broader question about how ADT Studio works (concepts like stages vs. steps, versioning, caching, what a specific pipeline feature does, where to find something). Don't assume every question is about the current page's content: read the user's message first and judge what kind of question it actually is. When it is about the current page, you have that page's context below (if any) — use it, and answer as if you already know what's on their screen, not generically. When it's a broader "how does this work" or conceptual question, answer that directly instead of forcing it back to the current page.
+
+## Tone — this is the most important rule
+
+Never frame an answer as an apology or a workaround for something you "can't" do. Do not say things like "I can't do that for you, but I can guide you" or "Unfortunately I'm unable to...". That framing centers your limitation instead of the user's problem, and it reads as making excuses.
+
+Instead: state the solution directly and confidently, as if it's simply the answer. If solving it takes several manual steps because no one-click action exists yet, present those steps as *the* way to do it — not as a consolation prize. The user does not care whether an action button exists or not; they care whether their problem gets solved.
+
+Bad: "I'm not able to split a section for you, but here's a workaround you could try..."
+Good: "Duplicate this section, then move the second activity's content into the duplicate. Here's exactly how:"
+
+**Confidence is about how you say things that are true. It is never permission to invent something that isn't.** If you don't actually know whether a feature, menu, or setting exists, do not describe clicking through one anyway — that is worse than admitting a limit, because the user will go looking for something that isn't there. When a feature genuinely doesn't exist, say so as a plain, confident fact (not an apology) and give the real answer instead — see the sharing example below for what that looks like in practice.
+
+## Facts about ADT Studio — ground your answers in these, don't improvise around them
+
+- It's a single-user, desktop-first app (no user accounts, workspaces, logins, or in-app member/sharing system exist anywhere in the product).
+- Each book's entire data lives in one local directory on disk (that's a deliberate design principle: book-level storage, zippable and shareable as a folder). There is no "invite a collaborator" or "share workspace" feature. If a user asks how to work on a book with someone else, the real answer is: copy or zip that book's folder and send it to them (email, shared drive, network folder) — not an in-app sharing flow.
+- Entities (pages, sections, etc.) are never overwritten — every change creates a new version, and rollback is possible.
+- LLM calls are cached by their exact inputs, so re-running a step is fast if nothing relevant changed.
+- Every LLM call the app makes (including your own replies) is logged and visible to the user under Debug → LLM Logs — nothing is a hidden black box.
+- Section-level actions that exist today: Duplicate, Merge with previous/next section, Delete, and editing individual text/image nodes within a section. There is currently no dedicated "split a section" action — the workaround is Duplicate, then trim each copy down to one activity.
+
+If a question falls outside both the current page and these facts, say plainly what you do and don't know rather than guessing at UI that may not exist.
+
+## What you can reference
+
+You can describe actions available in the current UI (e.g. Duplicate, Merge with previous/next section, Delete, editing individual text/image nodes within a section) and walk the user through using them step by step. You cannot perform actions yourself in this version — you only advise. Never imply you performed an action; describe what the user should click.
+
+{% if docs_base_url %}
+## Linking to documentation
+
+ADT Studio has a documentation site at {{ docs_base_url }}. When a question would benefit from more detail than fits in a chat reply — a concept, a full walkthrough, background on a feature — point the user there by including the link in your reply. Only link to {{ docs_base_url }} itself (the docs home); you do not know its internal page structure, so never invent a more specific sub-page path — that would send the user to a broken link.
+{% endif %}
+
+## Response format
+
+Return a JSON object with one field:
+- `reply`: your response to the user, in plain conversational text (not markdown headers, short paragraphs or a numbered list is fine for steps).
+{% endchat %}
+
+{% chat role: "user" %}
+{% if page_id %}
+## Current context
+
+The user is looking at page `{{ page_id }}`.
+{% if sections %}
+Here is the current rendered HTML of every section on this page, in order, so you can reference specific sections by index and know exactly what's in each one:
+{% for s in sections %}
+### Section {{ s.sectionIndex }}
+
+{{ s.html }}
+{% endfor %}
+{% endif %}
+{% endif %}
+
+{% if history %}
+## Conversation so far
+{% for turn in history %}
+{{ turn.role }}: {{ turn.content }}
+{% endfor %}
+{% endif %}
+
+## User's message
+
+{{ message }}
+{% endchat %}


### PR DESCRIPTION
## What this is

This is **not ready to merge** — I'm opening it as a draft so you can see where my head's at, follow the reasoning, and poke holes in it. No expectation you review it like a normal PR; I mainly want you to read the intention and the open questions below.

The core idea: a persistent "Assistant" chat panel inside Studio (bottom-right bubble, opens a side panel) that helps a user get unstuck — either about the specific page they're looking at, or a general "how does ADT Studio work" question. In this version it's **guidance-only**: it tells the user what to click, it never calls a mutating endpoint itself.

Why I wanted this: while testing a PDF→activity-book conversion, the pipeline merged two distinct activities into one section, and there's genuinely no "split" action in the product today — only Merge/Duplicate/Delete. The only path is a manual workaround, and nothing in the UI tells you that. This is meant to close that gap generally, not just for that one case.

Full technical writeup (request flow, prompt design, data contract, how it plugs into the existing `@adt/llm` client and logging) is in [`docs/ASSISTANT.md`](https://github.com/unicef/adt-studio/blob/worktree-assistant-widget/docs/ASSISTANT.md) — that's the place for the "how does this actually work" detail; this description is more about intent and open questions.

## How I tested it

- Rebased onto latest `develop` (this branch had gone stale for a bit) — `pnpm typecheck` and `pnpm lint` both clean.
- Verified the widget's rendering (bubble, panel open/close, empty state, no-API-key gate, composer) with real browser screenshots, not just "it compiles."
- Tested against a real book with my own OpenAI key. This surfaced two real problems, both fixed before this PR:
  - **A hallucination.** I asked it something not covered by the current page or my prompt's "facts" section, and it confidently invented a UI flow that doesn't exist (a fictional "share this book with a coworker" settings menu). Root cause: I'd told it to answer broader questions but hadn't grounded it in what's actually true about the product, combined with a "never hedge" tone rule — confident wording made the wrong answer more convincing, not more correct. Fixed by adding an explicit facts section to the prompt (single-user app, book-level storage, versioning, caching, etc.) plus a rule that confidence is about *how* it says true things, never license to invent untrue ones. Worth reading as a cautionary note if this prompt gets extended further.
  - **A layout bug.** A UI tweak I made (see below) rendered a dropdown that was structurally present but visually clipped to invisibility by a parent's `overflow-hidden`. Only caught by actually opening it in a browser, not by typecheck/lint.
- Every one of the assistant's LLM calls shows up in the existing Debug → LLM Logs panel exactly like every other AI feature's calls do — I actually watched this happen against my own test book, so that's not just an aspirational claim in the docs.

## What I intentionally did not do

- **No automated tests.** This is deliberately left for whoever picks this up — `assistant-chat-service.ts` and the route have no `*.test.ts`, unlike sibling AI-feature services. I see this as your call on when/how, not something to guess at.
- **No deep documentation linking yet** — see below, this is one of the open points.
- **No action-capability.** It only advises; it can't invoke Duplicate/Merge/Delete/etc. itself. Whether that's worth building is a v2 question, not something I've tried to answer here.

## Small unrelated thing bundled in

While testing I also moved the "Debug Panel" button — it used to live in the app's top-left logo bar, which never made sense since it opens per-book data. It's now a dropdown on the book's own row in the sidebar, with "Debug Panel" and "API Keys" as the two options (that row's gear used to only open API Keys). Separate concern from the Assistant itself, just happened to ride along in the same branch since I found it while testing.

## Open points — things on my mind, not yet built

1. **I want every answer to link back to the docs.** Right now there's a `DOCS_BASE_URL` env var wired end-to-end (route → service → prompt) that lets the assistant point to the documentation site — but it's deliberately restricted to linking the docs *home page* only, because the prompt has no index of what pages actually exist, and I didn't want it fabricating a specific sub-page URL that 404s. To do this properly we'd need to feed it an actual index (title + path per doc page) so it can link to the *right* page, not just the front door. Also worth noting: the docs site (`apps/site`) lives on a totally separate branch from `develop`, so this isn't wireable yet in a real sense until that lands somewhere this app can see it.

2. **I want a way to see what people are actually asking it**, so the docs work can be prioritized by real usage instead of guesswork — e.g. if "how do I do X" comes up constantly and there's no doc page for X, that's a strong signal of what to write next. Nothing like this exists today: the LLM logs record individual calls for transparency/debugging, but there's no aggregation layer that would let someone look at "top questions this month" across users. This is the one I'd love your read on most — whether it belongs in this app at all, or as a separate analysis pulled from the logs.

Would genuinely like your take on either of these, or anything else that jumps out at you.
