### PR TITLE
fix(storyboard): stop visual review from reverting user-directed section

### DIFF
--- a/apps/studio/src/components/pipeline/components/PromptViewer/promptLiquidVariables.ts
+++ b/apps/studio/src/components/pipeline/components/PromptViewer/promptLiquidVariables.ts
@@ -240,6 +240,7 @@ const PROMPT_VARIABLES: Record<string, string[]> = {
     "nodes",
     "leaf_texts",
     "viewports",
+    "has_merged_content",
   ],
   visual_review_flexible: [
     "page_image_base64",
@@ -248,6 +249,7 @@ const PROMPT_VARIABLES: Record<string, string[]> = {
     "nodes",
     "leaf_texts",
     "viewports",
+    "has_merged_content",
     "user_instructions",
   ],
   html_edit: [

--- a/apps/studio/src/components/pipeline/components/PromptViewer/promptLiquidVariables.ts
+++ b/apps/studio/src/components/pipeline/components/PromptViewer/promptLiquidVariables.ts
@@ -248,6 +248,7 @@ const PROMPT_VARIABLES: Record<string, string[]> = {
     "nodes",
     "leaf_texts",
     "viewports",
+    "user_instructions",
   ],
   html_edit: [
     "current_html",

--- a/packages/pipeline/src/__tests__/render-llm.test.ts
+++ b/packages/pipeline/src/__tests__/render-llm.test.ts
@@ -226,6 +226,28 @@ describe("renderSectionLlm visual review routing", () => {
     expect(calls[0].context.user_instructions).toBe("Use a yellow background and red text.")
   })
 
+  it("preserves a custom reviewer when instructions are provided", async () => {
+    const { model, calls } = makeReviewModel()
+    const customConfig: RenderConfig = {
+      ...config,
+      visualRefinement: {
+        ...config.visualRefinement!,
+        promptName: "custom_visual_review",
+      },
+    }
+
+    await renderSectionLlm(
+      makeInput("Use a yellow background and red text."),
+      customConfig,
+      renderModel,
+      makeDeps(model),
+    )
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0].promptName).toBe("custom_visual_review")
+    expect(calls[0].context.user_instructions).toBe("Use a yellow background and red text.")
+  })
+
   it("keeps the configured reviewer when there is no user prompt", async () => {
     const { model, calls } = makeReviewModel()
     await renderSectionLlm(makeInput(), config, renderModel, makeDeps(model))

--- a/packages/pipeline/src/__tests__/render-llm.test.ts
+++ b/packages/pipeline/src/__tests__/render-llm.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest"
+import type { GenerateObjectResult, LLMModel } from "@adt/llm"
 import {
   collectOptionalTextIds,
   minimumLearnerResponseCount,
+  renderSectionLlm,
 } from "../render-llm.js"
+import type { RenderConfig, RenderSectionInput } from "../web-rendering.js"
 
 describe("collectOptionalTextIds", () => {
   it("marks single-underscore blank-cell leaves as optional (crossword cells)", () => {
@@ -120,5 +123,124 @@ describe("minimumLearnerResponseCount", () => {
       { node_id: "q2", role: "activity_question", text: "Second?" },
       { node_id: "b1", role: "activity_fill_in_the_blank", text: "___" },
     ])).toBe(2)
+  })
+})
+
+describe("renderSectionLlm visual review routing", () => {
+  const RENDERED_HTML =
+    '<section role="region" data-section-type="text_only" data-section-id="s1"><p data-id="t1">Hello</p></section>'
+
+  /** Records which prompt the review loop rendered and with what context. */
+  function makeReviewModel(): {
+    model: LLMModel
+    calls: Array<{ promptName: string; context: Record<string, unknown> }>
+  } {
+    const calls: Array<{ promptName: string; context: Record<string, unknown> }> = []
+    const model: LLMModel = {
+      renderPrompt: async (promptName, context) => {
+        calls.push({ promptName, context })
+        return [{ role: "system", content: "You are a reviewer." }]
+      },
+      // Approve immediately — this test is about prompt selection, not revisions.
+      generateObject: async <T>() =>
+        ({
+          object: { approved: true, reasoning: "looks good", content: "" } as T,
+        }) as GenerateObjectResult<T>,
+    }
+    return { model, calls }
+  }
+
+  const renderModel: LLMModel = {
+    renderPrompt: async () => [{ role: "system", content: "You are a renderer." }],
+    generateObject: async <T>() =>
+      ({
+        object: { reasoning: "rendered", content: RENDERED_HTML } as T,
+      }) as GenerateObjectResult<T>,
+  }
+
+  function makeInput(userPrompt?: string): RenderSectionInput {
+    return {
+      label: "book",
+      pageId: "pg001",
+      pageImageBase64: "cGFnZQ==",
+      sectionIndex: 0,
+      section: {
+        sectionId: "s1",
+        sectionType: "text_only",
+        backgroundColor: "#fff",
+        textColor: "#000",
+        pageNumber: 1,
+        isPruned: false,
+        nodes: [],
+      },
+      context: {
+        nodes: [{ node_id: "t1", role: "paragraph", text: "Hello" }],
+        leaf_texts: [{ text_id: "t1", text_type: "paragraph", text: "Hello" }],
+        image_refs: [],
+        group_ids: [],
+      },
+      ...(userPrompt !== undefined && { userPrompt }),
+    }
+  }
+
+  const config: RenderConfig = {
+    renderType: "llm",
+    promptName: "web_generation_html",
+    modelId: "openai:gpt-5.4",
+    maxRetries: 1,
+    timeoutMs: 1000,
+    temperature: 0.2,
+    answerPromptName: "",
+    templateName: "",
+    visualRefinement: {
+      enabled: true,
+      promptName: "visual_review",
+      maxIterations: 1,
+      timeoutMs: 1000,
+      temperature: 0.2,
+    },
+  }
+
+  function makeDeps(reviewModel: LLMModel) {
+    return {
+      screenshotRenderer: {
+        screenshot: async () => "aGVsbG8=",
+        close: async () => {},
+      },
+      webAssetsDir: "/tmp/nonexistent",
+      llmModel: reviewModel,
+    }
+  }
+
+  it("uses the flexible reviewer and forwards instructions on a user-directed re-render", async () => {
+    const { model, calls } = makeReviewModel()
+    await renderSectionLlm(
+      makeInput("Use a yellow background and red text."),
+      config,
+      renderModel,
+      makeDeps(model),
+    )
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0].promptName).toBe("visual_review_flexible")
+    expect(calls[0].context.user_instructions).toBe("Use a yellow background and red text.")
+  })
+
+  it("keeps the configured reviewer when there is no user prompt", async () => {
+    const { model, calls } = makeReviewModel()
+    await renderSectionLlm(makeInput(), config, renderModel, makeDeps(model))
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0].promptName).toBe("visual_review")
+    expect(calls[0].context.user_instructions).toBe("")
+  })
+
+  it("treats a whitespace-only prompt as no instructions", async () => {
+    const { model, calls } = makeReviewModel()
+    await renderSectionLlm(makeInput("   \n  "), config, renderModel, makeDeps(model))
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0].promptName).toBe("visual_review")
+    expect(calls[0].context.user_instructions).toBe("")
   })
 })

