### PR TITLE
fix(site): docs videos 404 under the Pages base path; banner pills overlap the navbar

### DIFF
--- a/apps/site/content/docs/en/convert-pdf/extract.mdx
+++ b/apps/site/content/docs/en/convert-pdf/extract.mdx
@@ -28,25 +28,17 @@ Each clip below runs a real printed page through the full pipeline for its match
 
 **Textbooks & Activities** — a printed science chapter and a workbook activity page, both rebuilt into structured, accessible content.
 
-<video controls playsInline aria-label="A printed science textbook chapter on biomes is converted into an accessible e-learning page with easy-read mode, a glossary, and sign language." className="w-full rounded-lg border border-[color:var(--color-border)]">
-  <source src="/videos/los-biomas.mp4" type="video/mp4" />
-</video>
+<DocVideo src="/videos/los-biomas.mp4" label="A printed science textbook chapter on biomes is converted into an accessible e-learning page with easy-read mode, a glossary, and sign language." />
 
-<video controls playsInline aria-label="A printed workbook activity page is converted into an AI-generated, interactive accessible activity." className="w-full rounded-lg border border-[color:var(--color-border)]">
-  <source src="/videos/cuaderno5.mp4" type="video/mp4" />
-</video>
+<DocVideo src="/videos/cuaderno5.mp4" label="A printed workbook activity page is converted into an AI-generated, interactive accessible activity." />
 
 **Reference** — a dense, multi-column textbook page rebuilt as a responsive, semantic web layout.
 
-<video controls playsInline aria-label="A complex, multi-column printed textbook page is converted into a responsive web layout." className="w-full rounded-lg border border-[color:var(--color-border)]">
-  <source src="/videos/brazil.mp4" type="video/mp4" />
-</video>
+<DocVideo src="/videos/brazil.mp4" label="A complex, multi-column printed textbook page is converted into a responsive web layout." />
 
 **Storybook** — an illustrated story page gains text-to-speech narration, image descriptions, translations, and a quiz.
 
-<video controls playsInline aria-label="An illustrated storybook page gains text-to-speech narration, image descriptions, translations, and an interactive quiz." className="w-full rounded-lg border border-[color:var(--color-border)]">
-  <source src="/videos/momo.mp4" type="video/mp4" />
-</video>
+<DocVideo src="/videos/momo.mp4" label="An illustrated storybook page gains text-to-speech narration, image descriptions, translations, and an interactive quiz." />
 </Step>
 
 <Step>

--- a/apps/site/content/docs/en/convert-pdf/index.mdx
+++ b/apps/site/content/docs/en/convert-pdf/index.mdx
@@ -9,10 +9,7 @@ step — only the affected work is redone.
 
 <SectionBanner slug="convert-pdf" />
 
-<video autoPlay loop muted playsInline aria-hidden="true">
-  <source src="/videos/onboarding-how-it-works.webm" type="video/webm" />
-  <source src="/videos/onboarding-how-it-works.mp4" type="video/mp4" />
-</video>
+<DocVideo src={["/videos/onboarding-how-it-works.webm", "/videos/onboarding-how-it-works.mp4"]} ambient />
 
 <StageCards>
   <StageCard slug="convert-pdf/import-pdf" href="convert-pdf/import-pdf" title="Import a PDF" description="Start a new book project by bringing your PDF into ADT Studio." />

--- a/apps/site/content/docs/es/convert-pdf/extract.mdx
+++ b/apps/site/content/docs/es/convert-pdf/extract.mdx
@@ -28,25 +28,17 @@ Cada clip a continuación pasa una página impresa real por todo el proceso para
 
 **Libros de texto y actividades** — un capítulo de ciencias impreso y una página de actividad de cuaderno, ambos reconstruidos como contenido estructurado y accesible.
 
