### PR TITLE
Enforce consistent book-wide heading hierarchy

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -47,7 +47,20 @@ structure_types:
     code samples, ASCII layouts). Children are the text leaves, one per line.
 
 role_types:
-  heading: A heading-level leaf (chapter, section, or subheading text).
+  chapter_title: >
+    The highest heading level in the content hierarchy (H1): a chapter number,
+    chapter title, unit title, or other top-level display heading. Use the same
+    role for visually equivalent top-level headings throughout the book.
+  section_heading: >
+    The second heading level (H2): a major section within the current chapter
+    or unit. Use the same role for headings with the same visual and structural
+    rank throughout the book.
+  subheading: >
+    The third heading level (H3): a subsection, minor heading, callout heading,
+    or activity title nested under a section.
+  heading: >
+    A heading whose hierarchy genuinely cannot be resolved as chapter_title,
+    section_heading, or subheading. Use only as a last resort.
   text: Ordinary prose or narrative text.
   math: A mathematical expression (use LaTeX notation).
   image: >

--- a/packages/pipeline/src/__tests__/validate-typography-hierarchy.test.ts
+++ b/packages/pipeline/src/__tests__/validate-typography-hierarchy.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest"
+import { validateTypographyHierarchy } from "../validate-typography-hierarchy.js"
+
+describe("validateTypographyHierarchy", () => {
+  it("accepts authoritative H1/H2/H3 role mappings", () => {
+    const html = `<section><h1 class="adt-h1" data-id="chapter">Chapter</h1><h2 class="adt-h2"><span data-id="section">Section</span></h2><h3 class="adt-h3" data-id="sub">Sub</h3></section>`
+    expect(validateTypographyHierarchy(html, [
+      { text_id: "chapter", text_type: "chapter_title" },
+      { text_id: "section", text_type: "section_heading" },
+      { text_id: "sub", text_type: "subheading" },
+    ])).toEqual([])
+  })
+
+  it("rejects role/tag/class mismatches", () => {
+    const html = `<section><h2 class="adt-h1" data-id="chapter">Chapter</h2><h1 class="adt-h2" data-id="section">Section</h1></section>`
+    const errors = validateTypographyHierarchy(html, [
+      { text_id: "chapter", text_type: "chapter_title" },
+      { text_id: "section", text_type: "section_heading" },
+    ])
+    expect(errors).toEqual(expect.arrayContaining([
+      expect.stringContaining('chapter_title'),
+      expect.stringContaining('section_heading'),
+    ]))
+  })
+
+  it("keeps legacy heading tags aligned with their adt class", () => {
+    expect(validateTypographyHierarchy(
+      `<section><h1 class="adt-h2" data-id="legacy">Legacy</h1></section>`,
+      [{ text_id: "legacy", text_type: "heading" }],
+    )).toContainEqual(expect.stringContaining("must align"))
+  })
+
+  it("rejects utility and inline font-size overrides", () => {
+    const html = `<section><h2 class="adt-h2 text-[1.15rem]" data-id="section">Section</h2><p style="font-size:12px">Body</p></section>`
+    const errors = validateTypographyHierarchy(html, [
+      { text_id: "section", text_type: "section_heading" },
+    ])
+    expect(errors).toEqual(expect.arrayContaining([
+      expect.stringContaining("font-size utility"),
+      expect.stringContaining("inline font-size"),
+    ]))
+  })
+})

--- a/packages/pipeline/src/__tests__/web-rendering-prompts.test.ts
+++ b/packages/pipeline/src/__tests__/web-rendering-prompts.test.ts
@@ -81,4 +81,21 @@ describe("web rendering reading-order prompts", () => {
       prompt.indexOf('heading id=sense_heading "Sense"'),
     )
   })
+
+  it("maps semantic heading roles to one book-wide type scale", async () => {
+    const messages = await promptEngine.renderPrompt("web_generation_html", {
+      ...generationContext(),
+      typography: [
+        { className: "adt-h1", label: "Chapter title", mobilePx: 30, desktopPx: 48 },
+        { className: "adt-h2", label: "Section heading", mobilePx: 24, desktopPx: 36 },
+        { className: "adt-h3", label: "Subheading", mobilePx: 20, desktopPx: 28 },
+      ],
+    })
+    const prompt = messages.map(messageText).join("\n")
+
+    expect(prompt).toContain("Heading roles are authoritative")
+    expect(prompt).toContain('`chapter_title` → semantic `<h1 class="adt-h1">`')
+    expect(prompt).toContain('`section_heading` → `<h2 class="adt-h2">`')
+    expect(prompt).toContain('`subheading` → `<h3 class="adt-h3">`')
+  })
 })