--- a/packages/pipeline/src/render-llm.ts
+++ b/packages/pipeline/src/render-llm.ts
@@ -14,6 +14,7 @@ import {
 import { DEFAULT_TYPOGRAPHY } from "@adt/types"
 import { inspectOrderingActivityHtml } from "./ordering-contract.js"
 
+const BUILT_IN_STRICT_REVIEW_PROMPT = "visual_review"
 const USER_DIRECTED_REVIEW_PROMPT = "visual_review_flexible"
 
 /** Dependencies for the optional visual refinement loop. */
@@ -100,7 +101,10 @@ export async function renderSectionLlm(
   // Optional: visual refinement loop — screenshot the HTML and ask an LLM to review
   if (visualRefinement && config.visualRefinement?.enabled) {
     const vr = config.visualRefinement
-    const reviewPromptName = userInstructions ? USER_DIRECTED_REVIEW_PROMPT : vr.promptName
+    const reviewPromptName =
+      userInstructions && vr.promptName === BUILT_IN_STRICT_REVIEW_PROMPT
+        ? USER_DIRECTED_REVIEW_PROMPT
+        : vr.promptName
     const imagesForScreenshot = new Map<string, { base64: string }>()
     for (const img of renderContext.image_refs) {
       if (img.image_base64) {

--- a/packages/pipeline/src/render-llm.ts
+++ b/packages/pipeline/src/render-llm.ts
@@ -45,6 +45,9 @@ export async function renderSectionLlm(
   const isActivity = config.renderType === "activity"
   const taskType = isActivity ? "activity-rendering" : "web-rendering"
   const { section, context: renderContext } = input
+  // Trim once: a whitespace-only prompt must read as "no instructions" to both
+  // the prompt-selection branch below and the `user_instructions` template guard.
+  const userInstructions = (input.userPrompt ?? "").trim()
 
   // Page images for content merged in from other pages — the prompt shows
   // them after the hosting page's image so the LLM doesn't force-match all
@@ -69,7 +72,7 @@ export async function renderSectionLlm(
     typography: (input.typography ?? DEFAULT_TYPOGRAPHY).styles,
     viewports: getViewportBreakpoints(),
     _isActivity: isActivity,
-    user_instructions: input.userPrompt ?? "",
+    user_instructions: userInstructions,
   }
 
   const result = await llmModel.generateObject<{
@@ -97,8 +100,7 @@ export async function renderSectionLlm(
   // Optional: visual refinement loop — screenshot the HTML and ask an LLM to review
   if (visualRefinement && config.visualRefinement?.enabled) {
     const vr = config.visualRefinement
-    const hasUserPrompt = (input.userPrompt ?? "").trim().length > 0
-    const reviewPromptName = hasUserPrompt ? USER_DIRECTED_REVIEW_PROMPT : vr.promptName
+    const reviewPromptName = userInstructions ? USER_DIRECTED_REVIEW_PROMPT : vr.promptName
     const imagesForScreenshot = new Map<string, { base64: string }>()
     for (const img of renderContext.image_refs) {
       if (img.image_base64) {
@@ -131,7 +133,7 @@ export async function renderSectionLlm(
         nodes: renderContext.nodes,
         leaf_texts: renderContext.leaf_texts,
         has_merged_content: sourcePages.length > 0,
-        user_instructions: input.userPrompt ?? "",
+        user_instructions: userInstructions,
       },
       originalImageIntroText: "Here is the original page image (this is what the rendered page should resemble):",
       firstIterationScreenshotsText: "\nHere are screenshots of the current rendered HTML at three viewport sizes:\n",

--- a/packages/pipeline/src/render-llm.ts
+++ b/packages/pipeline/src/render-llm.ts
@@ -14,6 +14,8 @@ import {
 import { DEFAULT_TYPOGRAPHY } from "@adt/types"
 import { inspectOrderingActivityHtml } from "./ordering-contract.js"
 
+const USER_DIRECTED_REVIEW_PROMPT = "visual_review_flexible"
+
 /** Dependencies for the optional visual refinement loop. */
 export interface VisualRefinementDeps {
   screenshotRenderer: ScreenshotRenderer
@@ -95,6 +97,8 @@ export async function renderSectionLlm(
   // Optional: visual refinement loop — screenshot the HTML and ask an LLM to review
   if (visualRefinement && config.visualRefinement?.enabled) {
     const vr = config.visualRefinement
+    const hasUserPrompt = (input.userPrompt ?? "").trim().length > 0
+    const reviewPromptName = hasUserPrompt ? USER_DIRECTED_REVIEW_PROMPT : vr.promptName
     const imagesForScreenshot = new Map<string, { base64: string }>()
     for (const img of renderContext.image_refs) {
       if (img.image_base64) {
@@ -114,7 +118,7 @@ export async function renderSectionLlm(
         storeScreenshot: visualRefinement.storeScreenshot,
         typographyCss: buildTypographyCss(input.typography ?? DEFAULT_TYPOGRAPHY),
       },
-      promptName: vr.promptName,
+      promptName: reviewPromptName,
       maxIterations: vr.maxIterations,
       timeoutMs: vr.timeoutMs,
       temperature: vr.temperature,
@@ -127,6 +131,7 @@ export async function renderSectionLlm(
         nodes: renderContext.nodes,
         leaf_texts: renderContext.leaf_texts,
         has_merged_content: sourcePages.length > 0,
+        user_instructions: input.userPrompt ?? "",
       },
       originalImageIntroText: "Here is the original page image (this is what the rendered page should resemble):",
       firstIterationScreenshotsText: "\nHere are screenshots of the current rendered HTML at three viewport sizes:\n",

--- a/prompts/visual_review_flexible.liquid
+++ b/prompts/visual_review_flexible.liquid
@@ -13,6 +13,14 @@ The screenshots show a **single section**, which is typically only a SUBSET of t
 - **Locate the corresponding region** in the original page image that matches this section's content (by matching the text, images, and headings present in the rendered screenshot). Use that region as a reference for what content belongs here — NOT for what it should look like.
 - The rendered section will typically occupy the full viewport width, even if in the original it only takes up a column, a strip, or a small portion of the page. This is correct and expected — do NOT reject for this.
 - Other content visible in the original page image (other sections, headers, footers, page numbers, surrounding text, neighboring images) is NOT part of this section and MUST NOT appear in the rendering. Do NOT flag missing content that belongs to a different section.
+{% if user_instructions != "" %}
+## USER INSTRUCTIONS (HIGHEST PRIORITY)
+This section was re-rendered with explicit instructions from the user:
+
+> {{ user_instructions }}
+
+Confirm the rendering HONORS these instructions, and treat every change made to satisfy them — colors, backgrounds, text styling, spacing, layout — as INTENTIONAL and correct, even when it deviates sharply from the original page. Do NOT flag, undo, or "restore toward the original" anything the user asked for. Reject ONLY when a genuine functional defect from the rejection list below is present AND is unrelated to the user's request (i.e. does not merely implement it). If the requested change was clearly applied and the result is functionally sound and readable, approve it.
+{% endif %}
 {% if has_merged_content %}
 ## MERGED CONTENT FROM ANOTHER PAGE
 This section combines content merged from MORE THAN ONE original page (for example an activity or passage that continues across a page break). Additional continuation page images are provided after the primary page image. When locating this section's content, check ALL of the provided page images — part of the rendering appears only in a continuation page image. Do NOT flag that content as extraneous, hallucinated, or missing from the original merely because it is absent from the primary page image, and do NOT remove it.

--- a/prompts/visual_review_flexible.liquid
+++ b/prompts/visual_review_flexible.liquid
@@ -13,7 +13,7 @@ The screenshots show a **single section**, which is typically only a SUBSET of t
 - **Locate the corresponding region** in the original page image that matches this section's content (by matching the text, images, and headings present in the rendered screenshot). Use that region as a reference for what content belongs here — NOT for what it should look like.
 - The rendered section will typically occupy the full viewport width, even if in the original it only takes up a column, a strip, or a small portion of the page. This is correct and expected — do NOT reject for this.
 - Other content visible in the original page image (other sections, headers, footers, page numbers, surrounding text, neighboring images) is NOT part of this section and MUST NOT appear in the rendering. Do NOT flag missing content that belongs to a different section.
-{% if user_instructions != "" %}
+{% if user_instructions != blank %}
 ## USER INSTRUCTIONS (HIGHEST PRIORITY)
 This section was re-rendered with explicit instructions from the user:
 


### PR DESCRIPTION
## Problem

When re-rendering a single storyboard section with custom instructions (e.g. "yellow background, red text"), the change was generated correctly but then **reverted by the visual review loop**.

The visual reviewer (`visual_review` / strict) compares the rendered section against the original PDF page image and pushes the result back toward that reference. Since it had no knowledge of the user's instructions, it treated the intentional deviation (custom colors/layout) as a defect and "restored" the section toward the original print — silently undoing exactly what the user asked for.

Root cause: the reviewer prompt was selected **globally** (strict vs. flexible) and was applied identically to full pipeline runs, plain re-renders, and user-directed re-renders — with no awareness of the user's re-render prompt.

## Fix

Route the reviewer by **context** instead of a single global setting, reusing the already-existing `visual_review_flexible` prompt:

- **`packages/pipeline/src/render-llm.ts`** — when a section is re-rendered with user instructions (`input.userPrompt` is non-empty), the visual refinement loop now uses `visual_review_flexible` regardless of the global strict/flexible config. The user's instructions are forwarded to the reviewer via `user_instructions`.
- **`prompts/visual_review_flexible.liquid`** — added a conditional `USER INSTRUCTIONS (HIGHEST PRIORITY)` block: the reviewer must confirm the requested change was applied and treat every color/background/layout deviation made to satisfy it as intentional, rejecting only genuine functional defects (missing content, overlap, overflow, broken images, unreadable text) unrelated to the request.
- **`apps/studio/src/components/pipeline/components/PromptViewer/promptLiquidVariables.ts`** — registered `user_instructions` for the `visual_review_flexible` prompt in the prompt viewer.

The original page image is still sent to the flexible reviewer as a **content reference only** (so dropped text/images are still caught), but no longer as a visual-fidelity target.

### Behavior after the fix

| Scenario | Reviewer used |
|---|---|
| Full pipeline run / re-render **without** a prompt | strict or flexible (global config) |
| Re-render **with** a user prompt | `visual_review_flexible` + `user_instructions` (always) |

Plain re-renders and full pipeline runs are unaffected. No config schema change; the global strict/flexible toggle still governs the non-user-directed paths.

## How to test

1. Start the app (`pnpm dev`) and open a book that has already been through **page sectioning** and **storyboard** rendering.
2. Go to the **Storyboard** stage and select a page.
3. Click a section to open the **section edit panel** (right-hand drawer).
4. Click the **re-render** button (↻ icon) in the panel header to open the popover.
5. In *"Optional instructions for the LLM..."*, type a strong visual deviation, e.g. **"Use a yellow background and red text."**
6. Click **Re-render** and wait for it to finish.
7. **Expected:** the section keeps the yellow background and red text — the visual review no longer reverts it toward the original PDF colors.
8. **Regression check:** re-render another section **without** any prompt and confirm the normal review still runs and still matches the original layout (strict/flexible per your global setting).
9. Optional — inspect the LLM logs / prompt viewer: for the user-directed re-render, the review call should use `visual_review_flexible` and include the `user_instructions` text.

> Requires an API key configured for the render/review model.

Closes #614