### PR TITLE
fix(speech): remove duplicate en-jm key breaking speech prompts load

### DIFF
--- a/config/speech_instructions.yaml
+++ b/config/speech_instructions.yaml
@@ -1,8 +1,8 @@
 default: Speak in a cheerful and positive tone.
 en: Speak in a cheerful and positive tone.
 en-jm: |-
-  Speak it in a Jamaican English accent. Use the pronunciation and
-  intonation typical of Jamaica. Maintain a calm, conversational and positive tone.
+  Speak the text in a standard Jamaican English accent. Use the pronunciation and
+  intonation typical of a Jamaican urban area. Maintain a calm, conversational tone friendly for education.
 sq: |
   Style: Warm, natural, child-friendly conversational cadence at a calm, measured pace.
   Accent: Speak in an authentic Albanian accent native to Pristina, Kosovo. Use Gheg
@@ -87,7 +87,4 @@ ne: |-
   Use pronunciation influence only, not vocabulary or grammar changes.
 
   Speak in a cheerful and positive tone.
-en-jm: |-
-  Speak the text in a standard Jamaican English accent. Use the pronunciation and
-  intonation typical of a Jamaican urban area. Maintain a calm, conversational tone friendly for education.
 fr: Speak it an a French Benin accent. Use the pronunciation and intonation typical of Benin. Maintain a calm, conversational tone. Speak in a cheerful positive tone.


### PR DESCRIPTION
The `en-jm` speech instruction was defined twice in `config/speech_instructions.yaml` — added independently by #594 and #591 — and js-yaml v4 throws `YAMLException: duplicated mapping key`, so `GET /speech-config/instructions` and the pipeline's `loadSpeechInstructions` both failed to parse the file and the Speech Prompts editor never loaded. This consolidates `en-jm` into a single entry, keeping the newer (07-24) wording. Verified end-to-end: the API now returns HTTP 200 with all 13 language prompts.