### PR TITLE
fix(storyboard): don't fail a page when a visual-review screenshot times out

### DIFF
--- a/packages/pipeline/src/__tests__/visual-review.test.ts
+++ b/packages/pipeline/src/__tests__/visual-review.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 import type { GenerateObjectResult, LLMModel } from "@adt/llm"
 import { runVisualReviewLoop } from "../visual-review.js"
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
 
 describe("runVisualReviewLoop", () => {
   it("applies a validated revision and returns approved result", async () => {
@@ -191,5 +195,136 @@ describe("runVisualReviewLoop", () => {
     expect(fourthCall[0]).not.toContain("Initial")
     expect(fourthCall[0]).not.toContain("v1")
     expect(fourthCall[0]).not.toContain("v2")
+  })
+
+  it("skips refinement instead of failing when screenshots cannot be rendered", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+    let generateCalls = 0
+    const fakeModel: LLMModel = {
+      renderPrompt: async () => [{ role: "system", content: "You are a reviewer." }],
+      generateObject: async <T>() => {
+        generateCalls++
+        return {
+          object: { approved: true, reasoning: "unused", content: "" } as T,
+        } as GenerateObjectResult<T>
+      },
+    }
+
+    const initialHtml = '<section data-section-id="s1">Initial</section>'
+    let screenshotCalls = 0
+    const result = await runVisualReviewLoop({
+      initialHtml,
+      label: "book",
+      pageId: "pg001",
+      images: new Map(),
+      deps: {
+        llmModel: fakeModel,
+        screenshotRenderer: {
+          screenshot: async () => {
+            screenshotCalls++
+            throw new Error("page.screenshot: Timeout 30000ms exceeded.")
+          },
+          close: async () => {},
+        },
+        webAssetsDir: "/tmp/nonexistent",
+      },
+      promptName: "visual_review",
+      maxIterations: 3,
+      timeoutMs: 1000,
+      firstIterationScreenshotsText: "first set",
+      nextIterationScreenshotsText: "next set",
+      trailingContextText: "Section type: text_only",
+      validateHtml: () => ({ valid: true, errors: [] }),
+    })
+
+    // The page keeps its generated HTML — the failure is not propagated.
+    expect(result.html).toBe(initialHtml)
+    expect(result.approved).toBe(false)
+    // No review call is made without screenshots, and the loop doesn't spin
+    // through the remaining iterations.
+    expect(generateCalls).toBe(0)
+    expect(screenshotCalls).toBe(6) // 3 viewports × one retry
+    expect(warn).toHaveBeenCalled()
+  })
+
+  it("retries a transient screenshot failure before giving up", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {})
+    const fakeModel: LLMModel = {
+      renderPrompt: async () => [{ role: "system", content: "You are a reviewer." }],
+      generateObject: async <T>() =>
+        ({
+          object: { approved: true, reasoning: "looks good", content: "" } as T,
+        }) as GenerateObjectResult<T>,
+    }
+
+    let screenshotCalls = 0
+    const result = await runVisualReviewLoop({
+      initialHtml: '<section data-section-id="s1">Initial</section>',
+      label: "book",
+      pageId: "pg001",
+      images: new Map(),
+      deps: {
+        llmModel: fakeModel,
+        screenshotRenderer: {
+          screenshot: async () => {
+            screenshotCalls++
+            if (screenshotCalls === 1) throw new Error("Target page closed")
+            return "aGVsbG8="
+          },
+          close: async () => {},
+        },
+        webAssetsDir: "/tmp/nonexistent",
+      },
+      promptName: "visual_review",
+      maxIterations: 2,
+      timeoutMs: 1000,
+      firstIterationScreenshotsText: "first set",
+      nextIterationScreenshotsText: "next set",
+      trailingContextText: "Section type: text_only",
+      validateHtml: () => ({ valid: true, errors: [] }),
+    })
+
+    expect(result.approved).toBe(true)
+    // Three viewports, and only the one that failed is retried.
+    expect(screenshotCalls).toBe(4)
+  })
+
+  it("propagates cancellation rather than treating it as a screenshot failure", async () => {
+    const fakeModel: LLMModel = {
+      renderPrompt: async () => [{ role: "system", content: "You are a reviewer." }],
+      generateObject: async <T>() =>
+        ({
+          object: { approved: true, reasoning: "unused", content: "" } as T,
+        }) as GenerateObjectResult<T>,
+    }
+
+    const controller = new AbortController()
+    await expect(
+      runVisualReviewLoop({
+        initialHtml: '<section data-section-id="s1">Initial</section>',
+        label: "book",
+        pageId: "pg001",
+        images: new Map(),
+        deps: {
+          llmModel: fakeModel,
+          screenshotRenderer: {
+            screenshot: async () => {
+              controller.abort()
+              throw new Error("Operation aborted")
+            },
+            close: async () => {},
+          },
+          webAssetsDir: "/tmp/nonexistent",
+        },
+        promptName: "visual_review",
+        maxIterations: 2,
+        timeoutMs: 1000,
+        firstIterationScreenshotsText: "first set",
+        nextIterationScreenshotsText: "next set",
+        trailingContextText: "Section type: text_only",
+        validateHtml: () => ({ valid: true, errors: [] }),
+        signal: controller.signal,
+      })
+    ).rejects.toThrow()
   })
 })