-<video controls playsInline aria-label="A printed science textbook chapter on biomes is converted into an accessible e-learning page with easy-read mode, a glossary, and sign language." className="w-full rounded-lg border border-[color:var(--color-border)]">
-  <source src="/videos/los-biomas.mp4" type="video/mp4" />
-</video>
+<DocVideo src="/videos/los-biomas.mp4" label="A printed science textbook chapter on biomes is converted into an accessible e-learning page with easy-read mode, a glossary, and sign language." />
 
-<video controls playsInline aria-label="A printed workbook activity page is converted into an AI-generated, interactive accessible activity." className="w-full rounded-lg border border-[color:var(--color-border)]">
-  <source src="/videos/cuaderno5.mp4" type="video/mp4" />
-</video>
+<DocVideo src="/videos/cuaderno5.mp4" label="A printed workbook activity page is converted into an AI-generated, interactive accessible activity." />
 
 **Referencia** — una página densa y de varias columnas de un libro de texto, reconstruida como un diseño web responsivo y semántico.
 
-<video controls playsInline aria-label="A complex, multi-column printed textbook page is converted into a responsive web layout." className="w-full rounded-lg border border-[color:var(--color-border)]">
-  <source src="/videos/brazil.mp4" type="video/mp4" />
-</video>
+<DocVideo src="/videos/brazil.mp4" label="A complex, multi-column printed textbook page is converted into a responsive web layout." />
 
 **Cuento ilustrado** — una página de cuento ilustrado gana narración de texto a voz, descripciones de imágenes, traducciones y un cuestionario.
 
-<video controls playsInline aria-label="An illustrated storybook page gains text-to-speech narration, image descriptions, translations, and an interactive quiz." className="w-full rounded-lg border border-[color:var(--color-border)]">
-  <source src="/videos/momo.mp4" type="video/mp4" />
-</video>
+<DocVideo src="/videos/momo.mp4" label="An illustrated storybook page gains text-to-speech narration, image descriptions, translations, and an interactive quiz." />
 </Step>
 
 <Step>

--- a/apps/site/content/docs/es/convert-pdf/index.mdx
+++ b/apps/site/content/docs/es/convert-pdf/index.mdx
@@ -9,10 +9,7 @@ volver a ejecutar un paso anterior — solo se rehace el trabajo afectado.
 
 <SectionBanner slug="convert-pdf" />
 
-<video autoPlay loop muted playsInline aria-hidden="true">
-  <source src="/videos/onboarding-how-it-works.webm" type="video/webm" />
-  <source src="/videos/onboarding-how-it-works.mp4" type="video/mp4" />
-</video>
+<DocVideo src={["/videos/onboarding-how-it-works.webm", "/videos/onboarding-how-it-works.mp4"]} ambient />
 
 <StageCards>
   <StageCard slug="convert-pdf/import-pdf" href="convert-pdf/import-pdf" title="Importar un PDF" description="Inicia un nuevo proyecto de libro trayendo tu PDF a ADT Studio." />

--- a/apps/site/content/docs/fr/convert-pdf/extract.mdx
+++ b/apps/site/content/docs/fr/convert-pdf/extract.mdx
@@ -28,25 +28,17 @@ Chaque extrait ci-dessous fait passer une véritable page imprimée à travers l
 
 **Manuels et activités** — un chapitre de manuel de sciences imprimé et une page d'activité de cahier d'exercices, tous deux reconstruits en contenu structuré et accessible.
 
-<video controls playsInline aria-label="A printed science textbook chapter on biomes is converted into an accessible e-learning page with easy-read mode, a glossary, and sign language." className="w-full rounded-lg border border-[color:var(--color-border)]">
-  <source src="/videos/los-biomas.mp4" type="video/mp4" />
-</video>
+<DocVideo src="/videos/los-biomas.mp4" label="A printed science textbook chapter on biomes is converted into an accessible e-learning page with easy-read mode, a glossary, and sign language." />
 
-<video controls playsInline aria-label="A printed workbook activity page is converted into an AI-generated, interactive accessible activity." className="w-full rounded-lg border border-[color:var(--color-border)]">
-  <source src="/videos/cuaderno5.mp4" type="video/mp4" />
-</video>
+<DocVideo src="/videos/cuaderno5.mp4" label="A printed workbook activity page is converted into an AI-generated, interactive accessible activity." />
 
 **Référence** — une page de manuel imprimée dense et à plusieurs colonnes, reconstruite en une mise en page web réactive et sémantique.
 
