### PR TITLE
Validation: route findings to responsible fix stages

### DIFF
--- a/apps/api/src/routes/reviewer-validation.test.ts
+++ b/apps/api/src/routes/reviewer-validation.test.ts
@@ -139,6 +139,7 @@ describe("Reviewer validation routes", () => {
     const initial: ReviewerPageValidationRecord = {
       session_id: "session-1",
       page_id: "pg001",
+      section_id: "pg001_sec001",
       page_number: 1,
       href: "content/pages/pg001.html",
       language: "sw",
@@ -188,6 +189,7 @@ describe("Reviewer validation routes", () => {
     expect(listBody.records[0].version).toBe(2)
 
     expect(listBody.records[0].record.overall_comment).toBe("Fixed after template update.")
+    expect(listBody.records[0].record.section_id).toBe("pg001_sec001")
   })
 
   it("validates required sessionId query params for page-result listings", async () => {
@@ -240,10 +242,12 @@ describe("Reviewer validation routes", () => {
       "  sections:",
       "    - id: custom-checks",
       "      label: Custom checks",
+      "      fix_stage: sectioning",
       "      criteria:",
       "        - id: custom-criterion",
       "          label: Custom criterion",
       "          guidance: Check this custom requirement.",
+      "          fix_stage: storyboard",
       "  instructions:",
       "    - id: custom-workflow",
       "      title: Custom workflow",
@@ -265,6 +269,8 @@ describe("Reviewer validation routes", () => {
     expect(body.enabled).toBe(true)
     expect(body.pageSections).toHaveLength(1)
     expect(body.pageSections[0].id).toBe("custom-checks")
+    expect(body.pageSections[0].fix_stage).toBe("sectioning")
+    expect(body.pageSections[0].criteria[0].fix_stage).toBe("storyboard")
     expect(body.instructions[0].id).toBe("custom-workflow")
     expect(body.identificationFields).toHaveLength(1)
   })

--- a/apps/studio/eslint.config.js
+++ b/apps/studio/eslint.config.js
@@ -73,6 +73,9 @@ export default [
             // Form field name constants (e.g. const RADIO_NAME = "renderStrategy")
             "RADIO_NAME",
             "radioName",
+            // Internal Select sentinel values; labels are translated separately.
+            "AUTOMATIC_FIX_STAGE",
+            "INHERIT_FIX_STAGE",
             // Image processing preview pane focus key (ImageProcessingPreviewFocus — not user-visible)
             "previewFocus",
             // Day.js unit / format tokens are API identifiers, never UI copy.

--- a/apps/studio/src/components/pipeline/stages/PreviewValidationCard.tsx
+++ b/apps/studio/src/components/pipeline/stages/PreviewValidationCard.tsx
@@ -536,6 +536,7 @@ export function PreviewValidationCard({
     const record: ReviewerPageValidationRecord = {
       session_id: activeSession.session.session_id,
       page_id: currentPage.pageId,
+      section_id: currentPage.sectionId ?? undefined,
       page_number: currentPage.pageNumber ?? undefined,
       href: currentPage.href,
       language: activeSession.session.language,

--- a/apps/studio/src/components/pipeline/stages/sectioning/SectioningPageDetail.test.tsx
+++ b/apps/studio/src/components/pipeline/stages/sectioning/SectioningPageDetail.test.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+import React from "react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { cleanup, render, waitFor } from "@testing-library/react"
+
+const navigateMock = vi.fn()
+const searchMock = vi.fn(() => ({ previewHref: "chapter.html", sectionId: "pg001_sec002" }))
+const scrollIntoViewMock = vi.fn()
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => navigateMock,
+  useSearch: () => searchMock(),
+}))
+
+vi.mock("@lingui/react/macro", () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useLingui: () => ({
+    t(strings: TemplateStringsArray, ...values: unknown[]) {
+      return strings.reduce((text, part, index) => text + part + String(values[index] ?? ""), "")
+    },
+  }),
+}))
+
+vi.mock("@lingui/core/macro", () => ({
+  msg(strings: TemplateStringsArray, ...values: unknown[]) {
+    return {
+      id: strings.reduce((text, part, index) => text + part + String(values[index] ?? ""), ""),
+    }
+  },
+}))
+
+vi.mock("@lingui/core", () => ({
+  i18n: {
+    _: (value: unknown) => value && typeof value === "object" && "id" in value
+      ? String(value.id)
+      : String(value ?? ""),
+  },
+}))
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: () => ({ data: null }),
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}))
+
+vi.mock("@/api/client", () => ({ api: {} }))
+
+vi.mock("@/hooks/use-pages", () => ({
+  usePageImage: () => ({ data: null }),
+}))
+
+vi.mock("@/hooks/use-page-mutations", () => ({
+  invalidateStoryboardDependents: vi.fn(),
+}))
+
+vi.mock("../../components/StepViewRouter", () => ({
+  useStepHeader: () => ({ headerSlotEl: null }),
+}))
+
+vi.mock("@/components/section-tree-editor/SectionTreeEditor", () => ({
+  SectionTreeEditor: ({ section }: { section: { sectionId: string } }) => <div>{section.sectionId}-tree</div>,
+}))
+
+vi.mock("@/components/pipeline/stages/storyboard/components/SectionActionsDropdown", () => ({
+  SectionActionsDropdown: () => <div>section-actions</div>,
+}))
+
+vi.mock("@/components/ui/sonner", () => ({
+  toast: { warning: vi.fn() },
+}))
+
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DialogContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DialogFooter: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+const page = {
+  pageId: "pg001",
+  sectioningTree: {
+    reasoning: "",
+    sections: [
+      { sectionId: "pg001_sec001", sectionType: "content", nodes: [] },
+      { sectionId: "pg001_sec002", sectionType: "content", nodes: [] },
+    ],
+  },
+}
+
+beforeEach(() => {
+  navigateMock.mockClear()
+  scrollIntoViewMock.mockClear()
+  searchMock.mockReturnValue({ previewHref: "chapter.html", sectionId: "pg001_sec002" })
+  Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+    configurable: true,
+    value: scrollIntoViewMock,
+  })
+})
+
+afterEach(cleanup)
+
+describe("SectioningPageDetail validation section focus", () => {
+  it("scrolls to the stable section id and consumes only the one-shot search value", async () => {
+    const { SectioningPageDetail } = await import("./SectioningPageDetail")
+    render(
+      <SectioningPageDetail
+        bookLabel="demo-book"
+        pageId="pg001"
+        page={page as never}
+        navigationExtra={null}
+        navigationArrows={null}
+      />,
+    )
+
+    await waitFor(() => expect(scrollIntoViewMock).toHaveBeenCalledWith({
+      behavior: "smooth",
+      block: "center",
+    }))
+    expect(navigateMock).toHaveBeenCalledWith({
+      to: "/books/$label/$step/$pageId",
+      params: { label: "demo-book", step: "sectioning", pageId: "pg001" },
+      search: { previewHref: "chapter.html", sectionId: undefined },
+      replace: true,
+    })
+  })
+})

--- a/apps/studio/src/components/pipeline/stages/sectioning/SectioningPageDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/sectioning/SectioningPageDetail.tsx
@@ -32,6 +32,7 @@ import {
 } from "@/lib/section-constants"
 import { useStepHeader } from "../../components/StepViewRouter"
 import type { BookStepSearch } from "@/lib/book-step-search"
+import { toast } from "@/components/ui/sonner"
 
 export function SectioningPageDetail({
   bookLabel,
@@ -132,6 +133,7 @@ export function SectioningPageDetail({
       setFocusedSectionId(search.sectionId)
     } else {
       setFocusedSectionId(null)
+      toast.warning(t`The requested section is no longer available. Opened the page instead.`)
     }
 
     void navigate({
@@ -140,7 +142,7 @@ export function SectioningPageDetail({
       search: { ...search, sectionId: undefined },
       replace: true,
     })
-  }, [bookLabel, mergedSections.length, navigate, pageId, search])
+  }, [bookLabel, mergedSections.length, navigate, pageId, search, t])
 
   useEffect(() => {
     if (!focusedSectionId) return

--- a/apps/studio/src/components/pipeline/stages/sectioning/SectioningPageDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/sectioning/SectioningPageDetail.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react"
 import { createPortal } from "react-dom"
+import { useNavigate, useSearch } from "@tanstack/react-router"
 import { Eye } from "lucide-react"
 import { Trans, useLingui } from "@lingui/react/macro"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
@@ -30,6 +31,7 @@ import {
   getSectionTypeDescription,
 } from "@/lib/section-constants"
 import { useStepHeader } from "../../components/StepViewRouter"
+import type { BookStepSearch } from "@/lib/book-step-search"
 
 export function SectioningPageDetail({
   bookLabel,
@@ -49,6 +51,8 @@ export function SectioningPageDetail({
   hasNextPage?: boolean
 }) {
   const { t } = useLingui()
+  const navigate = useNavigate()
+  const search = useSearch({ strict: false }) as BookStepSearch
   const queryClient = useQueryClient()
   const { headerSlotEl } = useStepHeader()
   const { data: imageData } = usePageImage(bookLabel, pageId)
@@ -92,6 +96,9 @@ export function SectioningPageDetail({
     label: string
   } | null>(null)
   const [confirmDelete, setConfirmDelete] = useState<number | null>(null)
+  const sectionElementsRef = useRef(new Map<string, HTMLDivElement>())
+  const consumedSectionFocusRef = useRef<string | null>(null)
+  const [focusedSectionId, setFocusedSectionId] = useState<string | null>(null)
 
   // Reset pending edits when navigating to a different page.
   useEffect(() => {
@@ -110,6 +117,36 @@ export function SectioningPageDetail({
     [sectionsFromServer, pendingBySectionId]
   )
   const dirty = Object.keys(pendingBySectionId).length > 0
+
+  // Exact-section validation links are one-shot: focus the stable section id,
+  // then remove it from the URL without disturbing other step search state.
+  useEffect(() => {
+    if (!search.sectionId || mergedSections.length === 0) return
+    const focusKey = `${pageId}:${search.sectionId}`
+    if (consumedSectionFocusRef.current === focusKey) return
+    consumedSectionFocusRef.current = focusKey
+
+    const element = sectionElementsRef.current.get(search.sectionId)
+    if (element) {
+      element.scrollIntoView({ behavior: "smooth", block: "center" })
+      setFocusedSectionId(search.sectionId)
+    } else {
+      setFocusedSectionId(null)
+    }
+
+    void navigate({
+      to: "/books/$label/$step/$pageId",
+      params: { label: bookLabel, step: "sectioning", pageId },
+      search: { ...search, sectionId: undefined },
+      replace: true,
+    })
+  }, [bookLabel, mergedSections.length, navigate, pageId, search])
+
+  useEffect(() => {
+    if (!focusedSectionId) return
+    const timeout = window.setTimeout(() => setFocusedSectionId(null), 2_000)
+    return () => window.clearTimeout(timeout)
+  }, [focusedSectionId])
 
   const handleSectionChange = useCallback((next: PageSectioningSection) => {
     setPendingBySectionId((prev) => ({ ...prev, [next.sectionId]: next }))
@@ -325,7 +362,17 @@ export function SectioningPageDetail({
           </div>
         ) : (
           mergedSections.map((section, idx) => (
-            <div key={section.sectionId}>
+            <div
+              key={section.sectionId}
+              ref={(element) => {
+                if (element) sectionElementsRef.current.set(section.sectionId, element)
+                else sectionElementsRef.current.delete(section.sectionId)
+              }}
+              className={cn(
+                "rounded-md transition-shadow",
+                focusedSectionId === section.sectionId && "ring-2 ring-sky-500 ring-offset-2",
+              )}
+            >
               <div className="flex items-center gap-3 mb-2">
                 <div className="text-xs font-medium text-muted-foreground">
                   {`#${idx + 1}`}

--- a/apps/studio/src/components/pipeline/stages/storyboard/StoryboardView.test.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/StoryboardView.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+import React from "react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { cleanup, render, waitFor } from "@testing-library/react"
+
+const navigateMock = vi.fn()
+const searchMock = vi.fn(() => ({ tab: "details", sectionId: "pg001_sec002" }))
+const setSectionIndexMock = vi.fn()
+const toastWarningMock = vi.fn()
+
+const pages = [{ pageId: "pg001", pageNumber: 1, sectionCount: 2 }]
+const page = {
+  sectioningTree: {
+    sections: [
+      { sectionId: "pg001_sec001", sectionType: "content", nodes: [] },
+      { sectionId: "pg001_sec002", sectionType: "content", nodes: [] },
+    ],
+  },
+}
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => navigateMock,
+  useSearch: () => searchMock(),
+}))
+
+vi.mock("@lingui/react/macro", () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useLingui: () => ({
+    t(strings: TemplateStringsArray, ...values: unknown[]) {
+      return strings.reduce((text, part, index) => text + part + String(values[index] ?? ""), "")
+    },
+  }),
+}))
+
+vi.mock("@/hooks/use-pages", () => ({
+  usePages: () => ({ data: pages, isLoading: false }),
+  usePage: () => ({ data: page, isLoading: false }),
+}))
+
+vi.mock("../../components/StepViewRouter", () => ({
+  useStepHeader: () => ({ setExtra: vi.fn(), setOnLabelClick: vi.fn() }),
+}))
+
+vi.mock("@/hooks/use-book-run", () => ({
+  useBookRun: () => ({
+    stageState: (stage: string) => stage === "storyboard" || stage === "sectioning" ? "done" : "idle",
+    queueRun: vi.fn(),
+  }),
+}))
+
+vi.mock("@/hooks/use-api-key", () => ({
+  useApiKey: () => ({ apiKey: "test-key", hasApiKey: true }),
+}))
+
+vi.mock("@/routes/books.$label", () => ({
+  useSectionNav: () => ({
+    sectionIndex: 0,
+    setSectionIndex: setSectionIndexMock,
+    skipNextResetRef: { current: false },
+  }),
+}))
+
+vi.mock("../../components/floating-save", () => ({
+  useHasUnsavedChanges: () => false,
+}))
+
+vi.mock("@/components/ui/sonner", () => ({
+  toast: { warning: toastWarningMock },
+}))
+
+vi.mock("./components/StoryboardSectionDetail", () => ({
+  StoryboardSectionDetail: () => <div>storyboard-section</div>,
+}))
+
+vi.mock("./components/StoryboardQuizDetail", () => ({
+  StoryboardQuizDetail: () => <div>storyboard-quiz</div>,
+}))
+
+vi.mock("./components/SectioningOverview", () => ({
+  SectioningOverview: () => <div>sectioning-overview</div>,
+}))
+
+vi.mock("../../components/StageRunCard", () => ({
+  StageRunCard: () => <div>stage-run</div>,
+}))
+
+vi.mock("../../components/LoadingState", () => ({
+  LoadingState: () => <div>loading</div>,
+}))
+
+vi.mock("../../components/StageEmptyState", () => ({
+  StageEmptyState: () => <div>empty</div>,
+}))
+
+beforeEach(() => {
+  navigateMock.mockClear()
+  setSectionIndexMock.mockClear()
+  toastWarningMock.mockClear()
+  searchMock.mockReturnValue({ tab: "details", sectionId: "pg001_sec002" })
+})
+
+afterEach(cleanup)
+
+describe("StoryboardView validation section focus", () => {
+  it("selects the stable section id and consumes only the one-shot search value", async () => {
+    const { StoryboardView } = await import("./StoryboardView")
+    render(<StoryboardView bookLabel="demo-book" selectedPageId="pg001" />)
+
+    await waitFor(() => expect(setSectionIndexMock).toHaveBeenCalledWith(1))
+    expect(navigateMock).toHaveBeenCalledWith({
+      to: "/books/$label/$step/$pageId",
+      params: { label: "demo-book", step: "storyboard", pageId: "pg001" },
+      search: { tab: "details", sectionId: undefined },
+      replace: true,
+    })
+    expect(toastWarningMock).not.toHaveBeenCalled()
+  })
+})

--- a/apps/studio/src/components/pipeline/stages/storyboard/StoryboardView.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/StoryboardView.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useCallback, useState } from "react"
+import { useNavigate, useSearch } from "@tanstack/react-router"
 import { ArrowLeft, ArrowRight, LayoutGrid, Table2 } from "lucide-react"
 import { usePages, usePage } from "@/hooks/use-pages"
 import { useStepHeader } from "../../components/StepViewRouter"
@@ -14,10 +15,13 @@ import { useSectionNav } from "@/routes/books.$label"
 import { Trans } from "@lingui/react/macro"
 import { useLingui } from "@lingui/react/macro"
 import { useHasUnsavedChanges } from "../../components/floating-save"
+import type { BookStepSearch } from "@/lib/book-step-search"
 
 
 export function StoryboardView({ bookLabel, selectedPageId: selectedPageIdProp, onSelectPage }: { bookLabel: string; selectedPageId?: string; onSelectPage?: (pageId: string | null) => void }) {
   const { t } = useLingui()
+  const navigate = useNavigate()
+  const search = useSearch({ strict: false }) as BookStepSearch
   const { data: pages, isLoading: pagesLoading } = usePages(bookLabel)
   const setSelectedPageId = onSelectPage ?? (() => {})
   const [overviewMode, setOverviewMode] = useState(false)
@@ -47,6 +51,7 @@ export function StoryboardView({ bookLabel, selectedPageId: selectedPageIdProp, 
 
   const pageList = pages ?? []
   const { sectionIndex, setSectionIndex, skipNextResetRef } = useSectionNav()
+  const consumedSectionFocusRef = useRef<string | null>(null)
   // When navigating backward across page boundary, resolve to last section
   const pendingLastSection = useRef(false)
   // Guard: prevent silent navigation while AI image is generating
@@ -83,6 +88,28 @@ export function StoryboardView({ bookLabel, selectedPageId: selectedPageIdProp, 
   )
 
   const sectionCount = page?.sectioningTree?.sections.length ?? 0
+
+  // Validation deep links target a stable section id. Consume the search value
+  // once the requested page has loaded, then remove it so later navigation does
+  // not unexpectedly re-apply the focus.
+  useEffect(() => {
+    if (!search.sectionId || !selectedPageId || !page?.sectioningTree) return
+    const focusKey = `${selectedPageId}:${search.sectionId}`
+    if (consumedSectionFocusRef.current === focusKey) return
+    consumedSectionFocusRef.current = focusKey
+
+    const targetIndex = page.sectioningTree.sections.findIndex(
+      (section) => section.sectionId === search.sectionId,
+    )
+    setOverviewMode(false)
+    setSectionIndex(targetIndex >= 0 ? targetIndex : 0)
+    void navigate({
+      to: "/books/$label/$step/$pageId",
+      params: { label: bookLabel, step: "storyboard", pageId: selectedPageId },
+      search: { ...search, sectionId: undefined },
+      replace: true,
+    })
+  }, [bookLabel, navigate, page?.sectioningTree, search, selectedPageId, setSectionIndex])
 
   const confirmUnsavedNavigation = useCallback(
     () =>

--- a/apps/studio/src/components/pipeline/stages/storyboard/StoryboardView.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/StoryboardView.tsx
@@ -16,6 +16,7 @@ import { Trans } from "@lingui/react/macro"
 import { useLingui } from "@lingui/react/macro"
 import { useHasUnsavedChanges } from "../../components/floating-save"
 import type { BookStepSearch } from "@/lib/book-step-search"
+import { toast } from "@/components/ui/sonner"
 
 
 export function StoryboardView({ bookLabel, selectedPageId: selectedPageIdProp, onSelectPage }: { bookLabel: string; selectedPageId?: string; onSelectPage?: (pageId: string | null) => void }) {
@@ -101,6 +102,9 @@ export function StoryboardView({ bookLabel, selectedPageId: selectedPageIdProp, 
     const targetIndex = page.sectioningTree.sections.findIndex(
       (section) => section.sectionId === search.sectionId,
     )
+    if (targetIndex < 0) {
+      toast.warning(t`The requested section is no longer available. Opened the first section instead.`)
+    }
     setOverviewMode(false)
     setSectionIndex(targetIndex >= 0 ? targetIndex : 0)
     void navigate({
@@ -109,7 +113,7 @@ export function StoryboardView({ bookLabel, selectedPageId: selectedPageIdProp, 
       search: { ...search, sectionId: undefined },
       replace: true,
     })
-  }, [bookLabel, navigate, page?.sectioningTree, search, selectedPageId, setSectionIndex])
+  }, [bookLabel, navigate, page?.sectioningTree, search, selectedPageId, setSectionIndex, t])
 
   const confirmUnsavedNavigation = useCallback(
     () =>

--- a/apps/studio/src/components/validation/AccessibilityValidationTabs.test.tsx
+++ b/apps/studio/src/components/validation/AccessibilityValidationTabs.test.tsx
@@ -166,7 +166,7 @@ afterEach(() => {
 })
 
 describe("AccessibilityOverviewTab", () => {
-  it("filters findings by severity and opens affected pages in Preview", async () => {
+  it("filters findings by severity and opens affected pages in the responsible stage", async () => {
     const { AccessibilityOverviewTab } = await import("./AccessibilityValidationTabs")
     render(<AccessibilityOverviewTab label="demo-book" />)
 
@@ -179,8 +179,7 @@ describe("AccessibilityOverviewTab", () => {
     fireEvent.click(screen.getByRole("button", { name: /Page 1/i }))
     expect(navigateMock).toHaveBeenCalledWith({
       to: "/books/$label/$step",
-      params: { label: "demo-book", step: "preview" },
-      search: { previewHref: "index.html" },
+      params: { label: "demo-book", step: "captions" },
     })
   })
 
@@ -203,5 +202,19 @@ describe("AccessibilityOverviewTab", () => {
     expect(screen.getByText("Ensure page content is contained by landmarks")).toBeTruthy()
     expect(screen.getByText("Fix heading order")).toBeTruthy()
     expect(screen.queryByText("Add alt text")).toBeNull()
+  })
+
+  it("preserves page and section context for a section-aware fix stage", async () => {
+    const { AccessibilityOverviewTab } = await import("./AccessibilityValidationTabs")
+    render(<AccessibilityOverviewTab label="demo-book" />)
+
+    fireEvent.click(screen.getByRole("button", { name: /Structure & semantics/i }))
+    fireEvent.click(screen.getByRole("button", { name: /Page 1/i }))
+
+    expect(navigateMock).toHaveBeenCalledWith({
+      to: "/books/$label/$step/$pageId",
+      params: { label: "demo-book", step: "sectioning", pageId: "pg001" },
+      search: { sectionId: "pg001_sec001" },
+    })
   })
 })

--- a/apps/studio/src/components/validation/AccessibilityValidationTabs.tsx
+++ b/apps/studio/src/components/validation/AccessibilityValidationTabs.tsx
@@ -2,8 +2,8 @@ import { useEffect, useMemo, useState } from "react"
 import type { I18n } from "@lingui/core"
 import { msg } from "@lingui/core/macro"
 import { Trans, useLingui } from "@lingui/react/macro"
-import type { AccessibilityCategoryKey, AccessibilitySeverity } from "@/lib/accessibility-summary"
-import { ExternalLink } from "lucide-react"
+import type { AccessibilityCategoryKey, AccessibilityFindingPageSummary, AccessibilitySeverity } from "@/lib/accessibility-summary"
+import { ArrowRight, ExternalLink } from "lucide-react"
 import { useNavigate } from "@tanstack/react-router"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -14,6 +14,12 @@ import { useAccessibilityAssessment } from "@/hooks/use-debug"
 import { buildAccessibilityOverview, buildFrequentAccessibilityFindings, getAccessibilityCategoryLabel } from "@/lib/accessibility-summary"
 import { useAxeRuleTranslator } from "@/lib/axe-rule-locale"
 import { cn } from "@/lib/utils"
+import { STAGE_LABEL_MESSAGES } from "@/components/pipeline/pipeline-i18n"
+import {
+  resolveAccessibilityFixStage,
+  resolveValidationFixDestination,
+} from "@/lib/validation-fix-routing"
+import type { ValidationFixStage } from "@adt/types"
 
 interface AccessibilityTabProps {
   label: string
@@ -147,18 +153,24 @@ function formatFindingPageLabel(i18n: I18n, page: { pageNumber: number | null; t
 
 function FindingPageLinks({
   pages,
+  fixStage,
   onOpenPage,
 }: {
-  pages: Array<{ sectionId: string; href: string; title: string | null; pageNumber: number | null; count: number }>
-  onOpenPage: (href: string) => void
+  pages: AccessibilityFindingPageSummary[]
+  fixStage: ValidationFixStage
+  onOpenPage: (page: AccessibilityFindingPageSummary) => void
 }) {
   const { t, i18n } = useLingui()
   const [expanded, setExpanded] = useState(false)
   const visiblePages = expanded ? pages : pages.slice(0, 6)
+  const fixStageLabel = i18n._(STAGE_LABEL_MESSAGES[fixStage])
 
   return (
     <div className="mt-3 space-y-2">
-      <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground"><Trans>Affected pages</Trans></div>
+      <div className="flex flex-wrap items-center justify-between gap-2 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+        <Trans>Affected pages</Trans>
+        <span>{t`Fix in ${fixStageLabel}`}</span>
+      </div>
       <div className="flex flex-wrap gap-2">
         {visiblePages.map((page) => (
           <Button
@@ -166,10 +178,12 @@ function FindingPageLinks({
             variant="outline"
             size="sm"
             className="h-7 px-2.5 text-[11px]"
-            onClick={() => onOpenPage(page.href)}
+            onClick={() => onOpenPage(page)}
+            title={t`Open ${formatFindingPageLabel(i18n, page)} in ${fixStageLabel}`}
           >
             {formatFindingPageLabel(i18n, page)}
             {page.count > 1 ? <span className="ml-1 text-muted-foreground">({page.count})</span> : null}
+            <ArrowRight className="ml-1.5 h-3 w-3" />
           </Button>
         ))}
         {pages.length > 6 ? (
@@ -189,14 +203,12 @@ function FindingPageLinks({
 
 function FrequentFindingCard({
   finding,
-  pageCount,
   onOpenPage,
   onFilterSeverity,
   onFilterCategory,
 }: {
   finding: ReturnType<typeof buildFrequentAccessibilityFindings>[number]
-  pageCount: number
-  onOpenPage: (href: string) => void
+  onOpenPage: (page: AccessibilityFindingPageSummary) => void
   onFilterSeverity: (severity: AccessibilitySeverity) => void
   onFilterCategory: (category: AccessibilityCategoryKey) => void
 }) {
@@ -204,6 +216,7 @@ function FrequentFindingCard({
   const axeRules = useAxeRuleTranslator()
   const coveragePercent = Math.round(finding.pageCoverage * 100)
   const count = finding.count
+  const fixStage = resolveAccessibilityFixStage(finding.id, finding.categoryKey)
 
   return (
     <div className="rounded-lg border px-3 py-3">
@@ -271,7 +284,7 @@ function FrequentFindingCard({
         </div>
       </div>
 
-      <FindingPageLinks pages={finding.pages} onOpenPage={onOpenPage} />
+      <FindingPageLinks pages={finding.pages} fixStage={fixStage} onOpenPage={onOpenPage} />
     </div>
   )
 }
@@ -338,11 +351,29 @@ export function AccessibilityOverviewTab({ label }: AccessibilityTabProps) {
 
   const hasActiveFilter = severityFilter !== null || categoryFilter !== null
 
-  const openPreviewToPage = (href: string) => {
+  const openFindingFix = (
+    finding: ReturnType<typeof buildFrequentAccessibilityFindings>[number],
+    page: AccessibilityFindingPageSummary,
+  ) => {
+    const destination = resolveValidationFixDestination({
+      stage: resolveAccessibilityFixStage(finding.id, finding.categoryKey),
+      pageId: page.pageId,
+      sectionId: page.sectionId,
+      href: page.href,
+    })
+
+    if (destination.kind === "stage") {
+      void navigate({
+        to: "/books/$label/$step",
+        params: { label, step: destination.stage },
+      })
+      return
+    }
+
     void navigate({
-      to: "/books/$label/$step",
-      params: { label, step: "preview" },
-      search: { previewHref: href },
+      to: "/books/$label/$step/$pageId",
+      params: { label, step: destination.stage, pageId: destination.pageId },
+      search: destination.sectionId ? { sectionId: destination.sectionId } : {},
     })
   }
 
@@ -477,8 +508,7 @@ export function AccessibilityOverviewTab({ label }: AccessibilityTabProps) {
             <FrequentFindingCard
               key={`${finding.reviewOnly ? "review" : "violation"}:${finding.id}`}
               finding={finding}
-              pageCount={assessment.summary.pageCount}
-              onOpenPage={openPreviewToPage}
+              onOpenPage={(page) => openFindingFix(finding, page)}
               onFilterSeverity={(severity) => setSeverityFilter(severity)}
               onFilterCategory={(category) => setCategoryFilter(category)}
             />

--- a/apps/studio/src/components/validation/ReviewerChecklistSettingsTab.tsx
+++ b/apps/studio/src/components/validation/ReviewerChecklistSettingsTab.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react"
 import { Trans, useLingui } from "@lingui/react/macro"
-import type { ReviewerValidationSection } from "@adt/types"
+import type { ReviewerValidationSection, ValidationFixStage } from "@adt/types"
 import { ListChecks, Plus, RotateCcw, Save, Trash2 } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -18,12 +18,14 @@ interface EditableCriterion {
   guidance: string
   requires_comment_on_failure: boolean
   requires_suggested_modification_on_failure: boolean
+  fix_stage?: ValidationFixStage
   enabled: boolean
 }
 
 interface EditableSection {
   id: string
   label: string
+  fix_stage?: ValidationFixStage
   enabled: boolean
   criteria: EditableCriterion[]
 }
@@ -68,6 +70,7 @@ function toEditableSections(sections: ReviewerValidationSection[]): EditableSect
   return sections.map((section) => ({
     id: section.id,
     label: section.label,
+    fix_stage: section.fix_stage,
     enabled: true,
     criteria: section.criteria.map((criterion) => ({
       ...criterion,
@@ -82,12 +85,14 @@ function serializeSections(sections: EditableSection[], defaultGuidance: string)
     .map((section) => ({
       id: section.id,
       label: section.label.trim() || section.id,
+      fix_stage: section.fix_stage,
       criteria: section.criteria
         .filter((criterion) => criterion.enabled)
         .map((criterion) => ({
           id: criterion.id,
           label: criterion.label.trim() || criterion.id,
           guidance: criterion.guidance.trim() || defaultGuidance,
+          fix_stage: criterion.fix_stage,
           requires_comment_on_failure: criterion.requires_comment_on_failure,
           requires_suggested_modification_on_failure: criterion.requires_suggested_modification_on_failure,
         })),

--- a/apps/studio/src/components/validation/ReviewerChecklistSettingsTab.tsx
+++ b/apps/studio/src/components/validation/ReviewerChecklistSettingsTab.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react"
 import { Trans, useLingui } from "@lingui/react/macro"
-import type { ReviewerValidationSection, ValidationFixStage } from "@adt/types"
+import { ValidationFixStage, type ReviewerValidationSection } from "@adt/types"
 import { ListChecks, Plus, RotateCcw, Save, Trash2 } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -8,9 +8,17 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Switch } from "@/components/ui/switch"
 import { Textarea } from "@/components/ui/textarea"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import { useBookConfig, useUpdateBookConfig } from "@/hooks/use-book-config"
 import { useReviewerValidationCatalog } from "@/hooks/use-reviewer-validation"
 import { cn } from "@/lib/utils"
+import { STAGE_LABEL_MESSAGES } from "@/components/pipeline/pipeline-i18n"
 
 interface EditableCriterion {
   id: string
@@ -20,6 +28,47 @@ interface EditableCriterion {
   requires_suggested_modification_on_failure: boolean
   fix_stage?: ValidationFixStage
   enabled: boolean
+}
+
+const AUTOMATIC_FIX_STAGE = "__automatic__"
+const INHERIT_FIX_STAGE = "__inherit__"
+
+function FixStageSelect({
+  value,
+  fallback,
+  onValueChange,
+}: {
+  value?: ValidationFixStage
+  fallback: "automatic" | "inherit"
+  onValueChange: (value: ValidationFixStage | undefined) => void
+}) {
+  const { t, i18n } = useLingui()
+  const fallbackValue = fallback === "automatic" ? AUTOMATIC_FIX_STAGE : INHERIT_FIX_STAGE
+
+  return (
+    <Select
+      value={value ?? fallbackValue}
+      onValueChange={(next) => onValueChange(
+        next === AUTOMATIC_FIX_STAGE || next === INHERIT_FIX_STAGE
+          ? undefined
+          : ValidationFixStage.parse(next),
+      )}
+    >
+      <SelectTrigger className="h-8 text-xs">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value={fallbackValue} className="text-xs">
+          {fallback === "automatic" ? t`Automatic routing` : t`Use section destination`}
+        </SelectItem>
+        {ValidationFixStage.options.map((stage) => (
+          <SelectItem key={stage} value={stage} className="text-xs">
+            {i18n._(STAGE_LABEL_MESSAGES[stage])}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
 }
 
 interface EditableSection {
@@ -186,6 +235,7 @@ export function ReviewerChecklistSettingsTab({ label }: { label: string }) {
       {
         id: `custom-section-${index}`,
         label: t`Custom section ${index}`,
+        fix_stage: "storyboard",
         enabled: true,
         criteria: [
           {
@@ -393,6 +443,18 @@ export function ReviewerChecklistSettingsTab({ label }: { label: string }) {
                         }}
                       />
                     </div>
+
+                    <div className="space-y-1">
+                      <Label><Trans>Fix destination</Trans></Label>
+                      <FixStageSelect
+                        value={section.fix_stage}
+                        fallback="automatic"
+                        onValueChange={(fixStage) => setSection(section.id, (current) => ({
+                          ...current,
+                          fix_stage: fixStage,
+                        }))}
+                      />
+                    </div>
                   </div>
 
                   <Button variant="ghost" size="icon" className="h-8 w-8 shrink-0" onClick={() => removeSection(section.id)} title={t`Remove section`}>
@@ -439,6 +501,18 @@ export function ReviewerChecklistSettingsTab({ label }: { label: string }) {
                                 id: current.id.includes("criterion-") && current.id.startsWith(`${section.id}-criterion-`)
                                   ? `${section.id}-criterion-${criterionIndex + 1}`
                                   : current.id,
+                              }))}
+                            />
+                          </div>
+
+                          <div className="space-y-1">
+                            <Label><Trans>Fix destination</Trans></Label>
+                            <FixStageSelect
+                              value={criterion.fix_stage}
+                              fallback="inherit"
+                              onValueChange={(fixStage) => setCriterion(section.id, criterion.id, (current) => ({
+                                ...current,
+                                fix_stage: fixStage,
                               }))}
                             />
                           </div>

--- a/apps/studio/src/components/validation/ReviewerValidationSummaryTab.test.tsx
+++ b/apps/studio/src/components/validation/ReviewerValidationSummaryTab.test.tsx
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+import React from "react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import type {
+  ReviewerPageValidationRecord,
+  ReviewerValidationCatalogSnapshot,
+  ReviewerValidationSession,
+} from "@adt/types"
+
+const navigateMock = vi.fn()
+
+const legacyCatalog: ReviewerValidationCatalogSnapshot = {
+  identificationFields: [],
+  instructions: [],
+  pageSections: [{
+    id: "text-extracted-accuracy",
+    label: "Text extracted accuracy",
+    criteria: [{
+      id: "text-matches-original-reading-order",
+      label: "Text matches the original reading order",
+      guidance: "Check the reading order.",
+      requires_comment_on_failure: true,
+      requires_suggested_modification_on_failure: true,
+    }],
+  }],
+}
+
+const session: ReviewerValidationSession = {
+  session_id: "session-1",
+  reviewer_name: "Reviewer",
+  catalog_snapshot: legacyCatalog,
+}
+
+const record: ReviewerPageValidationRecord = {
+  session_id: "session-1",
+  page_id: "pg001",
+  section_id: "pg001_sec002",
+  page_number: 1,
+  href: "pg001_sec002.html",
+  results: [{
+    criterion_id: "text-matches-original-reading-order",
+    status: "needs-changes",
+    comment: "Reading order is incorrect.",
+  }],
+}
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => navigateMock,
+}))
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueries: () => [{ data: { records: [{ version: 1, record }] }, isLoading: false, error: null }],
+}))
+
+function templateToString(strings: TemplateStringsArray, values: unknown[] = []) {
+  let text = ""
+  for (let index = 0; index < strings.length; index += 1) {
+    text += strings[index]
+    if (index < values.length) text += String(values[index])
+  }
+  return text
+}
+
+const i18n = {
+  _: (value: unknown) => {
+    if (typeof value === "string") return value
+    if (value && typeof value === "object" && "id" in value) return String(value.id)
+    return String(value ?? "")
+  },
+}
+
+vi.mock("@lingui/core/macro", () => ({
+  msg(strings: TemplateStringsArray, ...values: unknown[]) {
+    return { id: templateToString(strings, values) }
+  },
+}))
+
+vi.mock("@lingui/react/macro", () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useLingui: () => ({
+    i18n,
+    t(value: TemplateStringsArray | { id?: string }, ...values: unknown[]) {
+      return Array.isArray(value)
+        ? templateToString(value as unknown as TemplateStringsArray, values)
+        : String((value as { id?: string }).id ?? "")
+    },
+  }),
+}))
+
+vi.mock("@/api/client", () => ({ api: {} }))
+
+vi.mock("@/hooks/use-reviewer-validation", () => ({
+  useReviewerValidationCatalog: () => ({
+    data: { enabled: true, ...legacyCatalog },
+    isLoading: false,
+    error: null,
+  }),
+  useReviewerValidationSessions: () => ({
+    data: { sessions: [{ version: 1, session }] },
+    isLoading: false,
+    error: null,
+  }),
+}))
+
+vi.mock("@/hooks/use-debug", () => ({
+  useAccessibilityAssessment: () => ({
+    data: { assessment: { summary: { pageCount: 1 } } },
+    isLoading: false,
+    error: null,
+  }),
+}))
+
+afterEach(() => {
+  cleanup()
+  navigateMock.mockClear()
+  window.sessionStorage.clear()
+})
+
+describe("ReviewerValidationSummaryTab", () => {
+  it("routes a finding from a historical checklist snapshot to its exact Sectioning section", async () => {
+    const { ReviewerValidationSummaryTab } = await import("./ReviewerValidationSummaryTab")
+    render(<ReviewerValidationSummaryTab label="demo-book" />)
+
+    const openButton = await screen.findByRole("button", { name: "Open in Sectioning" })
+    fireEvent.click(openButton)
+
+    await waitFor(() => expect(navigateMock).toHaveBeenCalledWith({
+      to: "/books/$label/$step/$pageId",
+      params: { label: "demo-book", step: "sectioning", pageId: "pg001" },
+      search: { sectionId: "pg001_sec002" },
+    }))
+  })
+})

--- a/apps/studio/src/components/validation/ReviewerValidationSummaryTab.tsx
+++ b/apps/studio/src/components/validation/ReviewerValidationSummaryTab.tsx
@@ -1,8 +1,14 @@
 import { useEffect, useMemo, useState } from "react"
 import { Trans, useLingui } from "@lingui/react/macro"
 import { useQueries } from "@tanstack/react-query"
-import { ClipboardCheck, ExternalLink, FileWarning, SkipForward } from "lucide-react"
-import type { ReviewerValidationCatalogSnapshot, ReviewerValidationStatus } from "@adt/types"
+import { useNavigate } from "@tanstack/react-router"
+import { ArrowRight, ClipboardCheck, ExternalLink, FileWarning, SkipForward } from "lucide-react"
+import type {
+  ReviewerValidationCatalogSnapshot,
+  ReviewerValidationCriterion,
+  ReviewerValidationSection,
+  ReviewerValidationStatus,
+} from "@adt/types"
 import { api, type ReviewerPageValidationRecordEntry } from "@/api/client"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -21,6 +27,11 @@ import {
 import { findResumeReviewerPage } from "@/lib/reviewer-validation-progress"
 import { getReviewerSessionStorageKey } from "@/lib/reviewer-validation-session"
 import { cn } from "@/lib/utils"
+import { STAGE_LABEL_MESSAGES } from "@/components/pipeline/pipeline-i18n"
+import {
+  resolveReviewerFixStage,
+  resolveValidationFixDestination,
+} from "@/lib/validation-fix-routing"
 
 
 function normalizeChecklistSnapshot(snapshot: ReviewerValidationCatalogSnapshot | null | undefined) {
@@ -149,7 +160,8 @@ export function ReviewerValidationSummaryTab({
   onOpenPreview,
   onOpenPreviewToPage,
 }: ReviewerValidationSummaryTabProps) {
-  const { t } = useLingui()
+  const { t, i18n } = useLingui()
+  const navigate = useNavigate()
   const catalog = useReviewerValidationCatalog(label)
   const sessions = useReviewerValidationSessions(label)
   const accessibilityAssessment = useAccessibilityAssessment(label)
@@ -230,10 +242,17 @@ export function ReviewerValidationSummaryTab({
   )
 
   const criterionMeta = useMemo(() => {
-    const map = new Map<string, { sectionLabel: string; criterionLabel: string }>()
+    const map = new Map<string, {
+      section: ReviewerValidationSection
+      criterion: ReviewerValidationCriterion
+      sectionLabel: string
+      criterionLabel: string
+    }>()
     for (const section of activePageSections) {
       for (const criterion of section.criteria) {
         map.set(criterion.id, {
+          section,
+          criterion,
           sectionLabel: section.label,
           criterionLabel: criterion.label,
         })
@@ -341,14 +360,20 @@ export function ReviewerValidationSummaryTab({
     return activeSessionRecords.flatMap((entry) =>
       entry.record.results
         .filter((result) => result.status === "needs-changes")
-        .map((result) => ({
-          pageId: entry.record.page_id,
-          pageNumber: entry.record.page_number,
-          href: entry.record.href,
-          comment: result.comment,
-          suggestedModification: result.suggested_modification,
-          ...criterionMeta.get(result.criterion_id),
-        })),
+        .map((result) => {
+          const meta = criterionMeta.get(result.criterion_id)
+          return {
+            pageId: entry.record.page_id,
+            sectionId: entry.record.section_id,
+            pageNumber: entry.record.page_number,
+            href: entry.record.href,
+            comment: result.comment,
+            suggestedModification: result.suggested_modification,
+            fixStage: meta ? resolveReviewerFixStage(meta.section, meta.criterion) : "storyboard" as const,
+            sectionLabel: meta?.sectionLabel,
+            criterionLabel: meta?.criterionLabel,
+          }
+        }),
     )
   }, [activeSessionRecords, criterionMeta])
 
@@ -367,6 +392,29 @@ export function ReviewerValidationSummaryTab({
   const anyRecordQueryLoading = sessionRecordQueries.some((query) => query.isLoading)
   const anyRecordQueryError = sessionRecordQueries.find((query) => query.error)?.error
   const pagesReviewed = activeMetrics.pagesReviewed
+
+  const openReviewerFix = (entry: (typeof flaggedEntries)[number]) => {
+    const destination = resolveValidationFixDestination({
+      stage: entry.fixStage,
+      pageId: entry.pageId,
+      sectionId: entry.sectionId,
+      href: entry.href,
+    })
+
+    if (destination.kind === "stage") {
+      void navigate({
+        to: "/books/$label/$step",
+        params: { label, step: destination.stage },
+      })
+      return
+    }
+
+    void navigate({
+      to: "/books/$label/$step/$pageId",
+      params: { label, step: destination.stage, pageId: destination.pageId },
+      search: destination.sectionId ? { sectionId: destination.sectionId } : {},
+    })
+  }
 
   if (sessions.isLoading || anyRecordQueryLoading || (!activeCatalog && catalog.isLoading)) {
     return <LoadingState message={t`Loading reviewer validation summary...`} />
@@ -612,6 +660,17 @@ export function ReviewerValidationSummaryTab({
                             <span className="font-medium text-foreground"><Trans>Suggested modification:</Trans></span> {entry.suggestedModification}
                           </div>
                         ) : null}
+                        <div className="mt-3 flex justify-end">
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className="h-7 text-[11px]"
+                            onClick={() => openReviewerFix(entry)}
+                          >
+                            {t`Open in ${i18n._(STAGE_LABEL_MESSAGES[entry.fixStage])}`}
+                            <ArrowRight className="ml-1.5 h-3 w-3" />
+                          </Button>
+                        </div>
                       </div>
                     ))}
                   </div>

--- a/apps/studio/src/components/validation/ReviewerValidationSummaryTab.tsx
+++ b/apps/studio/src/components/validation/ReviewerValidationSummaryTab.tsx
@@ -45,10 +45,12 @@ function normalizeChecklistSnapshot(snapshot: ReviewerValidationCatalogSnapshot 
     pageSections: snapshot.pageSections.map((section) => ({
       id: section.id,
       label: section.label,
+      fix_stage: section.fix_stage ?? null,
       criteria: section.criteria.map((criterion) => ({
         id: criterion.id,
         label: criterion.label,
         guidance: criterion.guidance,
+        fix_stage: criterion.fix_stage ?? null,
         requires_comment_on_failure: criterion.requires_comment_on_failure,
         requires_suggested_modification_on_failure: criterion.requires_suggested_modification_on_failure,
       })),

--- a/apps/studio/src/lib/accessibility-summary.test.ts
+++ b/apps/studio/src/lib/accessibility-summary.test.ts
@@ -164,7 +164,7 @@ describe("buildFrequentAccessibilityFindings", () => {
       pagesAffected: 1,
       pageCoverage: 1 / 3,
       pages: [
-        expect.objectContaining({ href: "index.html", pageNumber: 1, count: 1 }),
+        expect.objectContaining({ pageId: "pg001", href: "index.html", pageNumber: 1, count: 1 }),
       ],
     })
     expect(findings.find((entry) => entry.id === "color-contrast")).toMatchObject({

--- a/apps/studio/src/lib/accessibility-summary.ts
+++ b/apps/studio/src/lib/accessibility-summary.ts
@@ -25,6 +25,7 @@ export interface AccessibilityCategorySummary {
 }
 
 export interface AccessibilityFindingPageSummary {
+  pageId: string | null
   sectionId: string
   href: string
   title: string | null
@@ -244,6 +245,7 @@ export function buildFrequentAccessibilityFindings(
       }
       entry.count += 1
       const pageEntry = entry.pages.get(page.sectionId) ?? {
+        pageId: page.pageId,
         sectionId: page.sectionId,
         href: page.href,
         title: page.title,
@@ -271,6 +273,7 @@ export function buildFrequentAccessibilityFindings(
       }
       entry.count += 1
       const pageEntry = entry.pages.get(page.sectionId) ?? {
+        pageId: page.pageId,
         sectionId: page.sectionId,
         href: page.href,
         title: page.title,

--- a/apps/studio/src/lib/book-step-search.test.ts
+++ b/apps/studio/src/lib/book-step-search.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest"
+import { parseBookStepSearch } from "./book-step-search"
+
+describe("parseBookStepSearch", () => {
+  it("keeps supported search values", () => {
+    expect(parseBookStepSearch({
+      tab: "reviewer",
+      previewHref: "chapter.html",
+      sectionId: "pg001_sec002",
+      ignored: "value",
+    })).toEqual({
+      tab: "reviewer",
+      previewHref: "chapter.html",
+      sectionId: "pg001_sec002",
+    })
+  })
+
+  it("drops empty and non-string values", () => {
+    expect(parseBookStepSearch({ tab: "", previewHref: 3, sectionId: null })).toEqual({})
+  })
+})

--- a/apps/studio/src/lib/book-step-search.ts
+++ b/apps/studio/src/lib/book-step-search.ts
@@ -1,0 +1,17 @@
+import { z } from "zod"
+
+const optionalSearchString = z.preprocess(
+  (value) => typeof value === "string" && value.length > 0 ? value : undefined,
+  z.string().optional(),
+)
+
+export const BookStepSearch = z.object({
+  tab: optionalSearchString,
+  previewHref: optionalSearchString,
+  sectionId: optionalSearchString,
+})
+export type BookStepSearch = z.infer<typeof BookStepSearch>
+
+export function parseBookStepSearch(search: Record<string, unknown>): BookStepSearch {
+  return BookStepSearch.parse(search)
+}

--- a/apps/studio/src/lib/validation-fix-routing.test.ts
+++ b/apps/studio/src/lib/validation-fix-routing.test.ts
@@ -45,8 +45,25 @@ describe("resolveReviewerFixStage", () => {
 
   it("supports section metadata, legacy catalogs, and safe custom defaults", () => {
     expect(resolveReviewerFixStage(section({ fix_stage: "captions" }), criterion())).toBe("captions")
-    expect(resolveReviewerFixStage(section(), criterion())).toBe("sectioning")
     expect(resolveReviewerFixStage(section({ id: "custom", fix_stage: undefined }), criterion())).toBe("storyboard")
+  })
+
+  it.each([
+    ["text-extracted-accuracy", "sectioning"],
+    ["visual-media-image-description", "captions"],
+    ["audio-voice-over", "speech"],
+    ["easy-read", "easy-read"],
+    ["glossary", "glossary"],
+    ["interactivity", "storyboard"],
+    ["typography-layout-visual-readability", "storyboard"],
+    ["instructional-content-design", "sectioning"],
+    ["translation", "translate"],
+    ["sign-language", "sign-language"],
+  ] as const)("routes historical default section %s to %s", (sectionId, expectedStage) => {
+    expect(resolveReviewerFixStage(
+      section({ id: sectionId, fix_stage: undefined }),
+      criterion({ fix_stage: undefined }),
+    )).toBe(expectedStage)
   })
 })
 

--- a/apps/studio/src/lib/validation-fix-routing.test.ts
+++ b/apps/studio/src/lib/validation-fix-routing.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest"
+import type { ReviewerValidationCriterion, ReviewerValidationSection } from "@adt/types"
+import {
+  deriveSectionIdFromHref,
+  resolveAccessibilityFixStage,
+  resolveReviewerFixStage,
+  resolveValidationFixDestination,
+} from "./validation-fix-routing"
+
+const criterion = (overrides: Partial<ReviewerValidationCriterion> = {}): ReviewerValidationCriterion => ({
+  id: "criterion",
+  label: "Criterion",
+  guidance: "Guidance",
+  requires_comment_on_failure: true,
+  requires_suggested_modification_on_failure: false,
+  ...overrides,
+})
+
+const section = (overrides: Partial<ReviewerValidationSection> = {}): ReviewerValidationSection => ({
+  id: "text",
+  label: "Text",
+  criteria: [criterion()],
+  ...overrides,
+})
+
+describe("resolveAccessibilityFixStage", () => {
+  it("uses a rule override before the broad category", () => {
+    expect(resolveAccessibilityFixStage("image-alt", "structure-semantics")).toBe("captions")
+    expect(resolveAccessibilityFixStage("heading-order", "text-alternatives")).toBe("sectioning")
+  })
+
+  it("falls back to the category owner", () => {
+    expect(resolveAccessibilityFixStage("unknown-rule", "tables")).toBe("sectioning")
+    expect(resolveAccessibilityFixStage("unknown-rule", "forms-controls")).toBe("storyboard")
+  })
+})
+
+describe("resolveReviewerFixStage", () => {
+  it("prefers criterion metadata over section metadata", () => {
+    expect(resolveReviewerFixStage(
+      section({ fix_stage: "sectioning" }),
+      criterion({ fix_stage: "extract" }),
+    )).toBe("extract")
+  })
+
+  it("supports section metadata, legacy catalogs, and safe custom defaults", () => {
+    expect(resolveReviewerFixStage(section({ fix_stage: "captions" }), criterion())).toBe("captions")
+    expect(resolveReviewerFixStage(section(), criterion())).toBe("sectioning")
+    expect(resolveReviewerFixStage(section({ id: "custom", fix_stage: undefined }), criterion())).toBe("storyboard")
+  })
+})
+
+describe("deriveSectionIdFromHref", () => {
+  it("derives conventional section ids without treating arbitrary pages as sections", () => {
+    expect(deriveSectionIdFromHref("chapters/pg001_sec002.xhtml?lang=en#top")).toBe("pg001_sec002")
+    expect(deriveSectionIdFromHref("index.html")).toBeNull()
+    expect(deriveSectionIdFromHref("quiz.html")).toBeNull()
+  })
+})
+
+describe("resolveValidationFixDestination", () => {
+  it("creates an exact section deep link for section-aware page stages", () => {
+    expect(resolveValidationFixDestination({
+      stage: "sectioning",
+      pageId: "pg001",
+      sectionId: "pg001_sec002",
+    })).toEqual({
+      kind: "page",
+      stage: "sectioning",
+      pageId: "pg001",
+      sectionId: "pg001_sec002",
+    })
+  })
+
+  it("keeps page context without a section for other page stages", () => {
+    expect(resolveValidationFixDestination({
+      stage: "speech",
+      pageId: "pg001",
+      sectionId: "pg001_sec002",
+    })).toEqual({ kind: "page", stage: "speech", pageId: "pg001" })
+  })
+
+  it("uses a stage root when the owner has no page route or page context is absent", () => {
+    expect(resolveValidationFixDestination({ stage: "captions", pageId: "pg001" }))
+      .toEqual({ kind: "stage", stage: "captions" })
+    expect(resolveValidationFixDestination({ stage: "storyboard" }))
+      .toEqual({ kind: "stage", stage: "storyboard" })
+  })
+})

--- a/apps/studio/src/lib/validation-fix-routing.ts
+++ b/apps/studio/src/lib/validation-fix-routing.ts
@@ -1,0 +1,104 @@
+import type {
+  ReviewerValidationCriterion,
+  ReviewerValidationSection,
+  ValidationFixStage,
+} from "@adt/types"
+import { hasStagePages } from "@/components/pipeline/stage-config"
+import type { AccessibilityCategoryKey } from "./accessibility-summary"
+
+export interface ValidationFixLocation {
+  pageId?: string | null
+  sectionId?: string | null
+  href?: string | null
+}
+
+export interface ValidationFixTarget extends ValidationFixLocation {
+  stage: ValidationFixStage
+}
+
+export type ValidationFixDestination =
+  | { kind: "stage"; stage: ValidationFixStage }
+  | { kind: "page"; stage: ValidationFixStage; pageId: string; sectionId?: string }
+
+const ACCESSIBILITY_RULE_STAGES: Partial<Record<string, ValidationFixStage>> = {
+  "area-alt": "captions",
+  "image-alt": "captions",
+  "input-image-alt": "captions",
+  "object-alt": "captions",
+  "role-img-alt": "captions",
+  "svg-img-alt": "captions",
+  "audio-caption": "speech",
+  "video-caption": "speech",
+  "heading-order": "sectioning",
+  "landmark-one-main": "sectioning",
+  "page-has-heading-one": "sectioning",
+  "region": "sectioning",
+}
+
+const ACCESSIBILITY_CATEGORY_STAGES: Record<AccessibilityCategoryKey, ValidationFixStage> = {
+  "text-alternatives": "captions",
+  "structure-semantics": "sectioning",
+  "keyboard-navigation": "storyboard",
+  "forms-controls": "storyboard",
+  tables: "sectioning",
+  "media-timing": "speech",
+  "visual-cues": "storyboard",
+  other: "storyboard",
+}
+
+const LEGACY_REVIEWER_SECTION_STAGES: Partial<Record<string, ValidationFixStage>> = {
+  text: "sectioning",
+  "visual-media": "captions",
+  audio: "speech",
+  "easy-read": "easy-read",
+  glossary: "glossary",
+  interactivity: "storyboard",
+  typography: "storyboard",
+  "instructional-content": "sectioning",
+  translation: "translate",
+  "sign-language": "sign-language",
+}
+
+export function resolveAccessibilityFixStage(
+  ruleId: string,
+  categoryKey: AccessibilityCategoryKey,
+): ValidationFixStage {
+  return ACCESSIBILITY_RULE_STAGES[ruleId] ?? ACCESSIBILITY_CATEGORY_STAGES[categoryKey]
+}
+
+export function resolveReviewerFixStage(
+  section: ReviewerValidationSection,
+  criterion: ReviewerValidationCriterion,
+): ValidationFixStage {
+  return criterion.fix_stage
+    ?? section.fix_stage
+    ?? LEGACY_REVIEWER_SECTION_STAGES[section.id]
+    ?? "storyboard"
+}
+
+export function deriveSectionIdFromHref(href: string | null | undefined): string | null {
+  if (!href) return null
+  const pathname = href.split("#", 1)[0].split("?", 1)[0]
+  const basename = pathname.split("/").filter(Boolean).at(-1)
+  if (!basename) return null
+  const match = basename.match(/^(.+_sec\d{3,})\.(?:html|xhtml)$/i)
+  return match?.[1] ?? null
+}
+
+export function resolveValidationFixDestination(
+  target: ValidationFixTarget,
+): ValidationFixDestination {
+  if (!target.pageId || !hasStagePages(target.stage)) {
+    return { kind: "stage", stage: target.stage }
+  }
+
+  const sectionId = target.sectionId ?? deriveSectionIdFromHref(target.href)
+  const supportsExactSection = target.stage === "sectioning" || target.stage === "storyboard"
+
+  return {
+    kind: "page",
+    stage: target.stage,
+    pageId: target.pageId,
+    ...(supportsExactSection && sectionId ? { sectionId } : {}),
+  }
+}

--- a/apps/studio/src/lib/validation-fix-routing.ts
+++ b/apps/studio/src/lib/validation-fix-routing.ts
@@ -47,6 +47,12 @@ const ACCESSIBILITY_CATEGORY_STAGES: Record<AccessibilityCategoryKey, Validation
 }
 
 const LEGACY_REVIEWER_SECTION_STAGES: Partial<Record<string, ValidationFixStage>> = {
+  "text-extracted-accuracy": "sectioning",
+  "visual-media-image-description": "captions",
+  "audio-voice-over": "speech",
+  "typography-layout-visual-readability": "storyboard",
+  "instructional-content-design": "sectioning",
+  // Retain aliases for customized catalogs created before fix-stage metadata.
   text: "sectioning",
   "visual-media": "captions",
   audio: "speech",

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -1480,6 +1480,9 @@ msgstr "Auto-fill from book context"
 msgid "Auto-scroll"
 msgstr "Auto-scroll"
 
+msgid "Automatic routing"
+msgstr "Automatic routing"
+
 msgid "Automatically adapts the layout based on each page's content using AI."
 msgstr "Automatically adapts the layout based on each page's content using AI."
 
@@ -3502,6 +3505,12 @@ msgstr "First language is the default"
 
 msgid "Fit"
 msgstr "Fit"
+
+msgid "Fix destination"
+msgstr "Fix destination"
+
+msgid "Fix in {fixStageLabel}"
+msgstr "Fix in {fixStageLabel}"
 
 msgid "Fixed layout"
 msgstr "Fixed layout"
@@ -5624,6 +5633,10 @@ msgstr "Opacity"
 msgid "Open"
 msgstr "Open"
 
+#. placeholder {0}: formatFindingPageLabel(i18n, page)
+msgid "Open {0} in {fixStageLabel}"
+msgstr "Open {0} in {fixStageLabel}"
+
 msgid "Open a page in Preview to show its page-specific accessibility findings here."
 msgstr "Open a page in Preview to show its page-specific accessibility findings here."
 
@@ -5655,6 +5668,10 @@ msgstr "Open edit panel"
 
 msgid "Open image preview"
 msgstr "Open image preview"
+
+#. placeholder {0}: i18n._(STAGE_LABEL_MESSAGES[entry.fixStage])
+msgid "Open in {0}"
+msgstr "Open in {0}"
 
 msgid "Open in any EPUB 3 reader, e-reader, or accessibility tool."
 msgstr "Open in any EPUB 3 reader, e-reader, or accessibility tool."
@@ -8441,6 +8458,12 @@ msgstr "The quick brown fox jumps over the lazy dog."
 msgid "The rendering strategy used for sections without an explicit mapping."
 msgstr "The rendering strategy used for sections without an explicit mapping."
 
+msgid "The requested section is no longer available. Opened the first section instead."
+msgstr "The requested section is no longer available. Opened the first section instead."
+
+msgid "The requested section is no longer available. Opened the page instead."
+msgstr "The requested section is no longer available. Opened the page instead."
+
 msgid "The river meets the sea"
 msgstr "The river meets the sea"
 
@@ -9130,6 +9153,9 @@ msgstr "Use Liquid syntax to interpolate variables, loop over arrays, and condit
 #. placeholder {0}: page.pageNumber
 msgid "Use page {0} for the quiz"
 msgstr "Use page {0} for the quiz"
+
+msgid "Use section destination"
+msgstr "Use section destination"
 
 msgid "Use section headings verbatim. Fast, deterministic, and preserves the original wording from the book."
 msgstr "Use section headings verbatim. Fast, deterministic, and preserves the original wording from the book."

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -1480,6 +1480,9 @@ msgstr "Autocompletar desde el contexto del libro"
 msgid "Auto-scroll"
 msgstr "Desplazamiento automático"
 
+msgid "Automatic routing"
+msgstr "Enrutamiento automático"
+
 msgid "Automatically adapts the layout based on each page's content using AI."
 msgstr "Adapta automáticamente el diseño según el contenido de cada página usando IA."
 
@@ -3502,6 +3505,12 @@ msgstr "El primer idioma es el predeterminado"
 
 msgid "Fit"
 msgstr "Ajustar"
+
+msgid "Fix destination"
+msgstr "Destino de la corrección"
+
+msgid "Fix in {fixStageLabel}"
+msgstr "Corregir en {fixStageLabel}"
 
 msgid "Fixed layout"
 msgstr "Diseño fijo"
@@ -5624,6 +5633,10 @@ msgstr "Opacidad"
 msgid "Open"
 msgstr "Abrir"
 
+#. placeholder {0}: formatFindingPageLabel(i18n, page)
+msgid "Open {0} in {fixStageLabel}"
+msgstr "Abrir {0} en {fixStageLabel}"
+
 msgid "Open a page in Preview to show its page-specific accessibility findings here."
 msgstr "Open a page in Preview to show its page-specific accessibility findings here."
 
@@ -5655,6 +5668,10 @@ msgstr "Abrir panel de edición"
 
 msgid "Open image preview"
 msgstr "Abrir vista previa de la imagen"
+
+#. placeholder {0}: i18n._(STAGE_LABEL_MESSAGES[entry.fixStage])
+msgid "Open in {0}"
+msgstr "Abrir en {0}"
 
 msgid "Open in any EPUB 3 reader, e-reader, or accessibility tool."
 msgstr "Ábrelo en cualquier lector EPUB 3, lector electrónico o herramienta de accesibilidad."
@@ -8441,6 +8458,12 @@ msgstr "El veloz zorro marrón salta sobre el perro perezoso."
 msgid "The rendering strategy used for sections without an explicit mapping."
 msgstr "La estrategia de renderización usada para secciones sin un mapeo explícito."
 
+msgid "The requested section is no longer available. Opened the first section instead."
+msgstr "La sección solicitada ya no está disponible. Se abrió la primera sección en su lugar."
+
+msgid "The requested section is no longer available. Opened the page instead."
+msgstr "La sección solicitada ya no está disponible. Se abrió la página en su lugar."
+
 msgid "The river meets the sea"
 msgstr "El río se encuentra con el mar"
 
@@ -9130,6 +9153,9 @@ msgstr "Usa la sintaxis de Liquid para interpolar variables, recorrer arrays e i
 #. placeholder {0}: page.pageNumber
 msgid "Use page {0} for the quiz"
 msgstr "Usar la página {0} para el cuestionario"
+
+msgid "Use section destination"
+msgstr "Usar el destino de la sección"
 
 msgid "Use section headings verbatim. Fast, deterministic, and preserves the original wording from the book."
 msgstr "Usa los encabezados de sección textualmente. Rápido, determinista y preserva el texto original del libro."

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -1482,6 +1482,9 @@ msgstr "Remplissage automatique à partir du contexte du livre"
 msgid "Auto-scroll"
 msgstr "Défilement automatique"
 
+msgid "Automatic routing"
+msgstr "Routage automatique"
+
 msgid "Automatically adapts the layout based on each page's content using AI."
 msgstr "Adapte automatiquement la mise en page en fonction du contenu de chaque page grâce à l'IA."
 
@@ -3504,6 +3507,12 @@ msgstr "La première langue est la langue par défaut"
 
 msgid "Fit"
 msgstr "Ajuster"
+
+msgid "Fix destination"
+msgstr "Destination de la correction"
+
+msgid "Fix in {fixStageLabel}"
+msgstr "Corriger dans {fixStageLabel}"
 
 msgid "Fixed layout"
 msgstr "Mise en page fixe"
@@ -5626,6 +5635,10 @@ msgstr "Opacité"
 msgid "Open"
 msgstr "Ouvrir"
 
+#. placeholder {0}: formatFindingPageLabel(i18n, page)
+msgid "Open {0} in {fixStageLabel}"
+msgstr "Ouvrir {0} dans {fixStageLabel}"
+
 msgid "Open a page in Preview to show its page-specific accessibility findings here."
 msgstr "Ouvrez une page dans l'aperçu pour afficher les résultats d'accessibilité spécifiques à la page ici."
 
@@ -5657,6 +5670,10 @@ msgstr "Ouvrir le panneau de modification"
 
 msgid "Open image preview"
 msgstr "Ouvrir l'aperçu de l'image"
+
+#. placeholder {0}: i18n._(STAGE_LABEL_MESSAGES[entry.fixStage])
+msgid "Open in {0}"
+msgstr "Ouvrir dans {0}"
 
 msgid "Open in any EPUB 3 reader, e-reader, or accessibility tool."
 msgstr "Ouvrez-le dans n'importe quelle liseuse EPUB 3 ou outil d'accessibilité."
@@ -8443,6 +8460,12 @@ msgstr "Le vif renard brun saute par-dessus le chien paresseux."
 msgid "The rendering strategy used for sections without an explicit mapping."
 msgstr "La stratégie de rendu utilisée pour les sections sans correspondance explicite."
 
+msgid "The requested section is no longer available. Opened the first section instead."
+msgstr "La section demandée n’est plus disponible. La première section a été ouverte à la place."
+
+msgid "The requested section is no longer available. Opened the page instead."
+msgstr "La section demandée n’est plus disponible. La page a été ouverte à la place."
+
 msgid "The river meets the sea"
 msgstr "La rivière rejoint la mer"
 
@@ -9132,6 +9155,9 @@ msgstr "Utilisez la syntaxe Liquid pour interpoler des variables, parcourir des 
 #. placeholder {0}: page.pageNumber
 msgid "Use page {0} for the quiz"
 msgstr "Utiliser la page {0} pour le quiz"
+
+msgid "Use section destination"
+msgstr "Utiliser la destination de la section"
 
 msgid "Use section headings verbatim. Fast, deterministic, and preserves the original wording from the book."
 msgstr "Utilisez les titres de section textuellement. Rapide, déterministe et préserve le libellé original du livre."

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -1480,6 +1480,9 @@ msgstr "Preenchimento automático do contexto do livro"
 msgid "Auto-scroll"
 msgstr "Rolagem automática"
 
+msgid "Automatic routing"
+msgstr "Roteamento automático"
+
 msgid "Automatically adapts the layout based on each page's content using AI."
 msgstr "Adapta automaticamente o layout com base no conteúdo de cada página usando IA."
 
@@ -3502,6 +3505,12 @@ msgstr "O primeiro idioma é o padrão"
 
 msgid "Fit"
 msgstr "Ajustar"
+
+msgid "Fix destination"
+msgstr "Destino da correção"
+
+msgid "Fix in {fixStageLabel}"
+msgstr "Corrigir em {fixStageLabel}"
 
 msgid "Fixed layout"
 msgstr "Layout fixo"
@@ -5624,6 +5633,10 @@ msgstr "Opacidade"
 msgid "Open"
 msgstr "Abrir"
 
+#. placeholder {0}: formatFindingPageLabel(i18n, page)
+msgid "Open {0} in {fixStageLabel}"
+msgstr "Abrir {0} em {fixStageLabel}"
+
 msgid "Open a page in Preview to show its page-specific accessibility findings here."
 msgstr "Open a page in Preview to show its page-specific accessibility findings here."
 
@@ -5655,6 +5668,10 @@ msgstr "Abrir painel de edição"
 
 msgid "Open image preview"
 msgstr "Abrir pré-visualização da imagem"
+
+#. placeholder {0}: i18n._(STAGE_LABEL_MESSAGES[entry.fixStage])
+msgid "Open in {0}"
+msgstr "Abrir em {0}"
 
 msgid "Open in any EPUB 3 reader, e-reader, or accessibility tool."
 msgstr "Abra em qualquer leitor EPUB 3, leitor eletrônico ou ferramenta de acessibilidade."
@@ -8441,6 +8458,12 @@ msgstr "A rápida raposa marrom salta sobre o cão preguiçoso."
 msgid "The rendering strategy used for sections without an explicit mapping."
 msgstr "A estratégia de renderização usada para seções sem um mapeamento explícito."
 
+msgid "The requested section is no longer available. Opened the first section instead."
+msgstr "A seção solicitada não está mais disponível. A primeira seção foi aberta em seu lugar."
+
+msgid "The requested section is no longer available. Opened the page instead."
+msgstr "A seção solicitada não está mais disponível. A página foi aberta em seu lugar."
+
 msgid "The river meets the sea"
 msgstr "O rio encontra o mar"
 
@@ -9130,6 +9153,9 @@ msgstr "Use a sintaxe Liquid para interpolar variáveis, percorrer arrays e incl
 #. placeholder {0}: page.pageNumber
 msgid "Use page {0} for the quiz"
 msgstr "Usar a página {0} para o questionário"
+
+msgid "Use section destination"
+msgstr "Usar o destino da seção"
 
 msgid "Use section headings verbatim. Fast, deterministic, and preserves the original wording from the book."
 msgstr "Use os títulos das seções literalmente. Rápido, determinístico e preserva a redação original do livro."

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -1481,6 +1481,9 @@ msgstr "Plotëso automatikisht nga konteksti i librit"
 msgid "Auto-scroll"
 msgstr "Lëvizje automatike"
 
+msgid "Automatic routing"
+msgstr "Drejtim automatik"
+
 msgid "Automatically adapts the layout based on each page's content using AI."
 msgstr "Përshtaton automatikisht paraqitjen bazuar në përmbajtjen e çdo faqeje duke përdorur AI."
 
@@ -3503,6 +3506,12 @@ msgstr "Gjuha e parë është e parazgjedhur"
 
 msgid "Fit"
 msgstr "Përshtat"
+
+msgid "Fix destination"
+msgstr "Destinacioni i korrigjimit"
+
+msgid "Fix in {fixStageLabel}"
+msgstr "Korrigjo në {fixStageLabel}"
 
 msgid "Fixed layout"
 msgstr "Strukturë fikse"
@@ -5625,6 +5634,10 @@ msgstr "Transparenca"
 msgid "Open"
 msgstr "Hapni"
 
+#. placeholder {0}: formatFindingPageLabel(i18n, page)
+msgid "Open {0} in {fixStageLabel}"
+msgstr "Hap {0} në {fixStageLabel}"
+
 msgid "Open a page in Preview to show its page-specific accessibility findings here."
 msgstr "Hapni një faqe në Pamjen Paraprake për të shfaqur këtu gjetjet e aksesueshmërisë specifike të faqes."
 
@@ -5656,6 +5669,10 @@ msgstr "Hapni panelin e redaktimit"
 
 msgid "Open image preview"
 msgstr "Hapni pamjen paraprake të imazhit"
+
+#. placeholder {0}: i18n._(STAGE_LABEL_MESSAGES[entry.fixStage])
+msgid "Open in {0}"
+msgstr "Hap në {0}"
 
 msgid "Open in any EPUB 3 reader, e-reader, or accessibility tool."
 msgstr "Hapeni në çdo lexues EPUB 3, e-reader, ose mjet aksesueshmërie."
@@ -8442,6 +8459,12 @@ msgstr "Dhelpra e shpejtë kafe kërcen mbi qenin dembel."
 msgid "The rendering strategy used for sections without an explicit mapping."
 msgstr "Strategjia e renderimit e përdorur për seksionet pa një hartëzim eksplicit."
 
+msgid "The requested section is no longer available. Opened the first section instead."
+msgstr "Seksioni i kërkuar nuk është më i disponueshëm. Në vend të tij u hap seksioni i parë."
+
+msgid "The requested section is no longer available. Opened the page instead."
+msgstr "Seksioni i kërkuar nuk është më i disponueshëm. Në vend të tij u hap faqja."
+
 msgid "The river meets the sea"
 msgstr "Lumi takon detin"
 
@@ -9131,6 +9154,9 @@ msgstr "Përdor sintaksën Liquid për të interpoluar variabla, për të iterua
 #. placeholder {0}: page.pageNumber
 msgid "Use page {0} for the quiz"
 msgstr "Përdor faqen {0} për kuizin"
+
+msgid "Use section destination"
+msgstr "Përdor destinacionin e seksionit"
 
 msgid "Use section headings verbatim. Fast, deterministic, and preserves the original wording from the book."
 msgstr "Përdor titujt e seksioneve fjalë për fjalë. I shpejtë, deterministik dhe ruan formulimin origjinal të librit."

--- a/apps/studio/src/routes/books.$label.$step.$pageId.tsx
+++ b/apps/studio/src/routes/books.$label.$step.$pageId.tsx
@@ -1,8 +1,10 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router"
 import { useCallback } from "react"
 import { StepViewRouter } from "@/components/pipeline/components/StepViewRouter"
+import { parseBookStepSearch } from "@/lib/book-step-search"
 
 export const Route = createFileRoute("/books/$label/$step/$pageId")({
+  validateSearch: parseBookStepSearch,
   component: StepPageDetailPage,
 })
 

--- a/apps/studio/src/routes/books.$label.$step.index.tsx
+++ b/apps/studio/src/routes/books.$label.$step.index.tsx
@@ -2,12 +2,14 @@ import { createFileRoute, useNavigate, ErrorComponentProps } from "@tanstack/rea
 import { useCallback } from "react"
 import { StepViewRouter } from "@/components/pipeline/components/StepViewRouter"
 import { ErrorScreen } from "@/components/ErrorScreen"
+import { parseBookStepSearch } from "@/lib/book-step-search"
 
 function BookErrorComponent({ error, reset }: ErrorComponentProps) {
   return <ErrorScreen variant="route" error={error} reset={reset} />
 }
 
 export const Route = createFileRoute("/books/$label/$step/")({
+  validateSearch: parseBookStepSearch,
   component: StepIndexPage,
   errorComponent: BookErrorComponent,
 })

--- a/config/reviewer_validation.yaml
+++ b/config/reviewer_validation.yaml
@@ -52,6 +52,7 @@ instructions:
 sections:
 - id: text-extracted-accuracy
   label: Text extracted accuracy
+  fix_stage: sectioning
   criteria:
   - id: text-matches-original-reading-order
     label: Extracted text matches the original text and preserves the original reading order.
@@ -65,18 +66,22 @@ sections:
     requires_suggested_modification_on_failure: true
 - id: visual-media-image-description
   label: Visual media & image description
+  fix_stage: captions
   criteria:
   - id: images-match-original-framing
+    fix_stage: extract
     label: Extracted images match the original book and preserve framing and proportions.
     guidance: Extracted images must exactly match the original PDF images, preserving the original frame, resolution, aspect ratio, color fidelity, and visual integrity without distortion, cropping, or content alteration.
     requires_comment_on_failure: true
     requires_suggested_modification_on_failure: true
   - id: text-not-in-image-format
+    fix_stage: sectioning
     label: Text content is not in image format.
     guidance: Verify that no meaningful text has been saved as an image. All text associated with pictures should be separated and presented as selectable, readable text rather than embedded within an image.
     requires_comment_on_failure: true
     requires_suggested_modification_on_failure: true
   - id: illustrations-remain-consistent
+    fix_stage: storyboard
     label: Consistent illustrations are used to describe objects, places and others.
     guidance: When the same character, object, or location appears multiple times, the same illustration style should be used to maintain coherence and avoid confusion.
     requires_comment_on_failure: true
@@ -103,6 +108,7 @@ sections:
     requires_suggested_modification_on_failure: false
 - id: audio-voice-over
   label: Audio and voice-over
+  fix_stage: speech
   criteria:
   - id: audio-available-for-relevant-content
     label: Audio is available for all relevant content.
@@ -116,6 +122,7 @@ sections:
     requires_suggested_modification_on_failure: true
 - id: easy-read
   label: Easy-read
+  fix_stage: easy-read
   criteria:
   - id: easy-read-preserves-key-information
     label: Easy-read content simplifies language while preserving key information and pedagogical value.
@@ -134,6 +141,7 @@ sections:
     requires_suggested_modification_on_failure: false
 - id: glossary
   label: Glossary
+  fix_stage: glossary
   criteria:
   - id: glossary-includes-relevant-key-terms
     label: Glossary includes key words, new terminology, and concepts. Words that are not relevant should not be included.
@@ -147,6 +155,7 @@ sections:
     requires_suggested_modification_on_failure: true
 - id: interactivity
   label: Interactivity
+  fix_stage: storyboard
   criteria:
   - id: all-exercises-are-interactive
     label: All exercises are interactive.
@@ -180,6 +189,7 @@ sections:
     requires_suggested_modification_on_failure: true
 - id: typography-layout-visual-readability
   label: Typography, layout and visual readability
+  fix_stage: storyboard
   criteria:
   - id: design-maintains-learning-flow
     label: Design and layout maintain the intended learning flow from the original book.
@@ -193,6 +203,7 @@ sections:
     requires_suggested_modification_on_failure: true
 - id: instructional-content-design
   label: Instructional content design
+  fix_stage: sectioning
   criteria:
   - id: inclusive-language-used
     label: Inclusive language is used throughout all content.
@@ -221,6 +232,7 @@ sections:
     requires_suggested_modification_on_failure: true
 - id: translation
   label: Translation
+  fix_stage: translate
   criteria:
   - id: translation-accurate-fluent-preserves-meaning
     label: Translation is accurate, fluent and preserves meaning and complexity.
@@ -249,6 +261,7 @@ sections:
     requires_suggested_modification_on_failure: false
 - id: sign-language
   label: Sign language
+  fix_stage: sign-language
   criteria:
   - id: signing-movements-visible
     label: All types of signing movements and facial expressions are fully visible.

--- a/packages/types/src/__tests__/reviewer-validation.test.ts
+++ b/packages/types/src/__tests__/reviewer-validation.test.ts
@@ -3,6 +3,7 @@ import {
   ReviewerPageValidationRecord,
   ReviewerValidationCatalogSnapshot,
   ReviewerValidationSession,
+  ValidationFixStage,
 } from "../reviewer-validation.js"
 
 describe("reviewer validation schemas", () => {
@@ -18,6 +19,7 @@ describe("reviewer validation schemas", () => {
     const record = ReviewerPageValidationRecord.parse({
       session_id: session.session_id,
       page_id: "page-1",
+      section_id: "page-1_sec001",
       page_number: 1,
       href: "content/pages/page-1.html",
       language: "sw",
@@ -31,6 +33,7 @@ describe("reviewer validation schemas", () => {
     })
 
     expect(record.language).toBe("sw")
+    expect(record.section_id).toBe("page-1_sec001")
     expect(record.results[0]?.status).toBe("needs-changes")
   })
 
@@ -67,11 +70,13 @@ describe("reviewer validation schemas", () => {
         {
           id: "custom-checks",
           label: "Custom checks",
+          fix_stage: "sectioning",
           criteria: [
             {
               id: "custom-criterion",
               label: "Custom criterion",
               guidance: "Check this custom requirement.",
+              fix_stage: "storyboard",
             },
           ],
         },
@@ -86,5 +91,12 @@ describe("reviewer validation schemas", () => {
 
     expect(session.catalog_snapshot?.pageSections).toHaveLength(1)
     expect(session.catalog_snapshot?.pageSections[0]?.id).toBe("custom-checks")
+    expect(session.catalog_snapshot?.pageSections[0]?.fix_stage).toBe("sectioning")
+    expect(session.catalog_snapshot?.pageSections[0]?.criteria[0]?.fix_stage).toBe("storyboard")
+  })
+
+  it("limits fix routing to editable destination stages", () => {
+    expect(ValidationFixStage.safeParse("storyboard").success).toBe(true)
+    expect(ValidationFixStage.safeParse("validation").success).toBe(false)
   })
 })

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -344,6 +344,7 @@ export { TypographyStyle, BookTypography, DEFAULT_TYPOGRAPHY } from "./typograph
 export {
   ReviewerValidationStatus,
   ReviewerValidationFieldType,
+  ValidationFixStage,
   ReviewerValidationIdentificationField,
   ReviewerValidationInstruction,
   ReviewerValidationCriterion,

--- a/packages/types/src/reviewer-validation.ts
+++ b/packages/types/src/reviewer-validation.ts
@@ -11,6 +11,20 @@ export type ReviewerValidationStatus = z.infer<typeof ReviewerValidationStatus>
 export const ReviewerValidationFieldType = z.enum(["text", "number", "date", "textarea"])
 export type ReviewerValidationFieldType = z.infer<typeof ReviewerValidationFieldType>
 
+export const ValidationFixStage = z.enum([
+  "extract",
+  "sectioning",
+  "storyboard",
+  "captions",
+  "quizzes",
+  "glossary",
+  "easy-read",
+  "translate",
+  "speech",
+  "sign-language",
+])
+export type ValidationFixStage = z.infer<typeof ValidationFixStage>
+
 export const ReviewerValidationIdentificationField = z.object({
   id: z.string().regex(/^[a-z0-9-]+$/),
   label: z.string().min(1),
@@ -32,6 +46,7 @@ export const ReviewerValidationCriterion = z.object({
   id: z.string().regex(/^[a-z0-9-]+$/),
   label: z.string().min(1),
   guidance: z.string().min(1),
+  fix_stage: ValidationFixStage.optional(),
   requires_comment_on_failure: z.boolean().default(true),
   requires_suggested_modification_on_failure: z.boolean().default(false),
 })
@@ -40,6 +55,7 @@ export type ReviewerValidationCriterion = z.infer<typeof ReviewerValidationCrite
 export const ReviewerValidationSection = z.object({
   id: z.string().regex(/^[a-z0-9-]+$/),
   label: z.string().min(1),
+  fix_stage: ValidationFixStage.optional(),
   criteria: z.array(ReviewerValidationCriterion).min(1),
 })
 export type ReviewerValidationSection = z.infer<typeof ReviewerValidationSection>
@@ -90,6 +106,7 @@ export type ReviewerPageValidationResult = z.infer<typeof ReviewerPageValidation
 export const ReviewerPageValidationRecord = z.object({
   session_id: z.string().min(1),
   page_id: z.string().min(1),
+  section_id: z.string().min(1).optional(),
   page_number: z.number().int().min(1).optional(),
   href: z.string().min(1),
   language: z.string().min(1).optional(),


### PR DESCRIPTION
## Summary

This draft implements the direct-navigation portion of #618 so Validation findings can send users to the stage responsible for a fix.

- adds typed `fix_stage` ownership metadata to reviewer sections and criteria
- persists stable section context with reviewer page findings
- resolves automated Axe findings by rule override, then accessibility category
- resolves reviewer findings by criterion override, section ownership, historical defaults, then a safe Storyboard fallback
- opens page-aware destinations directly and focuses the exact stable section in Sectioning and Storyboard
- consumes deep-link focus state once and warns when a section no longer exists
- exposes reviewer fix destinations in checklist settings
- includes complete translations for en, es, fr, pt-BR, and sq

## Scope and known boundaries

This is intentionally a phase-one routing PR. It addresses the navigation workflow in #618 but does **not** close the full issue.

- Direct section rerender is deferred while #614 defines reliability expectations, #619 defines rerender scope, and #627 defines stale-section batching behavior.
- Destinations without page-aware routes currently open at the responsible stage root. Exact page/section context is preserved for page-aware stages and exact-section focus is supported in Sectioning and Storyboard.
- Automated ownership is a conservative rule/category mapping. A future iteration should move ownership/capability metadata alongside the shared pipeline definition and expose more routing provenance or manual override where useful.

Related issues:

- #618 — actionable Validation fix routing
- #614 — rerender reliability
- #619 — selected page/section/book rerender scope
- #627 — accumulated stale-section rerender workflow

## Compatibility

- Existing reviewer records remain valid because the new fields are optional.
- Existing reviewer sessions keep their immutable checklist snapshots.
- Historical default checklist IDs are mapped explicitly so pre-change sessions route to their original responsible stages.

## Verification

- `pnpm typecheck`
- `pnpm --filter @adt/studio lint` — no errors; 9 pre-existing unused-suppression warnings
- Lingui extract and compile — 0 missing translations in es, fr, pt-BR, and sq
- focused fix-routing tests — 21 passed
- repository tests excluding the known load-sensitive `part-service` file — 179 files, 2,215 tests passed
- isolated `apps/api/src/services/part-service.test.ts` — 13/13 passed
- production build completed through the `pnpm test` pretest step

The `part-service` tests can cross their existing 5-second timeout when the entire suite runs in parallel; they pass in isolation and are unrelated to these changes.

## Manual demonstration

1. Enable reviewer validation and inspect the new Fix destination controls under Validation settings.
2. Create a new reviewer session in Preview, mark a page criterion as Needs changes, and save it.
3. Open Reviewer Validation and use Open in Sectioning or Open in Storyboard.
4. Confirm that the original page opens, the exact stable section is focused, and the one-shot query parameter is removed.
5. Refresh automated validation, open a Structure and semantics finding, and confirm its affected-page action routes to the exact Sectioning section.
6. Use an invalid `sectionId` query value to confirm the warning and safe fallback behavior.
