### PR TITLE
Fix preview refresh after sign-language video changes

### DIFF
--- a/apps/api/src/routes/package.test.ts
+++ b/apps/api/src/routes/package.test.ts
@@ -204,6 +204,63 @@ describe("Package routes", () => {
       expect(JSON.parse(fs.readFileSync(configPath, "utf-8")).bundleVersion).toBe(secondBody.version)
     })
 
+    it("repackages when a sign-language video assignment changes", { timeout: 20_000 }, async () => {
+      const label = "book-sign-language-cache"
+      createRenderedBook(label)
+      createWebAssets()
+
+      const storage = createBookStorage(label, tmpDir)
+      storage.putSignLanguageVideo(
+        "video-1",
+        Buffer.from("video-content"),
+        "video.mp4",
+        "video/mp4",
+      )
+      storage.close()
+
+      const packageBook = async () => {
+        const response = await app.request(`/api/books/${label}/package-adt`, {
+          method: "POST",
+        })
+        expect(response.status).toBe(200)
+        return await response.json() as { version: string }
+      }
+      const videosPath = path.join(
+        tmpDir,
+        label,
+        "adt",
+        "content",
+        "i18n",
+        "en",
+        "videos.json",
+      )
+      const configPath = path.join(tmpDir, label, "adt", "assets", "config.json")
+
+      const unassignedPackage = await packageBook()
+      expect(JSON.parse(fs.readFileSync(videosPath, "utf-8"))).toEqual({})
+      expect(JSON.parse(fs.readFileSync(configPath, "utf-8")).features.signLanguage).toBe(false)
+
+      const assignedStorage = createBookStorage(label, tmpDir)
+      assignedStorage.assignSignLanguageVideo("video-1", "pg001_sec001")
+      assignedStorage.close()
+
+      const assignedPackage = await packageBook()
+      expect(assignedPackage.version).not.toBe(unassignedPackage.version)
+      expect(JSON.parse(fs.readFileSync(videosPath, "utf-8"))).toEqual({
+        "video-1": "sl_pg001_sec001.mp4",
+      })
+      expect(JSON.parse(fs.readFileSync(configPath, "utf-8")).features.signLanguage).toBe(true)
+
+      const unassignedStorage = createBookStorage(label, tmpDir)
+      unassignedStorage.assignSignLanguageVideo("video-1", null)
+      unassignedStorage.close()
+
+      const unassignedAgainPackage = await packageBook()
+      expect(unassignedAgainPackage.version).not.toBe(assignedPackage.version)
+      expect(JSON.parse(fs.readFileSync(videosPath, "utf-8"))).toEqual({})
+      expect(JSON.parse(fs.readFileSync(configPath, "utf-8")).features.signLanguage).toBe(false)
+    })
+
     it("reuses an active packaging task for duplicate preview requests", async () => {
       createRenderedBook("book-package-dedupe")
       createWebAssets()

--- a/apps/studio/src/hooks/use-sign-language-videos.test.tsx
+++ b/apps/studio/src/hooks/use-sign-language-videos.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { act, renderHook, waitFor } from "@testing-library/react"
+import type { ReactNode } from "react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { api } from "@/api/client"
+import {
+  useAssignSignLanguageVideo,
+  useDeleteSignLanguageVideo,
+  useUploadSignLanguageVideo,
+} from "./use-sign-language-videos"
+
+vi.mock("@/api/client", () => ({
+  api: {
+    uploadSignLanguageVideo: vi.fn(),
+    assignSignLanguageVideo: vi.fn(),
+    deleteSignLanguageVideo: vi.fn(),
+  },
+}))
+
+const label = "test-book"
+
+function setup<T>(hook: () => T) {
+  const queryClient = new QueryClient({
+    defaultOptions: { mutations: { retry: false } },
+  })
+  const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries")
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+  const result = renderHook(hook, { wrapper }).result
+
+  return { result, invalidateQueries }
+}
+
+async function expectPreviewRefresh(
+  invalidateQueries: ReturnType<typeof vi.spyOn>,
+  repackageListener: ReturnType<typeof vi.fn>,
+) {
+  await waitFor(() => {
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["books", label, "sign-language-videos"],
+    })
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["package-adt-status", label],
+    })
+    expect(repackageListener).toHaveBeenCalledOnce()
+  })
+}
+
+describe("sign-language video mutations", () => {
+  const repackageListener = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    window.addEventListener("adt:repackage", repackageListener)
+  })
+
+  afterEach(() => {
+    window.removeEventListener("adt:repackage", repackageListener)
+  })
+
+  it("refreshes Preview after uploading a video", async () => {
+    vi.mocked(api.uploadSignLanguageVideo).mockResolvedValue({ videoId: "video-1" })
+    const { result, invalidateQueries } = setup(() => useUploadSignLanguageVideo(label))
+
+    await act(() => result.current.mutateAsync(new File(["video"], "video.mp4")))
+
+    await expectPreviewRefresh(invalidateQueries, repackageListener)
+  })
+
+  it("refreshes Preview after assigning a video", async () => {
+    vi.mocked(api.assignSignLanguageVideo).mockResolvedValue({ ok: true })
+    const { result, invalidateQueries } = setup(() => useAssignSignLanguageVideo(label))
+
+    await act(() =>
+      result.current.mutateAsync({ videoId: "video-1", sectionId: "pg001_sec001" }),
+    )
+
+    await expectPreviewRefresh(invalidateQueries, repackageListener)
+  })
+
+  it("refreshes Preview after deleting a video", async () => {
+    vi.mocked(api.deleteSignLanguageVideo).mockResolvedValue({ ok: true })
+    const { result, invalidateQueries } = setup(() => useDeleteSignLanguageVideo(label))
+
+    await act(() => result.current.mutateAsync("video-1"))
+
+    await expectPreviewRefresh(invalidateQueries, repackageListener)
+  })
+})