--- a/packages/pipeline/src/render-llm.ts
+++ b/packages/pipeline/src/render-llm.ts
@@ -8,6 +8,7 @@ import type { RenderConfig, RenderExecutionOptions, RenderNode, RenderSectionInp
 import { runVisualReviewLoop } from "./visual-review.js"
 import { buildTypographyCss, typographyPreservationErrors } from "./typography.js"
 import { DEFAULT_TYPOGRAPHY } from "@adt/types"
+import { validateTypographyHierarchy } from "./validate-typography-hierarchy.js"
 
 /** Dependencies for the optional visual refinement loop. */
 export interface VisualRefinementDeps {
@@ -229,7 +230,8 @@ function validateWebRendering(
       expectedContentIdOrder: collectLeafDataIdOrder(nodes),
     }
   )
-  if (check.valid && check.sectionHtml) {
+  const typographyErrors = validateTypographyHierarchy(check.sectionHtml ?? candidateHtml, leaf_texts)
+  if (check.valid && typographyErrors.length === 0 && check.sectionHtml) {
     return {
       valid: true,
       errors: [],
@@ -237,7 +239,7 @@ function validateWebRendering(
     }
   }
 
-  return { valid: check.valid, errors: check.errors }
+  return { valid: false, errors: [...check.errors, ...typographyErrors] }
 }
 
 function collectLeafDataIdOrder(nodes: RenderNode[]): string[] {

--- a/packages/pipeline/src/validate-typography-hierarchy.ts
+++ b/packages/pipeline/src/validate-typography-hierarchy.ts
@@ -1,0 +1,95 @@
+import { parseDocument } from "htmlparser2"
+
+interface HtmlNode {
+  name?: string
+  attribs?: Record<string, string>
+  parent?: HtmlNode | null
+  children?: HtmlNode[]
+}
+
+interface LeafText {
+  text_id: string
+  text_type: string
+}
+
+const ROLE_HEADING = {
+  chapter_title: { tag: "h1", className: "adt-h1" },
+  section_heading: { tag: "h2", className: "adt-h2" },
+  subheading: { tag: "h3", className: "adt-h3" },
+} as const
+
+const TEXT_SIZE_RE = /\btext-(?:xs|sm|base|lg|xl|[2-9]xl)\b|\btext-\[(?:\d|\.\d|clamp\(|calc\(|var\(|length:)[^\]]*\]/
+
+function walk(node: HtmlNode, callback: (node: HtmlNode) => void): void {
+  callback(node)
+  for (const child of node.children ?? []) walk(child, callback)
+}
+
+function findByDataId(root: HtmlNode, id: string): HtmlNode | undefined {
+  let match: HtmlNode | undefined
+  walk(root, (node) => {
+    if (!match && node.attribs?.["data-id"] === id) match = node
+  })
+  return match
+}
+
+function closestHeading(node: HtmlNode | undefined): HtmlNode | undefined {
+  let current = node
+  while (current) {
+    if (/^h[1-6]$/.test(current.name ?? "")) return current
+    current = current.parent ?? undefined
+  }
+  return undefined
+}
+
+function hasClass(node: HtmlNode, className: string): boolean {
+  return (node.attribs?.class?.split(/\s+/) ?? []).includes(className)
+}
+
+/** Enforce the sectioning hierarchy and prevent per-page font-size overrides. */
+export function validateTypographyHierarchy(html: string, leafTexts: LeafText[]): string[] {
+  const root = parseDocument(html) as unknown as HtmlNode
+  const errors: string[] = []
+
+  walk(root, (node) => {
+    const classes = node.attribs?.class ?? ""
+    if (TEXT_SIZE_RE.test(classes)) {
+      errors.push(`Typography must not use a font-size utility: "${classes}".`)
+    }
+    if (/font-size\s*:/i.test(node.attribs?.style ?? "")) {
+      errors.push("Typography must not use inline font-size; use the book-wide adt-* class.")
+    }
+  })
+
+  for (const leaf of leafTexts) {
+    const expected = ROLE_HEADING[leaf.text_type as keyof typeof ROLE_HEADING]
+    const isLegacyHeading = leaf.text_type === "heading"
+    if (!expected && !isLegacyHeading) continue
+
+    const content = findByDataId(root, leaf.text_id)
+    const heading = closestHeading(content)
+    if (!heading) {
+      errors.push(`Heading "${leaf.text_id}" must be rendered inside a semantic <h1>, <h2>, or <h3>.`)
+      continue
+    }
+
+    if (expected) {
+      if (heading.name !== expected.tag || !hasClass(heading, expected.className)) {
+        errors.push(
+          `Heading role "${leaf.text_type}" (${leaf.text_id}) must use <${expected.tag} class="${expected.className}">.`,
+        )
+      }
+      continue
+    }
+
+    const level = heading.name?.slice(1)
+    const expectedClass = `adt-h${level}`
+    if (!level || !["1", "2", "3"].includes(level) || !hasClass(heading, expectedClass)) {
+      errors.push(
+        `Legacy heading "${leaf.text_id}" must align its semantic tag with its typography class (h1/adt-h1, h2/adt-h2, or h3/adt-h3).`,
+      )
+    }
+  }
+
+  return [...new Set(errors)]
+}

--- a/prompts/page_sectioning.liquid
+++ b/prompts/page_sectioning.liquid
@@ -29,6 +29,14 @@ Do NOT set both `structure` and `role` on the same node. Do NOT nest containers 
 
 {% for t in role_types %}- `{{ t.key }}`: {{ t.description }}
 {% endfor %}
+
+## HEADING HIERARCHY (BOOK-WIDE CONSISTENCY)
+
+- Classify every visible heading by its semantic rank, not merely by being bold: top-level chapter/unit/display heading → `chapter_title` (H1); major section within it → `section_heading` (H2); nested subsection/minor/callout/activity heading → `subheading` (H3).
+- Use visual evidence from the original page—font size, weight, colour, spacing, numbering, indentation, banner treatment—and the surrounding content structure together. A heading's wording alone does not determine its level.
+- Equivalent publisher styles must receive the same role throughout the book. For example, all chapter names use `chapter_title`, all peer topic headings use `section_heading`, and repeated "Prevention methods"-style children use `subheading`.
+- A chapter number and its adjacent chapter name may both be `chapter_title`; the renderer may compose them visually, but their hierarchy remains H1. Do not demote a long chapter title merely because it wraps.
+- Use the generic `heading` role only when the source provides insufficient evidence to choose H1/H2/H3. Never use ordinary `text` for a heading.
 ## SECTION TYPES
 
 {% for t in section_types %}- `{{ t.key }}`: {{ t.description }}

--- a/prompts/web_generation_html.liquid
+++ b/prompts/web_generation_html.liquid
@@ -73,7 +73,9 @@ This book uses a fixed, accessible type scale. Font SIZE is applied automaticall
 {% for s in typography %}- `{{ s.className }}` — {{ s.label }} ({{ s.mobilePx }}px mobile → {{ s.desktopPx }}px desktop)
 {% endfor %}
 Rules:
-- Put the right class directly on each text element: main chapter/display title → `adt-h1`; section headings → `adt-h2`; minor or callout/sidebar headings → `adt-h3`; paragraphs, running text, list items → `adt-body`; captions and image labels → `adt-caption`.
+- Heading roles are authoritative: `chapter_title` → semantic `<h1 class="adt-h1">`; `section_heading` → `<h2 class="adt-h2">`; `subheading` → `<h3 class="adt-h3">`. Put the provided `data-id` on that heading or a descendant inside it. Never render an H1 role with `adt-h2`, an H2 role with `adt-h1`, or otherwise mix heading tags and typography classes.
+- For the legacy generic `heading` role, infer H1/H2/H3 from the original page and surrounding hierarchy, then keep its semantic heading tag and `adt-h1`/`adt-h2`/`adt-h3` class aligned.
+- Paragraphs, running text, and list items use `adt-body`; captions and image labels use `adt-caption`.
 - Do NOT set any font-size utility (`text-sm` … `text-6xl`, `text-[..]`) or inline `font-size` — sizing comes only from the `adt-*` class, scales fluidly between mobile and desktop, and cannot be overridden. Handle responsiveness with LAYOUT (stack columns with `max-lg:flex-col`, adjust spacing), not font size.
 - Keep using Tailwind for everything else (font weight, color, spacing, alignment).
 {% endif %}


### PR DESCRIPTION
Closes #673.

## Summary

- classify chapter titles, section headings, and subheadings explicitly during page sectioning
- map those roles to matching semantic H1/H2/H3 tags and the shared book-wide type scale
- reject mismatched tags/classes and all page-specific font-size overrides before storyboard HTML is accepted
- preserve a guarded fallback for legacy generic heading roles

## SCIENCE STD 5 verification

The validator was run against the existing storyboard artifacts and detected the known defects:

- `pg008`: H1 tag paired with `adt-h2`
- `pg017`: H2 tag paired with `adt-h1`, plus a missing semantic heading
- `pg019`: page-specific `text-[...]` size overrides and missing semantic headings

This means the affected generated output will now fail validation and be retried instead of being silently stored.

## Tests

- `pnpm build`
- `pnpm typecheck`
- `pnpm test` — 182 files, 2,239 tests passed
- focused typography and rendering prompt tests — 54 tests passed
- `git diff --check`

The branch was rebased against the latest `develop` immediately before opening this PR.