### PR TITLE
Fix preview refresh after sign-language video changes

### DIFF
--- a/apps/studio/src/hooks/use-sign-language-videos.test.tsx
+++ b/apps/studio/src/hooks/use-sign-language-videos.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { act, renderHook, waitFor } from "@testing-library/react"
+import type { ReactNode } from "react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { api } from "@/api/client"
+import {
+  useAssignSignLanguageVideo,
+  useDeleteSignLanguageVideo,
+  useUploadSignLanguageVideo,
+} from "./use-sign-language-videos"
+
+vi.mock("@/api/client", () => ({
+  api: {
+    uploadSignLanguageVideo: vi.fn(),
+    assignSignLanguageVideo: vi.fn(),
+    deleteSignLanguageVideo: vi.fn(),
+  },
+}))
+
+const label = "test-book"
+
+function setup<T>(hook: () => T) {
+  const queryClient = new QueryClient({
+    defaultOptions: { mutations: { retry: false } },
+  })
+  const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries")
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+  const result = renderHook(hook, { wrapper }).result
+
+  return { result, invalidateQueries }
+}
+
+async function expectPreviewRefresh(
+  invalidateQueries: ReturnType<typeof vi.spyOn>,
+  repackageListener: ReturnType<typeof vi.fn>,
+) {
+  await waitFor(() => {
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["books", label, "sign-language-videos"],
+    })
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["package-adt-status", label],
+    })
+    expect(repackageListener).toHaveBeenCalledOnce()
+  })
+}
+
+describe("sign-language video mutations", () => {
+  const repackageListener = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    window.addEventListener("adt:repackage", repackageListener)
+  })
+
+  afterEach(() => {
+    window.removeEventListener("adt:repackage", repackageListener)
+  })
+
+  it("refreshes Preview after uploading a video", async () => {
+    vi.mocked(api.uploadSignLanguageVideo).mockResolvedValue({ videoId: "video-1" })
+    const { result, invalidateQueries } = setup(() => useUploadSignLanguageVideo(label))
+
+    await act(() => result.current.mutateAsync(new File(["video"], "video.mp4")))
+
+    await expectPreviewRefresh(invalidateQueries, repackageListener)
+  })
+
+  it("refreshes Preview after assigning a video", async () => {
+    vi.mocked(api.assignSignLanguageVideo).mockResolvedValue({ ok: true })
+    const { result, invalidateQueries } = setup(() => useAssignSignLanguageVideo(label))
+
+    await act(() =>
+      result.current.mutateAsync({ videoId: "video-1", sectionId: "pg001_sec001" }),
+    )
+
+    await expectPreviewRefresh(invalidateQueries, repackageListener)
+  })
+
+  it("refreshes Preview after deleting a video", async () => {
+    vi.mocked(api.deleteSignLanguageVideo).mockResolvedValue({ ok: true })
+    const { result, invalidateQueries } = setup(() => useDeleteSignLanguageVideo(label))
+
+    await act(() => result.current.mutateAsync("video-1"))
+
+    await expectPreviewRefresh(invalidateQueries, repackageListener)
+  })
+})

--- a/apps/studio/src/hooks/use-sign-language-videos.ts
+++ b/apps/studio/src/hooks/use-sign-language-videos.ts
@@ -1,6 +1,19 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
 import { api } from "@/api/client"
 
+function refreshVideoDataAndPreview(
+  queryClient: ReturnType<typeof useQueryClient>,
+  label: string,
+) {
+  void queryClient.invalidateQueries({
+    queryKey: ["books", label, "sign-language-videos"],
+  })
+  void queryClient.invalidateQueries({
+    queryKey: ["package-adt-status", label],
+  })
+  window.dispatchEvent(new CustomEvent("adt:repackage"))
+}
+
 export function useSignLanguageVideos(label: string) {
   return useQuery({
     queryKey: ["books", label, "sign-language-videos"],
@@ -14,7 +27,7 @@ export function useUploadSignLanguageVideo(label: string) {
   return useMutation({
     mutationFn: (file: File) => api.uploadSignLanguageVideo(label, file),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["books", label, "sign-language-videos"] })
+      refreshVideoDataAndPreview(queryClient, label)
     },
   })
 }
@@ -25,7 +38,7 @@ export function useAssignSignLanguageVideo(label: string) {
     mutationFn: ({ videoId, sectionId }: { videoId: string; sectionId: string | null }) =>
       api.assignSignLanguageVideo(label, videoId, sectionId),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["books", label, "sign-language-videos"] })
+      refreshVideoDataAndPreview(queryClient, label)
     },
   })
 }
@@ -35,7 +48,7 @@ export function useDeleteSignLanguageVideo(label: string) {
   return useMutation({
     mutationFn: (videoId: string) => api.deleteSignLanguageVideo(label, videoId),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["books", label, "sign-language-videos"] })
+      refreshVideoDataAndPreview(queryClient, label)
     },
   })
 }


### PR DESCRIPTION
## Summary

- refresh the sign-language video query after every video mutation
- invalidate packaged ADT preview status after upload, assignment/reassignment, and deletion
- dispatch the existing `adt:repackage` event so an open Preview rebuilds immediately
- add regression coverage for all three mutation hooks

Closes #655

## Verification

- `pnpm exec vitest run apps/studio/src/hooks/use-sign-language-videos.test.tsx`
- `pnpm typecheck`
- `pnpm --filter @adt/studio lint` (passes with 9 pre-existing unused-disable warnings)