-<video controls playsInline aria-label="A complex, multi-column printed textbook page is converted into a responsive web layout." className="w-full rounded-lg border border-[color:var(--color-border)]">
-  <source src="/videos/brazil.mp4" type="video/mp4" />
-</video>
+<DocVideo src="/videos/brazil.mp4" label="A complex, multi-column printed textbook page is converted into a responsive web layout." />
 
 **Livre d'histoires** — une page de récit illustrée acquiert une narration par synthèse vocale, des descriptions d'images, des traductions et un quiz.
 
-<video controls playsInline aria-label="An illustrated storybook page gains text-to-speech narration, image descriptions, translations, and an interactive quiz." className="w-full rounded-lg border border-[color:var(--color-border)]">
-  <source src="/videos/momo.mp4" type="video/mp4" />
-</video>
+<DocVideo src="/videos/momo.mp4" label="An illustrated storybook page gains text-to-speech narration, image descriptions, translations, and an interactive quiz." />
 </Step>
 
 <Step>

--- a/apps/site/content/docs/fr/convert-pdf/index.mdx
+++ b/apps/site/content/docs/fr/convert-pdf/index.mdx
@@ -9,10 +9,7 @@ relancer une étape antérieure — seul le travail concerné est refait.
 
 <SectionBanner slug="convert-pdf" />
 
-<video autoPlay loop muted playsInline aria-hidden="true">
-  <source src="/videos/onboarding-how-it-works.webm" type="video/webm" />
-  <source src="/videos/onboarding-how-it-works.mp4" type="video/mp4" />
-</video>
+<DocVideo src={["/videos/onboarding-how-it-works.webm", "/videos/onboarding-how-it-works.mp4"]} ambient />
 
 <StageCards>
   <StageCard slug="convert-pdf/import-pdf" href="convert-pdf/import-pdf" title="Importer un PDF" description="Démarrez un nouveau projet de livre en important votre PDF dans ADT Studio." />

--- a/apps/site/content/docs/pt-BR/convert-pdf/extract.mdx
+++ b/apps/site/content/docs/pt-BR/convert-pdf/extract.mdx
@@ -28,25 +28,17 @@ Cada clipe abaixo executa uma página impressa real por todo o pipeline para seu
 
 **Livros didáticos e atividades** — um capítulo impresso de ciências e uma página de atividade de caderno, ambos reconstruídos em conteúdo estruturado e acessível.
 
-<video controls playsInline aria-label="A printed science textbook chapter on biomes is converted into an accessible e-learning page with easy-read mode, a glossary, and sign language." className="w-full rounded-lg border border-[color:var(--color-border)]">
-  <source src="/videos/los-biomas.mp4" type="video/mp4" />
-</video>
+<DocVideo src="/videos/los-biomas.mp4" label="A printed science textbook chapter on biomes is converted into an accessible e-learning page with easy-read mode, a glossary, and sign language." />
 
-<video controls playsInline aria-label="A printed workbook activity page is converted into an AI-generated, interactive accessible activity." className="w-full rounded-lg border border-[color:var(--color-border)]">
-  <source src="/videos/cuaderno5.mp4" type="video/mp4" />
-</video>
+<DocVideo src="/videos/cuaderno5.mp4" label="A printed workbook activity page is converted into an AI-generated, interactive accessible activity." />
 
 **Referência** — uma página densa de livro didático com múltiplas colunas, reconstruída como um layout web responsivo e semântico.
 
-<video controls playsInline aria-label="A complex, multi-column printed textbook page is converted into a responsive web layout." className="w-full rounded-lg border border-[color:var(--color-border)]">
-  <source src="/videos/brazil.mp4" type="video/mp4" />
-</video>
+<DocVideo src="/videos/brazil.mp4" label="A complex, multi-column printed textbook page is converted into a responsive web layout." />
 
 **Livro de histórias** — uma página de história ilustrada ganha narração texto-para-fala, descrições de imagem, traduções e um questionário.
 
