### PR TITLE
fix(storyboard): resolve AI-edit model id with the standard fallback chain

### DIFF
--- a/apps/api/src/services/page-edit-service.test.ts
+++ b/apps/api/src/services/page-edit-service.test.ts
@@ -314,5 +314,62 @@ describe("page-edit-service", () => {
       expect(capturedHtml).not.toContain("img-first")
       expect(result.html).toContain("img-dup")
     })
+
+    // Regression: `page_sectioning` present without a `model` key used to yield
+    // `modelId: undefined`, which blew up inside resolveModel with
+    // "Cannot read properties of undefined (reading 'indexOf')".
+    it("falls back to default_model when page_sectioning has no model", async () => {
+      const pageId = `${label}_p1`
+      const storage = createBookStorage(label, tmpDir)
+      try {
+        storage.putNodeData("web-rendering", pageId, {
+          sections: [
+            {
+              sectionIndex: 0,
+              sectionType: "content",
+              reasoning: "ok",
+              html: `<section data-id="first">hello</section>`,
+            },
+          ],
+        })
+      } finally {
+        storage.close()
+      }
+
+      const configPath = path.join(tmpDir, "config.yaml")
+      fs.writeFileSync(
+        configPath,
+        [
+          'default_model: "openai:gpt-5.4"',
+          "structure_types: {}",
+          "role_types: {}",
+          "page_sectioning:",
+          "  prompt: page_sectioning",
+          "  max_refinements: 0",
+        ].join("\n")
+      )
+
+      llmMocks.generateObject.mockImplementation(async (opts: unknown) => {
+        const context = (opts as { context: { current_html: string } }).context
+        return {
+          object: { reasoning: "ok", content: context.current_html },
+        } as never
+      })
+
+      await aiEditSection({
+        label,
+        pageId,
+        sectionIndex: 0,
+        instruction: "Keep layout and wording",
+        booksDir: tmpDir,
+        promptsDir: tmpDir,
+        configPath,
+        apiKey: "test-key",
+      })
+
+      expect(llmMocks.createLLMModel).toHaveBeenCalledWith(
+        expect.objectContaining({ modelId: "openai:gpt-5.4" })
+      )
+    })
   })
 })

--- a/apps/api/src/services/page-edit-service.test.ts
+++ b/apps/api/src/services/page-edit-service.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs"
 import path from "node:path"
 import os from "node:os"
 import { createBookStorage } from "@adt/storage"