--- a/apps/studio/src/hooks/use-sign-language-videos.ts
+++ b/apps/studio/src/hooks/use-sign-language-videos.ts
@@ -1,6 +1,19 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
 import { api } from "@/api/client"
 
+function refreshVideoDataAndPreview(
+  queryClient: ReturnType<typeof useQueryClient>,
+  label: string,
+) {
+  void queryClient.invalidateQueries({
+    queryKey: ["books", label, "sign-language-videos"],
+  })
+  void queryClient.invalidateQueries({
+    queryKey: ["package-adt-status", label],
+  })
+  window.dispatchEvent(new CustomEvent("adt:repackage"))
+}
+
 export function useSignLanguageVideos(label: string) {
   return useQuery({
     queryKey: ["books", label, "sign-language-videos"],
@@ -14,7 +27,7 @@ export function useUploadSignLanguageVideo(label: string) {
   return useMutation({
     mutationFn: (file: File) => api.uploadSignLanguageVideo(label, file),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["books", label, "sign-language-videos"] })
+      refreshVideoDataAndPreview(queryClient, label)
     },
   })
 }
@@ -25,7 +38,7 @@ export function useAssignSignLanguageVideo(label: string) {
     mutationFn: ({ videoId, sectionId }: { videoId: string; sectionId: string | null }) =>
       api.assignSignLanguageVideo(label, videoId, sectionId),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["books", label, "sign-language-videos"] })
+      refreshVideoDataAndPreview(queryClient, label)
     },
   })
 }
@@ -35,7 +48,7 @@ export function useDeleteSignLanguageVideo(label: string) {
   return useMutation({
     mutationFn: (videoId: string) => api.deleteSignLanguageVideo(label, videoId),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["books", label, "sign-language-videos"] })
+      refreshVideoDataAndPreview(queryClient, label)
     },
   })
 }

--- a/packages/pipeline/src/packaging/web.ts
+++ b/packages/pipeline/src/packaging/web.ts
@@ -207,16 +207,23 @@ export function computePackagingInputHash(options: ComputePackagingInputHashOpti
   // 3. Book config (affects rendering, accessibility, etc.)
   hash.update(JSON.stringify(options.config))
 
-  // 4. Web assets directory fingerprint (file names + sizes + mtimes)
+  // 4. Sign-language metadata. Assigning or reassigning a video only updates
+  // SQLite, so the videos directory fingerprint below does not detect it.
+  const signLanguageVideos = options.storage.getSignLanguageVideos()
+    .map(({ videoId, sectionId, mimeType }) => ({ videoId, sectionId, mimeType }))
+    .sort((a, b) => a.videoId.localeCompare(b.videoId))
+  hash.update(JSON.stringify(signLanguageVideos))
+
+  // 5. Web assets directory fingerprint (file names + sizes + mtimes)
   const assetEntries = collectDirectoryFingerprint(options.webAssetsDir).sort((a, b) => a[0].localeCompare(b[0]))
   hash.update(JSON.stringify(assetEntries))
 
-  // 5. Images directory fingerprint
+  // 6. Images directory fingerprint
   const imagesDir = path.join(options.bookDir, "images")
   const imageEntries = collectDirectoryFingerprint(imagesDir).sort((a, b) => a[0].localeCompare(b[0]))
   hash.update(JSON.stringify(imageEntries))
 
-  // 6. Videos directory fingerprint
+  // 7. Videos directory fingerprint
   const videosDir = path.join(options.bookDir, "videos")
   const videoEntries = collectDirectoryFingerprint(videosDir).sort((a, b) => a[0].localeCompare(b[0]))
   hash.update(JSON.stringify(videoEntries))


### PR DESCRIPTION
## Summary

- refresh the sign-language video query after every video mutation
- invalidate packaged ADT preview status after upload, assignment/reassignment, and deletion
- dispatch the existing `adt:repackage` event so an open Preview rebuilds immediately
- add regression coverage for all three mutation hooks

Closes #655

Supersedes #656, which GitHub automatically closed when its source branch was renamed.

## Verification

- `pnpm exec vitest run apps/studio/src/hooks/use-sign-language-videos.test.tsx`
- `pnpm typecheck`
- `pnpm --filter @adt/studio lint` (passes with 9 pre-existing unused-disable warnings)