### PR TITLE
feat(validation): add expiring public review links

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -36,6 +36,7 @@ import { createSignLanguageVideoRoutes } from "./routes/sign-language-videos.js"
 import { createEditableActivitiesRoutes } from "./routes/editable-activities.js"
 import { createAgentRoutes } from "./routes/agents.js"
 import { createTranslationEvaluationRoutes } from "./routes/translation-evaluations.js"
+import { createValidationShareRoutes } from "./routes/validation-shares.js"
 
 // Resolve paths relative to monorepo root (2 levels up from apps/api/)
 const projectRoot = path.resolve(
@@ -119,6 +120,7 @@ app.route("/api", createPresetRoutes(configPath))
 app.route("/api", createAdtPreviewRoutes(booksDir, webAssetsDir, configPath))
 app.route("/api", createSpeechConfigRoutes(configPath))
 app.route("/api", createReviewerValidationRoutes(booksDir, configFolderPath, configPath))
+app.route("/api", createValidationShareRoutes(booksDir))
 app.route("/api", createSignLanguageVideoRoutes(booksDir))
 app.route("/api", createAgentRoutes(booksDir, promptsDir, configPath, taskService))
 app.route("/api", createTranslationEvaluationRoutes(booksDir, configPath, taskService))

--- a/apps/api/src/routes/validation-shares.test.ts
+++ b/apps/api/src/routes/validation-shares.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { Hono } from "hono"
+import { createBookStorage } from "@adt/storage"
+import { errorHandler } from "../middleware/error-handler.js"
+import { createValidationShareRoutes } from "./validation-shares.js"
+
+describe("validation share routes", () => {
+  const label = "shared-book"
+  let tmpDir: string
+  let app: Hono
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "validation-share-"))
+    createBookStorage(label, tmpDir).close()
+    const adtDir = path.join(tmpDir, label, "adt")
+    fs.mkdirSync(adtDir, { recursive: true })
+    fs.writeFileSync(path.join(adtDir, ".build-version"), "abc123")
+    app = new Hono()
+    app.onError(errorHandler)
+    app.route("/api", createValidationShareRoutes(tmpDir))
+  })
+
+  afterEach(() => fs.rmSync(tmpDir, { recursive: true, force: true }))
+
+  async function createShare() {
+    const response = await app.request(`/api/books/${label}/validation/shares`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ expires_in_days: 14 }),
+    })
+    expect(response.status).toBe(201)
+    return response.json() as Promise<{ url: string; share: { share_id: string; token_hash: string } }>
+  }
+
+  it("creates an opaque link without returning the stored token hash in the URL", async () => {
+    const created = await createShare()
+    expect(created.url).toContain(`/api/public/validation/${label}/`)
+    expect(created.url).not.toContain(created.share.token_hash)
+    expect(created.share.token_hash).toMatch(/^[a-f0-9]{64}$/)
+  })
+
+  it("serves the pinned interactive preview and accepts categorized feedback", async () => {
+    const created = await createShare()
+    const publicPath = new URL(created.url).pathname
+    const page = await app.request(publicPath)
+    expect(page.status).toBe(200)
+    expect(await page.text()).toContain(`/adt/v-abc123/index.html`)
+
+    const feedback = await app.request(`${publicPath}/feedback`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ reviewer_name: "Validator", category: "voice", comment: "The second phrase is too fast." }),
+    })
+    expect(feedback.status).toBe(201)
+    const listed = await app.request(`/api/books/${label}/validation/shares`)
+    const body = await listed.json() as { feedback: Array<{ feedback: { category: string; comment: string } }> }
+    expect(body.feedback[0]?.feedback).toMatchObject({ category: "voice", comment: "The second phrase is too fast." })
+  })
+
+  it("rejects a revoked link and prevents further feedback", async () => {
+    const created = await createShare()
+    await app.request(`/api/books/${label}/validation/shares/${created.share.share_id}/revoke`, { method: "POST" })
+    const publicPath = new URL(created.url).pathname
+    expect((await app.request(publicPath)).status).toBe(404)
+    expect((await app.request(`${publicPath}/feedback`, {
+      method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ reviewer_name: "A", category: "other", comment: "No" }),
+    })).status).toBe(404)
+  })
+
+  it("validates feedback instead of storing malformed public input", async () => {
+    const created = await createShare()
+    const response = await app.request(`${new URL(created.url).pathname}/feedback`, {
+      method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ reviewer_name: "", category: "unknown", comment: "" }),
+    })
+    expect(response.status).toBe(400)
+  })
+
+  it("publishes a newly packaged revision to the same link", async () => {
+    const created = await createShare()
+    fs.writeFileSync(path.join(tmpDir, label, "adt", ".build-version"), "def456")
+    const response = await app.request(`/api/books/${label}/validation/shares/${created.share.share_id}/publish`, { method: "POST" })
+    expect(response.status).toBe(200)
+    const page = await app.request(new URL(created.url).pathname)
+    expect(await page.text()).toContain(`/adt/v-def456/index.html`)
+  })
+})

