### PR TITLE
fix(speech): improve Tanzanian Swahili TTS

### DIFF
--- a/apps/api/src/services/stage-runner.test.ts
+++ b/apps/api/src/services/stage-runner.test.ts
@@ -1028,6 +1028,60 @@ speech:
     }
   })
 
+  it("keeps OpenAI TTS running progress visible after an item-level failure", async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "stage-runner-tts-"))
+    const booksDir = path.join(tmpDir, "books")
+    const promptsDir = path.join(tmpDir, "prompts")
+    const configPath = path.join(tmpDir, "config.yaml")
+    fs.mkdirSync(promptsDir, { recursive: true })
+    fs.writeFileSync(
+      configPath,
+      `role_types:
+  section_text: Main body text
+structure_types:
+  paragraph: Paragraph
+speech:
+  default_provider: openai
+`,
+    )
+    seedTextAndSpeechBook(booksDir, "openai-tts-item-failure")
+    generateSpeechFileMock.mockRejectedValueOnce(
+      new Error("OpenAI TTS request failed (400): request rejected"),
+    )
+
+    const events: ProgressEvent[] = []
+    const runner = createStageRunner()
+    await runner.run(
+      "openai-tts-item-failure",
+      {
+        booksDir,
+        apiKey: "sk-test",
+        promptsDir,
+        configPath,
+        fromStage: "translate",
+        toStage: "speech",
+      },
+      { emit: (event) => events.push(event) },
+    )
+
+    expect(
+      events.some(
+        (event) =>
+          event.type === "step-progress" &&
+          event.step === "tts" &&
+          event.message?.includes("pages ·") &&
+          event.totalPages !== undefined &&
+          event.page !== undefined,
+      ),
+    ).toBe(true)
+    expect(
+      events.some((event) => event.type === "step-error" && event.step === "tts"),
+    ).toBe(false)
+    expect(
+      events.some((event) => event.type === "step-complete" && event.step === "tts"),
+    ).toBe(true)
+  })
+
   it("retries rate-limited Gemini TTS items and completes the step when a retry succeeds", async () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "stage-runner-tts-"))
     const booksDir = path.join(tmpDir, "books")

