### PR TITLE
Preserve source-page design in By Page storyboard mode

### DIFF
--- a/packages/pipeline/src/__tests__/web-rendering.test.ts
+++ b/packages/pipeline/src/__tests__/web-rendering.test.ts
@@ -90,6 +90,50 @@ describe("buildRenderStrategyResolver", () => {
     expect(config.templateName).toBe("")
   })
 
+  it("uses full-page visual review by default in page sectioning mode", () => {
+    const appConfig: AppConfig = {
+      role_types: { heading: "Heading" },
+      structure_types: { paragraph: "Paragraph" },
+      page_sectioning: { mode: "page" },
+      default_render_strategy: "llm",
+      render_strategies: {
+        llm: {
+          render_type: "llm",
+          config: { visual_refinement: { enabled: true } },
+        },
+      },
+    }
+
+    const config = buildRenderStrategyResolver(appConfig)("text_only")
+
+    expect(config.visualRefinement?.promptName).toBe("visual_review_page")
+  })
+
+  it("keeps explicit visual review prompt overrides in page mode", () => {
+    const appConfig: AppConfig = {
+      role_types: { heading: "Heading" },
+      structure_types: { paragraph: "Paragraph" },
+      page_sectioning: { mode: "page" },
+      visual_review_prompt: "custom_visual_review",
+      default_render_strategy: "llm",
+      render_strategies: {
+        llm: {
+          render_type: "llm",
+          config: {
+            visual_refinement: {
+              enabled: true,
+              prompt: "strategy_visual_review",
+            },
+          },
+        },
+      },
+    }
+
+    const config = buildRenderStrategyResolver(appConfig)("text_only")
+
+    expect(config.visualRefinement?.promptName).toBe("custom_visual_review")
+  })
+
   it("uses the configured global default model when a strategy has no override", () => {
     const appConfig: AppConfig = {
       role_types: { heading: "Heading" },

--- a/packages/pipeline/src/web-rendering.ts
+++ b/packages/pipeline/src/web-rendering.ts
@@ -399,6 +399,8 @@ const DEFAULT_VISUAL_REFINEMENT = {
   temperature: 0.3,
 }
 
+const PAGE_MODE_VISUAL_REFINEMENT_PROMPT = "visual_review_page"
+
 /**
  * Build a resolver that returns a RenderConfig for a given section type.
  *
@@ -453,7 +455,12 @@ export function buildRenderStrategyResolver(
           // without editing every render strategy.
           maxIterations:
             appConfig.visual_review_max_iterations ?? vr.max_iterations ?? DEFAULT_VISUAL_REFINEMENT.max_iterations,
-          promptName: appConfig.visual_review_prompt ?? vr.prompt ?? DEFAULT_VISUAL_REFINEMENT.prompt,
+          promptName:
+            appConfig.visual_review_prompt ??
+            vr.prompt ??
+            (appConfig.page_sectioning?.mode === "page"
+              ? PAGE_MODE_VISUAL_REFINEMENT_PROMPT
+              : DEFAULT_VISUAL_REFINEMENT.prompt),
           timeoutMs: (vr.timeout ?? DEFAULT_VISUAL_REFINEMENT.timeout) * 1000,
           temperature: vr.temperature ?? DEFAULT_VISUAL_REFINEMENT.temperature,
         },

--- a/prompts/visual_review_page.liquid
+++ b/prompts/visual_review_page.liquid
@@ -1,0 +1,46 @@
+{% chat role: "system" %}
+You are a visual quality reviewer for accessible HTML textbook pages. The source was sectioned in BY PAGE mode, so the rendered HTML represents one complete source page. Compare it against the complete ORIGINAL PAGE IMAGE and revise it until a student immediately recognises it as the same book in digital form.
+
+## PRIMARY GOAL: PRESERVE THE BOOK'S VISUAL IDENTITY
+
+The print page is the visual target, not merely a content reference. Reproduce it as closely as responsive, accessible HTML permits:
+
+- Match the page's composition: column count, content order, relative widths, image placement, text wrapping, whitespace, margins, alignment, and visual balance.
+- Match its design language: background and panel colours, borders, corner shapes, rules, badges, callouts, chapter bands, and decorative treatments.
+- Match its hierarchy: title prominence, heading scale, body density, captions, labels, lists, tables, activities, headers, footers, and page numbers.
+- Preserve every supplied image and size/crop it in the same role and approximate proportion as the original.
+- Use the supplied book typography and existing semantic `adt-*` classes. Match weight, emphasis, casing, and alignment without inventing text.
+- Keep repeated book furniture and recurring page patterns visually consistent with the source.
+
+Do not approve a generic white web layout when the original has distinctive colours, columns, panels, artwork, or spatial relationships that can be reproduced with the allowed HTML and Tailwind utilities. A redesign that is merely attractive is not sufficient.
+
+Pixel identity is not required: the result must remain accessible and responsive, and mobile content may stack into reading order. At desktop width, however, preserve the original page geometry and proportions closely. At tablet and mobile widths, preserve the same colours, hierarchy, imagery, and visual identity while adapting without overlap or horizontal clipping.
+
+## REVIEW PROCESS
+
+1. Inspect the complete original page before judging the screenshots.
+2. Compare the desktop screenshot first for composition and visual fidelity.
+3. Compare tablet and mobile for a faithful responsive adaptation.
+4. Reject and correct meaningful differences in layout, colour, hierarchy, image scale/placement, spacing, or typography, as well as functional defects.
+5. Approve only when the result is recognisably the same textbook page and has no overlap, overflow, clipping, unreadable text, broken images, or visible placeholder tokens.
+
+## CONTENT AND SAFETY CONSTRAINTS
+
+- Preserve every existing `data-id` exactly once and keep its text unchanged.
+- Do not add, remove, duplicate, paraphrase, or reorder source content.
+- Do not change image `data-id` or `src` values.
+- Change only layout, positioning, spacing, colour, borders, and other visual styling.
+- Keep the `<section>` wrapper and its `data-section-type` and `data-section-id` attributes.
+- Do not add `<script>`, `<iframe>`, `<object>`, or `<embed>` tags.
+- Do not add event-handler attributes.
+- Use only Tailwind CSS utility classes already supported by the renderer.
+- Do not use fixed heights or overflow clipping to force a print-page aspect ratio; let content remain readable and complete.
+
+## RESPONSE FORMAT
+
+- `approved`: true only when the page is visually faithful and functionally sound; otherwise false.
+- `reasoning`: briefly name the most important similarities and remaining differences.
+- `content`: when not approved, return the complete corrected HTML fragment. When approved, return an empty string.
+
+If a necessary improvement cannot be made without violating the content constraints, return `approved: false` with an empty `content` string. Do not return an unchanged or token revision.
+{% endchat %}


### PR DESCRIPTION
Closes #668.

## Summary

- adds a full-page visual-fidelity reviewer for Storyboard pages generated in By Page sectioning mode
- makes the original PDF page the visual target for desktop composition, colors, imagery, hierarchy, spacing, and typography
- keeps responsive and accessibility requirements for tablet and mobile
- retains the existing section-focused reviewer for Dynamic mode
- preserves explicit global and strategy-level visual-review prompt overrides

## Verification

- `pnpm build`
- `pnpm typecheck`
- `pnpm exec vitest run packages/pipeline/src/__tests__/web-rendering.test.ts` (31 tests)