--- a/apps/api/src/routes/validation-shares.ts
+++ b/apps/api/src/routes/validation-shares.ts
@@ -1,0 +1,102 @@
+import fs from "node:fs"
+import path from "node:path"
+import { Hono } from "hono"
+import { HTTPException } from "hono/http-exception"
+import { CreateValidationShare, SubmitValidationShareFeedback, parseBookLabel } from "@adt/types"
+import {
+  createValidationShare,
+  listValidationShareFeedback,
+  listValidationShares,
+  requireActiveValidationShare,
+  publishValidationShareVersion,
+  revokeValidationShare,
+  saveValidationShareFeedback,
+} from "../services/validation-share-service.js"
+
+function readPackageVersion(label: string, booksDir: string) {
+  const safeLabel = parseBookLabel(label)
+  const versionPath = path.join(path.resolve(booksDir), safeLabel, "adt", ".build-version")
+  if (!fs.existsSync(versionPath)) throw new HTTPException(409, { message: "Package the ADT preview before sharing it" })
+  const version = fs.readFileSync(versionPath, "utf8").trim()
+  if (!version) throw new HTTPException(409, { message: "Package the ADT preview before sharing it" })
+  return { safeLabel, version }
+}
+
+function publicBaseUrl(requestUrl: string) {
+  return (process.env.VALIDATION_PUBLIC_BASE_URL || new URL(requestUrl).origin).replace(/\/$/, "")
+}
+
+function isPubliclyReachable(url: string) {
+  const hostname = new URL(url).hostname
+  return !["localhost", "127.0.0.1", "::1"].includes(hostname)
+}
+
+function renderSharedValidationPage(label: string, token: string, version: string, expiresAt: string) {
+  const previewUrl = `/api/books/${encodeURIComponent(label)}/adt/v-${encodeURIComponent(version)}/index.html`
+  const feedbackUrl = `/api/public/validation/${encodeURIComponent(label)}/${encodeURIComponent(token)}/feedback`
+  const scriptData = JSON.stringify({ feedbackUrl })
+  return `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>ADT book validation</title><style>
+*{box-sizing:border-box}body{margin:0;font:16px system-ui,sans-serif;background:#f8fafc;color:#172033}.bar{display:flex;gap:1rem;align-items:center;padding:.75rem 1rem;background:#fff;border-bottom:1px solid #dbe3ed}.bar strong{margin-right:auto}.layout{height:calc(100vh - 59px);display:grid;grid-template-columns:minmax(0,1fr) 22rem}.preview{width:100%;height:100%;border:0;background:#fff}.panel{padding:1rem;overflow:auto;border-left:1px solid #dbe3ed;background:#fff}label{display:block;font-weight:600;margin:.8rem 0 .3rem}input,select,textarea,button{width:100%;font:inherit;padding:.65rem;border:1px solid #9aa7b8;border-radius:.45rem}textarea{min-height:9rem;resize:vertical}button{margin-top:1rem;background:#087f5b;color:#fff;border:0;font-weight:700;cursor:pointer}button:focus,input:focus,select:focus,textarea:focus{outline:3px solid #66d9b7;outline-offset:2px}.hint,.status{font-size:.875rem;color:#526175}.status{min-height:1.3rem;margin-top:.75rem}@media(max-width:800px){.layout{height:auto;display:block}.preview{height:70vh}.panel{border-left:0;border-top:1px solid #dbe3ed}}
+</style></head><body>
+<header class="bar"><strong>ADT book validation</strong><span>Link expires ${new Date(expiresAt).toLocaleDateString("en")}</span></header>
+<main class="layout"><iframe id="preview" class="preview" src="${previewUrl}" title="Book preview"></iframe>
+<aside class="panel" aria-labelledby="feedback-title"><h1 id="feedback-title">Send feedback</h1><p class="hint">Play the narration and sign-language videos in the preview. Your note is saved directly in ADT for the expert.</p>
+<form id="feedback"><label for="reviewer">Your name</label><input id="reviewer" name="reviewer_name" required maxlength="200" autocomplete="name">
+<label for="category">Area</label><select id="category" name="category"><option value="content">Content</option><option value="voice">Voice or narration</option><option value="sign-language">Sign language</option><option value="accessibility">Accessibility</option><option value="other">Other</option></select>
+<label for="comment">Correction or comment</label><textarea id="comment" name="comment" required maxlength="10000"></textarea>
+<button type="submit">Send to ADT expert</button><p id="status" class="status" role="status" aria-live="polite"></p></form></aside></main>
+<script>const DATA=${scriptData};const form=document.getElementById('feedback'),status=document.getElementById('status'),frame=document.getElementById('preview');form.addEventListener('submit',async(e)=>{e.preventDefault();status.textContent='Sending…';let page_href;try{page_href=frame.contentWindow.location.pathname}catch{}const body=Object.fromEntries(new FormData(form));body.page_href=page_href;const res=await fetch(DATA.feedbackUrl,{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify(body)});if(res.ok){form.comment.value='';status.textContent='Feedback sent. Thank you.'}else{status.textContent='Could not send feedback. Please retry.'}});</script>
+</body></html>`
+}
+
+export function createValidationShareRoutes(booksDir: string): Hono {
+  const app = new Hono()
+
+  app.get("/books/:label/validation/shares", (c) => {
+    const shares = listValidationShares(c.req.param("label"), booksDir)
+    const feedback = listValidationShareFeedback(c.req.param("label"), booksDir)
+    return c.json({ shares, feedback })
+  })
+
+  app.post("/books/:label/validation/shares", async (c) => {
+    const parsed = CreateValidationShare.safeParse(await c.req.json<unknown>())
+    if (!parsed.success) throw new HTTPException(400, { message: parsed.error.message })
+    const { safeLabel, version } = readPackageVersion(c.req.param("label"), booksDir)
+    const created = createValidationShare(safeLabel, booksDir, version, parsed.data.expires_in_days)
+    const baseUrl = publicBaseUrl(c.req.url)
+    return c.json({
+      version: created.version,
+      share: created.share,
+      url: `${baseUrl}/api/public/validation/${encodeURIComponent(safeLabel)}/${encodeURIComponent(created.token)}`,
+      publicly_reachable: isPubliclyReachable(baseUrl),
+    }, 201)
+  })
+
+  app.post("/books/:label/validation/shares/:shareId/revoke", (c) =>
+    c.json(revokeValidationShare(c.req.param("label"), booksDir, c.req.param("shareId"))),
+  )
+
+  app.post("/books/:label/validation/shares/:shareId/publish", (c) => {
+    const { safeLabel, version } = readPackageVersion(c.req.param("label"), booksDir)
+    return c.json(publishValidationShareVersion(safeLabel, booksDir, c.req.param("shareId"), version))
+  })
+
+  app.get("/public/validation/:label/:token", (c) => {
+    const entry = requireActiveValidationShare(c.req.param("label"), booksDir, c.req.param("token"))
+    c.header("Content-Type", "text/html; charset=utf-8")
+    c.header("Cache-Control", "no-store")
+    c.header("X-Robots-Tag", "noindex, nofollow")
+    return c.body(renderSharedValidationPage(c.req.param("label"), c.req.param("token"), entry.share.package_version, entry.share.expires_at))
+  })
+
+  app.post("/public/validation/:label/:token/feedback", async (c) => {
+    const share = requireActiveValidationShare(c.req.param("label"), booksDir, c.req.param("token"))
+    const parsed = SubmitValidationShareFeedback.safeParse(await c.req.json<unknown>())
+    if (!parsed.success) throw new HTTPException(400, { message: parsed.error.message })
+    return c.json(saveValidationShareFeedback(c.req.param("label"), booksDir, share.share.share_id, parsed.data), 201)
+  })
+
+  return app
+}