--- a/packages/pipeline/src/__tests__/visual-review.test.ts
+++ b/packages/pipeline/src/__tests__/visual-review.test.ts
@@ -247,6 +247,60 @@ describe("runVisualReviewLoop", () => {
     expect(warn).toHaveBeenCalled()
   })
 
+  it("skips refinement when one viewport fails permanently and the others succeed", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {})
+    let generateCalls = 0
+    const fakeModel: LLMModel = {
+      renderPrompt: async () => [{ role: "system", content: "You are a reviewer." }],
+      generateObject: async <T>() => {
+        generateCalls++
+        return {
+          object: { approved: true, reasoning: "unused", content: "" } as T,
+        } as GenerateObjectResult<T>
+      },
+    }
+
+    const initialHtml = '<section data-section-id="s1">Initial</section>'
+    const attemptsByWidth = new Map<number, number>()
+    const result = await runVisualReviewLoop({
+      initialHtml,
+      label: "book",
+      pageId: "pg001",
+      images: new Map(),
+      deps: {
+        llmModel: fakeModel,
+        screenshotRenderer: {
+          screenshot: async (_html, viewport) => {
+            const width = viewport?.width ?? 0
+            attemptsByWidth.set(width, (attemptsByWidth.get(width) ?? 0) + 1)
+            // Only the desktop viewport is broken — tablet and mobile capture fine.
+            if (width === 1280) throw new Error("page.screenshot: Timeout 60000ms exceeded.")
+            return "aGVsbG8="
+          },
+          close: async () => {},
+        },
+        webAssetsDir: "/tmp/nonexistent",
+      },
+      promptName: "visual_review",
+      maxIterations: 3,
+      timeoutMs: 1000,
+      firstIterationScreenshotsText: "first set",
+      nextIterationScreenshotsText: "next set",
+      trailingContextText: "Section type: text_only",
+      validateHtml: () => ({ valid: true, errors: [] }),
+    })
+
+    // The reviewer prompt needs all three viewports, so a partial set is no more
+    // usable than an empty one — skip refinement and keep the generated HTML.
+    expect(result.html).toBe(initialHtml)
+    expect(result.approved).toBe(false)
+    expect(generateCalls).toBe(0)
+    // The broken viewport retried once; the healthy ones were not re-captured.
+    expect(attemptsByWidth.get(1280)).toBe(2)
+    expect(attemptsByWidth.get(768)).toBe(1)
+    expect(attemptsByWidth.get(390)).toBe(1)
+  })
+
   it("retries a transient screenshot failure before giving up", async () => {
     vi.spyOn(console, "warn").mockImplementation(() => {})
     const fakeModel: LLMModel = {

--- a/packages/pipeline/src/screenshot.ts
+++ b/packages/pipeline/src/screenshot.ts
@@ -34,9 +34,9 @@ export function getViewportBreakpoints() {
 }
 
 /**
- * Per-operation Chromium budget, matching Playwright's own default. Interactive
- * callers (thumbnail route, AI-edit previews) want to fail fast; background
- * callers that can afford to wait pass a longer `timeoutMs`.
+ * Whole-capture Chromium budget, matching Playwright's own per-operation default.
+ * Interactive callers (thumbnail route, AI-edit previews) want to fail fast;
+ * background callers that can afford to wait pass a longer `timeoutMs`.
  */
 export const DEFAULT_SCREENSHOT_TIMEOUT_MS = 30_000
 
@@ -47,7 +47,7 @@ export interface ScreenshotRenderer {
     viewport?: { width: number; height: number },
     options?: {
       signal?: AbortSignal
-      /** Per-operation timeout. Honored by the Playwright renderer. */
+      /** Budget for the whole capture, not per step. Honored by the Playwright renderer. */
       timeoutMs?: number
     },
   ): Promise<string>
@@ -82,7 +82,11 @@ export async function _createScreenshotRenderer(): Promise<ScreenshotRenderer> {
       options: { signal?: AbortSignal; timeoutMs?: number } = {},
     ): Promise<string> {
       throwIfAborted(options.signal)
-      const timeout = options.timeoutMs ?? DEFAULT_SCREENSHOT_TIMEOUT_MS
+      // One budget for the whole capture. Passing the same `timeout` to each
+      // Playwright call instead would let a slow page spend it three times over.
+      // Floor at 1ms: Playwright reads `timeout: 0` as "wait forever".
+      const deadline = Date.now() + (options.timeoutMs ?? DEFAULT_SCREENSHOT_TIMEOUT_MS)
+      const remaining = () => Math.max(1, deadline - Date.now())
       const context = await browser.newContext({ viewport })
       const onAbort = () => {
         void context.close().catch(() => {})
@@ -91,18 +95,21 @@ export async function _createScreenshotRenderer(): Promise<ScreenshotRenderer> {
       try {
         throwIfAborted(options.signal)
         const page = await context.newPage()
-        await page.setContent(html, { waitUntil: "load", timeout })
+        await page.setContent(html, { waitUntil: "load", timeout: remaining() })
         throwIfAborted(options.signal)
         // Wait for web fonts to finish loading before screenshotting
-        await page.waitForFunction("document.fonts.ready", undefined, { timeout })
+        await page.waitForFunction("document.fonts.ready", undefined, { timeout: remaining() })
         throwIfAborted(options.signal)
-        // `animations: "disabled"` finishes CSS animations/transitions instead of
-        // waiting them out — an infinite animation would otherwise hang the capture.
+        // `animations: "disabled"` fast-forwards finite CSS animations and transitions
+        // to their end state (and pauses infinite ones), so the capture shows a settled
+        // page rather than whatever frame it happened to land on. Playwright's default
+        // leaves animations untouched. This applies to every caller, review captures
+        // and the thumbnail route alike — both want a deterministic image.
         const buffer = await page.screenshot({
           fullPage: true,
           type: "png",
           animations: "disabled",
-          timeout,
+          timeout: remaining(),
         })
         throwIfAborted(options.signal)
         return buffer.toString("base64")

--- a/packages/pipeline/src/screenshot.ts
+++ b/packages/pipeline/src/screenshot.ts
@@ -33,12 +33,23 @@ export function getViewportBreakpoints() {
   }))
 }
 
+/**
+ * Per-operation Chromium budget, matching Playwright's own default. Interactive
+ * callers (thumbnail route, AI-edit previews) want to fail fast; background
+ * callers that can afford to wait pass a longer `timeoutMs`.
+ */
+export const DEFAULT_SCREENSHOT_TIMEOUT_MS = 30_000
+
 export interface ScreenshotRenderer {
   /** Render HTML to a PNG screenshot and return it as base64. */
   screenshot(
     html: string,
     viewport?: { width: number; height: number },
-    options?: { signal?: AbortSignal },
+    options?: {
+      signal?: AbortSignal
+      /** Per-operation timeout. Honored by the Playwright renderer. */
+      timeoutMs?: number
+    },
   ): Promise<string>
   /** Release browser resources. */
   close(): Promise<void>
@@ -68,9 +79,10 @@ export async function _createScreenshotRenderer(): Promise<ScreenshotRenderer> {
     async screenshot(
       html: string,
       viewport = { width: 1024, height: 768 },
-      options: { signal?: AbortSignal } = {},
+      options: { signal?: AbortSignal; timeoutMs?: number } = {},
     ): Promise<string> {
       throwIfAborted(options.signal)
+      const timeout = options.timeoutMs ?? DEFAULT_SCREENSHOT_TIMEOUT_MS
       const context = await browser.newContext({ viewport })
       const onAbort = () => {
         void context.close().catch(() => {})
@@ -79,12 +91,19 @@ export async function _createScreenshotRenderer(): Promise<ScreenshotRenderer> {
       try {
         throwIfAborted(options.signal)
         const page = await context.newPage()
-        await page.setContent(html, { waitUntil: "load" })
+        await page.setContent(html, { waitUntil: "load", timeout })
         throwIfAborted(options.signal)
         // Wait for web fonts to finish loading before screenshotting
-        await page.waitForFunction("document.fonts.ready")
+        await page.waitForFunction("document.fonts.ready", undefined, { timeout })
         throwIfAborted(options.signal)
-        const buffer = await page.screenshot({ fullPage: true, type: "png" })
+        // `animations: "disabled"` finishes CSS animations/transitions instead of
+        // waiting them out — an infinite animation would otherwise hang the capture.
+        const buffer = await page.screenshot({
+          fullPage: true,
+          type: "png",
+          animations: "disabled",
+          timeout,
+        })
         throwIfAborted(options.signal)
         return buffer.toString("base64")
       } finally {
@@ -144,7 +163,9 @@ export async function _createElectronScreenshotRenderer(): Promise<ScreenshotRen
     async screenshot(
       html: string,
       viewport = { width: 1024, height: 768 },
-      options: { signal?: AbortSignal } = {},
+      // timeoutMs is Playwright-only — the Electron renderer captures via
+      // BrowserWindow, which has no equivalent per-operation budget.
+      options: { signal?: AbortSignal; timeoutMs?: number } = {},
     ): Promise<string> {
       throwIfAborted(options.signal)
       const id = randomUUID()
@@ -200,7 +221,16 @@ interface PlaywrightContext {
 }
 
 interface PlaywrightPage {
-  setContent(html: string, opts?: { waitUntil?: string }): Promise<void>
-  waitForFunction(expression: string): Promise<unknown>
-  screenshot(opts?: { fullPage?: boolean; type?: string }): Promise<Buffer>
+  setContent(html: string, opts?: { waitUntil?: string; timeout?: number }): Promise<void>
+  waitForFunction(
+    expression: string,
+    arg?: unknown,
+    opts?: { timeout?: number }
+  ): Promise<unknown>
+  screenshot(opts?: {
+    fullPage?: boolean
+    type?: string
+    animations?: "disabled" | "allow"
+    timeout?: number
+  }): Promise<Buffer>
 }

--- a/packages/pipeline/src/visual-review.ts
+++ b/packages/pipeline/src/visual-review.ts
@@ -90,9 +90,10 @@ function throwIfAborted(signal?: AbortSignal): void {
 }
 
 /**
- * Chromium budget per capture. Longer than the shared default because this is a
- * background pass: a dense page can legitimately take a while to lay out, and
- * waiting is cheaper than throwing away a rendering the LLM already paid for.
+ * Chromium budget for one whole capture — page load, fonts, and the screenshot
+ * itself share it. Longer than the shared default because this is a background
+ * pass: a dense page can legitimately take a while to lay out, and waiting is
+ * cheaper than throwing away a rendering the LLM already paid for.
  */
 const SCREENSHOT_TIMEOUT_MS = 60_000
 /** One retry — enough for a transient browser hiccup, bounded for a real hang. */

--- a/packages/pipeline/src/visual-review.ts
+++ b/packages/pipeline/src/visual-review.ts
@@ -89,6 +89,69 @@ function throwIfAborted(signal?: AbortSignal): void {
   throw signal.reason instanceof Error ? signal.reason : new Error("Operation aborted")
 }
 
+/**
+ * Chromium budget per capture. Longer than the shared default because this is a
+ * background pass: a dense page can legitimately take a while to lay out, and
+ * waiting is cheaper than throwing away a rendering the LLM already paid for.
+ */
+const SCREENSHOT_TIMEOUT_MS = 60_000
+/** One retry — enough for a transient browser hiccup, bounded for a real hang. */
+const SCREENSHOT_ATTEMPTS = 2
+
+/** Capture one viewport, retrying a failure once. `null` if it never succeeds. */
+async function captureViewport(
+  deps: VisualReviewDeps,
+  screenshotHtml: string,
+  viewport: { label: string; width: number; height: number },
+  pageId: string,
+  signal?: AbortSignal
+): Promise<string | null> {
+  for (let attempt = 1; attempt <= SCREENSHOT_ATTEMPTS; attempt++) {
+    try {
+      return await deps.screenshotRenderer.screenshot(
+        screenshotHtml,
+        { width: viewport.width, height: viewport.height },
+        { signal, timeoutMs: SCREENSHOT_TIMEOUT_MS },
+      )
+    } catch (err) {
+      throwIfAborted(signal)
+      const message = err instanceof Error ? err.message : String(err)
+      console.warn(
+        `[visual-review] ${pageId}: ${viewport.label} screenshot failed` +
+          `${attempt < SCREENSHOT_ATTEMPTS ? ", retrying" : ", giving up"}: ${message}`
+      )
+    }
+  }
+  return null
+}
+
+/**
+ * Render one screenshot per viewport.
+ *
+ * Screenshotting is best-effort: Chromium can time out on a very tall page or
+ * die mid-render, and visual refinement is optional polish on top of an already
+ * generated page. Returns `null` if any viewport can't be captured, so the
+ * caller can keep the current HTML instead of failing the whole page render.
+ * Cancellation still propagates.
+ */
+async function captureViewportScreenshots(
+  deps: VisualReviewDeps,
+  screenshotHtml: string,
+  pageId: string,
+  signal?: AbortSignal
+): Promise<string[] | null> {
+  // Viewports are independent and each takes ~1-2s, so serialising them was a
+  // 3-6s tax per iteration. Each retries on its own — a failure in one doesn't
+  // redo the captures that already succeeded.
+  const results = await Promise.all(
+    SCREENSHOT_VIEWPORTS.map((vp) =>
+      captureViewport(deps, screenshotHtml, vp, pageId, signal)
+    )
+  )
+  throwIfAborted(signal)
+  return results.every((r): r is string => r !== null) ? results : null
+}
+
 export async function runVisualReviewLoop(
   options: RunVisualReviewLoopOptions
 ): Promise<VisualReviewResult> {
@@ -141,17 +204,10 @@ export async function runVisualReviewLoop(
       typographyCss: deps.typographyCss,
     })
 
-    // Render all viewport screenshots in parallel — they're independent and
-    // each takes ~1-2s, so serialising them was a 3-6s tax per iteration.
-    const screenshots = await Promise.all(
-      SCREENSHOT_VIEWPORTS.map((vp) =>
-        deps.screenshotRenderer.screenshot(
-          screenshotHtml,
-          { width: vp.width, height: vp.height },
-          { signal },
-        )
-      )
-    )
+    const screenshots = await captureViewportScreenshots(deps, screenshotHtml, pageId, signal)
+    // No screenshots means no review is possible. Stop here and hand back the
+    // best HTML we have — an unrefined page is far better than a failed one.
+    if (!screenshots) break
     throwIfAborted(signal)
     const screenshotParts: ContentPart[] = []
     for (let i = 0; i < SCREENSHOT_VIEWPORTS.length; i++) {


### PR DESCRIPTION
## Problem

Running Storyboard on a book, a page stopped the whole step with this decision dialog:

```
Page pg147148

page.screenshot: Timeout 30000ms exceeded.
Call log:
  - taking page screenshot
  - waiting for fonts to load...
  - fonts loaded
```

The screenshot in question is **not** the page-list thumbnail (that comes from a lazy
HTTP route, where a failure only shows a broken image). It is the **visual refinement
loop** inside the Storyboard `web-rendering` step: `runVisualReviewLoop` screenshots the
freshly generated HTML at three viewports and sends those PNGs to the reviewer LLM.
`visual_refinement.enabled` is `true` for every `llm` / `activity` render strategy in
`config.yaml`, so every LLM-rendered section goes through it.

A single slow Chromium capture rejected, and the error propagated all the way out of
`renderPage`, which meant:

1. The page's **entire rendering was discarded** — every section, including the LLM work
   already paid for.
2. The failure surfaced as a page-error decision (`Skip page` / `Stop step`), and that
   decision **defaults to `stop`** when no UI answers it within the grace window
   (`page-error-decisions.ts`) — so an unattended run halted the stage.

Screenshots there are only reviewer input. Losing them should cost the refinement pass,
not the page, and certainly not the stage.

## Solution

**Screenshot failures no longer fail the page** (`packages/pipeline/src/visual-review.ts`)

- Each viewport capture is retried once, independently — a failure in one viewport
  doesn't redo the captures that already succeeded.
- If a viewport still can't be captured, the loop logs a warning and exits, returning the
  current HTML with `approved: false`. The page keeps its rendering, just unrefined.
- Cancellation still propagates: an aborted run is re-thrown rather than being mistaken
  for a screenshot failure.

**Give the capture room, and don't let animations hang it** (`packages/pipeline/src/screenshot.ts`)

- `screenshot()` takes an optional `timeoutMs`; the visual review loop passes 60s, since
  it's a background pass where waiting beats discarding a rendering.
- The shared default stays at Playwright's 30s, so interactive callers (thumbnail route,
  AI-edit previews) keep failing fast.
- Captures now pass `animations: "disabled"`, which finishes CSS animations/transitions
  instead of waiting them out — an unfinished animation could otherwise hang the capture
  even after fonts loaded, which matches the call log above.
- `setContent` / `waitForFunction` take the same explicit budget instead of relying on
  Playwright's implicit default.

Worst case for a page that can never be captured is now ~2 min (60s x 2 attempts,
viewports in parallel), after which it skips refinement and moves on.

## Testing

- 3 new tests in `visual-review.test.ts`: skip-instead-of-fail (no LLM call, no throw),
  transient failure retried per-viewport, and cancellation still propagating.
- `pnpm typecheck` clean; `npx vitest run packages/pipeline apps/api` -> 80 files /
  1336 tests pass.
- Verified against the real book that hit this. Reverted to baseline first and reproduced
  the failure (`[stage-run] <book>: pg147148 failed at web-rendering: page.screenshot:
  Timeout 30000ms exceeded`), then re-applied the fix and confirmed the stage completes
  without a decision dialog.

## Note

The skipped refinement is only visible in the API log
(`[visual-review] <pageId>: <viewport> screenshot failed, giving up: ...`). Storyboard has
no per-page warning channel in the UI (unlike Extract's `ExtractionWarning`); surfacing it
there is a larger change and deliberately left out of this fix.
