### PR TITLE
fix(speech): remove duplicate en-jm key that broke instruction loading

### DIFF
--- a/config/speech_instructions.yaml
+++ b/config/speech_instructions.yaml
@@ -1,8 +1,5 @@
 default: Speak in a cheerful and positive tone.
 en: Speak in a cheerful and positive tone.
-en-jm: |-
-  Speak it in a Jamaican English accent. Use the pronunciation and
-  intonation typical of Jamaica. Maintain a calm, conversational and positive tone.
 sq: |
   Style: Warm, natural, child-friendly conversational cadence at a calm, measured pace.
   Accent: Speak in an authentic Albanian accent native to Pristina, Kosovo. Use Gheg


### PR DESCRIPTION
## Problem

`config/speech_instructions.yaml` defines `en-jm` **twice** — once at line 3 and again at line 89.

`js-yaml` rejects duplicate mapping keys by default, so `yaml.load()` throws:

```
YAMLException: duplicated mapping key (90:1)
```

That throw happens in `loadSpeechInstructions()` (`packages/pipeline/src/speech.ts:101`), *before* any per-language lookup — so it takes down accent/pronunciation instructions for **every** language, not just English. Speech generation was failing on Kiswahili and Albanian books too, which is how this surfaced.

Still reproducible on `develop` as of this PR.

## Cause

#591 added an `en-jm` entry. #594 later added a second one at the top of the file, unaware the key already existed.

## Fix

Remove the duplicate added by #594. This restores the entry that was in effect and working before #594 landed. `en-jm` itself is unaffected and still resolves — only the shadowing duplicate is gone.

## Verification

Before:
```
origin/develop: THROWS -> duplicated mapping key (90:1)
```

After:
```
parses OK — keys: 13
en-jm present: true
```

Existing speech suite passes:
```
packages/pipeline/src/__tests__/speech.test.ts — 54 passed (54)
```

## Follow-up (not in this PR)

Nothing currently guards against this class of error. A small test asserting `speech_instructions.yaml` parses and has no duplicate keys would stop it recurring — happy to add it here or separately if reviewers prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)