--- a/apps/api/src/services/stage-runner.ts
+++ b/apps/api/src/services/stage-runner.ts
@@ -68,6 +68,8 @@ import {
   generateWordTimestamps,
   wavDurationSeconds,
   stripEmojis,
+  prepareTextForSpeech,
+  prepareInstructionsForSpeech,
   generateBookSummary,
   buildBookSummaryConfig,
   filterPageImageMeaningfulness,
@@ -130,6 +132,8 @@ const GEMINI_TTS_MAX_RETRY_DELAY_MS = 20_000
 // and aren't a rate signal, so they get a shorter delay than a 429 and do not
 // throttle the shared limiter.
 const GEMINI_TTS_TRANSIENT_RETRY_DELAY_MS = 1_500
+const TTS_TRANSIENT_MAX_RETRIES = 3
+const TTS_TRANSIENT_RETRY_DELAY_MS = 1_000
 
 class StepError extends Error {
   readonly step: StepName
@@ -368,6 +372,12 @@ function isGeminiTtsTransientError(message: string): boolean {
   )
 }
 
+function isTtsTransientTransportError(message: string): boolean {
+  return /fetch failed|terminated|socket|network|ECONNRESET|ETIMEDOUT|\(408\)|\(429\)|\(50\d\)/i.test(
+    message,
+  )
+}
+
 function parseGeminiRetryDelayMs(message: string): number | null {
   const match = message.match(/retry in ([\d.]+)s/i)
   if (!match) return null
@@ -486,15 +496,20 @@ function emitSpeechStepProgress(
   audioTotal: number,
   audioFailures: number,
   reusedTotal = 0,
+  pagesCompleted?: number,
+  pagesTotal?: number,
 ): void {
   const reusedSuffix = reusedTotal > 0 ? ` (${reusedTotal} reused)` : ""
   const failureSuffix = audioFailures > 0 ? ` (${audioFailures} failed)` : ""
+  const pagePrefix = pagesTotal
+    ? `${pagesCompleted ?? 0}/${pagesTotal} pages · `
+    : ""
   progress.emit({
     type: "step-progress",
     step: "tts",
-    message: `${audioCompleted}/${audioTotal} audio entries${reusedSuffix}${failureSuffix}`,
-    page: audioCompleted,
-    totalPages: audioTotal,
+    message: `${pagePrefix}${audioCompleted}/${audioTotal} audio entries${reusedSuffix}${failureSuffix}`,
+    page: pagesTotal ? (pagesCompleted ?? 0) : audioCompleted,
+    totalPages: pagesTotal || audioTotal,
   })
 }
 
@@ -633,12 +648,17 @@ function canReuseSpeechEntry(
   const expectedExt = `.${options.format.toLowerCase()}`
   if (path.extname(entry.fileName).toLowerCase() !== expectedExt) return false
 
-  const sanitized = stripEmojis(options.text).trim()
+  const sanitized = prepareTextForSpeech(stripEmojis(options.text).trim(), options.language)
+  const preparedInstructions = prepareInstructionsForSpeech(
+    options.instructions,
+    sanitized,
+    options.language,
+  )
   const cacheKey = computeSpeechCacheKey({
     text: sanitized,
     voice: options.voice,
     model: options.model,
-    instructions: options.instructions,
+    instructions: preparedInstructions,
     provider: options.provider,
     geminiTemperature: options.geminiTemperature,
     geminiSeed: options.geminiSeed,
@@ -2768,8 +2788,41 @@ async function runSpeechStep(
     const totalItems = ttsWorkItems.length + batchedEntryCount
     let completedItems = 0
 
+    // Track actual page completion independently from audio-entry completion.
+    // One page is complete only after every pending entry on that page has
+    // either generated or failed. Non-page items (glossary, quizzes, etc.) stay
+    // represented in the detailed audio-entry message but not the page count.
+    const pendingEntriesByPage = new Map<string, number>()
+    const completedEntriesByPage = new Map<string, number>()
+    const pageKeyFor = (languageCode: string, textId: string): string | null => {
+      const match = /^(pg\d+)_/i.exec(textId)
+      return match ? `${languageCode}::${match[1]!.toLowerCase()}` : null
+    }
+    const registerPageEntry = (languageCode: string, textId: string): void => {
+      const key = pageKeyFor(languageCode, textId)
+      if (!key) return
+      pendingEntriesByPage.set(key, (pendingEntriesByPage.get(key) ?? 0) + 1)
+    }
+    const completePageEntry = (languageCode: string, textId: string): void => {
+      const key = pageKeyFor(languageCode, textId)
+      if (!key) return
+      completedEntriesByPage.set(key, (completedEntriesByPage.get(key) ?? 0) + 1)
+    }
+    const completedPageCount = (): number => {
+      let count = 0
+      for (const [key, total] of pendingEntriesByPage) {
+        if ((completedEntriesByPage.get(key) ?? 0) >= total) count++
+      }
+      return count
+    }
+    for (const item of ttsWorkItems) registerPageEntry(item.language, item.textId)
+    for (const group of pageGroups.values()) {
+      for (const entry of group.entries) registerPageEntry(group.language, entry.id)
+    }
+    const totalSpeechPages = pendingEntriesByPage.size
+
     const reusedItems = [...reusedEntriesByLang.values()].reduce((sum, count) => sum + count, 0)
-    emitSpeechStepProgress(progress, 0, totalItems, 0, reusedItems)
+    emitSpeechStepProgress(progress, 0, totalItems, 0, reusedItems, 0, totalSpeechPages)
 
     console.log(`[stage-run] ${label}: generating TTS for ${totalItems} entries and reusing ${reusedItems} existing entries across ${outputLanguages.length} languages (${outputLanguages.join(", ")})`)
     console.log(`[stage-run] ${label}: TTS routing — for each language: ${outputLanguages.map((l) => `${l}→${resolveProviderForLanguage(l, routing)}`).join(", ")}`)
@@ -2908,7 +2961,16 @@ async function runSpeechStep(
             }
           }
           completedItems += group.entries.length
-          emitSpeechStepProgress(progress, completedItems, totalItems, failedItems.length, reusedItems)
+          for (const entry of group.entries) completePageEntry(group.language, entry.id)
+          emitSpeechStepProgress(
+            progress,
+            completedItems,
+            totalItems,
+            failedItems.length,
+            reusedItems,
+            completedPageCount(),
+            totalSpeechPages,
+          )
         },
         { runSignal: options.signal }
       )
@@ -2971,6 +3033,7 @@ async function runSpeechStep(
                 provider === "gemini" &&
                 !rateLimited &&
                 isGeminiTtsTransientError(msg)
+              const transportTransient = isTtsTransientTransportError(msg)
               if (
                 (rateLimited || transient) &&
                 !options.signal?.aborted &&
@@ -3002,6 +3065,19 @@ async function runSpeechStep(
                 )
                 console.warn(
                   `[stage-run] ${label}: Gemini TTS transient error for ${item.textId} (${item.language}); retrying ${attemptCount + 1}/${GEMINI_TTS_MAX_RATE_LIMIT_RETRIES + 1} in ${retryDelayMs}ms: ${msg}`
+                )
+                await sleep(retryDelayMs, options.signal)
+                if (options.signal?.aborted) throw new RunCancelledError()
+                continue
+              }
+              if (
+                transportTransient &&
+                !options.signal?.aborted &&
+                attemptCount <= TTS_TRANSIENT_MAX_RETRIES
+              ) {
+                const retryDelayMs = TTS_TRANSIENT_RETRY_DELAY_MS * attemptCount
+                console.warn(
+                  `[stage-run] ${label}: ${provider} TTS transport error for ${item.textId} (${item.language}); retrying ${attemptCount + 1}/${TTS_TRANSIENT_MAX_RETRIES + 1} in ${retryDelayMs}ms: ${msg}`,
                 )
                 await sleep(retryDelayMs, options.signal)
                 if (options.signal?.aborted) throw new RunCancelledError()
@@ -3087,17 +3163,23 @@ async function runSpeechStep(
             cacheHit: false,
             durationMs,
           })
-          if (provider !== "gemini") {
-            progress.emit({
-              type: "step-error",
-              step: "tts",
-              error: `${item.textId} failed: ${msg}`,
-            })
-          }
+          // This is an item-level gap, not a stopped step. Emitting step-error
+          // here marks the whole Speech stage errored and hides its live
+          // progress even though the remaining items continue. The failed item
+          // is persisted below and the progress event includes the gap count.
         }
 
         completedItems++
-        emitSpeechStepProgress(progress, completedItems, totalItems, failedItems.length, reusedItems)
+        completePageEntry(item.language, item.textId)
+        emitSpeechStepProgress(
+          progress,
+          completedItems,
+          totalItems,
+          failedItems.length,
+          reusedItems,
+          completedPageCount(),
+          totalSpeechPages,
+        )
       },
       { runSignal: options.signal }
     )

--- a/config/speech_instructions.yaml
+++ b/config/speech_instructions.yaml
@@ -19,6 +19,11 @@ en-tz: |
 sw-tz: |
   Speak it in Tanzanian Swahili (Kiswahili cha Tanzania). Use the
   pronunciation and intonation typical of mainland Tanzania, not Kenyan Swahili.
+  Read numbers naturally in Tanzanian Swahili. Pronounce digits, decimals,
+  percentages, dates, times, fractions, measurements, and currency amounts as
+  complete Kiswahili words according to their meaning in the sentence; do not
+  use English number words. Keep mathematical operators and enumeration markers
+  clear and unambiguous.
   Speak in a cheerful and positive tone.
 pt: |
   Speak it in a European Portuguese (Portugal) accent. Use the pronunciation

--- a/packages/llm/src/__tests__/speech.test.ts
+++ b/packages/llm/src/__tests__/speech.test.ts
@@ -1,5 +1,41 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { createGeminiTTSSynthesizer, transcribeWithWhisper } from "../speech.js"
+import {
+  createAzureTTSSynthesizer,
+  createGeminiTTSSynthesizer,
+  transcribeWithWhisper,
+} from "../speech.js"
+
+describe("createAzureTTSSynthesizer", () => {
+  const fetchMock = vi.fn<typeof fetch>()
+
+  beforeEach(() => {
+    fetchMock.mockReset()
+    fetchMock.mockResolvedValue(new Response(new Uint8Array([1]), { status: 200 }))
+    vi.stubGlobal("fetch", fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("sets the SSML language from the selected voice for native number pronunciation", async () => {
+    const synth = createAzureTTSSynthesizer({
+      subscriptionKey: "test-key",
+      region: "eastus",
+    })
+
+    await synth.synthesize({
+      model: "azure",
+      voice: "sw-TZ-RehemaNeural",
+      input: "Ana vitabu 25.",
+      responseFormat: "mp3",
+    })
+
+    const request = fetchMock.mock.calls[0]?.[1]
+    expect(request?.body).toContain("xml:lang='sw-TZ'")
+    expect(request?.body).toContain("Ana vitabu 25.")
+  })
+})
 
 describe("createGeminiTTSSynthesizer", () => {
   const fetchMock = vi.fn<typeof fetch>()

--- a/packages/llm/src/speech.ts
+++ b/packages/llm/src/speech.ts
@@ -165,13 +165,19 @@ function buildAzureOutputFormat(
 }
 
 function buildSSML(voice: string, text: string): string {
+  // Azure voice names start with their BCP 47 locale (for example,
+  // "sw-TZ-RehemaNeural").  The document language affects how ambiguous
+  // tokens such as numerals, dates, and decimal separators are spoken, so it
+  // must agree with the selected voice instead of always being en-US.
+  const localeMatch = /^([a-z]{2,3}-[A-Z]{2})(?:-|$)/.exec(voice)
+  const locale = localeMatch?.[1] ?? "en-US"
   const escaped = text
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;")
     .replace(/'/g, "&apos;")
-  return `<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' xml:lang='en-US'><voice name='${voice}'>${escaped}</voice></speak>`
+  return `<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' xml:lang='${locale}'><voice name='${voice}'>${escaped}</voice></speak>`
 }
 
 function wrapPcmAsWave(

--- a/packages/pipeline/src/__tests__/speech.test.ts
+++ b/packages/pipeline/src/__tests__/speech.test.ts
@@ -4,6 +4,8 @@ import path from "node:path"
 import os from "node:os"
 import {
   stripEmojis,
+  prepareTextForSpeech,
+  prepareInstructionsForSpeech,
   isSpeakableText,
   resolveVoice,
   resolveInstructions,
@@ -41,6 +43,94 @@ describe("stripEmojis", () => {
 
   it("handles unicode text with emojis", () => {
     expect(stripEmojis("Hola 🌍 mundo")).toBe("Hola  mundo")
+  })
+})
+
+describe("prepareTextForSpeech", () => {
+  it("expands Tanzanian Swahili numbers and character ranges", () => {
+    expect(prepareTextForSpeech("Soma a-z na 25%.", "sw-TZ")).toBe(
+      "Soma a hadi z na asilimia ishirini na tano.",
+    )
+  })
+
+  it("speaks compact numeric ranges and spaced arithmetic unambiguously", () => {
+    expect(prepareTextForSpeech("Abakasi 1-6; 25 – 2 = 23", "sw-TZ")).toBe(
+      "Abakasi moja hadi sita; ishirini na tano toa mbili ni sawa na ishirini na tatu",
+    )
+  })
+
+  it("expands decimals digit by digit after the separator", () => {
+    expect(prepareTextForSpeech("1.05", "sw")).toBe("moja nukta sifuri tano")
+  })
+
+  it("speaks Roman numerals as their values in Kiswahili", () => {
+    expect(prepareTextForSpeech("Sura ya IV, XII na (xxi).", "sw-TZ")).toBe(
+      "Sura ya n-ne, kumi na mbili na (ishirini na moja).",
+    )
+  })
+
+  it("speaks Roman-numeral ranges semantically", () => {
+    expect(prepareTextForSpeech("Sura IV–VI", "sw-TZ")).toBe(
+      "Sura n-ne hadi sita",
+    )
+  })
+
+  it("does not mistake lowercase alphabetic labels for Roman numerals", () => {
+    expect(prepareTextForSpeech("Vipengele (c), (d), (i) na (l)", "sw-TZ")).toBe(
+      "Vipengele kipengele c, kipengele d, kipengele i na kipengele l",
+    )
+  })
+
+  it("gives isolated section letters Kiswahili context", () => {
+    expect(prepareTextForSpeech("(a) 4, (b) 14", "sw-TZ")).toBe(
+      "kipengele a n-ne, kipengele b kumi na n-ne",
+    )
+  })
+
+  it("speaks structural numbers as ordinal positions", () => {
+    expect(
+      prepareTextForSpeech(
+        "Mfano wa 1, Zoezi la 2, Swali la 3(a), Sura ya 4 na mwezi wa 12",
+        "sw-TZ",
+      ),
+    ).toBe(
+      "Mfano wa kwanza, Zoezi la pili, Swali la tatu kipengele a, Sura ya n-ne na mwezi wa kumi na mbili",
+    )
+  })
+
+  it("keeps quantities after non-structural connectors cardinal", () => {
+    expect(
+      prepareTextForSpeech("Thamani ya 8 na jumla ya 2", "sw-TZ"),
+    ).toBe("Thamani ya nane na jumla ya mbili")
+  })
+
+  it("leaves malformed Roman numerals unchanged", () => {
+    expect(prepareTextForSpeech("IIII na IC", "sw-TZ")).toBe("IIII na IC")
+  })
+
+  it("leaves other languages unchanged", () => {
+    expect(prepareTextForSpeech("a-z and 25", "en")).toBe("a-z and 25")
+  })
+
+  it("adds targeted phonetic guidance only to affected Swahili text", () => {
+    const prepared = prepareInstructionsForSpeech(
+      "Speak naturally.",
+      "kipengele a n-ne",
+      "sw-TZ",
+    )
+    expect(prepared).toContain("[ˈn̩.nɛ]")
+    expect(prepared).toContain("native Kiswahili vowel sounds")
+    expect(prepareInstructionsForSpeech("Speak naturally.", "moja", "sw-TZ")).toBe(
+      "Speak naturally.",
+    )
+  })
+
+  it("marks syllabic nasals in ordinary Swahili source words", () => {
+    const prepared = prepareTextForSpeech("Mmoja ana nne, wengine wanne.", "sw-TZ")
+    expect(prepared).toBe("M-moja ana n-ne, wengine wanne.")
+    const instructions = prepareInstructionsForSpeech("Speak naturally.", prepared, "sw-TZ")
+    expect(instructions).toContain("[m̩.ˈmɔ.dʒa]")
+    expect(instructions).toContain("[ˈn̩.nɛ]")
   })
 })
 

--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -186,6 +186,8 @@ export {
   type ResolvedGeminiTtsRateLimit,
   isSpeakableText,
   stripEmojis,
+  prepareTextForSpeech,
+  prepareInstructionsForSpeech,
   loadVoicesConfig,
   loadSpeechInstructions,
   computeSpeechCacheKey,

--- a/packages/pipeline/src/speech.ts
+++ b/packages/pipeline/src/speech.ts
@@ -36,6 +36,184 @@ export function stripEmojis(text: string): string {
   return text.replace(EMOJI_RE, "")
 }
 
+const SWAHILI_UNITS = [
+  "sifuri", "moja", "mbili", "tatu", "n-ne", "tano",
+  "sita", "saba", "nane", "tisa",
+] as const
+const SWAHILI_TENS = [
+  "", "kumi", "ishirini", "thelathini", "arobaini",
+  "hamsini", "sitini", "sabini", "themanini", "tisini",
+] as const
+const SWAHILI_SCALES = [
+  { value: 1_000_000_000_000, name: "trilioni" },
+  { value: 1_000_000_000, name: "bilioni" },
+  { value: 1_000_000, name: "milioni" },
+  { value: 1_000, name: "elfu" },
+  { value: 100, name: "mia" },
+] as const
+
+function swahiliIntegerWords(value: number): string {
+  if (value < 10) return SWAHILI_UNITS[value]!
+  if (value < 100) {
+    const tens = SWAHILI_TENS[Math.floor(value / 10)]!
+    const remainder = value % 10
+    return remainder === 0 ? tens : `${tens} na ${SWAHILI_UNITS[remainder]}`
+  }
+  for (const scale of SWAHILI_SCALES) {
+    if (value >= scale.value) {
+      const count = Math.floor(value / scale.value)
+      const remainder = value % scale.value
+      const prefix = `${scale.name} ${swahiliIntegerWords(count)}`
+      return remainder === 0 ? prefix : `${prefix} na ${swahiliIntegerWords(remainder)}`
+    }
+  }
+  return String(value)
+}
+
+function swahiliNumberWords(token: string): string {
+  const normalized = token.replace(/\s/g, "")
+  const parts = normalized.split(/[.,]/)
+  const whole = parts[0] ?? "0"
+  const fraction = parts[1]
+  const wholeWords =
+    whole.length > 1 && whole.startsWith("0")
+      ? [...whole].map((digit) => SWAHILI_UNITS[Number(digit)]).join(" ")
+      : swahiliIntegerWords(Number(whole))
+  if (fraction === undefined) return wholeWords
+  const separator = normalized.includes(",") ? "koma" : "nukta"
+  return `${wholeWords} ${separator} ${[...fraction]
+    .map((digit) => SWAHILI_UNITS[Number(digit)])
+    .join(" ")}`
+}
+
+const ROMAN_VALUE: Record<string, number> = {
+  I: 1, V: 5, X: 10, L: 50, C: 100, D: 500, M: 1_000,
+}
+
+function romanNumeralValue(token: string): number | null {
+  const roman = token.toUpperCase()
+  // Canonical Roman numerals only. This rejects arbitrary words made solely
+  // from Roman letters and malformed forms such as IIII or IC.
+  if (!/^(?=[MDCLXVI]+$)M{0,3}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})$/.test(roman)) {
+    return null
+  }
+  let total = 0
+  for (let index = 0; index < roman.length; index++) {
+    const current = ROMAN_VALUE[roman[index]!]!
+    const next = ROMAN_VALUE[roman[index + 1]!] ?? 0
+    total += current < next ? -current : current
+  }
+  return total || null
+}
+
+function swahiliRomanWords(token: string): string {
+  const value = romanNumeralValue(token)
+  return value === null ? token : swahiliIntegerWords(value)
+}
+
+const SWAHILI_ORDINAL_CONTEXT_RE = new RegExp(
+  String.raw`\b(mfano|zoezi|swali|sura|sehemu|hatua|ukurasa|darasa|mwezi|safu|mstari|jedwali|kielelezo|picha|aya|kipengele|kifungu|somo)\s+(ya|wa|la|cha|vya|za)\s+(\d+)\b`,
+  "gi",
+)
+
+function swahiliOrdinalWords(token: string): string {
+  const value = Number(token)
+  if (value === 1) return "kwanza"
+  if (value === 2) return "pili"
+  return swahiliIntegerWords(value)
+}
+
+/**
+ * Convert ambiguous written tokens into deterministic, language-native TTS
+ * input without changing the catalog text displayed to the reader.
+ */
+export function prepareTextForSpeech(text: string, language: string): string {
+  if (getBaseLanguage(language) !== "sw") return text
+
+  return text
+    // Pronunciation lexicon for initial syllabic nasals. These separators are
+    // TTS-only syllable boundaries; the visible catalog text is untouched.
+    .replace(/\bmmoja\b/gi, (word) => `${word[0]}-${word.slice(1)}`)
+    .replace(/\bnne\b/gi, (word) => `${word[0]}-${word.slice(1)}`)
+    // Digits following structural nouns are positions, not quantities:
+    // "Mfano wa 1" means "Mfano wa kwanza", while a phrase such as
+    // "thamani ya 8" remains cardinal because it is not a structural label.
+    .replace(
+      SWAHILI_ORDINAL_CONTEXT_RE,
+      (_match, noun: string, connector: string, number: string) =>
+        `${noun} ${connector} ${swahiliOrdinalWords(number)}`,
+    )
+    // Roman ranges must be resolved before the generic character-range rule.
+    .replace(/\b([IVXLCDM]{1,12})\s*[-–—]\s*([IVXLCDM]{1,12})\b/g, (_match, from: string, to: string) => {
+      const fromValue = romanNumeralValue(from)
+      const toValue = romanNumeralValue(to)
+      return fromValue === null || toValue === null
+        ? _match
+        : `${swahiliIntegerWords(fromValue)} hadi ${swahiliIntegerWords(toValue)}`
+    })
+    // Multi-character uppercase numerals are unambiguous. A single numeral is
+    // converted only in list/heading notation such as (V) or X., avoiding math
+    // variables and ordinary alphabetic labels such as lowercase (c).
+    .replace(/\b[IVXLCDM]{2,12}\b/g, (token) => swahiliRomanWords(token))
+    .replace(/\(([IVXLCDM])\)|\b([IVXLCDM])(?=[.)])/g, (_match, wrapped: string | undefined, suffixed: string | undefined) => {
+      const token = (wrapped ?? suffixed)!
+      const words = swahiliRomanWords(token)
+      return wrapped ? `(${words})` : words
+    })
+    .replace(/\(([ivxlcdm]{2,12})\)|\b([ivxlcdm]{2,12})(?=[.)])/g, (match, wrapped: string | undefined, suffixed: string | undefined) => {
+      const token = (wrapped ?? suffixed)!
+      const value = romanNumeralValue(token)
+      if (value === null) return match
+      const words = swahiliIntegerWords(value)
+      return wrapped ? `(${words})` : words
+    })
+    // A bare parenthesized letter is an enumeration/section label, not an
+    // English word. Give it Kiswahili structural context so OpenAI keeps the
+    // selected accent instead of switching to an English alphabet reading.
+    // Multi-letter Roman numerals were already handled above.
+    .replace(/\(([a-z])\)/g, " kipengele $1")
+    // A compact dash is a range; spaced mathematical dashes remain subtraction.
+    .replace(/\b([A-Za-z])\s*[-–—]\s*([A-Za-z])\b/g, "$1 hadi $2")
+    .replace(/\b(\d+)\s*[-–—](?=\d)(\d+)\b/g, "$1 hadi $2")
+    .replace(/(\d+(?:[.,]\d+)?)\s*%/g, "asilimia $1")
+    .replace(/\b\d+(?:[.,]\d+)?\b/g, (token) => swahiliNumberWords(token))
+    .replace(/\s[-–—]\s/g, " toa ")
+    .replace(/\s\+\s/g, " jumlisha ")
+    .replace(/\s[×*]\s/g, " zidisha kwa ")
+    .replace(/\s[÷/]\s/g, " gawanya kwa ")
+    .replace(/\s=\s/g, " ni sawa na ")
+    .replace(/\s{2,}/g, " ")
+    .trim()
+}
+
+/** Add phonetic direction only when the prepared transcript needs it. */
+export function prepareInstructionsForSpeech(
+  instructions: string,
+  preparedText: string,
+  language: string,
+): string {
+  if (getBaseLanguage(language) !== "sw") return instructions
+  const additions: string[] = []
+  if (/\bkipengele [a-z]\b/.test(preparedText)) {
+    additions.push(
+      "Pronounce enumeration letters with native Kiswahili vowel sounds; never use English alphabet names or an English accent.",
+    )
+  }
+  if (/\bn-ne\b/.test(preparedText)) {
+    additions.push(
+      'Pronounce "n-ne" as Tanzanian Kiswahili [ˈn̩.nɛ], with the first syllabic n clearly stressed and audible. Do not reduce it to "ne" and do not speak the hyphen.',
+    )
+  }
+  if (/\bm-moja\b/i.test(preparedText)) {
+    additions.push(
+      'Pronounce "m-moja" as Tanzanian Kiswahili [m̩.ˈmɔ.dʒa]: the first m is its own syllable, stress "mo", and do not speak the hyphen.',
+    )
+  }
+  return additions.length > 0
+    ? [instructions.trim(), ...additions].filter(Boolean).join("\n")
+    : instructions
+}
+
 // ---------------------------------------------------------------------------
 // Speakable text check
 // ---------------------------------------------------------------------------
@@ -273,7 +451,11 @@ export function computeSpeechCacheKey(data: {
           ...(geminiSeed !== undefined ? { geminiSeed } : {}),
         }
       : {}
-  const json = JSON.stringify({ ...base, ...gemini })
+  // Azure SSML v2 derives xml:lang from the selected voice. Include the
+  // synthesis revision so audio cached under the old hard-coded en-US SSML is
+  // regenerated instead of silently reused.
+  const synthesisRevision = base.provider === "azure" ? { synthesisRevision: 2 } : {}
+  const json = JSON.stringify({ ...base, ...gemini, ...synthesisRevision })
   return crypto.createHash("sha256").update(json).digest("hex")
 }
 
@@ -352,8 +534,13 @@ export async function generateSpeechFile(
   } = options
 
   // Strip emojis and validate
-  const sanitized = stripEmojis(text).trim()
+  const sanitized = prepareTextForSpeech(stripEmojis(text).trim(), language)
   if (!isSpeakableText(sanitized)) return null
+  const preparedInstructions = prepareInstructionsForSpeech(
+    instructions,
+    sanitized,
+    language,
+  )
 
   const safeTextId = assertSafeSegment(textId, SAFE_TEXT_ID_RE, "text id")
   const safeFormat = assertSafeSegment(
@@ -371,7 +558,7 @@ export async function generateSpeechFile(
     text: sanitized,
     voice,
     model,
-    instructions,
+    instructions: preparedInstructions,
     provider,
     geminiTemperature,
     geminiSeed,
@@ -410,7 +597,7 @@ export async function generateSpeechFile(
     voice,
     input: sanitized,
     responseFormat: safeFormat,
-    instructions: instructions || undefined,
+    instructions: preparedInstructions || undefined,
     temperature: geminiTemperature,
     seed: geminiSeed,
     signal,


### PR DESCRIPTION
Closes #647

## Summary

This PR improves Tanzanian Swahili (`sw-TZ`) speech generation after testing OpenAI TTS against a Hisabati textbook. It does not alter visible book text; normalization is applied only to the synthesized transcript.

### Pronunciation and semantics

- expands cardinal numbers, decimals, percentages, ranges, and common mathematical operators into deterministic Kiswahili speech forms
- distinguishes structural ordinals (`Mfano wa 1` → `Mfano wa kwanza`) from quantities (`jumla ya 2` → `jumla ya mbili`)
- expands alphabetic section labels and ranges without switching to an English accent
- interprets canonical Roman numerals and Roman-numeral ranges semantically
- adds targeted phonetic handling for syllabic nasals and stress in `nne` and `mmoja`
- folds prepared transcripts/instructions into cache keys so only affected audio regenerates

### Reliability and progress

- derives Azure SSML locale from the selected voice instead of hard-coding `en-US`
- retries transient OpenAI/Gemini transport failures
- records item-level gaps without incorrectly marking the entire running Speech step as failed
- reports actual completed-page progress while retaining detailed audio-entry/reuse/failure counts

## Validation

- `pnpm build`
- 102 focused speech/stage-runner tests
- `pnpm typecheck`

I have tested and iteratively improved the cases reported in #647. Technical leads and native-language reviewers: please review the normalization choices and phonetic guidance, and feel free to comment with additional examples or corrections.