--- a/apps/api/src/services/validation-share-service.ts
+++ b/apps/api/src/services/validation-share-service.ts
@@ -1,0 +1,128 @@
+import crypto from "node:crypto"
+import fs from "node:fs"
+import path from "node:path"
+import { HTTPException } from "hono/http-exception"
+import { createBookStorage, openBookDb } from "@adt/storage"
+import {
+  ValidationShare as ValidationShareSchema,
+  ValidationShareFeedback as ValidationShareFeedbackSchema,
+  parseBookLabel,
+  type ValidationShare,
+  type ValidationShareFeedback,
+  type SubmitValidationShareFeedback,
+} from "@adt/types"
+
+export const VALIDATION_SHARE_NODE = "validation-share"
+export const VALIDATION_SHARE_FEEDBACK_NODE = "validation-share-feedback"
+
+export type VersionedValidationShare = { version: number; share: ValidationShare }
+export type VersionedValidationShareFeedback = { version: number; feedback: ValidationShareFeedback }
+
+function dbPathFor(label: string, booksDir: string) {
+  const safeLabel = parseBookLabel(label)
+  const bookDir = path.join(path.resolve(booksDir), safeLabel)
+  const dbPath = path.join(bookDir, `${safeLabel}.db`)
+  if (!fs.existsSync(dbPath)) throw new HTTPException(404, { message: `Book not found: ${safeLabel}` })
+  return { safeLabel, bookDir, dbPath }
+}
+
+function latestRows(dbPath: string, node: string) {
+  const db = openBookDb(dbPath)
+  try {
+    return db.all(
+      `SELECT current.item_id, current.version, current.data FROM node_data current
+       INNER JOIN (SELECT item_id, MAX(version) max_version FROM node_data WHERE node = ? GROUP BY item_id) latest
+       ON current.item_id = latest.item_id AND current.version = latest.max_version
+       WHERE current.node = ? ORDER BY current.item_id`,
+      [node, node],
+    ) as Array<{ item_id: string; version: number; data: string }>
+  } finally { db.close() }
+}
+
+export function hashValidationShareToken(token: string) {
+  return crypto.createHash("sha256").update(token).digest("hex")
+}
+
+export function listValidationShares(label: string, booksDir: string): VersionedValidationShare[] {
+  const { dbPath } = dbPathFor(label, booksDir)
+  return latestRows(dbPath, VALIDATION_SHARE_NODE).map((row) => ({
+    version: row.version,
+    share: ValidationShareSchema.parse(JSON.parse(row.data)),
+  }))
+}
+
+export function createValidationShare(label: string, booksDir: string, packageVersion: string, expiresInDays: number) {
+  const { safeLabel } = dbPathFor(label, booksDir)
+  const token = crypto.randomBytes(32).toString("base64url")
+  const now = new Date()
+  const share: ValidationShare = {
+    share_id: crypto.randomUUID(),
+    token_hash: hashValidationShareToken(token),
+    package_version: packageVersion,
+    created_at: now.toISOString(),
+    expires_at: new Date(now.getTime() + expiresInDays * 86_400_000).toISOString(),
+  }
+  const storage = createBookStorage(safeLabel, booksDir)
+  try {
+    const version = storage.putNodeData(VALIDATION_SHARE_NODE, share.share_id, share)
+    return { version, share, token }
+  } finally { storage.close() }
+}
+
+export function revokeValidationShare(label: string, booksDir: string, shareId: string) {
+  const current = listValidationShares(label, booksDir).find((entry) => entry.share.share_id === shareId)
+  if (!current) throw new HTTPException(404, { message: "Validation share not found" })
+  const { safeLabel } = dbPathFor(label, booksDir)
+  const share = { ...current.share, revoked_at: new Date().toISOString() }
+  const storage = createBookStorage(safeLabel, booksDir)
+  try {
+    const version = storage.putNodeData(VALIDATION_SHARE_NODE, shareId, share)
+    return { version, share }
+  } finally { storage.close() }
+}
+
+export function publishValidationShareVersion(label: string, booksDir: string, shareId: string, packageVersion: string) {
+  const current = listValidationShares(label, booksDir).find((entry) => entry.share.share_id === shareId)
+  if (!current) throw new HTTPException(404, { message: "Validation share not found" })
+  if (current.share.revoked_at) throw new HTTPException(409, { message: "A revoked validation link cannot be republished" })
+  const { safeLabel } = dbPathFor(label, booksDir)
+  const share = { ...current.share, package_version: packageVersion }
+  const storage = createBookStorage(safeLabel, booksDir)
+  try {
+    const version = storage.putNodeData(VALIDATION_SHARE_NODE, shareId, share)
+    return { version, share }
+  } finally { storage.close() }
+}
+
+export function requireActiveValidationShare(label: string, booksDir: string, token: string) {
+  const tokenHash = hashValidationShareToken(token)
+  const entry = listValidationShares(label, booksDir).find(({ share }) =>
+    crypto.timingSafeEqual(Buffer.from(share.token_hash, "hex"), Buffer.from(tokenHash, "hex")),
+  )
+  if (!entry || entry.share.revoked_at || Date.parse(entry.share.expires_at) <= Date.now()) {
+    throw new HTTPException(404, { message: "This validation link is invalid or no longer active" })
+  }
+  return entry
+}
+
+export function listValidationShareFeedback(label: string, booksDir: string, shareId?: string) {
+  const { dbPath } = dbPathFor(label, booksDir)
+  return latestRows(dbPath, VALIDATION_SHARE_FEEDBACK_NODE)
+    .map((row) => ({ version: row.version, feedback: ValidationShareFeedbackSchema.parse(JSON.parse(row.data)) }))
+    .filter((entry) => !shareId || entry.feedback.share_id === shareId) as VersionedValidationShareFeedback[]
+}
+
+export function saveValidationShareFeedback(label: string, booksDir: string, shareId: string, input: SubmitValidationShareFeedback) {
+  const { safeLabel } = dbPathFor(label, booksDir)
+  const feedback: ValidationShareFeedback = ValidationShareFeedbackSchema.parse({
+    ...input,
+    feedback_id: crypto.randomUUID(),
+    share_id: shareId,
+    created_at: new Date().toISOString(),
+  })
+  const storage = createBookStorage(safeLabel, booksDir)
+  try {
+    const version = storage.putNodeData(VALIDATION_SHARE_FEEDBACK_NODE, feedback.feedback_id, feedback)
+    return { version, feedback }
+  } finally { storage.close() }
+}

--- a/apps/studio/src/api/client.ts
+++ b/apps/studio/src/api/client.ts
@@ -16,6 +16,8 @@ import type {
   ReviewerValidationInstruction,
   ReviewerValidationSection,
   ReviewerValidationSession,
+  ValidationShareType,
+  ValidationShareFeedbackType,
   TranslationEvaluationResult,
 } from "@adt/types"
 import type { ExportFormat } from "@/components/pipeline/stages/export/export-formats"
@@ -731,6 +733,18 @@ export interface ReviewerValidationSessionsResponse {
   sessions: ReviewerValidationSessionEntry[]
 }
 
+export interface ValidationSharesResponse {
+  shares: Array<{ version: number; share: ValidationShareType }>
+  feedback: Array<{ version: number; feedback: ValidationShareFeedbackType }>
+}
+
+export interface CreatedValidationShare {
+  version: number
+  share: ValidationShareType
+  url: string
+  publicly_reachable: boolean
+}
+
 export interface ReviewerPageValidationRecordEntry {
   version: number
   record: ReviewerPageValidationRecord
@@ -1429,6 +1443,27 @@ export const api = {
       method: "POST",
       body: JSON.stringify(record),
     }),