+import { DEFAULT_LLM_MODEL_ID } from "@adt/types"
 
 const llmMocks = vi.hoisted(() => ({
   generateObject: vi.fn(),
@@ -315,10 +316,32 @@ describe("page-edit-service", () => {
       expect(result.html).toContain("img-dup")
     })
 
-    // Regression: `page_sectioning` present without a `model` key used to yield
-    // `modelId: undefined`, which blew up inside resolveModel with
-    // "Cannot read properties of undefined (reading 'indexOf')".
-    it("falls back to default_model when page_sectioning has no model", async () => {
+    it.each([
+      {
+        name: "uses page_sectioning.model when configured",
+        defaultModelId: "openai:gpt-4.1",
+        pageSectioningModelId: "openai:gpt-4o",
+        expectedModelId: "openai:gpt-4o",
+      },
+      {
+        // Regression: `page_sectioning` present without a `model` key used to
+        // yield `modelId: undefined`, which blew up inside resolveModel.
+        name: "falls back to default_model when page_sectioning has no model",
+        defaultModelId: "openai:gpt-4.1",
+        pageSectioningModelId: undefined,
+        expectedModelId: "openai:gpt-4.1",
+      },
+      {
+        name: "falls back to DEFAULT_LLM_MODEL_ID when no model is configured",
+        defaultModelId: undefined,
+        pageSectioningModelId: undefined,
+        expectedModelId: DEFAULT_LLM_MODEL_ID,
+      },
+    ])("$name", async ({
+      defaultModelId,
+      pageSectioningModelId,
+      expectedModelId,
+    }) => {
       const pageId = `${label}_p1`
       const storage = createBookStorage(label, tmpDir)
       try {
@@ -340,12 +363,15 @@ describe("page-edit-service", () => {
       fs.writeFileSync(
         configPath,
         [
-          'default_model: "openai:gpt-5.4"',
+          ...(defaultModelId ? [`default_model: "${defaultModelId}"`] : []),
           "structure_types: {}",
           "role_types: {}",
           "page_sectioning:",
           "  prompt: page_sectioning",
           "  max_refinements: 0",
+          ...(pageSectioningModelId
+            ? [`  model: "${pageSectioningModelId}"`]
+            : []),
         ].join("\n")
       )
 
@@ -368,7 +394,7 @@ describe("page-edit-service", () => {
       })
 
       expect(llmMocks.createLLMModel).toHaveBeenCalledWith(
-        expect.objectContaining({ modelId: "openai:gpt-5.4" })
+        expect.objectContaining({ modelId: expectedModelId })
       )
     })
   })

--- a/apps/api/src/services/page-edit-service.ts
+++ b/apps/api/src/services/page-edit-service.ts
@@ -5,7 +5,7 @@ import { createLLMModel, createPromptEngine } from "@adt/llm"
 import type { LLMModel } from "@adt/llm"
 import { renderPage, buildRenderStrategyResolver, buildBookFontsPromptContext, readTypography, buildTypographyCss, collectReferencedImageIds, collectSourcePageImages, createTemplateEngine, loadBookConfig, createScreenshotRenderer, runVisualReviewLoop, DEFAULT_VISUAL_REVIEW_MODEL_ID, buildScreenshotHtml, SCREENSHOT_VIEWPORTS } from "@adt/pipeline"
 import type { VisualRefinementDeps } from "@adt/pipeline"
-import { PageSectioningOutput, WebRenderingOutput, webRenderingLLMSchema, editVerifyLLMSchema } from "@adt/types"
+import { PageSectioningOutput, WebRenderingOutput, webRenderingLLMSchema, editVerifyLLMSchema, DEFAULT_LLM_MODEL_ID } from "@adt/types"
 import { loadStyleguideContent } from "./styleguide.js"
 
 export interface ReRenderOptions {
@@ -277,11 +277,12 @@ export async function aiEditSection(
       currentHtml = section.html
     }
 
-    // Load config to get model ID for editing
+    // Load config to get model ID for editing. Same fallback chain every other
+    // "thoughtful" LLM step uses — `page_sectioning` may exist without a `model`
+    // key, so never key the fallback off the section's presence.
     const config = loadBookConfig(label, booksDir, configPath)
-    const modelId = (config as Record<string, unknown>).page_sectioning
-      ? ((config as Record<string, unknown>).page_sectioning as Record<string, unknown>).model as string
-      : "openai:gpt-4o"
+    const modelId =
+      config.page_sectioning?.model ?? config.default_model ?? DEFAULT_LLM_MODEL_ID
 
     // Build LLM model
     const cacheDir = path.join(path.resolve(booksDir), label, ".cache")


### PR DESCRIPTION
## Problem

Storyboard AI edits fail on any book whose config doesn't set `page_sectioning.model` explicitly — which is the default, since the root `config.yaml` only sets `prompt` and `max_refinements` under that key.

Observed on `cuaderno3`:

```
POST /api/books/cuaderno3/pages/pg008/sections/0/ai-edit
--> POST /api/books/cuaderno3/pages/pg008/sections/0/ai-edit 200 18ms
[LLM] web-rendering pg008 | error (attempt 1/4) | Cannot read properties of undefined (reading 'indexOf') | retrying in 1072ms
...
[LLM] web-rendering pg008 | error (attempt 4/4) | Cannot read properties of undefined (reading 'indexOf')
```

## Root cause

`aiEditSection` in `apps/api/src/services/page-edit-service.ts` resolved its model id with a ternary that branched on the **presence of the `page_sectioning` section**, not on whether that section has a **`model` key**:

```ts
const modelId = (config as Record<string, unknown>).page_sectioning
  ? ((config as Record<string, unknown>).page_sectioning as Record<string, unknown>).model as string
  : "openai:gpt-4o"
```

With `page_sectioning` present but no `model`, `modelId` was `undefined`. `resolveModel` in `packages/llm/src/client.ts` then does `modelId.indexOf(":")` → `Cannot read properties of undefined (reading 'indexOf')`. The failure is deterministic, so all 4 attempts failed and the `ai-edit` task died — while the HTTP POST had already returned `200` (task accepted), leaving the user with an edit that silently never applied.

The `as string` cast is what let this past `tsc`.

## Fix

Use the same fallback chain every other thoughtful LLM step already uses (`page-sectioning.ts`, `translation.ts`, `easy-read.ts`, `glossary.ts`, `toc-generation.ts`, …):

```ts
const modelId =
  config.page_sectioning?.model ?? config.default_model ?? DEFAULT_LLM_MODEL_ID
```

Dropping the two `Record<string, unknown>` casts means the typed `AppConfig` schema guards this class of bug going forward. Note the old literal fallback was also stale (`openai:gpt-4o`); the chain now honours the book's `default_model`.

## Testing

- Added a regression test that builds a config with `page_sectioning` but no `model` and asserts `createLLMModel` receives a defined model id. Verified it fails on `develop` (`modelId: undefined`) and passes with the fix.
- `apps/api/src/services/page-edit-service.test.ts` — 4/4 pass.
- `pnpm typecheck` clean.

## Follow-up (not in this PR)

This failed for ~30s of retries with nothing surfaced in the storyboard UI beyond the edit not applying. Worth a separate look at how `ai-edit` task errors propagate to `StoryboardSectionDetail`.