### PR TITLE
Enforce one section in By Page mode

### DIFF
--- a/packages/llm/src/__tests__/client.test.ts
+++ b/packages/llm/src/__tests__/client.test.ts
@@ -212,3 +212,56 @@ describe("createLLMModel cancellation", () => {
     expect(generateObjectMock).toHaveBeenCalledTimes(2)
   })
 })
+
+describe("createLLMModel validation retries", () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("feeds validation errors back to the model before retrying", async () => {
+    const validationError =
+      "Page mode requires exactly one section, but the response contains 2."
+
+    openaiProviderMock.mockReturnValue({ provider: "openai" })
+    generateObjectMock
+      .mockResolvedValueOnce({
+        object: { sections: [{ id: 1 }, { id: 2 }] },
+        usage: { promptTokens: 1, completionTokens: 1 },
+      })
+      .mockResolvedValueOnce({
+        object: { sections: [{ id: 1 }] },
+        usage: { promptTokens: 1, completionTokens: 1 },
+      })
+
+    const llm = createLLMModel({ modelId: "openai:gpt-4.1" })
+    const result = await llm.generateObject<{ sections: Array<{ id: number }> }>({
+      schema: z.object({ sections: z.array(z.object({ id: z.number() })) }),
+      messages: [{ role: "user", content: "Section this page" }],
+      maxRetries: 1,
+      validate: (value) => {
+        const sections = (value as { sections?: unknown[] }).sections
+        return sections?.length === 1
+          ? { valid: true, errors: [] }
+          : { valid: false, errors: [validationError] }
+      },
+    })
+
+    expect(result.object.sections).toEqual([{ id: 1 }])
+    expect(generateObjectMock).toHaveBeenCalledTimes(2)
+
+    const retryOptions = generateObjectMock.mock.calls[1]?.[0] as {
+      messages?: Array<{ role: string; content: string }>
+    }
+    expect(retryOptions.messages).toEqual([
+      { role: "user", content: "Section this page" },
+      {
+        role: "assistant",
+        content: JSON.stringify({ sections: [{ id: 1 }, { id: 2 }] }, null, 2),
+      },
+      {
+        role: "user",
+        content: expect.stringContaining(validationError),
+      },
+    ])
+  })
+})