-<video controls playsInline aria-label="An illustrated storybook page gains text-to-speech narration, image descriptions, translations, and an interactive quiz." className="w-full rounded-lg border border-[color:var(--color-border)]">
-  <source src="/videos/momo.mp4" type="video/mp4" />
-</video>
+<DocVideo src="/videos/momo.mp4" label="An illustrated storybook page gains text-to-speech narration, image descriptions, translations, and an interactive quiz." />
 </Step>
 
 <Step>

--- a/apps/site/content/docs/pt-BR/convert-pdf/index.mdx
+++ b/apps/site/content/docs/pt-BR/convert-pdf/index.mdx
@@ -9,10 +9,7 @@ uma etapa anterior — apenas o trabalho afetado é refeito.
 
 <SectionBanner slug="convert-pdf" />
 
-<video autoPlay loop muted playsInline aria-hidden="true">
-  <source src="/videos/onboarding-how-it-works.webm" type="video/webm" />
-  <source src="/videos/onboarding-how-it-works.mp4" type="video/mp4" />
-</video>
+<DocVideo src={["/videos/onboarding-how-it-works.webm", "/videos/onboarding-how-it-works.mp4"]} ambient />
 
 <StageCards>
   <StageCard slug="convert-pdf/import-pdf" href="convert-pdf/import-pdf" title="Importar um PDF" description="Comece um novo projeto de livro trazendo seu PDF para o ADT Studio." />

--- a/apps/site/src/components/docs/DocVideo.tsx
+++ b/apps/site/src/components/docs/DocVideo.tsx
@@ -1,0 +1,56 @@
+import { cn } from "@/lib/cn";
+import { withBase } from "@/lib/href";
+
+const MIME_TYPES: Record<string, string> = {
+  mp4: "video/mp4",
+  webm: "video/webm",
+};
+
+type DocVideoProps = {
+  /**
+   * Path under `public/`, e.g. "/videos/momo.mp4". Pass an array to offer the
+   * same clip in several formats, best-supported first.
+   */
+  src: string | string[];
+  /** Describes what the clip shows. Required unless `ambient`. */
+  label?: string;
+  /** Decorative loop: autoplays muted, no controls, hidden from screen readers. */
+  ambient?: boolean;
+  className?: string;
+};
+
+/**
+ * A video embedded in a docs page.
+ *
+ * Docs MDX must use this rather than a raw `<video>` tag. Literal lowercase JSX
+ * in MDX compiles straight to the HTML element and bypasses the component
+ * registry in `mdx.tsx`, so a raw tag gets neither the shared styling nor — the
+ * part that actually breaks — the deployment base prefix on its source paths.
+ * Under a subpath deploy (`/adt-studio/` on GitHub Pages) a root-absolute
+ * "/videos/x.mp4" 404s, and a video whose every source fails renders as nothing
+ * at all: no error, just a missing clip.
+ */
+export function DocVideo({ src, label, ambient = false, className }: DocVideoProps) {
+  const sources = Array.isArray(src) ? src : [src];
+
+  return (
+    <video
+      playsInline
+      {...(ambient
+        ? { autoPlay: true, loop: true, muted: true, "aria-hidden": true }
+        : { controls: true, "aria-label": label })}
+      className={cn(
+        "w-full rounded-lg border border-[color:var(--color-border)]",
+        className,
+      )}
+    >
+      {sources.map((path) => (
+        <source
+          key={path}
+          src={withBase(path)}
+          type={MIME_TYPES[path.split(".").pop()?.toLowerCase() ?? ""]}
+        />
+      ))}
+    </video>
+  );
+}

