### PR TITLE
feat(activities): link the activity editor to the page, both ways

### DIFF
--- a/apps/adt-runtime/src/app/ChromeRoot.tsx
+++ b/apps/adt-runtime/src/app/ChromeRoot.tsx
@@ -1,5 +1,7 @@
 import { Toaster } from "sonner"
+import { useAtomValue } from "jotai"
 import { useThemeSync } from "@/features/settings/hooks/useThemeSync"
+import { embedModeAtom } from "@/shared/state/ui.atoms"
 import { TooltipProvider } from "@/shared/ui/tooltip"
 import { Notepad } from "@/features/notepad/components/Notepad"
 import { Eli5Popup } from "@/features/eli5/components/Eli5Popup"
@@ -19,9 +21,24 @@ import { PagePrefetcher } from "@/features/navigation/components/PagePrefetcher"
  * The primary chrome (book metadata + page nav + the five surface triggers
  * — TOC, glossary, audio, language, settings) lives in the `BottomDock`
  * inside `NavRoot`.
+ *
+ * In embed mode none of it renders. A `?embed=1` preview exists to show one
+ * section the way the storyboard does — book content plus working activity
+ * controls — so reader features have no place there. They are skipped rather
+ * than hidden with CSS: the glossary highlighter and tutorial overlay mutate
+ * the page itself, which no stylesheet can undo, and the prefetcher would
+ * pull neighbouring pages a single-section preview never navigates to.
  */
 export function ChromeRoot() {
   useThemeSync()
+  const embed = useAtomValue(embedModeAtom)
+
+  // The toaster stays: activity feedback and load errors still need somewhere
+  // to surface, and it shows nothing until something is dispatched.
+  if (embed) {
+    return <Toaster position="top-center" richColors closeButton />
+  }
+
   return (
     <TooltipProvider delay={300} closeDelay={120}>
       {/*<SkipLink />*/}

--- a/apps/adt-runtime/src/app/ChromeRoot.tsx
+++ b/apps/adt-runtime/src/app/ChromeRoot.tsx
@@ -33,8 +33,6 @@ export function ChromeRoot() {
   useThemeSync()
   const embed = useAtomValue(embedModeAtom)
 
-  // The toaster stays: activity feedback and load errors still need somewhere
-  // to surface, and it shows nothing until something is dispatched.
   if (embed) {
     return <Toaster position="top-center" richColors closeButton />
   }

--- a/apps/adt-runtime/src/app/lifecycle.ts
+++ b/apps/adt-runtime/src/app/lifecycle.ts
@@ -81,11 +81,6 @@ function readIsActivityPage(): boolean {
   return !!document.querySelector('section[data-section-type^="activity_"]')
 }
 
-function readIsEmbedMode(): boolean {
-  if (typeof window === "undefined") return false
-  return new URLSearchParams(window.location.search).get("embed") === "1"
-}
-
 function readCurrentPageNumber(): number | null {
   const meta = document
     .querySelector('meta[name="page-section-id"]')
@@ -184,7 +179,10 @@ export async function bootRuntime(): Promise<void> {
     const isActivity = readIsActivityPage()
     store.set(isActivityPageAtom, isActivity)
     store.set(activityModeAtom, isActivity)
-    store.set(embedModeAtom, readIsEmbedMode())
+    // embedModeAtom self-initialises from the URL at module load — writing it
+    // again here would be a second parser of the same query param, and the
+    // whole point of the module-load read is that DOM-mutating paths run
+    // before boot gets this far.
 
     applyDOMTranslations()
 

--- a/apps/adt-runtime/src/app/lifecycle.ts
+++ b/apps/adt-runtime/src/app/lifecycle.ts
@@ -259,7 +259,12 @@ function applyDOMTranslations(): void {
   applyTranslationsToDOM(translations, { easyReadMode })
   applyImageVariants(images)
 
-  const glossaryEnabled = store.get(glossaryModeAtom) as boolean
+  // Glossary mode is a persisted reader preference, so it follows the user
+  // into an embedded preview — where a storyboard-style view of the section
+  // is wanted, not their reading setup. ChromeRoot's highlighter is skipped
+  // in embed mode; this second, non-React path has to opt out as well.
+  const glossaryEnabled =
+    (store.get(glossaryModeAtom) as boolean) && !(store.get(embedModeAtom) as boolean)
   if (glossaryEnabled) {
     const glossaryData = store.get(glossaryDataAtom)
     // Always wipe stale spans first so a re-apply (e.g. on language change)

--- a/apps/adt-runtime/src/app/lifecycle.ts
+++ b/apps/adt-runtime/src/app/lifecycle.ts
@@ -179,10 +179,6 @@ export async function bootRuntime(): Promise<void> {
     const isActivity = readIsActivityPage()
     store.set(isActivityPageAtom, isActivity)
     store.set(activityModeAtom, isActivity)
-    // embedModeAtom self-initialises from the URL at module load — writing it
-    // again here would be a second parser of the same query param, and the
-    // whole point of the module-load read is that DOM-mutating paths run
-    // before boot gets this far.
 
     applyDOMTranslations()
 
@@ -257,10 +253,6 @@ function applyDOMTranslations(): void {
   applyTranslationsToDOM(translations, { easyReadMode })
   applyImageVariants(images)
 
-  // Glossary mode is a persisted reader preference, so it follows the user
-  // into an embedded preview — where a storyboard-style view of the section
-  // is wanted, not their reading setup. ChromeRoot's highlighter is skipped
-  // in embed mode; this second, non-React path has to opt out as well.
   const glossaryEnabled =
     (store.get(glossaryModeAtom) as boolean) && !(store.get(embedModeAtom) as boolean)
   if (glossaryEnabled) {

--- a/apps/adt-runtime/src/shared/state/ui.atoms.ts
+++ b/apps/adt-runtime/src/shared/state/ui.atoms.ts
@@ -20,7 +20,6 @@ export const dockWidthAtom = persistedStringAtom("dockWidth", "full")
 export const dockPositionAtom = persistedStringAtom("dockPosition", "bottom")
 export const dockAlignAtom = persistedStringAtom("dockAlign", "spread")
 
-
 export type IconSize = "sm" | "md" | "lg"
 export const iconSizeAtom = persistedStringAtom("iconSize", "md")
 export const reduceMotionAtom = persistedBoolAtom("reduceMotion", false)
@@ -28,28 +27,14 @@ export const reduceMotionAtom = persistedBoolAtom("reduceMotion", false)
 export type Theme = "light" | "dark" | "system"
 export const themeAtom = persistedStringAtom("theme", "dark")
 
-
 export const dockReadyAtom = ephemeralAtom(false)
 export const dockHiddenAtom = ephemeralAtom(false)
 
-/**
- * Embed mode is a property of the URL, so it resolves at module load instead
- * of waiting for `bootRuntime`. That matters: the glossary highlighter
- * decorates the page as soon as its data lands, which happens *before* the
- * async boot would have set this flag — leaving a window in which highlights
- * get painted into a preview that is meant to show none.
- */
 function readEmbedModeFromUrl(): boolean {
   if (typeof window === "undefined") return false
   return new URLSearchParams(window.location.search).get("embed") === "1"
 }
 
-/**
- * True when the runtime is mounted inside a `?embed=1` preview iframe (e.g.
- * the Studio storyboard activity preview). The page then shows book content
- * plus the activity controls and nothing else: no dock, no glossary
- * highlighting, no notepad / ELI5 / sign-language surfaces, no tutorial.
- */
 export const embedModeAtom = ephemeralAtom(readEmbedModeFromUrl())
 export const sidebarOpenAtom = ephemeralAtom(false)
 export const navOpenAtom = ephemeralAtom(false)

--- a/apps/adt-runtime/src/shared/state/ui.atoms.ts
+++ b/apps/adt-runtime/src/shared/state/ui.atoms.ts
@@ -31,10 +31,26 @@ export const themeAtom = persistedStringAtom("theme", "dark")
 
 export const dockReadyAtom = ephemeralAtom(false)
 export const dockHiddenAtom = ephemeralAtom(false)
-// True when the runtime is mounted inside a `?embed=1` preview iframe (e.g.
-// the Studio storyboard activity preview). BottomDock hides itself so only
-// the activity Submit/Skip controls remain visible.
-export const embedModeAtom = ephemeralAtom(false)
+
+/**
+ * Embed mode is a property of the URL, so it resolves at module load instead
+ * of waiting for `bootRuntime`. That matters: the glossary highlighter
+ * decorates the page as soon as its data lands, which happens *before* the
+ * async boot would have set this flag — leaving a window in which highlights
+ * get painted into a preview that is meant to show none.
+ */
+function readEmbedModeFromUrl(): boolean {
+  if (typeof window === "undefined") return false
+  return new URLSearchParams(window.location.search).get("embed") === "1"
+}
+
+/**
+ * True when the runtime is mounted inside a `?embed=1` preview iframe (e.g.
+ * the Studio storyboard activity preview). The page then shows book content
+ * plus the activity controls and nothing else: no dock, no glossary
+ * highlighting, no notepad / ELI5 / sign-language surfaces, no tutorial.
+ */
+export const embedModeAtom = ephemeralAtom(readEmbedModeFromUrl())
 export const sidebarOpenAtom = ephemeralAtom(false)
 export const navOpenAtom = ephemeralAtom(false)
 export const navScrollPositionAtom = ephemeralAtom(0)

--- a/apps/studio/src/components/pipeline/stages/languages/LanguageLandingPage.tsx
+++ b/apps/studio/src/components/pipeline/stages/languages/LanguageLandingPage.tsx
@@ -25,6 +25,7 @@ import { usePersistConfig } from "@/hooks/use-persist-config"
 import { useBook } from "@/hooks/use-books"
 import { normalizeLocale } from "@/lib/languages"
 import { reconcileSourceOutputLanguage } from "./lib/translations-view-state"
+import { prefersReducedMotion } from "@/lib/utils"
 import { displayLang } from "./lib/display-lang"
 import { SelectImagesDialog } from "./components/SelectImagesDialog"
 import { ImageTranslationVisual } from "./components/ImageTranslationVisual"
@@ -99,10 +100,7 @@ export function LanguageLandingPage({ bookLabel }: { bookLabel: string }) {
   }, [activeConfigData, book, baseLanguage])
 
   const withChipTransition = (update: () => void) => {
-    const reduceMotion =
-      typeof window !== "undefined" &&
-      // eslint-disable-next-line lingui/no-unlocalized-strings -- CSS media query, not user-visible
-      window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    const reduceMotion = prefersReducedMotion()
     const doc = typeof document !== "undefined" ? document : null
     if (!doc || typeof doc.startViewTransition !== "function" || reduceMotion) {
       update()

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/BookPreviewFrame.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/BookPreviewFrame.tsx
@@ -50,14 +50,25 @@ function previewAssetsUrl(bookLabel: string): string {
  *  actual panel width. */
 const DEFAULT_RENDER_WIDTH = 1280
 
+/**
+ * Editor-only attributes that must never reach persisted HTML. Both style
+ * edit paths serialize the live iframe DOM, so anything the editor stamped on
+ * an element would otherwise be baked into the book's rendering and shipped
+ * in the exported bundle.
+ */
+const TRANSIENT_ATTRS = [
+  "data-adt-selected",
+  "data-adt-editing",
+  "data-adt-linked",
+  "data-adt-preview",
+  "data-adt-link-hover",
+  "contenteditable",
+] as const
+
 function stripTransientAttributes(doc: Document): void {
-  doc
-    .querySelectorAll("[data-adt-selected], [data-adt-editing], [contenteditable]")
-    .forEach((el) => {
-      el.removeAttribute("data-adt-selected")
-      el.removeAttribute("data-adt-editing")
-      el.removeAttribute("contenteditable")
-    })
+  doc.querySelectorAll(TRANSIENT_ATTRS.map((a) => `[${a}]`).join(", ")).forEach((el) => {
+    for (const attr of TRANSIENT_ATTRS) el.removeAttribute(attr)
+  })
 }
 
 /** Parse a pixel value (e.g. "612px") to a number, or null for non-px values. */

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/BookPreviewFrame.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/BookPreviewFrame.tsx
@@ -23,6 +23,14 @@ import {
   weightToToken,
 } from "./iframe-computed-styles"
 import { INTERACTIVE_SCRIPT, INTERACTIVE_STYLES } from "./iframe-interactive"
+import {
+  anchorKey,
+  anchorSelector,
+  parseAnchor,
+  parseAnchorKey,
+  resolveVisibleTarget,
+  type ActivityAnchor,
+} from "./activity-link"
 import { primaryFontFamily, googleFontsCss2Url, FIXED_LAYOUT_MAX_SCALE } from "@adt/types"
 
 export type { ComputedTypographyStyles }
@@ -81,6 +89,12 @@ export interface BookPreviewFrameHandle {
    *  used by the Typography inspector. Returns nulls when the element isn't
    *  in the iframe yet or a value can't be parsed. */
   getComputedTypographyStyles: (dataId: string) => ComputedTypographyStyles
+  /** Bounding box of an activity anchor in HOST viewport coordinates — the
+   *  in-iframe rect scaled by the preview's fit-transform and offset by the
+   *  iframe's own position. Lets the host scroll its container to reveal an
+   *  element that lives inside the iframe. Null when the anchor isn't in the
+   *  document (yet). */
+  getAnchorViewportRect: (anchor: ActivityAnchor) => DOMRect | null
 }
 
 export interface BookPreviewFrameProps {
@@ -110,6 +124,21 @@ export interface BookPreviewFrameProps {
   /** Reports the iframe's current on-screen width in CSS pixels (renderWidth × scale).
    *  Updates whenever the canvas resizes — useful for showing the active viewport size. */
   onVisibleWidthChange?: (width: number) => void
+  /** Link mode — clicks resolve to an activity anchor and are reported via
+   *  `onLinkSelect` instead of opening the inline editor. Mutually exclusive
+   *  with `editable`; the page becomes a click-to-locate map. */
+  linkMode?: boolean
+  /** Anchor to outline solid — the editor's committed selection. */
+  linkedAnchor?: ActivityAnchor | null
+  /** Anchor to outline dashed — a transient preview (the editor's pointer is
+   *  over the matching field). Ignored when it equals `linkedAnchor`. */
+  previewAnchor?: ActivityAnchor | null
+  /** Fired when an element is clicked in link mode; null when the click
+   *  landed on nothing addressable. */
+  onLinkSelect?: (anchor: ActivityAnchor | null) => void
+  /** Fired as the pointer crosses addressable elements in link mode. Purely a
+   *  preview signal — the consumer decides whether to act on it. */
+  onLinkHover?: (anchor: ActivityAnchor | null) => void
   /** Resolved reflowable base-font CSS chain (e.g. `'Atkinson
    *  Hyperlegible','Merriweather',sans-serif`). When set, the shell loads the
    *  family from Google Fonts and overrides the global Merriweather, matching
@@ -143,6 +172,11 @@ export const BookPreviewFrame = forwardRef<BookPreviewFrameHandle, BookPreviewFr
   renderWidth = DEFAULT_RENDER_WIDTH,
   deviceView,
   onVisibleWidthChange,
+  linkMode = false,
+  linkedAnchor,
+  previewAnchor,
+  onLinkSelect,
+  onLinkHover,
   bodyFontFamily,
 }, ref) {
   const iframeRef = useRef<HTMLIFrameElement>(null)
@@ -264,6 +298,23 @@ export const BookPreviewFrame = forwardRef<BookPreviewFrameHandle, BookPreviewFr
         fontFamily: family || null,
         inlineFontFamily: inlineFamily || null,
       }
+    },
+    getAnchorViewportRect: (anchor: ActivityAnchor): DOMRect | null => {
+      const doc = iframeRef.current?.contentDocument
+      const iframeRect = iframeRef.current?.getBoundingClientRect()
+      if (!doc || !iframeRect) return null
+      const el = doc.querySelector(anchorSelector(anchor))
+      if (!el) return null
+      // The in-iframe rect is in unscaled document coordinates; the iframe
+      // element itself is drawn through the wrapper's fit-transform, so its
+      // own rect already carries the scale and the page offset.
+      const r = resolveVisibleTarget(el).getBoundingClientRect()
+      return new DOMRect(
+        iframeRect.left + r.left * scale,
+        iframeRect.top + r.top * scale,
+        r.width * scale,
+        r.height * scale,
+      )
     },
   }))
   const [iframeReady, setIframeReady] = useState(false)
@@ -411,16 +462,20 @@ ${autoFitScript}
   )
 
   // Listen for postMessage from iframe
-  const callbacksRef = useRef({ onSelectElement, onTextChanged })
-  callbacksRef.current = { onSelectElement, onTextChanged }
+  const callbacksRef = useRef({ onSelectElement, onTextChanged, onLinkSelect, onLinkHover })
+  callbacksRef.current = { onSelectElement, onTextChanged, onLinkSelect, onLinkHover }
 
   const handleMessage = useCallback((e: MessageEvent) => {
     const iframe = iframeRef.current
     if (!iframe || e.source !== iframe.contentWindow) return
     const data = e.data ?? {}
     if (typeof data !== "object" || !data.type) return
-    const { type, dataId, rect, newText, editedInnerHtml, tagName } = data
-    if (type === "select" || type === "select-image" || type === "select-container") {
+    const { type, dataId, rect, newText, editedInnerHtml, tagName, kind, id } = data
+    if (type === "link-select") {
+      callbacksRef.current.onLinkSelect?.(parseAnchor(kind, id))
+    } else if (type === "link-hover") {
+      callbacksRef.current.onLinkHover?.(parseAnchor(kind, id))
+    } else if (type === "select" || type === "select-image" || type === "select-container") {
       callbacksRef.current.onSelectElement?.(dataId, rect, tagName)
     } else if (type === "text-changed") {
       // Splice the edited element's innerHTML into the original LaTeX-form HTML
@@ -585,12 +640,39 @@ ${autoFitScript}
     if (el) el.setAttribute("data-adt-selected", "true")
   }, [selectedDataId, displayHtml, iframeReady])
 
-  // Toggle editability dynamically via data attribute (no iframe reload needed)
+  // Toggle editability dynamically via data attribute (no iframe reload
+  // needed). Link mode wins: while the activity panel drives the page, inline
+  // editing must stay off so a click can never start a contentEditable session.
   useEffect(() => {
     const doc = iframeRef.current?.contentDocument
     if (!doc?.body) return
-    doc.body.dataset.editable = editable ? "true" : "false"
-  }, [editable, iframeReady])
+    doc.body.dataset.editable = editable && !linkMode ? "true" : "false"
+    doc.body.dataset.linkMode = linkMode ? "true" : "false"
+  }, [editable, linkMode, iframeReady])
+
+  // Outline the selection (solid) and the preview (dashed). Re-runs after each
+  // body rebuild — a panel edit re-injects the HTML — so both survive live
+  // editing. Keyed on the anchor *values*, not the objects, which the parent
+  // rebuilds on every render.
+  const linkedKey = linkedAnchor ? anchorKey(linkedAnchor) : ""
+  const previewKey = previewAnchor ? anchorKey(previewAnchor) : ""
+  useEffect(() => {
+    const doc = iframeRef.current?.contentDocument
+    if (!doc) return
+    doc.querySelectorAll("[data-adt-linked], [data-adt-preview]").forEach((el) => {
+      el.removeAttribute("data-adt-linked")
+      el.removeAttribute("data-adt-preview")
+    })
+    const stamp = (key: string, attr: string) => {
+      const anchor = parseAnchorKey(key)
+      if (!anchor) return
+      const el = doc.querySelector(anchorSelector(anchor))
+      if (el) resolveVisibleTarget(el).setAttribute(attr, "true")
+    }
+    // Solid wins: a previewed element that is also selected reads as selected.
+    if (previewKey && previewKey !== linkedKey) stamp(previewKey, "data-adt-preview")
+    stamp(linkedKey, "data-adt-linked")
+  }, [linkedKey, previewKey, displayHtml, iframeReady])
 
   // Suppress the iframe's own scrollbar in desktop view (where the iframe is
   // sized to its content and the host container provides the scroll). Phone

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/BookPreviewFrame.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/BookPreviewFrame.tsx
@@ -50,12 +50,6 @@ function previewAssetsUrl(bookLabel: string): string {
  *  actual panel width. */
 const DEFAULT_RENDER_WIDTH = 1280
 
-/**
- * Editor-only attributes that must never reach persisted HTML. Both style
- * edit paths serialize the live iframe DOM, so anything the editor stamped on
- * an element would otherwise be baked into the book's rendering and shipped
- * in the exported bundle.
- */
 const TRANSIENT_ATTRS = [
   "data-adt-selected",
   "data-adt-editing",
@@ -100,11 +94,6 @@ export interface BookPreviewFrameHandle {
    *  used by the Typography inspector. Returns nulls when the element isn't
    *  in the iframe yet or a value can't be parsed. */
   getComputedTypographyStyles: (dataId: string) => ComputedTypographyStyles
-  /** Bounding box of an activity anchor in HOST viewport coordinates — the
-   *  in-iframe rect scaled by the preview's fit-transform and offset by the
-   *  iframe's own position. Lets the host scroll its container to reveal an
-   *  element that lives inside the iframe. Null when the anchor isn't in the
-   *  document (yet). */
   getAnchorViewportRect: (anchor: ActivityAnchor) => DOMRect | null
 }
 
@@ -316,9 +305,6 @@ export const BookPreviewFrame = forwardRef<BookPreviewFrameHandle, BookPreviewFr
       if (!doc || !iframeRect) return null
       const el = doc.querySelector(anchorSelector(anchor))
       if (!el) return null
-      // The in-iframe rect is in unscaled document coordinates; the iframe
-      // element itself is drawn through the wrapper's fit-transform, so its
-      // own rect already carries the scale and the page offset.
       const r = resolveVisibleTarget(el).getBoundingClientRect()
       return new DOMRect(
         iframeRect.left + r.left * scale,
@@ -651,9 +637,6 @@ ${autoFitScript}
     if (el) el.setAttribute("data-adt-selected", "true")
   }, [selectedDataId, displayHtml, iframeReady])
 
-  // Toggle editability dynamically via data attribute (no iframe reload
-  // needed). Link mode wins: while the activity panel drives the page, inline
-  // editing must stay off so a click can never start a contentEditable session.
   useEffect(() => {
     const doc = iframeRef.current?.contentDocument
     if (!doc?.body) return
@@ -661,10 +644,6 @@ ${autoFitScript}
     doc.body.dataset.linkMode = linkMode ? "true" : "false"
   }, [editable, linkMode, iframeReady])
 
-  // Outline the selection (solid) and the preview (dashed). Re-runs after each
-  // body rebuild — a panel edit re-injects the HTML — so both survive live
-  // editing. Keyed on the anchor *values*, not the objects, which the parent
-  // rebuilds on every render.
   const linkedKey = linkedAnchor ? anchorKey(linkedAnchor) : ""
   const previewKey = previewAnchor ? anchorKey(previewAnchor) : ""
   useEffect(() => {
@@ -680,7 +659,6 @@ ${autoFitScript}
       const el = doc.querySelector(anchorSelector(anchor))
       if (el) resolveVisibleTarget(el).setAttribute(attr, "true")
     }
-    // Solid wins: a previewed element that is also selected reads as selected.
     if (previewKey && previewKey !== linkedKey) stamp(previewKey, "data-adt-preview")
     stamp(linkedKey, "data-adt-linked")
   }, [linkedKey, previewKey, displayHtml, iframeReady])

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/ClassicActivityPanel.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/ClassicActivityPanel.tsx
@@ -22,12 +22,8 @@
  * [[blank:item-N]] markers) — editing through the tree text would silently
  * strip the markers and break the blanks.
  *
- * Controls are wrapped in `Anchored`, tying each to its element in the page
- * preview (see `activity-link.ts`). Two intensities, and the distinction is
- * the whole interaction model: with nothing selected, hovering either surface
- * *previews* the pairing; once something is selected the preview is muted and
- * only another selection moves the highlight, so the page stays put while you
- * type. Escape clears the selection and re-arms hover.
+ * Controls are wrapped in `Anchored`, which ties each to its element in the
+ * page preview — see `activity-link.ts`.
  */
 import {
   createContext,
@@ -96,17 +92,9 @@ const DEFAULT_PANEL_WIDTH = 460
 const PANEL_WIDTH_STORAGE_KEY = "adt:activity-panel-width"
 const HINT_DISMISSED_STORAGE_KEY = "adt:activity-panel-hint-dismissed"
 
-/** Sentinel item-id for "no option marked correct" — Radix RadioGroup
- *  cannot take an empty string as its value. */
 // eslint-disable-next-line lingui/no-unlocalized-strings -- sentinel value, never rendered
 const NO_CHOICE_ID = "__none__"
 
-/**
- * localStorage throws outright where site data is blocked (third-party
- * context, a locked-down Electron partition) and on quota. These reads happen
- * in render, so an unguarded throw would blank the whole storyboard stage
- * rather than fall back to a default width.
- */
 function readStoredWidth(): number {
   try {
     const stored = Number(localStorage.getItem(PANEL_WIDTH_STORAGE_KEY))
@@ -121,7 +109,6 @@ function writeStoredWidth(width: number): void {
   try {
     localStorage.setItem(PANEL_WIDTH_STORAGE_KEY, String(width))
   } catch {
-    // A non-persisted width is a cosmetic loss; never break the editor for it.
   }
 }
 
@@ -133,12 +120,6 @@ function readHintDismissed(): boolean {
   }
 }
 
-/**
- * Suppresses a control's own focus ring. Not a loss of affordance: a field can
- * only be focused when it is the selection, so `Anchored` is already drawing a
- * violet outline around it. Without this the answer inputs carry three
- * concentric rings — emerald border, blue focus ring, violet outline.
- */
 const NO_INNER_RING = "focus-visible:ring-0 focus-visible:ring-offset-0"
 
 interface ClassicActivityPanelProps {
@@ -285,15 +266,6 @@ function buildTextMap(
   return fromTree
 }
 
-/**
- * An item's wording as it reads in the printed exercise: blank markers become
- * underscores. Used for the resting state of a card title — the raw
- * `[[blank:…]]` source only appears once the title is being edited, which is
- * the only moment the marker can be broken.
- *
- * Not truncated here: the full string stays in the DOM (CSS clips it) so
- * assistive tech gets the whole sentence, not an ellipsis.
- */
 function readableText(text: string | undefined): string {
   if (!text) return ""
   return text
@@ -308,8 +280,6 @@ function imageSrc(bookLabel: string, image: { imageId?: string; src: string }): 
   return `${BASE_URL}/books/${bookLabel}/adt-preview/${image.src}`
 }
 
-// ── Page ↔ panel link plumbing ────────────────────────────────────────────
-
 interface LinkContextValue {
   linked: ActivityAnchor | null
   hovered: ActivityAnchor | null
@@ -322,23 +292,8 @@ const LinkContext = createContext<LinkContextValue>({
   fromPage: false,
 })
 
-/**
- * The anchor an enclosing card has already claimed. An item card highlights as
- * a whole, so the one field that stands for it must not re-anchor itself —
- * otherwise two nodes answer to the same anchor and the ring lands on the
- * inner input instead of the card the pointer is actually over.
- */
 const ClaimedAnchorContext = createContext<string | null>(null)
 
-/**
- * Ties one control to its element in the page. Hover and focus reporting is
- * delegated to the scroll container (see `linkDelegation`) rather than handled
- * here: anchors nest — a card owns the item, a row inside it owns the answer,
- * an input inside that owns the option text — and per-element enter/leave
- * handlers would drop the outer anchor the moment the pointer crossed into an
- * inner one. One delegated listener resolving `closest("[data-anchor]")`
- * always picks the innermost.
- */
 function Anchored({
   anchor,
   className,
@@ -351,21 +306,14 @@ function Anchored({
   const { linked, hovered, fromPage } = useContext(LinkContext)
   const claimed = useContext(ClaimedAnchorContext)
   const ref = useRef<HTMLDivElement>(null)
-  // Claimed by the card above: stay out of the way entirely — no anchor
-  // attribute, no ring, no reveal. The card owns all three.
   const isClaimed = claimed !== null && claimed === anchorKey(anchor)
   const isLinked = !isClaimed && sameAnchor(linked, anchor)
-  // A selection freezes the pairing: previewing something else while the user
-  // works in a field would drag the page out from under them.
   const isPreviewed = !isClaimed && !linked && sameAnchor(hovered, anchor)
 
   useEffect(() => {
     if (!isLinked || !fromPage) return
     const el = ref.current
     if (!el) return
-    // Scoped to the panel's own scroller. `scrollIntoView` walks every
-    // scrollable ancestor, so it would also drag the storyboard canvas — the
-    // Studio layout jumping while the user only meant to move within the list.
     const viewport = el.closest<HTMLElement>("[data-radix-scroll-area-viewport]")
     if (viewport) {
       const target = el.getBoundingClientRect()
@@ -377,8 +325,6 @@ function Anchored({
     } else {
       el.scrollIntoView({ block: "center", behavior: scrollBehavior() })
     }
-    // Hand over the caret so a page click lands the user ready to type, or on
-    // the choice control when the row has no text field.
     const focusable =
       el.querySelector<HTMLElement>("textarea, input, select") ??
       el.querySelector<HTMLElement>("[role=radio]")
@@ -392,13 +338,7 @@ function Anchored({
       ref={ref}
       data-anchor={anchorKey(anchor)}
       className={cn(
-        // No outline utilities in the base: `outline-solid` on its own resolves
-        // to the browser's default medium/currentColor outline, which would
-        // draw a black box around every field.
         "relative rounded-md outline-offset-2 transition-all duration-200 ease-out motion-reduce:transition-none",
-        // Both states are solid here and differ by weight — the dashed outline
-        // is the page's own preview vocabulary and stays there, where it reads
-        // against book content rather than against form controls.
         isLinked && "outline-2 outline-solid outline-violet-500 dark:outline-violet-400",
         isPreviewed && "outline-2 outline-solid outline-violet-300 dark:outline-violet-600",
         className,
@@ -409,8 +349,6 @@ function Anchored({
   )
 }
 
-/** Textarea that grows with its content — the row-count heuristic it replaces
- *  mis-sized wrapped text and jumped a full line at a time while typing. */
 function AutoTextarea({
   value,
   onChange,
@@ -447,17 +385,6 @@ function AutoTextarea({
   )
 }
 
-/**
- * A card's title, which is also the item's main text field — showing both
- * would print the same sentence twice.
- *
- * At rest it is a real `<button>`, not a `<p>`: that keeps it in the tab
- * order, announces as actionable, and carries the full untruncated sentence as
- * its accessible name. Activating it (click, Enter, Space) selects the card,
- * which is what flips `editing` — so the swap is a consequence of selection
- * rather than a second, separate mode. Focus is moved into the textarea on the
- * way in; Escape releases the selection and hands focus back.
- */
 function InlineTitle({
   value,
   onChange,
@@ -490,9 +417,6 @@ function InlineTitle({
     }
     if (!wasEditing.current) return
     wasEditing.current = false
-    // Leaving edit mode unmounts the textarea. If that orphaned the focus —
-    // Escape, rather than a click on some other control — put it back on the
-    // button so keyboard users keep their place.
     if (document.activeElement === document.body) {
       buttonRef.current?.focus({ preventScroll: true })
     }
@@ -503,16 +427,11 @@ function InlineTitle({
       <button
         ref={buttonRef}
         type="button"
-        // Focusing this button must NOT select the card: Escape restores focus
-        // here, and if that re-selected we would bounce straight back into the
-        // editor. Activating it (click / Enter / Space) still selects, via the
-        // container's click delegation.
         data-title-button="true"
         aria-label={`${label}: ${readableText(value)}`}
         className={cn(
           "flex min-w-0 flex-1 cursor-text items-center gap-1.5 rounded text-left text-xs font-medium",
           "transition-colors duration-200 hover:text-violet-700 motion-reduce:transition-none dark:hover:text-violet-300",
-          // The UA default focus ring is blue; keep the panel's one accent.
           "focus-visible:outline-2 focus-visible:outline-solid focus-visible:outline-violet-400 focus-visible:outline-offset-2",
         )}
       >
@@ -562,12 +481,6 @@ function SectionHeading({ children, count }: { children: ReactNode; count?: numb
   )
 }
 
-/**
- * The answer key's storage key. Technical — the only way to correlate an
- * editor row with the page markup when something looks wrong — so it's styled
- * to recede. Deliberately not hover-revealed: in the flat answer list this
- * chip is the row's only label.
- */
 function ItemIdChip({ itemId, hint }: { itemId: string; hint: string }) {
   return (
     <Tooltip>
@@ -703,9 +616,6 @@ export function ClassicActivityPanel({
     if (!dirty) setTexts(buildTextMap(leaves, structure, outline))
   }, [dirty, leaves, structure, outline])
 
-  // Desktop tool: the panel competes with the page preview for width, so the
-  // split is the user's to set. Persisted globally — it's a workspace
-  // preference, not per-book state.
   const [panelWidth, setPanelWidth] = useState(readStoredWidth)
   const startResize = useCallback(
     (e: React.PointerEvent<HTMLDivElement>) => {
@@ -726,10 +636,6 @@ export function ClassicActivityPanel({
         writeStoredWidth(clamp(ev))
       }
 
-      // Capture is what makes this survive the drag: the grip sits on the
-      // panel's left edge, so widening drags the pointer straight over the
-      // preview iframe, which would otherwise receive the events itself —
-      // freezing the drag and leaving the listeners attached for good.
       grip.setPointerCapture?.(pointerId)
       grip.addEventListener("pointermove", onMove)
       grip.addEventListener("pointerup", finish)
@@ -743,7 +649,6 @@ export function ClassicActivityPanel({
     try {
       localStorage.setItem(HINT_DISMISSED_STORAGE_KEY, "1")
     } catch {
-      // Dismissal just won't persist across reloads.
     }
     setHintDismissed(true)
   }, [])
@@ -753,8 +658,6 @@ export function ClassicActivityPanel({
     onTextEdited(dataId, value)
   }
 
-  // ⌘S saves. Escape releases the selection first — that's what re-arms the
-  // hover preview — and only closes the panel once nothing is selected.
   const panelRef = useRef<HTMLDivElement>(null)
   useEffect(() => {
     if (!open) return
@@ -765,9 +668,6 @@ export function ClassicActivityPanel({
         return
       }
       if (e.key !== "Escape") return
-      // Releasing the selection doesn't require focus to be in the panel:
-      // clicking a card selects it without focusing anything, and that
-      // selection still has to be dismissable.
       if (linkedAnchor) {
         e.preventDefault()
         ;(document.activeElement as HTMLElement | null)?.blur()
@@ -789,7 +689,6 @@ export function ClassicActivityPanel({
     [linkedAnchor, hoveredAnchor, linkedFromPage],
   )
 
-  /** One delegated listener set for the whole form — see {@link Anchored}. */
   const anchorAt = (target: EventTarget | null): ActivityAnchor | null =>
     parseAnchorKey(
       (target as HTMLElement | null)?.closest?.("[data-anchor]")?.getAttribute("data-anchor"),
@@ -797,9 +696,6 @@ export function ClassicActivityPanel({
   const linkDelegation = {
     onMouseOver: (e: React.MouseEvent) => onAnchorHover(anchorAt(e.target)),
     onMouseLeave: () => onAnchorHover(null),
-    // Clicking a card selects it and jumps the page there; clicking a field
-    // inside selects that field instead (closest() resolves the innermost).
-    // Clicking the gaps between cards releases the selection.
     onClick: (e: React.MouseEvent) => onAnchorSelect(anchorAt(e.target)),
     onFocusCapture: (e: React.FocusEvent) => {
       if ((e.target as HTMLElement).dataset?.titleButton) return
@@ -843,9 +739,6 @@ export function ClassicActivityPanel({
     />
   )
 
-  /** The id chip sits OUTSIDE the anchor so the selection outline hugs the
-   *  field itself; wrapping the whole row made it bulge around the chip and
-   *  collide with the answer zone's edge. */
   const answerField = (itemId: string) => (
     <div key={itemId} className="flex items-center gap-2">
       <Anchored anchor={answerAnchor(itemId)} className="flex-1">
@@ -862,11 +755,6 @@ export function ClassicActivityPanel({
     </span>
   )
 
-  /**
-   * Marks the answer key apart from the question. A left accent bar rather
-   * than a filled box: every item has one of these, and a stack of saturated
-   * green panels turned the whole panel green.
-   */
   const answerZone = (children: ReactNode) => (
     <div className="space-y-2 border-l-2 border-emerald-400 pl-2.5 dark:border-emerald-500/60">
       {children}
@@ -877,9 +765,6 @@ export function ClassicActivityPanel({
     <Anchored key={imageId} anchor={imageAnchor(imageId)} className="inline-flex">
       <img
         src={`${BASE_URL}/books/${bookLabel}/images/${imageId}`}
-        // Decorative only when the caller has nothing to say about it —
-        // the ungrouped-images grid does, and dropping it left that whole
-        // section silent to a screen reader.
         alt={alt ?? ""}
         title={imageId}
         className={className}
@@ -889,7 +774,6 @@ export function ClassicActivityPanel({
 
   const ANSWER_AREA_CLASS = "space-y-2 rounded-md border border-dashed bg-muted/40 p-2.5"
 
-  /** Writable-answer block for an outline input (open-ended, table cell…). */
   const answerArea = (itemId: string | undefined, index: number, children: ReactNode) =>
     itemId ? (
       <Anchored key={itemId} anchor={answerAnchor(itemId)} className={ANSWER_AREA_CLASS}>
@@ -901,8 +785,6 @@ export function ClassicActivityPanel({
       </div>
     )
 
-  /** A choice row is the answer's editing surface — anchoring it is what lets
-   *  a click on the option's box in the page land here. */
   const optionRow = (itemId: string | undefined, index: number, children: ReactNode) =>
     itemId ? (
       <Anchored key={itemId} anchor={answerAnchor(itemId)} className="flex items-center gap-2">
@@ -924,18 +806,9 @@ export function ClassicActivityPanel({
     />
   )
 
-  /** The item-id currently flagged correct in a single-choice group. */
   const correctOf = (ids: (string | undefined)[]) =>
     ids.find((id) => id && isCorrectAnswer(answers?.[id])) ?? NO_CHOICE_ID
 
-  /**
-   * The stored value for a value-choice (true/false) group, matched back to
-   * the option that carries it. The answer key and the rendered `value`
-   * attribute come from different producers, so they drift in case — a key of
-   * "True" against `value="true"` must still read as selected, or the editor
-   * reports an answered item as unanswered and the author re-picks it,
-   * silently rewriting a correct key.
-   */
   const selectedValueOf = (item: ActivityOutlineItem, itemId: string): string => {
     const stored = String(answers?.[itemId] ?? "").trim().toLowerCase()
     if (!stored) return NO_CHOICE_ID
@@ -966,31 +839,16 @@ export function ClassicActivityPanel({
     )
   }
 
-  /**
-   * Card shell. The card is itself the anchor for the item, and it *claims*
-   * that anchor so the field standing for it renders plain — hovering anywhere
-   * on the card rings the card, and only a genuinely different target (an
-   * answer, an option) rings a narrower box.
-   *
-   * The cursor override keeps text fields feeling like text fields even though
-   * their container is clickable.
-   */
   const CARD_CLASS =
-    // Neutral on hover: violet is reserved for the page↔panel link, so a
-    // violet card border would compete with the outline that means "this is
-    // the element highlighted in the book".
     "group/card space-y-2.5 rounded-lg border bg-card p-3 transition-colors duration-200 ease-out hover:border-muted-foreground/30 motion-reduce:transition-none"
 
   const itemCard = (opts: {
     key: string
     index: number
     label: string
-    /** The item's main text, edited in the header rather than repeated as a
-     *  field below it. Its dataId is normally also the card's anchor. */
     titleField?: { dataId: string; label: string; mono?: boolean }
     anchor?: ActivityAnchor
     itemId?: string
-    /** Flags an item whose answer key is still blank. */
     unanswered?: boolean
     children: ReactNode
   }) => {
@@ -1062,9 +920,6 @@ export function ClassicActivityPanel({
   const outlineItemCard = (item: ActivityOutlineItem, i: number) => {
     const valueItemId = item.choice === "value" ? item.options[0]?.itemId : undefined
     const anchorItemId = item.inputs[0]?.itemId ?? valueItemId
-    // Prefer the question text over the bare "1)" marker: it's what the card
-    // is about, so it's both the better thing to light up in the page and the
-    // better thing to read in the header.
     const cardAnchor = item.prompts[0]?.dataId
       ? textAnchor(item.prompts[0].dataId)
       : item.number?.dataId
@@ -1073,8 +928,6 @@ export function ClassicActivityPanel({
           ? answerAnchor(anchorItemId)
           : undefined
 
-    // Only flag items that actually have an answer unit — an open-ended
-    // question with no key isn't "missing" anything.
     const filled: boolean[] = []
     for (const input of item.inputs) {
       const id = input.itemId
@@ -1091,8 +944,6 @@ export function ClassicActivityPanel({
       filled.push(item.options.some((o) => isCorrectAnswer(answers?.[o.itemId ?? ""])))
     }
 
-    // The first prompt becomes the card title; any further prompts stay as
-    // fields so nothing is silently unreachable.
     const titlePrompt = item.prompts[0]?.dataId ? item.prompts[0] : undefined
     const bodyPrompts = item.prompts.filter((p) => p !== titlePrompt)
 
@@ -1238,10 +1089,6 @@ export function ClassicActivityPanel({
                 <RadioGroup
                   value={correctOf(item.options.map((o) => o.itemId))}
                   onValueChange={(id) => {
-                    // An option the extractor could not resolve carries a
-                    // synthetic value. Selecting it must be inert: writing the
-                    // group would set every real option to false and wipe the
-                    // answer the author already had.
                     if (!item.options.some((x) => x.itemId === id)) return
                     onAnswersEdited(
                       Object.fromEntries(
@@ -1506,8 +1353,6 @@ export function ClassicActivityPanel({
                   {t`Select an item to edit its text — [[blank:…]] marks where a blank appears, so keep it to keep the blank.`}
                 </p>
                 {structure.steps.map((step, si) => {
-                  // The first addressable sentence becomes the card title; the
-                  // rest (rare — a two-line item) stay as fields below it.
                   const titleSentence = step.sentences.find((s) => s.dataId)
                   return itemCard({
                     key: step.id,

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/ClassicActivityPanel.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/ClassicActivityPanel.tsx
@@ -21,10 +21,37 @@
  * Grouped sentence fields bind to the RENDERED text (which includes
  * [[blank:item-N]] markers) — editing through the tree text would silently
  * strip the markers and break the blanks.
+ *
+ * Controls are wrapped in `Anchored`, tying each to its element in the page
+ * preview (see `activity-link.ts`). Two intensities, and the distinction is
+ * the whole interaction model: with nothing selected, hovering either surface
+ * *previews* the pairing; once something is selected the preview is muted and
+ * only another selection moves the highlight, so the page stays put while you
+ * type. Escape clears the selection and re-arms hover.
  */
-import { useEffect, useMemo, useState } from "react"
+import {
+  createContext,
+  useContext,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react"
 import { useLingui } from "@lingui/react/macro"
-import { Check, ImageIcon, Sparkles, TextCursorInput, X } from "lucide-react"
+import {
+  Check,
+  ImageIcon,
+  Loader2,
+  MousePointerClick,
+  Pencil,
+  Puzzle,
+  Sparkles,
+  TextCursorInput,
+  X,
+} from "lucide-react"
 import type {
   ActivityOutline,
   ActivityOutlineItem,
@@ -36,8 +63,51 @@ import type {
   McStep,
 } from "@adt/types"
 import { BASE_URL } from "@/api/client"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
+import { cn, scrollBehavior } from "@/lib/utils"
 import { getSectionTypeLabel } from "@/lib/section-constants"
+import {
+  answerAnchor,
+  anchorKey,
+  imageAnchor,
+  parseAnchorKey,
+  sameAnchor,
+  textAnchor,
+  type ActivityAnchor,
+} from "./activity-link"
+
+const MIN_PANEL_WIDTH = 380
+const MAX_PANEL_WIDTH = 760
+const DEFAULT_PANEL_WIDTH = 460
+const PANEL_WIDTH_STORAGE_KEY = "adt:activity-panel-width"
+const HINT_DISMISSED_STORAGE_KEY = "adt:activity-panel-hint-dismissed"
+
+/** Sentinel item-id for "no option marked correct" — Radix RadioGroup
+ *  cannot take an empty string as its value. */
+// eslint-disable-next-line lingui/no-unlocalized-strings -- sentinel value, never rendered
+const NO_CHOICE_ID = "__none__"
+
+/**
+ * Suppresses a control's own focus ring. Not a loss of affordance: a field can
+ * only be focused when it is the selection, so `Anchored` is already drawing a
+ * violet outline around it. Without this the answer inputs carry three
+ * concentric rings — emerald border, blue focus ring, violet outline.
+ */
+const NO_INNER_RING = "focus-visible:ring-0 focus-visible:ring-offset-0"
 
 interface ClassicActivityPanelProps {
   open: boolean
@@ -62,6 +132,17 @@ interface ClassicActivityPanelProps {
   onAnswerEdited: (itemId: string, value: string) => void
   /** Atomic multi-key answer update (radio-group correct flips). */
   onAnswersEdited: (patch: Record<string, string | boolean>) => void
+  /** Committed selection — survives pointer movement. */
+  linkedAnchor: ActivityAnchor | null
+  /** Element under the pointer on either surface. Ignored while something is
+   *  selected. */
+  hoveredAnchor: ActivityAnchor | null
+  /** True when the selection came from a click in the page — the matching
+   *  field then scrolls into view and takes focus. Panel-originated ones must
+   *  not scroll, or the view would jump while the user types. */
+  linkedFromPage: boolean
+  onAnchorSelect: (anchor: ActivityAnchor | null) => void
+  onAnchorHover: (anchor: ActivityAnchor | null) => void
   dirty: boolean
   saving: boolean
   onSave: () => void
@@ -172,10 +253,296 @@ function buildTextMap(
   return fromTree
 }
 
+/**
+ * An item's wording as it reads in the printed exercise: blank markers become
+ * underscores. Used for the resting state of a card title — the raw
+ * `[[blank:…]]` source only appears once the title is being edited, which is
+ * the only moment the marker can be broken.
+ *
+ * Not truncated here: the full string stays in the DOM (CSS clips it) so
+ * assistive tech gets the whole sentence, not an ellipsis.
+ */
+function readableText(text: string | undefined): string {
+  if (!text) return ""
+  return text
+    .replace(/\[\[blank:[^\]]+\]\]/g, "___")
+    .replace(/\s+/g, " ")
+    .trim()
+}
+
 function imageSrc(bookLabel: string, image: { imageId?: string; src: string }): string {
   if (image.imageId) return `${BASE_URL}/books/${bookLabel}/images/${image.imageId}`
   if (image.src.startsWith("http") || image.src.startsWith("/")) return image.src
   return `${BASE_URL}/books/${bookLabel}/adt-preview/${image.src}`
+}
+
+// ── Page ↔ panel link plumbing ────────────────────────────────────────────
+
+interface LinkContextValue {
+  linked: ActivityAnchor | null
+  hovered: ActivityAnchor | null
+  fromPage: boolean
+}
+
+const LinkContext = createContext<LinkContextValue>({
+  linked: null,
+  hovered: null,
+  fromPage: false,
+})
+
+/**
+ * The anchor an enclosing card has already claimed. An item card highlights as
+ * a whole, so the one field that stands for it must not re-anchor itself —
+ * otherwise two nodes answer to the same anchor and the ring lands on the
+ * inner input instead of the card the pointer is actually over.
+ */
+const ClaimedAnchorContext = createContext<string | null>(null)
+
+/**
+ * Ties one control to its element in the page. Hover and focus reporting is
+ * delegated to the scroll container (see `linkDelegation`) rather than handled
+ * here: anchors nest — a card owns the item, a row inside it owns the answer,
+ * an input inside that owns the option text — and per-element enter/leave
+ * handlers would drop the outer anchor the moment the pointer crossed into an
+ * inner one. One delegated listener resolving `closest("[data-anchor]")`
+ * always picks the innermost.
+ */
+function Anchored({
+  anchor,
+  className,
+  children,
+}: {
+  anchor: ActivityAnchor
+  className?: string
+  children: ReactNode
+}) {
+  const { linked, hovered, fromPage } = useContext(LinkContext)
+  const claimed = useContext(ClaimedAnchorContext)
+  const ref = useRef<HTMLDivElement>(null)
+  // Claimed by the card above: stay out of the way entirely — no anchor
+  // attribute, no ring, no reveal. The card owns all three.
+  const isClaimed = claimed !== null && claimed === anchorKey(anchor)
+  const isLinked = !isClaimed && sameAnchor(linked, anchor)
+  // A selection freezes the pairing: previewing something else while the user
+  // works in a field would drag the page out from under them.
+  const isPreviewed = !isClaimed && !linked && sameAnchor(hovered, anchor)
+
+  useEffect(() => {
+    if (!isLinked || !fromPage) return
+    const el = ref.current
+    if (!el) return
+    el.scrollIntoView({ block: "center", behavior: scrollBehavior() })
+    // Hand over the caret so a page click lands the user ready to type, or on
+    // the choice control when the row has no text field.
+    const focusable =
+      el.querySelector<HTMLElement>("textarea, input, select") ??
+      el.querySelector<HTMLElement>("[role=radio]")
+    focusable?.focus({ preventScroll: true })
+  }, [isLinked, fromPage])
+
+  if (isClaimed) return <div className={className}>{children}</div>
+
+  return (
+    <div
+      ref={ref}
+      data-anchor={anchorKey(anchor)}
+      className={cn(
+        // No outline utilities in the base: `outline-solid` on its own resolves
+        // to the browser's default medium/currentColor outline, which would
+        // draw a black box around every field.
+        "relative rounded-md outline-offset-2 transition-all duration-200 ease-out motion-reduce:transition-none",
+        // Both states are solid here and differ by weight — the dashed outline
+        // is the page's own preview vocabulary and stays there, where it reads
+        // against book content rather than against form controls.
+        isLinked && "outline-2 outline-solid outline-violet-500 dark:outline-violet-400",
+        isPreviewed && "outline-2 outline-solid outline-violet-300 dark:outline-violet-600",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  )
+}
+
+/** Textarea that grows with its content — the row-count heuristic it replaces
+ *  mis-sized wrapped text and jumped a full line at a time while typing. */
+function AutoTextarea({
+  value,
+  onChange,
+  mono,
+  label,
+}: {
+  value: string
+  onChange: (value: string) => void
+  mono?: boolean
+  label: string
+}) {
+  const ref = useRef<HTMLTextAreaElement>(null)
+  useLayoutEffect(() => {
+    const el = ref.current
+    if (!el) return
+    el.style.height = "auto"
+    el.style.height = `${Math.min(el.scrollHeight, 220)}px`
+  }, [value])
+  return (
+    <Textarea
+      ref={ref}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      rows={1}
+      aria-label={label}
+      className={cn(
+        "min-h-0 resize-none px-2.5 py-1.5 text-xs leading-relaxed md:text-xs",
+        NO_INNER_RING,
+        "transition-colors duration-200 ease-out motion-reduce:transition-none",
+        "hover:border-violet-300 dark:hover:border-violet-500/50",
+        mono && "font-mono",
+      )}
+    />
+  )
+}
+
+/**
+ * A card's title, which is also the item's main text field — showing both
+ * would print the same sentence twice.
+ *
+ * At rest it is a real `<button>`, not a `<p>`: that keeps it in the tab
+ * order, announces as actionable, and carries the full untruncated sentence as
+ * its accessible name. Activating it (click, Enter, Space) selects the card,
+ * which is what flips `editing` — so the swap is a consequence of selection
+ * rather than a second, separate mode. Focus is moved into the textarea on the
+ * way in; Escape releases the selection and hands focus back.
+ */
+function InlineTitle({
+  value,
+  onChange,
+  label,
+  editing,
+  mono,
+}: {
+  value: string
+  onChange: (value: string) => void
+  label: string
+  editing: boolean
+  mono?: boolean
+}) {
+  const ref = useRef<HTMLTextAreaElement>(null)
+  const buttonRef = useRef<HTMLButtonElement>(null)
+  const wasEditing = useRef(false)
+
+  useLayoutEffect(() => {
+    const el = ref.current
+    if (!editing || !el) return
+    el.style.height = "auto"
+    el.style.height = `${Math.min(el.scrollHeight, 220)}px`
+  }, [editing, value])
+
+  useEffect(() => {
+    if (editing) {
+      wasEditing.current = true
+      ref.current?.focus({ preventScroll: true })
+      return
+    }
+    if (!wasEditing.current) return
+    wasEditing.current = false
+    // Leaving edit mode unmounts the textarea. If that orphaned the focus —
+    // Escape, rather than a click on some other control — put it back on the
+    // button so keyboard users keep their place.
+    if (document.activeElement === document.body) {
+      buttonRef.current?.focus({ preventScroll: true })
+    }
+  }, [editing])
+
+  if (!editing) {
+    return (
+      <button
+        ref={buttonRef}
+        type="button"
+        // Focusing this button must NOT select the card: Escape restores focus
+        // here, and if that re-selected we would bounce straight back into the
+        // editor. Activating it (click / Enter / Space) still selects, via the
+        // container's click delegation.
+        data-title-button="true"
+        aria-label={`${label}: ${readableText(value)}`}
+        className={cn(
+          "flex min-w-0 flex-1 cursor-text items-center gap-1.5 rounded text-left text-xs font-medium",
+          "transition-colors duration-200 hover:text-violet-700 motion-reduce:transition-none dark:hover:text-violet-300",
+          // The UA default focus ring is blue; keep the panel's one accent.
+          "focus-visible:outline-2 focus-visible:outline-solid focus-visible:outline-violet-400 focus-visible:outline-offset-2",
+        )}
+      >
+        <span className="truncate">{readableText(value)}</span>
+        {/* The title reads as plain text, so the affordance has to be standing
+            — revealing it on hover only tells people who already guessed.
+            Muted at rest, firming up with the rest of the card on hover.
+            Decorative: the button's own label already carries the meaning. */}
+        <Pencil
+          className="h-3 w-3 shrink-0 text-muted-foreground/50 transition-colors duration-200 group-hover/card:text-muted-foreground motion-reduce:transition-none"
+          aria-hidden="true"
+        />
+      </button>
+    )
+  }
+  return (
+    <Textarea
+      ref={ref}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      rows={1}
+      aria-label={label}
+      className={cn(
+        "min-h-0 flex-1 resize-none px-2 py-1 text-xs leading-relaxed md:text-xs",
+        NO_INNER_RING,
+        mono && "font-mono",
+      )}
+    />
+  )
+}
+
+function SectionHeading({ children, count }: { children: ReactNode; count?: number }) {
+  return (
+    <div className="flex items-center gap-2">
+      <h3 className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+        {children}
+      </h3>
+      {count !== undefined && (
+        <Badge
+          variant="secondary"
+          className="px-1.5 py-0 text-[11px] font-medium tabular-nums"
+        >
+          {count}
+        </Badge>
+      )}
+    </div>
+  )
+}
+
+/**
+ * The answer key's storage key. Technical — the only way to correlate an
+ * editor row with the page markup when something looks wrong — so it's styled
+ * to recede. Deliberately not hover-revealed: in the flat answer list this
+ * chip is the row's only label.
+ */
+function ItemIdChip({ itemId, hint }: { itemId: string; hint: string }) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Badge
+          variant="outline"
+          className="shrink-0 border-transparent bg-muted/60 px-1.5 font-mono text-[11px] font-normal text-muted-foreground/70"
+        >
+          {itemId}
+        </Badge>
+      </TooltipTrigger>
+      <TooltipContent>{hint}</TooltipContent>
+    </Tooltip>
+  )
+}
+
+function FieldLabel({ children }: { children: ReactNode }) {
+  return (
+    <Label className="text-[11px] font-medium text-muted-foreground">{children}</Label>
+  )
 }
 
 export function ClassicActivityPanel({
@@ -194,6 +561,11 @@ export function ClassicActivityPanel({
   onTextEdited,
   onAnswerEdited,
   onAnswersEdited,
+  linkedAnchor,
+  hoveredAnchor,
+  linkedFromPage,
+  onAnchorSelect,
+  onAnchorHover,
   dirty,
   saving,
   onSave,
@@ -286,83 +658,230 @@ export function ClassicActivityPanel({
     if (!dirty) setTexts(buildTextMap(leaves, structure, outline))
   }, [dirty, leaves, structure, outline])
 
+  // Desktop tool: the panel competes with the page preview for width, so the
+  // split is the user's to set. Persisted globally — it's a workspace
+  // preference, not per-book state.
+  const [panelWidth, setPanelWidth] = useState(() => {
+    const stored = Number(localStorage.getItem(PANEL_WIDTH_STORAGE_KEY))
+    if (!Number.isFinite(stored) || stored <= 0) return DEFAULT_PANEL_WIDTH
+    return Math.min(MAX_PANEL_WIDTH, Math.max(MIN_PANEL_WIDTH, stored))
+  })
+  const startResize = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      e.preventDefault()
+      const startX = e.clientX
+      const startWidth = panelWidth
+      const clamp = (ev: PointerEvent) =>
+        Math.min(MAX_PANEL_WIDTH, Math.max(MIN_PANEL_WIDTH, startWidth + (startX - ev.clientX)))
+      const onMove = (ev: PointerEvent) => setPanelWidth(clamp(ev))
+      const onUp = (ev: PointerEvent) => {
+        window.removeEventListener("pointermove", onMove)
+        window.removeEventListener("pointerup", onUp)
+        localStorage.setItem(PANEL_WIDTH_STORAGE_KEY, String(clamp(ev)))
+      }
+      window.addEventListener("pointermove", onMove)
+      window.addEventListener("pointerup", onUp)
+    },
+    [panelWidth],
+  )
+
+  const [hintDismissed, setHintDismissed] = useState(
+    () => localStorage.getItem(HINT_DISMISSED_STORAGE_KEY) === "1",
+  )
+  const dismissHint = useCallback(() => {
+    localStorage.setItem(HINT_DISMISSED_STORAGE_KEY, "1")
+    setHintDismissed(true)
+  }, [])
+
   const handleTextChange = (dataId: string, value: string) => {
     setTexts((prev) => ({ ...prev, [dataId]: value }))
     onTextEdited(dataId, value)
   }
 
-  const textField = (dataId: string, mono: boolean, label: string) => (
-    <textarea
-      value={texts[dataId] ?? ""}
-      onChange={(e) => handleTextChange(dataId, e.target.value)}
-      rows={Math.min(4, Math.max(1, Math.ceil((texts[dataId]?.length ?? 0) / 50)))}
-      className={`w-full rounded border bg-background p-2 text-xs ${mono ? "font-mono" : ""}`}
-      aria-label={label}
-    />
+  // ⌘S saves. Escape releases the selection first — that's what re-arms the
+  // hover preview — and only closes the panel once nothing is selected.
+  const panelRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    if (!open) return
+    const onKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "s") {
+        e.preventDefault()
+        if (dirty && !saving) onSave()
+        return
+      }
+      if (e.key !== "Escape") return
+      // Releasing the selection doesn't require focus to be in the panel:
+      // clicking a card selects it without focusing anything, and that
+      // selection still has to be dismissable.
+      if (linkedAnchor) {
+        e.preventDefault()
+        ;(document.activeElement as HTMLElement | null)?.blur()
+        onAnchorSelect(null)
+      } else if (panelRef.current?.contains(document.activeElement)) {
+        onClose()
+      }
+    }
+    window.addEventListener("keydown", onKeyDown)
+    return () => window.removeEventListener("keydown", onKeyDown)
+  }, [open, dirty, saving, onSave, onClose, linkedAnchor, onAnchorSelect])
+
+  const linkContext = useMemo<LinkContextValue>(
+    () => ({
+      linked: linkedAnchor,
+      hovered: hoveredAnchor,
+      fromPage: linkedFromPage,
+    }),
+    [linkedAnchor, hoveredAnchor, linkedFromPage],
   )
 
-  const caption = (label: string) => (
-    <span className="block text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
-      {label}
-    </span>
+  /** One delegated listener set for the whole form — see {@link Anchored}. */
+  const anchorAt = (target: EventTarget | null): ActivityAnchor | null =>
+    parseAnchorKey(
+      (target as HTMLElement | null)?.closest?.("[data-anchor]")?.getAttribute("data-anchor"),
+    )
+  const linkDelegation = {
+    onMouseOver: (e: React.MouseEvent) => onAnchorHover(anchorAt(e.target)),
+    onMouseLeave: () => onAnchorHover(null),
+    // Clicking a card selects it and jumps the page there; clicking a field
+    // inside selects that field instead (closest() resolves the innermost).
+    // Clicking the gaps between cards releases the selection.
+    onClick: (e: React.MouseEvent) => onAnchorSelect(anchorAt(e.target)),
+    onFocusCapture: (e: React.FocusEvent) => {
+      if ((e.target as HTMLElement).dataset?.titleButton) return
+      const anchor = anchorAt(e.target)
+      if (anchor) onAnchorSelect(anchor)
+    },
+  }
+
+  const textField = (dataId: string, mono: boolean, label: string) => (
+    <Anchored anchor={textAnchor(dataId)}>
+      <AutoTextarea
+        value={texts[dataId] ?? ""}
+        onChange={(value) => handleTextChange(dataId, value)}
+        mono={mono}
+        label={label}
+      />
+    </Anchored>
   )
 
   const captionedText = (entry: ActivityOutlineText, label: string) => (
-    <div className="space-y-0.5">
-      {caption(label)}
+    <div className="space-y-1">
+      <FieldLabel>{label}</FieldLabel>
       {entry.dataId ? (
         textField(entry.dataId, false, label)
       ) : (
-        <p className="text-xs text-muted-foreground">{entry.text}</p>
+        <p className="text-xs leading-relaxed text-muted-foreground">{entry.text}</p>
       )}
     </div>
   )
 
+  const answerInput = (itemId: string) => (
+    <Input
+      value={String(answers?.[itemId] ?? "")}
+      onChange={(e) => onAnswerEdited(itemId, e.target.value)}
+      placeholder={t`Correct answer (alternatives separated by |)`}
+      aria-label={t`Correct answer`}
+      className={cn(
+        "h-7 border-emerald-300 bg-white text-xs dark:border-emerald-500/40 dark:bg-emerald-950/30",
+        NO_INNER_RING,
+      )}
+    />
+  )
+
+  /** The id chip sits OUTSIDE the anchor so the selection outline hugs the
+   *  field itself; wrapping the whole row made it bulge around the chip and
+   *  collide with the answer zone's edge. */
   const answerField = (itemId: string) => (
     <div key={itemId} className="flex items-center gap-2">
-      <Input
-        value={String(answers?.[itemId] ?? "")}
-        onChange={(e) => onAnswerEdited(itemId, e.target.value)}
-        placeholder={t`Correct answer (alternatives separated by |)`}
-        className="h-7 text-xs border-green-300 bg-green-50/60"
-      />
-      <span
-        className="text-[10px] font-mono text-muted-foreground shrink-0"
-        title={t`Blank reference`}
-      >
-        {itemId}
-      </span>
+      <Anchored anchor={answerAnchor(itemId)} className="flex-1">
+        {answerInput(itemId)}
+      </Anchored>
+      <ItemIdChip itemId={itemId} hint={t`Answer key reference`} />
     </div>
   )
 
-  const answersHeading = (count: number) => (
-    <span className="flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wide text-green-700">
-      <Check className="h-3 w-3" aria-hidden="true" />
-      {count === 1 ? t`Answer` : t`Answers`}
+  const answersHeading = (label: ReactNode) => (
+    <span className="flex items-center gap-1.5 text-[11px] font-semibold text-emerald-700 dark:text-emerald-300">
+      <Check className="h-3.5 w-3.5" aria-hidden="true" />
+      {label}
     </span>
   )
 
+  /**
+   * Marks the answer key apart from the question. A left accent bar rather
+   * than a filled box: every item has one of these, and a stack of saturated
+   * green panels turned the whole panel green.
+   */
+  const answerZone = (children: ReactNode) => (
+    <div className="space-y-2 border-l-2 border-emerald-400 pl-2.5 dark:border-emerald-500/60">
+      {children}
+    </div>
+  )
+
   const imageThumb = (imageId: string, className: string) => (
-    <img
-      key={imageId}
-      src={`${BASE_URL}/books/${bookLabel}/images/${imageId}`}
-      alt=""
-      title={imageId}
-      className={className}
+    <Anchored key={imageId} anchor={imageAnchor(imageId)} className="inline-flex">
+      <img
+        src={`${BASE_URL}/books/${bookLabel}/images/${imageId}`}
+        alt=""
+        title={imageId}
+        className={className}
+      />
+    </Anchored>
+  )
+
+  const ANSWER_AREA_CLASS = "space-y-2 rounded-md border border-dashed bg-muted/40 p-2.5"
+
+  /** Writable-answer block for an outline input (open-ended, table cell…). */
+  const answerArea = (itemId: string | undefined, index: number, children: ReactNode) =>
+    itemId ? (
+      <Anchored key={itemId} anchor={answerAnchor(itemId)} className={ANSWER_AREA_CLASS}>
+        {children}
+      </Anchored>
+    ) : (
+      <div key={index} className={ANSWER_AREA_CLASS}>
+        {children}
+      </div>
+    )
+
+  /** A choice row is the answer's editing surface — anchoring it is what lets
+   *  a click on the option's box in the page land here. */
+  const optionRow = (itemId: string | undefined, index: number, children: ReactNode) =>
+    itemId ? (
+      <Anchored key={itemId} anchor={answerAnchor(itemId)} className="flex items-center gap-2">
+        {children}
+      </Anchored>
+    ) : (
+      <div key={index} className="flex items-center gap-2">
+        {children}
+      </div>
+    )
+
+  const correctRadio = (value: string) => (
+    <RadioGroupItem
+      value={value}
+      aria-label={t`Correct answer`}
+      className="shrink-0 border-emerald-500 text-emerald-600 dark:border-emerald-400 dark:text-emerald-400"
     />
   )
+
+  /** The item-id currently flagged correct in a single-choice group. */
+  const correctOf = (ids: (string | undefined)[]) =>
+    ids.find((id) => id && isCorrectAnswer(answers?.[id])) ?? NO_CHOICE_ID
 
   const optionTextControl = (item: ActivityOutlineItem, optIndex: number) => {
     const o = item.options[optIndex]
     if (o.text?.dataId) {
       const dataId = o.text.dataId
       return (
-        <Input
-          value={texts[dataId] ?? ""}
-          onChange={(e) => handleTextChange(dataId, e.target.value)}
-          placeholder={t`Option text`}
-          className="h-7 text-xs"
-        />
+        <Anchored anchor={textAnchor(dataId)} className="flex-1">
+          <Input
+            value={texts[dataId] ?? ""}
+            onChange={(e) => handleTextChange(dataId, e.target.value)}
+            placeholder={t`Option text`}
+            aria-label={t`Option text`}
+            className={cn("h-7 text-xs", NO_INNER_RING)}
+          />
+        </Anchored>
       )
     }
     return (
@@ -372,161 +891,327 @@ export function ClassicActivityPanel({
     )
   }
 
+  /**
+   * Card shell. The card is itself the anchor for the item, and it *claims*
+   * that anchor so the field standing for it renders plain — hovering anywhere
+   * on the card rings the card, and only a genuinely different target (an
+   * answer, an option) rings a narrower box.
+   *
+   * The cursor override keeps text fields feeling like text fields even though
+   * their container is clickable.
+   */
+  const CARD_CLASS =
+    // Neutral on hover: violet is reserved for the page↔panel link, so a
+    // violet card border would compete with the outline that means "this is
+    // the element highlighted in the book".
+    "group/card space-y-2.5 rounded-lg border bg-card p-3 transition-colors duration-200 ease-out hover:border-muted-foreground/30 motion-reduce:transition-none"
+
+  const itemCard = (opts: {
+    key: string
+    index: number
+    label: string
+    /** The item's main text, edited in the header rather than repeated as a
+     *  field below it. Its dataId is normally also the card's anchor. */
+    titleField?: { dataId: string; label: string; mono?: boolean }
+    anchor?: ActivityAnchor
+    itemId?: string
+    /** Flags an item whose answer key is still blank. */
+    unanswered?: boolean
+    children: ReactNode
+  }) => {
+    const isSelected = Boolean(opts.anchor && sameAnchor(linkedAnchor, opts.anchor))
+    const editingTitle = Boolean(opts.titleField) && isSelected
+    const head = (
+      <>
+        <div className={cn("flex gap-2", editingTitle ? "items-start" : "items-center")}>
+          <span
+            className={cn(
+              "flex h-5 w-5 shrink-0 items-center justify-center rounded-md bg-muted text-[11px] font-semibold tabular-nums text-muted-foreground",
+              editingTitle && "mt-0.5",
+            )}
+          >
+            {opts.index}
+          </span>
+          {opts.titleField ? (
+            <InlineTitle
+              value={texts[opts.titleField.dataId] ?? ""}
+              onChange={(v) => handleTextChange(opts.titleField!.dataId, v)}
+              label={opts.titleField.label}
+              mono={opts.titleField.mono}
+              editing={editingTitle}
+            />
+          ) : (
+            <span className="min-w-0 flex-1 truncate text-xs font-medium">{opts.label}</span>
+          )}
+          {opts.unanswered && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span
+                  className="h-1.5 w-1.5 shrink-0 rounded-full bg-amber-500"
+                  aria-label={t`No answer set`}
+                />
+              </TooltipTrigger>
+              <TooltipContent>{t`No answer set`}</TooltipContent>
+            </Tooltip>
+          )}
+          {opts.itemId && <ItemIdChip itemId={opts.itemId} hint={t`Answer key reference`} />}
+        </div>
+        {opts.children}
+      </>
+    )
+    if (!opts.anchor) {
+      return (
+        <div key={opts.key} className={CARD_CLASS}>
+          {head}
+        </div>
+      )
+    }
+    return (
+      <Anchored
+        key={opts.key}
+        anchor={opts.anchor}
+        className={cn(
+          CARD_CLASS,
+          "cursor-pointer [&_input]:cursor-auto [&_textarea]:cursor-auto [&_input[type=checkbox]]:cursor-pointer",
+        )}
+      >
+        {/* Inside the Anchored, not around it — the card must not read its own
+            claim and render itself inert. */}
+        <ClaimedAnchorContext.Provider value={anchorKey(opts.anchor)}>
+          {head}
+        </ClaimedAnchorContext.Provider>
+      </Anchored>
+    )
+  }
+
   const outlineItemCard = (item: ActivityOutlineItem, i: number) => {
     const valueItemId = item.choice === "value" ? item.options[0]?.itemId : undefined
-    return (
-      <div key={i} className="rounded border p-3 space-y-2">
-        <div className="flex items-center justify-between gap-2">
-          <span className="text-xs font-medium">
-            {item.options.length > 0 ? t`Question ${i + 1}` : t`Item ${i + 1}`}
-          </span>
-          {(item.inputs[0]?.itemId ?? valueItemId) && (
-            <span className="text-[10px] font-mono text-muted-foreground shrink-0">
-              {item.inputs[0]?.itemId ?? valueItemId}
-            </span>
-          )}
-        </div>
-        {item.number?.dataId && (
-          <div className="space-y-0.5">
-            {caption(t`Label`)}
-            <Input
-              value={texts[item.number.dataId] ?? ""}
-              onChange={(e) => handleTextChange(item.number!.dataId!, e.target.value)}
-              className="h-7 w-24 text-xs"
-              aria-label={t`Label`}
-            />
-          </div>
-        )}
-        {item.prompts.length > 0 && (
-          <div className="space-y-1">
-            {caption(t`Instruction`)}
-            {item.prompts.map((p, pi) =>
-              p.dataId ? (
-                <div key={p.dataId}>{textField(p.dataId, false, t`Instruction`)}</div>
-              ) : (
-                <p key={pi} className="text-xs text-muted-foreground">
-                  {p.text}
-                </p>
-              ),
-            )}
-          </div>
-        )}
-        {item.imageIds.length > 0 && (
-          <div className="flex flex-wrap gap-2">
-            {item.imageIds.map((id) => imageThumb(id, "max-h-24 rounded border object-contain"))}
-          </div>
-        )}
-        {/* Writable answer areas — visually distinct from the editable
-            question texts above. */}
-        {item.inputs.map((input, k) => (
-          <div key={input.itemId ?? k} className="rounded border border-dashed bg-muted/40 p-2 space-y-1.5">
-            <div className="flex items-center justify-between gap-2">
-              <span className="flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
-                <TextCursorInput className="h-3 w-3" aria-hidden="true" />
-                {t`Answer area`}
-              </span>
-              <span className="text-[10px] rounded bg-muted px-1.5 py-0.5 text-muted-foreground shrink-0">
-                {input.kind === "textarea"
-                  ? t`Long answer`
-                  : input.kind === "select"
-                    ? t`Dropdown`
-                    : t`Short answer`}
-              </span>
-            </div>
-            {input.itemId &&
-            answers &&
-            input.itemId in answers &&
-            typeof answers[input.itemId] !== "boolean" ? (
-              answerField(input.itemId)
-            ) : (
-              <p className="text-[10px] text-muted-foreground">{t`Accepts any answer`}</p>
-            )}
-          </div>
-        ))}
-        {/* True/false-style: options share one item-id, the answer is the
-            selected option's value. Options without value attributes can't
-            drive radios — fall back to the raw answer field. */}
-        {item.choice === "value" &&
-          item.options.length > 0 &&
-          valueItemId &&
-          (item.options.every((o) => o.value !== undefined) ? (
-            <div className="space-y-1.5">
-              {answersHeading(1)}
-              <div className="flex flex-wrap items-center gap-4">
-                {item.options.map((o, oi) => (
-                  <label key={oi} className="flex items-center gap-1.5">
-                    <input
-                      type="radio"
-                      name={`outline-value-${i}`}
-                      checked={
-                        String(answers?.[valueItemId] ?? "").toLowerCase() ===
-                        (o.value ?? "").toLowerCase()
-                      }
-                      onChange={() => onAnswersEdited({ [valueItemId]: o.value! })}
-                      title={t`Correct answer`}
-                      className="cursor-pointer accent-green-600"
-                    />
-                    {o.text?.dataId ? (
-                      <Input
-                        value={texts[o.text.dataId] ?? ""}
-                        onChange={(e) => handleTextChange(o.text!.dataId!, e.target.value)}
-                        className="h-7 w-16 text-xs"
-                        aria-label={t`Option text`}
-                      />
-                    ) : (
-                      <span className="text-xs">{o.text?.text ?? o.value}</span>
-                    )}
-                  </label>
-                ))}
-              </div>
-            </div>
-          ) : answers && valueItemId in answers && typeof answers[valueItemId] !== "boolean" ? (
-            <div className="space-y-1.5">
-              {answersHeading(1)}
-              {answerField(valueItemId)}
-            </div>
-          ) : null)}
-        {/* Single-choice (MC-style): the selected radio marks the correct
-            option. Multi-select: every checked option is correct. */}
-        {(item.choice === "single" || item.choice === "multi") && item.options.length > 0 && (
-          <div className="space-y-1.5">
-            <span className="flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wide text-green-700">
-              <Check className="h-3 w-3" aria-hidden="true" />
-              {item.choice === "single"
-                ? t`Options — the selected radio marks the correct answer`
-                : t`Options — checked options are the correct answers`}
-            </span>
-            {item.options.map((o, oi) => (
-              <div key={o.itemId ?? oi} className="flex items-center gap-2">
-                <input
-                  type={item.choice === "single" ? "radio" : "checkbox"}
-                  name={item.choice === "single" ? `outline-single-${i}` : undefined}
-                  checked={isCorrectAnswer(answers?.[o.itemId ?? ""])}
-                  onChange={(e) => {
-                    if (!o.itemId) return
-                    if (item.choice === "single") {
-                      onAnswersEdited(
-                        Object.fromEntries(
-                          item.options
-                            .filter((x) => x.itemId)
-                            .map((x) => [x.itemId!, x.itemId === o.itemId]),
-                        ),
-                      )
-                    } else {
-                      onAnswersEdited({ [o.itemId]: e.target.checked })
-                    }
-                  }}
-                  title={t`Correct answer`}
-                  className="cursor-pointer accent-green-600"
+    const anchorItemId = item.inputs[0]?.itemId ?? valueItemId
+    // Prefer the question text over the bare "1)" marker: it's what the card
+    // is about, so it's both the better thing to light up in the page and the
+    // better thing to read in the header.
+    const cardAnchor = item.prompts[0]?.dataId
+      ? textAnchor(item.prompts[0].dataId)
+      : item.number?.dataId
+        ? textAnchor(item.number.dataId)
+        : anchorItemId
+          ? answerAnchor(anchorItemId)
+          : undefined
+
+    // Only flag items that actually have an answer unit — an open-ended
+    // question with no key isn't "missing" anything.
+    const filled: boolean[] = []
+    for (const input of item.inputs) {
+      const id = input.itemId
+      if (id && answers && id in answers && typeof answers[id] !== "boolean") {
+        filled.push(Boolean(String(answers[id] ?? "").trim()))
+      }
+    }
+    if (item.choice === "value" && valueItemId) {
+      filled.push(Boolean(String(answers?.[valueItemId] ?? "").trim()))
+    } else if (
+      (item.choice === "single" || item.choice === "multi") &&
+      item.options.length > 0
+    ) {
+      filled.push(item.options.some((o) => isCorrectAnswer(answers?.[o.itemId ?? ""])))
+    }
+
+    // The first prompt becomes the card title; any further prompts stay as
+    // fields so nothing is silently unreachable.
+    const titlePrompt = item.prompts[0]?.dataId ? item.prompts[0] : undefined
+    const bodyPrompts = item.prompts.filter((p) => p !== titlePrompt)
+
+    return itemCard({
+      key: String(i),
+      index: i + 1,
+      label: item.options.length > 0 ? t`Question` : t`Item`,
+      titleField: titlePrompt?.dataId
+        ? { dataId: titlePrompt.dataId, label: t`Instruction` }
+        : undefined,
+      unanswered: filled.length > 0 && filled.some((ok) => !ok),
+      anchor: cardAnchor,
+      itemId: anchorItemId,
+      children: (
+        <>
+          {item.number?.dataId && (
+            <div className="space-y-1">
+              <FieldLabel>{t`Label`}</FieldLabel>
+              <Anchored anchor={textAnchor(item.number.dataId)} className="w-24">
+                <Input
+                  value={texts[item.number.dataId] ?? ""}
+                  onChange={(e) => handleTextChange(item.number!.dataId!, e.target.value)}
+                  className={cn("h-7 text-xs", NO_INNER_RING)}
+                  aria-label={t`Label`}
                 />
-                {o.imageId && imageThumb(o.imageId, "h-8 w-8 rounded border object-cover shrink-0")}
-                {optionTextControl(item, oi)}
-              </div>
-            ))}
-          </div>
-        )}
-      </div>
-    )
+              </Anchored>
+            </div>
+          )}
+          {bodyPrompts.length > 0 && (
+            <div className="space-y-1">
+              <FieldLabel>{t`Instruction`}</FieldLabel>
+              {bodyPrompts.map((p, pi) =>
+                p.dataId ? (
+                  <div key={p.dataId}>{textField(p.dataId, false, t`Instruction`)}</div>
+                ) : (
+                  <p key={pi} className="text-xs leading-relaxed text-muted-foreground">
+                    {p.text}
+                  </p>
+                ),
+              )}
+            </div>
+          )}
+          {item.imageIds.length > 0 && (
+            <div className="flex flex-wrap gap-2">
+              {item.imageIds.map((id) =>
+                imageThumb(id, "max-h-24 rounded border object-contain"),
+              )}
+            </div>
+          )}
+          {/* Writable answer areas — visually distinct from the editable
+              question texts above. Anchored even when the answer accepts
+              anything, so clicking the blank in the page still lands here. */}
+          {item.inputs.map((input, k) =>
+            answerArea(
+              input.itemId,
+              k,
+              <>
+                <div className="flex items-center justify-between gap-2">
+                  <span className="flex items-center gap-1.5 text-[11px] font-medium text-muted-foreground">
+                    <TextCursorInput className="h-3.5 w-3.5" aria-hidden="true" />
+                    {t`Answer area`}
+                  </span>
+                  <Badge variant="secondary" className="shrink-0 px-1.5 py-0 text-[11px] font-normal">
+                    {input.kind === "textarea"
+                      ? t`Long answer`
+                      : input.kind === "select"
+                        ? t`Dropdown`
+                        : t`Short answer`}
+                  </Badge>
+                </div>
+                {input.itemId &&
+                answers &&
+                input.itemId in answers &&
+                typeof answers[input.itemId] !== "boolean" ? (
+                  <div className="flex items-center gap-2">
+                    {answerInput(input.itemId)}
+                    <ItemIdChip itemId={input.itemId} hint={t`Answer key reference`} />
+                  </div>
+                ) : (
+                  <p className="text-[11px] text-muted-foreground">{t`Accepts any answer`}</p>
+                )}
+              </>,
+            ),
+          )}
+          {/* True/false-style: options share one item-id, the answer is the
+              selected option's value. Options without value attributes can't
+              drive radios — fall back to the raw answer field. */}
+          {item.choice === "value" &&
+            item.options.length > 0 &&
+            valueItemId &&
+            (item.options.every((o) => o.value !== undefined)
+              ? answerZone(
+                  <>
+                    {answersHeading(t`Answer`)}
+                    {/* The options share one item-id — the whole row is that
+                        single answer, so it anchors as one unit. */}
+                    <Anchored anchor={answerAnchor(valueItemId)}>
+                      <RadioGroup
+                        value={String(answers?.[valueItemId] ?? NO_CHOICE_ID)}
+                        onValueChange={(v) => onAnswersEdited({ [valueItemId]: v })}
+                        className="flex flex-wrap items-center gap-4"
+                      >
+                        {item.options.map((o, oi) => (
+                          <div key={oi} className="flex items-center gap-1.5">
+                            {correctRadio(o.value!)}
+                            {o.text?.dataId ? (
+                              <Anchored anchor={textAnchor(o.text.dataId)} className="w-16">
+                                <Input
+                                  value={texts[o.text.dataId] ?? ""}
+                                  onChange={(e) =>
+                                    handleTextChange(o.text!.dataId!, e.target.value)
+                                  }
+                                  className={cn("h-7 text-xs", NO_INNER_RING)}
+                                  aria-label={t`Option text`}
+                                />
+                              </Anchored>
+                            ) : (
+                              <span className="text-xs">{o.text?.text ?? o.value}</span>
+                            )}
+                          </div>
+                        ))}
+                      </RadioGroup>
+                    </Anchored>
+                  </>,
+                )
+              : answers &&
+                  valueItemId in answers &&
+                  typeof answers[valueItemId] !== "boolean"
+                ? answerZone(
+                    <>
+                      {answersHeading(t`Answer`)}
+                      {answerField(valueItemId)}
+                    </>,
+                  )
+                : null)}
+          {/* Single-choice (MC-style): the selected radio marks the correct
+              option. Multi-select: every checked option is correct. */}
+          {item.choice === "single" &&
+            item.options.length > 0 &&
+            answerZone(
+              <>
+                {answersHeading(t`Options — the selected radio marks the correct answer`)}
+                <RadioGroup
+                  value={correctOf(item.options.map((o) => o.itemId))}
+                  onValueChange={(id) =>
+                    onAnswersEdited(
+                      Object.fromEntries(
+                        item.options.filter((x) => x.itemId).map((x) => [x.itemId!, x.itemId === id]),
+                      ),
+                    )
+                  }
+                  className="gap-2"
+                >
+                  {item.options.map((o, oi) =>
+                    optionRow(o.itemId, oi, (
+                      <>
+                        {correctRadio(o.itemId ?? `${NO_CHOICE_ID}-${oi}`)}
+                        {o.imageId &&
+                          imageThumb(o.imageId, "h-8 w-8 rounded border object-cover shrink-0")}
+                        {optionTextControl(item, oi)}
+                      </>
+                    )),
+                  )}
+                </RadioGroup>
+              </>,
+            )}
+          {item.choice === "multi" &&
+            item.options.length > 0 &&
+            answerZone(
+              <>
+                {answersHeading(t`Options — checked options are the correct answers`)}
+                {item.options.map((o, oi) =>
+                  optionRow(o.itemId, oi, (
+                    <>
+                      <input
+                        type="checkbox"
+                        checked={isCorrectAnswer(answers?.[o.itemId ?? ""])}
+                        onChange={(e) => {
+                          if (o.itemId) onAnswersEdited({ [o.itemId]: e.target.checked })
+                        }}
+                        aria-label={t`Correct answer`}
+                        className="h-4 w-4 shrink-0 cursor-pointer accent-emerald-600"
+                      />
+                      {o.imageId &&
+                        imageThumb(o.imageId, "h-8 w-8 rounded border object-cover shrink-0")}
+                      {optionTextControl(item, oi)}
+                    </>
+                  )),
+                )}
+              </>,
+            )}
+        </>
+      ),
+    })
   }
 
   // Per-field fallback: whatever the outline missed but the extractor found
@@ -546,312 +1231,469 @@ export function ClassicActivityPanel({
     headerTexts.badges.length > 0 ||
     headerTexts.instructions.length > 0
 
+  const isEmpty =
+    !hasHeader &&
+    !structure &&
+    visibleOutlineItems.length === 0 &&
+    otherAnswerEntries.length === 0 &&
+    otherTextLeaves.length === 0 &&
+    otherImageLeaves.length === 0
+
   return (
     <div
+      ref={panelRef}
       // inert while closed — the panel is only moved off-screen by the
       // transform, so without it Tab still reaches its inputs and the browser
       // scrolls the hidden panel into view.
       inert={!open}
-      className={`absolute top-0 right-0 h-full w-[420px] flex flex-col bg-background border-l shadow-lg transition-transform duration-200 ease-in-out z-30 ${
-        open ? "translate-x-0" : "translate-x-full"
-      }`}
+      style={{ width: panelWidth }}
+      className={cn(
+        "absolute top-0 right-0 z-30 flex h-full flex-col border-l bg-background shadow-xl",
+        "transition-transform duration-200 ease-out motion-reduce:transition-none",
+        open ? "translate-x-0" : "translate-x-full",
+      )}
     >
+      {/* Drag-to-resize edge */}
+      <div
+        onPointerDown={startResize}
+        role="separator"
+        aria-orientation="vertical"
+        aria-label={t`Resize panel`}
+        className="absolute inset-y-0 left-0 z-40 w-1.5 cursor-col-resize bg-transparent transition-colors duration-200 hover:bg-violet-400/50 motion-reduce:transition-none"
+      />
+
       {/* Header */}
-      <div className="flex items-center justify-between border-b px-4 py-2.5">
-        <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-          {t`Activity content`}
+      <div className="flex shrink-0 items-center gap-2 border-b px-4 py-2.5">
+        <span className="flex h-6 w-6 items-center justify-center rounded-md bg-violet-100 text-violet-700 dark:bg-violet-500/15 dark:text-violet-300">
+          <Puzzle className="h-3.5 w-3.5" aria-hidden="true" />
         </span>
-        <button
+        <h2 className="flex-1 text-sm font-semibold">{t`Activity content`}</h2>
+        <Button
           type="button"
+          variant="ghost"
+          size="icon"
           onClick={onClose}
-          className="p-1 rounded hover:bg-accent cursor-pointer"
-          title={t`Close`}
+          className="h-7 w-7 text-muted-foreground"
+          aria-label={t`Close`}
         >
           <X className="h-4 w-4" />
-        </button>
+        </Button>
       </div>
 
-      {/* Form */}
-      <div className="flex-1 overflow-y-auto p-4 space-y-5">
-        <p className="text-[11px] text-muted-foreground leading-snug">
-          {t`Edits apply to the matching elements of the activity's layout. To change the layout itself, use "Edit layout" in the banner.`}
-        </p>
+      {/* Link affordance — the panel and the page are one surface. Explains
+          itself once, then gets out of the way; the pinned state always shows,
+          since that one is a mode the user needs a way out of. */}
+      {(linkedAnchor || !hintDismissed) && (
+        <div className="flex shrink-0 items-start gap-2 border-b bg-violet-50/60 px-4 py-2 dark:bg-violet-500/10">
+          <MousePointerClick
+            className="mt-px h-3.5 w-3.5 shrink-0 text-violet-600 dark:text-violet-300"
+            aria-hidden="true"
+          />
+          <p className="flex-1 text-[11px] leading-snug text-muted-foreground">
+            {linkedAnchor
+              ? t`Pinned to one element — press Esc to release it and go back to previewing on hover.`
+              : t`Hover a card to find it in the page and click to pin it — or click anything in the page to edit it here.`}
+          </p>
+          {!linkedAnchor && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              onClick={dismissHint}
+              className="-my-0.5 h-5 w-5 shrink-0 text-muted-foreground"
+              aria-label={t`Dismiss`}
+            >
+              <X className="h-3 w-3" />
+            </Button>
+          )}
+        </div>
+      )}
 
-        {/* Activity type + regenerate */}
-        {activityTypes && sectionType && (
-          <div className="space-y-1.5">
-            <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-              {t`Activity type`}
-            </h3>
-            <div className="flex items-center gap-2">
-              <select
-                value={sectionType}
-                onChange={(e) => onChangeType(e.target.value)}
-                className="h-7 min-w-0 flex-1 rounded border bg-background px-2 text-xs"
-              >
+      {/* Activity type + regenerate — pinned so it stays reachable in long
+          activities. */}
+      {activityTypes && sectionType && (
+        <div className="shrink-0 space-y-1.5 border-b px-4 py-2.5">
+          <FieldLabel>{t`Activity type`}</FieldLabel>
+          <div className="flex items-center gap-2">
+            <Select value={sectionType} onValueChange={onChangeType}>
+              <SelectTrigger className="h-7 min-w-0 flex-1 text-xs" aria-label={t`Activity type`}>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
                 {!(sectionType in activityTypes) && (
-                  <option value={sectionType}>{getSectionTypeLabel(sectionType)}</option>
+                  <SelectItem value={sectionType} className="text-xs">
+                    {getSectionTypeLabel(sectionType)}
+                  </SelectItem>
                 )}
                 {/* The config values are LLM-facing descriptions — show the
                     human name and keep the description as a hover tooltip. */}
                 {Object.entries(activityTypes).map(([key, description]) => (
-                  <option key={key} value={key} title={description}>
+                  <SelectItem key={key} value={key} title={description} className="text-xs">
                     {getSectionTypeLabel(key)}
-                  </option>
+                  </SelectItem>
                 ))}
-              </select>
-              <button
-                type="button"
-                onClick={onRegenerate}
-                disabled={!canRegenerate}
-                title={t`Regenerate this activity with AI (requires a saved state and an API key)`}
-                className="flex items-center gap-1.5 h-7 px-2.5 rounded-md text-xs font-medium border border-violet-300 text-violet-700 hover:bg-violet-50 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed shrink-0"
-              >
-                <Sparkles className="h-3.5 w-3.5" />
-                {t`Regenerate`}
-              </button>
-            </div>
-            <p className="text-[10px] text-muted-foreground">
-              {t`Changing the type regenerates the activity when you save.`}
-            </p>
+              </SelectContent>
+            </Select>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="shrink-0">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={onRegenerate}
+                    disabled={!canRegenerate}
+                    className="h-7 gap-1.5 border-violet-300 px-2.5 text-xs font-medium text-violet-700 hover:bg-violet-50 hover:text-violet-800 dark:border-violet-500/40 dark:text-violet-300 dark:hover:bg-violet-500/10"
+                  >
+                    <Sparkles className="h-3.5 w-3.5" />
+                    {t`Regenerate`}
+                  </Button>
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>
+                {t`Regenerate this activity with AI (requires a saved state and an API key)`}
+              </TooltipContent>
+            </Tooltip>
           </div>
-        )}
+          <p className="text-[11px] text-muted-foreground">
+            {t`Changing the type regenerates the activity when you save.`}
+          </p>
+        </div>
+      )}
 
-        {/* Page header: title, badges, instructions — pinned at the top for
-            every activity type. */}
-        {hasHeader && (
-          <div className="space-y-2">
-            <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-              {t`Header`}
-            </h3>
-            {headerTexts.title && captionedText(headerTexts.title, t`Title`)}
-            {headerTexts.badges.map((b, bi) => (
-              <div key={b.dataId ?? bi} className="space-y-0.5">
-                {caption(t`Badge`)}
-                {b.dataId ? (
-                  <Input
-                    value={texts[b.dataId] ?? ""}
-                    onChange={(e) => handleTextChange(b.dataId!, e.target.value)}
-                    className="h-7 w-40 text-xs"
-                    aria-label={t`Badge`}
-                  />
-                ) : (
-                  <p className="text-xs text-muted-foreground">{b.text}</p>
-                )}
-              </div>
-            ))}
-            {headerTexts.instructions.length > 0 && (
-              <div className="space-y-1">
-                {caption(t`Instructions`)}
-                {headerTexts.instructions.map((ins, ii) =>
-                  ins.dataId ? (
-                    <div key={ins.dataId}>{textField(ins.dataId, false, t`Instructions`)}</div>
-                  ) : (
-                    <p key={ii} className="text-xs text-muted-foreground">
-                      {ins.text}
-                    </p>
-                  ),
-                )}
+      {/* Form */}
+      <LinkContext.Provider value={linkContext}>
+        <ScrollArea className="min-h-0 flex-1" {...linkDelegation}>
+          <div className="space-y-5 p-4">
+            {isEmpty && (
+              <div className="flex flex-col items-center gap-2 px-6 py-12 text-center">
+                <span className="flex h-10 w-10 items-center justify-center rounded-full bg-muted">
+                  <Puzzle className="h-5 w-5 text-muted-foreground" aria-hidden="true" />
+                </span>
+                <p className="text-xs font-medium">{t`Nothing to edit yet`}</p>
+                <p className="text-[11px] leading-snug text-muted-foreground">
+                  {t`This activity has no addressable text or answers. Regenerate it, or use "Edit layout" to change the page directly.`}
+                </p>
               </div>
             )}
-          </div>
-        )}
 
-        {/* Grouped item cards — image, prompt/sentence, and answer together */}
-        {structure && structure.kind === "fill-in-the-blank" && (
-          <div className="space-y-3">
-            <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-              {t`Items`} ({structure.steps.length})
-            </h3>
-            {structure.steps.map((step, si) => (
-              <div key={step.id} className="rounded border p-3 space-y-2">
-                <span className="text-xs font-medium">{t`Item ${si + 1}`}</span>
-                {step.image && (
-                  <img
-                    src={imageSrc(bookLabel, step.image)}
-                    alt={step.image.alt ?? ""}
-                    className="max-h-24 rounded border object-contain"
-                  />
-                )}
-                {step.sentences.map((sentence, sni) =>
-                  sentence.dataId ? (
-                    <div key={sni}>{textField(sentence.dataId, true, t`Sentence with blank markers`)}</div>
-                  ) : (
-                    <p key={sni} className="text-xs font-mono text-muted-foreground">
-                      {sentence.text}
-                    </p>
-                  ),
-                )}
-                <div className="space-y-1.5">
-                  {answersHeading(step.blanks.length)}
-                  {step.blanks.map((blank) => answerField(blank.itemId))}
-                </div>
-              </div>
-            ))}
-          </div>
-        )}
-
-        {structure && structure.kind === "multiple-choice" && (
-          <div className="space-y-3">
-            <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-              {t`Questions`} ({structure.steps.length})
-            </h3>
-            {structure.steps.map((step, si) => (
-              <div key={step.id} className="rounded border p-3 space-y-2">
-                <span className="text-xs font-medium">{t`Question ${si + 1}`}</span>
-                {step.image && (
-                  <img
-                    src={imageSrc(bookLabel, step.image)}
-                    alt={step.image.alt ?? ""}
-                    className="max-h-24 rounded border object-contain"
-                  />
-                )}
-                {step.prompt?.dataId && textField(step.prompt.dataId, false, t`Question prompt`)}
-                <div className="space-y-1.5">
-                  <span className="flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wide text-green-700">
-                    <Check className="h-3 w-3" aria-hidden="true" />
-                    {t`Options — the selected radio marks the correct answer`}
-                  </span>
-                  {step.options.map((option) => (
-                    <div key={option.itemId} className="flex items-center gap-2">
-                      <input
-                        type="radio"
-                        name={`classic-correct-${step.id}`}
-                        checked={isCorrectAnswer(answers?.[option.itemId])}
-                        onChange={() =>
-                          onAnswersEdited(
-                            Object.fromEntries(
-                              step.options.map((o) => [o.itemId, o.itemId === option.itemId]),
-                            ),
-                          )
-                        }
-                        title={t`Correct answer`}
-                        className="cursor-pointer accent-green-600"
-                      />
-                      {option.image && (
-                        <img
-                          src={imageSrc(bookLabel, option.image)}
-                          alt={option.image.alt ?? ""}
-                          className="h-8 w-8 rounded border object-cover shrink-0"
-                        />
-                      )}
-                      {option.text?.dataId ? (
+            {/* Page header: title, badges, instructions — pinned at the top for
+                every activity type. */}
+            {hasHeader && (
+              <div className="space-y-2">
+                <SectionHeading>{t`Header`}</SectionHeading>
+                {headerTexts.title && captionedText(headerTexts.title, t`Title`)}
+                {headerTexts.badges.map((b, bi) => (
+                  <div key={b.dataId ?? bi} className="space-y-1">
+                    <FieldLabel>{t`Badge`}</FieldLabel>
+                    {b.dataId ? (
+                      <Anchored anchor={textAnchor(b.dataId)} className="w-40">
                         <Input
-                          value={texts[option.text.dataId] ?? ""}
-                          onChange={(e) => handleTextChange(option.text!.dataId!, e.target.value)}
-                          placeholder={t`Option text`}
-                          className="h-7 text-xs"
+                          value={texts[b.dataId] ?? ""}
+                          onChange={(e) => handleTextChange(b.dataId!, e.target.value)}
+                          className={cn("h-7 text-xs", NO_INNER_RING)}
+                          aria-label={t`Badge`}
                         />
+                      </Anchored>
+                    ) : (
+                      <p className="text-xs text-muted-foreground">{b.text}</p>
+                    )}
+                  </div>
+                ))}
+                {headerTexts.instructions.length > 0 && (
+                  <div className="space-y-1">
+                    <FieldLabel>{t`Instructions`}</FieldLabel>
+                    {headerTexts.instructions.map((ins, ii) =>
+                      ins.dataId ? (
+                        <div key={ins.dataId}>
+                          {textField(ins.dataId, false, t`Instructions`)}
+                        </div>
                       ) : (
-                        <span className="flex-1 text-xs text-muted-foreground">
-                          {option.text?.text ?? option.itemId}
-                        </span>
-                      )}
-                    </div>
-                  ))}
-                </div>
+                        <p key={ii} className="text-xs leading-relaxed text-muted-foreground">
+                          {ins.text}
+                        </p>
+                      ),
+                    )}
+                  </div>
+                )}
               </div>
-            ))}
-          </div>
-        )}
+            )}
 
-        {/* Outline item cards — every activity type the structure doesn't
-            cover (open-ended, true/false, multi-select, tables), plus answer
-            units a successful FITB/MC extraction missed. */}
-        {visibleOutlineItems.length > 0 && (
-          <div className="space-y-3">
-            <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-              {structure ? t`Other items` : t`Items`} ({visibleOutlineItems.length})
-            </h3>
-            {visibleOutlineItems.map((item, i) => outlineItemCard(item, i))}
-          </div>
-        )}
+            {/* Grouped item cards — image, prompt/sentence, and answer together */}
+            {structure && structure.kind === "fill-in-the-blank" && (
+              <div className="space-y-2.5">
+                <SectionHeading count={structure.steps.length}>{t`Items`}</SectionHeading>
+                <p className="text-[11px] leading-snug text-muted-foreground">
+                  {t`Select an item to edit its text — [[blank:…]] marks where a blank appears, so keep it to keep the blank.`}
+                </p>
+                {structure.steps.map((step, si) => {
+                  // The first addressable sentence becomes the card title; the
+                  // rest (rare — a two-line item) stay as fields below it.
+                  const titleSentence = step.sentences.find((s) => s.dataId)
+                  return itemCard({
+                    key: step.id,
+                    index: si + 1,
+                    label: t`Item`,
+                    titleField: titleSentence?.dataId
+                      ? {
+                          dataId: titleSentence.dataId,
+                          label: t`Sentence with blank markers`,
+                          mono: true,
+                        }
+                      : undefined,
+                    unanswered: step.blanks.some(
+                      (b) => !String(answers?.[b.itemId] ?? "").trim(),
+                    ),
+                    anchor: titleSentence?.dataId
+                      ? textAnchor(titleSentence.dataId)
+                      : step.blanks[0]
+                        ? answerAnchor(step.blanks[0].itemId)
+                        : undefined,
+                    children: (
+                      <>
+                        {step.image && (
+                          <img
+                            src={imageSrc(bookLabel, step.image)}
+                            alt={step.image.alt ?? ""}
+                            className="max-h-24 rounded border object-contain"
+                          />
+                        )}
+                        {step.sentences
+                          .filter((s) => s !== titleSentence)
+                          .map((sentence, sni) =>
+                            sentence.dataId ? (
+                              <div key={sni}>
+                                {textField(sentence.dataId, true, t`Sentence with blank markers`)}
+                              </div>
+                            ) : (
+                              <p key={sni} className="font-mono text-xs text-muted-foreground">
+                                {sentence.text}
+                              </p>
+                            ),
+                          )}
+                        {answerZone(
+                          <>
+                            {answersHeading(
+                              step.blanks.length === 1 ? t`Answer` : t`Answers`,
+                            )}
+                            {step.blanks.map((blank) => answerField(blank.itemId))}
+                          </>,
+                        )}
+                      </>
+                    ),
+                  })
+                })}
+              </div>
+            )}
 
-        {/* Ungrouped answers (flat — always shown when present). Boolean
-            entries are correctness flags: checked = correct. */}
-        {otherAnswerEntries.length > 0 && (
-          <div className="space-y-1.5">
-            {answersHeading(otherAnswerEntries.length)}
-            {otherAnswerEntries.map(([itemId, value]) =>
-              typeof value === "boolean" ? (
-                <label key={itemId} className="flex items-center gap-2">
-                  <input
-                    type="checkbox"
-                    checked={isCorrectAnswer(value)}
-                    onChange={(e) => onAnswersEdited({ [itemId]: e.target.checked })}
-                    title={t`Correct answer`}
-                    className="cursor-pointer accent-green-600"
-                  />
-                  <span className="text-[10px] font-mono text-muted-foreground">{itemId}</span>
-                </label>
-              ) : (
-                answerField(itemId)
-              ),
+            {structure && structure.kind === "multiple-choice" && (
+              <div className="space-y-2.5">
+                <SectionHeading count={structure.steps.length}>{t`Questions`}</SectionHeading>
+                {structure.steps.map((step, si) =>
+                  itemCard({
+                    key: step.id,
+                    index: si + 1,
+                    label: t`Question`,
+                    titleField: step.prompt?.dataId
+                      ? { dataId: step.prompt.dataId, label: t`Question prompt` }
+                      : undefined,
+                    unanswered: !step.options.some((o) =>
+                      isCorrectAnswer(answers?.[o.itemId]),
+                    ),
+                    anchor: step.prompt?.dataId
+                      ? textAnchor(step.prompt.dataId)
+                      : step.options[0]
+                        ? answerAnchor(step.options[0].itemId)
+                        : undefined,
+                    children: (
+                      <>
+                        {step.image && (
+                          <img
+                            src={imageSrc(bookLabel, step.image)}
+                            alt={step.image.alt ?? ""}
+                            className="max-h-24 rounded border object-contain"
+                          />
+                        )}
+                        {/* The prompt lives in the card title — see itemCard. */}
+                        {answerZone(
+                          <>
+                            {answersHeading(
+                              t`Options — the selected radio marks the correct answer`,
+                            )}
+                            <RadioGroup
+                              value={correctOf(step.options.map((o) => o.itemId))}
+                              onValueChange={(id) =>
+                                onAnswersEdited(
+                                  Object.fromEntries(
+                                    step.options.map((o) => [o.itemId, o.itemId === id]),
+                                  ),
+                                )
+                              }
+                              className="gap-2"
+                            >
+                              {step.options.map((option, oi) =>
+                                optionRow(option.itemId, oi, (
+                                  <>
+                                    {correctRadio(option.itemId)}
+                                    {option.image && (
+                                      <img
+                                        src={imageSrc(bookLabel, option.image)}
+                                        alt={option.image.alt ?? ""}
+                                        className="h-8 w-8 shrink-0 rounded border object-cover"
+                                      />
+                                    )}
+                                    {option.text?.dataId ? (
+                                      <Anchored
+                                        anchor={textAnchor(option.text.dataId)}
+                                        className="flex-1"
+                                      >
+                                        <Input
+                                          value={texts[option.text.dataId] ?? ""}
+                                          onChange={(e) =>
+                                            handleTextChange(
+                                              option.text!.dataId!,
+                                              e.target.value,
+                                            )
+                                          }
+                                          placeholder={t`Option text`}
+                                          aria-label={t`Option text`}
+                                          className={cn("h-7 text-xs", NO_INNER_RING)}
+                                        />
+                                      </Anchored>
+                                    ) : (
+                                      <span className="flex-1 text-xs text-muted-foreground">
+                                        {option.text?.text ?? option.itemId}
+                                      </span>
+                                    )}
+                                  </>
+                                )),
+                              )}
+                            </RadioGroup>
+                          </>,
+                        )}
+                      </>
+                    ),
+                  }),
+                )}
+              </div>
+            )}
+
+            {/* Outline item cards — every activity type the structure doesn't
+                cover (open-ended, true/false, multi-select, tables), plus answer
+                units a successful FITB/MC extraction missed. */}
+            {visibleOutlineItems.length > 0 && (
+              <div className="space-y-2.5">
+                <SectionHeading count={visibleOutlineItems.length}>
+                  {structure ? t`Other items` : t`Items`}
+                </SectionHeading>
+                {visibleOutlineItems.map((item, i) => outlineItemCard(item, i))}
+              </div>
+            )}
+
+            {/* Ungrouped answers (flat — always shown when present). Boolean
+                entries are correctness flags: checked = correct. */}
+            {otherAnswerEntries.length > 0 &&
+              answerZone(
+                <>
+                  {answersHeading(
+                    otherAnswerEntries.length === 1 ? t`Answer` : t`Answers`,
+                  )}
+                  {otherAnswerEntries.map(([itemId, value]) =>
+                    typeof value === "boolean" ? (
+                      <Anchored key={itemId} anchor={answerAnchor(itemId)}>
+                        <label className="flex cursor-pointer items-center gap-2">
+                          <input
+                            type="checkbox"
+                            checked={isCorrectAnswer(value)}
+                            onChange={(e) => onAnswersEdited({ [itemId]: e.target.checked })}
+                            aria-label={t`Correct answer`}
+                            className="h-4 w-4 shrink-0 cursor-pointer accent-emerald-600"
+                          />
+                          <ItemIdChip itemId={itemId} hint={t`Answer key reference`} />
+                        </label>
+                      </Anchored>
+                    ) : (
+                      answerField(itemId)
+                    ),
+                  )}
+                </>,
+              )}
+
+            {/* Ungrouped texts */}
+            {otherTextLeaves.length > 0 && (
+              <div className="space-y-2">
+                <SectionHeading count={otherTextLeaves.length}>
+                  {structure || visibleOutlineItems.length > 0 ? t`Other text` : t`Text`}
+                </SectionHeading>
+                {otherTextLeaves.map((leaf) => (
+                  <div key={leaf.nodeId} className="space-y-1">
+                    {leaf.role && leaf.role !== "paragraph" && (
+                      <span className="font-mono text-[11px] text-muted-foreground">
+                        {leaf.role}
+                      </span>
+                    )}
+                    {textField(leaf.nodeId, false, t`Activity text`)}
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {/* Ungrouped images (read-only — swapping happens in the layout editor) */}
+            {otherImageLeaves.length > 0 && (
+              <div className="space-y-2">
+                <SectionHeading count={otherImageLeaves.length}>
+                  <span className="flex items-center gap-1.5">
+                    <ImageIcon className="h-3 w-3" aria-hidden="true" />
+                    {t`Images`}
+                  </span>
+                </SectionHeading>
+                <div className="grid grid-cols-3 gap-2">
+                  {otherImageLeaves.map((leaf) =>
+                    imageThumb(
+                      leaf.nodeId,
+                      "h-20 w-full rounded border bg-white object-contain",
+                    ),
+                  )}
+                </div>
+                <p className="text-[11px] text-muted-foreground">
+                  {t`To replace an image, use "Edit layout" and click the image.`}
+                </p>
+              </div>
             )}
           </div>
-        )}
-
-        {/* Ungrouped texts */}
-        {otherTextLeaves.length > 0 && (
-          <div className="space-y-1.5">
-            <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-              {structure || visibleOutlineItems.length > 0 ? t`Other text` : t`Text`} (
-              {otherTextLeaves.length})
-            </h3>
-            {otherTextLeaves.map((leaf) => (
-              <div key={leaf.nodeId} className="space-y-0.5">
-                {leaf.role && leaf.role !== "paragraph" && (
-                  <span className="text-[10px] font-mono text-muted-foreground">{leaf.role}</span>
-                )}
-                {textField(leaf.nodeId, false, t`Activity text`)}
-              </div>
-            ))}
-          </div>
-        )}
-
-        {/* Ungrouped images (read-only — swapping happens in the layout editor) */}
-        {otherImageLeaves.length > 0 && (
-          <div className="space-y-1.5">
-            <h3 className="flex items-center gap-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-              <ImageIcon className="h-3 w-3" aria-hidden="true" />
-              {t`Images`} ({otherImageLeaves.length})
-            </h3>
-            <div className="grid grid-cols-3 gap-2">
-              {otherImageLeaves.map((leaf) => (
-                <img
-                  key={leaf.nodeId}
-                  src={`${BASE_URL}/books/${bookLabel}/images/${leaf.nodeId}`}
-                  alt={leaf.text ?? ""}
-                  title={leaf.nodeId}
-                  className="h-20 w-full rounded border object-contain bg-white"
-                />
-              ))}
-            </div>
-            <p className="text-[10px] text-muted-foreground">
-              {t`To replace an image, use "Edit layout" and click the image.`}
-            </p>
-          </div>
-        )}
-      </div>
+        </ScrollArea>
+      </LinkContext.Provider>
 
       {/* Save bar */}
-      <div className="border-t bg-background p-3 flex items-center justify-end gap-2">
-        <button
+      <div className="flex shrink-0 items-center gap-2 border-t bg-background p-3">
+        <span className="flex flex-1 items-center gap-1.5 text-[11px] text-muted-foreground">
+          {dirty && <span className="h-1.5 w-1.5 rounded-full bg-amber-500" aria-hidden="true" />}
+          {dirty ? t`Unsaved changes` : t`All changes saved`}
+        </span>
+        <Button
           type="button"
+          variant="secondary"
           onClick={onDiscard}
           disabled={!dirty || saving}
-          className="h-8 px-3 rounded text-xs font-medium bg-muted hover:bg-accent disabled:opacity-40 transition-colors cursor-pointer"
+          className="h-8 px-3 text-xs"
         >
           {t`Discard`}
-        </button>
-        <button
-          type="button"
-          onClick={onSave}
-          disabled={!dirty || saving}
-          className="h-8 px-4 rounded text-xs font-medium bg-violet-600 text-white hover:bg-violet-700 disabled:opacity-40 transition-colors cursor-pointer"
-        >
-          {saving ? t`Saving…` : t`Save activity`}
-        </button>
+        </Button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span>
+              <Button
+                type="button"
+                onClick={onSave}
+                disabled={!dirty || saving}
+                className="h-8 gap-1.5 bg-violet-600 px-4 text-xs text-white hover:bg-violet-700"
+              >
+                {saving && <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />}
+                {saving ? t`Saving…` : t`Save activity`}
+              </Button>
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>{t`Save activity (⌘S)`}</TooltipContent>
+        </Tooltip>
       </div>
     </div>
   )

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/ClassicActivityPanel.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/ClassicActivityPanel.tsx
@@ -102,6 +102,38 @@ const HINT_DISMISSED_STORAGE_KEY = "adt:activity-panel-hint-dismissed"
 const NO_CHOICE_ID = "__none__"
 
 /**
+ * localStorage throws outright where site data is blocked (third-party
+ * context, a locked-down Electron partition) and on quota. These reads happen
+ * in render, so an unguarded throw would blank the whole storyboard stage
+ * rather than fall back to a default width.
+ */
+function readStoredWidth(): number {
+  try {
+    const stored = Number(localStorage.getItem(PANEL_WIDTH_STORAGE_KEY))
+    if (!Number.isFinite(stored) || stored <= 0) return DEFAULT_PANEL_WIDTH
+    return Math.min(MAX_PANEL_WIDTH, Math.max(MIN_PANEL_WIDTH, stored))
+  } catch {
+    return DEFAULT_PANEL_WIDTH
+  }
+}
+
+function writeStoredWidth(width: number): void {
+  try {
+    localStorage.setItem(PANEL_WIDTH_STORAGE_KEY, String(width))
+  } catch {
+    // A non-persisted width is a cosmetic loss; never break the editor for it.
+  }
+}
+
+function readHintDismissed(): boolean {
+  try {
+    return localStorage.getItem(HINT_DISMISSED_STORAGE_KEY) === "1"
+  } catch {
+    return false
+  }
+}
+
+/**
  * Suppresses a control's own focus ring. Not a loss of affordance: a field can
  * only be focused when it is the selection, so `Anchored` is already drawing a
  * violet outline around it. Without this the answer inputs carry three
@@ -331,7 +363,20 @@ function Anchored({
     if (!isLinked || !fromPage) return
     const el = ref.current
     if (!el) return
-    el.scrollIntoView({ block: "center", behavior: scrollBehavior() })
+    // Scoped to the panel's own scroller. `scrollIntoView` walks every
+    // scrollable ancestor, so it would also drag the storyboard canvas — the
+    // Studio layout jumping while the user only meant to move within the list.
+    const viewport = el.closest<HTMLElement>("[data-radix-scroll-area-viewport]")
+    if (viewport) {
+      const target = el.getBoundingClientRect()
+      const view = viewport.getBoundingClientRect()
+      viewport.scrollBy({
+        top: target.top - view.top - (view.height - target.height) / 2,
+        behavior: scrollBehavior(),
+      })
+    } else {
+      el.scrollIntoView({ block: "center", behavior: scrollBehavior() })
+    }
     // Hand over the caret so a page click lands the user ready to type, or on
     // the choice control when the row has no text field.
     const focusable =
@@ -661,35 +706,45 @@ export function ClassicActivityPanel({
   // Desktop tool: the panel competes with the page preview for width, so the
   // split is the user's to set. Persisted globally — it's a workspace
   // preference, not per-book state.
-  const [panelWidth, setPanelWidth] = useState(() => {
-    const stored = Number(localStorage.getItem(PANEL_WIDTH_STORAGE_KEY))
-    if (!Number.isFinite(stored) || stored <= 0) return DEFAULT_PANEL_WIDTH
-    return Math.min(MAX_PANEL_WIDTH, Math.max(MIN_PANEL_WIDTH, stored))
-  })
+  const [panelWidth, setPanelWidth] = useState(readStoredWidth)
   const startResize = useCallback(
     (e: React.PointerEvent<HTMLDivElement>) => {
       e.preventDefault()
+      const grip = e.currentTarget
+      const pointerId = e.pointerId
       const startX = e.clientX
       const startWidth = panelWidth
       const clamp = (ev: PointerEvent) =>
         Math.min(MAX_PANEL_WIDTH, Math.max(MIN_PANEL_WIDTH, startWidth + (startX - ev.clientX)))
+
       const onMove = (ev: PointerEvent) => setPanelWidth(clamp(ev))
-      const onUp = (ev: PointerEvent) => {
-        window.removeEventListener("pointermove", onMove)
-        window.removeEventListener("pointerup", onUp)
-        localStorage.setItem(PANEL_WIDTH_STORAGE_KEY, String(clamp(ev)))
+      const finish = (ev: PointerEvent) => {
+        grip.removeEventListener("pointermove", onMove)
+        grip.removeEventListener("pointerup", finish)
+        grip.removeEventListener("pointercancel", finish)
+        grip.releasePointerCapture?.(pointerId)
+        writeStoredWidth(clamp(ev))
       }
-      window.addEventListener("pointermove", onMove)
-      window.addEventListener("pointerup", onUp)
+
+      // Capture is what makes this survive the drag: the grip sits on the
+      // panel's left edge, so widening drags the pointer straight over the
+      // preview iframe, which would otherwise receive the events itself —
+      // freezing the drag and leaving the listeners attached for good.
+      grip.setPointerCapture?.(pointerId)
+      grip.addEventListener("pointermove", onMove)
+      grip.addEventListener("pointerup", finish)
+      grip.addEventListener("pointercancel", finish)
     },
     [panelWidth],
   )
 
-  const [hintDismissed, setHintDismissed] = useState(
-    () => localStorage.getItem(HINT_DISMISSED_STORAGE_KEY) === "1",
-  )
+  const [hintDismissed, setHintDismissed] = useState(readHintDismissed)
   const dismissHint = useCallback(() => {
-    localStorage.setItem(HINT_DISMISSED_STORAGE_KEY, "1")
+    try {
+      localStorage.setItem(HINT_DISMISSED_STORAGE_KEY, "1")
+    } catch {
+      // Dismissal just won't persist across reloads.
+    }
     setHintDismissed(true)
   }, [])
 
@@ -818,11 +873,14 @@ export function ClassicActivityPanel({
     </div>
   )
 
-  const imageThumb = (imageId: string, className: string) => (
+  const imageThumb = (imageId: string, className: string, alt?: string) => (
     <Anchored key={imageId} anchor={imageAnchor(imageId)} className="inline-flex">
       <img
         src={`${BASE_URL}/books/${bookLabel}/images/${imageId}`}
-        alt=""
+        // Decorative only when the caller has nothing to say about it —
+        // the ungrouped-images grid does, and dropping it left that whole
+        // section silent to a screen reader.
+        alt={alt ?? ""}
         title={imageId}
         className={className}
       />
@@ -856,10 +914,12 @@ export function ClassicActivityPanel({
       </div>
     )
 
-  const correctRadio = (value: string) => (
+  const correctRadio = (value: string, disabled = false) => (
     <RadioGroupItem
       value={value}
+      disabled={disabled}
       aria-label={t`Correct answer`}
+      title={disabled ? t`This option has no answer key entry` : undefined}
       className="shrink-0 border-emerald-500 text-emerald-600 dark:border-emerald-400 dark:text-emerald-400"
     />
   )
@@ -867,6 +927,21 @@ export function ClassicActivityPanel({
   /** The item-id currently flagged correct in a single-choice group. */
   const correctOf = (ids: (string | undefined)[]) =>
     ids.find((id) => id && isCorrectAnswer(answers?.[id])) ?? NO_CHOICE_ID
+
+  /**
+   * The stored value for a value-choice (true/false) group, matched back to
+   * the option that carries it. The answer key and the rendered `value`
+   * attribute come from different producers, so they drift in case — a key of
+   * "True" against `value="true"` must still read as selected, or the editor
+   * reports an answered item as unanswered and the author re-picks it,
+   * silently rewriting a correct key.
+   */
+  const selectedValueOf = (item: ActivityOutlineItem, itemId: string): string => {
+    const stored = String(answers?.[itemId] ?? "").trim().toLowerCase()
+    if (!stored) return NO_CHOICE_ID
+    const match = item.options.find((o) => (o.value ?? "").trim().toLowerCase() === stored)
+    return match?.value ?? NO_CHOICE_ID
+  }
 
   const optionTextControl = (item: ActivityOutlineItem, optIndex: number) => {
     const o = item.options[optIndex]
@@ -1116,7 +1191,7 @@ export function ClassicActivityPanel({
                         single answer, so it anchors as one unit. */}
                     <Anchored anchor={answerAnchor(valueItemId)}>
                       <RadioGroup
-                        value={String(answers?.[valueItemId] ?? NO_CHOICE_ID)}
+                        value={selectedValueOf(item, valueItemId)}
                         onValueChange={(v) => onAnswersEdited({ [valueItemId]: v })}
                         className="flex flex-wrap items-center gap-4"
                       >
@@ -1162,19 +1237,24 @@ export function ClassicActivityPanel({
                 {answersHeading(t`Options — the selected radio marks the correct answer`)}
                 <RadioGroup
                   value={correctOf(item.options.map((o) => o.itemId))}
-                  onValueChange={(id) =>
+                  onValueChange={(id) => {
+                    // An option the extractor could not resolve carries a
+                    // synthetic value. Selecting it must be inert: writing the
+                    // group would set every real option to false and wipe the
+                    // answer the author already had.
+                    if (!item.options.some((x) => x.itemId === id)) return
                     onAnswersEdited(
                       Object.fromEntries(
                         item.options.filter((x) => x.itemId).map((x) => [x.itemId!, x.itemId === id]),
                       ),
                     )
-                  }
+                  }}
                   className="gap-2"
                 >
                   {item.options.map((o, oi) =>
                     optionRow(o.itemId, oi, (
                       <>
-                        {correctRadio(o.itemId ?? `${NO_CHOICE_ID}-${oi}`)}
+                        {correctRadio(o.itemId ?? `${NO_CHOICE_ID}-${oi}`, !o.itemId)}
                         {o.imageId &&
                           imageThumb(o.imageId, "h-8 w-8 rounded border object-cover shrink-0")}
                         {optionTextControl(item, oi)}
@@ -1651,6 +1731,7 @@ export function ClassicActivityPanel({
                     imageThumb(
                       leaf.nodeId,
                       "h-20 w-full rounded border bg-white object-contain",
+                      leaf.text ?? "",
                     ),
                   )}
                 </div>

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
@@ -59,7 +59,7 @@ import { SectionEditPanel } from "./SectionEditPanel"
 import { StorySectionBanner } from "./StorySectionBanner"
 import { EditableActivityPanel } from "./EditableActivityPanel"
 import { ClassicActivityPanel } from "./ClassicActivityPanel"
-import type { ActivityAnchor } from "./activity-link"
+import { sameAnchor, type ActivityAnchor } from "./activity-link"
 import { scrollBehavior } from "@/lib/utils"
 import { StepperActivityPreview } from "./StepperActivityPreview"
 import {
@@ -1353,6 +1353,16 @@ export function StoryboardSectionDetail({
     setLinkedFromPage(true)
   }, [])
 
+  /**
+   * Hover fires once per element the pointer crosses, and each report is a
+   * freshly allocated anchor — so a plain identity set would re-render this
+   * whole component (and every anchored field) on every mouse move, even when
+   * the resolved anchor has not actually changed. Collapse by value.
+   */
+  const handleAnchorHover = useCallback((anchor: ActivityAnchor | null) => {
+    setHoverAnchor((prev) => (sameAnchor(prev, anchor) || prev === anchor ? prev : anchor))
+  }, [])
+
   const handleClassesChange = useCallback(
     (dataId: string, classes: string[]) => {
       if (!page.rendering) return
@@ -2230,15 +2240,13 @@ export function StoryboardSectionDetail({
                             layout/style work. */}
                         <button
                           type="button"
-                          onClick={() => {
-                            // Editing content needs the WYSIWYG frame: it
-                            // updates live and carries the link channel, while
-                            // the interactive preview only reflects saves.
-                            setEditActivityPanelOpen((v) => {
-                              if (!v) setActivityPreviewMode(false)
-                              return !v
-                            })
-                          }}
+                          // Only toggles the panel. The render gate below
+                          // already swaps in the WYSIWYG frame while it is
+                          // open — which is what content editing needs, since
+                          // that frame updates live and carries the link
+                          // channel — so the user's Try Activity preference
+                          // survives to when they close the panel again.
+                          onClick={() => setEditActivityPanelOpen((v) => !v)}
                           className="flex items-center gap-1.5 h-7 px-3 rounded-md text-xs font-medium bg-violet-600 text-white hover:bg-violet-700 transition-colors cursor-pointer"
                         >
                           <ListChecks className="h-3.5 w-3.5" />
@@ -2331,7 +2339,7 @@ export function StoryboardSectionDetail({
                   linkedAnchor={linkedAnchor}
                   previewAnchor={linkedAnchor ? null : hoverAnchor}
                   onLinkSelect={handleLinkSelectFromPage}
-                  onLinkHover={setHoverAnchor}
+                  onLinkHover={handleAnchorHover}
                   onVisibleWidthChange={setPreviewVisibleWidth}
                   bodyFontFamily={pageDetail?.reflowableFontFamily ?? undefined}
                 />
@@ -2563,7 +2571,7 @@ export function StoryboardSectionDetail({
           hoveredAnchor={hoverAnchor}
           linkedFromPage={linkedFromPage}
           onAnchorSelect={handleAnchorSelectFromPanel}
-          onAnchorHover={setHoverAnchor}
+          onAnchorHover={handleAnchorHover}
           dirty={renderingDirty || dirty}
           saving={saving}
           onSave={() => {

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
@@ -59,6 +59,8 @@ import { SectionEditPanel } from "./SectionEditPanel"
 import { StorySectionBanner } from "./StorySectionBanner"
 import { EditableActivityPanel } from "./EditableActivityPanel"
 import { ClassicActivityPanel } from "./ClassicActivityPanel"
+import type { ActivityAnchor } from "./activity-link"
+import { scrollBehavior } from "@/lib/utils"
 import { StepperActivityPreview } from "./StepperActivityPreview"
 import {
   useActivityStructure,
@@ -574,6 +576,20 @@ export function StoryboardSectionDetail({
     pageHasActivitySection,
   )
   const [editActivityPanelOpen, setEditActivityPanelOpen] = useState(false)
+  // Two-way link between the activity editor and the rendered page.
+  //
+  // `linkedAnchor` is the committed selection (a click in the page, a focused
+  // field, the panel's "show in page" button); `hoverAnchor` is a preview from
+  // whichever surface the pointer is over — only one can be hovered at a time,
+  // so a single slot serves both directions.
+  //
+  // The selection wins: `linkedAnchor ?? hoverAnchor`. With nothing selected,
+  // sweeping either surface previews the pairing; once something is selected
+  // the highlight is pinned and only another selection moves it, so the page
+  // holds still while the user edits. Escape releases it.
+  const [linkedAnchor, setLinkedAnchor] = useState<ActivityAnchor | null>(null)
+  const [linkedFromPage, setLinkedFromPage] = useState(false)
+  const [hoverAnchor, setHoverAnchor] = useState<ActivityAnchor | null>(null)
   // Read-only structure + outline of a classic activity — organizes the
   // classic activity editor. Works for all activity types, but is only
   // consumed by the edit panel, so don't fetch until it opens (the server
@@ -1306,6 +1322,37 @@ export function StoryboardSectionDetail({
     setSelectedElementClasses(previewFrameRef.current?.getElementClasses(dataId) ?? null)
   }, [])
 
+  // ── Activity editor ↔ page linking ──────────────────────────────────────
+  /** Scroll the preview so the anchored element is visible. The element lives
+   *  inside the iframe, which doesn't scroll in desktop view — the host's
+   *  scroll container is the one that has to move. */
+  const revealAnchorInPage = useCallback((anchor: ActivityAnchor) => {
+    const container = scrollContainerRef.current
+    const rect = previewFrameRef.current?.getAnchorViewportRect(anchor)
+    if (!container || !rect) return
+    const view = container.getBoundingClientRect()
+    const margin = 24
+    if (rect.top >= view.top + margin && rect.bottom <= view.bottom - margin) return
+    container.scrollBy({
+      top: rect.top - view.top - (view.height - rect.height) / 2,
+      behavior: scrollBehavior(),
+    })
+  }, [])
+
+  const handleAnchorSelectFromPanel = useCallback(
+    (anchor: ActivityAnchor | null) => {
+      setLinkedAnchor(anchor)
+      setLinkedFromPage(false)
+      if (anchor) revealAnchorInPage(anchor)
+    },
+    [revealAnchorInPage],
+  )
+
+  const handleLinkSelectFromPage = useCallback((anchor: ActivityAnchor | null) => {
+    setLinkedAnchor(anchor)
+    setLinkedFromPage(true)
+  }, [])
+
   const handleClassesChange = useCallback(
     (dataId: string, classes: string[]) => {
       if (!page.rendering) return
@@ -1955,6 +2002,26 @@ export function StoryboardSectionDetail({
   const editableBusy =
     convertEditableActivity.isPending || setEditablePresentation.isPending
 
+  // With the classic activity editor open the page becomes a click-to-locate
+  // map: inline editing is off (content is edited in the panel) and clicks
+  // report an anchor instead. The panel also forces the WYSIWYG preview, so
+  // edits appear immediately rather than after a save + re-render.
+  const activityLinkMode = isActivitySection && !stepperEnabled && editActivityPanelOpen
+
+  // Drop stale links when the panel toggles or the user moves to another
+  // section — an anchor from a different page would highlight nothing. Opening
+  // the panel also dismisses the style inspector: its element selection came
+  // from the layout editor, which link mode has just switched off.
+  useEffect(() => {
+    setLinkedAnchor(null)
+    setLinkedFromPage(false)
+    setHoverAnchor(null)
+    if (editActivityPanelOpen) {
+      setSelectedElement(null)
+      setSelectedElementClasses(null)
+    }
+  }, [editActivityPanelOpen, sectionIndex, pageId])
+
   const handleToggleStepper = () => {
     if (editableEntry) {
       const enabling = !editableEntry.enabled
@@ -2163,7 +2230,15 @@ export function StoryboardSectionDetail({
                             layout/style work. */}
                         <button
                           type="button"
-                          onClick={() => setEditActivityPanelOpen((v) => !v)}
+                          onClick={() => {
+                            // Editing content needs the WYSIWYG frame: it
+                            // updates live and carries the link channel, while
+                            // the interactive preview only reflects saves.
+                            setEditActivityPanelOpen((v) => {
+                              if (!v) setActivityPreviewMode(false)
+                              return !v
+                            })
+                          }}
                           className="flex items-center gap-1.5 h-7 px-3 rounded-md text-xs font-medium bg-violet-600 text-white hover:bg-violet-700 transition-colors cursor-pointer"
                         >
                           <ListChecks className="h-3.5 w-3.5" />
@@ -2222,7 +2297,7 @@ export function StoryboardSectionDetail({
                   deviceView={deviceView}
                 />
               </>
-            ) : isActivitySection && activityPreviewMode ? (
+            ) : isActivitySection && activityPreviewMode && !editActivityPanelOpen ? (
               <>
                 {renderingDirty && (
                   <div className="mb-2 flex justify-center">
@@ -2252,6 +2327,11 @@ export function StoryboardSectionDetail({
                   selectedDataId={selectedElement?.dataId ?? null}
                   renderWidth={DEVICE_WIDTHS[deviceView]}
                   deviceView={deviceView}
+                  linkMode={activityLinkMode}
+                  linkedAnchor={linkedAnchor}
+                  previewAnchor={linkedAnchor ? null : hoverAnchor}
+                  onLinkSelect={handleLinkSelectFromPage}
+                  onLinkHover={setHoverAnchor}
                   onVisibleWidthChange={setPreviewVisibleWidth}
                   bodyFontFamily={pageDetail?.reflowableFontFamily ?? undefined}
                 />
@@ -2479,6 +2559,11 @@ export function StoryboardSectionDetail({
           onTextEdited={handleLeafTextEdited}
           onAnswerEdited={updateAnswer}
           onAnswersEdited={updateAnswers}
+          linkedAnchor={linkedAnchor}
+          hoveredAnchor={hoverAnchor}
+          linkedFromPage={linkedFromPage}
+          onAnchorSelect={handleAnchorSelectFromPanel}
+          onAnchorHover={setHoverAnchor}
           dirty={renderingDirty || dirty}
           saving={saving}
           onSave={() => {

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
@@ -576,17 +576,6 @@ export function StoryboardSectionDetail({
     pageHasActivitySection,
   )
   const [editActivityPanelOpen, setEditActivityPanelOpen] = useState(false)
-  // Two-way link between the activity editor and the rendered page.
-  //
-  // `linkedAnchor` is the committed selection (a click in the page, a focused
-  // field, the panel's "show in page" button); `hoverAnchor` is a preview from
-  // whichever surface the pointer is over — only one can be hovered at a time,
-  // so a single slot serves both directions.
-  //
-  // The selection wins: `linkedAnchor ?? hoverAnchor`. With nothing selected,
-  // sweeping either surface previews the pairing; once something is selected
-  // the highlight is pinned and only another selection moves it, so the page
-  // holds still while the user edits. Escape releases it.
   const [linkedAnchor, setLinkedAnchor] = useState<ActivityAnchor | null>(null)
   const [linkedFromPage, setLinkedFromPage] = useState(false)
   const [hoverAnchor, setHoverAnchor] = useState<ActivityAnchor | null>(null)
@@ -1322,10 +1311,6 @@ export function StoryboardSectionDetail({
     setSelectedElementClasses(previewFrameRef.current?.getElementClasses(dataId) ?? null)
   }, [])
 
-  // ── Activity editor ↔ page linking ──────────────────────────────────────
-  /** Scroll the preview so the anchored element is visible. The element lives
-   *  inside the iframe, which doesn't scroll in desktop view — the host's
-   *  scroll container is the one that has to move. */
   const revealAnchorInPage = useCallback((anchor: ActivityAnchor) => {
     const container = scrollContainerRef.current
     const rect = previewFrameRef.current?.getAnchorViewportRect(anchor)
@@ -1353,12 +1338,6 @@ export function StoryboardSectionDetail({
     setLinkedFromPage(true)
   }, [])
 
-  /**
-   * Hover fires once per element the pointer crosses, and each report is a
-   * freshly allocated anchor — so a plain identity set would re-render this
-   * whole component (and every anchored field) on every mouse move, even when
-   * the resolved anchor has not actually changed. Collapse by value.
-   */
   const handleAnchorHover = useCallback((anchor: ActivityAnchor | null) => {
     setHoverAnchor((prev) => (sameAnchor(prev, anchor) || prev === anchor ? prev : anchor))
   }, [])
@@ -2012,16 +1991,8 @@ export function StoryboardSectionDetail({
   const editableBusy =
     convertEditableActivity.isPending || setEditablePresentation.isPending
 
-  // With the classic activity editor open the page becomes a click-to-locate
-  // map: inline editing is off (content is edited in the panel) and clicks
-  // report an anchor instead. The panel also forces the WYSIWYG preview, so
-  // edits appear immediately rather than after a save + re-render.
   const activityLinkMode = isActivitySection && !stepperEnabled && editActivityPanelOpen
 
-  // Drop stale links when the panel toggles or the user moves to another
-  // section — an anchor from a different page would highlight nothing. Opening
-  // the panel also dismisses the style inspector: its element selection came
-  // from the layout editor, which link mode has just switched off.
   useEffect(() => {
     setLinkedAnchor(null)
     setLinkedFromPage(false)
@@ -2240,12 +2211,6 @@ export function StoryboardSectionDetail({
                             layout/style work. */}
                         <button
                           type="button"
-                          // Only toggles the panel. The render gate below
-                          // already swaps in the WYSIWYG frame while it is
-                          // open — which is what content editing needs, since
-                          // that frame updates live and carries the link
-                          // channel — so the user's Try Activity preference
-                          // survives to when they close the panel again.
                           onClick={() => setEditActivityPanelOpen((v) => !v)}
                           className="flex items-center gap-1.5 h-7 px-3 rounded-md text-xs font-medium bg-violet-600 text-white hover:bg-violet-700 transition-colors cursor-pointer"
                         >
@@ -2518,9 +2483,6 @@ export function StoryboardSectionDetail({
           </div>
         </div>
       )}
-
-
-
 
       {/* Slide-out step-by-step activity editor (CMS). The key MUST include
           book+page: the component instance survives page navigation, and a

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/activity-link.ts
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/activity-link.ts
@@ -1,0 +1,85 @@
+/**
+ * Shared anchor vocabulary for the two-way link between the classic-activity
+ * editor panel and the rendered page in the preview iframe.
+ *
+ * Both sides already address the same content deterministically — texts and
+ * images by `data-id`, answer fields by `data-activity-item` (the item-id the
+ * answer key is stored under). An anchor is just that pair, so a click in the
+ * page resolves to exactly one editor field and vice versa; no positional or
+ * heuristic matching is involved.
+ */
+
+export type ActivityAnchorKind = "text" | "image" | "answer"
+
+export interface ActivityAnchor {
+  kind: ActivityAnchorKind
+  id: string
+}
+
+export function textAnchor(id: string): ActivityAnchor {
+  return { kind: "text", id }
+}
+
+export function imageAnchor(id: string): ActivityAnchor {
+  return { kind: "image", id }
+}
+
+export function answerAnchor(id: string): ActivityAnchor {
+  return { kind: "answer", id }
+}
+
+/** Stable identity string — usable as a React key or a DOM attribute. */
+export function anchorKey(anchor: ActivityAnchor): string {
+  return `${anchor.kind}:${anchor.id}`
+}
+
+/** Inverse of {@link anchorKey}; ids may contain ":" so only split once. */
+export function parseAnchorKey(key: string | null | undefined): ActivityAnchor | null {
+  if (!key) return null
+  const sep = key.indexOf(":")
+  if (sep < 0) return null
+  return parseAnchor(key.slice(0, sep), key.slice(sep + 1))
+}
+
+export function sameAnchor(
+  a: ActivityAnchor | null | undefined,
+  b: ActivityAnchor | null | undefined,
+): boolean {
+  if (!a || !b) return false
+  return a.kind === b.kind && a.id === b.id
+}
+
+/**
+ * CSS selector locating the anchor inside the preview document. Images and
+ * texts share the `data-id` channel — the kind only tells the editor which
+ * control to focus, so it doesn't change the selector.
+ */
+export function anchorSelector(anchor: ActivityAnchor): string {
+  const escaped = CSS.escape(anchor.id)
+  return anchor.kind === "answer"
+    ? `[data-activity-item="${escaped}"]`
+    : `[data-id="${escaped}"]`
+}
+
+/**
+ * The element to outline for an anchor. Answer controls are routinely
+ * `sr-only` (the visible affordance is a styled sibling box), so outlining the
+ * matched element itself would draw nothing — climb to the first ancestor with
+ * a real box, which is the option label or field wrapper.
+ */
+export function resolveVisibleTarget(el: Element): Element {
+  let node: Element | null = el
+  for (let depth = 0; depth < 4 && node; depth++) {
+    const rect = node.getBoundingClientRect()
+    if (rect.width > 2 && rect.height > 2) return node
+    node = node.parentElement
+  }
+  return el
+}
+
+/** Narrow an untrusted postMessage payload to an anchor. */
+export function parseAnchor(kind: unknown, id: unknown): ActivityAnchor | null {
+  if (typeof id !== "string" || !id) return null
+  if (kind !== "text" && kind !== "image" && kind !== "answer") return null
+  return { kind, id }
+}

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/activity-link.ts
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/activity-link.ts
@@ -1,14 +1,9 @@
 /**
  * Shared anchor vocabulary for the two-way link between the classic-activity
- * editor panel and the rendered page in the preview iframe.
- *
- * Both sides already address the same content deterministically — texts and
- * images by `data-id`, answer fields by `data-activity-item` (the item-id the
- * answer key is stored under). An anchor is just that pair, so a click in the
- * page resolves to exactly one editor field and vice versa; no positional or
- * heuristic matching is involved.
+ * editor and the rendered page. Texts and images are addressed by `data-id`,
+ * answers by `data-activity-item`, so a click on either surface resolves to
+ * exactly one target on the other.
  */
-
 export type ActivityAnchorKind = "text" | "image" | "answer"
 
 export interface ActivityAnchor {
@@ -28,12 +23,10 @@ export function answerAnchor(id: string): ActivityAnchor {
   return { kind: "answer", id }
 }
 
-/** Stable identity string — usable as a React key or a DOM attribute. */
 export function anchorKey(anchor: ActivityAnchor): string {
   return `${anchor.kind}:${anchor.id}`
 }
 
-/** Inverse of {@link anchorKey}; ids may contain ":" so only split once. */
 export function parseAnchorKey(key: string | null | undefined): ActivityAnchor | null {
   if (!key) return null
   const sep = key.indexOf(":")
@@ -49,11 +42,6 @@ export function sameAnchor(
   return a.kind === b.kind && a.id === b.id
 }
 
-/**
- * CSS selector locating the anchor inside the preview document. Images and
- * texts share the `data-id` channel — the kind only tells the editor which
- * control to focus, so it doesn't change the selector.
- */
 export function anchorSelector(anchor: ActivityAnchor): string {
   const escaped = CSS.escape(anchor.id)
   return anchor.kind === "answer"
@@ -61,12 +49,6 @@ export function anchorSelector(anchor: ActivityAnchor): string {
     : `[data-id="${escaped}"]`
 }
 
-/**
- * The element to outline for an anchor. Answer controls are routinely
- * `sr-only` (the visible affordance is a styled sibling box), so outlining the
- * matched element itself would draw nothing — climb to the first ancestor with
- * a real box, which is the option label or field wrapper.
- */
 export function resolveVisibleTarget(el: Element): Element {
   let node: Element | null = el
   for (let depth = 0; depth < 4 && node; depth++) {
@@ -77,7 +59,6 @@ export function resolveVisibleTarget(el: Element): Element {
   return el
 }
 
-/** Narrow an untrusted postMessage payload to an anchor. */
 export function parseAnchor(kind: unknown, id: unknown): ActivityAnchor | null {
   if (typeof id !== "string" || !id) return null
   if (kind !== "text" && kind !== "image" && kind !== "answer") return null

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/iframe-interactive.ts
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/iframe-interactive.ts
@@ -1,6 +1,12 @@
 // Interactive editing script + styles injected into the BookPreviewFrame
 // iframe. The script is gated by `body[data-editable="true"]`, so toggling
 // editability does not require an iframe reload.
+//
+// A second, mutually exclusive gate — `body[data-link-mode="true"]` — powers
+// the activity editor's page↔panel linking: clicks resolve to an anchor and
+// are reported to the parent instead of opening an inline editor, and every
+// default action is suppressed so clicking a blank in the page never types
+// into the preview.
 
 export const INTERACTIVE_SCRIPT = `<script>
 (function() {
@@ -9,8 +15,67 @@ export const INTERACTIVE_SCRIPT = `<script>
   var savedDisplayHtml = null;
   var savedOriginalText = null;
   var containerIdCounter = 0;
+  var hoveredLink = null;
 
   function isEditable() { return document.body.dataset.editable === 'true'; }
+  function isLinkMode() { return document.body.dataset.linkMode === 'true'; }
+
+  // Answer controls are usually sr-only — the visible affordance is a styled
+  // sibling box. Outlining the control itself would draw nothing, so climb to
+  // the first ancestor that has a real box.
+  function visibleTarget(el) {
+    var node = el;
+    for (var d = 0; d < 4 && node; d++) {
+      var r = node.getBoundingClientRect();
+      if (r.width > 2 && r.height > 2) return node;
+      node = node.parentElement;
+    }
+    return el;
+  }
+
+  // Nearest addressable ancestor, resolved by intent rather than raw proximity:
+  //   • text or an image with actual content wins — the user clicked words or
+  //     a picture and means to edit them (this keeps a sentence with an inline
+  //     blank editable as text);
+  //   • otherwise the enclosing region owning exactly ONE answer control is
+  //     that answer, which is how clicking an empty checkbox box or an
+  //     option's letter selects the answer instead of a decorative span.
+  // Requiring exactly one control stops the walk from swallowing a whole
+  // question list once it reaches a shared container.
+  function findAnchor(target) {
+    var el = target;
+    var answerRegion = null;
+    while (el && el !== document.body) {
+      if (el.nodeType === 1) {
+        var itemId = el.getAttribute('data-activity-item');
+        if (itemId) return { el: visibleTarget(el), kind: 'answer', id: itemId };
+        var dataId = el.getAttribute('data-id');
+        if (dataId) {
+          if (el.tagName === 'IMG') return { el: el, kind: 'image', id: dataId };
+          if ((el.textContent || '').trim()) return { el: el, kind: 'text', id: dataId };
+        }
+        if (!answerRegion) {
+          var owned = el.querySelectorAll('[data-activity-item]');
+          if (owned.length === 1) {
+            answerRegion = {
+              el: el,
+              kind: 'answer',
+              id: owned[0].getAttribute('data-activity-item')
+            };
+          }
+        }
+      }
+      el = el.parentElement;
+    }
+    return answerRegion;
+  }
+
+  function setHoveredLink(el) {
+    if (hoveredLink === el) return;
+    if (hoveredLink) hoveredLink.removeAttribute('data-adt-link-hover');
+    hoveredLink = el;
+    if (hoveredLink) hoveredLink.setAttribute('data-adt-link-hover', 'true');
+  }
 
   // Walk up from target; preventDefault if any ancestor is a tag whose default
   // action would steal the click (navigate the iframe, submit a form, focus
@@ -132,6 +197,63 @@ export const INTERACTIVE_SCRIPT = `<script>
     }, '*');
   }
 
+  // ── Link mode ───────────────────────────────────────────────────────────
+  // Entering link mode must tear down any inline edit already in flight —
+  // contentEditable and the selection outline are set on the element itself,
+  // so flipping the body flag alone would leave the page typeable underneath
+  // the activity panel.
+  new MutationObserver(function() {
+    if (!isLinkMode()) return;
+    if (editing) finishEditing();
+    clearSelection();
+    setHoveredLink(null);
+  }).observe(document.body, { attributes: true, attributeFilter: ['data-link-mode'] });
+
+  // Capture phase so the page's own controls (inputs, labels, radios) never
+  // see the event: in link mode the page is a map, not a form.
+  document.addEventListener('mousedown', function(e) {
+    if (!isLinkMode()) return;
+    e.preventDefault();
+    e.stopPropagation();
+  }, true);
+
+  document.addEventListener('click', function(e) {
+    if (!isLinkMode()) return;
+    e.preventDefault();
+    e.stopPropagation();
+    var a = findAnchor(e.target);
+    parent.postMessage(
+      a ? { type: 'link-select', kind: a.kind, id: a.id } : { type: 'link-select' },
+      '*'
+    );
+  }, true);
+
+  // Hover outlines what a click would pick and reports it up, so the editor
+  // can preview the pairing. The parent decides whether to act on it — it
+  // ignores hover entirely while something is selected.
+  var lastHoverKey = null;
+  function reportHover(a) {
+    var key = a ? a.kind + ':' + a.id : '';
+    if (key === lastHoverKey) return;
+    lastHoverKey = key;
+    parent.postMessage(
+      a ? { type: 'link-hover', kind: a.kind, id: a.id } : { type: 'link-hover' },
+      '*'
+    );
+  }
+
+  document.addEventListener('mousemove', function(e) {
+    if (!isLinkMode()) { setHoveredLink(null); reportHover(null); return; }
+    var a = findAnchor(e.target);
+    setHoveredLink(a ? a.el : null);
+    reportHover(a);
+  });
+
+  document.documentElement.addEventListener('mouseleave', function() {
+    setHoveredLink(null);
+    reportHover(null);
+  });
+
   // Enter edit mode on mousedown (before the browser's default selection
   // behavior) so native drag-to-select works within the contentEditable
   // element. Handling this on 'click' was too late: the selection created
@@ -218,4 +340,26 @@ export const INTERACTIVE_STYLES = `body[data-editable="true"] *:hover:not(:has(*
     }
     body[data-editable="true"] img[data-id] { position: relative; z-index: 1; }
     [data-adt-selected] { outline: 2px solid rgb(124, 58, 237) !important; outline-offset: 2px !important; }
-    [data-adt-editing] { outline: 2px solid rgb(91, 33, 182) !important; outline-offset: 2px !important; }`
+    [data-adt-editing] { outline: 2px solid rgb(91, 33, 182) !important; outline-offset: 2px !important; }
+    body[data-link-mode="true"] [data-id],
+    body[data-link-mode="true"] [data-activity-item] { cursor: pointer; }
+    /* Preview — dashed. Either the pointer is over it in the page
+       (data-adt-link-hover, stamped locally for zero latency) or over its
+       field in the editor (data-adt-preview, driven by the parent). */
+    [data-adt-link-hover],
+    [data-adt-preview] {
+      outline: 2px dashed rgba(124, 58, 237, 0.6) !important;
+      outline-offset: 3px !important;
+      border-radius: 3px;
+    }
+    /* Selection — solid and filled. */
+    [data-adt-linked] {
+      outline: 2px solid rgb(124, 58, 237) !important;
+      outline-offset: 3px !important;
+      background-color: rgba(124, 58, 237, 0.1) !important;
+      border-radius: 3px;
+      transition: outline-color 200ms ease-out, background-color 200ms ease-out;
+    }
+    @media (prefers-reduced-motion: reduce) {
+      [data-adt-linked] { transition: none; }
+    }`

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/iframe-interactive.ts
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/iframe-interactive.ts
@@ -20,6 +20,20 @@ export const INTERACTIVE_SCRIPT = `<script>
   function isEditable() { return document.body.dataset.editable === 'true'; }
   function isLinkMode() { return document.body.dataset.linkMode === 'true'; }
 
+  // The page's answer controls, cached for the duration of a link-mode
+  // session. Invalidated whenever the body is rebuilt (a panel edit re-injects
+  // the HTML) or link mode is re-entered.
+  var answerControlCache = null;
+  function answerControls() {
+    if (!answerControlCache) {
+      answerControlCache = Array.prototype.slice.call(
+        document.querySelectorAll('[data-activity-item]')
+      );
+    }
+    return answerControlCache;
+  }
+  function invalidateAnswerControls() { answerControlCache = null; }
+
   // Answer controls are usually sr-only — the visible affordance is a styled
   // sibling box. Outlining the control itself would draw nothing, so climb to
   // the first ancestor that has a real box.
@@ -55,7 +69,12 @@ export const INTERACTIVE_SCRIPT = `<script>
           if ((el.textContent || '').trim()) return { el: el, kind: 'text', id: dataId };
         }
         if (!answerRegion) {
-          var owned = el.querySelectorAll('[data-activity-item]');
+          // Counted against a cached document-wide list rather than
+          // re-querying each ancestor's subtree: the walk runs on every
+          // mousemove, and scanning subtrees per level made the cost the sum
+          // of those subtrees — the whole page once the walk reached a
+          // top-level container.
+          var owned = answerControls().filter(function(input) { return el.contains(input); });
           if (owned.length === 1) {
             answerRegion = {
               el: el,
@@ -202,12 +221,21 @@ export const INTERACTIVE_SCRIPT = `<script>
   // contentEditable and the selection outline are set on the element itself,
   // so flipping the body flag alone would leave the page typeable underneath
   // the activity panel.
+  // Runs on both edges. Leaving link mode has to clear the hover stamp too:
+  // the outline it drives is not scoped to link mode, so a pointer resting on
+  // an element when the panel closes would strand a dashed outline on the
+  // page until the next mousemove inside the frame.
   new MutationObserver(function() {
+    invalidateAnswerControls();
+    setHoveredLink(null);
     if (!isLinkMode()) return;
     if (editing) finishEditing();
     clearSelection();
-    setHoveredLink(null);
   }).observe(document.body, { attributes: true, attributeFilter: ['data-link-mode'] });
+
+  // A panel edit re-injects the body, detaching every cached control.
+  new MutationObserver(invalidateAnswerControls)
+    .observe(document.body, { childList: true, subtree: true });
 
   // Capture phase so the page's own controls (inputs, labels, radios) never
   // see the event: in link mode the page is a map, not a form.
@@ -345,9 +373,11 @@ export const INTERACTIVE_STYLES = `body[data-editable="true"] *:hover:not(:has(*
     body[data-link-mode="true"] [data-activity-item] { cursor: pointer; }
     /* Preview — dashed. Either the pointer is over it in the page
        (data-adt-link-hover, stamped locally for zero latency) or over its
-       field in the editor (data-adt-preview, driven by the parent). */
-    [data-adt-link-hover],
-    [data-adt-preview] {
+       field in the editor (data-adt-preview, driven by the parent).
+       Both are scoped to link mode so a stamp that outlives it cannot paint
+       over the ordinary layout editor. */
+    body[data-link-mode="true"] [data-adt-link-hover],
+    body[data-link-mode="true"] [data-adt-preview] {
       outline: 2px dashed rgba(124, 58, 237, 0.6) !important;
       outline-offset: 3px !important;
       border-radius: 3px;

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/iframe-interactive.ts
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/iframe-interactive.ts
@@ -20,9 +20,6 @@ export const INTERACTIVE_SCRIPT = `<script>
   function isEditable() { return document.body.dataset.editable === 'true'; }
   function isLinkMode() { return document.body.dataset.linkMode === 'true'; }
 
-  // The page's answer controls, cached for the duration of a link-mode
-  // session. Invalidated whenever the body is rebuilt (a panel edit re-injects
-  // the HTML) or link mode is re-entered.
   var answerControlCache = null;
   function answerControls() {
     if (!answerControlCache) {
@@ -34,9 +31,6 @@ export const INTERACTIVE_SCRIPT = `<script>
   }
   function invalidateAnswerControls() { answerControlCache = null; }
 
-  // Answer controls are usually sr-only — the visible affordance is a styled
-  // sibling box. Outlining the control itself would draw nothing, so climb to
-  // the first ancestor that has a real box.
   function visibleTarget(el) {
     var node = el;
     for (var d = 0; d < 4 && node; d++) {
@@ -47,15 +41,6 @@ export const INTERACTIVE_SCRIPT = `<script>
     return el;
   }
 
-  // Nearest addressable ancestor, resolved by intent rather than raw proximity:
-  //   • text or an image with actual content wins — the user clicked words or
-  //     a picture and means to edit them (this keeps a sentence with an inline
-  //     blank editable as text);
-  //   • otherwise the enclosing region owning exactly ONE answer control is
-  //     that answer, which is how clicking an empty checkbox box or an
-  //     option's letter selects the answer instead of a decorative span.
-  // Requiring exactly one control stops the walk from swallowing a whole
-  // question list once it reaches a shared container.
   function findAnchor(target) {
     var el = target;
     var answerRegion = null;
@@ -69,11 +54,6 @@ export const INTERACTIVE_SCRIPT = `<script>
           if ((el.textContent || '').trim()) return { el: el, kind: 'text', id: dataId };
         }
         if (!answerRegion) {
-          // Counted against a cached document-wide list rather than
-          // re-querying each ancestor's subtree: the walk runs on every
-          // mousemove, and scanning subtrees per level made the cost the sum
-          // of those subtrees — the whole page once the walk reached a
-          // top-level container.
           var owned = answerControls().filter(function(input) { return el.contains(input); });
           if (owned.length === 1) {
             answerRegion = {
@@ -216,15 +196,6 @@ export const INTERACTIVE_SCRIPT = `<script>
     }, '*');
   }
 
-  // ── Link mode ───────────────────────────────────────────────────────────
-  // Entering link mode must tear down any inline edit already in flight —
-  // contentEditable and the selection outline are set on the element itself,
-  // so flipping the body flag alone would leave the page typeable underneath
-  // the activity panel.
-  // Runs on both edges. Leaving link mode has to clear the hover stamp too:
-  // the outline it drives is not scoped to link mode, so a pointer resting on
-  // an element when the panel closes would strand a dashed outline on the
-  // page until the next mousemove inside the frame.
   new MutationObserver(function() {
     invalidateAnswerControls();
     setHoveredLink(null);
@@ -233,12 +204,9 @@ export const INTERACTIVE_SCRIPT = `<script>
     clearSelection();
   }).observe(document.body, { attributes: true, attributeFilter: ['data-link-mode'] });
 
-  // A panel edit re-injects the body, detaching every cached control.
   new MutationObserver(invalidateAnswerControls)
     .observe(document.body, { childList: true, subtree: true });
 
-  // Capture phase so the page's own controls (inputs, labels, radios) never
-  // see the event: in link mode the page is a map, not a form.
   document.addEventListener('mousedown', function(e) {
     if (!isLinkMode()) return;
     e.preventDefault();
@@ -256,9 +224,6 @@ export const INTERACTIVE_SCRIPT = `<script>
     );
   }, true);
 
-  // Hover outlines what a click would pick and reports it up, so the editor
-  // can preview the pairing. The parent decides whether to act on it — it
-  // ignores hover entirely while something is selected.
   var lastHoverKey = null;
   function reportHover(a) {
     var key = a ? a.kind + ':' + a.id : '';
@@ -371,18 +336,12 @@ export const INTERACTIVE_STYLES = `body[data-editable="true"] *:hover:not(:has(*
     [data-adt-editing] { outline: 2px solid rgb(91, 33, 182) !important; outline-offset: 2px !important; }
     body[data-link-mode="true"] [data-id],
     body[data-link-mode="true"] [data-activity-item] { cursor: pointer; }
-    /* Preview — dashed. Either the pointer is over it in the page
-       (data-adt-link-hover, stamped locally for zero latency) or over its
-       field in the editor (data-adt-preview, driven by the parent).
-       Both are scoped to link mode so a stamp that outlives it cannot paint
-       over the ordinary layout editor. */
     body[data-link-mode="true"] [data-adt-link-hover],
     body[data-link-mode="true"] [data-adt-preview] {
       outline: 2px dashed rgba(124, 58, 237, 0.6) !important;
       outline-offset: 3px !important;
       border-radius: 3px;
     }
-    /* Selection — solid and filled. */
     [data-adt-linked] {
       outline: 2px solid rgb(124, 58, 237) !important;
       outline-offset: 3px !important;

--- a/apps/studio/src/components/pipeline/stages/toc/TocLandingPage.tsx
+++ b/apps/studio/src/components/pipeline/stages/toc/TocLandingPage.tsx
@@ -14,6 +14,7 @@ import { useStageStatus } from "@/hooks/use-stage-status"
 import { useBookRun } from "@/hooks/use-book-run"
 import { useApiKey } from "@/hooks/use-api-key"
 import { usePersistConfig } from "@/hooks/use-persist-config"
+import { prefersReducedMotion } from "@/lib/utils"
 import { TocPreview, type TocModeKey } from "./components/TocPreview"
 import { TocModeVisual } from "./components/TocModeVisual"
 
@@ -42,10 +43,7 @@ export function TocLandingPage({ bookLabel }: { bookLabel: string }) {
       setTocMode(value)
       persist({ toc_mode: value })
     }
-    const reduceMotion =
-      typeof window !== "undefined" &&
-      // eslint-disable-next-line lingui/no-unlocalized-strings -- CSS media query, not user-visible
-      window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    const reduceMotion = prefersReducedMotion()
     const doc = typeof document !== "undefined" ? document : null
     if (!doc || typeof doc.startViewTransition !== "function" || reduceMotion) {
       update()

--- a/apps/studio/src/components/ui/scroll-area.tsx
+++ b/apps/studio/src/components/ui/scroll-area.tsx
@@ -12,7 +12,11 @@ const ScrollArea = React.forwardRef<
     className={cn("relative overflow-hidden", className)}
     {...props}
   >
-    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+    {/* Radix wraps children in a `display: table` box, which is shrink-to-fit:
+        a `truncate` descendant reports its full text as min-content and widens
+        the wrapper past the viewport instead of ellipsizing. Forcing a block
+        box keeps it at the viewport width so width-constrained layouts work. */}
+    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit] [&>div]:!block">
       {children}
     </ScrollAreaPrimitive.Viewport>
     <ScrollBar />

--- a/apps/studio/src/lib/utils.ts
+++ b/apps/studio/src/lib/utils.ts
@@ -21,15 +21,12 @@ export function isZipFile(f: File): boolean {
   )
 }
 
-/** True when the OS asks for reduced motion. Read at call time rather than
- *  cached — the setting can change while the app is open. */
 export function prefersReducedMotion(): boolean {
   if (typeof window === "undefined" || !window.matchMedia) return false
   /* eslint-disable-next-line lingui/no-unlocalized-strings -- CSS media query */
   return window.matchMedia("(prefers-reduced-motion: reduce)").matches
 }
 
-/** `scrollIntoView`/`scrollTo` behavior honouring the reduced-motion setting. */
 export function scrollBehavior(): ScrollBehavior {
   return prefersReducedMotion() ? "auto" : "smooth"
 }

--- a/apps/studio/src/lib/utils.ts
+++ b/apps/studio/src/lib/utils.ts
@@ -21,6 +21,19 @@ export function isZipFile(f: File): boolean {
   )
 }
 
+/** True when the OS asks for reduced motion. Read at call time rather than
+ *  cached — the setting can change while the app is open. */
+export function prefersReducedMotion(): boolean {
+  if (typeof window === "undefined" || !window.matchMedia) return false
+  /* eslint-disable-next-line lingui/no-unlocalized-strings -- CSS media query */
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches
+}
+
+/** `scrollIntoView`/`scrollTo` behavior honouring the reduced-motion setting. */
+export function scrollBehavior(): ScrollBehavior {
+  return prefersReducedMotion() ? "auto" : "smooth"
+}
+
 export function formatBytes(bytes: number): string {
   /* eslint-disable-next-line lingui/no-unlocalized-strings */
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -1122,6 +1122,9 @@ msgstr "All categories"
 msgid "All Categories"
 msgstr "All Categories"
 
+msgid "All changes saved"
+msgstr "All changes saved"
+
 msgid "All issues and manual review items"
 msgstr "All issues and manual review items"
 
@@ -1196,6 +1199,9 @@ msgstr "Answer"
 
 msgid "Answer area"
 msgstr "Answer area"
+
+msgid "Answer key reference"
+msgstr "Answer key reference"
 
 msgid "Answer Prompt"
 msgstr "Answer Prompt"
@@ -2784,8 +2790,8 @@ msgstr "Editing is disabled while the storyboard is running"
 msgid "Editing Language"
 msgstr "Editing Language"
 
-msgid "Edits apply to the matching elements of the activity's layout. To change the layout itself, use \"Edit layout\" in the banner."
-msgstr "Edits apply to the matching elements of the activity's layout. To change the layout itself, use \"Edit layout\" in the banner."
+#~ msgid "Edits apply to the matching elements of the activity's layout. To change the layout itself, use \"Edit layout\" in the banner."
+#~ msgstr "Edits apply to the matching elements of the activity's layout. To change the layout itself, use \"Edit layout\" in the banner."
 
 msgid "Edits go to this Tailwind variant prefix"
 msgstr "Edits go to this Tailwind variant prefix"
@@ -3599,6 +3605,9 @@ msgstr "Hit"
 msgid "Home / Chapter 1"
 msgstr "Home / Chapter 1"
 
+msgid "Hover a card to find it in the page and click to pin it — or click anything in the page to edit it here."
+msgstr "Hover a card to find it in the page and click to pin it — or click anything in the page to edit it here."
+
 msgid "Hover a setting to see how LLM cropping, segmentation, or the size threshold changes extracted images."
 msgstr "Hover a setting to see how LLM cropping, segmentation, or the size threshold changes extracted images."
 
@@ -3944,8 +3953,6 @@ msgid "Item"
 msgstr "Item"
 
 #. placeholder {0}: criterionIndex + 1
-#. placeholder {0}: i + 1
-#. placeholder {0}: si + 1
 msgid "Item {0}"
 msgstr "Item {0}"
 
@@ -4717,6 +4724,9 @@ msgstr "No accessibility findings were reported for this page."
 msgid "No AI edits yet for this section."
 msgstr "No AI edits yet for this section."
 
+msgid "No answer set"
+msgstr "No answer set"
+
 #. placeholder {0}: linguiI18n._(PROVIDER_LABELS[provider])
 msgid "No API key for {0} yet. Add one in Book settings to enable this provider."
 msgstr "No API key for {0} yet. Add one in Book settings to enable this provider."
@@ -5059,6 +5069,9 @@ msgstr "Note"
 
 msgid "Nothing important is missing or added"
 msgstr "Nothing important is missing or added"
+
+msgid "Nothing to edit yet"
+msgstr "Nothing to edit yet"
 
 msgid "Nothing to show"
 msgstr "Nothing to show"
@@ -5663,6 +5676,9 @@ msgstr "Picture books and early readers"
 msgid "Pinned"
 msgstr "Pinned"
 
+msgid "Pinned to one element — press Esc to release it and go back to previewing on hover."
+msgstr "Pinned to one element — press Esc to release it and go back to previewing on hover."
+
 msgid "Pipeline · extract"
 msgstr "Pipeline · extract"
 
@@ -5868,7 +5884,9 @@ msgstr "Query param"
 msgid "question"
 msgstr "question"
 
-#. placeholder {0}: i + 1
+msgid "Question"
+msgstr "Question"
+
 #. placeholder {0}: si + 1
 msgid "Question {0}"
 msgstr "Question {0}"
@@ -6277,6 +6295,9 @@ msgstr "Reset to the book's accent"
 msgid "Reset zoom"
 msgstr "Reset zoom"
 
+msgid "Resize panel"
+msgstr "Resize panel"
+
 msgid "Resolving source language..."
 msgstr "Resolving source language..."
 
@@ -6575,6 +6596,9 @@ msgstr "Save & Re-run"
 msgid "Save activity"
 msgstr "Save activity"
 
+msgid "Save activity (⌘S)"
+msgstr "Save activity (⌘S)"
+
 msgid "Save changes"
 msgstr "Save changes"
 
@@ -6872,6 +6896,9 @@ msgstr "Select activity type..."
 
 msgid "Select all"
 msgstr "Select all"
+
+msgid "Select an item to edit its text — [[blank:…]] marks where a blank appears, so keep it to keep the blank."
+msgstr "Select an item to edit its text — [[blank:…]] marks where a blank appears, so keep it to keep the blank."
 
 msgid "Select images to translate"
 msgstr "Select images to translate"
@@ -7808,6 +7835,9 @@ msgstr "They produce flowers to attract pollinators."
 msgid "They release oxygen directly into the air."
 msgstr "They release oxygen directly into the air."
 
+msgid "This activity has no addressable text or answers. Regenerate it, or use \"Edit layout\" to change the page directly."
+msgstr "This activity has no addressable text or answers. Regenerate it, or use \"Edit layout\" to change the page directly."
+
 msgid "This archive can't be opened safely"
 msgstr "This archive can't be opened safely"
 
@@ -7881,6 +7911,9 @@ msgstr "This isn't a valid ADT Studio project"
 
 msgid "This isn't a valid part file"
 msgstr "This isn't a valid part file"
+
+msgid "This option has no answer key entry"
+msgstr "This option has no answer key entry"
 
 msgid "This page has no captioned images"
 msgstr "This page has no captioned images"

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -1122,6 +1122,9 @@ msgstr "Todas las categorías"
 msgid "All Categories"
 msgstr "All Categories"
 
+msgid "All changes saved"
+msgstr "Todos los cambios guardados"
+
 msgid "All issues and manual review items"
 msgstr "Todos los problemas y elementos de revisión manual"
 
@@ -1196,6 +1199,9 @@ msgstr "Respuesta"
 
 msgid "Answer area"
 msgstr "Área de respuesta"
+
+msgid "Answer key reference"
+msgstr "Referencia de la clave de respuestas"
 
 msgid "Answer Prompt"
 msgstr "Prompt de respuesta"
@@ -2784,8 +2790,8 @@ msgstr "La edición está deshabilitada mientras el storyboard se está ejecutan
 msgid "Editing Language"
 msgstr "Idioma de edición"
 
-msgid "Edits apply to the matching elements of the activity's layout. To change the layout itself, use \"Edit layout\" in the banner."
-msgstr "Los cambios se aplican a los elementos correspondientes del diseño de la actividad. Para cambiar el diseño en sí, usa \\\"Editar diseño\\\" en el banner."
+#~ msgid "Edits apply to the matching elements of the activity's layout. To change the layout itself, use \"Edit layout\" in the banner."
+#~ msgstr "Los cambios se aplican a los elementos correspondientes del diseño de la actividad. Para cambiar el diseño en sí, usa \\\"Editar diseño\\\" en el banner."
 
 msgid "Edits go to this Tailwind variant prefix"
 msgstr "Las ediciones van a este prefijo de variante Tailwind"
@@ -3599,6 +3605,9 @@ msgstr "Hit"
 msgid "Home / Chapter 1"
 msgstr "Inicio / Capítulo 1"
 
+msgid "Hover a card to find it in the page and click to pin it — or click anything in the page to edit it here."
+msgstr "Pasa el cursor sobre una tarjeta para localizarla en la página y haz clic para fijarla, o haz clic en cualquier elemento de la página para editarlo aquí."
+
 msgid "Hover a setting to see how LLM cropping, segmentation, or the size threshold changes extracted images."
 msgstr "Pasa el cursor sobre una configuración para ver cómo el recorte, segmentación o el umbral de tamaño del LLM cambian las imágenes extraídas."
 
@@ -3944,8 +3953,6 @@ msgid "Item"
 msgstr "Ítem"
 
 #. placeholder {0}: criterionIndex + 1
-#. placeholder {0}: i + 1
-#. placeholder {0}: si + 1
 msgid "Item {0}"
 msgstr "Item {0}"
 
@@ -4717,6 +4724,9 @@ msgstr "No accessibility findings were reported for this page."
 msgid "No AI edits yet for this section."
 msgstr "Aún no hay ediciones con IA para esta sección."
 
+msgid "No answer set"
+msgstr "Sin respuesta definida"
+
 #. placeholder {0}: linguiI18n._(PROVIDER_LABELS[provider])
 msgid "No API key for {0} yet. Add one in Book settings to enable this provider."
 msgstr "Aún no hay clave API para {0}. Añade una en la configuración del libro para habilitar este proveedor."
@@ -5059,6 +5069,9 @@ msgstr "Nota"
 
 msgid "Nothing important is missing or added"
 msgstr "No falta ni se añade nada importante"
+
+msgid "Nothing to edit yet"
+msgstr "Todavía no hay nada que editar"
 
 msgid "Nothing to show"
 msgstr "Nada que mostrar"
@@ -5663,6 +5676,9 @@ msgstr "Libros ilustrados y primeros lectores"
 msgid "Pinned"
 msgstr "Fijada"
 
+msgid "Pinned to one element — press Esc to release it and go back to previewing on hover."
+msgstr "Fijado a un elemento: pulsa Esc para soltarlo y volver a la vista previa al pasar el cursor."
+
 msgid "Pipeline · extract"
 msgstr "Pipeline · extracción"
 
@@ -5868,7 +5884,9 @@ msgstr "Parámetro de consulta"
 msgid "question"
 msgstr "pregunta"
 
-#. placeholder {0}: i + 1
+msgid "Question"
+msgstr "Pregunta"
+
 #. placeholder {0}: si + 1
 msgid "Question {0}"
 msgstr "Pregunta {0}"
@@ -6277,6 +6295,9 @@ msgstr "Restablecer al color de acento del libro"
 msgid "Reset zoom"
 msgstr "Restablecer zoom"
 
+msgid "Resize panel"
+msgstr "Redimensionar el panel"
+
 msgid "Resolving source language..."
 msgstr "Resolviendo idioma de origen..."
 
@@ -6575,6 +6596,9 @@ msgstr "Guardar y re-ejecutar"
 msgid "Save activity"
 msgstr "Guardar actividad"
 
+msgid "Save activity (⌘S)"
+msgstr "Guardar actividad (⌘S)"
+
 msgid "Save changes"
 msgstr "Guardar cambios"
 
@@ -6872,6 +6896,9 @@ msgstr "Seleccionar tipo de actividad..."
 
 msgid "Select all"
 msgstr "Seleccionar todo"
+
+msgid "Select an item to edit its text — [[blank:…]] marks where a blank appears, so keep it to keep the blank."
+msgstr "Selecciona un elemento para editar su texto: [[blank:…]] indica dónde aparece un espacio en blanco, así que consérvalo para mantener el espacio."
 
 msgid "Select images to translate"
 msgstr "Seleccionar imágenes para traducir"
@@ -7808,6 +7835,9 @@ msgstr "Producen flores para atraer polinizadores."
 msgid "They release oxygen directly into the air."
 msgstr "Liberan oxígeno directamente al aire."
 
+msgid "This activity has no addressable text or answers. Regenerate it, or use \"Edit layout\" to change the page directly."
+msgstr "Esta actividad no tiene textos ni respuestas direccionables. Vuelve a generarla o usa \"Editar diseño\" para modificar la página directamente."
+
 msgid "This archive can't be opened safely"
 msgstr "Este archivo no se puede abrir de forma segura"
 
@@ -7881,6 +7911,9 @@ msgstr "Este no es un proyecto válido de ADT Studio"
 
 msgid "This isn't a valid part file"
 msgstr "Este no es un archivo de parte válido"
+
+msgid "This option has no answer key entry"
+msgstr "Esta opción no tiene entrada en la clave de respuestas"
 
 msgid "This page has no captioned images"
 msgstr "Esta página no tiene imágenes con leyendas"

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -1124,6 +1124,9 @@ msgstr "Toutes les catégories"
 msgid "All Categories"
 msgstr "Toutes les catégories"
 
+msgid "All changes saved"
+msgstr "Toutes les modifications sont enregistrées"
+
 msgid "All issues and manual review items"
 msgstr "Tous les problèmes et éléments de révision manuelle"
 
@@ -1198,6 +1201,9 @@ msgstr "Réponse"
 
 msgid "Answer area"
 msgstr "Zone de réponse"
+
+msgid "Answer key reference"
+msgstr "Référence du corrigé"
 
 msgid "Answer Prompt"
 msgstr "Réponse Invite"
@@ -2786,8 +2792,8 @@ msgstr "La modification est désactivée pendant l'exécution du scénarimage"
 msgid "Editing Language"
 msgstr "Langue d'édition"
 
-msgid "Edits apply to the matching elements of the activity's layout. To change the layout itself, use \"Edit layout\" in the banner."
-msgstr "Les modifications s'appliquent aux éléments correspondants de la mise en page de l'activité. Pour modifier la mise en page elle-même, utilisez \\\"Modifier la mise en page\\\" dans la bannière."
+#~ msgid "Edits apply to the matching elements of the activity's layout. To change the layout itself, use \"Edit layout\" in the banner."
+#~ msgstr "Les modifications s'appliquent aux éléments correspondants de la mise en page de l'activité. Pour modifier la mise en page elle-même, utilisez \\\"Modifier la mise en page\\\" dans la bannière."
 
 msgid "Edits go to this Tailwind variant prefix"
 msgstr "Les modifications vont à ce préfixe de variante Tailwind"
@@ -3601,6 +3607,9 @@ msgstr "Hit"
 msgid "Home / Chapter 1"
 msgstr "Accueil / Chapitre 1"
 
+msgid "Hover a card to find it in the page and click to pin it — or click anything in the page to edit it here."
+msgstr "Survolez une carte pour la localiser dans la page et cliquez pour l'épingler — ou cliquez sur n'importe quel élément de la page pour le modifier ici."
+
 msgid "Hover a setting to see how LLM cropping, segmentation, or the size threshold changes extracted images."
 msgstr "Survolez un paramètre pour voir comment le recadrage LLM, la segmentation ou le seuil de taille modifient les images extraites."
 
@@ -3946,8 +3955,6 @@ msgid "Item"
 msgstr "Élément"
 
 #. placeholder {0}: criterionIndex + 1
-#. placeholder {0}: i + 1
-#. placeholder {0}: si + 1
 msgid "Item {0}"
 msgstr "Élément {0}"
 
@@ -4719,6 +4726,9 @@ msgstr "Aucun résultat d'accessibilité n'a été signalé pour cette page."
 msgid "No AI edits yet for this section."
 msgstr "Aucune modification IA pour cette section pour l'instant."
 
+msgid "No answer set"
+msgstr "Aucune réponse définie"
+
 #. placeholder {0}: linguiI18n._(PROVIDER_LABELS[provider])
 msgid "No API key for {0} yet. Add one in Book settings to enable this provider."
 msgstr "Pas encore de clé API pour {0}. Ajoutez-en une dans les paramètres du livre pour activer ce fournisseur."
@@ -5061,6 +5071,9 @@ msgstr "Note"
 
 msgid "Nothing important is missing or added"
 msgstr "Rien d'important n'est manquant ou ajouté"
+
+msgid "Nothing to edit yet"
+msgstr "Rien à modifier pour l'instant"
 
 msgid "Nothing to show"
 msgstr "Rien à afficher"
@@ -5665,6 +5678,9 @@ msgstr "Albums illustrés et premières lectures"
 msgid "Pinned"
 msgstr "Épinglée"
 
+msgid "Pinned to one element — press Esc to release it and go back to previewing on hover."
+msgstr "Épinglé à un élément : appuyez sur Échap pour le libérer et revenir à l'aperçu au survol."
+
 msgid "Pipeline · extract"
 msgstr "Pipeline · extraction"
 
@@ -5870,7 +5886,9 @@ msgstr "Paramètre de requête"
 msgid "question"
 msgstr "question"
 
-#. placeholder {0}: i + 1
+msgid "Question"
+msgstr "Question"
+
 #. placeholder {0}: si + 1
 msgid "Question {0}"
 msgstr "Question {0}"
@@ -6279,6 +6297,9 @@ msgstr "Rétablir la couleur d'accent du livre"
 msgid "Reset zoom"
 msgstr "Réinitialiser le zoom"
 
+msgid "Resize panel"
+msgstr "Redimensionner le panneau"
+
 msgid "Resolving source language..."
 msgstr "Résolution de la langue source..."
 
@@ -6577,6 +6598,9 @@ msgstr "Enregistrer et relancer"
 msgid "Save activity"
 msgstr "Enregistrer l'activité"
 
+msgid "Save activity (⌘S)"
+msgstr "Enregistrer l'activité (⌘S)"
+
 msgid "Save changes"
 msgstr "Enregistrer les modifications"
 
@@ -6874,6 +6898,9 @@ msgstr "Sélectionnez le type d'activité..."
 
 msgid "Select all"
 msgstr "Tout sélectionner"
+
+msgid "Select an item to edit its text — [[blank:…]] marks where a blank appears, so keep it to keep the blank."
+msgstr "Sélectionnez un élément pour modifier son texte : [[blank:…]] indique l'emplacement d'un blanc, conservez-le pour conserver le blanc."
 
 msgid "Select images to translate"
 msgstr "Sélectionner les images à traduire"
@@ -7810,6 +7837,9 @@ msgstr "Elles produisent des fleurs pour attirer les pollinisateurs."
 msgid "They release oxygen directly into the air."
 msgstr "Elles libèrent de l'oxygène directement dans l'air."
 
+msgid "This activity has no addressable text or answers. Regenerate it, or use \"Edit layout\" to change the page directly."
+msgstr "Cette activité ne contient aucun texte ni aucune réponse adressable. Régénérez-la ou utilisez \"Modifier la mise en page\" pour modifier directement la page."
+
 msgid "This archive can't be opened safely"
 msgstr "Cette archive ne peut pas être ouverte en toute sécurité"
 
@@ -7883,6 +7913,9 @@ msgstr "Ce n'est pas un projet ADT Studio valide"
 
 msgid "This isn't a valid part file"
 msgstr "Ce n'est pas un fichier de partie valide"
+
+msgid "This option has no answer key entry"
+msgstr "Cette option n'a pas d'entrée dans le corrigé"
 
 msgid "This page has no captioned images"
 msgstr "Cette page n'a pas d'images légendées"

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -1122,6 +1122,9 @@ msgstr "Todas as categorias"
 msgid "All Categories"
 msgstr "All Categories"
 
+msgid "All changes saved"
+msgstr "Todas as alterações salvas"
+
 msgid "All issues and manual review items"
 msgstr "Todos os problemas e itens de revisão manual"
 
@@ -1196,6 +1199,9 @@ msgstr "Resposta"
 
 msgid "Answer area"
 msgstr "Área de resposta"
+
+msgid "Answer key reference"
+msgstr "Referência do gabarito"
 
 msgid "Answer Prompt"
 msgstr "Prompt de resposta"
@@ -2784,8 +2790,8 @@ msgstr "A edição está desabilitada enquanto o storyboard está em execução"
 msgid "Editing Language"
 msgstr "Idioma de edição"
 
-msgid "Edits apply to the matching elements of the activity's layout. To change the layout itself, use \"Edit layout\" in the banner."
-msgstr "As edições se aplicam aos elementos correspondentes do layout da atividade. Para mudar o layout em si, use \\\"Editar layout\\\" no banner."
+#~ msgid "Edits apply to the matching elements of the activity's layout. To change the layout itself, use \"Edit layout\" in the banner."
+#~ msgstr "As edições se aplicam aos elementos correspondentes do layout da atividade. Para mudar o layout em si, use \\\"Editar layout\\\" no banner."
 
 msgid "Edits go to this Tailwind variant prefix"
 msgstr "Edições vão para este prefixo de variante Tailwind"
@@ -3599,6 +3605,9 @@ msgstr "Hit"
 msgid "Home / Chapter 1"
 msgstr "Início / Capítulo 1"
 
+msgid "Hover a card to find it in the page and click to pin it — or click anything in the page to edit it here."
+msgstr "Passe o cursor sobre um cartão para localizá-lo na página e clique para fixá-lo — ou clique em qualquer elemento da página para editá-lo aqui."
+
 msgid "Hover a setting to see how LLM cropping, segmentation, or the size threshold changes extracted images."
 msgstr "Passe o mouse sobre uma configuração para ver como o corte, segmentação ou o limite de tamanho do LLM altera as imagens extraídas."
 
@@ -3944,8 +3953,6 @@ msgid "Item"
 msgstr "Item"
 
 #. placeholder {0}: criterionIndex + 1
-#. placeholder {0}: i + 1
-#. placeholder {0}: si + 1
 msgid "Item {0}"
 msgstr "Item {0}"
 
@@ -4717,6 +4724,9 @@ msgstr "No accessibility findings were reported for this page."
 msgid "No AI edits yet for this section."
 msgstr "Ainda não há edições com IA para esta seção."
 
+msgid "No answer set"
+msgstr "Sem resposta definida"
+
 #. placeholder {0}: linguiI18n._(PROVIDER_LABELS[provider])
 msgid "No API key for {0} yet. Add one in Book settings to enable this provider."
 msgstr "Ainda não há chave de API para {0}. Adicione uma nas configurações do Livro para ativar este provedor."
@@ -5059,6 +5069,9 @@ msgstr "Nota"
 
 msgid "Nothing important is missing or added"
 msgstr "Nada importante está faltando ou foi adicionado"
+
+msgid "Nothing to edit yet"
+msgstr "Ainda não há nada para editar"
 
 msgid "Nothing to show"
 msgstr "Nada para mostrar"
@@ -5663,6 +5676,9 @@ msgstr "Livros ilustrados e leitores iniciantes"
 msgid "Pinned"
 msgstr "Fixado"
 
+msgid "Pinned to one element — press Esc to release it and go back to previewing on hover."
+msgstr "Fixado em um elemento: pressione Esc para soltá-lo e voltar à pré-visualização ao passar o cursor."
+
 msgid "Pipeline · extract"
 msgstr "Pipeline · extração"
 
@@ -5868,7 +5884,9 @@ msgstr "Parâmetro de consulta"
 msgid "question"
 msgstr "pergunta"
 
-#. placeholder {0}: i + 1
+msgid "Question"
+msgstr "Pergunta"
+
 #. placeholder {0}: si + 1
 msgid "Question {0}"
 msgstr "Pergunta {0}"
@@ -6277,6 +6295,9 @@ msgstr "Restaurar a cor de destaque do livro"
 msgid "Reset zoom"
 msgstr "Redefinir zoom"
 
+msgid "Resize panel"
+msgstr "Redimensionar o painel"
+
 msgid "Resolving source language..."
 msgstr "Resolvendo idioma de origem..."
 
@@ -6575,6 +6596,9 @@ msgstr "Salvar e reexecutar"
 msgid "Save activity"
 msgstr "Salvar atividade"
 
+msgid "Save activity (⌘S)"
+msgstr "Salvar atividade (⌘S)"
+
 msgid "Save changes"
 msgstr "Salvar alterações"
 
@@ -6872,6 +6896,9 @@ msgstr "Selecionar tipo de atividade..."
 
 msgid "Select all"
 msgstr "Selecionar tudo"
+
+msgid "Select an item to edit its text — [[blank:…]] marks where a blank appears, so keep it to keep the blank."
+msgstr "Selecione um item para editar seu texto: [[blank:…]] marca onde aparece uma lacuna, então mantenha-o para preservar a lacuna."
 
 msgid "Select images to translate"
 msgstr "Selecionar imagens para traduzir"
@@ -7808,6 +7835,9 @@ msgstr "Produzem flores para atrair polinizadores."
 msgid "They release oxygen directly into the air."
 msgstr "Liberam oxigênio diretamente no ar."
 
+msgid "This activity has no addressable text or answers. Regenerate it, or use \"Edit layout\" to change the page directly."
+msgstr "Esta atividade não tem textos nem respostas endereçáveis. Gere-a novamente ou use \"Editar layout\" para alterar a página diretamente."
+
 msgid "This archive can't be opened safely"
 msgstr "Este arquivo não pode ser aberto com segurança"
 
@@ -7881,6 +7911,9 @@ msgstr "Este não é um projeto válido do ADT Studio"
 
 msgid "This isn't a valid part file"
 msgstr "Este não é um arquivo de parte válido"
+
+msgid "This option has no answer key entry"
+msgstr "Esta opção não tem entrada no gabarito"
 
 msgid "This page has no captioned images"
 msgstr "Esta página não tem imagens legendadas"

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -1123,6 +1123,9 @@ msgstr "Të gjitha kategoritë"
 msgid "All Categories"
 msgstr "Të Gjitha Kategoritë"
 
+msgid "All changes saved"
+msgstr "Të gjitha ndryshimet u ruajtën"
+
 msgid "All issues and manual review items"
 msgstr "Të gjitha problemet dhe elementet e rishikimit manual"
 
@@ -1197,6 +1200,9 @@ msgstr "Përgjigje"
 
 msgid "Answer area"
 msgstr "Zona e përgjigjes"
+
+msgid "Answer key reference"
+msgstr "Referenca e çelësit të përgjigjeve"
 
 msgid "Answer Prompt"
 msgstr "Prompt përgjigjeje"
@@ -2785,8 +2791,8 @@ msgstr "Redaktimi është i çaktivizuar ndërsa storyboard-i është duke u ekz
 msgid "Editing Language"
 msgstr "Gjuha e redaktimit"
 
-msgid "Edits apply to the matching elements of the activity's layout. To change the layout itself, use \"Edit layout\" in the banner."
-msgstr "Ndryshimet zbatohen te elementet përkatëse të strukturës së aktivitetit. Për të ndryshuar vetë strukturën, përdorni \\\"Modifiko strukturën\\\" në banderolë."
+#~ msgid "Edits apply to the matching elements of the activity's layout. To change the layout itself, use \"Edit layout\" in the banner."
+#~ msgstr "Ndryshimet zbatohen te elementet përkatëse të strukturës së aktivitetit. Për të ndryshuar vetë strukturën, përdorni \\\"Modifiko strukturën\\\" në banderolë."
 
 msgid "Edits go to this Tailwind variant prefix"
 msgstr "Ndryshimet shkojnë tek ky prefiks i variantit Tailwind"
@@ -3600,6 +3606,9 @@ msgstr "Goditje"
 msgid "Home / Chapter 1"
 msgstr "Kryefaqja / Kapitulli 1"
 
+msgid "Hover a card to find it in the page and click to pin it — or click anything in the page to edit it here."
+msgstr "Kaloni kursorin mbi një kartë për ta gjetur në faqe dhe klikoni për ta fiksuar — ose klikoni çdo element në faqe për ta redaktuar këtu."
+
 msgid "Hover a setting to see how LLM cropping, segmentation, or the size threshold changes extracted images."
 msgstr "Vendos kursorin mbi një cilësim për të parë si ndryshon prerja LLM, segmentimi ose pragu i madhësisë imazhet e ekstraktuara."
 
@@ -3945,8 +3954,6 @@ msgid "Item"
 msgstr "Element"
 
 #. placeholder {0}: criterionIndex + 1
-#. placeholder {0}: i + 1
-#. placeholder {0}: si + 1
 msgid "Item {0}"
 msgstr "Elementi {0}"
 
@@ -4718,6 +4725,9 @@ msgstr "Nuk u raportuan gjetje aksesueshmërie për këtë faqe."
 msgid "No AI edits yet for this section."
 msgstr "Nuk ka redaktime të AI ende për këtë seksion."
 
+msgid "No answer set"
+msgstr "Pa përgjigje të caktuar"
+
 #. placeholder {0}: linguiI18n._(PROVIDER_LABELS[provider])
 msgid "No API key for {0} yet. Add one in Book settings to enable this provider."
 msgstr "Nuk ka ende çelës API për {0}. Shto një te cilësimet e Librit për të aktivizuar këtë ofrues."
@@ -5060,6 +5070,9 @@ msgstr "Shënim"
 
 msgid "Nothing important is missing or added"
 msgstr "Asgjë e rëndësishme nuk mungon ose nuk është shtuar"
+
+msgid "Nothing to edit yet"
+msgstr "Ende s'ka asgjë për të redaktuar"
 
 msgid "Nothing to show"
 msgstr "Nuk ka asgjë për të shfaqur"
@@ -5664,6 +5677,9 @@ msgstr "Libra me ilustrime dhe lexues fillestarë"
 msgid "Pinned"
 msgstr "E fiksuar"
 
+msgid "Pinned to one element — press Esc to release it and go back to previewing on hover."
+msgstr "I fiksuar te një element — shtypni Esc për ta liruar dhe për t'u kthyer te pamja paraprake me kalimin e kursorit."
+
 msgid "Pipeline · extract"
 msgstr "Pipeline · nxjerrje"
 
@@ -5869,7 +5885,9 @@ msgstr "Parametri i pyetjes"
 msgid "question"
 msgstr "pyetje"
 
-#. placeholder {0}: i + 1
+msgid "Question"
+msgstr "Pyetje"
+
 #. placeholder {0}: si + 1
 msgid "Question {0}"
 msgstr "Pyetja {0}"
@@ -6278,6 +6296,9 @@ msgstr "Rikthe ngjyrën e theksit të librit"
 msgid "Reset zoom"
 msgstr "Rivendos zmadhimin"
 
+msgid "Resize panel"
+msgstr "Ripërmasoni panelin"
+
 msgid "Resolving source language..."
 msgstr "Duke zgjidhur gjuhën burimore..."
 
@@ -6576,6 +6597,9 @@ msgstr "Ruaj dhe ri-ekzekuto"
 msgid "Save activity"
 msgstr "Ruaj aktivitetin"
 
+msgid "Save activity (⌘S)"
+msgstr "Ruaj aktivitetin (⌘S)"
+
 msgid "Save changes"
 msgstr "Ruaj ndryshimet"
 
@@ -6873,6 +6897,9 @@ msgstr "Zgjidhni llojin e aktivitetit..."
 
 msgid "Select all"
 msgstr "Zgjidhni të gjitha"
+
+msgid "Select an item to edit its text — [[blank:…]] marks where a blank appears, so keep it to keep the blank."
+msgstr "Zgjidhni një element për të redaktuar tekstin e tij — [[blank:…]] shënon vendin ku shfaqet një hapësirë bosh, prandaj ruajeni që të ruhet hapësira."
 
 msgid "Select images to translate"
 msgstr "Zgjidhni imazhet për të përkthyer"
@@ -7809,6 +7836,9 @@ msgstr "Ato prodhojnë lule për të tërhequr polenizuesit."
 msgid "They release oxygen directly into the air."
 msgstr "Ato lëshojnë oksigjen drejtpërdrejt në ajër."
 
+msgid "This activity has no addressable text or answers. Regenerate it, or use \"Edit layout\" to change the page directly."
+msgstr "Ky aktivitet nuk ka tekste apo përgjigje të adresueshme. Rigjeneroni atë ose përdorni \"Ndrysho paraqitjen\" për ta ndryshuar faqen drejtpërdrejt."
+
 msgid "This archive can't be opened safely"
 msgstr "Ky arkiv nuk mund të hapet në mënyrë të sigurt"
 
@@ -7882,6 +7912,9 @@ msgstr "Ky nuk është një projekt i vlefshëm i ADT Studio"
 
 msgid "This isn't a valid part file"
 msgstr "Ky nuk është një skedar i vlefshëm pjese"
+
+msgid "This option has no answer key entry"
+msgstr "Ky opsion nuk ka hyrje në çelësin e përgjigjeve"
 
 msgid "This page has no captioned images"
 msgstr "Kjo faqe nuk ka imazhe me tituj"

--- a/packages/pipeline/src/packaging/web.ts
+++ b/packages/pipeline/src/packaging/web.ts
@@ -1140,7 +1140,6 @@ function injectOpacityClass(html: string): string {
   )
 }
 
-
 export function stripContentEditable(html: string): string {
   return html.replace(
     /\s+contenteditable(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+))?/gi,
@@ -1223,20 +1222,6 @@ ${fallbackHeadingHtml}${contentBlock}
       ? ` style="background-color: ${escapeAttr(bgMatch[1])};"`
       : ""
   }
-
-  // Embed mode — showing just the section and its activity controls — is
-  // enforced entirely in the runtime: `embedModeAtom` makes ChromeRoot skip
-  // the glossary highlighter, tutorial, notepad, ELI5 and sign-language
-  // surfaces, and BottomDock render nothing.
-  //
-  // There used to be a stylesheet here hiding twelve element ids. Every one
-  // of them belonged to the pre-React reader and matched nothing, so it hid
-  // nothing; embed previews only looked clean because BottomDock opted out on
-  // its own. CSS could not have done this job anyway — the highlighter and
-  // the tutorial rewrite the page's own DOM, which no rule can undo.
-  //
-  // #nav-container stays visible: the runtime mounts the activity
-  // Submit/Reset pair into it.
 
   // Reflowable base-font override: re-declare the same elements fonts.css
   // targets with the chosen family, placed last in <head> so it wins. Omitted
@@ -1560,7 +1545,6 @@ export function buildImageMap(imagesDir: string): Map<string, string> {
   return map
 }
 
-
 function loadImageCaptionMap(storage: Storage, pageId: string): Map<string, string> {
   const row = storage.getLatestNodeData("image-captioning", pageId)
   if (!row) return new Map<string, string>()
@@ -1672,7 +1656,6 @@ export function buildPreferredImageAltMap(
   }
   return section ? applyDuplicateImageAltPolicy(section, preferredImageAltMap) : preferredImageAltMap
 }
-
 
 /** Rewrite image URLs from /api/books/{label}/images/{id} to images/{filename} */
 export function rewriteImageUrls(

--- a/packages/pipeline/src/packaging/web.ts
+++ b/packages/pipeline/src/packaging/web.ts
@@ -1224,19 +1224,19 @@ ${fallbackHeadingHtml}${contentBlock}
       : ""
   }
 
-  // In embed mode, hide non-essential chrome. The React runtime mounts the
-  // activity Submit/Skip buttons inside #nav-container, so it must stay
-  // visible — BottomDock self-hides via embedModeAtom (see ui.atoms.ts).
-  const embedStyles = opts.embed
-    ? `
-    <style>
-      /* Hide navigation, sidebar, and other chrome in embed mode */
-      #back-forward-buttons, #nav-popup,
-      #open-sidebar, #sidebar, #tts-quick-toggle-button, #play-bar,
-      #sl-quick-toggle-button, #sign-language-video,
-      #explain-me-button, #eli5-content, #notepad-button, #notepad-content { display: none !important; }
-    </style>`
-    : ""
+  // Embed mode — showing just the section and its activity controls — is
+  // enforced entirely in the runtime: `embedModeAtom` makes ChromeRoot skip
+  // the glossary highlighter, tutorial, notepad, ELI5 and sign-language
+  // surfaces, and BottomDock render nothing.
+  //
+  // There used to be a stylesheet here hiding twelve element ids. Every one
+  // of them belonged to the pre-React reader and matched nothing, so it hid
+  // nothing; embed previews only looked clean because BottomDock opted out on
+  // its own. CSS could not have done this job anyway — the highlighter and
+  // the tutorial rewrite the page's own DOM, which no rule can undo.
+  //
+  // #nav-container stays visible: the runtime mounts the activity
+  // Submit/Reset pair into it.
 
   // Reflowable base-font override: re-declare the same elements fonts.css
   // targets with the chosen family, placed last in <head> so it wins. Omitted
@@ -1281,7 +1281,7 @@ ${fallbackHeadingHtml}${contentBlock}
     <link href="./content/tailwind_output.css" rel="stylesheet">
     <link href="./assets/libs/fontawesome/css/all.min.css" rel="stylesheet">
     <link href="./assets/fonts.css" rel="stylesheet">${googleFontsLinks}
-${mathScript}${embedStyles}${bodyFontStyle}${flFit ? `${flFit.headStyle}\n` : ""}</head>
+${mathScript}${bodyFontStyle}${flFit ? `${flFit.headStyle}\n` : ""}</head>
 
 <body${opts.fixedViewport ? ` style="margin:0;overflow:hidden;width:100%;height:100%"` : ` class="min-h-screen flex items-center justify-center"${bodyStyle}`}>
 ${mainBlock}


### PR DESCRIPTION
Stacked on `elasticsounds/step-by-step-activity-mode`. Everything here is additive to your classic-activity editor — no pipeline or API changes.

## What this adds

### 1. The panel and the page become one surface

Today the editor and the rendered page are disconnected: you edit a field without seeing which part of the book it drives, and there's no way to go from the page back to the field.

Both sides already address content deterministically — texts and images by `data-id`, answers by `data-activity-item` — so this turns that into an *anchor* they share (`activity-link.ts`, ~70 lines).

- **Nothing selected** — hovering either surface previews the pairing: dashed outline in the page, light outline in the panel.
- **Click either surface** — selects, pinning the highlight so the page holds still while you type. Only another selection moves it; <kbd>Esc</kbd> releases and re-arms hover.
- Clicking in the page reveals and focuses the matching field; selecting in the panel scrolls the page to its element.

While the panel is open the page runs in a **link mode**: inline editing is off and clicks resolve to an anchor instead. Opening the panel also switches to the WYSIWYG frame, so edits appear immediately rather than after a save — the interactive preview only reflects saved state.

Anchor resolution goes by intent, not raw proximity. Text with content wins, so a sentence containing an inline blank stays editable as text; otherwise the region owning exactly one answer control *is* that answer, which is what makes clicking an empty checkbox select the answer rather than a decorative span. Answer controls are usually `sr-only`, so the outline climbs to the first ancestor with a real box.

### 2. Panel rebuilt on the shared UI kit

Moved onto the repo's shadcn primitives (Select, Button, Badge, ScrollArea, Textarea, Label, Tooltip, RadioGroup) and reorganised for scanning a long activity:

- **Item cards are titled by their own wording, edited in place.** A resting `<button>` swaps to a textarea on selection, so the sentence isn't printed twice. Blank markers read as `___` at rest and as source while editing — the only moment they can be broken.
- Always-visible pencil marks the title editable; an amber dot flags items whose answer key is blank.
- Answer zones use a left accent bar rather than filled green panels.
- Resizable width (persisted), dismissible hint, auto-growing fields, empty state, <kbd>⌘S</kbd> to save.

Accessibility: the resting title is focusable and carries the full untruncated sentence as its accessible name; focus moves into the editor on the way in and is restored on the way out only when Escape orphaned it. Controls inside an anchor drop their own focus ring, since the selection outline already serves as the focus indicator.

### 3. Reader features no longer leak into "Try activity"

`?embed=1` previews are meant to show a section the way the storyboard does, plus working activity controls. They weren't: with the persisted **Glossário** toggle on, terms were highlighted inside the preview, and the notepad / ELI5 / sign-language surfaces and tutorial overlay were all mounted.

Only `BottomDock` ever checked `embedModeAtom`. The stylesheet meant to hide the rest targeted twelve element ids from the pre-React reader — **eleven no longer exist anywhere in the repo**, so it hid nothing. Previews only looked clean when a book happened to have no glossary matches and no audio. CSS couldn't have done the job regardless: the highlighter and tutorial rewrite the page's own DOM.

Gated at the source instead, and `embedModeAtom` now resolves from the URL at module load — glossary data lands before the async boot would otherwise have set the flag.

## Things to weigh before keeping this

Honest list, so you can decide rather than discover:

- **Card titles truncate to one line at rest.** Deliberate — it's what removes the duplication — but it means you can't scan long sentences or verify `[[blank:…]]` placement without selecting each card. This is the most reversible design decision here.
- **`ClassicActivityPanel` grew to ~1,700 lines** with 15+ render closures. It wants splitting into anchor / fields / card modules; I left that out rather than balloon the diff.
- **`AutoTextarea` now exists 5× in the repo** (3 predate this branch) with three different sizing formulas.
- **The panel shell duplicates `EditableActivityPanel`** — same `inert` slide-out trick, same save bar — and the two are already drifting.
- **`resolveVisibleTarget` is transcribed by hand into the injected iframe script.** Both copies must agree or the two surfaces outline different boxes; nothing enforces it.
- **Multiple `true` entries in one answer key collapse to a single selected radio,** so a malformed key looks fine. Surfacing it properly needs a validation affordance, not a rendering tweak.
- **`ActivityAnchor` is a plain TS interface, not a Zod schema in `packages/types`.** Judged UI-only plumbing that never crosses HTTP, but `AGENTS.md` states the rule broadly — flagging it as your call.
- **On fill-in-the-blank pages** the storyboard HTML holds literal `[[blank:item-N]]` text rather than real inputs, so answer anchors have no page counterpart there. Multiple-choice links fine; the card anchor covers FITB.

## Regressions caught and fixed in review

A review pass over the first two commits found ten defects (third commit). Three could have corrupted a book, and one was mine undoing yours:

- **Editor-only attributes could reach persisted HTML.** `stripTransientAttributes` is the only sanitiser on the two paths that serialise the live iframe DOM, and it didn't know about the three attributes this branch adds — a stranded one plus a style edit would have baked it into `rendering.sections[].html` and the export.
- **True/false lost case-insensitive matching**, regressing the fix you landed in 02e4be621. A key of `"True"` against `value="true"` showed nothing selected, so an author re-picks it and silently rewrites a correct key.
- **Single-choice lost its `if (!o.itemId) return` guard** — selecting an option the extractor couldn't resolve wrote `false` across every sibling and wiped the answer. Your multi-select branch had kept its guard.

Also fixed: resize grip had no pointer capture (the grip is on the panel's left edge, so widening dragged across the preview iframe, which swallowed the events — freezing the drag and leaking a listener that then resized on plain hover); a stale hover outline could persist into the layout editor; unguarded `localStorage` in render; an impure state updater that also destroyed the Try Activity preference; `scrollIntoView` jumping the whole Studio layout; `alt=""` hardcoded on the ungrouped-images grid. Two perf fixes: `findAnchor` ran a `querySelectorAll` per ancestor on every mousemove, and hover allocated a fresh anchor per event so React never bailed out of re-rendering `StoryboardSectionDetail`.

## Verification

- 1940/1940 tests, typecheck, studio lint — all green.
- i18n: 12 new strings extracted and translated for `es`, `pt-BR`, `fr`, `sq`; all four report 0 missing.
- Driven end-to-end against a real book: both link directions, selection pinning, card-vs-field resolution, reveal scrolling, live edit, and embed vs full reader.
- `pnpm lint` can't run for `@adt/runtime` — `eslint` isn't installed for that package; pre-existing.

The runtime ships as a prebuilt bundle (`assets/adt/base.bundle.min.js`, gitignored), so the embed fix needs `pnpm --filter @adt/runtime build` — already part of the root `pnpm build`.
