### PR TITLE
fix(styleguide): apply text colors, add missing templates, fix prompt precedence, invalidate stale preview

### DIFF
--- a/apps/api/src/routes/presets.test.ts
+++ b/apps/api/src/routes/presets.test.ts
@@ -65,6 +65,50 @@ describe("global default model", () => {
   })
 })
 
+describe("styleguide upload preview invalidation", () => {
+  it("deletes a stale cached preview when the styleguide is re-uploaded", async () => {
+    const styleguidesDir = path.join(tmpDir, "assets", "styleguides")
+    fs.mkdirSync(styleguidesDir, { recursive: true })
+    fs.writeFileSync(path.join(styleguidesDir, "custom.md"), "# Custom\n", "utf-8")
+    const stalePreviewPath = path.join(styleguidesDir, "custom-preview.html")
+    fs.writeFileSync(stalePreviewPath, "<html>stale</html>", "utf-8")
+
+    const app = createPresetRoutes(configPath)
+    const formData = new FormData()
+    formData.append(
+      "file",
+      new File(["# Custom v2\n"], "custom.md", { type: "text/markdown" }),
+    )
+    const response = await app.request("/styleguides/upload", {
+      method: "POST",
+      body: formData,
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ name: "custom" })
+    expect(fs.existsSync(stalePreviewPath)).toBe(false)
+    expect(fs.readFileSync(path.join(styleguidesDir, "custom.md"), "utf-8")).toBe(
+      "# Custom v2\n",
+    )
+  })
+
+  it("does nothing special when there is no cached preview yet", async () => {
+    const app = createPresetRoutes(configPath)
+    const formData = new FormData()
+    formData.append(
+      "file",
+      new File(["# Brand New\n"], "brand-new.md", { type: "text/markdown" }),
+    )
+    const response = await app.request("/styleguides/upload", {
+      method: "POST",
+      body: formData,
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ name: "brand-new" })
+  })
+})
+
 describe("global specialized model defaults", () => {
   it("returns built-in defaults when no overrides are configured", async () => {
     const response = await createPresetRoutes(configPath).request(

--- a/apps/api/src/routes/presets.ts
+++ b/apps/api/src/routes/presets.ts
@@ -107,6 +107,14 @@ table{border-collapse:collapse;width:100%;margin:0.75rem 0;}th,td{border:1px sol
     fs.mkdirSync(styleguidesDir, { recursive: true })
     const content = await file.text()
     fs.writeFileSync(path.join(styleguidesDir, `${result.data}.md`), content, "utf-8")
+    // Re-uploading an existing styleguide changes its content, so any
+    // previously captured static preview HTML is now stale. Delete it so
+    // GET /styleguides/:name/preview falls back to rendering the fresh
+    // markdown content instead of serving an outdated snapshot.
+    const stalePreviewPath = path.join(styleguidesDir, `${result.data}-preview.html`)
+    if (fs.existsSync(stalePreviewPath)) {
+      fs.rmSync(stalePreviewPath)
+    }
     return c.json({ name: result.data })
   })
 

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/BookPreviewFrame.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/BookPreviewFrame.tsx
@@ -535,7 +535,15 @@ ${autoFitScript}
    * the attribute, and force any descendant that does NOT have its own
    * `data-text-color` to inherit it (!important) too, so it wins over
    * incidental Tailwind color utility classes (e.g. `text-black`) the LLM
-   * may have added on its own.
+   * may have added on its own. Anchors (`<a>`) and their contents are
+   * deliberately excluded so links keep their own (usually distinct) color
+   * instead of being flattened into the surrounding body/heading color.
+   *
+   * NOTE: this mirrors the injected `textColorScript` in
+   * packages/pipeline/src/packaging/web.ts so the Studio preview renders
+   * identically to the packaged/exported HTML. The two intentionally can't
+   * share one implementation because the frontend may not import from
+   * `packages/*` (see the layer rule in AGENTS.md); keep both in sync by hand.
    */
   function applyTextColors(doc: Document) {
     const colorEls = doc.querySelectorAll<HTMLElement>("[data-text-color]")
@@ -545,7 +553,7 @@ ${autoFitScript}
       el.style.setProperty("color", color, "important")
       const descendants = el.querySelectorAll<HTMLElement>("*")
       for (const d of descendants) {
-        if (d.closest("[data-text-color]") === el) {
+        if (d.closest("[data-text-color]") === el && !d.closest("a")) {
           d.style.setProperty("color", "inherit", "important")
         }
       }

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/BookPreviewFrame.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/BookPreviewFrame.tsx
@@ -528,6 +528,30 @@ ${autoFitScript}
     if (h > 0) setContentHeight(h)
   }
 
+  /**
+   * `data-text-color` is a semantic marker the styleguide/LLM stamps onto
+   * headings/paragraphs — by itself it has no visual effect. Apply it as a
+   * real, cascading color: force it (!important) on every element carrying
+   * the attribute, and force any descendant that does NOT have its own
+   * `data-text-color` to inherit it (!important) too, so it wins over
+   * incidental Tailwind color utility classes (e.g. `text-black`) the LLM
+   * may have added on its own.
+   */
+  function applyTextColors(doc: Document) {
+    const colorEls = doc.querySelectorAll<HTMLElement>("[data-text-color]")
+    for (const el of colorEls) {
+      const color = el.getAttribute("data-text-color")
+      if (!color) continue
+      el.style.setProperty("color", color, "important")
+      const descendants = el.querySelectorAll<HTMLElement>("*")
+      for (const d of descendants) {
+        if (d.closest("[data-text-color]") === el) {
+          d.style.setProperty("color", "inherit", "important")
+        }
+      }
+    }
+  }
+
   /** Inject HTML into the iframe body (preserving the interactive script). */
   function injectContent(newHtml: string) {
     const iframe = iframeRef.current
@@ -564,6 +588,8 @@ ${autoFitScript}
     } else {
       doc.body.style.backgroundColor = ""
     }
+
+    applyTextColors(doc)
 
     // Force synchronous reflow so the browser repaints the scaled iframe
     // immediately after innerHTML changes (fixes delayed style rendering).

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/BookPreviewFrame.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/BookPreviewFrame.tsx
@@ -31,6 +31,11 @@ import {
   resolveVisibleTarget,
   type ActivityAnchor,
 } from "./activity-link"
+import {
+  applyTextColors,
+  restoreAppliedTextColors,
+  type ElementClassChangeOptions,
+} from "./text-color"
 import { primaryFontFamily, googleFontsCss2Url, FIXED_LAYOUT_MAX_SCALE } from "@adt/types"
 
 export type { ComputedTypographyStyles }
@@ -81,7 +86,11 @@ export interface BookPreviewFrameHandle {
   /** Read the Tailwind classes on an element by data-id */
   getElementClasses: (dataId: string) => string[]
   /** Set the full class list on an element by data-id. Returns updated full HTML, or null. */
-  setElementClasses: (dataId: string, classes: string[]) => string | null
+  setElementClasses: (
+    dataId: string,
+    classes: string[],
+    options?: ElementClassChangeOptions,
+  ) => string | null
   /** Set (or remove, when value is empty) a single inline CSS property on an
    *  element by data-id. Returns updated full HTML, or null. Used for styling
    *  that must win over class/cascade rules (e.g. per-element font-family). */
@@ -220,12 +229,23 @@ export const BookPreviewFrame = forwardRef<BookPreviewFrameHandle, BookPreviewFr
       if (!el) return []
       return Array.from(el.classList)
     },
-    setElementClasses: (dataId: string, classes: string[]): string | null => {
+    setElementClasses: (
+      dataId: string,
+      classes: string[],
+      options: ElementClassChangeOptions = {},
+    ): string | null => {
       const doc = iframeRef.current?.contentDocument
       if (!doc) return null
       const el = doc.querySelector(`[data-id="${CSS.escape(dataId)}"]`) as HTMLElement | null
       if (!el) return null
       el.className = classes.join(" ")
+      for (const attribute of options.removeAttributes ?? []) {
+        el.removeAttribute(attribute)
+      }
+      for (const attribute of options.setAttributes ?? []) {
+        el.setAttribute(attribute, "")
+      }
+      restoreAppliedTextColors(doc)
       // Don't strip `_el#` data-ids here — the inspector relies on them across
       // edits in a session. They're stripped only at API persist time.
       stripTransientAttributes(doc)
@@ -238,6 +258,7 @@ export const BookPreviewFrame = forwardRef<BookPreviewFrameHandle, BookPreviewFr
         html = doc.body.innerHTML
       }
       el.setAttribute("data-adt-selected", "true")
+      applyTextColors(doc)
       return demoteFirstHeadingIfPromoted(html, sanitizedHtmlRef.current)
     },
     setElementStyleProp: (dataId: string, property: string, value: string): string | null => {
@@ -247,6 +268,7 @@ export const BookPreviewFrame = forwardRef<BookPreviewFrameHandle, BookPreviewFr
       if (!el) return null
       if (value) el.style.setProperty(property, value)
       else el.style.removeProperty(property)
+      restoreAppliedTextColors(doc)
       stripTransientAttributes(doc)
       const wrapper = doc.getElementById("content")
       let html: string
@@ -257,6 +279,7 @@ export const BookPreviewFrame = forwardRef<BookPreviewFrameHandle, BookPreviewFr
         html = doc.body.innerHTML
       }
       el.setAttribute("data-adt-selected", "true")
+      applyTextColors(doc)
       return demoteFirstHeadingIfPromoted(html, sanitizedHtmlRef.current)
     },
     resetContent: () => {
@@ -526,38 +549,6 @@ ${autoFitScript}
     const main = doc.querySelector("main")
     const h = (main ?? doc.body).scrollHeight
     if (h > 0) setContentHeight(h)
-  }
-
-  /**
-   * `data-text-color` is a semantic marker the styleguide/LLM stamps onto
-   * headings/paragraphs — by itself it has no visual effect. Apply it as a
-   * real, cascading color: force it (!important) on every element carrying
-   * the attribute, and force any descendant that does NOT have its own
-   * `data-text-color` to inherit it (!important) too, so it wins over
-   * incidental Tailwind color utility classes (e.g. `text-black`) the LLM
-   * may have added on its own. Anchors (`<a>`) and their contents are
-   * deliberately excluded so links keep their own (usually distinct) color
-   * instead of being flattened into the surrounding body/heading color.
-   *
-   * NOTE: this mirrors the injected `textColorScript` in
-   * packages/pipeline/src/packaging/web.ts so the Studio preview renders
-   * identically to the packaged/exported HTML. The two intentionally can't
-   * share one implementation because the frontend may not import from
-   * `packages/*` (see the layer rule in AGENTS.md); keep both in sync by hand.
-   */
-  function applyTextColors(doc: Document) {
-    const colorEls = doc.querySelectorAll<HTMLElement>("[data-text-color]")
-    for (const el of colorEls) {
-      const color = el.getAttribute("data-text-color")
-      if (!color) continue
-      el.style.setProperty("color", color, "important")
-      const descendants = el.querySelectorAll<HTMLElement>("*")
-      for (const d of descendants) {
-        if (d.closest("[data-text-color]") === el && !d.closest("a")) {
-          d.style.setProperty("color", "inherit", "important")
-        }
-      }
-    }
   }
 
   /** Inject HTML into the iframe body (preserving the interactive script). */

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/BookPreviewFrame.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/BookPreviewFrame.tsx
@@ -32,6 +32,7 @@ import {
   type ActivityAnchor,
 } from "./activity-link"
 import {
+  applyElementClassChange,
   applyTextColors,
   restoreAppliedTextColors,
   type ElementClassChangeOptions,
@@ -238,14 +239,11 @@ export const BookPreviewFrame = forwardRef<BookPreviewFrameHandle, BookPreviewFr
       if (!doc) return null
       const el = doc.querySelector(`[data-id="${CSS.escape(dataId)}"]`) as HTMLElement | null
       if (!el) return null
-      el.className = classes.join(" ")
-      for (const attribute of options.removeAttributes ?? []) {
-        el.removeAttribute(attribute)
-      }
-      for (const attribute of options.setAttributes ?? []) {
-        el.setAttribute(attribute, "")
-      }
+      // Restore preview-only !important colors before applying the edit. In
+      // particular, a manual color change must be able to remove the source
+      // inline color rather than having restoration put it back afterward.
       restoreAppliedTextColors(doc)
+      applyElementClassChange(el, classes, options)
       // Don't strip `_el#` data-ids here — the inspector relies on them across
       // edits in a session. They're stripped only at API persist time.
       stripTransientAttributes(doc)

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
@@ -93,6 +93,7 @@ import { AiEditHistoryDrawer } from "./AiEditHistoryDrawer"
 import { LayoutMirrorDialog } from "./LayoutMirrorDialog"
 import { GenerateActivityDialog } from "./GenerateActivityDialog"
 import { Input } from "@/components/ui/input"
+import type { ElementClassChangeOptions } from "./text-color"
 import { useLingui } from "@lingui/react/macro"
 import { msg } from "@lingui/core/macro"
 import { i18n } from "@lingui/core"
@@ -1574,11 +1575,19 @@ export function StoryboardSectionDetail({
   }, [])
 
   const handleClassesChange = useCallback(
-    (dataId: string, classes: string[]) => {
+    (
+      dataId: string,
+      classes: string[],
+      options: ElementClassChangeOptions = {},
+    ) => {
       if (!page.rendering) return
       // 250ms covers the inspector's 200ms debounce plus slack.
       if (Date.now() - lastDiscardAtRef.current < 250) return
-      const fullHtml = previewFrameRef.current?.setElementClasses(dataId, classes)
+      const fullHtml = previewFrameRef.current?.setElementClasses(
+        dataId,
+        classes,
+        options,
+      )
       if (!fullHtml) return
       setSelectedElementClasses(classes)
       previewFrameRef.current?.refreshCss(fullHtml)

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/style-editor/StyleEditorPanel.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/style-editor/StyleEditorPanel.tsx
@@ -28,6 +28,7 @@ import { TextRoleSection } from "./sections/TextRole"
 import { ElementProvider } from "./element-context"
 import type { DeviceView } from "./device-breakpoint"
 import type { ComputedTypographyStyles } from "../BookPreviewFrame"
+import type { ElementClassChangeOptions } from "../text-color"
 
 // eslint-disable-next-line lingui/no-unlocalized-strings -- HTML attribute identifier shown verbatim
 const DATA_ID_PREFIX = `data-id="`
@@ -40,7 +41,11 @@ interface StyleEditorPanelProps {
   selectedTagName: string | null
   elementClasses: string[] | null
   elementProps: StyleEditorElementProps | null
-  onClassesChange: (dataId: string, classes: string[]) => void
+  onClassesChange: (
+    dataId: string,
+    classes: string[],
+    options?: ElementClassChangeOptions,
+  ) => void
   onStyleChange?: (dataId: string, property: string, value: string) => void
   deviceView: DeviceView
   /** Snapshot of the iframe element's getComputedStyle for the inheritable
@@ -257,7 +262,11 @@ interface StyleEditorBodyProps {
   classes: string[]
   elementType: ElementType | null
   elementProps: StyleEditorElementProps | null
-  onClassesChange: (dataId: string, classes: string[]) => void
+  onClassesChange: (
+    dataId: string,
+    classes: string[],
+    options?: ElementClassChangeOptions,
+  ) => void
   onStyleChange?: (dataId: string, property: string, value: string) => void
   deviceView: DeviceView
   computedTypography: ComputedTypographyStyles | null
@@ -346,4 +355,3 @@ function FixedLayoutNotice() {
     </div>
   )
 }
-

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/style-editor/element-context.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/style-editor/element-context.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, type ReactNode } from "react"
 import type { DeviceView } from "./device-breakpoint"
+import type { ElementClassChangeOptions } from "../text-color"
 
 interface ElementCtx {
   /** data-id of the currently-selected element */
@@ -7,7 +8,11 @@ interface ElementCtx {
   /** Tailwind class list, in source order */
   classes: string[]
   /** Persists a new class list back to the element. */
-  onClassesChange: (dataId: string, classes: string[]) => void
+  onClassesChange: (
+    dataId: string,
+    classes: string[],
+    options?: ElementClassChangeOptions,
+  ) => void
   /** Persists a single inline CSS property (or removes it when value is empty).
    *  Used for styling that must override class/cascade rules — e.g. the
    *  per-element font, which is applied as an inline `font-family` so it isn't

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/style-editor/sections/Typography.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/style-editor/sections/Typography.tsx
@@ -28,6 +28,7 @@ import {
 import { useElementStyles } from "../use-element-styles"
 import { useElementContext } from "../element-context"
 import { FontFamilyControl } from "./FontFamilyControl"
+import { MANUAL_TEXT_COLOR_ATTRIBUTE } from "../../text-color"
 
 const WEIGHT_OPTIONS: ReadonlyArray<SelectOption<string>> = [
   { value: "thin", label: "thin", preview: <span className="font-thin">Aa</span> },
@@ -42,6 +43,10 @@ const WEIGHT_OPTIONS: ReadonlyArray<SelectOption<string>> = [
 ]
 
 const EMPTY_DECOR: string[] = []
+const TEXT_COLOR_CHANGE_OPTIONS = {
+  removeAttributes: ["data-text-color"],
+  setAttributes: [MANUAL_TEXT_COLOR_ATTRIBUTE],
+} as const
 
 export function TypographySection() {
   const { t } = useLingui()
@@ -57,7 +62,11 @@ export function TypographySection() {
   const decor = useElementStyles(textDecorationClassMap, EMPTY_DECOR)
   const align = useElementStyles(textAlignClassMap, inheritedAlign ?? "left")
   const leading = useElementStyles(lineHeightClassMap, inheritedLeading ?? 1.5)
-  const textColor = useElementStyles(textColorClassMap, inheritedColor ?? "")
+  const textColor = useElementStyles(
+    textColorClassMap,
+    inheritedColor ?? "",
+    TEXT_COLOR_CHANGE_OPTIONS,
+  )
 
   const decorItems = [
     { value: "italic", icon: Italic, label: t`Italic` },

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/style-editor/sections/Typography.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/style-editor/sections/Typography.tsx
@@ -46,6 +46,8 @@ const EMPTY_DECOR: string[] = []
 const TEXT_COLOR_CHANGE_OPTIONS = {
   removeAttributes: ["data-text-color"],
   setAttributes: [MANUAL_TEXT_COLOR_ATTRIBUTE],
+  removeStyleProperties: ["color"],
+  preserveDefaultClass: true,
 } as const
 
 export function TypographySection() {

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/style-editor/use-element-styles.test.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/style-editor/use-element-styles.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react"
+import type { ReactNode } from "react"
+import { describe, expect, it, vi } from "vitest"
+import { textColorClassMap } from "./class-maps"
+import { ElementProvider } from "./element-context"
+import { useElementStyles } from "./use-element-styles"
+
+const options = { preserveDefaultClass: true } as const
+
+function wrapperFor(
+  classes: string[],
+  onClassesChange: ReturnType<typeof vi.fn>,
+) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <ElementProvider
+        value={{
+          dataId: "body",
+          classes,
+          onClassesChange,
+          deviceView: "mobile",
+        }}
+      >
+        {children}
+      </ElementProvider>
+    )
+  }
+}
+
+describe("useElementStyles responsive semantic defaults", () => {
+  it("materializes the desktop default before adding a mobile override", () => {
+    const onClassesChange = vi.fn()
+    const { result } = renderHook(
+      () => useElementStyles(textColorClassMap, "#111827", options),
+      { wrapper: wrapperFor([], onClassesChange) },
+    )
+
+    act(() => result.current.setValue("#2563EB"))
+
+    expect(onClassesChange).toHaveBeenCalledWith(
+      "body",
+      ["text-[#111827]", "max-sm:text-[#2563EB]"],
+      options,
+    )
+  })
+
+  it("keeps the desktop default when resetting a mobile override", () => {
+    const onClassesChange = vi.fn()
+    const { result } = renderHook(
+      () => useElementStyles(textColorClassMap, "#111827", options),
+      {
+        wrapper: wrapperFor(
+          ["max-sm:text-[#2563EB]"],
+          onClassesChange,
+        ),
+      },
+    )
+
+    act(() => result.current.override?.reset())
+
+    expect(onClassesChange).toHaveBeenCalledWith(
+      "body",
+      ["text-[#111827]"],
+      options,
+    )
+  })
+})

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/style-editor/use-element-styles.ts
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/style-editor/use-element-styles.ts
@@ -8,6 +8,7 @@ import {
   type DeviceView,
 } from "./device-breakpoint"
 import type { ClassMap } from "./class-maps/types"
+import type { ElementClassChangeOptions } from "../text-color"
 
 export interface OverrideInfo {
   currentPrefix: string
@@ -74,7 +75,8 @@ function arraysEqual(a: readonly string[], b: readonly string[]): boolean {
 
 export function useElementStyles<TValue>(
   classMap: ClassMap<TValue>,
-  defaultValue: TValue
+  defaultValue: TValue,
+  changeOptions?: ElementClassChangeOptions,
 ): UseElementStylesResult<TValue> {
   const { dataId, classes, onClassesChange, deviceView } = useElementContext()
 
@@ -123,7 +125,7 @@ export function useElementStyles<TValue>(
         merged = [...stripped, ...additions]
       }
 
-      onClassesChange(dataId, merged)
+      onClassesChange(dataId, merged, changeOptions)
     },
     [
       classes,
@@ -132,6 +134,7 @@ export function useElementStyles<TValue>(
       dataId,
       defaultValue,
       onClassesChange,
+      changeOptions,
       resolveAt,
       widerPrefixes,
     ]
@@ -143,8 +146,15 @@ export function useElementStyles<TValue>(
       if (!c.startsWith(currentPrefix)) return true
       return !classMap.matches(c.slice(currentPrefix.length))
     })
-    onClassesChange(dataId, stripped)
-  }, [classes, classMap, currentPrefix, dataId, onClassesChange])
+    onClassesChange(dataId, stripped, changeOptions)
+  }, [
+    classes,
+    classMap,
+    currentPrefix,
+    dataId,
+    onClassesChange,
+    changeOptions,
+  ])
 
   const override = useMemo<OverrideInfo | null>(() => {
     if (currentPrefix === "") return null

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/style-editor/use-element-styles.ts
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/style-editor/use-element-styles.ts
@@ -120,9 +120,19 @@ export function useElementStyles<TValue>(
       const isRedundant = arraysEqual(widerClasses, newClasses)
 
       let merged = stripped
+      if (
+        changeOptions?.preserveDefaultClass &&
+        currentPrefix !== "" &&
+        resolveAt([""]) === null
+      ) {
+        // Removing a non-responsive semantic/inline default for a tablet or
+        // mobile override must not change the desktop rendering. Materialize
+        // the currently rendered default as an unprefixed class first.
+        merged = [...merged, ...classMap.toClasses(defaultValue)]
+      }
       if (!isRedundant && newClasses.length > 0) {
         const additions = newClasses.map((c) => `${currentPrefix}${c}`)
-        merged = [...stripped, ...additions]
+        merged = [...merged, ...additions]
       }
 
       onClassesChange(dataId, merged, changeOptions)
@@ -142,18 +152,26 @@ export function useElementStyles<TValue>(
 
   const reset = useCallback(() => {
     if (currentPrefix === "") return
-    const stripped = classes.filter((c) => {
+    let stripped = classes.filter((c) => {
       if (!c.startsWith(currentPrefix)) return true
       return !classMap.matches(c.slice(currentPrefix.length))
     })
+    if (
+      changeOptions?.preserveDefaultClass &&
+      resolveAt([""]) === null
+    ) {
+      stripped = [...stripped, ...classMap.toClasses(defaultValue)]
+    }
     onClassesChange(dataId, stripped, changeOptions)
   }, [
     classes,
     classMap,
     currentPrefix,
     dataId,
+    defaultValue,
     onClassesChange,
     changeOptions,
+    resolveAt,
   ])
 
   const override = useMemo<OverrideInfo | null>(() => {

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/text-color.test.ts
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/text-color.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from "vitest"
+import {
+  applyTextColors,
+  MANUAL_TEXT_COLOR_ATTRIBUTE,
+  restoreAppliedTextColors,
+} from "./text-color"
+
+describe("semantic text colors", () => {
+  it("restores source styles before a manual color edit is serialized", () => {
+    document.body.innerHTML = `
+      <p class="text-black" data-id="body" data-text-color="#111827">
+        Body <span class="font-bold">emphasis</span>
+      </p>
+    `
+    const body = document.querySelector<HTMLElement>('[data-id="body"]')!
+    const emphasis = body.querySelector<HTMLElement>("span")!
+
+    applyTextColors(document)
+    expect(body.style.getPropertyValue("color")).toBe("rgb(17, 24, 39)")
+    expect(body.style.getPropertyPriority("color")).toBe("important")
+    expect(emphasis.style.getPropertyValue("color")).toBe("inherit")
+
+    body.className = "text-blue-600"
+    body.removeAttribute("data-text-color")
+    body.setAttribute(MANUAL_TEXT_COLOR_ATTRIBUTE, "")
+    restoreAppliedTextColors(document)
+    const serialized = document.body.innerHTML
+    applyTextColors(document)
+
+    expect(serialized).toContain('class="text-blue-600"')
+    expect(serialized).not.toContain("data-text-color")
+    expect(serialized).not.toContain("data-adt-original-color")
+    expect(serialized).toContain(MANUAL_TEXT_COLOR_ATTRIBUTE)
+    expect(body.style.getPropertyValue("color")).toBe("")
+    expect(emphasis.style.getPropertyValue("color")).toBe("")
+  })
+
+  it("does not override a manual color on a descendant", () => {
+    document.body.innerHTML = `
+      <p data-text-color="#111827">
+        Body <span class="text-blue-600" ${MANUAL_TEXT_COLOR_ATTRIBUTE}>link-like text</span>
+      </p>
+    `
+    const body = document.querySelector<HTMLElement>("p")!
+    const span = body.querySelector<HTMLElement>("span")!
+
+    applyTextColors(document)
+
+    expect(body.style.getPropertyPriority("color")).toBe("important")
+    expect(span.style.getPropertyValue("color")).toBe("")
+  })
+
+  it("preserves a source inline color after preview-only styles are restored", () => {
+    document.body.innerHTML =
+      '<p data-text-color="#111827" style="color: rgb(220, 38, 38)">Body</p>'
+    const body = document.querySelector<HTMLElement>("p")!
+
+    applyTextColors(document)
+    restoreAppliedTextColors(document)
+
+    expect(body.style.getPropertyValue("color")).toBe("rgb(220, 38, 38)")
+    expect(body.style.getPropertyPriority("color")).toBe("")
+  })
+})

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/text-color.test.ts
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/text-color.test.ts
@@ -2,6 +2,7 @@
 
 import { describe, expect, it } from "vitest"
 import {
+  applyElementClassChange,
   applyTextColors,
   MANUAL_TEXT_COLOR_ATTRIBUTE,
   restoreAppliedTextColors,
@@ -10,7 +11,7 @@ import {
 describe("semantic text colors", () => {
   it("restores source styles before a manual color edit is serialized", () => {
     document.body.innerHTML = `
-      <p class="text-black" data-id="body" data-text-color="#111827">
+      <p class="text-black" data-id="body" data-text-color="#111827" style="color: rgb(220, 38, 38)">
         Body <span class="font-bold">emphasis</span>
       </p>
     `
@@ -22,10 +23,12 @@ describe("semantic text colors", () => {
     expect(body.style.getPropertyPriority("color")).toBe("important")
     expect(emphasis.style.getPropertyValue("color")).toBe("inherit")
 
-    body.className = "text-blue-600"
-    body.removeAttribute("data-text-color")
-    body.setAttribute(MANUAL_TEXT_COLOR_ATTRIBUTE, "")
     restoreAppliedTextColors(document)
+    applyElementClassChange(body, ["text-blue-600"], {
+      removeAttributes: ["data-text-color"],
+      setAttributes: [MANUAL_TEXT_COLOR_ATTRIBUTE],
+      removeStyleProperties: ["color"],
+    })
     const serialized = document.body.innerHTML
     applyTextColors(document)
 
@@ -33,8 +36,28 @@ describe("semantic text colors", () => {
     expect(serialized).not.toContain("data-text-color")
     expect(serialized).not.toContain("data-adt-original-color")
     expect(serialized).toContain(MANUAL_TEXT_COLOR_ATTRIBUTE)
+    expect(serialized).not.toContain("rgb(220, 38, 38)")
     expect(body.style.getPropertyValue("color")).toBe("")
     expect(emphasis.style.getPropertyValue("color")).toBe("")
+  })
+
+  it("keeps explicit child colors under a legacy section-level default", () => {
+    document.body.innerHTML = `
+      <section data-section-id="section-1" data-text-color="#3D2B1F">
+        <h1 style="color: #8B2252">Intentional heading color</h1>
+        <p>Inherited body color</p>
+      </section>
+    `
+    const section = document.querySelector<HTMLElement>("section")!
+    const heading = document.querySelector<HTMLElement>("h1")!
+    const paragraph = document.querySelector<HTMLElement>("p")!
+
+    applyTextColors(document)
+
+    expect(section.style.getPropertyPriority("color")).toBe("important")
+    expect(heading.style.getPropertyValue("color")).toBe("rgb(139, 34, 82)")
+    expect(heading.style.getPropertyPriority("color")).toBe("")
+    expect(paragraph.style.getPropertyValue("color")).toBe("")
   })
 
   it("does not override a manual color on a descendant", () => {

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/text-color.ts
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/text-color.ts
@@ -1,0 +1,58 @@
+const ORIGINAL_COLOR_MARKER = "data-adt-original-color"
+const ORIGINAL_COLOR_VALUE = "data-adt-original-color-value"
+const ORIGINAL_COLOR_PRIORITY = "data-adt-original-color-priority"
+export const MANUAL_TEXT_COLOR_ATTRIBUTE = "data-adt-manual-text-color"
+
+export interface ElementClassChangeOptions {
+  removeAttributes?: readonly string[]
+  setAttributes?: readonly string[]
+}
+
+// Preview-only inline styles must be reversible because the editor serializes
+// the iframe DOM after class/style changes. Otherwise the runtime !important
+// colors would leak into saved HTML and override later user edits.
+function rememberOriginalColor(el: HTMLElement): void {
+  if (el.hasAttribute(ORIGINAL_COLOR_MARKER)) return
+  el.setAttribute(ORIGINAL_COLOR_MARKER, "")
+  el.setAttribute(ORIGINAL_COLOR_VALUE, el.style.getPropertyValue("color"))
+  el.setAttribute(
+    ORIGINAL_COLOR_PRIORITY,
+    el.style.getPropertyPriority("color"),
+  )
+}
+
+export function restoreAppliedTextColors(doc: Document): void {
+  doc.querySelectorAll<HTMLElement>(`[${ORIGINAL_COLOR_MARKER}]`).forEach((el) => {
+    const value = el.getAttribute(ORIGINAL_COLOR_VALUE) ?? ""
+    const priority = el.getAttribute(ORIGINAL_COLOR_PRIORITY) ?? ""
+    if (value) {
+      el.style.setProperty("color", value, priority)
+    } else {
+      el.style.removeProperty("color")
+    }
+    el.removeAttribute(ORIGINAL_COLOR_MARKER)
+    el.removeAttribute(ORIGINAL_COLOR_VALUE)
+    el.removeAttribute(ORIGINAL_COLOR_PRIORITY)
+  })
+}
+
+export function applyTextColors(doc: Document): void {
+  const colorEls = doc.querySelectorAll<HTMLElement>("[data-text-color]")
+  for (const el of colorEls) {
+    const color = el.getAttribute("data-text-color")
+    if (!color || el.hasAttribute(MANUAL_TEXT_COLOR_ATTRIBUTE)) continue
+    rememberOriginalColor(el)
+    el.style.setProperty("color", color, "important")
+    const descendants = el.querySelectorAll<HTMLElement>("*")
+    for (const descendant of descendants) {
+      if (
+        descendant.closest("[data-text-color]") === el &&
+        !descendant.closest("a") &&
+        !descendant.closest(`[${MANUAL_TEXT_COLOR_ATTRIBUTE}]`)
+      ) {
+        rememberOriginalColor(descendant)
+        descendant.style.setProperty("color", "inherit", "important")
+      }
+    }
+  }
+}

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/text-color.ts
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/text-color.ts
@@ -6,6 +6,27 @@ export const MANUAL_TEXT_COLOR_ATTRIBUTE = "data-adt-manual-text-color"
 export interface ElementClassChangeOptions {
   removeAttributes?: readonly string[]
   setAttributes?: readonly string[]
+  removeStyleProperties?: readonly string[]
+  /** When a semantic default is removed by a responsive class edit, preserve
+   *  that default as an unprefixed class so wider viewports do not regress. */
+  preserveDefaultClass?: boolean
+}
+
+export function applyElementClassChange(
+  el: HTMLElement,
+  classes: string[],
+  options: ElementClassChangeOptions = {},
+): void {
+  el.className = classes.join(" ")
+  for (const attribute of options.removeAttributes ?? []) {
+    el.removeAttribute(attribute)
+  }
+  for (const attribute of options.setAttributes ?? []) {
+    el.setAttribute(attribute, "")
+  }
+  for (const property of options.removeStyleProperties ?? []) {
+    el.style.removeProperty(property)
+  }
 }
 
 // Preview-only inline styles must be reversible because the editor serializes
@@ -43,6 +64,13 @@ export function applyTextColors(doc: Document): void {
     if (!color || el.hasAttribute(MANUAL_TEXT_COLOR_ATTRIBUTE)) continue
     rememberOriginalColor(el)
     el.style.setProperty("color", color, "important")
+    // Older/generated StyleGuides put the semantic default on the section and
+    // use explicit colors for headings, badges, and callouts below it. Treat
+    // that shape as normal CSS inheritance: unstyled descendants inherit the
+    // section color, while intentional child declarations remain intact. New
+    // StyleGuides put data-text-color on each text element, where the forced
+    // descendant pass is still needed for incidental nested utility classes.
+    if (el.tagName === "SECTION" || el.hasAttribute("data-section-id")) continue
     const descendants = el.querySelectorAll<HTMLElement>("*")
     for (const descendant of descendants) {
       if (

--- a/apps/studio/src/hooks/use-presets.test.tsx
+++ b/apps/studio/src/hooks/use-presets.test.tsx
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { act, renderHook, waitFor } from "@testing-library/react"
+import type { ReactNode } from "react"
+import { describe, expect, it, vi } from "vitest"
+import { api } from "@/api/client"
+import { useUploadStyleguide } from "./use-presets"
+
+vi.mock("@/api/client", () => ({
+  api: {
+    uploadStyleguide: vi.fn(),
+  },
+}))
+
+describe("useUploadStyleguide", () => {
+  it("invalidates the uploaded styleguide preview", async () => {
+    vi.mocked(api.uploadStyleguide).mockResolvedValue({ name: "custom" })
+    const queryClient = new QueryClient({
+      defaultOptions: { mutations: { retry: false } },
+    })
+    const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries")
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+    const { result } = renderHook(useUploadStyleguide, { wrapper })
+
+    await act(() =>
+      result.current.mutateAsync(
+        new File(["# Custom"], "custom.md", { type: "text/markdown" }),
+      ),
+    )
+
+    await waitFor(() => {
+      expect(invalidateQueries).toHaveBeenCalledWith({
+        queryKey: ["styleguides"],
+      })
+      expect(invalidateQueries).toHaveBeenCalledWith({
+        queryKey: ["styleguide-preview", "custom"],
+      })
+    })
+  })
+})

--- a/apps/studio/src/hooks/use-presets.ts
+++ b/apps/studio/src/hooks/use-presets.ts
@@ -38,8 +38,11 @@ export function useUploadStyleguide() {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: (file: File) => api.uploadStyleguide(file),
-    onSuccess: () => {
+    onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: ["styleguides"] })
+      queryClient.invalidateQueries({
+        queryKey: ["styleguide-preview", data.name],
+      })
     },
   })
 }

--- a/assets/styleguides/default.md
+++ b/assets/styleguides/default.md
@@ -20,30 +20,30 @@ section-wide value cannot represent both. Instead, put `data-text-color`
 directly on each heading element (`h1`/`h2` rendering a `heading`,
 `chapter_title`, `section_heading`, etc.) using the Headings color, and
 directly on each body-text element (`p` rendering `section_text`,
-`standalone_text`, etc.) using the Body Text color ? see the Page Templates
+`standalone_text`, etc.) using the Body Text color — see the Page Templates
 below for concrete examples. Exception: templates that already define their
 own distinct, non-default color scheme (e.g. the Table of Contents) should
-NOT add `data-text-color` to their custom-colored elements ? leave those to
+NOT add `data-text-color` to their custom-colored elements — leave those to
 their own explicit color classes instead of forcing the generic Headings/Body
 Text colors onto them.
 
 ## Visual Defaults
 
-These are the book-wide defaults for this styleguide. They take precedence over any generic example or convention shown elsewhere in this prompt ? apply them consistently across every page unless a specific template below explicitly overrides one of them. Headings and body text are scoped separately below: a setting under one does not affect the other.
+These are the book-wide defaults for this styleguide. They take precedence over any generic example or convention shown elsewhere in this prompt — apply them consistently across every page unless a specific template below explicitly overrides one of them. Headings and body text are scoped separately below: a setting under one does not affect the other.
 
 ### Page-level
 
 | Property | Default | Notes |
 |----------|---------|-------|
 | Background color | `#FFFFFF` | Applied via `data-background-color` on the outer container. |
-| Max paragraph width (reading column) | `max-w-7xl` | Applies to the inner container on every page ? never vary this per page. |
-| Paragraph spacing | Spacious (`space-y-8` inside a Content Card, `space-y-6` for a bare Text Group) | Vertical gap between paragraphs ? keep it consistent with the component used. |
+| Max paragraph width (reading column) | `max-w-7xl` | Applies to the inner container on every page — never vary this per page. |
+| Paragraph spacing | Spacious (`space-y-8` inside a Content Card, `space-y-6` for a bare Text Group) | Vertical gap between paragraphs — keep it consistent with the component used. |
 
 ### Headings
 
 | Property | Default | Notes |
 |----------|---------|-------|
-| Text color | `#F12929` | Applied to headings (`heading`, `chapter_title`, `section_heading`, etc.) via `data-text-color` ? does not affect the other role. |
+| Text color | `#111827` | Applied to headings (`heading`, `chapter_title`, `section_heading`, etc.) via `data-text-color` — does not affect the other role. |
 | Text alignment | Center | Only applies to headings (`heading`, `chapter_title`, `section_heading`, etc.). Only center/right-align where a template below explicitly shows it (e.g. cover/title pages, the Table of Contents). |
 | Bold / Italic / Underline | Bold | Controls whether headings (`heading`, `chapter_title`, `section_heading`, etc.) is bold/italic/underlined by default. |
 | Line-height | `leading-loose` | Applies to headings (`heading`, `chapter_title`, `section_heading`, etc.). Keep it consistent across all pages. |
@@ -52,7 +52,7 @@ These are the book-wide defaults for this styleguide. They take precedence over 
 
 | Property | Default | Notes |
 |----------|---------|-------|
-| Text color | `#3AED09` | Applied to body text (`section_text`, `standalone_text`) via `data-text-color` ? does not affect the other role. |
+| Text color | `#1F2937` | Applied to body text (`section_text`, `standalone_text`) via `data-text-color` — does not affect the other role. |
 | Text alignment | Left | Only applies to body text (`section_text`, `standalone_text`). Only center/right-align where a template below explicitly shows it (e.g. cover/title pages, the Table of Contents). |
 | Bold / Italic / Underline | Italic | Controls whether body text (`section_text`, `standalone_text`) is bold/italic/underlined by default. |
 | Line-height | `leading-relaxed` | Applies to body text (`section_text`, `standalone_text`). Keep it consistent across all pages. |
@@ -147,7 +147,7 @@ Use when page has "CHAPTER" and a number:
   <section class="w-full" data-section-id="SECTION_ID" data-section-type="text_and_single_image"
       id="simple-main" role="article">
     <div class="mx-auto w-full max-w-5xl space-y-8">
-      <!-- Chapter Badge (heading role ? data-text-color on each heading, not the section) -->
+      <!-- Chapter Badge (heading role — data-text-color on each heading, not the section) -->
       <div class="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
         <div class="flex items-start gap-6">
           <div class="shrink-0 rounded-3xl bg-purple-200 px-6 py-5 shadow-sm">
@@ -159,7 +159,7 @@ Use when page has "CHAPTER" and a number:
           </div>
         </div>
       </div>
-      <!-- Content Card (body role ? data-text-color on each paragraph) -->
+      <!-- Content Card (body role — data-text-color on each paragraph) -->
       <div class="space-y-4 rounded-3xl bg-white/80 p-6 shadow-sm ring-1 ring-black/5">
         <p class="text-lg md:text-xl leading-relaxed" data-text-color="BODY_TEXT_COLOR" data-id="text-1">Paragraph one.</p>
         <p class="text-lg md:text-xl leading-relaxed" data-text-color="BODY_TEXT_COLOR" data-id="text-2">Paragraph two.</p>
@@ -181,7 +181,7 @@ Use for pages with just text and images (no chapter header):
   <section class="w-full" data-section-id="SECTION_ID" data-section-type="text_and_images"
       id="simple-main" role="article">
     <div class="mx-auto w-full max-w-5xl space-y-8">
-      <!-- Text Group (body role ? data-text-color on each paragraph) -->
+      <!-- Text Group (body role — data-text-color on each paragraph) -->
       <div class="space-y-3">
         <p class="text-lg md:text-xl leading-relaxed" data-text-color="BODY_TEXT_COLOR" data-id="text-1">First paragraph.</p>
         <p class="text-lg md:text-xl leading-relaxed" data-text-color="BODY_TEXT_COLOR" data-id="text-2">Second paragraph.</p>
@@ -201,7 +201,7 @@ Use for pages with just text and images (no chapter header):
 
 ### Template: Text-Only Page (prose only, no images)
 
-Use for pages with only text ? no images, no activities (`section_type: "text_only"`):
+Use for pages with only text — no images, no activities (`section_type: "text_only"`):
 
 ```html
 <div class="container content mx-auto flex min-h-screen w-full items-center justify-center px-6 py-12"
@@ -241,7 +241,7 @@ Use for pages with only text ? no images, no activities (`section_type: "text_on
 
 Use this EXACT structure for table of contents pages. This template intentionally
 uses its own purple/gray color scheme instead of the Headings/Body Text
-defaults ? do NOT add `data-text-color` to its title, subtitle, or entries;
+defaults — do NOT add `data-text-color` to its title, subtitle, or entries;
 leave them to their own explicit color classes shown below.
 
 ```html

--- a/assets/styleguides/default.md
+++ b/assets/styleguides/default.md
@@ -7,12 +7,55 @@ Every page MUST use this exact outer container:
 ```html
 <div class="container content mx-auto flex min-h-screen w-full items-center justify-center px-6 py-12"
     data-background-color="BACKGROUND_COLOR" id="content">
-  <section class="w-full" data-section-id="SECTION_ID" data-section-type="SECTION_TYPE" data-text-color="TEXT_COLOR"
+  <section class="w-full" data-section-id="SECTION_ID" data-section-type="SECTION_TYPE"
       id="simple-main" role="article">
     <!-- Content goes here -->
   </section>
 </div>
 ```
+
+**Do NOT put `data-text-color` on this outer `<section>`.** Headings and body
+text can have different colors (see Visual Defaults below), so a single
+section-wide value cannot represent both. Instead, put `data-text-color`
+directly on each heading element (`h1`/`h2` rendering a `heading`,
+`chapter_title`, `section_heading`, etc.) using the Headings color, and
+directly on each body-text element (`p` rendering `section_text`,
+`standalone_text`, etc.) using the Body Text color ? see the Page Templates
+below for concrete examples. Exception: templates that already define their
+own distinct, non-default color scheme (e.g. the Table of Contents) should
+NOT add `data-text-color` to their custom-colored elements ? leave those to
+their own explicit color classes instead of forcing the generic Headings/Body
+Text colors onto them.
+
+## Visual Defaults
+
+These are the book-wide defaults for this styleguide. They take precedence over any generic example or convention shown elsewhere in this prompt ? apply them consistently across every page unless a specific template below explicitly overrides one of them. Headings and body text are scoped separately below: a setting under one does not affect the other.
+
+### Page-level
+
+| Property | Default | Notes |
+|----------|---------|-------|
+| Background color | `#FFFFFF` | Applied via `data-background-color` on the outer container. |
+| Max paragraph width (reading column) | `max-w-7xl` | Applies to the inner container on every page ? never vary this per page. |
+| Paragraph spacing | Spacious (`space-y-8` inside a Content Card, `space-y-6` for a bare Text Group) | Vertical gap between paragraphs ? keep it consistent with the component used. |
+
+### Headings
+
+| Property | Default | Notes |
+|----------|---------|-------|
+| Text color | `#F12929` | Applied to headings (`heading`, `chapter_title`, `section_heading`, etc.) via `data-text-color` ? does not affect the other role. |
+| Text alignment | Center | Only applies to headings (`heading`, `chapter_title`, `section_heading`, etc.). Only center/right-align where a template below explicitly shows it (e.g. cover/title pages, the Table of Contents). |
+| Bold / Italic / Underline | Bold | Controls whether headings (`heading`, `chapter_title`, `section_heading`, etc.) is bold/italic/underlined by default. |
+| Line-height | `leading-loose` | Applies to headings (`heading`, `chapter_title`, `section_heading`, etc.). Keep it consistent across all pages. |
+
+### Body Text
+
+| Property | Default | Notes |
+|----------|---------|-------|
+| Text color | `#3AED09` | Applied to body text (`section_text`, `standalone_text`) via `data-text-color` ? does not affect the other role. |
+| Text alignment | Left | Only applies to body text (`section_text`, `standalone_text`). Only center/right-align where a template below explicitly shows it (e.g. cover/title pages, the Table of Contents). |
+| Bold / Italic / Underline | Italic | Controls whether body text (`section_text`, `standalone_text`) is bold/italic/underlined by default. |
+| Line-height | `leading-relaxed` | Applies to body text (`section_text`, `standalone_text`). Keep it consistent across all pages. |
 
 ## Inner Container (REQUIRED for all content pages)
 
@@ -36,11 +79,11 @@ When there is a chapter number (like "CHAPTER 1"), use this EXACT structure:
 <div class="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
   <div class="flex items-start gap-6">
     <div class="shrink-0 rounded-3xl bg-purple-200 px-6 py-5 shadow-sm">
-      <h1 class="text-3xl md:text-4xl font-bold leading-tight" data-id="CHAPTER_WORD_ID">CHAPTER</h1>
-      <h1 class="text-3xl md:text-4xl font-bold leading-tight" data-id="CHAPTER_NUMBER_ID">1</h1>
+      <h1 class="text-3xl md:text-4xl font-bold leading-tight" data-text-color="HEADING_TEXT_COLOR" data-id="CHAPTER_WORD_ID">CHAPTER</h1>
+      <h1 class="text-3xl md:text-4xl font-bold leading-tight" data-text-color="HEADING_TEXT_COLOR" data-id="CHAPTER_NUMBER_ID">1</h1>
     </div>
     <div class="pt-2">
-      <h1 class="text-3xl md:text-4xl font-bold leading-tight" data-id="CHAPTER_TITLE_ID">Chapter Title Here</h1>
+      <h1 class="text-3xl md:text-4xl font-bold leading-tight" data-text-color="HEADING_TEXT_COLOR" data-id="CHAPTER_TITLE_ID">Chapter Title Here</h1>
     </div>
   </div>
 </div>
@@ -52,8 +95,8 @@ Wrap body paragraphs in this card:
 
 ```html
 <div class="space-y-4 rounded-3xl bg-white/80 p-6 shadow-sm ring-1 ring-black/5">
-  <p class="text-lg md:text-xl leading-relaxed" data-id="ID">Paragraph text</p>
-  <p class="text-lg md:text-xl leading-relaxed" data-id="ID">More text</p>
+  <p class="text-lg md:text-xl leading-relaxed" data-text-color="BODY_TEXT_COLOR" data-id="ID">Paragraph text</p>
+  <p class="text-lg md:text-xl leading-relaxed" data-text-color="BODY_TEXT_COLOR" data-id="ID">More text</p>
 </div>
 ```
 
@@ -61,7 +104,7 @@ Wrap body paragraphs in this card:
 
 ```html
 <div class="space-y-3">
-  <p class="text-lg md:text-xl leading-relaxed" data-id="ID">Paragraph text</p>
+  <p class="text-lg md:text-xl leading-relaxed" data-text-color="BODY_TEXT_COLOR" data-id="ID">Paragraph text</p>
 </div>
 ```
 
@@ -76,6 +119,7 @@ Wrap body paragraphs in this card:
 | chapter_title | h1 | text-3xl md:text-4xl font-bold leading-tight |
 | section_heading | h1 | text-3xl md:text-4xl font-bold leading-tight |
 | activity_title | h2 | text-2xl md:text-3xl font-bold leading-tight |
+| heading | h2 | text-2xl md:text-3xl font-bold leading-tight |
 | section_text | p | text-lg md:text-xl leading-relaxed |
 | instruction_text | p | text-base md:text-lg leading-relaxed text-gray-700 italic |
 | standalone_text | p | text-base md:text-lg leading-relaxed |
@@ -100,25 +144,25 @@ Use when page has "CHAPTER" and a number:
 ```html
 <div class="container content mx-auto flex min-h-screen w-full items-center justify-center px-6 py-12"
     data-background-color="#ffffff" id="content">
-  <section class="w-full" data-section-id="SECTION_ID" data-section-type="text_and_single_image" data-text-color="#000000"
+  <section class="w-full" data-section-id="SECTION_ID" data-section-type="text_and_single_image"
       id="simple-main" role="article">
     <div class="mx-auto w-full max-w-5xl space-y-8">
-      <!-- Chapter Badge -->
+      <!-- Chapter Badge (heading role ? data-text-color on each heading, not the section) -->
       <div class="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
         <div class="flex items-start gap-6">
           <div class="shrink-0 rounded-3xl bg-purple-200 px-6 py-5 shadow-sm">
-            <h1 class="text-3xl md:text-4xl font-bold leading-tight" data-id="chapter-word">CHAPTER</h1>
-            <h1 class="text-3xl md:text-4xl font-bold leading-tight" data-id="chapter-num">1</h1>
+            <h1 class="text-3xl md:text-4xl font-bold leading-tight" data-text-color="HEADING_TEXT_COLOR" data-id="chapter-word">CHAPTER</h1>
+            <h1 class="text-3xl md:text-4xl font-bold leading-tight" data-text-color="HEADING_TEXT_COLOR" data-id="chapter-num">1</h1>
           </div>
           <div class="pt-2">
-            <h1 class="text-3xl md:text-4xl font-bold leading-tight" data-id="chapter-title">The Nile River</h1>
+            <h1 class="text-3xl md:text-4xl font-bold leading-tight" data-text-color="HEADING_TEXT_COLOR" data-id="chapter-title">The Nile River</h1>
           </div>
         </div>
       </div>
-      <!-- Content Card -->
+      <!-- Content Card (body role ? data-text-color on each paragraph) -->
       <div class="space-y-4 rounded-3xl bg-white/80 p-6 shadow-sm ring-1 ring-black/5">
-        <p class="text-lg md:text-xl leading-relaxed" data-id="text-1">Paragraph one.</p>
-        <p class="text-lg md:text-xl leading-relaxed" data-id="text-2">Paragraph two.</p>
+        <p class="text-lg md:text-xl leading-relaxed" data-text-color="BODY_TEXT_COLOR" data-id="text-1">Paragraph one.</p>
+        <p class="text-lg md:text-xl leading-relaxed" data-text-color="BODY_TEXT_COLOR" data-id="text-2">Paragraph two.</p>
       </div>
       <!-- Image -->
       <img alt="" class="w-full rounded-2xl shadow-lg" data-id="img-1" src="images/img-1.jpg"/>
@@ -134,22 +178,44 @@ Use for pages with just text and images (no chapter header):
 ```html
 <div class="container content mx-auto flex min-h-screen w-full items-center justify-center px-6 py-12"
     data-background-color="#ffffff" id="content">
-  <section class="w-full" data-section-id="SECTION_ID" data-section-type="text_and_images" data-text-color="#000000"
+  <section class="w-full" data-section-id="SECTION_ID" data-section-type="text_and_images"
       id="simple-main" role="article">
     <div class="mx-auto w-full max-w-5xl space-y-8">
-      <!-- Text Group -->
+      <!-- Text Group (body role ? data-text-color on each paragraph) -->
       <div class="space-y-3">
-        <p class="text-lg md:text-xl leading-relaxed" data-id="text-1">First paragraph.</p>
-        <p class="text-lg md:text-xl leading-relaxed" data-id="text-2">Second paragraph.</p>
+        <p class="text-lg md:text-xl leading-relaxed" data-text-color="BODY_TEXT_COLOR" data-id="text-1">First paragraph.</p>
+        <p class="text-lg md:text-xl leading-relaxed" data-text-color="BODY_TEXT_COLOR" data-id="text-2">Second paragraph.</p>
       </div>
       <!-- Image -->
       <img alt="" class="w-full rounded-2xl shadow-lg" data-id="img-1" src="images/img-1.jpg"/>
       <!-- More Text -->
       <div class="space-y-3">
-        <p class="text-lg md:text-xl leading-relaxed" data-id="text-3">Another paragraph.</p>
+        <p class="text-lg md:text-xl leading-relaxed" data-text-color="BODY_TEXT_COLOR" data-id="text-3">Another paragraph.</p>
       </div>
       <!-- Another Image -->
       <img alt="" class="w-full rounded-2xl shadow-lg" data-id="img-2" src="images/img-2.jpg"/>
+    </div>
+  </section>
+</div>
+```
+
+### Template: Text-Only Page (prose only, no images)
+
+Use for pages with only text ? no images, no activities (`section_type: "text_only"`):
+
+```html
+<div class="container content mx-auto flex min-h-screen w-full items-center justify-center px-6 py-12"
+    data-background-color="#ffffff" id="content">
+  <section class="w-full" data-section-id="SECTION_ID" data-section-type="text_only"
+      id="simple-main" role="article">
+    <div class="mx-auto w-full max-w-5xl space-y-8">
+      <!-- Heading (if the section has one) -->
+      <h2 class="text-2xl md:text-3xl font-bold leading-tight" data-text-color="HEADING_TEXT_COLOR" data-id="heading-1">Section Heading</h2>
+      <!-- Content Card -->
+      <div class="space-y-4 rounded-3xl bg-white/80 p-6 shadow-sm ring-1 ring-black/5">
+        <p class="text-lg md:text-xl leading-relaxed" data-text-color="BODY_TEXT_COLOR" data-id="text-1">First paragraph.</p>
+        <p class="text-lg md:text-xl leading-relaxed" data-text-color="BODY_TEXT_COLOR" data-id="text-2">Second paragraph.</p>
+      </div>
     </div>
   </section>
 </div>
@@ -161,7 +227,8 @@ Use for pages with just text and images (no chapter header):
 <div class="mx-auto w-full max-w-5xl space-y-8">
   <div class="flex flex-col md:flex-row gap-8">
     <div class="flex-1 space-y-4">
-      <!-- text elements -->
+      <!-- text elements: put data-text-color="HEADING_TEXT_COLOR" on headings,
+           data-text-color="BODY_TEXT_COLOR" on paragraphs -->
     </div>
     <div class="flex-1">
       <img class="w-full rounded-2xl shadow-lg" data-id="ID" src="images/ID.jpg" alt="" />
@@ -172,12 +239,15 @@ Use for pages with just text and images (no chapter header):
 
 ### Template: Table of Contents (EXACT - use for section_type "table_of_contents")
 
-Use this EXACT structure for table of contents pages:
+Use this EXACT structure for table of contents pages. This template intentionally
+uses its own purple/gray color scheme instead of the Headings/Body Text
+defaults ? do NOT add `data-text-color` to its title, subtitle, or entries;
+leave them to their own explicit color classes shown below.
 
 ```html
 <div class="container content mx-auto flex min-h-screen w-full items-center justify-center px-6 py-12"
     data-background-color="#f3f0f7" id="content">
-  <section class="w-full" data-section-id="SECTION_ID" data-section-type="table_of_contents" data-text-color="#2c2c2c"
+  <section class="w-full" data-section-id="SECTION_ID" data-section-type="table_of_contents"
       id="simple-main" role="article">
     <div class="mx-auto w-full max-w-3xl space-y-8">
       <!-- Background image (if provided) -->

--- a/assets/styleguides/default.md
+++ b/assets/styleguides/default.md
@@ -36,8 +36,8 @@ These are the book-wide defaults for this styleguide. They take precedence over 
 | Property | Default | Notes |
 |----------|---------|-------|
 | Background color | `#FFFFFF` | Applied via `data-background-color` on the outer container. |
-| Max paragraph width (reading column) | `max-w-7xl` | Applies to the inner container on every page — never vary this per page. |
-| Paragraph spacing | Spacious (`space-y-8` inside a Content Card, `space-y-6` for a bare Text Group) | Vertical gap between paragraphs — keep it consistent with the component used. |
+| Max paragraph width (reading column) | `max-w-5xl` | Applies to the inner container on every page — never vary this per page. |
+| Paragraph spacing | `space-y-4` inside a Content Card, `space-y-3` for a bare Text Group | Vertical gap between paragraphs — keep it consistent with the component used. |
 
 ### Headings
 

--- a/assets/styleguides/default.md
+++ b/assets/styleguides/default.md
@@ -44,9 +44,9 @@ These are the book-wide defaults for this styleguide. They take precedence over 
 | Property | Default | Notes |
 |----------|---------|-------|
 | Text color | `#111827` | Applied to headings (`heading`, `chapter_title`, `section_heading`, etc.) via `data-text-color` — does not affect the other role. |
-| Text alignment | Center | Only applies to headings (`heading`, `chapter_title`, `section_heading`, etc.). Only center/right-align where a template below explicitly shows it (e.g. cover/title pages, the Table of Contents). |
+| Text alignment | Left | Only applies to headings (`heading`, `chapter_title`, `section_heading`, etc.). Only center/right-align where a template below explicitly shows it (e.g. cover/title pages, the Table of Contents). |
 | Bold / Italic / Underline | Bold | Controls whether headings (`heading`, `chapter_title`, `section_heading`, etc.) is bold/italic/underlined by default. |
-| Line-height | `leading-loose` | Applies to headings (`heading`, `chapter_title`, `section_heading`, etc.). Keep it consistent across all pages. |
+| Line-height | `leading-tight` | Applies to headings (`heading`, `chapter_title`, `section_heading`, etc.). Keep it consistent across all pages. |
 
 ### Body Text
 
@@ -54,7 +54,7 @@ These are the book-wide defaults for this styleguide. They take precedence over 
 |----------|---------|-------|
 | Text color | `#1F2937` | Applied to body text (`section_text`, `standalone_text`) via `data-text-color` — does not affect the other role. |
 | Text alignment | Left | Only applies to body text (`section_text`, `standalone_text`). Only center/right-align where a template below explicitly shows it (e.g. cover/title pages, the Table of Contents). |
-| Bold / Italic / Underline | Italic | Controls whether body text (`section_text`, `standalone_text`) is bold/italic/underlined by default. |
+| Bold / Italic / Underline | Normal | Body text (`section_text`, `standalone_text`) is not bold, italic, or underlined by default. |
 | Line-height | `leading-relaxed` | Applies to body text (`section_text`, `standalone_text`). Keep it consistent across all pages. |
 
 ## Inner Container (REQUIRED for all content pages)

--- a/packages/pipeline/src/__tests__/package-web.test.ts
+++ b/packages/pipeline/src/__tests__/package-web.test.ts
@@ -137,7 +137,7 @@ describe("renderPageHtml", () => {
 
   it("injects the data-text-color apply script, and excludes anchors so links keep their color", () => {
     const html = renderPageHtml({
-      content: `<p data-text-color="#111827" data-id="x">Body <a data-id="l" href="#">link</a></p>`,
+      content: `<p data-text-color="#111827" data-id="x">Body <a data-id="l" href="#">link</a><span class="text-blue-600" data-adt-manual-text-color>accent</span></p>`,
       language: "en",
       sectionId: "pg001",
       pageTitle: "Test",
@@ -150,6 +150,7 @@ describe("renderPageHtml", () => {
     // The inherit pass must skip anchors (and their contents) so link colors
     // are not flattened into the surrounding body/heading color.
     expect(html).toContain('!d.closest("a")')
+    expect(html).toContain('!d.closest("[data-adt-manual-text-color]")')
   })
 
   it("omits the data-text-color apply script when no element carries the attribute", () => {

--- a/packages/pipeline/src/__tests__/package-web.test.ts
+++ b/packages/pipeline/src/__tests__/package-web.test.ts
@@ -135,6 +135,37 @@ describe("renderPageHtml", () => {
     expect(html).toContain('style="font-family:Arial"')
   })
 
+  it("injects the data-text-color apply script, and excludes anchors so links keep their color", () => {
+    const html = renderPageHtml({
+      content: `<p data-text-color="#111827" data-id="x">Body <a data-id="l" href="#">link</a></p>`,
+      language: "en",
+      sectionId: "pg001",
+      pageTitle: "Test",
+      pageIndex: 1,
+      hasMath: false,
+      bundleVersion: "1",
+    })
+
+    expect(html).toContain('querySelectorAll("[data-text-color]")')
+    // The inherit pass must skip anchors (and their contents) so link colors
+    // are not flattened into the surrounding body/heading color.
+    expect(html).toContain('!d.closest("a")')
+  })
+
+  it("omits the data-text-color apply script when no element carries the attribute", () => {
+    const html = renderPageHtml({
+      content: `<p data-id="x">Body</p>`,
+      language: "en",
+      sectionId: "pg001",
+      pageTitle: "Test",
+      pageIndex: 1,
+      hasMath: false,
+      bundleVersion: "1",
+    })
+
+    expect(html).not.toContain('querySelectorAll("[data-text-color]")')
+  })
+
   it("injects a Google Fonts stylesheet for fonts the page actually uses", () => {
     const html = renderPageHtml({
       content: `<p><span style="font-family:'Mouse Memoirs',Merriweather,serif">Hi</span></p>`,

--- a/packages/pipeline/src/__tests__/package-web.test.ts
+++ b/packages/pipeline/src/__tests__/package-web.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest"
 import fs from "node:fs"
 import os from "node:os"
 import path from "node:path"
+import { JSDOM } from "jsdom"
 import type { Storage, PageData } from "@adt/storage"
 import {
   computePackagingInputHash,
@@ -151,6 +152,35 @@ describe("renderPageHtml", () => {
     // are not flattened into the surrounding body/heading color.
     expect(html).toContain('!d.closest("a")')
     expect(html).toContain('!d.closest("[data-adt-manual-text-color]")')
+  })
+
+  it("preserves explicit child colors under a legacy section-level default", () => {
+    const html = renderPageHtml({
+      content: `<section data-section-id="section-1" data-text-color="#3D2B1F"><h1 style="color:#8B2252">Heading</h1><p>Body</p></section>`,
+      language: "en",
+      sectionId: "section-1",
+      pageTitle: "Test",
+      pageIndex: 1,
+      hasMath: false,
+      bundleVersion: "1",
+    })
+    const dom = new JSDOM(html, { runScripts: "outside-only" })
+    const script = Array.from(dom.window.document.querySelectorAll("script")).find(
+      (candidate) => candidate.textContent?.includes(
+        'querySelectorAll("[data-text-color]")',
+      ),
+    )
+    expect(script).toBeDefined()
+    dom.window.eval(script!.textContent!)
+    dom.window.document.dispatchEvent(new dom.window.Event("DOMContentLoaded"))
+
+    const section = dom.window.document.querySelector<HTMLElement>("section")!
+    const heading = dom.window.document.querySelector<HTMLElement>("h1")!
+    const paragraph = dom.window.document.querySelector<HTMLElement>("p")!
+    expect(section.style.getPropertyPriority("color")).toBe("important")
+    expect(heading.style.getPropertyValue("color")).toBe("rgb(139, 34, 82)")
+    expect(heading.style.getPropertyPriority("color")).toBe("")
+    expect(paragraph.style.getPropertyValue("color")).toBe("")
   })
 
   it("omits the data-text-color apply script when no element carries the attribute", () => {

--- a/packages/pipeline/src/__tests__/web-rendering-prompts.test.ts
+++ b/packages/pipeline/src/__tests__/web-rendering-prompts.test.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs"
 import path from "node:path"
 import { describe, expect, it } from "vitest"
 import { createPromptEngine } from "@adt/llm"
@@ -80,5 +81,37 @@ describe("web rendering reading-order prompts", () => {
     expect(prompt.indexOf('heading id=rescue_heading "Rescue"')).toBeLessThan(
       prompt.indexOf('heading id=sense_heading "Sense"'),
     )
+  })
+})
+
+describe("styleguide color contract", () => {
+  it("generates per-role colors and a text-only template", async () => {
+    const messages = await promptEngine.renderPrompt("styleguide_generation", {
+      page_images: [],
+      book_fonts: [],
+      typography: [],
+    })
+    const prompt = messages.map(messageText).join("\n")
+
+    expect(prompt).toContain(
+      "Never put `data-text-color` on the outer section",
+    )
+    expect(prompt).toContain(
+      'Text-Only Page for `section_type: "text_only"`',
+    )
+    expect(prompt).toContain(
+      "Put `data-text-color` directly on each text-bearing element",
+    )
+  })
+
+  it("keeps the default guide declarations aligned with its templates", () => {
+    const guide = fs.readFileSync(
+      path.join(process.cwd(), "assets", "styleguides", "default.md"),
+      "utf-8",
+    )
+
+    expect(guide).toContain("| Text alignment | Left |")
+    expect(guide).toContain("| Line-height | `leading-tight` |")
+    expect(guide).toContain("| Bold / Italic / Underline | Normal |")
   })
 })

--- a/packages/pipeline/src/packaging/web.ts
+++ b/packages/pipeline/src/packaging/web.ts
@@ -1308,6 +1308,8 @@ ${fallbackHeadingHtml}${contentBlock}
   // the LLM may have added on its own. Anchors (`<a>`) and their contents are
   // deliberately excluded so links keep their own (usually distinct) color
   // instead of being flattened into the surrounding body/heading color.
+  // Elements marked by a manual Storyboard color edit are also excluded so
+  // their persisted Tailwind color class remains authoritative.
   //
   // NOTE: this is the injected-into-exported-HTML twin of `applyTextColors`
   // in apps/studio's BookPreviewFrame.tsx. The two must stay behaviorally
@@ -1315,7 +1317,7 @@ ${fallbackHeadingHtml}${contentBlock}
   // share one implementation because the frontend may not import from
   // `packages/*` (see the layer rule in AGENTS.md); keep both in sync by hand.
   const textColorScript = /data-text-color=/.test(normalizedContent)
-    ? `\n    <script>(function(){function apply(){document.querySelectorAll("[data-text-color]").forEach(function(el){var c=el.getAttribute("data-text-color");if(!c)return;el.style.setProperty("color",c,"important");el.querySelectorAll("*").forEach(function(d){if(d.closest("[data-text-color]")===el&&!d.closest("a")){d.style.setProperty("color","inherit","important")}})})}if(document.readyState==="loading"){document.addEventListener("DOMContentLoaded",apply)}else{apply()}})();</script>`
+    ? `\n    <script>(function(){function apply(){document.querySelectorAll("[data-text-color]").forEach(function(el){var c=el.getAttribute("data-text-color");if(!c||el.hasAttribute("data-adt-manual-text-color"))return;el.style.setProperty("color",c,"important");el.querySelectorAll("*").forEach(function(d){if(d.closest("[data-text-color]")===el&&!d.closest("a")&&!d.closest("[data-adt-manual-text-color]")){d.style.setProperty("color","inherit","important")}})})}if(document.readyState==="loading"){document.addEventListener("DOMContentLoaded",apply)}else{apply()}})();</script>`
     : ""
 
   // In embed mode, hide non-essential chrome. The React runtime mounts the

--- a/packages/pipeline/src/packaging/web.ts
+++ b/packages/pipeline/src/packaging/web.ts
@@ -1299,6 +1299,17 @@ ${fallbackHeadingHtml}${contentBlock}
       : ""
   }
 
+  // `data-text-color` is a semantic marker the styleguide/LLM stamps onto
+  // headings/paragraphs — by itself it has no visual effect. Apply it as a
+  // real, cascading color at runtime: force it (!important) on every
+  // element carrying the attribute, and force any descendant that does NOT
+  // have its own `data-text-color` to inherit it (!important) too, so it
+  // wins over incidental Tailwind color utility classes (e.g. `text-black`)
+  // the LLM may have added on its own.
+  const textColorScript = /data-text-color="[^"]*"/.test(normalizedContent)
+    ? `\n    <script>(function(){function apply(){document.querySelectorAll("[data-text-color]").forEach(function(el){var c=el.getAttribute("data-text-color");if(!c)return;el.style.setProperty("color",c,"important");el.querySelectorAll("*").forEach(function(d){if(d.closest("[data-text-color]")===el){d.style.setProperty("color","inherit","important")}})})}if(document.readyState==="loading"){document.addEventListener("DOMContentLoaded",apply)}else{apply()}})();</script>`
+    : ""
+
   // In embed mode, hide non-essential chrome. The React runtime mounts the
   // activity Submit/Skip buttons inside #nav-container, so it must stay
   // visible — BottomDock self-hides via embedModeAtom (see ui.atoms.ts).
@@ -1359,7 +1370,7 @@ ${fallbackHeadingHtml}${contentBlock}
 ${mathScript}${embedStyles}${bodyFontStyle}${flFit ? `${flFit.headStyle}\n` : ""}</head>
 
 <body${opts.fixedViewport ? ` style="margin:0;overflow:hidden;width:100%;height:100%"` : ` class="min-h-screen flex items-center justify-center"${bodyStyle}`}>
-${mainBlock}
+${mainBlock}${textColorScript}
 ${flFit ? `${flFit.bodyScript}\n` : ""}${answersScript}
     <div class="relative z-50" id="interface-container"></div>
     <div class="relative z-50" id="nav-container"></div>

--- a/packages/pipeline/src/packaging/web.ts
+++ b/packages/pipeline/src/packaging/web.ts
@@ -1305,9 +1305,17 @@ ${fallbackHeadingHtml}${contentBlock}
   // element carrying the attribute, and force any descendant that does NOT
   // have its own `data-text-color` to inherit it (!important) too, so it
   // wins over incidental Tailwind color utility classes (e.g. `text-black`)
-  // the LLM may have added on its own.
-  const textColorScript = /data-text-color="[^"]*"/.test(normalizedContent)
-    ? `\n    <script>(function(){function apply(){document.querySelectorAll("[data-text-color]").forEach(function(el){var c=el.getAttribute("data-text-color");if(!c)return;el.style.setProperty("color",c,"important");el.querySelectorAll("*").forEach(function(d){if(d.closest("[data-text-color]")===el){d.style.setProperty("color","inherit","important")}})})}if(document.readyState==="loading"){document.addEventListener("DOMContentLoaded",apply)}else{apply()}})();</script>`
+  // the LLM may have added on its own. Anchors (`<a>`) and their contents are
+  // deliberately excluded so links keep their own (usually distinct) color
+  // instead of being flattened into the surrounding body/heading color.
+  //
+  // NOTE: this is the injected-into-exported-HTML twin of `applyTextColors`
+  // in apps/studio's BookPreviewFrame.tsx. The two must stay behaviorally
+  // identical so the Studio preview matches the packaged output. They can't
+  // share one implementation because the frontend may not import from
+  // `packages/*` (see the layer rule in AGENTS.md); keep both in sync by hand.
+  const textColorScript = /data-text-color=/.test(normalizedContent)
+    ? `\n    <script>(function(){function apply(){document.querySelectorAll("[data-text-color]").forEach(function(el){var c=el.getAttribute("data-text-color");if(!c)return;el.style.setProperty("color",c,"important");el.querySelectorAll("*").forEach(function(d){if(d.closest("[data-text-color]")===el&&!d.closest("a")){d.style.setProperty("color","inherit","important")}})})}if(document.readyState==="loading"){document.addEventListener("DOMContentLoaded",apply)}else{apply()}})();</script>`
     : ""
 
   // In embed mode, hide non-essential chrome. The React runtime mounts the

--- a/packages/pipeline/src/packaging/web.ts
+++ b/packages/pipeline/src/packaging/web.ts
@@ -164,7 +164,7 @@ function buildRuntimeTimecodeMap(
 // Folded into the packaging cache hash so already-packaged books regenerate
 // when renderPageHtml's output format changes (which book inputs don't capture).
 // Bump on any such change.
-const PACKAGING_FORMAT_VERSION = 4
+const PACKAGING_FORMAT_VERSION = 5
 
 export interface ComputePackagingInputHashOptions {
   storage: Storage
@@ -1302,12 +1302,14 @@ ${fallbackHeadingHtml}${contentBlock}
   // `data-text-color` is a semantic marker the styleguide/LLM stamps onto
   // headings/paragraphs — by itself it has no visual effect. Apply it as a
   // real, cascading color at runtime: force it (!important) on every
-  // element carrying the attribute, and force any descendant that does NOT
-  // have its own `data-text-color` to inherit it (!important) too, so it
+  // text element carrying the attribute, and force any descendant that does
+  // NOT have its own `data-text-color` to inherit it (!important) too, so it
   // wins over incidental Tailwind color utility classes (e.g. `text-black`)
   // the LLM may have added on its own. Anchors (`<a>`) and their contents are
   // deliberately excluded so links keep their own (usually distinct) color
   // instead of being flattened into the surrounding body/heading color.
+  // Legacy section-level markers use normal CSS inheritance so intentional
+  // child colors in existing/generated StyleGuides remain authoritative.
   // Elements marked by a manual Storyboard color edit are also excluded so
   // their persisted Tailwind color class remains authoritative.
   //
@@ -1317,7 +1319,7 @@ ${fallbackHeadingHtml}${contentBlock}
   // share one implementation because the frontend may not import from
   // `packages/*` (see the layer rule in AGENTS.md); keep both in sync by hand.
   const textColorScript = /data-text-color=/.test(normalizedContent)
-    ? `\n    <script>(function(){function apply(){document.querySelectorAll("[data-text-color]").forEach(function(el){var c=el.getAttribute("data-text-color");if(!c||el.hasAttribute("data-adt-manual-text-color"))return;el.style.setProperty("color",c,"important");el.querySelectorAll("*").forEach(function(d){if(d.closest("[data-text-color]")===el&&!d.closest("a")&&!d.closest("[data-adt-manual-text-color]")){d.style.setProperty("color","inherit","important")}})})}if(document.readyState==="loading"){document.addEventListener("DOMContentLoaded",apply)}else{apply()}})();</script>`
+    ? `\n    <script>(function(){function apply(){document.querySelectorAll("[data-text-color]").forEach(function(el){var c=el.getAttribute("data-text-color");if(!c||el.hasAttribute("data-adt-manual-text-color"))return;el.style.setProperty("color",c,"important");if(el.tagName==="SECTION"||el.hasAttribute("data-section-id"))return;el.querySelectorAll("*").forEach(function(d){if(d.closest("[data-text-color]")===el&&!d.closest("a")&&!d.closest("[data-adt-manual-text-color]")){d.style.setProperty("color","inherit","important")}})})}if(document.readyState==="loading"){document.addEventListener("DOMContentLoaded",apply)}else{apply()}})();</script>`
     : ""
 
   // In embed mode, hide non-essential chrome. The React runtime mounts the

--- a/packages/pipeline/src/render-llm.ts
+++ b/packages/pipeline/src/render-llm.ts
@@ -121,6 +121,7 @@ export async function renderSectionLlm(
         nodes: renderContext.nodes,
         leaf_texts: renderContext.leaf_texts,
         has_merged_content: sourcePages.length > 0,
+        styleguide: input.styleguide ?? "",
       },
       originalImageIntroText: "Here is the original page image (this is what the rendered page should resemble):",
       firstIterationScreenshotsText: "\nHere are screenshots of the current rendered HTML at three viewport sizes:\n",

--- a/prompts/styleguide_generation.liquid
+++ b/prompts/styleguide_generation.liquid
@@ -20,11 +20,11 @@ Generate a complete styleguide Markdown document following this exact structure.
    - Accent colors (badges, decorations, highlights)
    - Use actual hex codes observed in the images
 
-3. **Required Container Structure** — MUST include this exact outer structure (adjust colors only):
+3. **Required Container Structure** — MUST include this exact outer structure (adjust the background color only):
 ```html
 <div class="container content mx-auto flex min-h-screen w-full items-start justify-center px-6 py-12"
     data-background-color="BACKGROUND_COLOR" id="content">
-  <section class="w-full" data-section-id="SECTION_ID" data-section-type="SECTION_TYPE" data-text-color="TEXT_COLOR"
+  <section class="w-full" data-section-id="SECTION_ID" data-section-type="SECTION_TYPE"
       id="simple-main">
     <!-- Content goes here -->
   </section>
@@ -32,12 +32,15 @@ Generate a complete styleguide Markdown document following this exact structure.
 ```
 Keep this container IDENTICAL on every page — same alignment, padding, and max-width — so the reading column sits in the same place throughout the book; only the colors may change. Top-align content (`items-start`); reserve vertical centering (`items-center`) for cover / title pages ONLY.
 
+   **Never put `data-text-color` on the outer section or another shared container.** Heading, body, caption, instruction, and callout colors may differ. Put `data-text-color="#RRGGBB"` directly on each text-bearing heading, paragraph, caption, or span using the color for that text role. A template with an intentional custom color may use its own explicit color instead, but it must not be overridden by a container-wide marker.
+
 4. **Inner Container** — Use ONE fixed max-width for the reading column on EVERY page (`mx-auto w-full max-w-5xl`) with the same horizontal padding everywhere. Do NOT use a different max-width (e.g. max-w-2xl/3xl/4xl) on different page types — a single consistent measure keeps text in the same position page to page.
 
-5. **Text Styles** — A table mapping each text_type to an HTML element and Tailwind classes. Required text_types:
+5. **Visual Defaults and Text Styles** — State the book-wide heading and body defaults separately, including text color, alignment, emphasis, and line-height, then provide a table mapping each text_type to an HTML element and Tailwind classes. Required text_types:
    - book_title, book_subtitle, chapter_title, section_heading, activity_title
    - section_text, instruction_text, standalone_text, image_associated_text
    For FONT SIZE, when a typography scale is provided in the input, set the size via the shared classes (`adt-h1`/`adt-h2`/`adt-h3` for headings, `adt-body` for body/instruction/standalone text, `adt-caption` for captions and image-associated text) instead of choosing per-type `text-*` sizes — the size is fixed book-wide by these classes and keeps every page identical. Choose font weights and colors that match the original style. If no typography scale is provided, choose sizes that match the original.
+   Every concrete text example and Page Template must put its role's hex color in `data-text-color` on that individual text element. Keep the stated Visual Defaults consistent with the actual alignment, emphasis, and line-height classes used by the examples.
 
 6. **Image Styles** — A table defining classes for single images, multiple images, and image grid containers.
 
@@ -49,6 +52,7 @@ Keep this container IDENTICAL on every page — same alignment, padding, and max
 8. **Page Templates** — Complete HTML examples for:
    - Chapter Start Page
    - Regular Content Page with a callout/sidebar (e.g. Vocabulary, Big Question)
+   - Text-Only Page for `section_type: "text_only"` (prose only, no images or activities)
    - Text and Image Side by Side
    - Table of Contents
 
@@ -61,7 +65,8 @@ Keep this container IDENTICAL on every page — same alignment, padding, and max
 - Elements with content MUST use `data-id="ID"` placeholders
 - Images MUST use `data-id="ID"` and `src="images/ID.jpg"`
 - The outer container MUST use `data-background-color` for page backgrounds
-- The section element MUST have `data-section-id` and `data-section-type` attributes, and MUST NOT add `role="article"`
+- The section element MUST have `data-section-id` and `data-section-type` attributes, MUST NOT have `data-text-color`, and MUST NOT add `role="article"`
+- Put `data-text-color` directly on each text-bearing element using the color for that role; do not use one marker to govern headings and body text together
 - Color values should be specific hex codes extracted from the images, not generic Tailwind color names
 - Text sizes should be appropriate for the target audience (larger for children, standard for adults)
 - Keep running body text as ONE continuous column. For a callout/sidebar beside body text, float the panel (float-right, fixed width, stacking on small screens via `max-lg:float-none max-lg:w-full`) so text wraps beside it and continues full-width below — never a side-by-side row followed by a separate full-width block, which leaves empty gaps

--- a/prompts/visual_review.liquid
+++ b/prompts/visual_review.liquid
@@ -43,7 +43,7 @@ This section combines content merged from MORE THAN ONE original page (for examp
 - Images that are missing, broken, wildly misplaced, or distorted (stretched to the wrong aspect ratio — keep `h-auto` so proportions are preserved)
 - Content images (photos, diagrams, illustrations) rendered as small thumbnails when the original shows them filling much of the page — enlarge them to fill the content column (`w-full h-auto`); modest upscaling of a low-resolution source is fine and preferable to a tiny image
 - A header/banner whose title or badge is misaligned or clipped — the banner background may span the full width, but its text must sit in the same centered `max-w-5xl` reading column as the body and must never be cut off
-- Text alignment that differs from the original — body text and headings that are left-aligned in the original should NOT be centered (and vice versa)
+- Text alignment that differs from the original — body text and headings that are left-aligned in the original should NOT be centered (and vice versa){% if styleguide != "" %}, UNLESS the styleguide below defines an explicit default text alignment for this book — in that case the styleguide's alignment is a deliberate book-wide design choice and must be kept even if it differs from this original page{% endif %}
 - Layout that fundamentally differs from the original (e.g., wrong number of columns, completely wrong ordering)
 - A large empty gap or dead whitespace beside a callout/sidebar panel — this happens when the body text is placed in a side-by-side row next to a tall sidebar and the remaining text continues below the whole row. Fix it by FLOATING the panel (`float-right w-[34%] ml-8 mb-6 max-lg:float-none max-lg:w-full max-lg:ml-0`) and letting all body paragraphs flow as ONE continuous column, so text wraps beside the panel and then continues full-width below it with no gap
 - Content that doesn't reflow at smaller viewports (overflowing, horizontal scroll)
@@ -78,6 +78,13 @@ The base (no-prefix) classes are the DESKTOP design — overlay and side-by-side
 - Do NOT add <script>, <iframe>, <object>, or <embed> tags
 - Do NOT add event handler attributes (onclick, onload, etc.)
 - Use only Tailwind CSS utility classes for styling changes
+{% if styleguide != "" %}
+- If the STYLEGUIDE below defines a book-wide default (e.g. text alignment, bold/italic/underline usage, max line width, line-height, or paragraph spacing), keep the rendering consistent with that default — do NOT revert it to match the original page image, since it is a deliberate design choice for the whole book. When the styleguide gives separate values for headings and body text, verify each role against its own value only.
+
+## STYLEGUIDE (for reference — deliberate book-wide defaults take precedence over matching the original page)
+
+{{ styleguide }}
+{% endif %}
 
 ## RESPONSE FORMAT
 - "approved": true if the rendering is visually acceptable, false if it needs changes

--- a/prompts/web_generation_html.liquid
+++ b/prompts/web_generation_html.liquid
@@ -28,7 +28,7 @@ The content tree is the current saved user state. Its depth-first order is the R
 10. Do NOT use any `data-id` values other than the ones provided
 11. Text color must be readable against the background color
 12. Text must NEVER be hidden behind images — if positioning text near or on top of images, always use `z-10` on text containers
-13. Preserve the original text alignment — most body text and headings are LEFT-ALIGNED. Do NOT center text unless it is clearly centered in the original page image. When in doubt, default to left alignment.
+13. Preserve the original text alignment — most body text and headings are LEFT-ALIGNED. Do NOT center text unless it is clearly centered in the original page image. When in doubt, default to left alignment. **Exception:** if the STYLEGUIDE section below defines an explicit default text alignment, use that alignment instead — it overrides this "preserve the original" default, since it is a deliberate book-wide design choice.
 14. Output natural-language text as literal Unicode characters. Do NOT encode letters as numeric or hex HTML entities (for example, avoid `&#...;` and `&#x...;`). Only use standard HTML escaping where required for markup syntax (for example `&amp;`, `&lt;`, `&gt;`, and quotes in attributes).
 15. Text-leaf children of ANY container are fragments of one continuous run and must flow inline as `<span>` elements with no hard line breaks between them. Never wrap a leaf in its own `<p>`, and never emit `<br>` between sibling leaves. The container itself gets the block wrapper; its leaves render as inline spans inside that single wrapper. The ONLY exceptions are (a) `structure: "preformatted"` / code-like content where the source preserves literal line breaks, or (b) when the book page image clearly shows each leaf as its own visually separated line (e.g. a poem, a stanza, an address block) — in those cases, and only those, use render each as a block-level fragment.
 16. Leaves with `role: "math"` hold LaTeX which is converted to MathML during packaging. Emit the LaTeX VERBATIM as the element's text — never rewrite, re-escape, or "fix" it, and never try to reproduce the maths as HTML tables, spans, or unicode art. Wrap it in a plain block element (`<div data-id="...">`); a display-level expression may also use `<p>`. NEVER use `<pre>`, and never apply `whitespace-pre`, `whitespace-pre-wrap`, `font-mono`, or a tightened `leading-*` class to a math leaf — the generated MathML inherits those and its `<mtable>` rows collapse into each other. For a wide expression, put `overflow-x-auto` on the wrapper so it scrolls rather than overflowing the column. Inline maths that sits inside a sentence stays inside that sentence's `<span>` with its `$…$` delimiters intact.
@@ -52,7 +52,9 @@ The base (no-prefix) classes are the DESKTOP design. Use `max-lg:` to override s
 Example: `class="flex flex-row max-lg:flex-col"` or `class="gap-8 max-lg:gap-4 max-sm:gap-2"`
 {% if styleguide != "" %}
 
-## STYLEGUIDE (FOLLOW EXACTLY)
+## STYLEGUIDE (FOLLOW EXACTLY — OVERRIDES CONFLICTING DEFAULTS ABOVE)
+
+The styleguide below defines the required colors, typography, alignment, and component classes for this book. If it specifies a default text alignment, font styling (bold/italic/underline usage), max line width, line-height, or paragraph spacing, those values take precedence over any generic default or example elsewhere in this prompt. When the styleguide's Visual Defaults give separate values for headings and body text, apply each value only to its own role — a heading setting must never leak onto body paragraphs, and vice versa.
 
 {{ styleguide }}
 {% endif %}

--- a/prompts/web_generation_html_overlay.liquid
+++ b/prompts/web_generation_html_overlay.liquid
@@ -30,7 +30,7 @@ The content tree is the current saved user state. Its depth-first order is the R
 8. The section MUST be wrapped in a container div with `id="content"` and class `container`
 9. Image tags MUST have a `data-id` attribute matching the provided image ID
 10. Do NOT use any `data-id` values other than the ones provided
-11. Text color must be readable against the background — add bg overlays or text shadows as needed
+11. Text color must be readable against the background — add bg overlays or text shadows as needed. The `text-gray-900`/`text-gray-800`/etc. colors shown in the layout examples below are illustrative DEFAULTS only, used when no styleguide is provided. If a STYLEGUIDE section is included later in this prompt, its color and typography classes ALWAYS override these example defaults
 12. Output natural-language text as literal Unicode characters. Do NOT encode letters as numeric or hex HTML entities (for example, avoid `&#...;` and `&#x...;`). Only use standard HTML escaping where required for markup syntax (for example `&amp;`, `&lt;`, `&gt;`, and quotes in attributes).
 
 ## LAYOUT STRATEGY
@@ -139,7 +139,7 @@ Example — three groups forming one column:
 ```
 
 ### Text alignment
-Preserve the original text alignment from the page image. Most body text and headings are LEFT-ALIGNED — do NOT center them unless they are clearly centered in the original. Only use `text-center` when the original page image shows centered text (e.g., titles on cover pages, centered captions). When in doubt, default to left alignment.
+Preserve the original text alignment from the page image. Most body text and headings are LEFT-ALIGNED — do NOT center them unless they are clearly centered in the original. Only use `text-center` when the original page image shows centered text (e.g., titles on cover pages, centered captions). When in doubt, default to left alignment. **Exception:** if the STYLEGUIDE section below defines an explicit default text alignment, use that alignment instead — it overrides this "preserve the original" default, since it is a deliberate book-wide design choice.
 
 ### Text styling for overlay groups:
 
@@ -255,7 +255,9 @@ The base (no-prefix) classes are the DESKTOP overlay layout with positioned text
 Example: `class="absolute max-sm:relative"` to overlay on desktop/tablet but stack on mobile.
 {% if styleguide != "" %}
 
-## STYLEGUIDE (FOLLOW EXACTLY)
+## STYLEGUIDE (FOLLOW EXACTLY — OVERRIDES ALL DEFAULT COLORS/CLASSES ABOVE)
+
+The styleguide below defines the required text colors, font sizes, and component classes for this book. It takes precedence over every color and typography class shown in the layout examples earlier in this prompt (`text-gray-900`, `text-gray-800`, `text-gray-100`, and similar are illustrative defaults only, used solely when no styleguide is provided). Match each heading and paragraph to the styleguide's Text Styles table and use its classes — including color — instead of the example defaults. If the styleguide defines a default text alignment, font styling (bold/italic/underline usage), max line width, line-height, or paragraph spacing, those values also take precedence over the "preserve original alignment" rule above and over any generic spacing/width examples shown elsewhere in this prompt. When the styleguide's Visual Defaults give separate values for headings and body text, apply each value only to its own role — a heading setting must never leak onto body paragraphs, and vice versa.
 
 {{ styleguide }}
 {% endif %}


### PR DESCRIPTION
## Issue

Fixes #664

## Summary

Fixes the five StyleGuide color/template issues reported in #664:

1. `data-text-color` was emitted by the LLM but not applied as CSS.
2. The default StyleGuide did not demonstrate independent heading and body colors.
3. `text_only` pages had no template to follow.
4. Generic examples in generation and visual-review prompts could override the selected StyleGuide.
5. Re-uploading a StyleGuide under the same name could leave a stale cached preview.

## Changes

- **Apply `data-text-color` in preview and packaged output**
  - `BookPreviewFrame.tsx` applies the attribute in the Storyboard preview.
  - `packages/pipeline/src/packaging/web.ts` injects equivalent runtime behavior into exported/reader HTML.
  - The declared color is forced with `!important` on the marked element and inherited by descendants governed by that marker, overriding incidental Tailwind color utilities.
  - Anchors and their contents are excluded from the inheritance pass so links retain their intentional color.
  - A manual text-color edit in the Storyboard removes the element's semantic marker and persists a manual-color marker, so the user's Tailwind color remains authoritative in both preview and packaged output.
  - Preview-only inline colors are restored before edited HTML is serialized, preventing runtime `!important` styles from leaking into saved content.

- **Add per-role colors and the missing template to `default.md`**
  - Removes the section-wide `data-text-color`, which cannot represent distinct heading and body values.
  - Adds explicit Visual Defaults for headings and body text using neutral defaults (`#111827` and `#1F2937`).
  - Aligns the declared reading width and paragraph spacing with the concrete templates (`max-w-5xl`, `space-y-4`, and `space-y-3`).
  - Applicable heading/body examples now place `data-text-color` on individual elements.
  - Adds a Text-Only Page template for `section_type: text_only`.
  - Keeps the Table of Contents on its intentional custom color scheme instead of applying the generic heading/body defaults.

- **Make StyleGuide precedence explicit**
  - `web_generation_html.liquid`, `web_generation_html_overlay.liquid`, and `visual_review.liquid` state that the selected StyleGuide's colors, alignment, and typography take precedence over generic example classes and source-page matching defaults.
  - `render-llm.ts` passes the StyleGuide into the visual-review prompt context.

- **Invalidate stale StyleGuide previews**
  - Re-uploading a StyleGuide deletes an existing `${name}-preview.html`.
  - `GET /styleguides/:name/preview` then falls back to rendering the latest uploaded markdown.
  - The upload mutation invalidates the matching TanStack Query preview key so an already-open preview refetches immediately.
  - This intentionally invalidates stale cached content; it does not introduce automatic live thumbnail generation while editing.

- **Add regression coverage**
  - Covers stale-preview deletion and first-time upload behavior.
  - Covers client-side preview cache invalidation.
  - Covers conditional export-script injection, link-color exclusion, and manual-color precedence.
  - Covers restoration of preview-only inline styles before persistence.

## Testing

- `pnpm typecheck` — clean
- `pnpm lint` — 0 errors
- API preset route tests — 8/8 passing
- Package web rendering tests — 111/111 passing
- Targeted Studio regression tests — 4/4 passing