--- a/apps/site/src/components/docs/GetStartedBanner.tsx
+++ b/apps/site/src/components/docs/GetStartedBanner.tsx
@@ -8,6 +8,11 @@ import { STAGES } from "@/data/stages";
  * with a subtle glow, the app icon centered above the pipeline stages (each in
  * its own brand color), and the heading/description bottom-left on a shadow
  * scrim. Links to the Quick Start.
+ *
+ * `isolate` is load-bearing: the inner layers use `z-10` to sit above the
+ * gradient/grid/glow, and the sticky docs navbar is also `z-10`. Without a
+ * stacking context here those tie on z-index and DOM order wins, so the stage
+ * pills paint over the navbar as the card scrolls under it.
  */
 export function GetStartedBanner() {
   const { i18n } = useLingui();
@@ -16,7 +21,7 @@ export function GetStartedBanner() {
     <Link
       to="/docs/$"
       params={{ _splat: "get-started" }}
-      className="not-prose group relative mt-8 flex w-full flex-col overflow-hidden rounded-2xl border border-fd-border shadow-sm transition-shadow hover:shadow-lg sm:aspect-[3/2] sm:items-center sm:justify-center"
+      className="not-prose group relative isolate mt-8 flex w-full flex-col overflow-hidden rounded-2xl border border-fd-border shadow-sm transition-shadow hover:shadow-lg sm:aspect-[3/2] sm:items-center sm:justify-center"
     >
       {/* Gradient base */}
       <div className="absolute inset-0 bg-gradient-to-br from-[oklch(0.63_0.19_260)] via-[oklch(0.5_0.18_262)] to-[oklch(0.37_0.15_266)]" />

--- a/apps/site/src/components/docs/SectionBanner.tsx
+++ b/apps/site/src/components/docs/SectionBanner.tsx
@@ -87,6 +87,10 @@ const SECTIONS: Record<string, Pill[]> = {
  * UI), scoped to a section's own brand color and its sub-pages. Reserved for
  * the five first-layer nav pages (Get Started, Convert a PDF, Enhance,
  * Export, Troubleshooting & FAQ) — sub-pages don't get one of these.
+ *
+ * `isolate` is load-bearing for the same reason as in `GetStartedBanner`:
+ * it keeps the inner `z-10` layers from tying with the sticky docs navbar and
+ * painting the pills over it on scroll.
  */
 export function SectionBanner({ slug }: { slug: keyof typeof SECTIONS }) {
   const { i18n } = useLingui();
@@ -98,7 +102,7 @@ export function SectionBanner({ slug }: { slug: keyof typeof SECTIONS }) {
 
   return (
     <div
-      className="not-prose relative my-6 flex flex-col items-center gap-4 overflow-hidden rounded-2xl border border-fd-border px-6 py-9"
+      className="not-prose relative isolate my-6 flex flex-col items-center gap-4 overflow-hidden rounded-2xl border border-fd-border px-6 py-9"
       style={{ "--c": color } as CSSProperties}
     >
       <div

--- a/apps/site/src/components/mdx.tsx
+++ b/apps/site/src/components/mdx.tsx
@@ -6,6 +6,7 @@ import { ImageZoom } from 'fumadocs-ui/components/image-zoom';
 import type { MDXComponents } from 'mdx/types';
 import type { ComponentProps } from 'react';
 import { cn } from '@/lib/cn';
+import { DocVideo } from '@/components/docs/DocVideo';
 import { DocsHero } from '@/components/docs/DocsHero';
 import { GetStartedBanner } from '@/components/docs/GetStartedBanner';
 import { WhereToBegin, Principles } from '@/components/docs/OverviewSections';
@@ -27,15 +28,7 @@ export function getMDXComponents(components?: MDXComponents) {
         )}
       />
     ),
-    video: (props: ComponentProps<'video'>) => (
-      <video
-        {...props}
-        className={cn(
-          'w-full rounded-lg border border-[color:var(--color-border)]',
-          props.className,
-        )}
-      />
-    ),
+    DocVideo,
     Accordion,
     Accordions,
     Step,


### PR DESCRIPTION
Two fixes for the hosted docs site (https://unicef.github.io/adt-studio/docs).

## 1. Docs videos are missing on the hosted site

Reported on `/docs/convert-pdf/extract`, where all four preset clips were absent.

The site is served under `/adt-studio/`, but the docs MDX hardcoded root-absolute
video paths, so every source resolved off the base and 404'd:

| URL | status |
|---|---|
| `unicef.github.io/videos/los-biomas.mp4` (what shipped) | **404** |
| `unicef.github.io/adt-studio/videos/los-biomas.mp4` | 200 |

A `<video>` whose every source 404s renders as **nothing at all** — no error, no
broken-media placeholder — which is why the clips just silently disappeared.

### Why the existing registry override didn't catch it

`mdx.tsx` already had a `video:` entry in `getMDXComponents`. It never ran. MDX only
routes tags it *generates from markdown* through the component registry; a lowercase
tag written **literally** in `.mdx` compiles straight to `jsx("video", …)` — a raw DOM
element — and bypasses it. Confirmed in the built bundle: raw `video`/`source` emit as
string tags, while `StageCard` resolves via `...e.components`. That also explains why
these MDX blocks duplicated the registry's `className` inline: the override was dead
code from the start.

Adding a `source:` override would have been dead code for the same reason.

### Fix

New `DocVideo` component — capitalized, so it *does* resolve through the registry. It
applies `withBase()` to every source, derives the MIME type from the extension, and
carries the shared styling. Raw `<video>` blocks replaced across 8 files (4 locales ×
2 pages) and the dead `video:` override removed.

```mdx
<DocVideo src="/videos/los-biomas.mp4" label="A printed science textbook chapter…" />
<DocVideo src={["/videos/onboarding-how-it-works.webm", "/videos/onboarding-how-it-works.mp4"]} ambient />
```

Docs bodies are **not** prerendered (the built `docs/**/index.html` is shell-only; MDX
renders client-side), so grepping built HTML proves nothing here. Verified by serving
`.output/public` behind the `/adt-studio/` prefix from a real `BASE_PATH` build and
driving headless Chromium:

| | live site | this branch |
|---|---|---|
| resolved URL | `…/videos/…` → 404 | `…/adt-studio/videos/…` → 200 |
| element state | `networkState=3` (`NETWORK_NO_SOURCE`) | `readyState=4` (buffered) |

All 5 videos across both pages load, with `controls`/`aria-label` on the demos and
`autoplay muted aria-hidden` on the ambient loop.

## 2. Banner pills paint over the sticky docs navbar

On mobile the stage pills rendered on top of the navbar while scrolling, obscuring the
logo and title.

`GetStartedBanner` and `SectionBanner` both layer content with `z-10` to sit above their
gradient/grid/glow. Their roots are `relative` with `z-index: auto`, which is **not** a
stacking context — so those layers landed in the page's root stacking context, tied with
`#nd-subnav` (also `z-10`), and won on DOM order.

Fix: `isolate` on both roots, keeping the internal layering internal. Relative order
inside each banner is unchanged.

A/B verified with `elementFromPoint` at 414px, scrolling the pill row into the navbar box:

| page | before | after |
|---|---|---|
| `/docs` (GetStartedBanner) | 3/3 pills painting over the navbar | 0 |
| `/docs/convert-pdf` (SectionBanner) | 3/3 | 0 |

The leaking pills were exactly `Extract` / `Sectioning` / `Storyboard`, matching the
original report. Tablet and desktop stacking unchanged.

## Notes for reviewers

- `pnpm types:check` clean.
- **Untranslated `aria-label`s:** the demo video labels are still English in `es`/`fr`/`pt-BR`.
  Pre-existing content gap; preserved verbatim to keep this diff scoped to the bug.
- **Pre-existing prerender error:** the build logs `Failed to fetch /adt-studio/docs/quickstart`
  and its exit code flaps between 0 and 1, even though no `quickstart` reference exists
  anywhere in the repo. Reproduced on a clean worktree at `landing-page` HEAD, so it
  predates this branch — but it does make CI unreliable and is worth a separate issue.