### PR TITLE
feat(site): publish localized LLM docs artifacts

### DIFF
--- a/apps/site/src/lib/source.ts
+++ b/apps/site/src/lib/source.ts
@@ -3,7 +3,7 @@ import { defineI18n } from 'fumadocs-core/i18n';
 import { lucideIconsPlugin } from 'fumadocs-core/source/lucide-icons';
 import { docs } from 'collections/server';
 import { docsRoute } from './shared';
-import { DEFAULT_LOCALE, LOCALES } from '@/i18n/locales';
+import { DEFAULT_LOCALE, LOCALES, type AppLocale } from '@/i18n/locales';
 
 /**
  * Docs i18n. Translations live in per-locale folders (`parser: 'dir'`), so a
@@ -57,4 +57,16 @@ export async function getLLMText(page: (typeof source)['$inferPage']) {
   return `# ${page.data.title} (${page.url})
 
 ${processed}`;
+}
+
+/**
+ * Build the complete, deterministic documentation corpus for one locale.
+ * Fumadocs supplies the English fallback for any missing translated page.
+ */
+export async function getLLMFullText(locale: AppLocale) {
+  const pages = [...source.getPages(locale)].sort((a, b) =>
+    a.url.localeCompare(b.url),
+  );
+  const scanned = await Promise.all(pages.map(getLLMText));
+  return scanned.join('\n\n');
 }

--- a/apps/site/src/routes/llms-full/{$}[.]txt.ts
+++ b/apps/site/src/routes/llms-full/{$}[.]txt.ts
@@ -1,0 +1,20 @@
+import { createFileRoute, notFound } from '@tanstack/react-router';
+import { isAppLocale } from '@/i18n/locales';
+import { getLLMFullText } from '@/lib/source';
+
+export const Route = createFileRoute('/llms-full/{$}.txt')({
+  server: {
+    handlers: {
+      GET: async ({ params }) => {
+        const locale = params._splat;
+        if (!locale || !isAppLocale(locale)) throw notFound();
+
+        return new Response(await getLLMFullText(locale), {
+          headers: {
+            'Content-Type': 'text/plain; charset=utf-8',
+          },
+        });
+      },
+    },
+  },
+});

--- a/apps/site/vite.config.ts
+++ b/apps/site/vite.config.ts
@@ -6,6 +6,7 @@ import mdx from 'fumadocs-mdx/vite';
 import { nitro } from 'nitro/vite';
 import { lingui } from '@lingui/vite-plugin';
 import * as babel from '@babel/core';
+import { LOCALES } from './src/i18n/locales';
 
 /**
  * @vitejs/plugin-react v6 transforms with oxc and no longer accepts a `babel`
@@ -67,6 +68,7 @@ export default defineConfig({
         { path: '/releases' },
         { path: '/docs' },
         { path: '/api/search' },
+        ...LOCALES.map((locale) => ({ path: `/llms-full/${locale}.txt` })),
       ],
     }),
     linguiMacro(),


### PR DESCRIPTION
## Summary
- publish deterministic full-docs artifacts for en, pt-BR, es, and fr
- prerender `/llms-full/{locale}.txt` into the GitHub Pages output
- reuse Fumadocs processed Markdown with English fallback for missing translations

## Validation
- `pnpm --filter @adt/site build`
- `pnpm --filter @adt/site types:check`
- verified 28 pages in each generated artifact
- locally served all four artifacts with CORS and verified byte-for-byte SHA-256 matches
- exercised Studio’s real docs fetch path against the local artifacts

This PR targets the standalone `landing-page` deployment branch and does not touch `develop`.