### PR TITLE
fix(storyboard): make saved reading order authoritative

### DIFF
--- a/apps/studio/src/components/section-tree-editor/SectionTreeEditor.test.tsx
+++ b/apps/studio/src/components/section-tree-editor/SectionTreeEditor.test.tsx
@@ -1,0 +1,224 @@
+// @vitest-environment jsdom
+import React, { useState } from "react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import type { PageSectioningSection } from "@adt/types"
+import { SectionTreeEditor, TREE_DRAG_TYPE } from "./SectionTreeEditor"
+
+vi.mock("@lingui/react/macro", () => ({
+  useLingui: () => ({
+    t(strings: TemplateStringsArray, ...values: unknown[]) {
+      return strings.reduce(
+        (text, part, index) => text + part + (index < values.length ? String(values[index]) : ""),
+        ""
+      )
+    },
+  }),
+}))
+
+vi.mock("@/components/ui/action-menu", () => ({
+  ActionMenu: () => null,
+}))
+
+const initialSection: PageSectioningSection = {
+  sectionId: "section-1",
+  sectionType: "standard",
+  backgroundColor: "#ffffff",
+  textColor: "#000000",
+  pageNumber: 1,
+  isPruned: false,
+  nodes: [
+    { nodeId: "snake-image", role: "image", isPruned: false },
+    {
+      nodeId: "rescue-group",
+      structure: "group",
+      isPruned: false,
+      children: [
+        { nodeId: "rescue-text", role: "text", text: "Rescue", isPruned: false },
+      ],
+    },
+    {
+      nodeId: "sense-group",
+      structure: "group",
+      isPruned: false,
+      children: [
+        { nodeId: "sense-text", role: "text", text: "Sense", isPruned: false },
+      ],
+    },
+    { nodeId: "dog-image", role: "image", isPruned: false },
+  ],
+}
+
+function createDataTransfer() {
+  const values = new Map<string, string>()
+  return {
+    effectAllowed: "none",
+    dropEffect: "none",
+    get types() {
+      return [...values.keys()]
+    },
+    setData(type: string, value: string) {
+      values.set(type, value)
+    },
+    getData(type: string) {
+      return values.get(type) ?? ""
+    },
+  }
+}
+
+function Harness({
+  onStructuralChange,
+  initial = initialSection,
+}: {
+  onStructuralChange: () => void
+  initial?: PageSectioningSection
+}) {
+  const [section, setSection] = useState(initial)
+  return (
+    <SectionTreeEditor
+      section={section}
+      onChange={setSection}
+      bookLabel="test-book"
+      onStructuralChange={onStructuralChange}
+    />
+  )
+}
+
+beforeEach(() => {
+  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+    callback(0)
+    return 1
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+describe("SectionTreeEditor drag and drop", () => {
+  it("moves an image leaf between content groups and keeps the paired reading order", async () => {
+    const onStructuralChange = vi.fn()
+    render(<Harness onStructuralChange={onStructuralChange} />)
+
+    const dogImage = screen.getByAltText("dog-image")
+    const dragHandle = dogImage.parentElement?.querySelector<HTMLElement>(
+      '[title="Drag to move"]'
+    )
+    expect(dragHandle).toBeTruthy()
+
+    const dataTransfer = createDataTransfer()
+    fireEvent.dragStart(dragHandle!, { dataTransfer })
+    expect(dataTransfer.getData(TREE_DRAG_TYPE)).toBe("dog-image")
+
+    await waitFor(() => {
+      const editor = screen.getByTestId("section-tree-editor")
+      const rootDropZones = Array.from(
+        editor.querySelectorAll<HTMLElement>("div.relative.h-2.flex.items-center")
+      ).filter(
+        (zone) =>
+          zone.parentElement === editor || zone.parentElement?.parentElement === editor
+      )
+      expect(rootDropZones).toHaveLength(initialSection.nodes.length + 1)
+
+      // Place the dog image immediately before Rescue, leaving each image
+      // adjacent to the text group it illustrates.
+      fireEvent.dragOver(rootDropZones[1], { dataTransfer })
+      fireEvent.drop(rootDropZones[1], { dataTransfer })
+    })
+
+    await waitFor(() => {
+      const editor = screen.getByTestId("section-tree-editor")
+      const rootIds = Array.from(editor.children)
+        .flatMap((element) => Array.from(element.querySelectorAll("img")))
+        .map((image) => image.getAttribute("alt"))
+      expect(rootIds).toEqual(["snake-image", "dog-image"])
+      expect(onStructuralChange).toHaveBeenCalledTimes(1)
+    })
+
+    const editorText = screen.getByTestId("section-tree-editor").textContent ?? ""
+    expect(editorText.indexOf("dog-image")).toBeLessThan(editorText.indexOf("Rescue"))
+    expect(editorText.indexOf("Rescue")).toBeLessThan(editorText.indexOf("Sense"))
+  })
+
+  it("moves an image-and-caption container as one reading-order unit", async () => {
+    const pairedSection: PageSectioningSection = {
+      ...initialSection,
+      nodes: [
+        { nodeId: "page-heading", role: "heading", text: "Atmosphere", isPruned: false },
+        {
+          nodeId: "weather-image-group",
+          structure: "image_group",
+          isPruned: false,
+          children: [
+            { nodeId: "weather-image", role: "image", isPruned: false },
+            { nodeId: "weather-caption", role: "caption", text: "Blue atmosphere", isPruned: false },
+          ],
+        },
+        {
+          nodeId: "body-group",
+          structure: "group",
+          isPruned: false,
+          children: [
+            { nodeId: "body-text", role: "text", text: "Main explanation", isPruned: false },
+          ],
+        },
+        {
+          nodeId: "question-sidebar",
+          structure: "sidebar",
+          isPruned: false,
+          children: [
+            { nodeId: "question-text", role: "text", text: "Big Question", isPruned: false },
+          ],
+        },
+      ],
+    }
+    const onStructuralChange = vi.fn()
+    render(
+      <Harness
+        initial={pairedSection}
+        onStructuralChange={onStructuralChange}
+      />
+    )
+
+    const editor = screen.getByTestId("section-tree-editor")
+    const image = screen.getByAltText("weather-image")
+    const imageGroupWrapper = Array.from(editor.children).find((element) =>
+      element.contains(image)
+    )
+    const dragHandle = imageGroupWrapper?.querySelector<HTMLElement>(
+      '[title="Drag to move"]'
+    )
+    expect(dragHandle).toBeTruthy()
+
+    const dataTransfer = createDataTransfer()
+    fireEvent.dragStart(dragHandle!, { dataTransfer })
+    expect(dataTransfer.getData(TREE_DRAG_TYPE)).toBe("weather-image-group")
+
+    await waitFor(() => {
+      const rootDropZones = Array.from(
+        editor.querySelectorAll<HTMLElement>("div.relative.h-2.flex.items-center")
+      ).filter(
+        (zone) =>
+          zone.parentElement === editor || zone.parentElement?.parentElement === editor
+      )
+      expect(rootDropZones).toHaveLength(pairedSection.nodes.length + 1)
+      fireEvent.dragOver(rootDropZones[3], { dataTransfer })
+      fireEvent.drop(rootDropZones[3], { dataTransfer })
+    })
+
+    await waitFor(() => {
+      const text = editor.textContent ?? ""
+      expect(text.indexOf("Main explanation")).toBeLessThan(
+        text.indexOf("weather-image")
+      )
+      expect(text.indexOf("weather-image")).toBeLessThan(
+        text.indexOf("Blue atmosphere")
+      )
+      expect(text.indexOf("Blue atmosphere")).toBeLessThan(
+        text.indexOf("Big Question")
+      )
+      expect(onStructuralChange).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/packages/pipeline/src/__tests__/validate-html.test.ts
+++ b/packages/pipeline/src/__tests__/validate-html.test.ts
@@ -56,6 +56,112 @@ describe("validateSectionHtml", () => {
     )
   })
 
+  it("preserves the authoritative text data-id order", () => {
+    const html = `
+      <section>
+        <div data-id="rescue_group">
+          <h2 data-id="rescue_heading">Rescue</h2>
+        </div>
+        <img data-id="rescue_image" src="placeholder" alt="Rescue" />
+        <div data-id="sense_group">
+          <h2 data-id="sense_heading">Sense</h2>
+        </div>
+      </section>
+    `
+    const result = validateSectionHtml(
+      html,
+      ["rescue_heading", "sense_heading"],
+      ["rescue_image"],
+      undefined,
+      {
+        allowedContainerIds: ["rescue_group", "sense_group"],
+        expectedContentIdOrder: [
+          "rescue_heading",
+          "rescue_image",
+          "sense_heading",
+        ],
+      },
+    )
+
+    expect(result.valid).toBe(true)
+    expect(result.errors).toEqual([])
+  })
+
+  it("rejects text data-ids restored to the original image order", () => {
+    const html = `
+      <section>
+        <h2 data-id="sense_heading">Sense</h2>
+        <h2 data-id="rescue_heading">Rescue</h2>
+      </section>
+    `
+    const result = validateSectionHtml(
+      html,
+      ["rescue_heading", "sense_heading"],
+      [],
+      undefined,
+      { expectedContentIdOrder: ["rescue_heading", "sense_heading"] },
+    )
+
+    expect(result.valid).toBe(false)
+    expect(result.errors).toContainEqual(
+      expect.stringContaining(
+        'expected "rescue_heading" but found "sense_heading"',
+      ),
+    )
+  })
+
+  it("keeps relative order when optional text data-ids are omitted", () => {
+    const html = `
+      <section>
+        <p data-id="body_1">First</p>
+        <p data-id="body_2">Second</p>
+      </section>
+    `
+    const result = validateSectionHtml(
+      html,
+      ["page_number", "body_1", "footer", "body_2"],
+      [],
+      undefined,
+      {
+        optionalTextIds: new Set(["page_number", "footer"]),
+        expectedContentIdOrder: ["page_number", "body_1", "footer", "body_2"],
+      },
+    )
+
+    expect(result.valid).toBe(true)
+    expect(result.errors).toEqual([])
+  })
+
+  it("rejects images restored to their original image order", () => {
+    const html = `
+      <section>
+        <h2 data-id="rescue_heading">Rescue</h2>
+        <h2 data-id="sense_heading">Sense</h2>
+        <img data-id="rescue_image" src="placeholder" alt="Rescue" />
+      </section>
+    `
+    const result = validateSectionHtml(
+      html,
+      ["rescue_heading", "sense_heading"],
+      ["rescue_image"],
+      undefined,
+      {
+        expectedContentIdOrder: [
+          "rescue_heading",
+          "rescue_image",
+          "sense_heading",
+        ],
+      },
+    )
+
+    expect(result.valid).toBe(false)
+    expect(result.errors).toContainEqual(
+      expect.stringContaining(
+        'expected "rescue_image" but found "sense_heading"',
+      ),
+    )
+  })
+
   it("detects unknown data-id", () => {
     const html = `
       <section>

--- a/packages/pipeline/src/__tests__/web-rendering-prompts.test.ts
+++ b/packages/pipeline/src/__tests__/web-rendering-prompts.test.ts
@@ -1,0 +1,84 @@
+import path from "node:path"
+import { describe, expect, it } from "vitest"
+import { createPromptEngine } from "@adt/llm"
+import type { Message } from "@adt/llm"
+
+const promptEngine = createPromptEngine(path.join(process.cwd(), "prompts"))
+
+const nodes = [
+  {
+    node_id: "rescue_group",
+    structure: "group",
+    children: [
+      { node_id: "rescue_heading", role: "heading", text: "Rescue" },
+    ],
+  },
+  {
+    node_id: "sense_group",
+    structure: "group",
+    children: [
+      { node_id: "sense_heading", role: "heading", text: "Sense" },
+    ],
+  },
+]
+
+function messageText(message: Message | undefined): string {
+  if (!message) return ""
+  if (typeof message.content === "string") return message.content
+  return message.content
+    .filter((part) => part.type === "text")
+    .map((part) => part.text)
+    .join("\n")
+}
+
+function generationContext(): Record<string, unknown> {
+  return {
+    page_image_base64: "page-image",
+    source_pages: [],
+    section_id: "pg006_sec001",
+    section_type: "text_and_images",
+    images: [],
+    nodes,
+    styleguide: "",
+    book_fonts: [],
+    typography: [],
+    viewports: [{ label: "Desktop", width: 1280, tailwind_prefix: "" }],
+    user_instructions: "",
+  }
+}
+
+describe("web rendering reading-order prompts", () => {
+  for (const promptName of [
+    "web_generation_html",
+    "web_generation_html_overlay",
+  ]) {
+    it(`${promptName} makes the saved tree authoritative`, async () => {
+      const messages = await promptEngine.renderPrompt(
+        promptName,
+        generationContext(),
+      )
+      const prompt = messages.map(messageText).join("\n")
+
+      expect(prompt).toContain("content tree wins")
+      expect(prompt).toContain("Never restore or infer an older order")
+      expect(prompt.indexOf('heading id=rescue_heading "Rescue"')).toBeLessThan(
+        prompt.indexOf('heading id=sense_heading "Sense"'),
+      )
+    })
+  }
+
+  it("gives the visual reviewer the same authoritative tree", async () => {
+    const messages = await promptEngine.renderPrompt("visual_review", {
+      nodes,
+      has_merged_content: false,
+      viewports: [{ label: "Desktop", width: 1280, tailwind_prefix: "" }],
+    })
+    const prompt = messages.map(messageText).join("\n")
+
+    expect(prompt).toContain("Reject a rendering")
+    expect(prompt).toContain("content tree wins")
+    expect(prompt.indexOf('heading id=rescue_heading "Rescue"')).toBeLessThan(
+      prompt.indexOf('heading id=sense_heading "Sense"'),
+    )
+  })
+})

--- a/packages/pipeline/src/__tests__/web-rendering.test.ts
+++ b/packages/pipeline/src/__tests__/web-rendering.test.ts
@@ -196,6 +196,61 @@ describe("renderPage", () => {
     content: '<div id="content" class="container"><section data-section-type="text_only" data-section-id="pg001_sec001"><p data-id="pg001_gp001_tx001">Hello</p></section></div>',
   }
 
+  it("passes authoritative text order to LLM output validation", async () => {
+    let validation: { valid: boolean; errors: string[] } | undefined
+    const outOfOrderResponse = {
+      reasoning: "restored the page-image order",
+      content:
+        '<div id="content" class="container"><section data-section-type="text_only" data-section-id="pg001_sec001"><h2 data-id="sense_heading">Sense</h2><h2 data-id="rescue_heading">Rescue</h2></section></div>',
+    }
+    const fakeLlm: LLMModel = {
+      generateObject: async <T>(opts: GenerateObjectOptions) => {
+        validation = opts.validate?.(
+          outOfOrderResponse,
+          opts.context ?? {},
+        )
+        return {
+          object: outOfOrderResponse as T,
+        } as GenerateObjectResult<T>
+      },
+    }
+
+    await renderPage(
+      {
+        label: "test-book",
+        pageId: "pg001",
+        pageImageBase64: "base64img",
+        sectioning: {
+          reasoning: "user reordered Rescue before Sense",
+          sections: [
+            {
+              sectionId: "pg001_sec001",
+              sectionType: "text_only",
+              nodes: [
+                leafNode("rescue_heading", "heading", "Rescue"),
+                leafNode("sense_heading", "heading", "Sense"),
+              ],
+              backgroundColor: "#ffffff",
+              textColor: "#000000",
+              pageNumber: 1,
+              isPruned: false,
+            },
+          ],
+        },
+        images: new Map(),
+      },
+      defaultResolveConfig,
+      fakeLlm,
+    )
+
+    expect(validation?.valid).toBe(false)
+    expect(validation?.errors).toContainEqual(
+      expect.stringContaining(
+        'expected "rescue_heading" but found "sense_heading"',
+      ),
+    )
+  })
+
   it("passes the cancellation signal to LLM calls and stops between sections", async () => {
     const controller = new AbortController()
     const seenSignals: Array<AbortSignal | undefined> = []

--- a/packages/pipeline/src/render-llm.ts
+++ b/packages/pipeline/src/render-llm.ts
@@ -4,7 +4,7 @@ import type { LLMModel, ValidationResult } from "@adt/llm"
 import { autoRepairUnderlineActivityHtml } from "./activity-underline-repair.js"
 import { validateSectionHtml, isEnumerationMarker } from "./validate-html.js"
 import { getViewportBreakpoints, type ScreenshotRenderer } from "./screenshot.js"
-import type { RenderConfig, RenderExecutionOptions, RenderSectionInput } from "./web-rendering.js"
+import type { RenderConfig, RenderExecutionOptions, RenderNode, RenderSectionInput } from "./web-rendering.js"
 import { runVisualReviewLoop } from "./visual-review.js"
 import { buildTypographyCss, typographyPreservationErrors } from "./typography.js"
 import { DEFAULT_TYPOGRAPHY } from "@adt/types"
@@ -202,6 +202,7 @@ function validateWebRendering(
   const label = context.label as string
   const leaf_texts = context.leaf_texts as Array<{ text_id: string; text_type: string; text: string }>
   const images = context.images as Array<{ image_id: string }>
+  const nodes = context.nodes as RenderNode[]
   const group_ids = context.group_ids as string[]
   const isActivity = context._isActivity as boolean | undefined
   const sectionId = context.section_id as string
@@ -225,6 +226,7 @@ function validateWebRendering(
       expectedSectionType: sectionType,
       expectedSectionId: sectionId,
       optionalTextIds,
+      expectedContentIdOrder: collectLeafDataIdOrder(nodes),
     }
   )
   if (check.valid && check.sectionHtml) {
@@ -236,6 +238,19 @@ function validateWebRendering(
   }
 
   return { valid: check.valid, errors: check.errors }
+}
+
+function collectLeafDataIdOrder(nodes: RenderNode[]): string[] {
+  const ids: string[] = []
+  function walk(node: RenderNode): void {
+    if (node.role) {
+      ids.push(node.node_id)
+      return
+    }
+    for (const child of node.children ?? []) walk(child)
+  }
+  for (const node of nodes) walk(node)
+  return ids
 }
 
 // Recognize underscore runs of any length (single-cell crossword blanks emit

--- a/packages/pipeline/src/validate-html.ts
+++ b/packages/pipeline/src/validate-html.ts
@@ -128,6 +128,13 @@ export interface HtmlValidationOptions {
    * suppressed if it doesn't.
    */
   optionalTextIds?: Set<string>
+  /**
+   * Leaf data-ids (text and images) in the authoritative content-tree reading
+   * order. When provided, rendered content elements must appear in the same
+   * DOM order. Optional text ids and omitted images may be absent, but any ids
+   * that are present must keep their relative order.
+   */
+  expectedContentIdOrder?: string[]
 }
 
 export function validateSectionHtml(
@@ -195,6 +202,10 @@ export function validateSectionHtml(
         errors.push(`Missing required text data-id: "${textId}"`)
       }
     }
+  }
+
+  if (options?.expectedContentIdOrder?.length) {
+    validateContentDataIdOrder(section, options.expectedContentIdOrder, errors)
   }
 
   if (imageUrlPrefix) {
@@ -578,6 +589,47 @@ function collectDataIds(node: any, ids: Set<string>): void {
     for (const child of node.children) {
       collectDataIds(child, ids)
     }
+  }
+}
+
+/** Validate that rendered text and image leaves preserve the tree's DFS order. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function validateContentDataIdOrder(
+  section: any,
+  expectedOrder: string[],
+  errors: string[],
+): void {
+  const expectedIds = new Set(expectedOrder)
+  const renderedOrder: string[] = []
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function collect(node: any): void {
+    if (node.type === "tag") {
+      const dataId = node.attribs?.["data-id"]
+      if (typeof dataId === "string" && expectedIds.has(dataId)) {
+        renderedOrder.push(dataId)
+      }
+    }
+    if (node.children) {
+      for (const child of node.children) collect(child)
+    }
+  }
+
+  collect(section)
+  const renderedIds = new Set(renderedOrder)
+  const expectedRenderedOrder = expectedOrder.filter((id) => renderedIds.has(id))
+  const mismatchIndex = renderedOrder.findIndex(
+    (id, index) => id !== expectedRenderedOrder[index],
+  )
+  const hasLengthMismatch = renderedOrder.length !== expectedRenderedOrder.length
+
+  if (mismatchIndex !== -1 || hasLengthMismatch) {
+    const index = mismatchIndex === -1
+      ? Math.min(renderedOrder.length, expectedRenderedOrder.length)
+      : mismatchIndex
+    errors.push(
+      `Content data-id order does not match the authoritative content tree at position ${index + 1}: expected "${expectedRenderedOrder[index] ?? "<end>"}" but found "${renderedOrder[index] ?? "<end>"}"`,
+    )
   }
 }
 

--- a/prompts/visual_review.liquid
+++ b/prompts/visual_review.liquid
@@ -7,6 +7,15 @@ You are a visual quality reviewer for HTML textbook pages. Your job is to compar
 3. Prioritize: readability, attractive appearance, no overlapping text/elements, and responsive behavior across all three viewport sizes
 4. If the rendering looks good, approve it. If there are real problems, provide corrected HTML
 
+## AUTHORITATIVE CONTENT ORDER
+The content tree below is the current saved user state. Its depth-first order is the REQUIRED reading order and may intentionally differ from the original page image after a user edit.
+- Treat the original page image only as a visual style and layout reference. If its apparent order conflicts with the content tree, the content tree wins.
+- Reject a rendering when its text elements appear in a different HTML DOM order or its visual layout presents groups in a different reading order.
+- When correcting HTML, keep the tree's order and move layout positions as needed. Never restore or infer an older order from the page image.
+
+Content tree (authoritative reading order):
+{% include "_render_node", nodes: nodes, depth: 0 %}
+
 ## IMPORTANT: SECTION SCOPE
 The screenshots show a **single section**, which is typically only a SUBSET of the original page — not the whole page. A page is usually composed of multiple sections (a header, a body paragraph, an image with caption, a sidebar, etc.), and you are only reviewing ONE of them at a time.
 

--- a/prompts/web_generation_html.liquid
+++ b/prompts/web_generation_html.liquid
@@ -8,6 +8,13 @@ You are an expert frontend engineer. Generate a beautiful, kid-friendly HTML pag
 2. A content tree for the section (indentation shows hierarchy) — containers wrap leaves in reading order
 3. Section type
 
+## AUTHORITATIVE CONTENT ORDER
+The content tree is the current saved user state. Its depth-first order is the REQUIRED reading order and may intentionally differ from the original page image after a user edit.
+- Treat the original page image only as a visual style and layout reference. If its apparent order conflicts with the content tree, the content tree wins.
+- Emit all content-bearing elements in the HTML DOM in content-tree order.
+- Arrange columns, cards, and positioned groups so their visual reading order follows that same order at every viewport.
+- Never restore or infer an older order from the page image.
+
 ## RULES
 1. Each text ID must appear EXACTLY ONCE - no duplicates
 2. Use the EXACT text provided - no modifications

--- a/prompts/web_generation_html_overlay.liquid
+++ b/prompts/web_generation_html_overlay.liquid
@@ -12,6 +12,13 @@ Recreate the original textbook page as closely as possible by using the page ima
 3. Images with their IDs
 4. Section type
 
+## AUTHORITATIVE CONTENT ORDER
+The content tree is the current saved user state. Its depth-first order is the REQUIRED reading order and may intentionally differ from the original page image after a user edit.
+- Treat the original page image only as a visual style and layout reference. If its apparent order conflicts with the content tree, the content tree wins.
+- Emit all content-bearing elements in the HTML DOM in content-tree order.
+- Assign overlay positions so the visual reading order follows that same order at every viewport. When necessary, move a group away from its original position rather than restoring the image's older order.
+- Never restore or infer an older order from the page image.
+
 ## FUNDAMENTAL RULES
 1. Each text ID must appear EXACTLY ONCE — no duplicates
 2. Use the EXACT text provided — no modifications
@@ -287,8 +294,8 @@ Image ID: {{ image.image_id }}
 {% image image.image_base64 %}
 {% endfor %}
 
-Page content in DOCUMENT FLOW ORDER (top-to-bottom as they appear on the page).
-Use this ordering plus the page image to determine the vertical position of each group.
+Page content in AUTHORITATIVE DOCUMENT FLOW ORDER.
+Use this ordering for both DOM order and visual reading order. Use the page image only to guide style and the available layout positions.
 
 Content tree (indentation shows hierarchy):
 {% include "_render_node", nodes: nodes, depth: 0 %}


### PR DESCRIPTION
## Summary

Storyboard users can save a reordered section tree, but an LLM rendering or visual-review pass can still restore the source PDF's apparent order. This is especially likely for overlay rendering, whose previous instructions treated the PDF's top-to-bottom arrangement as authoritative.

This PR makes the persisted content tree the unconditional source of truth for reading order. Generated HTML must preserve the tree's depth-first text-and-image leaf order, regardless of whether the render is entered from drag-and-drop, a later rerender, cache reuse, or another workflow.

## Why this supersedes #573

#573 models a reorder as transient intent and threads an `intentionalReadingOrder` flag through Studio, API, and pipeline layers. That makes correct behavior conditional on every entry point preserving the flag.

This implementation replaces that conditional state with a stable invariant:

> Once a section tree is saved, its leaf order is authoritative.

The source PDF remains the reference for styling and composition, but it cannot override persisted content order. A deterministic validator enforces the invariant after generation, so prompt compliance is verified rather than assumed.

## Changes

- Instruct standard and overlay web generation to emit text and image elements in saved tree order.
- Instruct overlay generation to move positioned groups when necessary instead of restoring their former PDF positions.
- Give visual review the authoritative content tree and prevent it from undoing saved order while it continues to assess clipping, overlap, readability, responsiveness, and visual quality.
- Collect the non-pruned leaf `data-id` sequence from the render tree.
- Validate generated text and image elements against that sequence in DOM order, while preserving existing rules for optional text and omitted images.
- Add editor regressions for native drag/drop handlers covering:
  - an individual image moved between text groups;
  - an image-and-caption container moved as one reading-order unit.
- Add prompt and HTML-validation regressions for standard, overlay, and visual-review paths.

## End-to-end verification

### Representative storybook

Verified a paired `Dog image → Rescue → Snake image → Sense` reorder through:

- section save and Studio reload;
- fresh model rerender;
- cached rerender;
- API-process restart;
- desktop, tablet, and mobile previews;
- DOM and screen-reader order;
- packaged ADT output.

The saved tree, generated HTML, accessible order, and packaged HTML all matched.

### Independent textbook and model

Ran pages 7-8 of `weather-climate.pdf` from Extract through Storyboard using `openai:gpt-5.4-mini`. After moving a complete image-and-caption group below the main text, the rerendered section matched all 14 saved leaf IDs in exact DOM order. Local LLM audit metadata confirmed the alternate model was used.

## Automated verification

- `pnpm typecheck` — passed.
- `pnpm lint` — passed with 0 errors (9 pre-existing unused-disable warnings).
- `pnpm test` — build passed; 2,212 tests passed. Five `part-service.test.ts` cases reached their existing 5-second timeout under full parallel load.
- `pnpm exec vitest run apps/api/src/services/part-service.test.ts` — all 13 tests passed in isolation.
- New drag/drop component regressions — 2/2 passed.

## Reviewer check

The native HTML5 drag/drop handlers are covered by component-level browser events. A brief physical Chrome drag smoke test is still recommended because the available in-app automation driver cannot synthesize this browser drag implementation reliably.

Fixes #227
Fixes #250
Supersedes #573