--- a/packages/pipeline/src/__tests__/page-sectioning.test.ts
+++ b/packages/pipeline/src/__tests__/page-sectioning.test.ts
@@ -24,6 +24,7 @@ function makeCtx(overrides?: {
   roleKeys?: string[]
   sectionTypeKeys?: string[]
   availableImageIds?: string[]
+  mode?: "page" | "dynamic"
 }) {
   return {
     structureKeys: new Set(
@@ -40,6 +41,7 @@ function makeCtx(overrides?: {
       overrides?.sectionTypeKeys ?? ["text_only", "images_only"]
     ),
     availableImageIds: new Set(overrides?.availableImageIds ?? []),
+    mode: overrides?.mode,
   }
 }
 
@@ -220,6 +222,36 @@ describe("buildPageSectioningConfig", () => {
 // ── runValidator ────────────────────────────────────────────────
 
 describe("runValidator", () => {
+  it("requires exactly one section in page mode", () => {
+    const result = runValidator(
+      {
+        reasoning: "Split the page",
+        sections: [
+          {
+            section_type: "text_only",
+            background_color: "#fff",
+            text_color: "#000",
+            page_number: 1,
+            nodes: [{ role: "text", text: "First" }],
+          },
+          {
+            section_type: "text_only",
+            background_color: "#fff",
+            text_color: "#000",
+            page_number: 1,
+            nodes: [{ role: "text", text: "Second" }],
+          },
+        ],
+      },
+      makeCtx({ mode: "page" }),
+    )
+
+    expect(result.valid).toBe(false)
+    expect(result.errors).toContain(
+      "Page mode requires exactly one section, but the response contains 2. Merge all page content into one section."
+    )
+  })
+
   it("accepts a simple section with a leaf-only node", () => {
     const result = runValidator(
       {

--- a/packages/pipeline/src/__tests__/page-sectioning.test.ts
+++ b/packages/pipeline/src/__tests__/page-sectioning.test.ts
@@ -860,6 +860,63 @@ describe("sectionPage", () => {
     expect(output.sections[0].nodes[0].children?.[0].text).toBe("Hello")
   })
 
+  it("wires page mode into the initial generation validator", async () => {
+    const invalidTree = {
+      reasoning: "Split the page",
+      sections: [
+        {
+          section_type: "text_only",
+          background_color: "#fff",
+          text_color: "#000",
+          page_number: 1,
+          nodes: [{ role: "text", text: "First" }],
+        },
+        {
+          section_type: "text_only",
+          background_color: "#fff",
+          text_color: "#000",
+          page_number: 1,
+          nodes: [{ role: "text", text: "Second" }],
+        },
+      ],
+    }
+    const validTree = {
+      ...invalidTree,
+      reasoning: "Merged the page",
+      sections: invalidTree.sections.slice(0, 1),
+    }
+
+    const fakeLlm: LLMModel = {
+      generateObject: async <T>(opts: GenerateObjectOptions) => {
+        if (opts.prompt === "page_sectioning") {
+          expect(opts.validate?.(invalidTree, opts.context ?? {})).toEqual({
+            valid: false,
+            errors: [
+              "Page mode requires exactly one section, but the response contains 2. Merge all page content into one section.",
+            ],
+          })
+          return { object: validTree as T }
+        }
+        return {
+          object: {
+            approved: true,
+            reasoning: "Looks good.",
+            nodes_and_sections: null,
+          } as T,
+        }
+      },
+    }
+
+    const output = await sectionPage(
+      makeInput(),
+      makeConfig({ mode: "page" }),
+      fakeLlm,
+    )
+
+    expect(output.reasoning).toBe("Merged the page")
+    expect(output.sections).toHaveLength(1)
+  })
+
   it("adopts reviewer's replacement tree when reviewer rejects then proposes valid replacement", async () => {
     const initialTree = {
       reasoning: "Initial draft",

--- a/packages/pipeline/src/page-sectioning.ts
+++ b/packages/pipeline/src/page-sectioning.ts
@@ -93,6 +93,7 @@ export async function sectionPage(
     roleKeys: new Set(config.roleTypes.map((t) => t.key)),
     sectionTypeKeys: new Set(config.sectionTypes.map((t) => t.key)),
     availableImageIds: new Set(input.availableImages.map((i) => i.imageId)),
+    mode: config.mode,
   }
 
   // Initial generation (with built-in validation retry).
@@ -339,6 +340,7 @@ interface ValidatorContext {
   roleKeys: Set<string>
   sectionTypeKeys: Set<string>
   availableImageIds: Set<string>
+  mode?: "page" | "dynamic"
 }
 
 /**
@@ -354,6 +356,12 @@ export function runValidator(
   const result = raw as LLMStructuringResult | null
   if (!result || !Array.isArray(result.sections)) {
     return { valid: false, errors: ["Response is missing a `sections` array."] }
+  }
+
+  if (ctx.mode === "page" && result.sections.length !== 1) {
+    errors.push(
+      `Page mode requires exactly one section, but the response contains ${result.sections.length}. Merge all page content into one section.`
+    )
   }
 
   const usedImageIds = new Set<string>()


### PR DESCRIPTION
## Summary

- pass `page_sectioning.mode` into the runtime validator
- reject multi-section LLM output when **By Page** mode is selected
- route invalid output through the existing validation-feedback/retry loop
- add regression coverage for the one-section invariant

Fixes #666.

## Why

The prompt already instructs the model to emit one section in page mode, but this was not programmatically enforced. A model response containing multiple sections could therefore reach Storyboard, where each section becomes a separate rendered page.

## Verification

- `pnpm build`
- `pnpm exec vitest run packages/pipeline/src/__tests__/page-sectioning.test.ts` (48 tests passed)
- `pnpm typecheck`
- `git diff --check`