+
+  getValidationShares: (label: string) =>
+    request<ValidationSharesResponse>(`/books/${label}/validation/shares`),
+
+  createValidationShare: (label: string, expiresInDays: number) =>
+    request<CreatedValidationShare>(`/books/${label}/validation/shares`, {
+      method: "POST",
+      body: JSON.stringify({ expires_in_days: expiresInDays }),
+    }),
+
+  revokeValidationShare: (label: string, shareId: string) =>
+    request<{ version: number; share: ValidationShareType }>(
+      `/books/${label}/validation/shares/${shareId}/revoke`,
+      { method: "POST" },
+    ),
+
+  publishValidationShare: (label: string, shareId: string) =>
+    request<{ version: number; share: ValidationShareType }>(
+      `/books/${label}/validation/shares/${shareId}/publish`,
+      { method: "POST" },
+    ),
 
   getVersionHistory: (
     label: string,

--- a/apps/studio/src/components/pipeline/stages/ValidationView.test.tsx
+++ b/apps/studio/src/components/pipeline/stages/ValidationView.test.tsx
@@ -62,6 +62,10 @@ vi.mock("@/components/validation/ReviewerValidationSummaryTab", () => ({
   ReviewerValidationSummaryTab: ({ label }: { label: string }) => <div>reviewer-validation:{label}</div>,
 }))
 
+vi.mock("@/components/validation/ValidationShareDialog", () => ({
+  ValidationShareDialog: ({ label }: { label: string }) => <button>share-validation:{label}</button>,
+}))
+
 afterEach(() => {
   cleanup()
   vi.clearAllMocks()

--- a/apps/studio/src/components/pipeline/stages/ValidationView.tsx
+++ b/apps/studio/src/components/pipeline/stages/ValidationView.tsx
@@ -13,6 +13,7 @@ import { useBookTasks } from "@/hooks/use-book-tasks"
 import { AccessibilityOverviewTab } from "@/components/validation/AccessibilityValidationTabs"
 import { ReviewerValidationSummaryTab } from "@/components/validation/ReviewerValidationSummaryTab"
 import { useReviewerValidationCatalog } from "@/hooks/use-reviewer-validation"
+import { ValidationShareDialog } from "@/components/validation/ValidationShareDialog"
 
 const VALIDATION_TABS = new Set([
   "accessibility-summary",
@@ -121,10 +122,13 @@ export function ValidationView({ bookLabel }: { bookLabel: string }) {
             </div>
           </div>
 
-          <Button variant="outline" size="sm" className="h-8 text-xs" onClick={() => void runPackage()}>
-            <RotateCcw className="h-3.5 w-3.5" />
-            <Trans>Refresh validation</Trans>
-          </Button>
+          <div className="flex items-center gap-2">
+            <ValidationShareDialog label={bookLabel} />
+            <Button variant="outline" size="sm" className="h-8 text-xs" onClick={() => void runPackage()}>
+              <RotateCcw className="h-3.5 w-3.5" />
+              <Trans>Refresh validation</Trans>
+            </Button>
+          </div>
         </div>
 
         {error ? (

--- a/apps/studio/src/components/validation/ValidationShareDialog.tsx
+++ b/apps/studio/src/components/validation/ValidationShareDialog.tsx
@@ -1,0 +1,73 @@
+import { useState } from "react"
+import { Trans, useLingui } from "@lingui/react/macro"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { Check, Copy, ExternalLink, Link2, Loader2, RefreshCw, ShieldX } from "lucide-react"
+import { api } from "@/api/client"
+import { Button } from "@/components/ui/button"
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog"
+import { Label } from "@/components/ui/label"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+
+export function ValidationShareDialog({ label }: { label: string }) {
+  const { t } = useLingui()
+  const queryClient = useQueryClient()
+  const [days, setDays] = useState("14")
+  const [createdUrl, setCreatedUrl] = useState<string | null>(null)
+  const [isPublic, setIsPublic] = useState(true)
+  const [copied, setCopied] = useState(false)
+  const shares = useQuery({
+    queryKey: ["validation-shares", label],
+    queryFn: () => api.getValidationShares(label),
+  })
+  const createShare = useMutation({
+    mutationFn: () => api.createValidationShare(label, Number(days)),
+    onSuccess: (result) => {
+      setCreatedUrl(result.url)
+      setIsPublic(result.publicly_reachable)
+      void queryClient.invalidateQueries({ queryKey: ["validation-shares", label] })
+    },
+  })
+  const revokeShare = useMutation({
+    mutationFn: (shareId: string) => api.revokeValidationShare(label, shareId),
+    onSuccess: () => void queryClient.invalidateQueries({ queryKey: ["validation-shares", label] }),
+  })
+  const publishShare = useMutation({
+    mutationFn: (shareId: string) => api.publishValidationShare(label, shareId),
+    onSuccess: () => void queryClient.invalidateQueries({ queryKey: ["validation-shares", label] }),
+  })
+  const activeShares = (shares.data?.shares ?? []).filter(({ share }) =>
+    !share.revoked_at && Date.parse(share.expires_at) > Date.now(),
+  )
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild><Button size="sm"><Link2 className="h-4 w-4" /><Trans>Share for validation</Trans></Button></DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle><Trans>Share book for validation</Trans></DialogTitle>
+          <DialogDescription><Trans>Create an expiring link where validators can test content, narration, sign language, and accessibility without exporting the book.</Trans></DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div className="space-y-2"><Label htmlFor="share-expiry"><Trans>Link expiry</Trans></Label>
+            <Select value={days} onValueChange={setDays}><SelectTrigger id="share-expiry"><SelectValue /></SelectTrigger><SelectContent>
+              <SelectItem value="7"><Trans>7 days</Trans></SelectItem><SelectItem value="14"><Trans>14 days</Trans></SelectItem><SelectItem value="30"><Trans>30 days</Trans></SelectItem>
+            </SelectContent></Select>
+          </div>
+          <Button className="w-full" disabled={createShare.isPending} onClick={() => createShare.mutate()}>
+            {createShare.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Link2 className="h-4 w-4" />}<Trans>Publish validation link</Trans>
+          </Button>
+          {createShare.error ? <p className="text-sm text-destructive">{createShare.error.message}</p> : null}
+          {createdUrl ? <div className="rounded-lg border p-3"><p className="break-all text-sm">{createdUrl}</p>
+            {!isPublic ? <p className="mt-2 text-sm text-amber-700"><Trans>This is a local link. Configure VALIDATION_PUBLIC_BASE_URL to a deployed ADT address before sending it to another device.</Trans></p> : null}
+            <div className="mt-3 flex gap-2"><Button variant="outline" size="sm" onClick={() => { void navigator.clipboard.writeText(createdUrl); setCopied(true) }}>{copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}{copied ? t`Copied` : t`Copy link`}</Button>
+              <Button variant="outline" size="sm" asChild><a href={createdUrl} target="_blank" rel="noreferrer"><ExternalLink className="h-4 w-4" /><Trans>Open</Trans></a></Button></div>
+          </div> : null}
+          {activeShares.length > 0 ? <div className="space-y-2 border-t pt-4"><h3 className="text-sm font-semibold"><Trans>Active links</Trans></h3>
+            {activeShares.map(({ share }) => <div key={share.share_id} className="rounded-md border px-3 py-2 text-sm"><div className="flex items-center justify-between gap-3"><span><Trans>Expires</Trans> {new Date(share.expires_at).toLocaleDateString()}</span><div className="flex gap-1"><Button variant="ghost" size="sm" disabled={publishShare.isPending} onClick={() => publishShare.mutate(share.share_id)}><RefreshCw className="h-4 w-4" /><Trans>Publish latest fixes</Trans></Button><Button variant="ghost" size="sm" disabled={revokeShare.isPending} onClick={() => revokeShare.mutate(share.share_id)}><ShieldX className="h-4 w-4" /><Trans>Revoke</Trans></Button></div></div><p className="mt-1 text-xs text-muted-foreground"><Trans>Published revision:</Trans> {share.package_version}</p></div>)}
+          </div> : null}
+          {(shares.data?.feedback.length ?? 0) > 0 ? <p className="text-sm text-muted-foreground"><Trans>{shares.data?.feedback.length ?? 0} validator feedback items are saved in this book.</Trans></p> : null}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -256,6 +256,10 @@ msgstr "{0} texts"
 msgid "{0} translations"
 msgstr "{0} translations"
 
+#. placeholder {0}: shares.data?.feedback.length ?? 0
+msgid "{0} validator feedback items are saved in this book."
+msgstr "{0} validator feedback items are saved in this book."
+
 #. placeholder {0}: versions.length
 #~ msgid "{0} versions"
 #~ msgstr "{0} versions"
@@ -493,6 +497,9 @@ msgstr "1.1 Background"
 msgid "1.2 Scope"
 msgstr "1.2 Scope"
 
+msgid "14 days"
+msgstr "14 days"
+
 msgid "14.2 kB"
 msgstr "14.2 kB"
 
@@ -526,11 +533,17 @@ msgstr "3 of 5 modules"
 msgid "3.2.1 — Authentication Methods"
 msgstr "3.2.1 — Authentication Methods"
 
+msgid "30 days"
+msgstr "30 days"
+
 msgid "36 spreads"
 msgstr "36 spreads"
 
 msgid "42 figs"
 msgstr "42 figs"
+
+msgid "7 days"
+msgstr "7 days"
 
 msgid "72 panels"
 msgstr "72 panels"
@@ -729,6 +742,9 @@ msgstr "active item"
 
 msgid "active items"
 msgstr "active items"
+
+msgid "Active links"
+msgstr "Active links"
 
 msgid "Active reviewer session"
 msgstr "Active reviewer session"
@@ -2303,6 +2319,9 @@ msgstr "Copy error details"
 msgid "Copy error output"
 msgstr "Copy error output"
 
+msgid "Copy link"
+msgstr "Copy link"
+
 msgid "Coral reefs cover less than 1% of the ocean floor, yet they support roughly 25% of all marine species. Often called the 'rainforests of the sea,' these underwater ecosystems are built by tiny animals called coral polyps."
 msgstr "Coral reefs cover less than 1% of the ocean floor, yet they support roughly 25% of all marine species. Often called the 'rainforests of the sea,' these underwater ecosystems are built by tiny animals called coral polyps."
 
@@ -2387,6 +2406,9 @@ msgstr "Create a reviewer session for this book."
 
 msgid "Create ADT"
 msgstr "Create ADT"
+
+msgid "Create an expiring link where validators can test content, narration, sign language, and accessibility without exporting the book."
+msgstr "Create an expiring link where validators can test content, narration, sign language, and accessibility without exporting the book."
 
 msgid "Create descriptive captions for images to improve accessibility."
 msgstr "Create descriptive captions for images to improve accessibility."
@@ -3267,6 +3289,9 @@ msgstr "Expand all sections"
 
 msgid "Experimental configurations"
 msgstr "Experimental configurations"
+
+msgid "Expires"
+msgstr "Expires"
 
 msgid "Expiry"
 msgstr "Expiry"
@@ -4514,6 +4539,9 @@ msgstr "Língua Portuguesa - 3° Ano"
 
 msgid "Link"
 msgstr "Link"
+
+msgid "Link expiry"
+msgstr "Link expiry"
 
 msgid "Link page"
 msgstr "Link page"
@@ -6429,8 +6457,17 @@ msgstr "Pruned: {reason}"
 msgid "PT"
 msgstr "PT"
 
+msgid "Publish latest fixes"
+msgstr "Publish latest fixes"
+
+msgid "Publish validation link"
+msgstr "Publish validation link"
+
 msgid "published in"
 msgstr "published in"
+
+msgid "Published revision:"
+msgstr "Published revision:"
 
 msgid "Publisher"
 msgstr "Publisher"
@@ -7047,6 +7084,9 @@ msgstr "Reviewer validation summary"
 msgid "Reviewing..."
 msgstr "Reviewing..."
 
+msgid "Revoke"
+msgstr "Revoke"
+
 msgid "Rewriting the story of this section..."
 msgstr "Rewriting the story of this section..."
 
@@ -7626,6 +7666,12 @@ msgstr "Settings navigation"
 
 msgid "Shadow"
 msgstr "Shadow"
+
+msgid "Share book for validation"
+msgstr "Share book for validation"
+
+msgid "Share for validation"
+msgstr "Share for validation"
 
 msgid "Shared prompt versions"
 msgstr "Shared prompt versions"
@@ -8571,6 +8617,9 @@ msgstr "This image is marked decorative — click to un-mark"
 
 msgid "This is <0>ADT Studio</0>."
 msgstr "This is <0>ADT Studio</0>."
+
+msgid "This is a local link. Configure VALIDATION_PUBLIC_BASE_URL to a deployed ADT address before sending it to another device."
+msgstr "This is a local link. Configure VALIDATION_PUBLIC_BASE_URL to a deployed ADT address before sending it to another device."
 
 msgid "This is a preview of the options you have selected for your book, each option affects the preview in a different way."
 msgstr "This is a preview of the options you have selected for your book, each option affects the preview in a different way."

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -256,6 +256,10 @@ msgstr "{0} textos"
 msgid "{0} translations"
 msgstr "{0} traducciones"
 
+#. placeholder {0}: shares.data?.feedback.length ?? 0
+msgid "{0} validator feedback items are saved in this book."
+msgstr "{0} elementos de comentarios de validadores están guardados en este libro."
+
 #. placeholder {0}: versions.length
 #~ msgid "{0} versions"
 #~ msgstr "{0} versiones"
@@ -493,6 +497,9 @@ msgstr "1.1 Antecedentes"
 msgid "1.2 Scope"
 msgstr "1.2 Alcance"
 
+msgid "14 days"
+msgstr "14 días"
+
 msgid "14.2 kB"
 msgstr "14,2 kB"
 
@@ -526,11 +533,17 @@ msgstr "3 de 5 módulos"
 msgid "3.2.1 — Authentication Methods"
 msgstr "3.2.1 — Métodos de Autenticación"
 
+msgid "30 days"
+msgstr "30 días"
+
 msgid "36 spreads"
 msgstr "36 páginas dobles"
 
 msgid "42 figs"
 msgstr "42 figs"
+
+msgid "7 days"
+msgstr "7 días"
 
 msgid "72 panels"
 msgstr "72 paneles"
@@ -729,6 +742,9 @@ msgstr "active item"
 
 msgid "active items"
 msgstr "active items"
+
+msgid "Active links"
+msgstr "Enlaces activos"
 
 msgid "Active reviewer session"
 msgstr "Active reviewer session"
@@ -2303,6 +2319,9 @@ msgstr "Copiar detalles del error"
 msgid "Copy error output"
 msgstr "Copiar salida de error"
 
+msgid "Copy link"
+msgstr "Copiar enlace"
+
 msgid "Coral reefs cover less than 1% of the ocean floor, yet they support roughly 25% of all marine species. Often called the 'rainforests of the sea,' these underwater ecosystems are built by tiny animals called coral polyps."
 msgstr "Los arrecifes de coral cubren menos del 1% del fondo oceánico, pero sostienen aproximadamente el 25% de todas las especies marinas. A menudo llamados 'los bosques lluviosos del mar', estos ecosistemas submarinos son construidos por pequeños animales llamados pólipos de coral."
 
@@ -2387,6 +2406,9 @@ msgstr "Create a reviewer session for this book."
 
 msgid "Create ADT"
 msgstr "Crear ADT"
+
+msgid "Create an expiring link where validators can test content, narration, sign language, and accessibility without exporting the book."
+msgstr "Crea un enlace con caducidad donde los validadores puedan probar el contenido, la narración, la lengua de signos y la accesibilidad sin exportar el libro."
 
 msgid "Create descriptive captions for images to improve accessibility."
 msgstr "Crea subtítulos descriptivos para las imágenes para mejorar la accesibilidad."
@@ -3267,6 +3289,9 @@ msgstr "Expandir todas las secciones"
 
 msgid "Experimental configurations"
 msgstr "Configuraciones experimentales"
+
+msgid "Expires"
+msgstr "Caduca"
 
 msgid "Expiry"
 msgstr "Vencimiento"
@@ -4514,6 +4539,9 @@ msgstr "Lengua Portuguesa - 3° Año"
 
 msgid "Link"
 msgstr "Enlace"
+
+msgid "Link expiry"
+msgstr "Caducidad del enlace"
 
 msgid "Link page"
 msgstr "Enlazar página"
@@ -6429,8 +6457,17 @@ msgstr "Eliminado: {0}"
 msgid "PT"
 msgstr "PT"
 
+msgid "Publish latest fixes"
+msgstr "Publicar las últimas correcciones"
+
+msgid "Publish validation link"
+msgstr "Publicar enlace de validación"
+
 msgid "published in"
 msgstr "publicado en"
+
+msgid "Published revision:"
+msgstr "Revisión publicada:"
 
 msgid "Publisher"
 msgstr "Editorial"
@@ -7047,6 +7084,9 @@ msgstr "Reviewer validation summary"
 msgid "Reviewing..."
 msgstr "Revisando..."
 
+msgid "Revoke"
+msgstr "Revocar"
+
 msgid "Rewriting the story of this section..."
 msgstr "Reescribiendo la historia de esta sección..."
 
@@ -7626,6 +7666,12 @@ msgstr "Navegación de configuración"
 
 msgid "Shadow"
 msgstr "Sombra"
+
+msgid "Share book for validation"
+msgstr "Compartir libro para validación"
+
+msgid "Share for validation"
+msgstr "Compartir para validación"
 
 msgid "Shared prompt versions"
 msgstr "Versiones compartidas de prompts"
@@ -8571,6 +8617,9 @@ msgstr "Esta imagen está marcada como decorativa — haz clic para desmarcar"
 
 msgid "This is <0>ADT Studio</0>."
 msgstr "Esto es <0>ADT Studio</0>."
+
+msgid "This is a local link. Configure VALIDATION_PUBLIC_BASE_URL to a deployed ADT address before sending it to another device."
+msgstr "Este es un enlace local. Configura VALIDATION_PUBLIC_BASE_URL con una dirección ADT desplegada antes de enviarlo a otro dispositivo."
 
 msgid "This is a preview of the options you have selected for your book, each option affects the preview in a different way."
 msgstr "Esta es una vista previa de las opciones que has seleccionado para tu libro, cada opción afecta la vista previa de una manera diferente."

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -258,6 +258,10 @@ msgstr "{0} textes"
 msgid "{0} translations"
 msgstr "{0} traductions"
 
+#. placeholder {0}: shares.data?.feedback.length ?? 0
+msgid "{0} validator feedback items are saved in this book."
+msgstr "{0} éléments de retour des validateurs sont enregistrés dans ce livre."
+
 #. placeholder {0}: versions.length
 #~ msgid "{0} versions"
 #~ msgstr "{0} versions"
@@ -495,6 +499,9 @@ msgstr "1.1 Contexte"
 msgid "1.2 Scope"
 msgstr "1.2 Portée"
 
+msgid "14 days"
+msgstr "14 jours"
+
 msgid "14.2 kB"
 msgstr "14,2 ko"
 
@@ -528,11 +535,17 @@ msgstr "3 sur 5 modules"
 msgid "3.2.1 — Authentication Methods"
 msgstr "3.2.1 — Méthodes d'authentification"
 
+msgid "30 days"
+msgstr "30 jours"
+
 msgid "36 spreads"
 msgstr "36 doubles pages"
 
 msgid "42 figs"
 msgstr "42 figs"
+
+msgid "7 days"
+msgstr "7 jours"
 
 msgid "72 panels"
 msgstr "72 panneaux"
@@ -731,6 +744,9 @@ msgstr "élément actif"
 
 msgid "active items"
 msgstr "éléments actifs"
+
+msgid "Active links"
+msgstr "Liens actifs"
 
 msgid "Active reviewer session"
 msgstr "Session de révision active"
@@ -2305,6 +2321,9 @@ msgstr "Copier les détails de l'erreur"
 msgid "Copy error output"
 msgstr "Copier la sortie d'erreur"
 
+msgid "Copy link"
+msgstr "Copier le lien"
+
 msgid "Coral reefs cover less than 1% of the ocean floor, yet they support roughly 25% of all marine species. Often called the 'rainforests of the sea,' these underwater ecosystems are built by tiny animals called coral polyps."
 msgstr "Les récifs coralliens couvrent moins de 1 % du fond océanique, mais ils abritent environ 25 % de toutes les espèces marines. Souvent appelés les « forêts tropicales de la mer », ces écosystèmes sous-marins sont construits par de minuscules animaux appelés polypes coralliens."
 
@@ -2389,6 +2408,9 @@ msgstr "Créer une session de révision pour ce livre."
 
 msgid "Create ADT"
 msgstr "Créer ADT"
+
+msgid "Create an expiring link where validators can test content, narration, sign language, and accessibility without exporting the book."
+msgstr "Créez un lien temporaire permettant aux validateurs de tester le contenu, la narration, la langue des signes et l’accessibilité sans exporter le livre."
 
 msgid "Create descriptive captions for images to improve accessibility."
 msgstr "Créez des légendes descriptives pour les images afin d'améliorer l'accessibilité."
@@ -3269,6 +3291,9 @@ msgstr "Développer toutes les sections"
 
 msgid "Experimental configurations"
 msgstr "Configurations expérimentales"
+
+msgid "Expires"
+msgstr "Expire"
 
 msgid "Expiry"
 msgstr "Expiration"
@@ -4516,6 +4541,9 @@ msgstr "Língua Portuguesa - 3° Ano"
 
 msgid "Link"
 msgstr "Lien"
+
+msgid "Link expiry"
+msgstr "Expiration du lien"
 
 msgid "Link page"
 msgstr "Lier la page"
@@ -6431,8 +6459,17 @@ msgstr "Élagué : {reason}"
 msgid "PT"
 msgstr "PT"
 
+msgid "Publish latest fixes"
+msgstr "Publier les dernières corrections"
+
+msgid "Publish validation link"
+msgstr "Publier le lien de validation"
+
 msgid "published in"
 msgstr "publié en"
+
+msgid "Published revision:"
+msgstr "Révision publiée :"
 
 msgid "Publisher"
 msgstr "Éditeur"
@@ -7049,6 +7086,9 @@ msgstr "Résumé de validation du réviseur"
 msgid "Reviewing..."
 msgstr "Révision..."
 
+msgid "Revoke"
+msgstr "Révoquer"
+
 msgid "Rewriting the story of this section..."
 msgstr "Réécriture de l'histoire de cette section..."
 
@@ -7628,6 +7668,12 @@ msgstr "Navigation des paramètres"
 
 msgid "Shadow"
 msgstr "Ombre"
+
+msgid "Share book for validation"
+msgstr "Partager le livre pour validation"
+
+msgid "Share for validation"
+msgstr "Partager pour validation"
 
 msgid "Shared prompt versions"
 msgstr "Versions partagées des prompts"
@@ -8573,6 +8619,9 @@ msgstr "Cette image est marquée comme décorative — cliquez pour désélectio
 
 msgid "This is <0>ADT Studio</0>."
 msgstr "Voici <0>ADT Studio</0>."
+
+msgid "This is a local link. Configure VALIDATION_PUBLIC_BASE_URL to a deployed ADT address before sending it to another device."
+msgstr "Ceci est un lien local. Configurez VALIDATION_PUBLIC_BASE_URL avec une adresse ADT déployée avant de l’envoyer vers un autre appareil."
 
 msgid "This is a preview of the options you have selected for your book, each option affects the preview in a different way."
 msgstr "Ceci est un aperçu des options que vous avez sélectionnées pour votre livre. Chaque option affecte l'aperçu de manière différente."

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -256,6 +256,10 @@ msgstr "{0} textos"
 msgid "{0} translations"
 msgstr "{0} traduções"
 
+#. placeholder {0}: shares.data?.feedback.length ?? 0
+msgid "{0} validator feedback items are saved in this book."
+msgstr "{0} itens de feedback dos validadores estão salvos neste livro."
+
 #. placeholder {0}: versions.length
 #~ msgid "{0} versions"
 #~ msgstr "{0} versões"
@@ -493,6 +497,9 @@ msgstr "1.1 Contexto"
 msgid "1.2 Scope"
 msgstr "1.2 Escopo"
 
+msgid "14 days"
+msgstr "14 dias"
+
 msgid "14.2 kB"
 msgstr "14,2 kB"
 
@@ -526,11 +533,17 @@ msgstr "3 de 5 módulos"
 msgid "3.2.1 — Authentication Methods"
 msgstr "3.2.1 — Métodos de Autenticação"
 
+msgid "30 days"
+msgstr "30 dias"
+
 msgid "36 spreads"
 msgstr "36 páginas duplas"
 
 msgid "42 figs"
 msgstr "42 figs"
+
+msgid "7 days"
+msgstr "7 dias"
 
 msgid "72 panels"
 msgstr "72 painéis"
@@ -729,6 +742,9 @@ msgstr "active item"
 
 msgid "active items"
 msgstr "active items"
+
+msgid "Active links"
+msgstr "Links ativos"
 
 msgid "Active reviewer session"
 msgstr "Active reviewer session"
@@ -2303,6 +2319,9 @@ msgstr "Copiar detalhes do erro"
 msgid "Copy error output"
 msgstr "Copiar saída de erro"
 
+msgid "Copy link"
+msgstr "Copiar link"
+
 msgid "Coral reefs cover less than 1% of the ocean floor, yet they support roughly 25% of all marine species. Often called the 'rainforests of the sea,' these underwater ecosystems are built by tiny animals called coral polyps."
 msgstr "Os recifes de coral cobrem menos de 1% do fundo do oceano, mas sustentam cerca de 25% de todas as espécies marinhas. Frequentemente chamados de 'florestas tropicais do mar', esses ecossistemas subaquáticos são construídos por pequenos animais chamados pólipos de coral."
 
@@ -2387,6 +2406,9 @@ msgstr "Create a reviewer session for this book."
 
 msgid "Create ADT"
 msgstr "Criar ADT"
+
+msgid "Create an expiring link where validators can test content, narration, sign language, and accessibility without exporting the book."
+msgstr "Crie um link com expiração para que os validadores testem conteúdo, narração, língua de sinais e acessibilidade sem exportar o livro."
 
 msgid "Create descriptive captions for images to improve accessibility."
 msgstr "Cria legendas descritivas para imagens para melhorar a acessibilidade."
@@ -3267,6 +3289,9 @@ msgstr "Expandir todas as seções"
 
 msgid "Experimental configurations"
 msgstr "Configurações experimentais"
+
+msgid "Expires"
+msgstr "Expira"
 
 msgid "Expiry"
 msgstr "Expiração"
@@ -4514,6 +4539,9 @@ msgstr "Língua Portuguesa - 3° Ano"
 
 msgid "Link"
 msgstr "Link"
+
+msgid "Link expiry"
+msgstr "Expiração do link"
 
 msgid "Link page"
 msgstr "Vincular página"
@@ -6429,8 +6457,17 @@ msgstr "Removido: {0}"
 msgid "PT"
 msgstr "PT"
 
+msgid "Publish latest fixes"
+msgstr "Publicar correções mais recentes"
+
+msgid "Publish validation link"
+msgstr "Publicar link de validação"
+
 msgid "published in"
 msgstr "publicado em"
+
+msgid "Published revision:"
+msgstr "Revisão publicada:"
 
 msgid "Publisher"
 msgstr "Editora"
@@ -7047,6 +7084,9 @@ msgstr "Reviewer validation summary"
 msgid "Reviewing..."
 msgstr "Revisando..."
 
+msgid "Revoke"
+msgstr "Revogar"
+
 msgid "Rewriting the story of this section..."
 msgstr "Reescrevendo a história desta seção..."
 
@@ -7626,6 +7666,12 @@ msgstr "Navegação das configurações"
 
 msgid "Shadow"
 msgstr "Sombra"
+
+msgid "Share book for validation"
+msgstr "Compartilhar livro para validação"
+
+msgid "Share for validation"
+msgstr "Compartilhar para validação"
 
 msgid "Shared prompt versions"
 msgstr "Versões compartilhadas de prompts"
@@ -8571,6 +8617,9 @@ msgstr "Esta imagem está marcada como decorativa — clique para desmarcar"
 
 msgid "This is <0>ADT Studio</0>."
 msgstr "Isto é o <0>ADT Studio</0>."
+
+msgid "This is a local link. Configure VALIDATION_PUBLIC_BASE_URL to a deployed ADT address before sending it to another device."
+msgstr "Este é um link local. Configure VALIDATION_PUBLIC_BASE_URL com um endereço ADT implantado antes de enviá-lo para outro dispositivo."
 
 msgid "This is a preview of the options you have selected for your book, each option affects the preview in a different way."
 msgstr "Esta é uma pré-visualização das opções que você selecionou para o seu livro, cada opção afeta a pré-visualização de uma maneira diferente."

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -257,6 +257,10 @@ msgstr "{0} tekste"
 msgid "{0} translations"
 msgstr "{0} përkthime"
 
+#. placeholder {0}: shares.data?.feedback.length ?? 0
+msgid "{0} validator feedback items are saved in this book."
+msgstr "{0} komente të vlerësuesve janë ruajtur në këtë libër."
+
 #. placeholder {0}: versions.length
 #~ msgid "{0} versions"
 #~ msgstr "{0} versione"
@@ -494,6 +498,9 @@ msgstr "1.1 Sfondi"
 msgid "1.2 Scope"
 msgstr "1.2 Shtrirja"
 
+msgid "14 days"
+msgstr "14 ditë"
+
 msgid "14.2 kB"
 msgstr "14.2 kB"
 
@@ -527,11 +534,17 @@ msgstr "3 nga 5 module"
 msgid "3.2.1 — Authentication Methods"
 msgstr "3.2.1 — Metodat e Autentifikimit"
 
+msgid "30 days"
+msgstr "30 ditë"
+
 msgid "36 spreads"
 msgstr "36 shpërndarje"
 
 msgid "42 figs"
 msgstr "42 figura"
+
+msgid "7 days"
+msgstr "7 ditë"
 
 msgid "72 panels"
 msgstr "72 panele"
@@ -730,6 +743,9 @@ msgstr "element aktiv"
 
 msgid "active items"
 msgstr "elementë aktivë"
+
+msgid "Active links"
+msgstr "Lidhjet aktive"
 
 msgid "Active reviewer session"
 msgstr "Sesion aktiv i rishikuesit"
@@ -2304,6 +2320,9 @@ msgstr "Kopjo detajet e gabimit"
 msgid "Copy error output"
 msgstr "Kopjo daljen e gabimit"
 
+msgid "Copy link"
+msgstr "Kopjo lidhjen"
+
 msgid "Coral reefs cover less than 1% of the ocean floor, yet they support roughly 25% of all marine species. Often called the 'rainforests of the sea,' these underwater ecosystems are built by tiny animals called coral polyps."
 msgstr "Rifet koraliere mbulojnë më pak se 1% të dyshemesë së oqeanit, por mbështesin rreth 25% të të gjitha specieve detare. Shpesh të quajtura 'pyjet e shiut të detit', këto ekosisteme nënujore ndërtohen nga kafshë të vogla të quajtura polipe korali."
 
@@ -2388,6 +2407,9 @@ msgstr "Krijoni një sesion rishikuesi për këtë libër."
 
 msgid "Create ADT"
 msgstr "Krijo ADT"
+
+msgid "Create an expiring link where validators can test content, narration, sign language, and accessibility without exporting the book."
+msgstr "Krijoni një lidhje me afat ku vlerësuesit mund të testojnë përmbajtjen, rrëfimin, gjuhën e shenjave dhe qasshmërinë pa eksportuar librin."
 
 msgid "Create descriptive captions for images to improve accessibility."
 msgstr "Krijoni përshkrime përshkruese për imazhet për të përmirësuar aksesueshmërinë."
@@ -3268,6 +3290,9 @@ msgstr "Zgjer të gjitha seksionet"
 
 msgid "Experimental configurations"
 msgstr "Konfigurime eksperimentale"
+
+msgid "Expires"
+msgstr "Skadon"
 
 msgid "Expiry"
 msgstr "Skadimi"
@@ -4515,6 +4540,9 @@ msgstr "Língua Portuguesa - 3° Ano"
 
 msgid "Link"
 msgstr "Lidhje"
+
+msgid "Link expiry"
+msgstr "Skadimi i lidhjes"
 
 msgid "Link page"
 msgstr "Faqe lidhje"
@@ -6430,8 +6458,17 @@ msgstr "Shkurtuar: {reason}"
 msgid "PT"
 msgstr "PT"
 
+msgid "Publish latest fixes"
+msgstr "Publiko rregullimet e fundit"
+
+msgid "Publish validation link"
+msgstr "Publiko lidhjen e vlerësimit"
+
 msgid "published in"
 msgstr "botuar në"
+
+msgid "Published revision:"
+msgstr "Rishikimi i publikuar:"
 
 msgid "Publisher"
 msgstr "Botuesi"
@@ -7048,6 +7085,9 @@ msgstr "Përmbledhja e validimit të rishikuesit"
 msgid "Reviewing..."
 msgstr "Duke rishikuar..."
 
+msgid "Revoke"
+msgstr "Revoko"
+
 msgid "Rewriting the story of this section..."
 msgstr "Duke rishkruar historinë e këtij seksioni..."
 
@@ -7627,6 +7667,12 @@ msgstr "Navigimi i cilësimeve"
 
 msgid "Shadow"
 msgstr "Hije"
+
+msgid "Share book for validation"
+msgstr "Ndaj librin për vlerësim"
+
+msgid "Share for validation"
+msgstr "Ndaj për vlerësim"
 
 msgid "Shared prompt versions"
 msgstr "Versionet e përbashkëta të prompt-eve"
@@ -8572,6 +8618,9 @@ msgstr "Ky imazh është shënuar si dekorativ — kliko për ta hequr shënimin
 
 msgid "This is <0>ADT Studio</0>."
 msgstr "Ky është <0>ADT Studio</0>."
+
+msgid "This is a local link. Configure VALIDATION_PUBLIC_BASE_URL to a deployed ADT address before sending it to another device."
+msgstr "Kjo është një lidhje lokale. Konfiguroni VALIDATION_PUBLIC_BASE_URL me një adresë ADT të publikuar para se ta dërgoni në një pajisje tjetër."
 
 msgid "This is a preview of the options you have selected for your book, each option affects the preview in a different way."
 msgstr "Ky është një paraparim i opsioneve të zgjedhura për librin tuaj, çdo opsion ndikon paraparimimin në mënyra të ndryshme."

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -128,6 +128,7 @@ These variables configure the API server process. Set them in your process manag
 | `CONFIG_PATH` | `./config.yaml` | Path to the global pipeline configuration file. |
 | `PROJECT_ROOT` | `.` | Base path for resolving relative paths inside the API. |
 | `OPENAI_API_KEY` | _(unset)_ | Server-level API key fallback. When set, used if no key is supplied via the `X-OpenAI-Key` request header. |
+| `VALIDATION_PUBLIC_BASE_URL` | Request origin | Public HTTPS origin used for expiring validator links (for example, `https://adt.example.org`). Required when ADT runs on localhost but links must open on another device. |
 
 When `OPENAI_API_KEY` is set server-side, users do not need to enter an API key in the UI settings dialog.
 
@@ -170,6 +171,8 @@ When hosting for a team, you have two options:
 ### Authentication
 
 ADT Studio has no built-in authentication layer. If you are hosting it for a team (not just locally), add authentication at the reverse proxy level before the application is accessible over a network:
+
+The expiring validator route (`/api/public/validation/*`) is intentionally public and protected by a 256-bit bearer token, expiry, and revocation. Keep administrative `/api/books/*` routes behind authentication, allow only the public validation route through without login, terminate TLS at the proxy, and never log full validation URLs because the URL contains the bearer token. Validator feedback is schema-validated and stored as versioned data inside the corresponding book database.
 
 ```nginx
 # Example: basic auth in nginx

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -98,6 +98,20 @@ export {
 
 export { PartRange, PartManifest, ExportedPartEntry, PartsLedger } from "./part.js"
 
+export {
+  ValidationShare,
+  CreateValidationShare,
+  ValidationShareFeedbackCategory,
+  ValidationShareFeedback,
+  SubmitValidationShareFeedback,
+} from "./validation-share.js"
+export type {
+  ValidationShare as ValidationShareType,
+  CreateValidationShare as CreateValidationShareType,
+  ValidationShareFeedback as ValidationShareFeedbackType,
+  SubmitValidationShareFeedback as SubmitValidationShareFeedbackType,
+} from "./validation-share.js"
+
 export { ProgressEvent } from "./progress.js"
 
 export {

--- a/packages/types/src/validation-share.ts
+++ b/packages/types/src/validation-share.ts
@@ -1,0 +1,44 @@
+import { z } from "zod"
+
+export const ValidationShare = z.object({
+  share_id: z.string().min(1),
+  token_hash: z.string().regex(/^[a-f0-9]{64}$/),
+  package_version: z.string().min(1),
+  created_at: z.string().datetime(),
+  expires_at: z.string().datetime(),
+  revoked_at: z.string().datetime().optional(),
+})
+export type ValidationShare = z.infer<typeof ValidationShare>
+
+export const CreateValidationShare = z.object({
+  expires_in_days: z.number().int().min(1).max(90).default(14),
+})
+export type CreateValidationShare = z.infer<typeof CreateValidationShare>
+
+export const ValidationShareFeedbackCategory = z.enum([
+  "content",
+  "voice",
+  "sign-language",
+  "accessibility",
+  "other",
+])
+
+export const ValidationShareFeedback = z.object({
+  feedback_id: z.string().min(1),
+  share_id: z.string().min(1),
+  reviewer_name: z.string().min(1).max(200),
+  category: ValidationShareFeedbackCategory,
+  page_href: z.string().max(1000).optional(),
+  comment: z.string().min(1).max(10_000),
+  created_at: z.string().datetime(),
+  resolved_at: z.string().datetime().optional(),
+})
+export type ValidationShareFeedback = z.infer<typeof ValidationShareFeedback>
+
+export const SubmitValidationShareFeedback = ValidationShareFeedback.pick({
+  reviewer_name: true,
+  category: true,
+  page_href: true,
+  comment: true,
+})
+export type SubmitValidationShareFeedback = z.infer<typeof SubmitValidationShareFeedback>


### PR DESCRIPTION
Closes #698

## Summary
- add expiring, revocable validation links backed by versioned book storage
- serve the real interactive ADT reader so validators can verify content, TTS narration, sign-language media, activities, and accessibility
- accept categorized validator feedback directly into the book database
- let experts publish the latest packaged fixes to the same link
- distinguish localhost-only links from publicly reachable deployments via `VALIDATION_PUBLIC_BASE_URL`
- document reverse-proxy and bearer-token security requirements

## Verification
- `pnpm exec vitest run apps/api/src/routes/validation-shares.test.ts` (5 tests)
- `pnpm typecheck`
- `pnpm lint` (0 errors; 9 pre-existing warnings)
- `pnpm --filter @adt/studio compile`
- browser-tested link creation, live 72-page reader loading, feedback submission, responsive validator panel, and link management with ENGLISH-STD-3-PB--2023-

## Deployment note
A cross-device URL requires ADT to be reachable over HTTPS and `VALIDATION_PUBLIC_BASE_URL` to be set. The UI explicitly warns when it can only create a localhost URL.