### PR TITLE
feat: make selective speech regeneration durable

### DIFF
--- a/apps/api/src/routes/tts.test.ts
+++ b/apps/api/src/routes/tts.test.ts
@@ -120,7 +120,7 @@ describe("POST /books/:label/tts/generate-one", () => {
     expect(res.status).toBe(200)
     const body = await res.json()
     expect(body.entry.textId).toBe("pg001_t001")
-    expect(body.entry.fileName).toBe("pg001_t001.wav")
+    expect(body.entry.fileName).toMatch(/^pg001_t001\.[a-f0-9]{12}\.wav$/)
     expect(body.completed).toBe(true)
     expect(body.remainingItems).toBe(0)
 
@@ -137,8 +137,44 @@ describe("POST /books/:label/tts/generate-one", () => {
     }
 
     expect(
-      fs.existsSync(path.join(tmpDir, label, "audio", "en", "pg001_t001.wav"))
+      fs.existsSync(path.join(tmpDir, label, "audio", "en", body.entry.fileName))
     ).toBe(true)
+  })
+
+  it("bypasses the speech cache for an explicit single-clip regeneration", async () => {
+    const label = "force-regenerate-audio"
+    seedBook(label)
+    fetchMock
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        candidates: [{ content: { parts: [{ inlineData: { data: Buffer.from("first-audio").toString("base64") } }] } }],
+      }), { status: 200, headers: { "Content-Type": "application/json" } }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        candidates: [{ content: { parts: [{ inlineData: { data: Buffer.from("fresh-audio").toString("base64") } }] } }],
+      }), { status: 200, headers: { "Content-Type": "application/json" } }))
+
+    const app = createTTSRoutes(tmpDir, configPath)
+    const request = (forceRegenerate: boolean, text?: string) => app.request(`/books/${label}/tts/generate-one`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "X-Gemini-API-Key": "gm-test" },
+      body: JSON.stringify({ textId: "pg001_t001", text, language: "en", forceRegenerate }),
+    })
+    const originalResponse = await request(false)
+    expect(originalResponse.status).toBe(200)
+    const originalBody = await originalResponse.json()
+    const regeneratedResponse = await request(true, "You")
+    expect(regeneratedResponse.status).toBe(200)
+    const regeneratedBody = await regeneratedResponse.json()
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    const regenerationRequest = String(fetchMock.mock.calls[1]?.[1]?.body)
+    expect(regenerationRequest).toContain("You")
+    expect(regenerationRequest).not.toContain("Hello world")
+    expect(regeneratedBody.entry.fileName).not.toBe(originalBody.entry.fileName)
+    const regeneratedAudio = fs.readFileSync(path.join(tmpDir, label, "audio", "en", regeneratedBody.entry.fileName), "utf8")
+    expect(regeneratedAudio).toContain("fresh-audio")
+    expect(regeneratedAudio).not.toContain("first-audio")
+    expect(fs.readFileSync(path.join(tmpDir, label, "audio", "en", originalBody.entry.fileName), "utf8"))
+      .toContain("first-audio")
   })
 
   it("treats excluded catalog entries as complete after generating the remaining audio", async () => {
@@ -303,7 +339,7 @@ describe("POST /books/:label/tts/generate-one", () => {
 
     expect(res.status).toBe(200)
     const body = await res.json()
-    expect(body.entry.fileName).toBe("pg001_t001.wav")
+    expect(body.entry.fileName).toMatch(/^pg001_t001\.[a-f0-9]{12}\.wav$/)
     expect(body.remainingItems).toBe(0)
   })
 
@@ -369,7 +405,7 @@ describe("POST /books/:label/tts/generate-one", () => {
 
     expect(res.status).toBe(200)
     const body = await res.json()
-    expect(body.entry.fileName).toBe("pg001_t001.wav")
+    expect(body.entry.fileName).toMatch(/^pg001_t001\.[a-f0-9]{12}\.wav$/)
     expect(body.entry.model).toBe("gemini-2.5-pro-preview-tts")
     expect(fetchMock).toHaveBeenCalledTimes(2)
 
@@ -442,7 +478,7 @@ describe("POST /books/:label/tts/generate-one", () => {
 
     expect(res.status).toBe(200)
     const body = await res.json()
-    expect(body.entry.fileName).toBe("pg001_t001.wav")
+    expect(body.entry.fileName).toMatch(/^pg001_t001\.[a-f0-9]{12}\.wav$/)
     expect(body.entry.provider).toBe("openai")
     expect(body.entry.model).toBe("tts-1-hd")
     expect(fetchMock).toHaveBeenCalledTimes(3)
@@ -460,25 +496,33 @@ describe("POST /books/:label/tts/generate-one", () => {
     expect(JSON.parse(String(thirdInit?.body))).toMatchObject({ model: "tts-1-hd" })
   })
 
-  it("rejects single-item generation when the language is not routed to Gemini", async () => {
+  it("regenerates a single item with the configured OpenAI provider", async () => {
     writeConfig("openai")
     const label = "openai-audio"
     seedBook(label)
+    fetchMock.mockResolvedValue(
+      new Response(new Uint8Array([1, 2, 3, 4]), {
+        status: 200,
+        headers: { "Content-Type": "audio/mpeg" },
+      })
+    )
 
     const app = createTTSRoutes(tmpDir, configPath)
     const res = await app.request(`/books/${label}/tts/generate-one`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        "X-Gemini-API-Key": "gm-test",
+        "X-OpenAI-Key": "sk-test",
       },
       body: JSON.stringify({ textId: "pg001_t001", language: "en" }),
     })
 
-    expect(res.status).toBe(400)
-    await expect(res.text()).resolves.toContain(
-      "Single-item audio generation is only available when Gemini is selected for that language."
-    )
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.entry.textId).toBe("pg001_t001")
+    expect(body.entry.provider).toBe("openai")
+    expect(body.entry.fileName).toMatch(/^pg001_t001\.[a-f0-9]{12}\.mp3$/)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/apps/api/src/routes/tts.ts
+++ b/apps/api/src/routes/tts.ts
@@ -43,7 +43,9 @@ import { getLiveSpeechRun } from "../services/speech-progress.js"
 const GenerateSingleTTSBody = z
   .object({
     textId: z.string().min(1),
+    text: z.string().min(1).max(100_000).optional(),
     language: z.string().min(1),
+    forceRegenerate: z.boolean().optional().default(false),
   })
   .strict()
 
@@ -155,6 +157,31 @@ function getCatalogEntriesForLanguage(
   }
 
   return (translatedRow.data as TextCatalogOutput).entries
+}
+
+function persistCatalogTextVersion(
+  storage: ReturnType<typeof createBookStorage>,
+  sourceLanguage: string,
+  language: string,
+  textId: string,
+  text: string,
+): void {
+  const normalizedLanguage = normalizeLocale(language)
+  const isSource = getBaseLanguage(sourceLanguage) === getBaseLanguage(normalizedLanguage)
+  const node = isSource ? "text-catalog" : "text-catalog-translation"
+  const itemId = isSource ? "book" : normalizedLanguage
+  const legacyItemId = normalizedLanguage.replace("-", "_")
+  const row = storage.getLatestNodeData(node, itemId) ??
+    (!isSource ? storage.getLatestNodeData(node, legacyItemId) : undefined)
+  if (!row) throw new HTTPException(404, { message: `Text catalog not found for ${normalizedLanguage}` })
+  const catalog = row.data as TextCatalogOutput
+  const current = catalog.entries.find((entry) => entry.id === textId)
+  if (!current || current.text === text) return
+  storage.putNodeData(node, itemId, {
+    ...catalog,
+    entries: catalog.entries.map((entry) => entry.id === textId ? { ...entry, text } : entry),
+    generatedAt: new Date().toISOString(),
+  } satisfies TextCatalogOutput)
 }
 
 function getLatestTtsEntries(
@@ -698,12 +725,6 @@ export function createTTSRoutes(booksDir: string, configPath?: string, taskServi
     const openaiApiKey = c.req.header("X-OpenAI-Key")?.trim()
     const azureSpeechKey = c.req.header("X-Azure-Speech-Key")?.trim()
     const azureSpeechRegion = c.req.header("X-Azure-Speech-Region")?.trim()
-    if (!geminiApiKey) {
-      throw new HTTPException(400, {
-        message: "Gemini API key required. Set X-Gemini-API-Key header.",
-      })
-    }
-
     const normalizedLanguage = normalizeLocale(parsed.data.language)
     const storage = createBookStorage(safeLabel, booksDir)
 
@@ -728,10 +749,19 @@ export function createTTSRoutes(booksDir: string, configPath?: string, taskServi
         defaultProvider: config.speech?.default_provider ?? "openai",
       }
       const provider = resolveProviderForLanguage(normalizedLanguage, routing)
-      if (provider !== "gemini") {
+      if (provider === "gemini" && !geminiApiKey) {
         throw new HTTPException(400, {
-          message:
-            "Single-item audio generation is only available when Gemini is selected for that language.",
+          message: "Gemini API key required. Set X-Gemini-API-Key header.",
+        })
+      }
+      if (provider === "openai" && !openaiApiKey) {
+        throw new HTTPException(400, {
+          message: "OpenAI API key required. Set X-OpenAI-Key header.",
+        })
+      }
+      if (provider === "azure" && (!azureSpeechKey || !azureSpeechRegion)) {
+        throw new HTTPException(400, {
+          message: "Azure Speech key and region are required.",
         })
       }
 
@@ -748,6 +778,12 @@ export function createTTSRoutes(booksDir: string, configPath?: string, taskServi
           message: `Text entry not found for ${parsed.data.textId} (${normalizedLanguage})`,
         })
       }
+      // The Studio may be displaying an unsaved or newer entity version than
+      // the persisted catalog snapshot read above. Explicit single-item
+      // regeneration must synthesize exactly what the user sees, while the
+      // catalog lookup still verifies that the requested entity ID exists.
+      const requestedText = parsed.data.text ?? textEntry.text
+      persistCatalogTextVersion(storage, sourceLanguage, normalizedLanguage, textEntry.id, requestedText)
 
       const configDir = getConfigDir(configPath)
       const voiceMaps = loadVoicesConfig(configDir)
@@ -786,7 +822,7 @@ export function createTTSRoutes(booksDir: string, configPath?: string, taskServi
       }) =>
         generateSpeechFile({
           textId: textEntry.id,
-          text: textEntry.text,
+          text: requestedText,
           language: normalizedLanguage,
           model: options.targetModel,
           voice: options.targetVoice,
@@ -803,7 +839,7 @@ export function createTTSRoutes(booksDir: string, configPath?: string, taskServi
           cacheDir,
           ttsSynthesizer:
             options.targetProvider === "gemini"
-              ? createGeminiTTSSynthesizer({ apiKey: geminiApiKey })
+              ? createGeminiTTSSynthesizer({ apiKey: geminiApiKey! })
               : options.targetProvider === "azure"
                 ? createAzureTTSSynthesizer({
                     subscriptionKey: azureSpeechKey!,
@@ -813,6 +849,7 @@ export function createTTSRoutes(booksDir: string, configPath?: string, taskServi
           provider: options.targetProvider,
           geminiTemperature: config.speech?.temperature,
           geminiSeed: config.speech?.seed,
+          forceRegenerate: parsed.data.forceRegenerate,
         })
 
       try {
@@ -860,7 +897,7 @@ export function createTTSRoutes(booksDir: string, configPath?: string, taskServi
           voice: usedVoice,
           model: usedModel,
           provider: usedProvider,
-          text: textEntry.text,
+          text: requestedText,
           durationMs: Date.now() - startMs,
           success: true,
           cached: entry.cached,
@@ -872,6 +909,7 @@ export function createTTSRoutes(booksDir: string, configPath?: string, taskServi
           languageEntries.map((item) => item.id)
         )
 
+        clearWordTimestampEntry(storage, normalizedLanguage, textEntry.id)
         const version = storage.putNodeData(
           "tts",
           normalizedLanguage,
@@ -935,7 +973,7 @@ export function createTTSRoutes(booksDir: string, configPath?: string, taskServi
                 voice: attempt.voice,
                 model: attempt.model,
                 provider: attempt.provider,
-                text: textEntry.text,
+                text: requestedText,
                 durationMs: Date.now() - startMs,
                 success: true,
                 cached: entry.cached,
@@ -947,6 +985,7 @@ export function createTTSRoutes(booksDir: string, configPath?: string, taskServi
                 languageEntries.map((item) => item.id)
               )
 
+              clearWordTimestampEntry(storage, normalizedLanguage, textEntry.id)
               const version = storage.putNodeData(
                 "tts",
                 normalizedLanguage,
@@ -967,7 +1006,7 @@ export function createTTSRoutes(booksDir: string, configPath?: string, taskServi
                 if (currentStatus === "error") {
                   storage.recordStepError(
                     "tts",
-                    `${completion.remainingItems} Gemini audio item(s) still need generation.`
+                    `${completion.remainingItems} audio item(s) still need generation.`
                   )
                 }
               }
@@ -1003,7 +1042,7 @@ export function createTTSRoutes(booksDir: string, configPath?: string, taskServi
         })
         storage.recordStepError(
           "tts",
-          `Gemini audio generation failed for ${textEntry.id}: ${fallbackFailureMessage}`
+          `Audio generation failed for ${textEntry.id}: ${fallbackFailureMessage}`
         )
 
         const status = /\(429\)|quota|rate limit/i.test(fallbackFailureMessage) ? 429 : 502

--- a/apps/api/src/services/stage-runner.test.ts
+++ b/apps/api/src/services/stage-runner.test.ts
@@ -1028,6 +1028,60 @@ speech:
     }
   })
 
+  it("keeps OpenAI TTS running progress visible after an item-level failure", async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "stage-runner-tts-"))
+    const booksDir = path.join(tmpDir, "books")
+    const promptsDir = path.join(tmpDir, "prompts")
+    const configPath = path.join(tmpDir, "config.yaml")
+    fs.mkdirSync(promptsDir, { recursive: true })
+    fs.writeFileSync(
+      configPath,
+      `role_types:
+  section_text: Main body text
+structure_types:
+  paragraph: Paragraph
+speech:
+  default_provider: openai
+`,
+    )
+    seedTextAndSpeechBook(booksDir, "openai-tts-item-failure")
+    generateSpeechFileMock.mockRejectedValueOnce(
+      new Error("OpenAI TTS request failed (400): request rejected"),
+    )
+
+    const events: ProgressEvent[] = []
+    const runner = createStageRunner()
+    await runner.run(
+      "openai-tts-item-failure",
+      {
+        booksDir,
+        apiKey: "sk-test",
+        promptsDir,
+        configPath,
+        fromStage: "translate",
+        toStage: "speech",
+      },
+      { emit: (event) => events.push(event) },
+    )
+
+    expect(
+      events.some(
+        (event) =>
+          event.type === "step-progress" &&
+          event.step === "tts" &&
+          event.message?.includes("pages ·") &&
+          event.totalPages !== undefined &&
+          event.page !== undefined,
+      ),
+    ).toBe(true)
+    expect(
+      events.some((event) => event.type === "step-error" && event.step === "tts"),
+    ).toBe(false)
+    expect(
+      events.some((event) => event.type === "step-complete" && event.step === "tts"),
+    ).toBe(true)
+  })
+
   it("retries rate-limited Gemini TTS items and completes the step when a retry succeeds", async () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "stage-runner-tts-"))
     const booksDir = path.join(tmpDir, "books")

--- a/apps/api/src/services/stage-runner.ts
+++ b/apps/api/src/services/stage-runner.ts
@@ -68,6 +68,8 @@ import {
   generateWordTimestamps,
   wavDurationSeconds,
   stripEmojis,
+  prepareTextForSpeech,
+  prepareInstructionsForSpeech,
   generateBookSummary,
   buildBookSummaryConfig,
   filterPageImageMeaningfulness,
@@ -130,6 +132,8 @@ const GEMINI_TTS_MAX_RETRY_DELAY_MS = 20_000
 // and aren't a rate signal, so they get a shorter delay than a 429 and do not
 // throttle the shared limiter.
 const GEMINI_TTS_TRANSIENT_RETRY_DELAY_MS = 1_500
+const TTS_TRANSIENT_MAX_RETRIES = 3
+const TTS_TRANSIENT_RETRY_DELAY_MS = 1_000
 
 class StepError extends Error {
   readonly step: StepName
@@ -368,6 +372,12 @@ function isGeminiTtsTransientError(message: string): boolean {
   )
 }
 
+function isTtsTransientTransportError(message: string): boolean {
+  return /fetch failed|terminated|socket|network|ECONNRESET|ETIMEDOUT|\(408\)|\(429\)|\(50\d\)/i.test(
+    message,
+  )
+}
+
 function parseGeminiRetryDelayMs(message: string): number | null {
   const match = message.match(/retry in ([\d.]+)s/i)
   if (!match) return null
@@ -486,15 +496,20 @@ function emitSpeechStepProgress(
   audioTotal: number,
   audioFailures: number,
   reusedTotal = 0,
+  pagesCompleted?: number,
+  pagesTotal?: number,
 ): void {
   const reusedSuffix = reusedTotal > 0 ? ` (${reusedTotal} reused)` : ""
   const failureSuffix = audioFailures > 0 ? ` (${audioFailures} failed)` : ""
+  const pagePrefix = pagesTotal
+    ? `${pagesCompleted ?? 0}/${pagesTotal} pages · `
+    : ""
   progress.emit({
     type: "step-progress",
     step: "tts",
-    message: `${audioCompleted}/${audioTotal} audio entries${reusedSuffix}${failureSuffix}`,
-    page: audioCompleted,
-    totalPages: audioTotal,
+    message: `${pagePrefix}${audioCompleted}/${audioTotal} audio entries${reusedSuffix}${failureSuffix}`,
+    page: pagesTotal ? (pagesCompleted ?? 0) : audioCompleted,
+    totalPages: pagesTotal || audioTotal,
   })
 }
 
@@ -633,20 +648,27 @@ function canReuseSpeechEntry(
   const expectedExt = `.${options.format.toLowerCase()}`
   if (path.extname(entry.fileName).toLowerCase() !== expectedExt) return false
 
-  const sanitized = stripEmojis(options.text).trim()
+  const sanitized = prepareTextForSpeech(stripEmojis(options.text).trim(), options.language)
+  const preparedInstructions = prepareInstructionsForSpeech(
+    options.instructions,
+    sanitized,
+    options.language,
+  )
   const cacheKey = computeSpeechCacheKey({
     text: sanitized,
     voice: options.voice,
     model: options.model,
-    instructions: options.instructions,
+    instructions: preparedInstructions,
     provider: options.provider,
     geminiTemperature: options.geminiTemperature,
     geminiSeed: options.geminiSeed,
   })
+  const outputPath = resolveSpeechOutputPath(options.bookDir, options.language, entry.fileName)
+  if (entry.sourceHash === cacheKey && outputPath && fs.existsSync(outputPath)) {
+    return true
+  }
   const cachePath = resolveSpeechCachePath(options.cacheDir, cacheKey, options.format.toLowerCase())
   if (!cachePath || !fs.existsSync(cachePath)) return false
-
-  const outputPath = resolveSpeechOutputPath(options.bookDir, options.language, entry.fileName)
   if (!outputPath) return false
 
   fs.mkdirSync(path.dirname(outputPath), { recursive: true })
@@ -2703,6 +2725,32 @@ async function runSpeechStep(
         if (isTtsExcluded(entry.id, config.speech)) continue
         languageTextMap.set(entry.id, entry.text)
 
+        const providerModel = resolveSpeechModel(provider, providerConfigs, speechModel)
+        const outputFormat = resolveSpeechFormat(provider, config.speech?.format)
+        const voice = resolveVoice(provider, lang, voiceMaps, config.speech?.voice)
+        const instructions = provider === "openai" || provider === "gemini"
+          ? resolveInstructions(lang, instructionsMap)
+          : ""
+        const existingEntry = existingSpeechEntries.get(entry.id)
+
+        if (canReuseSpeechEntry(existingEntry, {
+          bookDir,
+          cacheDir,
+          language: lang,
+          text: entry.text,
+          provider,
+          model: providerModel,
+          voice,
+          instructions,
+          format: outputFormat,
+          geminiTemperature: config.speech?.temperature,
+          geminiSeed: config.speech?.seed,
+        })) {
+          ttsResultsByLang.get(lang)?.push(existingEntry)
+          reusedEntriesByLang.set(lang, (reusedEntriesByLang.get(lang) ?? 0) + 1)
+          continue
+        }
+
         // Route page-scoped entries of a Gemini language into a per-page group
         // (generated together below). Skips the per-entry reuse check — page
         // audio is cached at the page level inside generatePageSpeechFiles.
@@ -2725,40 +2773,6 @@ async function runSpeechStep(
           continue
         }
 
-        const provider = resolveProviderForLanguage(lang, routing)
-        const providerModel = resolveSpeechModel(provider, providerConfigs, speechModel)
-        const outputFormat = resolveSpeechFormat(provider, config.speech?.format)
-        const voice = resolveVoice(provider, lang, voiceMaps, config.speech?.voice)
-        // OpenAI consumes instructions via its `instructions` field; Gemini embeds
-        // them in the prompt text (it rejects systemInstruction). Both paths must
-        // resolve identically here and in the generation loop below so the cache key
-        // (computeSpeechCacheKey) stays in sync with canReuseSpeechEntry.
-        const instructions =
-          provider === "openai" || provider === "gemini"
-            ? resolveInstructions(lang, instructionsMap)
-            : ""
-        const existingEntry = existingSpeechEntries.get(entry.id)
-
-        if (
-          canReuseSpeechEntry(existingEntry, {
-            bookDir,
-            cacheDir,
-            language: lang,
-            text: entry.text,
-            provider,
-            model: providerModel,
-            voice,
-            instructions,
-            format: outputFormat,
-            geminiTemperature: config.speech?.temperature,
-            geminiSeed: config.speech?.seed,
-          })
-        ) {
-          ttsResultsByLang.get(lang)?.push(existingEntry)
-          reusedEntriesByLang.set(lang, (reusedEntriesByLang.get(lang) ?? 0) + 1)
-          continue
-        }
-
         ttsWorkItems.push({ textId: entry.id, text: entry.text, language: lang })
       }
       textByLanguage.set(lang, languageTextMap)
@@ -2768,8 +2782,41 @@ async function runSpeechStep(
     const totalItems = ttsWorkItems.length + batchedEntryCount
     let completedItems = 0
 
+    // Track actual page completion independently from audio-entry completion.
+    // One page is complete only after every pending entry on that page has
+    // either generated or failed. Non-page items (glossary, quizzes, etc.) stay
+    // represented in the detailed audio-entry message but not the page count.
+    const pendingEntriesByPage = new Map<string, number>()
+    const completedEntriesByPage = new Map<string, number>()
+    const pageKeyFor = (languageCode: string, textId: string): string | null => {
+      const match = /^(pg\d+)_/i.exec(textId)
+      return match ? `${languageCode}::${match[1]!.toLowerCase()}` : null
+    }
+    const registerPageEntry = (languageCode: string, textId: string): void => {
+      const key = pageKeyFor(languageCode, textId)
+      if (!key) return
+      pendingEntriesByPage.set(key, (pendingEntriesByPage.get(key) ?? 0) + 1)
+    }
+    const completePageEntry = (languageCode: string, textId: string): void => {
+      const key = pageKeyFor(languageCode, textId)
+      if (!key) return
+      completedEntriesByPage.set(key, (completedEntriesByPage.get(key) ?? 0) + 1)
+    }
+    const completedPageCount = (): number => {
+      let count = 0
+      for (const [key, total] of pendingEntriesByPage) {
+        if ((completedEntriesByPage.get(key) ?? 0) >= total) count++
+      }
+      return count
+    }
+    for (const item of ttsWorkItems) registerPageEntry(item.language, item.textId)
+    for (const group of pageGroups.values()) {
+      for (const entry of group.entries) registerPageEntry(group.language, entry.id)
+    }
+    const totalSpeechPages = pendingEntriesByPage.size
+
     const reusedItems = [...reusedEntriesByLang.values()].reduce((sum, count) => sum + count, 0)
-    emitSpeechStepProgress(progress, 0, totalItems, 0, reusedItems)
+    emitSpeechStepProgress(progress, 0, totalItems, 0, reusedItems, 0, totalSpeechPages)
 
     console.log(`[stage-run] ${label}: generating TTS for ${totalItems} entries and reusing ${reusedItems} existing entries across ${outputLanguages.length} languages (${outputLanguages.join(", ")})`)
     console.log(`[stage-run] ${label}: TTS routing — for each language: ${outputLanguages.map((l) => `${l}→${resolveProviderForLanguage(l, routing)}`).join(", ")}`)
@@ -2908,7 +2955,16 @@ async function runSpeechStep(
             }
           }
           completedItems += group.entries.length
-          emitSpeechStepProgress(progress, completedItems, totalItems, failedItems.length, reusedItems)
+          for (const entry of group.entries) completePageEntry(group.language, entry.id)
+          emitSpeechStepProgress(
+            progress,
+            completedItems,
+            totalItems,
+            failedItems.length,
+            reusedItems,
+            completedPageCount(),
+            totalSpeechPages,
+          )
         },
         { runSignal: options.signal }
       )
@@ -2971,6 +3027,7 @@ async function runSpeechStep(
                 provider === "gemini" &&
                 !rateLimited &&
                 isGeminiTtsTransientError(msg)
+              const transportTransient = isTtsTransientTransportError(msg)
               if (
                 (rateLimited || transient) &&
                 !options.signal?.aborted &&
@@ -3002,6 +3059,19 @@ async function runSpeechStep(
                 )
                 console.warn(
                   `[stage-run] ${label}: Gemini TTS transient error for ${item.textId} (${item.language}); retrying ${attemptCount + 1}/${GEMINI_TTS_MAX_RATE_LIMIT_RETRIES + 1} in ${retryDelayMs}ms: ${msg}`
+                )
+                await sleep(retryDelayMs, options.signal)
+                if (options.signal?.aborted) throw new RunCancelledError()
+                continue
+              }
+              if (
+                transportTransient &&
+                !options.signal?.aborted &&
+                attemptCount <= TTS_TRANSIENT_MAX_RETRIES
+              ) {
+                const retryDelayMs = TTS_TRANSIENT_RETRY_DELAY_MS * attemptCount
+                console.warn(
+                  `[stage-run] ${label}: ${provider} TTS transport error for ${item.textId} (${item.language}); retrying ${attemptCount + 1}/${TTS_TRANSIENT_MAX_RETRIES + 1} in ${retryDelayMs}ms: ${msg}`,
                 )
                 await sleep(retryDelayMs, options.signal)
                 if (options.signal?.aborted) throw new RunCancelledError()
@@ -3087,17 +3157,23 @@ async function runSpeechStep(
             cacheHit: false,
             durationMs,
           })
-          if (provider !== "gemini") {
-            progress.emit({
-              type: "step-error",
-              step: "tts",
-              error: `${item.textId} failed: ${msg}`,
-            })
-          }
+          // This is an item-level gap, not a stopped step. Emitting step-error
+          // here marks the whole Speech stage errored and hides its live
+          // progress even though the remaining items continue. The failed item
+          // is persisted below and the progress event includes the gap count.
         }
 
         completedItems++
-        emitSpeechStepProgress(progress, completedItems, totalItems, failedItems.length, reusedItems)
+        completePageEntry(item.language, item.textId)
+        emitSpeechStepProgress(
+          progress,
+          completedItems,
+          totalItems,
+          failedItems.length,
+          reusedItems,
+          completedPageCount(),
+          totalSpeechPages,
+        )
       },
       { runSignal: options.signal }
     )

--- a/apps/studio/src/api/client.ts
+++ b/apps/studio/src/api/client.ts
@@ -1659,28 +1659,39 @@ export const api = {
   getTTS: (label: string) =>
     request<TTSResponse>(`/books/${label}/tts`),
 
+  // Added by the Publish feature. Keeping the typed client call here lets the
+  // Speech UI consume the changed-entity suggestions once that independent PR
+  // is present, without importing Publish implementation details.
+  getGitHubSpeechSuggestions: (label: string) =>
+    request<{
+      source: "working-tree" | "latest-deployment" | "none"
+      items: Array<{ textId: string; files: string[] }>
+    }>(`/books/${label}/github-publishing/speech-suggestions`),
+
   deleteTTS: (label: string) =>
     request<{ ok: boolean }>(`/books/${label}/tts`, { method: "DELETE" }),
 
-  generateGeminiTTSForItem: (
+  generateTTSForItem: (
     label: string,
     textId: string,
+    text: string,
     language: string,
     credentials: {
-      geminiApiKey: string
+      geminiApiKey?: string
       openaiApiKey?: string
       azure?: AzureCredentials
-    }
+    },
+    options?: { forceRegenerate?: boolean },
   ) =>
     request<GenerateSingleTTSResponse>(`/books/${label}/tts/generate-one`, {
       method: "POST",
       headers: {
-        "X-Gemini-API-Key": credentials.geminiApiKey,
+        ...(credentials.geminiApiKey ? { "X-Gemini-API-Key": credentials.geminiApiKey } : {}),
         ...(credentials.openaiApiKey ? { "X-OpenAI-Key": credentials.openaiApiKey } : {}),
         ...(credentials.azure?.key ? { "X-Azure-Speech-Key": credentials.azure.key } : {}),
         ...(credentials.azure?.region ? { "X-Azure-Speech-Region": credentials.azure.region } : {}),
       },
-      body: JSON.stringify({ textId, language }),
+      body: JSON.stringify({ textId, text, language, forceRegenerate: options?.forceRegenerate ?? false }),
     }),
 
   uploadTTSForItem: (

--- a/apps/studio/src/components/pipeline/stages/languages/LanguageView.tsx
+++ b/apps/studio/src/components/pipeline/stages/languages/LanguageView.tsx
@@ -354,6 +354,12 @@ export function LanguageView({
     queryFn: () => api.getTTS(bookLabel),
     enabled: !!bookLabel,
   });
+  const { data: speechSuggestions, isLoading: speechSuggestionsLoading } = useQuery({
+    queryKey: ["books", bookLabel, "github-speech-suggestions"],
+    queryFn: () => api.getGitHubSpeechSuggestions(bookLabel),
+    enabled: isSpeechStage && !!bookLabel,
+    refetchInterval: isSpeechStage ? 5_000 : false,
+  });
 
   const merged = activeConfigData?.merged as
     Record<string, unknown> | undefined;
@@ -421,6 +427,11 @@ export function LanguageView({
   // When active, the entry list is narrowed to speakable items that have no
   // audio yet (toggled from the "N missing" pill in the header).
   const [showMissingOnly, setShowMissingOnly] = useState(false);
+  const [speechListTab, setSpeechListTab] = useState<"all" | "suggested">("all");
+  const [audioSelectionMode, setAudioSelectionMode] = useState(false);
+  const [selectedAudioIds, setSelectedAudioIds] = useState<Set<string>>(
+    () => new Set(),
+  );
   const [lightbox, setLightbox] = useState<{
     src: string;
     caption?: string;
@@ -529,6 +540,15 @@ export function LanguageView({
   const currentLanguageUsesGemini =
     !!audioLang &&
     languageUsesSpeechProvider(audioLang, "gemini", speechConfig);
+  const currentSpeechProvider = audioLang
+    ? resolveSpeechProviderForLanguage(audioLang, speechConfig)
+    : null;
+  const hasCurrentProviderKey =
+    currentSpeechProvider === "gemini"
+      ? geminiKey.length > 0
+      : currentSpeechProvider === "azure"
+        ? azureKey.length > 0 && azureRegion.length > 0
+        : apiKey.length > 0;
   // Speech keeps the entry list on screen during runs (audio fills in live via
   // the run's snapshot) and after failures (failed rows are marked); the run
   // card only shows before the first speech run. Translate keeps the original
@@ -1048,7 +1068,43 @@ export function LanguageView({
   );
   const missingFilterActive =
     isSpeechStage && showMissingOnly && missingAudioCount > 0;
-  const visibleEntries = missingFilterActive ? missingEntries : displayEntries;
+  const suggestedAudioIds = useMemo(
+    () => new Set((speechSuggestions?.items ?? []).map((item) => item.textId)),
+    [speechSuggestions?.items],
+  );
+  const speechTabEntries =
+    isSpeechStage && speechListTab === "suggested"
+      ? displayEntries.filter((entry) => suggestedAudioIds.has(entry.id))
+      : displayEntries;
+  const visibleEntries = missingFilterActive
+    ? speechTabEntries.filter((entry) => !audioMap.has(entry.id))
+    : speechTabEntries;
+  const visibleSelectableAudioIds = isSpeechStage
+    ? visibleEntries
+        .filter(
+          (entry) =>
+            !isAnswerEntry(entry.id) &&
+            !getEntryTtsExclusion(entry.id, ttsExclusionConfig).excluded &&
+            (isSourceLang || translatedMap.has(entry.id)),
+        )
+        .map((entry) => entry.id)
+    : [];
+  const allVisibleAudioSelected =
+    visibleSelectableAudioIds.length > 0 &&
+    visibleSelectableAudioIds.every((id) => selectedAudioIds.has(id));
+
+  const toggleAudioSelection = useCallback((textId: string) => {
+    setSelectedAudioIds((current) => {
+      const next = new Set(current);
+      if (next.has(textId)) next.delete(textId);
+      else next.add(textId);
+      return next;
+    });
+  }, []);
+
+  useEffect(() => {
+    setSelectedAudioIds(new Set());
+  }, [audioLang, speechListTab]);
 
   // Once every missing item has been generated (or the language changes so the
   // pill disappears), drop back to the full list instead of leaving the user
@@ -1103,24 +1159,24 @@ export function LanguageView({
   ]);
 
   const generateAudioMutation = useMutation({
-    mutationFn: async (variables: { textId: string; language: string }) => {
-      if (!geminiKey) {
-        throw new Error(
-          i18n._(msg`Gemini API key is required to generate audio.`),
-        );
+    mutationFn: async (variables: { textId: string; text: string; language: string }) => {
+      if (!hasCurrentProviderKey) {
+        throw new Error(i18n._(msg`The selected speech provider requires an API key.`));
       }
-      return api.generateGeminiTTSForItem(
+      return api.generateTTSForItem(
         bookLabel,
         variables.textId,
+        variables.text,
         variables.language,
         {
-          geminiApiKey: geminiKey,
+          geminiApiKey: geminiKey || undefined,
           openaiApiKey: apiKey || undefined,
           azure:
             azureKey && azureRegion
               ? { key: azureKey, region: azureRegion }
               : undefined,
         },
+        { forceRegenerate: true },
       );
     },
     onMutate: (variables) => {
@@ -1154,12 +1210,58 @@ export function LanguageView({
   });
 
   const handleGenerateAudio = useCallback(
-    (textId: string) => {
-      if (!audioLang || !currentLanguageUsesGemini) return;
-      generateAudioMutation.mutate({ textId, language: audioLang });
+    (textId: string, text: string) => {
+      if (!audioLang || !hasCurrentProviderKey) return;
+      generateAudioMutation.mutate({ textId, text, language: audioLang });
     },
-    [audioLang, currentLanguageUsesGemini, generateAudioMutation],
+    [audioLang, hasCurrentProviderKey, generateAudioMutation],
   );
+
+  const regenerateSelectedMutation = useMutation({
+    mutationFn: async (variables: {
+      items: Array<{ textId: string; text: string }>;
+      language: string;
+    }) => {
+      if (!hasCurrentProviderKey) {
+        throw new Error(i18n._(msg`The selected speech provider requires an API key.`));
+      }
+      const succeeded: string[] = [];
+      const failed: Array<{ textId: string; error: string }> = [];
+      for (const item of variables.items) {
+        try {
+          await api.generateTTSForItem(bookLabel, item.textId, item.text, variables.language, {
+            geminiApiKey: geminiKey || undefined,
+            openaiApiKey: apiKey || undefined,
+            azure: azureKey && azureRegion ? { key: azureKey, region: azureRegion } : undefined,
+          }, { forceRegenerate: true });
+          succeeded.push(item.textId);
+        } catch (error) {
+          failed.push({ textId: item.textId, error: error instanceof Error ? error.message : String(error) });
+        }
+      }
+      return { succeeded, failed };
+    },
+    onSuccess: async ({ succeeded, failed }) => {
+      const failedIds = new Set(failed.map((item) => item.textId));
+      setSelectedAudioIds(failedIds);
+      setGenerateErrorById((previous) => {
+        const next = { ...previous };
+        for (const textId of succeeded) delete next[textId];
+        for (const item of failed) next[item.textId] = item.error;
+        return next;
+      });
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "tts"] }),
+        queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "step-status"] }),
+      ]);
+    },
+    onError: (error) => {
+      const message = error instanceof Error ? error.message : String(error);
+      setGenerateErrorById((previous) => Object.fromEntries(
+        [...selectedAudioIds].map((textId) => [textId, previous[textId] ?? message]),
+      ));
+    },
+  });
 
   const uploadAudioMutation = useMutation({
     mutationFn: async (variables: {
@@ -1688,6 +1790,125 @@ export function LanguageView({
       <div className="flex flex-col h-full">
         {/* Fixed header: alerts, language tabs, column headers */}
         <div className="shrink-0 px-4 pt-4 space-y-3">
+          {isSpeechStage && (
+            <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-rose-200 bg-rose-50 px-3 py-2.5">
+              <div className="flex items-center gap-1 rounded-md border border-rose-200 bg-white p-1" role="tablist" aria-label={t`Speech regeneration views`}>
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={speechListTab === "all"}
+                  onClick={() => setSpeechListTab("all")}
+                  className={cn(
+                    "rounded px-2.5 py-1 text-xs font-medium",
+                    speechListTab === "all" ? "bg-rose-600 text-white" : "text-rose-800 hover:bg-rose-50",
+                  )}
+                >
+                  {t`All audio`}
+                </button>
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={speechListTab === "suggested"}
+                  onClick={() => setSpeechListTab("suggested")}
+                  className={cn(
+                    "inline-flex items-center gap-1.5 rounded px-2.5 py-1 text-xs font-medium",
+                    speechListTab === "suggested" ? "bg-rose-600 text-white" : "text-rose-800 hover:bg-rose-50",
+                  )}
+                >
+                  {speechSuggestionsLoading ? <Loader2 className="h-3 w-3 animate-spin" /> : null}
+                  {t`Suggested`}
+                  <span
+                    className={cn(
+                      "rounded-full px-1.5 text-[10px]",
+                      speechListTab === "suggested"
+                        ? "bg-white/20 text-white"
+                        : "bg-rose-100 text-rose-800",
+                    )}
+                  >
+                    {suggestedAudioIds.size}
+                  </span>
+                </button>
+              </div>
+              {!audioSelectionMode ? (
+                <Button type="button" size="sm" variant="outline" onClick={() => setAudioSelectionMode(true)}>
+                  {t`Select audio`}
+                </Button>
+              ) : <label className="inline-flex cursor-pointer items-center gap-2 text-xs font-medium text-rose-950">
+                <input
+                  type="checkbox"
+                  checked={allVisibleAudioSelected}
+                  onChange={() =>
+                    setSelectedAudioIds((current) => {
+                      const next = new Set(current);
+                      if (allVisibleAudioSelected) {
+                        visibleSelectableAudioIds.forEach((id) => next.delete(id));
+                      } else {
+                        visibleSelectableAudioIds.forEach((id) => next.add(id));
+                      }
+                      return next;
+                    })
+                  }
+                  disabled={
+                    visibleSelectableAudioIds.length === 0 ||
+                    regenerateSelectedMutation.isPending
+                  }
+                  className="h-4 w-4 accent-rose-600"
+                />
+                {allVisibleAudioSelected
+                  ? t`Clear visible selection`
+                  : t`Select visible audio`}
+              </label>}
+              {audioSelectionMode ? <div className="flex items-center gap-2">
+                <span className="text-xs text-rose-800">
+                  {t`${selectedAudioIds.size} selected`}
+                </span>
+                <Button
+                  type="button"
+                  size="sm"
+                  onClick={() => {
+                    if (!audioLang || selectedAudioIds.size === 0) return;
+                    regenerateSelectedMutation.mutate({
+                      items: Array.from(selectedAudioIds).flatMap((textId) => {
+                        const entry = visibleEntries.find((item) => item.id === textId);
+                        if (!entry) return [];
+                        const text = isSourceLang
+                          ? entry.text
+                          : translatedMap.get(textId);
+                        // Never synthesize source-language fallback text with
+                        // a target-language voice. Missing translations remain
+                        // visibly unavailable until translation is complete.
+                        if (!text) return [];
+                        return [{ textId, text }];
+                      }),
+                      language: audioLang,
+                    });
+                  }}
+                  disabled={
+                    selectedAudioIds.size === 0 ||
+                    !audioLang ||
+                    !hasCurrentProviderKey ||
+                    isRunning ||
+                    regenerateSelectedMutation.isPending
+                  }
+                  title={
+                    hasCurrentProviderKey
+                      ? t`Regenerate only the selected audio clips`
+                      : t`The selected speech provider requires an API key.`
+                  }
+                  className="h-8 bg-rose-600 px-3 text-xs text-white hover:bg-rose-700"
+                >
+                  {regenerateSelectedMutation.isPending ? (
+                    <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                  ) : (
+                    <WandSparkles className="mr-1.5 h-3.5 w-3.5" />
+                  )}
+                  {t`Regenerate selected`}
+                </Button>
+                <Button type="button" size="sm" variant="ghost" onClick={() => { setSelectedAudioIds(new Set()); setAudioSelectionMode(false); }}>{t`Done selecting`}</Button>
+              </div> : null}
+            </div>
+          )}
+
           {isSpeechStage && hasStageError && runError && (
             <Alert variant="destructive" className="rounded-md">
               <AlertDescription className="text-xs whitespace-pre-wrap break-words">
@@ -2032,6 +2253,16 @@ export function LanguageView({
             stageSlug="translate"
             label={t`Resolving source language...`}
           />
+        ) : isSpeechStage &&
+          speechListTab === "suggested" &&
+          !speechSuggestionsLoading &&
+          visibleEntries.length === 0 ? (
+          <StageEmptyState
+            icon={AudioLines}
+            color="rose"
+            title={t`No changed content needs speech regeneration`}
+            subtitle={t`Git has not detected changed text entities for this view.`}
+          />
         ) : hasReviewResults &&
           displayEntries.length === 0 &&
           categoryFilteredEntries.length > 0 ? (
@@ -2184,6 +2415,15 @@ export function LanguageView({
                           )}
                         >
                           <div className="flex items-start gap-3">
+                            {isSpeechStage && audioSelectionMode && !isAnswer && !exclusion.excluded && (
+                              <input
+                                type="checkbox"
+                                checked={selectedAudioIds.has(entry.id)}
+                                onChange={() => toggleAudioSelection(entry.id)}
+                                aria-label={t`Select audio for ${entry.text}`}
+                                className="mt-0.5 h-4 w-4 shrink-0 accent-rose-600"
+                              />
+                            )}
                             {isImg && (
                               <img
                                 src={`${BASE_URL}/books/${bookLabel}/images/${entry.id}`}
@@ -2239,8 +2479,9 @@ export function LanguageView({
                                 audioLang={audioLang}
                                 bookLabel={bookLabel}
                                 textId={entry.id}
-                                canGenerate={currentLanguageUsesGemini}
-                                hasGeminiKey={geminiKey.length > 0}
+                                text={entry.text}
+                                canGenerate={true}
+                                hasGeminiKey={hasCurrentProviderKey}
                                 onGenerate={handleGenerateAudio}
                                 isGenerating={
                                   generateAudioMutation.isPending &&
@@ -2296,6 +2537,17 @@ export function LanguageView({
                             isAnswer ? "bg-amber-50/60" : "bg-card",
                           )}
                         >
+                          {isSpeechStage && audioSelectionMode && !isAnswer && !exclusion.excluded && (
+                            <label className="mb-2 inline-flex items-center gap-2 text-[10px] font-medium text-muted-foreground">
+                              <input
+                                type="checkbox"
+                                checked={selectedAudioIds.has(entry.id)}
+                                onChange={() => toggleAudioSelection(entry.id)}
+                                className="h-4 w-4 accent-rose-600"
+                              />
+                              {t`Select this audio`}
+                            </label>
+                          )}
                           <div className="grid grid-cols-2 gap-3">
                             <div>
                               <div className="flex items-start gap-3">
@@ -2458,8 +2710,9 @@ export function LanguageView({
                                     audioLang={audioLang}
                                     bookLabel={bookLabel}
                                     textId={entry.id}
-                                    canGenerate={currentLanguageUsesGemini}
-                                    hasGeminiKey={geminiKey.length > 0}
+                                    text={translated ?? ""}
+                                    canGenerate={translated !== undefined}
+                                    hasGeminiKey={hasCurrentProviderKey}
                                     onGenerate={handleGenerateAudio}
                                     isGenerating={
                                       generateAudioMutation.isPending &&
@@ -3116,6 +3369,7 @@ function AudioAction({
   audioLang,
   bookLabel,
   textId,
+  text,
   canGenerate,
   hasGeminiKey,
   onGenerate,
@@ -3137,9 +3391,10 @@ function AudioAction({
   audioLang: string | null;
   bookLabel: string;
   textId: string;
+  text: string;
   canGenerate: boolean;
   hasGeminiKey: boolean;
-  onGenerate: (textId: string) => void;
+  onGenerate: (textId: string, text: string) => void;
   isGenerating: boolean;
   onUpload?: (textId: string, file: File) => void;
   isUploading?: boolean;
@@ -3198,9 +3453,31 @@ function AudioAction({
   if (audio && audioLang) {
     return (
       <div>
-        {uploadButton && (
-          <div className="mb-1 flex justify-end">{uploadButton}</div>
-        )}
+        <div className="mb-1 flex justify-end gap-1">
+          {canGenerate && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-7 px-2 text-[10px]"
+              disabled={isGenerating || !hasGeminiKey}
+              onClick={() => onGenerate(textId, text)}
+              title={
+                hasGeminiKey
+                  ? t`Regenerate this audio clip`
+                  : t`Set the selected speech provider's API key to generate audio`
+              }
+            >
+              {isGenerating ? (
+                <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+              ) : (
+                <RotateCcw className="mr-1 h-3 w-3" />
+              )}
+              {t`Regenerate`}
+            </Button>
+          )}
+          {uploadButton}
+        </div>
         <WaveformPlayer
           key={`${audioLang}:${audio.fileName}:${audio.cacheKey ?? ""}`}
           audioUrl={getAudioUrl(
@@ -3268,11 +3545,11 @@ function AudioAction({
             size="sm"
             className="h-7 px-2 text-[10px]"
             disabled={isGenerating || !hasGeminiKey}
-            onClick={() => onGenerate(textId)}
+            onClick={() => onGenerate(textId, text)}
             title={
               hasGeminiKey
-                ? t`Generate missing Gemini audio`
-                : t`Set a Gemini API key to generate audio`
+                ? t`Regenerate this audio clip`
+                : t`Set the selected speech provider's API key to generate audio`
             }
           >
             {isGenerating ? (

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -2962,6 +2962,9 @@ msgstr "DONE"
 #~ msgid "Downgrade"
 #~ msgstr "Downgrade"
 
+msgid "Done selecting"
+msgstr "Done selecting"
+
 msgid "Download a full backup of this project"
 msgstr "Download a full backup of this project"
 
@@ -7948,6 +7951,9 @@ msgstr "Select all"
 
 msgid "Select an item to edit its text — [[blank:…]] marks where a blank appears, so keep it to keep the blank."
 msgstr "Select an item to edit its text — [[blank:…]] marks where a blank appears, so keep it to keep the blank."
+
+msgid "Select audio"
+msgstr "Select audio"
 
 #. placeholder {0}: entry.text
 msgid "Select audio for {0}"

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -3821,8 +3821,8 @@ msgstr "Gathering the evidence"
 msgid "Gemini"
 msgstr "Gemini"
 
-#~ msgid "Gemini API key is required to generate audio."
-#~ msgstr "Gemini API key is required to generate audio."
+msgid "Gemini API key is required to generate audio."
+msgstr "Gemini API key is required to generate audio."
 
 #~ msgid "Gemini generates each sentence in its own request, so its tone can drift between sentences. A lower temperature (e.g. 0.4) reduces that variation and a fixed seed makes delivery reproducible. Only affects languages routed to Gemini — OpenAI and Azure ignore these. Changing either value regenerates Gemini audio on the next run."
 #~ msgstr "Gemini generates each sentence in its own request, so its tone can drift between sentences. A lower temperature (e.g. 0.4) reduces that variation and a fixed seed makes delivery reproducible. Only affects languages routed to Gemini — OpenAI and Azure ignore these. Changing either value regenerates Gemini audio on the next run."
@@ -3896,8 +3896,8 @@ msgstr "Generate from pages"
 msgid "Generate global prompts"
 msgstr "Generate global prompts"
 
-#~ msgid "Generate missing Gemini audio"
-#~ msgstr "Generate missing Gemini audio"
+msgid "Generate missing Gemini audio"
+msgstr "Generate missing Gemini audio"
 
 msgid "Generate multiple-choice comprehension quizzes from the book's content. Create them automatically across the whole book, or add a single quiz from specific pages."
 msgstr "Generate multiple-choice comprehension quizzes from the book's content. Create them automatically across the whole book, or add a single quiz from specific pages."
@@ -8051,8 +8051,8 @@ msgstr "Sessions"
 msgid "Sessions let different reviewers capture findings independently, including language-specific reviews."
 msgstr "Sessions let different reviewers capture findings independently, including language-specific reviews."
 
-#~ msgid "Set a Gemini API key to generate audio"
-#~ msgstr "Set a Gemini API key to generate audio"
+msgid "Set a Gemini API key to generate audio"
+msgstr "Set a Gemini API key to generate audio"
 
 msgid "Set Administration to Read and write so ADT can configure the repository and create the GitHub Pages site."
 msgstr "Set Administration to Read and write so ADT can configure the repository and create the GitHub Pages site."

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -9933,3 +9933,50 @@ msgstr "Zoom in"
 
 msgid "Zoom out"
 msgstr "Zoom out"
+
+#. placeholder {0}: selectedAudioIds.size
+msgid "{0} selected"
+msgstr "{0} selected"
+
+msgid "All audio"
+msgstr "All audio"
+
+msgid "Clear visible selection"
+msgstr "Clear visible selection"
+
+msgid "Git has not detected changed text entities for this view."
+msgstr "Git has not detected changed text entities for this view."
+
+msgid "No changed content needs speech regeneration"
+msgstr "No changed content needs speech regeneration"
+
+msgid "Regenerate only the selected audio clips"
+msgstr "Regenerate only the selected audio clips"
+
+msgid "Regenerate selected"
+msgstr "Regenerate selected"
+
+msgid "Regenerate this audio clip"
+msgstr "Regenerate this audio clip"
+
+#. placeholder {0}: entry.text
+msgid "Select audio for {0}"
+msgstr "Select audio for {0}"
+
+msgid "Select this audio"
+msgstr "Select this audio"
+
+msgid "Select visible audio"
+msgstr "Select visible audio"
+
+msgid "Set the selected speech provider's API key to generate audio"
+msgstr "Set the selected speech provider's API key to generate audio"
+
+msgid "Speech regeneration views"
+msgstr "Speech regeneration views"
+
+msgid "Suggested"
+msgstr "Suggested"
+
+msgid "The selected speech provider requires an API key."
+msgstr "The selected speech provider requires an API key."

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -243,6 +243,10 @@ msgstr "{0} questions"
 msgid "{0} sections"
 msgstr "{0} sections"
 
+#. placeholder {0}: selectedAudioIds.size
+msgid "{0} selected"
+msgstr "{0} selected"
+
 #. placeholder {0}: String(stale.length)
 msgid "{0} selected images are no longer in the storyboard."
 msgstr "{0} selected images are no longer in the storyboard."
@@ -262,6 +266,10 @@ msgstr "{0} texts"
 #. placeholder {0}: outputLanguages.length
 msgid "{0} translations"
 msgstr "{0} translations"
+
+#. placeholder {0}: changesQuery.data.changes.length
+#~ msgid "{0} unpublished file changes"
+#~ msgstr "{0} unpublished file changes"
 
 #. placeholder {0}: versions.length
 #~ msgid "{0} versions"
@@ -821,6 +829,9 @@ msgstr "Activity: Multiple Choice"
 msgid "Activity: Open-Ended Answer"
 msgstr "Activity: Open-Ended Answer"
 
+#~ msgid "Activity: Ordering"
+#~ msgstr "Activity: Ordering"
+
 msgid "Activity: Other"
 msgstr "Activity: Other"
 
@@ -1203,6 +1214,9 @@ msgstr "All"
 msgid "All {0} pages merged in"
 msgstr "All {0} pages merged in"
 
+msgid "All audio"
+msgstr "All audio"
+
 msgid "All categories"
 msgstr "All categories"
 
@@ -1259,6 +1273,9 @@ msgstr "Amount"
 
 msgid "An activity that does not fit the standard categories."
 msgstr "An activity that does not fit the standard categories."
+
+#~ msgid "An activity where learners arrange items into the correct order."
+#~ msgstr "An activity where learners arrange items into the correct order."
 
 msgid "An activity where the learner underlines one or more words, phrases, or sentences directly in the text."
 msgstr "An activity where the learner underlines one or more words, phrases, or sentences directly in the text."
@@ -1654,6 +1671,9 @@ msgstr "Body text uses this font today. Attach a font below and assign it the �
 msgid "Book"
 msgstr "Book"
 
+#~ msgid "Book change history"
+#~ msgstr "Book change history"
+
 msgid "Book coverage"
 msgstr "Book coverage"
 
@@ -1671,6 +1691,9 @@ msgstr "Book images"
 
 msgid "Book info"
 msgstr "Book info"
+
+#~ msgid "Book is published"
+#~ msgstr "Book is published"
 
 msgid "Book Language"
 msgstr "Book Language"
@@ -1929,6 +1952,9 @@ msgstr "Change the book language?"
 msgid "Change the picture for this term"
 msgstr "Change the picture for this term"
 
+#~ msgid "Changed files"
+#~ msgstr "Changed files"
+
 #~ msgid "Changes apply the next time you run Storyboard and Export."
 #~ msgstr "Changes apply the next time you run Storyboard and Export."
 
@@ -1973,6 +1999,9 @@ msgstr "Chapter title"
 
 msgid "Chart / Graph"
 msgstr "Chart / Graph"
+
+#~ msgid "Check changes"
+#~ msgstr "Check changes"
 
 #~ msgid "Check for updates"
 #~ msgstr "Check for updates"
@@ -2085,6 +2114,9 @@ msgstr "Clear model"
 msgid "Clear search"
 msgstr "Clear search"
 
+msgid "Clear visible selection"
+msgstr "Clear visible selection"
+
 msgid "Clear, descriptive captions for middle and high school readers."
 msgstr "Clear, descriptive captions for middle and high school readers."
 
@@ -2190,6 +2222,9 @@ msgstr "Compare versions"
 msgid "Compared with fallback prompt."
 msgstr "Compared with fallback prompt."
 
+#~ msgid "Complete the guided setup before starting the publishing workflow."
+#~ msgstr "Complete the guided setup before starting the publishing workflow."
+
 msgid "Completed"
 msgstr "Completed"
 
@@ -2244,6 +2279,12 @@ msgstr "Configure each stage — extract, storyboard, layout — then let ADT St
 msgid "Configure features to include in the export"
 msgstr "Configure features to include in the export"
 
+#~ msgid "Configure GitHub publishing"
+#~ msgstr "Configure GitHub publishing"
+
+#~ msgid "Configure GitHub to start publishing"
+#~ msgstr "Configure GitHub to start publishing"
+
 #~ msgid "Configure provider credentials and global prompt fallbacks used by ADT Studio."
 #~ msgstr "Configure provider credentials and global prompt fallbacks used by ADT Studio."
 
@@ -2258,6 +2299,12 @@ msgstr "Configure voices and accents"
 
 msgid "Confirm merge"
 msgstr "Confirm merge"
+
+#~ msgid "Confirm the destination below. Publishing will open the live workflow screen automatically."
+#~ msgstr "Confirm the destination below. Publishing will open the live workflow screen automatically."
+
+#~ msgid "Connect an account and choose a repository before running this workflow."
+#~ msgstr "Connect an account and choose a repository before running this workflow."
 
 msgid "Connect an AI provider"
 msgstr "Connect an AI provider"
@@ -2282,6 +2329,9 @@ msgstr "Content Processing"
 
 msgid "Contents"
 msgstr "Contents"
+
+msgid "Contents — Read and write; Administration — Read and write; Pages — Read and write; Metadata — Read-only."
+msgstr "Contents — Read and write; Administration — Read and write; Pages — Read and write; Metadata — Read-only."
 
 msgid "Context"
 msgstr "Context"
@@ -2446,6 +2496,9 @@ msgstr "Create a reviewer session for this book."
 msgid "Create ADT"
 msgstr "Create ADT"
 
+#~ msgid "Create classic token on GitHub"
+#~ msgstr "Create classic token on GitHub"
+
 msgid "Create descriptive captions for images to improve accessibility."
 msgstr "Create descriptive captions for images to improve accessibility."
 
@@ -2454,6 +2507,9 @@ msgstr "Create file"
 
 msgid "Create files"
 msgstr "Create files"
+
+#~ msgid "Create fine-grained token on GitHub"
+#~ msgstr "Create fine-grained token on GitHub"
 
 msgid "Create from scratch using your description"
 msgstr "Create from scratch using your description"
@@ -2469,6 +2525,9 @@ msgstr "Create prompt file from template"
 
 msgid "Create session"
 msgstr "Create session"
+
+#~ msgid "Create the destination repository first, then select its owner and that repository as the token resource."
+#~ msgstr "Create the destination repository first, then select its owner and that repository as the token resource."
 
 msgid "Created {created} prompt files for {normalizedTargetModel}."
 msgstr "Created {created} prompt files for {normalizedTargetModel}."
@@ -2532,6 +2591,9 @@ msgstr "Current (v{currentVersion})"
 
 msgid "Current book font"
 msgstr "Current book font"
+
+#~ msgid "Current book workspace"
+#~ msgstr "Current book workspace"
 
 msgid "Current effective values"
 msgstr "Current effective values"
@@ -3053,6 +3115,9 @@ msgstr "Each iteration is one LLM call. Lower values are faster and cheaper; hig
 msgid "Each kind of pipeline task uses a compatible model. Image generation and speech use their own task-specific defaults."
 msgstr "Each kind of pipeline task uses a compatible model. Image generation and speech use their own task-specific defaults."
 
+#~ msgid "Each node updates live as ADT Studio publishes the book."
+#~ msgstr "Each node updates live as ADT Studio publishes the book."
+
 msgid "Each polyp secretes a hard calcium carbonate skeleton. Over hundreds of years, millions of these skeletons build up into the massive reef structures we see today."
 msgstr "Each polyp secretes a hard calcium carbonate skeleton. Over hundreds of years, millions of these skeletons build up into the massive reef structures we see today."
 
@@ -3070,6 +3135,9 @@ msgstr "Earlier stages haven't run yet"
 
 msgid "Early"
 msgstr "Early"
+
+msgid "Easiest complete setup"
+msgstr "Easiest complete setup"
 
 msgid "Easy Read"
 msgstr "Easy Read"
@@ -3591,6 +3659,9 @@ msgstr "Filters out decorative or non-content images on each page."
 msgid "Final Page"
 msgstr "Final Page"
 
+msgid "Fine-grained token for an existing repository"
+msgstr "Fine-grained token for an existing repository"
+
 msgid "First images from the deep-field telescope."
 msgstr "First images from the deep-field telescope."
 
@@ -3747,8 +3818,8 @@ msgstr "Gathering the evidence"
 msgid "Gemini"
 msgstr "Gemini"
 
-msgid "Gemini API key is required to generate audio."
-msgstr "Gemini API key is required to generate audio."
+#~ msgid "Gemini API key is required to generate audio."
+#~ msgstr "Gemini API key is required to generate audio."
 
 #~ msgid "Gemini generates each sentence in its own request, so its tone can drift between sentences. A lower temperature (e.g. 0.4) reduces that variation and a fixed seed makes delivery reproducible. Only affects languages routed to Gemini — OpenAI and Azure ignore these. Changing either value regenerates Gemini audio on the next run."
 #~ msgstr "Gemini generates each sentence in its own request, so its tone can drift between sentences. A lower temperature (e.g. 0.4) reduces that variation and a fixed seed makes delivery reproducible. Only affects languages routed to Gemini — OpenAI and Azure ignore these. Changing either value regenerates Gemini audio on the next run."
@@ -3822,8 +3893,8 @@ msgstr "Generate from pages"
 msgid "Generate global prompts"
 msgstr "Generate global prompts"
 
-msgid "Generate missing Gemini audio"
-msgstr "Generate missing Gemini audio"
+#~ msgid "Generate missing Gemini audio"
+#~ msgstr "Generate missing Gemini audio"
 
 msgid "Generate multiple-choice comprehension quizzes from the book's content. Create them automatically across the whole book, or add a single quiz from specific pages."
 msgstr "Generate multiple-choice comprehension quizzes from the book's content. Create them automatically across the whole book, or add a single quiz from specific pages."
@@ -3919,6 +3990,12 @@ msgstr "Generation Prompt"
 
 msgid "Get started"
 msgstr "Get started"
+
+msgid "Git has not detected changed text entities for this view."
+msgstr "Git has not detected changed text entities for this view."
+
+#~ msgid "Git publishing workflow"
+#~ msgstr "Git publishing workflow"
 
 msgid "Global prompt reset to default."
 msgstr "Global prompt reset to default."
@@ -4552,6 +4629,9 @@ msgstr "Large images, narrative flow. Best for illustrated books with high-fidel
 #~ msgid "Last"
 #~ msgstr "Last"
 
+#~ msgid "Last activity"
+#~ msgstr "Last activity"
+
 msgid "Last change"
 msgstr "Last change"
 
@@ -4560,6 +4640,12 @@ msgstr "Last modified"
 
 #~ msgid "Last week"
 #~ msgstr "Last week"
+
+#~ msgid "Latest deployment"
+#~ msgstr "Latest deployment"
+
+#~ msgid "Latest GitHub changes synchronized."
+#~ msgstr "Latest GitHub changes synchronized."
 
 msgid "Launch the app with"
 msgstr "Launch the app with"
@@ -4581,6 +4667,9 @@ msgstr "Layout mirrored onto this section"
 
 msgid "Leading"
 msgstr "Leading"
+
+#~ msgid "Learn how with a guided setup"
+#~ msgstr "Learn how with a guided setup"
 
 msgid "Least used"
 msgstr "Least used"
@@ -4732,6 +4821,9 @@ msgstr "Loading books..."
 msgid "Loading catalog..."
 msgstr "Loading catalog..."
 
+#~ msgid "Loading deployments"
+#~ msgstr "Loading deployments"
+
 msgid "Loading Easy Read..."
 msgstr "Loading Easy Read..."
 
@@ -4824,6 +4916,12 @@ msgstr "Loading..."
 
 msgid "Loading…"
 msgstr "Loading…"
+
+#~ msgid "Local and GitHub changes need resolution before synchronization."
+#~ msgstr "Local and GitHub changes need resolution before synchronization."
+
+#~ msgid "Local book is up to date."
+#~ msgstr "Local book is up to date."
 
 msgid "Localization"
 msgstr "Localization"
@@ -5364,6 +5462,9 @@ msgstr "No captions match these filters"
 msgid "No captions match your search"
 msgstr "No captions match your search"
 
+msgid "No changed content needs speech regeneration"
+msgstr "No changed content needs speech regeneration"
+
 msgid "no changes"
 msgstr "no changes"
 
@@ -5679,8 +5780,14 @@ msgstr "noise"
 msgid "None"
 msgstr "None"
 
+#~ msgid "Not committed yet"
+#~ msgstr "Not committed yet"
+
 msgid "Not compatible with Fixed Layout"
 msgstr "Not compatible with Fixed Layout"
+
+#~ msgid "Not configured"
+#~ msgstr "Not configured"
 
 msgid "Not detected"
 msgstr "Not detected"
@@ -5854,6 +5961,9 @@ msgstr "Open page preview for {pageId}"
 
 msgid "Open Preview"
 msgstr "Open Preview"
+
+#~ msgid "Open public book"
+#~ msgstr "Open public book"
 
 #. placeholder {0}: pullRequest.number
 msgid "Open pull request {0}"
@@ -6066,6 +6176,9 @@ msgstr "Package the book for distribution. Pick a format, choose what content go
 
 msgid "Package the finished book with every accessibility feature baked in — ready for a kid to open, listen, and read along."
 msgstr "Package the finished book with every accessibility feature baked in — ready for a kid to open, listen, and read along."
+
+#~ msgid "Package, commit, push, host, and preview the accessible book without leaving ADT Studio."
+#~ msgstr "Package, commit, push, host, and preview the accessible book without leaving ADT Studio."
 
 msgid "Packaging"
 msgstr "Packaging"
@@ -6642,11 +6755,20 @@ msgstr "Pruned: {reason}"
 msgid "PT"
 msgstr "PT"
 
+#~ msgid "Publish book"
+#~ msgstr "Publish book"
+
+#~ msgid "Publish with GitHub Pages"
+#~ msgstr "Publish with GitHub Pages"
+
 msgid "published in"
 msgstr "published in"
 
 msgid "Publisher"
 msgstr "Publisher"
+
+#~ msgid "Pull remote changes"
+#~ msgstr "Pull remote changes"
 
 msgid "Pull requests"
 msgstr "Pull requests"
@@ -6893,6 +7015,9 @@ msgstr "Recommended for"
 msgid "Recommended for {0}"
 msgstr "Recommended for {0}"
 
+msgid "Recommended for creating a new repository"
+msgstr "Recommended for creating a new repository"
+
 msgid "Record reviewer findings for the current page and save them to the active validation session."
 msgstr "Record reviewer findings for the current page and save them to the active validation session."
 
@@ -6935,11 +7060,24 @@ msgstr "Regenerate definition, variations, and emoji"
 msgid "Regenerate Easy Read"
 msgstr "Regenerate Easy Read"
 
+msgid "Regenerate only the selected audio clips"
+msgstr "Regenerate only the selected audio clips"
+
+msgid "Regenerate selected"
+msgstr "Regenerate selected"
+
+#. placeholder {0}: selectedAudioIds.size
+#~ msgid "Regenerate selected ({0})"
+#~ msgstr "Regenerate selected ({0})"
+
 msgid "Regenerate selected images for each output language so that any text burned into them is shown in the target language."
 msgstr "Regenerate selected images for each output language so that any text burned into them is shown in the target language."
 
 msgid "Regenerate this activity with AI (requires a saved state and an API key)"
 msgstr "Regenerate this activity with AI (requires a saved state and an API key)"
+
+msgid "Regenerate this audio clip"
+msgstr "Regenerate this audio clip"
 
 msgid "Region"
 msgstr "Region"
@@ -6964,6 +7102,12 @@ msgstr "Release to upload"
 
 msgid "Reload app"
 msgstr "Reload app"
+
+#~ msgid "Remote changes are available."
+#~ msgstr "Remote changes are available."
+
+#~ msgid "Remote changes available"
+#~ msgstr "Remote changes available"
 
 msgid "Remove"
 msgstr "Remove"
@@ -7189,6 +7333,9 @@ msgstr "Review"
 #~ msgid "Review {selectedCount} selected"
 #~ msgstr "Review {selectedCount} selected"
 
+#~ msgid "Review and publish"
+#~ msgstr "Review and publish"
+
 msgid "Review and refine each simplified block side-by-side with the original before packaging."
 msgstr "Review and refine each simplified block side-by-side with the original before packaging."
 
@@ -7232,6 +7379,9 @@ msgstr "Review strictness"
 
 msgid "Review style"
 msgstr "Review style"
+
+#~ msgid "Review the most recent publishing workflow and open its public result."
+#~ msgstr "Review the most recent publishing workflow and open its public result."
 
 msgid "Review the project details below and confirm the import."
 msgstr "Review the project details below and confirm the import."
@@ -7381,6 +7531,9 @@ msgstr "Run Translation"
 msgid "Run whole-book validation checks and configure accessibility assessment settings."
 msgstr "Run whole-book validation checks and configure accessibility assessment settings."
 
+#~ msgid "Run workflow"
+#~ msgstr "Run workflow"
+
 msgid "Run-only tags"
 msgstr "Run-only tags"
 
@@ -7447,6 +7600,9 @@ msgstr "Save activity"
 msgid "Save activity (⌘S)"
 msgstr "Save activity (⌘S)"
 
+#~ msgid "Save and publish"
+#~ msgstr "Save and publish"
+
 msgid "Save changes"
 msgstr "Save changes"
 
@@ -7467,6 +7623,9 @@ msgstr "Save checklist"
 
 msgid "Save failed"
 msgstr "Save failed"
+
+#~ msgid "Save or discard your edits before splitting"
+#~ msgstr "Save or discard your edits before splitting"
 
 msgid "Save or discard your edits first"
 msgstr "Save or discard your edits first"
@@ -7685,6 +7844,12 @@ msgstr "sections"
 msgid "Sections"
 msgstr "Sections"
 
+msgid "Security: use the shortest practical expiration, never share the token, and revoke it in GitHub when it is no longer needed. ADT Studio keeps this token locally on this device and does not store it in the book directory."
+msgstr "Security: use the shortest practical expiration, never share the token, and revoke it in GitHub when it is no longer needed. ADT Studio keeps this token locally on this device and does not store it in the book directory."
+
+#~ msgid "Security: use the shortest practical expiration, never share the token, and revoke it in GitHub when it is no longer needed. ADT Studio keeps this token only for the current browser session and does not store it in the book directory."
+#~ msgstr "Security: use the shortest practical expiration, never share the token, and revoke it in GitHub when it is no longer needed. ADT Studio keeps this token only for the current browser session and does not store it in the book directory."
+
 msgid "See examples"
 msgstr "See examples"
 
@@ -7784,6 +7949,10 @@ msgstr "Select all"
 msgid "Select an item to edit its text — [[blank:…]] marks where a blank appears, so keep it to keep the blank."
 msgstr "Select an item to edit its text — [[blank:…]] marks where a blank appears, so keep it to keep the blank."
 
+#. placeholder {0}: entry.text
+msgid "Select audio for {0}"
+msgstr "Select audio for {0}"
+
 msgid "Select images to translate"
 msgstr "Select images to translate"
 
@@ -7808,8 +7977,17 @@ msgstr "Select template..."
 msgid "Select the pages the quiz is written from, then choose where it appears using the buttons between pages."
 msgstr "Select the pages the quiz is written from, then choose where it appears using the buttons between pages."
 
+#~ msgid "Select the repo scope. It covers repository creation, file publishing, and GitHub Pages configuration."
+#~ msgstr "Select the repo scope. It covers repository creation, file publishing, and GitHub Pages configuration."
+
+msgid "Select this audio"
+msgstr "Select this audio"
+
 msgid "Select up to 5 pages to use as visual references. The LLM will analyze them and generate a styleguide."
 msgstr "Select up to 5 pages to use as visual references. The LLM will analyze them and generate a styleguide."
+
+msgid "Select visible audio"
+msgstr "Select visible audio"
 
 #~ msgid "Selected"
 #~ msgstr "Selected"
@@ -7867,8 +8045,11 @@ msgstr "Sessions"
 msgid "Sessions let different reviewers capture findings independently, including language-specific reviews."
 msgstr "Sessions let different reviewers capture findings independently, including language-specific reviews."
 
-msgid "Set a Gemini API key to generate audio"
-msgstr "Set a Gemini API key to generate audio"
+#~ msgid "Set a Gemini API key to generate audio"
+#~ msgstr "Set a Gemini API key to generate audio"
+
+msgid "Set Administration to Read and write so ADT can configure the repository and create the GitHub Pages site."
+msgstr "Set Administration to Read and write so ADT can configure the repository and create the GitHub Pages site."
 
 msgid "Set fonts for the whole book"
 msgstr "Set fonts for the whole book"
@@ -7878,6 +8059,9 @@ msgstr "Set manually"
 
 msgid "Set the editing language and choose output languages for the book."
 msgstr "Set the editing language and choose output languages for the book."
+
+msgid "Set the selected speech provider's API key to generate audio"
+msgstr "Set the selected speech provider's API key to generate audio"
 
 msgid "Set your API key first"
 msgstr "Set your API key first"
@@ -8139,6 +8323,9 @@ msgstr "Speech Preview"
 msgid "Speech Prompts"
 msgstr "Speech Prompts"
 
+msgid "Speech regeneration views"
+msgstr "Speech regeneration views"
+
 msgid "Speech Settings"
 msgstr "Speech Settings"
 
@@ -8396,6 +8583,9 @@ msgstr "Successfully uploaded"
 
 msgid "Suggest improved translations when an entry needs attention"
 msgstr "Suggest improved translations when an entry needs attention"
+
+msgid "Suggested"
+msgstr "Suggested"
 
 msgid "Suggested modification"
 msgstr "Suggested modification"
@@ -8747,6 +8937,9 @@ msgstr "The saved translation review is stale. Run Review again for the visible 
 msgid "The section was edited after conversion — use \"Rebuild from page\" to refresh the steps."
 msgstr "The section was edited after conversion — use \"Rebuild from page\" to refresh the steps."
 
+msgid "The selected speech provider requires an API key."
+msgstr "The selected speech provider requires an API key."
+
 msgid "The storyboard must be completed before generating {stageName}. Run the Storyboard stage first."
 msgstr "The storyboard must be completed before generating {stageName}. Run the Storyboard stage first."
 
@@ -8758,6 +8951,9 @@ msgstr "The table of contents."
 
 msgid "The TOC lists the typed sections placed by Storyboard. Finish Storyboard before running this stage."
 msgstr "The TOC lists the typed sections placed by Storyboard. Finish Storyboard before running this stage."
+
+#~ msgid "The token needs repository contents, administration, and Pages permissions."
+#~ msgstr "The token needs repository contents, administration, and Pages permissions."
 
 msgid "The Water Cycle"
 msgstr "The Water Cycle"
@@ -8815,6 +9011,9 @@ msgstr "This activity has no addressable text or answers. Regenerate it, or use 
 
 msgid "This archive can't be opened safely"
 msgstr "This archive can't be opened safely"
+
+#~ msgid "This book asset will be included in the next commit."
+#~ msgstr "This book asset will be included in the next commit."
 
 msgid "This book has {pageCount} pages."
 msgstr "This book has {pageCount} pages."
@@ -9103,6 +9302,9 @@ msgstr "Total Tokens"
 msgid "Track reviewer progress and review findings captured from Preview."
 msgstr "Track reviewer progress and review findings captured from Preview."
 
+#~ msgid "Track the book's local edits, commits, publishing status, and GitHub metadata."
+#~ msgstr "Track the book's local edits, commits, publishing status, and GitHub metadata."
+
 msgid "Translate"
 msgstr "Translate"
 
@@ -9318,6 +9520,9 @@ msgstr "Uncategorized"
 
 msgid "Unchanged"
 msgstr "Unchanged"
+
+#~ msgid "Under Repository permissions, grant Contents, Administration, and Pages read and write access."
+#~ msgstr "Under Repository permissions, grant Contents, Administration, and Pages read and write access."
 
 msgid "Underline"
 msgstr "Underline"
@@ -9610,6 +9815,9 @@ msgstr "View"
 #~ msgid "View all changes"
 #~ msgstr "View all changes"
 
+#~ msgid "View deployment"
+#~ msgstr "View deployment"
+
 msgid "View details"
 msgstr "View details"
 
@@ -9848,6 +10056,9 @@ msgstr "Word-level highlighting"
 msgid "words"
 msgstr "words"
 
+#~ msgid "Workspace changes"
+#~ msgstr "Workspace changes"
+
 msgid "Wrap in group"
 msgstr "Wrap in group"
 
@@ -9933,50 +10144,3 @@ msgstr "Zoom in"
 
 msgid "Zoom out"
 msgstr "Zoom out"
-
-#. placeholder {0}: selectedAudioIds.size
-msgid "{0} selected"
-msgstr "{0} selected"
-
-msgid "All audio"
-msgstr "All audio"
-
-msgid "Clear visible selection"
-msgstr "Clear visible selection"
-
-msgid "Git has not detected changed text entities for this view."
-msgstr "Git has not detected changed text entities for this view."
-
-msgid "No changed content needs speech regeneration"
-msgstr "No changed content needs speech regeneration"
-
-msgid "Regenerate only the selected audio clips"
-msgstr "Regenerate only the selected audio clips"
-
-msgid "Regenerate selected"
-msgstr "Regenerate selected"
-
-msgid "Regenerate this audio clip"
-msgstr "Regenerate this audio clip"
-
-#. placeholder {0}: entry.text
-msgid "Select audio for {0}"
-msgstr "Select audio for {0}"
-
-msgid "Select this audio"
-msgstr "Select this audio"
-
-msgid "Select visible audio"
-msgstr "Select visible audio"
-
-msgid "Set the selected speech provider's API key to generate audio"
-msgstr "Set the selected speech provider's API key to generate audio"
-
-msgid "Speech regeneration views"
-msgstr "Speech regeneration views"
-
-msgid "Suggested"
-msgstr "Suggested"
-
-msgid "The selected speech provider requires an API key."
-msgstr "The selected speech provider requires an API key."

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -243,6 +243,10 @@ msgstr "{0} preguntas"
 msgid "{0} sections"
 msgstr "{0} secciones"
 
+#. placeholder {0}: selectedAudioIds.size
+msgid "{0} selected"
+msgstr "{0} seleccionados"
+
 #. placeholder {0}: String(stale.length)
 msgid "{0} selected images are no longer in the storyboard."
 msgstr "{0} imágenes seleccionadas ya no están en el guion gráfico."
@@ -262,6 +266,10 @@ msgstr "{0} textos"
 #. placeholder {0}: outputLanguages.length
 msgid "{0} translations"
 msgstr "{0} traducciones"
+
+#. placeholder {0}: changesQuery.data.changes.length
+#~ msgid "{0} unpublished file changes"
+#~ msgstr "{0} cambios de archivo sin publicar"
 
 #. placeholder {0}: versions.length
 #~ msgid "{0} versions"
@@ -821,6 +829,9 @@ msgstr "Actividad: Selección múltiple"
 msgid "Activity: Open-Ended Answer"
 msgstr "Actividad: Respuesta abierta"
 
+#~ msgid "Activity: Ordering"
+#~ msgstr "Actividad: Ordenación"
+
 msgid "Activity: Other"
 msgstr "Actividad: Otra"
 
@@ -1203,6 +1214,9 @@ msgstr "Todo"
 msgid "All {0} pages merged in"
 msgstr "Las {0} páginas están fusionadas"
 
+msgid "All audio"
+msgstr "Todo el audio"
+
 msgid "All categories"
 msgstr "Todas las categorías"
 
@@ -1259,6 +1273,9 @@ msgstr "Cantidad"
 
 msgid "An activity that does not fit the standard categories."
 msgstr "Una actividad que no encaja en las categorías estándar."
+
+#~ msgid "An activity where learners arrange items into the correct order."
+#~ msgstr "Una actividad en la que los estudiantes organizan elementos en el orden correcto."
 
 msgid "An activity where the learner underlines one or more words, phrases, or sentences directly in the text."
 msgstr "Una actividad en la que el estudiante subraya una o más palabras, frases u oraciones directamente en el texto."
@@ -1654,6 +1671,9 @@ msgstr "El cuerpo del texto usa esta fuente hoy. Adjunta una fuente abajo y así
 msgid "Book"
 msgstr "Libro"
 
+#~ msgid "Book change history"
+#~ msgstr "Historial de cambios del libro"
+
 msgid "Book coverage"
 msgstr "Cobertura del libro"
 
@@ -1671,6 +1691,9 @@ msgstr "Imágenes del libro"
 
 msgid "Book info"
 msgstr "Información del libro"
+
+#~ msgid "Book is published"
+#~ msgstr "El libro está publicado"
 
 msgid "Book Language"
 msgstr "Idioma del libro"
@@ -1929,6 +1952,9 @@ msgstr "¿Cambiar el idioma del libro?"
 msgid "Change the picture for this term"
 msgstr "Cambiar la imagen de este término"
 
+#~ msgid "Changed files"
+#~ msgstr "Archivos modificados"
+
 #~ msgid "Changes apply the next time you run Storyboard and Export."
 #~ msgstr "Los cambios se aplican la próxima vez que ejecutes Storyboard y Exportar."
 
@@ -1973,6 +1999,9 @@ msgstr "Título de capítulo"
 
 msgid "Chart / Graph"
 msgstr "Gráfico / Tabla"
+
+#~ msgid "Check changes"
+#~ msgstr "Comprobar cambios"
 
 #~ msgid "Check for updates"
 #~ msgstr "Buscar actualizaciones"
@@ -2085,6 +2114,9 @@ msgstr "Borrar modelo"
 msgid "Clear search"
 msgstr "Limpiar búsqueda"
 
+msgid "Clear visible selection"
+msgstr "Limpiar selección visible"
+
 msgid "Clear, descriptive captions for middle and high school readers."
 msgstr "Subtítulos claros y descriptivos para lectores de secundaria y preparatoria."
 
@@ -2190,6 +2222,9 @@ msgstr "Comparar versiones"
 msgid "Compared with fallback prompt."
 msgstr "Comparado con el prompt fallback."
 
+#~ msgid "Complete the guided setup before starting the publishing workflow."
+#~ msgstr "Completa la configuración guiada antes de iniciar el flujo de publicación."
+
 msgid "Completed"
 msgstr "Completado"
 
@@ -2244,6 +2279,12 @@ msgstr "Configura cada etapa — extraer, guión gráfico, diseño — luego dej
 msgid "Configure features to include in the export"
 msgstr "Configura las características a incluir en la exportación"
 
+#~ msgid "Configure GitHub publishing"
+#~ msgstr "Configurar la publicación en GitHub"
+
+#~ msgid "Configure GitHub to start publishing"
+#~ msgstr "Configura GitHub para comenzar a publicar"
+
 #~ msgid "Configure provider credentials and global prompt fallbacks used by ADT Studio."
 #~ msgstr "Configura las credenciales de los proveedores y los prompts fallback globales usados por ADT Studio."
 
@@ -2258,6 +2299,12 @@ msgstr "Configurar voces y acentos"
 
 msgid "Confirm merge"
 msgstr "Confirmar fusión"
+
+#~ msgid "Confirm the destination below. Publishing will open the live workflow screen automatically."
+#~ msgstr "Confirma el destino. La publicación abrirá automáticamente la pantalla del flujo en vivo."
+
+#~ msgid "Connect an account and choose a repository before running this workflow."
+#~ msgstr "Conecta una cuenta y elige un repositorio antes de ejecutar este flujo."
 
 msgid "Connect an AI provider"
 msgstr "Conecta un proveedor de IA"
@@ -2282,6 +2329,9 @@ msgstr "Procesamiento de Contenido"
 
 msgid "Contents"
 msgstr "Contenidos"
+
+msgid "Contents — Read and write; Administration — Read and write; Pages — Read and write; Metadata — Read-only."
+msgstr "Contenido: lectura y escritura; Administración: lectura y escritura; Pages: lectura y escritura; Metadatos: solo lectura."
 
 msgid "Context"
 msgstr "Contexto"
@@ -2446,6 +2496,9 @@ msgstr "Create a reviewer session for this book."
 msgid "Create ADT"
 msgstr "Crear ADT"
 
+#~ msgid "Create classic token on GitHub"
+#~ msgstr "Crear token clásico en GitHub"
+
 msgid "Create descriptive captions for images to improve accessibility."
 msgstr "Crea subtítulos descriptivos para las imágenes para mejorar la accesibilidad."
 
@@ -2454,6 +2507,9 @@ msgstr "Crear archivo"
 
 msgid "Create files"
 msgstr "Crear archivos"
+
+#~ msgid "Create fine-grained token on GitHub"
+#~ msgstr "Crear token específico en GitHub"
 
 msgid "Create from scratch using your description"
 msgstr "Crear desde cero con tu descripción"
@@ -2469,6 +2525,9 @@ msgstr "Crear archivo de prompt desde plantilla"
 
 msgid "Create session"
 msgstr "Create session"
+
+#~ msgid "Create the destination repository first, then select its owner and that repository as the token resource."
+#~ msgstr "Crea primero el repositorio de destino y luego selecciona su propietario y ese repositorio como recurso del token."
 
 msgid "Created {created} prompt files for {normalizedTargetModel}."
 msgstr "Se crearon {created} archivos de prompt para {normalizedTargetModel}."
@@ -2532,6 +2591,9 @@ msgstr "Actual (v{currentVersion})"
 
 msgid "Current book font"
 msgstr "Fuente actual del libro"
+
+#~ msgid "Current book workspace"
+#~ msgstr "Espacio de trabajo actual del libro"
 
 msgid "Current effective values"
 msgstr "Current effective values"
@@ -3053,6 +3115,9 @@ msgstr "Cada iteración es una llamada LLM. Valores más bajos son más rápidos
 msgid "Each kind of pipeline task uses a compatible model. Image generation and speech use their own task-specific defaults."
 msgstr "Cada tipo de tarea del flujo de trabajo utiliza un modelo compatible. La generación de imágenes y de voz utiliza sus propios valores predeterminados específicos para cada tarea."
 
+#~ msgid "Each node updates live as ADT Studio publishes the book."
+#~ msgstr "Cada nodo se actualiza en vivo mientras ADT Studio publica el libro."
+
 msgid "Each polyp secretes a hard calcium carbonate skeleton. Over hundreds of years, millions of these skeletons build up into the massive reef structures we see today."
 msgstr "Cada pólipo secreta un esqueleto duro de carbonato de calcio. Durante cientos de años, millones de estos esqueletos se acumulan en las estructuras masivas de arrecifes que vemos hoy."
 
@@ -3070,6 +3135,9 @@ msgstr "Las etapas anteriores aún no se han ejecutado"
 
 msgid "Early"
 msgstr "Temprano"
+
+msgid "Easiest complete setup"
+msgstr "Configuración completa más sencilla"
 
 msgid "Easy Read"
 msgstr "Lectura Fácil"
@@ -3591,6 +3659,9 @@ msgstr "Filtra imágenes decorativas o sin contenido en cada página."
 msgid "Final Page"
 msgstr "Página Final"
 
+msgid "Fine-grained token for an existing repository"
+msgstr "Token específico para un repositorio existente"
+
 msgid "First images from the deep-field telescope."
 msgstr "Primeras imágenes del telescopio de campo profundo."
 
@@ -3747,8 +3818,8 @@ msgstr "Reuniendo la evidencia"
 msgid "Gemini"
 msgstr "Gemini"
 
-msgid "Gemini API key is required to generate audio."
-msgstr "Se necesita una clave de API de Gemini para generar audio."
+#~ msgid "Gemini API key is required to generate audio."
+#~ msgstr "Se necesita una clave de API de Gemini para generar audio."
 
 #~ msgid "Gemini generates each sentence in its own request, so its tone can drift between sentences. A lower temperature (e.g. 0.4) reduces that variation and a fixed seed makes delivery reproducible. Only affects languages routed to Gemini — OpenAI and Azure ignore these. Changing either value regenerates Gemini audio on the next run."
 #~ msgstr "Gemini genera cada oración en su propia solicitud, por lo que su tono puede variar entre oraciones. Una temperatura más baja (p. ej., 0.4) reduce esa variación y una semilla fija hace que la lectura sea reproducible. Solo afecta a los idiomas enrutados a Gemini: OpenAI y Azure los ignoran. Cambiar cualquiera de los valores regenera el audio de Gemini en la próxima ejecución."
@@ -3822,8 +3893,8 @@ msgstr "Generar desde páginas"
 msgid "Generate global prompts"
 msgstr "Generar prompts globales"
 
-msgid "Generate missing Gemini audio"
-msgstr "Generar audio de Gemini faltante"
+#~ msgid "Generate missing Gemini audio"
+#~ msgstr "Generar audio de Gemini faltante"
 
 msgid "Generate multiple-choice comprehension quizzes from the book's content. Create them automatically across the whole book, or add a single quiz from specific pages."
 msgstr "Genera cuestionarios de comprensión de opción múltiple a partir del contenido del libro. Créalos automáticamente en todo el libro o añade un único cuestionario a partir de páginas específicas."
@@ -3919,6 +3990,12 @@ msgstr "Prompt de generación"
 
 msgid "Get started"
 msgstr "Comenzar"
+
+msgid "Git has not detected changed text entities for this view."
+msgstr "Git no ha detectado entidades de texto modificadas para esta vista."
+
+#~ msgid "Git publishing workflow"
+#~ msgstr "Flujo de publicación Git"
 
 msgid "Global prompt reset to default."
 msgstr "Prompt global restablecido al valor predeterminado."
@@ -4552,6 +4629,9 @@ msgstr "Imágenes grandes, flujo narrativo. Mejor para libros ilustrados con voc
 #~ msgid "Last"
 #~ msgstr "Última"
 
+#~ msgid "Last activity"
+#~ msgstr "Última actividad"
+
 msgid "Last change"
 msgstr "Último cambio"
 
@@ -4560,6 +4640,12 @@ msgstr "Última modificación"
 
 #~ msgid "Last week"
 #~ msgstr "La semana pasada"
+
+#~ msgid "Latest deployment"
+#~ msgstr "Último despliegue"
+
+#~ msgid "Latest GitHub changes synchronized."
+#~ msgstr "Últimos cambios de GitHub sincronizados."
 
 msgid "Launch the app with"
 msgstr "Iniciar la aplicación con"
@@ -4581,6 +4667,9 @@ msgstr "Diseño copiado a esta sección"
 
 msgid "Leading"
 msgstr "Interlineado"
+
+#~ msgid "Learn how with a guided setup"
+#~ msgstr "Aprende con una configuración guiada"
 
 msgid "Least used"
 msgstr "Menos usado"
@@ -4732,6 +4821,9 @@ msgstr "Cargando libros..."
 msgid "Loading catalog..."
 msgstr "Cargando catálogo..."
 
+#~ msgid "Loading deployments"
+#~ msgstr "Cargando implementaciones"
+
 msgid "Loading Easy Read..."
 msgstr "Cargando Lectura Fácil..."
 
@@ -4824,6 +4916,12 @@ msgstr "Cargando..."
 
 msgid "Loading…"
 msgstr "Cargando…"
+
+#~ msgid "Local and GitHub changes need resolution before synchronization."
+#~ msgstr "Los cambios locales y de GitHub deben resolverse antes de sincronizar."
+
+#~ msgid "Local book is up to date."
+#~ msgstr "El libro local está actualizado."
 
 msgid "Localization"
 msgstr "Localización"
@@ -5364,6 +5462,9 @@ msgstr "No hay leyendas que coincidan con estos filtros"
 msgid "No captions match your search"
 msgstr "No hay leyendas que coincidan con tu búsqueda"
 
+msgid "No changed content needs speech regeneration"
+msgstr "Ningún contenido modificado necesita regeneración de voz"
+
 msgid "no changes"
 msgstr "sin cambios"
 
@@ -5679,8 +5780,14 @@ msgstr "ruido"
 msgid "None"
 msgstr "Ninguno"
 
+#~ msgid "Not committed yet"
+#~ msgstr "Aún sin commit"
+
 msgid "Not compatible with Fixed Layout"
 msgstr "No compatible con Diseño Fijo"
+
+#~ msgid "Not configured"
+#~ msgstr "Sin configurar"
 
 msgid "Not detected"
 msgstr "No detectado"
@@ -5854,6 +5961,9 @@ msgstr "Abrir vista previa de la página {0}"
 
 msgid "Open Preview"
 msgstr "Open Preview"
+
+#~ msgid "Open public book"
+#~ msgstr "Abrir libro público"
 
 #. placeholder {0}: pullRequest.number
 msgid "Open pull request {0}"
@@ -6066,6 +6176,9 @@ msgstr "Empaqueta el libro para distribución. Elige un formato, selecciona qué
 
 msgid "Package the finished book with every accessibility feature baked in — ready for a kid to open, listen, and read along."
 msgstr "Empaqueta el libro terminado con todas las funciones de accesibilidad integradas — listo para que un niño lo abra, escuche y siga la lectura."
+
+#~ msgid "Package, commit, push, host, and preview the accessible book without leaving ADT Studio."
+#~ msgstr "Empaqueta, confirma, publica, aloja y previsualiza el libro accesible sin salir de ADT Studio."
 
 msgid "Packaging"
 msgstr "Empaquetando"
@@ -6642,11 +6755,20 @@ msgstr "Eliminado: {0}"
 msgid "PT"
 msgstr "PT"
 
+#~ msgid "Publish book"
+#~ msgstr "Publicar libro"
+
+#~ msgid "Publish with GitHub Pages"
+#~ msgstr "Publicar con GitHub Pages"
+
 msgid "published in"
 msgstr "publicado en"
 
 msgid "Publisher"
 msgstr "Editorial"
+
+#~ msgid "Pull remote changes"
+#~ msgstr "Descargar cambios remotos"
 
 msgid "Pull requests"
 msgstr "Pull requests"
@@ -6893,6 +7015,9 @@ msgstr "Recomendado para"
 msgid "Recommended for {0}"
 msgstr "Recomendado para {0}"
 
+msgid "Recommended for creating a new repository"
+msgstr "Recomendado para crear un repositorio nuevo"
+
 msgid "Record reviewer findings for the current page and save them to the active validation session."
 msgstr "Record reviewer findings for the current page and save them to the active validation session."
 
@@ -6935,11 +7060,24 @@ msgstr "Regenerar definición, variaciones y emoji"
 msgid "Regenerate Easy Read"
 msgstr "Regenerar Lectura Fácil"
 
+msgid "Regenerate only the selected audio clips"
+msgstr "Regenerar solo los clips de audio seleccionados"
+
+msgid "Regenerate selected"
+msgstr "Regenerar seleccionados"
+
+#. placeholder {0}: selectedAudioIds.size
+#~ msgid "Regenerate selected ({0})"
+#~ msgstr "Regenerar seleccionados ({0})"
+
 msgid "Regenerate selected images for each output language so that any text burned into them is shown in the target language."
 msgstr "Regenera las imágenes seleccionadas para cada idioma de salida de modo que el texto incrustado en ellas aparezca en el idioma de destino."
 
 msgid "Regenerate this activity with AI (requires a saved state and an API key)"
 msgstr "Regenera esta actividad con IA (requiere un estado guardado y una clave de API)"
+
+msgid "Regenerate this audio clip"
+msgstr "Regenerar este clip de audio"
 
 msgid "Region"
 msgstr "Región"
@@ -6964,6 +7102,12 @@ msgstr "Suelta para subir"
 
 msgid "Reload app"
 msgstr "Recargar aplicación"
+
+#~ msgid "Remote changes are available."
+#~ msgstr "Hay cambios remotos disponibles."
+
+#~ msgid "Remote changes available"
+#~ msgstr "Hay cambios remotos disponibles"
 
 msgid "Remove"
 msgstr "Quitar"
@@ -7189,6 +7333,9 @@ msgstr "Revisar"
 #~ msgid "Review {selectedCount} selected"
 #~ msgstr "Revisar {selectedCount} seleccionados"
 
+#~ msgid "Review and publish"
+#~ msgstr "Revisar y publicar"
+
 msgid "Review and refine each simplified block side-by-side with the original before packaging."
 msgstr "Revisa y refina cada bloque simplificado junto al original antes de empaquetar."
 
@@ -7232,6 +7379,9 @@ msgstr "Rigor de la revisión"
 
 msgid "Review style"
 msgstr "Estilo de revisión"
+
+#~ msgid "Review the most recent publishing workflow and open its public result."
+#~ msgstr "Revisa el flujo de publicación más reciente y abre su resultado público."
 
 msgid "Review the project details below and confirm the import."
 msgstr "Revisa los detalles del proyecto a continuación y confirma la importación."
@@ -7381,6 +7531,9 @@ msgstr "Ejecutar Traducción"
 msgid "Run whole-book validation checks and configure accessibility assessment settings."
 msgstr "Run whole-book validation checks and configure accessibility assessment settings."
 
+#~ msgid "Run workflow"
+#~ msgstr "Ejecutar flujo"
+
 msgid "Run-only tags"
 msgstr "Run-only tags"
 
@@ -7447,6 +7600,9 @@ msgstr "Guardar actividad"
 msgid "Save activity (⌘S)"
 msgstr "Guardar actividad (⌘S)"
 
+#~ msgid "Save and publish"
+#~ msgstr "Guardar y publicar"
+
 msgid "Save changes"
 msgstr "Guardar cambios"
 
@@ -7467,6 +7623,9 @@ msgstr "Save checklist"
 
 msgid "Save failed"
 msgstr "Save failed"
+
+#~ msgid "Save or discard your edits before splitting"
+#~ msgstr "Guarda o descarta tus cambios antes de dividir"
 
 msgid "Save or discard your edits first"
 msgstr "Primero guarda o descarta tus cambios"
@@ -7685,6 +7844,12 @@ msgstr "secciones"
 msgid "Sections"
 msgstr "Secciones"
 
+msgid "Security: use the shortest practical expiration, never share the token, and revoke it in GitHub when it is no longer needed. ADT Studio keeps this token locally on this device and does not store it in the book directory."
+msgstr "Seguridad: usa la caducidad práctica más corta, nunca compartas el token y revócalo en GitHub cuando ya no sea necesario. ADT Studio guarda este token localmente en este dispositivo y no lo almacena en el directorio del libro."
+
+#~ msgid "Security: use the shortest practical expiration, never share the token, and revoke it in GitHub when it is no longer needed. ADT Studio keeps this token only for the current browser session and does not store it in the book directory."
+#~ msgstr "Seguridad: usa la caducidad práctica más corta, nunca compartas el token y revócalo en GitHub cuando ya no sea necesario. ADT Studio conserva este token solo durante la sesión actual del navegador y no lo almacena en el directorio del libro."
+
 msgid "See examples"
 msgstr "Ver ejemplos"
 
@@ -7784,6 +7949,10 @@ msgstr "Seleccionar todo"
 msgid "Select an item to edit its text — [[blank:…]] marks where a blank appears, so keep it to keep the blank."
 msgstr "Selecciona un elemento para editar su texto: [[blank:…]] indica dónde aparece un espacio en blanco, así que consérvalo para mantener el espacio."
 
+#. placeholder {0}: entry.text
+msgid "Select audio for {0}"
+msgstr "Seleccionar audio para {0}"
+
 msgid "Select images to translate"
 msgstr "Seleccionar imágenes para traducir"
 
@@ -7808,8 +7977,17 @@ msgstr "Seleccionar plantilla..."
 msgid "Select the pages the quiz is written from, then choose where it appears using the buttons between pages."
 msgstr "Selecciona las páginas en las que se basa el cuestionario y elige dónde aparece con los botones entre páginas."
 
+#~ msgid "Select the repo scope. It covers repository creation, file publishing, and GitHub Pages configuration."
+#~ msgstr "Selecciona el ámbito repo. Incluye la creación del repositorio, la publicación de archivos y la configuración de GitHub Pages."
+
+msgid "Select this audio"
+msgstr "Seleccionar este audio"
+
 msgid "Select up to 5 pages to use as visual references. The LLM will analyze them and generate a styleguide."
 msgstr "Selecciona hasta 5 páginas para usar como referencias visuales. El LLM las analizará y generará una guía de estilo."
+
+msgid "Select visible audio"
+msgstr "Seleccionar audio visible"
 
 #~ msgid "Selected"
 #~ msgstr "Seleccionada"
@@ -7867,8 +8045,11 @@ msgstr "Sessions"
 msgid "Sessions let different reviewers capture findings independently, including language-specific reviews."
 msgstr "Sessions let different reviewers capture findings independently, including language-specific reviews."
 
-msgid "Set a Gemini API key to generate audio"
-msgstr "Configura una clave de API de Gemini para generar audio"
+#~ msgid "Set a Gemini API key to generate audio"
+#~ msgstr "Configura una clave de API de Gemini para generar audio"
+
+msgid "Set Administration to Read and write so ADT can configure the repository and create the GitHub Pages site."
+msgstr "Configura Administración como Lectura y escritura para que ADT pueda configurar el repositorio y crear el sitio de GitHub Pages."
 
 msgid "Set fonts for the whole book"
 msgstr "Establecer las fuentes de todo el libro"
@@ -7878,6 +8059,9 @@ msgstr "Definida manualmente"
 
 msgid "Set the editing language and choose output languages for the book."
 msgstr "Establece el idioma de edición y elige los idiomas de salida para el libro."
+
+msgid "Set the selected speech provider's API key to generate audio"
+msgstr "Configure la clave API del proveedor de voz seleccionado para generar audio"
 
 msgid "Set your API key first"
 msgstr "Configura primero tu clave de API"
@@ -8139,6 +8323,9 @@ msgstr "Vista previa de Voz"
 msgid "Speech Prompts"
 msgstr "Indicaciones de voz"
 
+msgid "Speech regeneration views"
+msgstr "Vistas de regeneración de voz"
+
 msgid "Speech Settings"
 msgstr "Configuración de Voz"
 
@@ -8396,6 +8583,9 @@ msgstr "Subido con éxito"
 
 msgid "Suggest improved translations when an entry needs attention"
 msgstr "Sugerir traducciones mejoradas cuando una entrada necesita atención"
+
+msgid "Suggested"
+msgstr "Sugerido"
 
 msgid "Suggested modification"
 msgstr "Suggested modification"
@@ -8747,6 +8937,9 @@ msgstr "La revisión de traducción guardada está obsoleta. Vuelve a ejecutar R
 msgid "The section was edited after conversion — use \"Rebuild from page\" to refresh the steps."
 msgstr "La sección se editó después de la conversión: usa «Reconstruir desde la página» para actualizar los pasos."
 
+msgid "The selected speech provider requires an API key."
+msgstr "El proveedor de voz seleccionado requiere una clave API."
+
 msgid "The storyboard must be completed before generating {stageName}. Run the Storyboard stage first."
 msgstr "El storyboard debe completarse antes de generar {stageName}. Ejecuta la etapa de Storyboard primero."
 
@@ -8758,6 +8951,9 @@ msgstr "La tabla de contenidos."
 
 msgid "The TOC lists the typed sections placed by Storyboard. Finish Storyboard before running this stage."
 msgstr "El TOC lista las secciones escritas colocadas por el Storyboard. Termina el Storyboard antes de ejecutar esta etapa."
+
+#~ msgid "The token needs repository contents, administration, and Pages permissions."
+#~ msgstr "El token necesita permisos de contenido del repositorio, administración y Pages."
 
 msgid "The Water Cycle"
 msgstr "El Ciclo del Agua"
@@ -8815,6 +9011,9 @@ msgstr "Esta actividad no tiene textos ni respuestas direccionables. Vuelve a ge
 
 msgid "This archive can't be opened safely"
 msgstr "Este archivo no se puede abrir de forma segura"
+
+#~ msgid "This book asset will be included in the next commit."
+#~ msgstr "Este recurso del libro se incluirá en el próximo commit."
 
 msgid "This book has {pageCount} pages."
 msgstr "Este libro tiene {pageCount} páginas."
@@ -9103,6 +9302,9 @@ msgstr "Tokens totales"
 msgid "Track reviewer progress and review findings captured from Preview."
 msgstr "Track reviewer progress and review findings captured from Preview."
 
+#~ msgid "Track the book's local edits, commits, publishing status, and GitHub metadata."
+#~ msgstr "Sigue las ediciones locales, los commits, el estado de publicación y los metadatos de GitHub del libro."
+
 msgid "Translate"
 msgstr "Traducir"
 
@@ -9318,6 +9520,9 @@ msgstr "Uncategorized"
 
 msgid "Unchanged"
 msgstr "Sin cambios"
+
+#~ msgid "Under Repository permissions, grant Contents, Administration, and Pages read and write access."
+#~ msgstr "En Permisos del repositorio, concede acceso de lectura y escritura a Contenido, Administración y Pages."
 
 msgid "Underline"
 msgstr "Subrayado"
@@ -9610,6 +9815,9 @@ msgstr "Ver"
 #~ msgid "View all changes"
 #~ msgstr "Ver todos los cambios"
 
+#~ msgid "View deployment"
+#~ msgstr "Ver despliegue"
+
 msgid "View details"
 msgstr "Ver detalles"
 
@@ -9848,6 +10056,9 @@ msgstr "Resaltado por palabra"
 msgid "words"
 msgstr "palabras"
 
+#~ msgid "Workspace changes"
+#~ msgstr "Cambios del espacio de trabajo"
+
 msgid "Wrap in group"
 msgstr "Envolver en grupo"
 
@@ -9933,50 +10144,3 @@ msgstr "Acercar"
 
 msgid "Zoom out"
 msgstr "Alejar"
-
-#. placeholder {0}: selectedAudioIds.size
-msgid "{0} selected"
-msgstr "{0} seleccionados"
-
-msgid "All audio"
-msgstr "Todo el audio"
-
-msgid "Clear visible selection"
-msgstr "Limpiar selección visible"
-
-msgid "Git has not detected changed text entities for this view."
-msgstr "Git no ha detectado entidades de texto modificadas para esta vista."
-
-msgid "No changed content needs speech regeneration"
-msgstr "Ningún contenido modificado necesita regeneración de voz"
-
-msgid "Regenerate only the selected audio clips"
-msgstr "Regenerar solo los clips de audio seleccionados"
-
-msgid "Regenerate selected"
-msgstr "Regenerar seleccionados"
-
-msgid "Regenerate this audio clip"
-msgstr "Regenerar este clip de audio"
-
-#. placeholder {0}: entry.text
-msgid "Select audio for {0}"
-msgstr "Seleccionar audio para {0}"
-
-msgid "Select this audio"
-msgstr "Seleccionar este audio"
-
-msgid "Select visible audio"
-msgstr "Seleccionar audio visible"
-
-msgid "Set the selected speech provider's API key to generate audio"
-msgstr "Configure la clave API del proveedor de voz seleccionado para generar audio"
-
-msgid "Speech regeneration views"
-msgstr "Vistas de regeneración de voz"
-
-msgid "Suggested"
-msgstr "Sugerido"
-
-msgid "The selected speech provider requires an API key."
-msgstr "El proveedor de voz seleccionado requiere una clave API."

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -2962,6 +2962,9 @@ msgstr "HECHO"
 #~ msgid "Downgrade"
 #~ msgstr "Bajar de versión"
 
+msgid "Done selecting"
+msgstr "Finalizar selección"
+
 msgid "Download a full backup of this project"
 msgstr "Descargar una copia de seguridad completa de este proyecto"
 
@@ -7948,6 +7951,9 @@ msgstr "Seleccionar todo"
 
 msgid "Select an item to edit its text — [[blank:…]] marks where a blank appears, so keep it to keep the blank."
 msgstr "Selecciona un elemento para editar su texto: [[blank:…]] indica dónde aparece un espacio en blanco, así que consérvalo para mantener el espacio."
+
+msgid "Select audio"
+msgstr "Seleccionar audio"
 
 #. placeholder {0}: entry.text
 msgid "Select audio for {0}"

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -3821,8 +3821,8 @@ msgstr "Reuniendo la evidencia"
 msgid "Gemini"
 msgstr "Gemini"
 
-#~ msgid "Gemini API key is required to generate audio."
-#~ msgstr "Se necesita una clave de API de Gemini para generar audio."
+msgid "Gemini API key is required to generate audio."
+msgstr "Se requiere una clave de API de Gemini para generar audio."
 
 #~ msgid "Gemini generates each sentence in its own request, so its tone can drift between sentences. A lower temperature (e.g. 0.4) reduces that variation and a fixed seed makes delivery reproducible. Only affects languages routed to Gemini — OpenAI and Azure ignore these. Changing either value regenerates Gemini audio on the next run."
 #~ msgstr "Gemini genera cada oración en su propia solicitud, por lo que su tono puede variar entre oraciones. Una temperatura más baja (p. ej., 0.4) reduce esa variación y una semilla fija hace que la lectura sea reproducible. Solo afecta a los idiomas enrutados a Gemini: OpenAI y Azure los ignoran. Cambiar cualquiera de los valores regenera el audio de Gemini en la próxima ejecución."
@@ -3896,8 +3896,8 @@ msgstr "Generar desde páginas"
 msgid "Generate global prompts"
 msgstr "Generar prompts globales"
 
-#~ msgid "Generate missing Gemini audio"
-#~ msgstr "Generar audio de Gemini faltante"
+msgid "Generate missing Gemini audio"
+msgstr "Generar el audio de Gemini que falta"
 
 msgid "Generate multiple-choice comprehension quizzes from the book's content. Create them automatically across the whole book, or add a single quiz from specific pages."
 msgstr "Genera cuestionarios de comprensión de opción múltiple a partir del contenido del libro. Créalos automáticamente en todo el libro o añade un único cuestionario a partir de páginas específicas."
@@ -8051,8 +8051,8 @@ msgstr "Sessions"
 msgid "Sessions let different reviewers capture findings independently, including language-specific reviews."
 msgstr "Sessions let different reviewers capture findings independently, including language-specific reviews."
 
-#~ msgid "Set a Gemini API key to generate audio"
-#~ msgstr "Configura una clave de API de Gemini para generar audio"
+msgid "Set a Gemini API key to generate audio"
+msgstr "Configura una clave de API de Gemini para generar audio"
 
 msgid "Set Administration to Read and write so ADT can configure the repository and create the GitHub Pages site."
 msgstr "Configura Administración como Lectura y escritura para que ADT pueda configurar el repositorio y crear el sitio de GitHub Pages."

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -9933,3 +9933,50 @@ msgstr "Acercar"
 
 msgid "Zoom out"
 msgstr "Alejar"
+
+#. placeholder {0}: selectedAudioIds.size
+msgid "{0} selected"
+msgstr "{0} seleccionados"
+
+msgid "All audio"
+msgstr "Todo el audio"
+
+msgid "Clear visible selection"
+msgstr "Limpiar selección visible"
+
+msgid "Git has not detected changed text entities for this view."
+msgstr "Git no ha detectado entidades de texto modificadas para esta vista."
+
+msgid "No changed content needs speech regeneration"
+msgstr "Ningún contenido modificado necesita regeneración de voz"
+
+msgid "Regenerate only the selected audio clips"
+msgstr "Regenerar solo los clips de audio seleccionados"
+
+msgid "Regenerate selected"
+msgstr "Regenerar seleccionados"
+
+msgid "Regenerate this audio clip"
+msgstr "Regenerar este clip de audio"
+
+#. placeholder {0}: entry.text
+msgid "Select audio for {0}"
+msgstr "Seleccionar audio para {0}"
+
+msgid "Select this audio"
+msgstr "Seleccionar este audio"
+
+msgid "Select visible audio"
+msgstr "Seleccionar audio visible"
+
+msgid "Set the selected speech provider's API key to generate audio"
+msgstr "Configure la clave API del proveedor de voz seleccionado para generar audio"
+
+msgid "Speech regeneration views"
+msgstr "Vistas de regeneración de voz"
+
+msgid "Suggested"
+msgstr "Sugerido"
+
+msgid "The selected speech provider requires an API key."
+msgstr "El proveedor de voz seleccionado requiere una clave API."

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -3823,8 +3823,8 @@ msgstr "Rassembler les preuves"
 msgid "Gemini"
 msgstr "Gemini"
 
-#~ msgid "Gemini API key is required to generate audio."
-#~ msgstr "La clé API Gemini est requise pour générer l'audio."
+msgid "Gemini API key is required to generate audio."
+msgstr "Une clé API Gemini est requise pour générer l’audio."
 
 #~ msgid "Gemini generates each sentence in its own request, so its tone can drift between sentences. A lower temperature (e.g. 0.4) reduces that variation and a fixed seed makes delivery reproducible. Only affects languages routed to Gemini — OpenAI and Azure ignore these. Changing either value regenerates Gemini audio on the next run."
 #~ msgstr "Gemini génère chaque phrase dans sa propre requête, si bien que son ton peut varier d'une phrase à l'autre. Une température plus basse (p. ex. 0,4) réduit cette variation et une graine fixe rend la lecture reproductible. Ne concerne que les langues acheminées vers Gemini — OpenAI et Azure les ignorent. Modifier l'une de ces valeurs régénère l'audio Gemini lors de la prochaine exécution."
@@ -3898,8 +3898,8 @@ msgstr "Générer à partir des pages"
 msgid "Generate global prompts"
 msgstr "Générer des prompts globaux"
 
-#~ msgid "Generate missing Gemini audio"
-#~ msgstr "Générer l'audio Gemini manquant"
+msgid "Generate missing Gemini audio"
+msgstr "Générer l’audio Gemini manquant"
 
 msgid "Generate multiple-choice comprehension quizzes from the book's content. Create them automatically across the whole book, or add a single quiz from specific pages."
 msgstr "Générez des quiz de compréhension à choix multiples à partir du contenu du livre. Créez-les automatiquement dans tout le livre ou ajoutez un seul quiz à partir de pages spécifiques."
@@ -8053,8 +8053,8 @@ msgstr "Sessions"
 msgid "Sessions let different reviewers capture findings independently, including language-specific reviews."
 msgstr "Les sessions permettent à différents réviseurs de capturer leurs résultats indépendamment, y compris les révisions spécifiques à une langue."
 
-#~ msgid "Set a Gemini API key to generate audio"
-#~ msgstr "Définissez une clé API Gemini pour générer l'audio"
+msgid "Set a Gemini API key to generate audio"
+msgstr "Configurez une clé API Gemini pour générer l’audio"
 
 msgid "Set Administration to Read and write so ADT can configure the repository and create the GitHub Pages site."
 msgstr "Réglez Administration sur Lecture et écriture afin qu’ADT puisse configurer le dépôt et créer le site GitHub Pages."

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -245,6 +245,10 @@ msgstr "{0} questions"
 msgid "{0} sections"
 msgstr "{0} sections"
 
+#. placeholder {0}: selectedAudioIds.size
+msgid "{0} selected"
+msgstr "{0} sélectionnés"
+
 #. placeholder {0}: String(stale.length)
 msgid "{0} selected images are no longer in the storyboard."
 msgstr "{0} images sélectionnées ne figurent plus dans le storyboard."
@@ -264,6 +268,10 @@ msgstr "{0} textes"
 #. placeholder {0}: outputLanguages.length
 msgid "{0} translations"
 msgstr "{0} traductions"
+
+#. placeholder {0}: changesQuery.data.changes.length
+#~ msgid "{0} unpublished file changes"
+#~ msgstr "{0} modifications de fichiers non publiées"
 
 #. placeholder {0}: versions.length
 #~ msgid "{0} versions"
@@ -823,6 +831,9 @@ msgstr "Activité : Choix multiple"
 msgid "Activity: Open-Ended Answer"
 msgstr "Activité : Réponse ouverte"
 
+#~ msgid "Activity: Ordering"
+#~ msgstr "Activité : Mise en ordre"
+
 msgid "Activity: Other"
 msgstr "Activité : Autre"
 
@@ -1205,6 +1216,9 @@ msgstr "Tout"
 msgid "All {0} pages merged in"
 msgstr "Les {0} pages sont fusionnées"
 
+msgid "All audio"
+msgstr "Tous les fichiers audio"
+
 msgid "All categories"
 msgstr "Toutes les catégories"
 
@@ -1261,6 +1275,9 @@ msgstr "Montant"
 
 msgid "An activity that does not fit the standard categories."
 msgstr "Une activité qui ne correspond pas aux catégories standard."
+
+#~ msgid "An activity where learners arrange items into the correct order."
+#~ msgstr "Une activité dans laquelle les élèves placent des éléments dans le bon ordre."
 
 msgid "An activity where the learner underlines one or more words, phrases, or sentences directly in the text."
 msgstr "Une activité où l'apprenant souligne un ou plusieurs mots, expressions ou phrases directement dans le texte."
@@ -1656,6 +1673,9 @@ msgstr "Le corps du texte utilise cette police aujourd'hui. Joignez une police c
 msgid "Book"
 msgstr "Livre"
 
+#~ msgid "Book change history"
+#~ msgstr "Historique des modifications du livre"
+
 msgid "Book coverage"
 msgstr "Couverture du livre"
 
@@ -1673,6 +1693,9 @@ msgstr "Images du livre"
 
 msgid "Book info"
 msgstr "Infos du livre"
+
+#~ msgid "Book is published"
+#~ msgstr "Le livre est publié"
 
 msgid "Book Language"
 msgstr "Livre Langue"
@@ -1931,6 +1954,9 @@ msgstr "Changer la langue du livre ?"
 msgid "Change the picture for this term"
 msgstr "Changer l'image de ce terme"
 
+#~ msgid "Changed files"
+#~ msgstr "Fichiers modifiés"
+
 #~ msgid "Changes apply the next time you run Storyboard and Export."
 #~ msgstr "Les modifications s'appliquent au prochain lancement du Storyboard et de l'Export."
 
@@ -1975,6 +2001,9 @@ msgstr "Titre de chapitre"
 
 msgid "Chart / Graph"
 msgstr "Graphique / Diagramme"
+
+#~ msgid "Check changes"
+#~ msgstr "Vérifier les modifications"
 
 #~ msgid "Check for updates"
 #~ msgstr "Vérifier les mises à jour"
@@ -2087,6 +2116,9 @@ msgstr "Clear modèle"
 msgid "Clear search"
 msgstr "Effacer la recherche"
 
+msgid "Clear visible selection"
+msgstr "Effacer la sélection visible"
+
 msgid "Clear, descriptive captions for middle and high school readers."
 msgstr "Des sous-titres clairs et descriptifs pour les lecteurs de collège et de lycée."
 
@@ -2192,6 +2224,9 @@ msgstr "Comparer les versions"
 msgid "Compared with fallback prompt."
 msgstr "Comparé au prompt de repli."
 
+#~ msgid "Complete the guided setup before starting the publishing workflow."
+#~ msgstr "Terminez la configuration guidée avant de lancer le flux de publication."
+
 msgid "Completed"
 msgstr "Terminé"
 
@@ -2246,6 +2281,12 @@ msgstr "Configurez chaque étape — extraction, storyboard, mise en page — pu
 msgid "Configure features to include in the export"
 msgstr "Configurer les fonctionnalités à inclure dans l'exportation"
 
+#~ msgid "Configure GitHub publishing"
+#~ msgstr "Configurer la publication GitHub"
+
+#~ msgid "Configure GitHub to start publishing"
+#~ msgstr "Configurez GitHub pour commencer la publication"
+
 #~ msgid "Configure provider credentials and global prompt fallbacks used by ADT Studio."
 #~ msgstr "Configurez les identifiants des fournisseurs et les prompts de fallback globaux utilisés par ADT Studio."
 
@@ -2260,6 +2301,12 @@ msgstr "Configurer les voix et les accents"
 
 msgid "Confirm merge"
 msgstr "Confirmer la fusion"
+
+#~ msgid "Confirm the destination below. Publishing will open the live workflow screen automatically."
+#~ msgstr "Confirmez la destination ci-dessous. La publication ouvrira automatiquement l’écran du flux en direct."
+
+#~ msgid "Connect an account and choose a repository before running this workflow."
+#~ msgstr "Connectez un compte et choisissez un dépôt avant d’exécuter ce flux."
 
 msgid "Connect an AI provider"
 msgstr "Connectez un fournisseur d'IA"
@@ -2284,6 +2331,9 @@ msgstr "Traitement du contenu"
 
 msgid "Contents"
 msgstr "Contenu"
+
+msgid "Contents — Read and write; Administration — Read and write; Pages — Read and write; Metadata — Read-only."
+msgstr "Contenu — Lecture et écriture ; Administration — Lecture et écriture ; Pages — Lecture et écriture ; Métadonnées — Lecture seule."
 
 msgid "Context"
 msgstr "Contexte"
@@ -2448,6 +2498,9 @@ msgstr "Créer une session de révision pour ce livre."
 msgid "Create ADT"
 msgstr "Créer ADT"
 
+#~ msgid "Create classic token on GitHub"
+#~ msgstr "Créer un jeton classique sur GitHub"
+
 msgid "Create descriptive captions for images to improve accessibility."
 msgstr "Créez des légendes descriptives pour les images afin d'améliorer l'accessibilité."
 
@@ -2456,6 +2509,9 @@ msgstr "Créer le fichier"
 
 msgid "Create files"
 msgstr "Créer les fichiers"
+
+#~ msgid "Create fine-grained token on GitHub"
+#~ msgstr "Créer un jeton à granularité fine sur GitHub"
 
 msgid "Create from scratch using your description"
 msgstr "Créer à partir de zéro en utilisant votre description"
@@ -2471,6 +2527,9 @@ msgstr "Créer un fichier de prompt à partir du modèle"
 
 msgid "Create session"
 msgstr "Créer une session"
+
+#~ msgid "Create the destination repository first, then select its owner and that repository as the token resource."
+#~ msgstr "Créez d’abord le dépôt de destination, puis sélectionnez son propriétaire et ce dépôt comme ressource du jeton."
 
 msgid "Created {created} prompt files for {normalizedTargetModel}."
 msgstr "{created} fichiers de prompt créés pour {normalizedTargetModel}."
@@ -2534,6 +2593,9 @@ msgstr "Actuelle (v{currentVersion})"
 
 msgid "Current book font"
 msgstr "Police actuelle du livre"
+
+#~ msgid "Current book workspace"
+#~ msgstr "Espace de travail actuel du livre"
 
 msgid "Current effective values"
 msgstr "Valeurs effectives actuelles"
@@ -3055,6 +3117,9 @@ msgstr "Chaque itération est un appel LLM. Des valeurs plus basses sont plus ra
 msgid "Each kind of pipeline task uses a compatible model. Image generation and speech use their own task-specific defaults."
 msgstr "Chaque type de tâche du pipeline utilise un modèle compatible. La génération d’images et la synthèse vocale utilisent leurs propres modèles par défaut spécifiques."
 
+#~ msgid "Each node updates live as ADT Studio publishes the book."
+#~ msgstr "Chaque nœud se met à jour en direct pendant qu’ADT Studio publie le livre."
+
 msgid "Each polyp secretes a hard calcium carbonate skeleton. Over hundreds of years, millions of these skeletons build up into the massive reef structures we see today."
 msgstr "Chaque polype sécrète un squelette rigide de carbonate de calcium. Au fil de centaines d'années, des millions de ces squelettes s'accumulent pour former les immenses structures récifales que nous voyons aujourd'hui."
 
@@ -3072,6 +3137,9 @@ msgstr "Les étapes précédentes n'ont pas encore été exécutées"
 
 msgid "Early"
 msgstr "Précoce"
+
+msgid "Easiest complete setup"
+msgstr "Configuration complète la plus simple"
 
 msgid "Easy Read"
 msgstr "Lecture Facile"
@@ -3593,6 +3661,9 @@ msgstr "Filtre les images décoratives ou non pertinentes sur chaque page."
 msgid "Final Page"
 msgstr "Page finale"
 
+msgid "Fine-grained token for an existing repository"
+msgstr "Jeton à granularité fine pour un dépôt existant"
+
 msgid "First images from the deep-field telescope."
 msgstr "Premières images du télescope à champ profond."
 
@@ -3749,8 +3820,8 @@ msgstr "Rassembler les preuves"
 msgid "Gemini"
 msgstr "Gemini"
 
-msgid "Gemini API key is required to generate audio."
-msgstr "La clé API Gemini est requise pour générer l'audio."
+#~ msgid "Gemini API key is required to generate audio."
+#~ msgstr "La clé API Gemini est requise pour générer l'audio."
 
 #~ msgid "Gemini generates each sentence in its own request, so its tone can drift between sentences. A lower temperature (e.g. 0.4) reduces that variation and a fixed seed makes delivery reproducible. Only affects languages routed to Gemini — OpenAI and Azure ignore these. Changing either value regenerates Gemini audio on the next run."
 #~ msgstr "Gemini génère chaque phrase dans sa propre requête, si bien que son ton peut varier d'une phrase à l'autre. Une température plus basse (p. ex. 0,4) réduit cette variation et une graine fixe rend la lecture reproductible. Ne concerne que les langues acheminées vers Gemini — OpenAI et Azure les ignorent. Modifier l'une de ces valeurs régénère l'audio Gemini lors de la prochaine exécution."
@@ -3824,8 +3895,8 @@ msgstr "Générer à partir des pages"
 msgid "Generate global prompts"
 msgstr "Générer des prompts globaux"
 
-msgid "Generate missing Gemini audio"
-msgstr "Générer l'audio Gemini manquant"
+#~ msgid "Generate missing Gemini audio"
+#~ msgstr "Générer l'audio Gemini manquant"
 
 msgid "Generate multiple-choice comprehension quizzes from the book's content. Create them automatically across the whole book, or add a single quiz from specific pages."
 msgstr "Générez des quiz de compréhension à choix multiples à partir du contenu du livre. Créez-les automatiquement dans tout le livre ou ajoutez un seul quiz à partir de pages spécifiques."
@@ -3921,6 +3992,12 @@ msgstr "Génération Invite"
 
 msgid "Get started"
 msgstr "Commencer"
+
+msgid "Git has not detected changed text entities for this view."
+msgstr "Git n’a détecté aucune entité de texte modifiée pour cette vue."
+
+#~ msgid "Git publishing workflow"
+#~ msgstr "Flux de publication Git"
 
 msgid "Global prompt reset to default."
 msgstr "Prompt global réinitialisé par défaut."
@@ -4554,6 +4631,9 @@ msgstr "Grandes images, flux narratif. Idéal pour les livres illustrés avec de
 #~ msgid "Last"
 #~ msgstr "Dernier"
 
+#~ msgid "Last activity"
+#~ msgstr "Dernière activité"
+
 msgid "Last change"
 msgstr "Dernière modification"
 
@@ -4562,6 +4642,12 @@ msgstr "Dernière modification"
 
 #~ msgid "Last week"
 #~ msgstr "La semaine dernière"
+
+#~ msgid "Latest deployment"
+#~ msgstr "Dernier déploiement"
+
+#~ msgid "Latest GitHub changes synchronized."
+#~ msgstr "Dernières modifications GitHub synchronisées."
 
 msgid "Launch the app with"
 msgstr "Lancer l'application avec"
@@ -4583,6 +4669,9 @@ msgstr "Mise en page reproduite sur cette section"
 
 msgid "Leading"
 msgstr "Interligne"
+
+#~ msgid "Learn how with a guided setup"
+#~ msgstr "Suivez la configuration guidée"
 
 msgid "Least used"
 msgstr "Moins utilisé"
@@ -4734,6 +4823,9 @@ msgstr "Chargement des livres..."
 msgid "Loading catalog..."
 msgstr "Chargement du catalogue..."
 
+#~ msgid "Loading deployments"
+#~ msgstr "Chargement des déploiements"
+
 msgid "Loading Easy Read..."
 msgstr "Chargement de Lecture Facile..."
 
@@ -4826,6 +4918,12 @@ msgstr "Chargement..."
 
 msgid "Loading…"
 msgstr "Chargement…"
+
+#~ msgid "Local and GitHub changes need resolution before synchronization."
+#~ msgstr "Les modifications locales et GitHub doivent être résolues avant la synchronisation."
+
+#~ msgid "Local book is up to date."
+#~ msgstr "Le livre local est à jour."
 
 msgid "Localization"
 msgstr "Localisation"
@@ -5366,6 +5464,9 @@ msgstr "Aucune légende ne correspond à ces filtres"
 msgid "No captions match your search"
 msgstr "Aucune légende ne correspond à votre recherche"
 
+msgid "No changed content needs speech regeneration"
+msgstr "Aucun contenu modifié ne nécessite de régénération vocale"
+
 msgid "no changes"
 msgstr "aucune modification"
 
@@ -5681,8 +5782,14 @@ msgstr "bruit"
 msgid "None"
 msgstr "Aucun"
 
+#~ msgid "Not committed yet"
+#~ msgstr "Pas encore validé"
+
 msgid "Not compatible with Fixed Layout"
 msgstr "Incompatible avec la mise en page fixe"
+
+#~ msgid "Not configured"
+#~ msgstr "Non configuré"
 
 msgid "Not detected"
 msgstr "Non détecté"
@@ -5856,6 +5963,9 @@ msgstr "Ouvrir l'aperçu de la page {pageId}"
 
 msgid "Open Preview"
 msgstr "Ouvrir l'aperçu"
+
+#~ msgid "Open public book"
+#~ msgstr "Ouvrir le livre public"
 
 #. placeholder {0}: pullRequest.number
 msgid "Open pull request {0}"
@@ -6068,6 +6178,9 @@ msgstr "Emballez le livre pour la distribution. Choisissez un format, sélection
 
 msgid "Package the finished book with every accessibility feature baked in — ready for a kid to open, listen, and read along."
 msgstr "Empaquetez le livre terminé avec toutes les fonctionnalités d'accessibilité intégrées — prêt pour qu'un enfant l'ouvre, l'écoute et suive la lecture."
+
+#~ msgid "Package, commit, push, host, and preview the accessible book without leaving ADT Studio."
+#~ msgstr "Créez le paquet, validez, publiez, hébergez et prévisualisez le livre accessible sans quitter ADT Studio."
 
 msgid "Packaging"
 msgstr "Empaquetage"
@@ -6644,11 +6757,20 @@ msgstr "Élagué : {reason}"
 msgid "PT"
 msgstr "PT"
 
+#~ msgid "Publish book"
+#~ msgstr "Publier le livre"
+
+#~ msgid "Publish with GitHub Pages"
+#~ msgstr "Publier avec GitHub Pages"
+
 msgid "published in"
 msgstr "publié en"
 
 msgid "Publisher"
 msgstr "Éditeur"
+
+#~ msgid "Pull remote changes"
+#~ msgstr "Récupérer les modifications distantes"
 
 msgid "Pull requests"
 msgstr "Pull requests"
@@ -6895,6 +7017,9 @@ msgstr "Recommandé pour"
 msgid "Recommended for {0}"
 msgstr "Recommandé pour {0}"
 
+msgid "Recommended for creating a new repository"
+msgstr "Recommandé pour créer un nouveau dépôt"
+
 msgid "Record reviewer findings for the current page and save them to the active validation session."
 msgstr "Enregistrez les résultats du réviseur pour la page actuelle et sauvegardez-les dans la session de validation active."
 
@@ -6937,11 +7062,24 @@ msgstr "Regénérer la définition, les variations et l'emoji"
 msgid "Regenerate Easy Read"
 msgstr "Régénérer Lecture Facile"
 
+msgid "Regenerate only the selected audio clips"
+msgstr "Régénérer uniquement les extraits audio sélectionnés"
+
+msgid "Regenerate selected"
+msgstr "Régénérer la sélection"
+
+#. placeholder {0}: selectedAudioIds.size
+#~ msgid "Regenerate selected ({0})"
+#~ msgstr "Régénérer la sélection ({0})"
+
 msgid "Regenerate selected images for each output language so that any text burned into them is shown in the target language."
 msgstr "Régénère les images sélectionnées pour chaque langue de sortie afin que tout texte intégré soit affiché dans la langue cible."
 
 msgid "Regenerate this activity with AI (requires a saved state and an API key)"
 msgstr "Régénérer cette activité avec l'IA (nécessite un état enregistré et une clé API)"
+
+msgid "Regenerate this audio clip"
+msgstr "Régénérer cet extrait audio"
 
 msgid "Region"
 msgstr "Région"
@@ -6966,6 +7104,12 @@ msgstr "Relâchez pour importer"
 
 msgid "Reload app"
 msgstr "Recharger l'application"
+
+#~ msgid "Remote changes are available."
+#~ msgstr "Des modifications distantes sont disponibles."
+
+#~ msgid "Remote changes available"
+#~ msgstr "Des modifications distantes sont disponibles"
 
 msgid "Remove"
 msgstr "Retirer"
@@ -7191,6 +7335,9 @@ msgstr "Réviser"
 #~ msgid "Review {selectedCount} selected"
 #~ msgstr "Revoir {selectedCount} sélectionnées"
 
+#~ msgid "Review and publish"
+#~ msgstr "Vérifier et publier"
+
 msgid "Review and refine each simplified block side-by-side with the original before packaging."
 msgstr "Examinez et peaufinez chaque bloc simplifié côte à côte avec l'original avant l'emballage."
 
@@ -7234,6 +7381,9 @@ msgstr "Rigueur de la révision"
 
 msgid "Review style"
 msgstr "Style de révision"
+
+#~ msgid "Review the most recent publishing workflow and open its public result."
+#~ msgstr "Consultez le flux de publication le plus récent et ouvrez son résultat public."
 
 msgid "Review the project details below and confirm the import."
 msgstr "Vérifiez les détails du projet ci-dessous et confirmez l'importation."
@@ -7383,6 +7533,9 @@ msgstr "Exécuter la traduction"
 msgid "Run whole-book validation checks and configure accessibility assessment settings."
 msgstr "Exécutez les vérifications de validation du livre entier et configurez les paramètres d'évaluation d'accessibilité."
 
+#~ msgid "Run workflow"
+#~ msgstr "Exécuter le flux"
+
 msgid "Run-only tags"
 msgstr "Tags d'exécution uniquement"
 
@@ -7449,6 +7602,9 @@ msgstr "Enregistrer l'activité"
 msgid "Save activity (⌘S)"
 msgstr "Enregistrer l'activité (⌘S)"
 
+#~ msgid "Save and publish"
+#~ msgstr "Enregistrer et publier"
+
 msgid "Save changes"
 msgstr "Enregistrer les modifications"
 
@@ -7469,6 +7625,9 @@ msgstr "Enregistrer la liste de contrôle"
 
 msgid "Save failed"
 msgstr "L'enregistrement a échoué"
+
+#~ msgid "Save or discard your edits before splitting"
+#~ msgstr "Enregistrez ou abandonnez vos modifications avant de diviser"
 
 msgid "Save or discard your edits first"
 msgstr "Enregistrez ou abandonnez d'abord vos modifications"
@@ -7687,6 +7846,12 @@ msgstr "sections"
 msgid "Sections"
 msgstr "Sections"
 
+msgid "Security: use the shortest practical expiration, never share the token, and revoke it in GitHub when it is no longer needed. ADT Studio keeps this token locally on this device and does not store it in the book directory."
+msgstr "Sécurité : utilisez la durée d’expiration pratique la plus courte, ne partagez jamais le jeton et révoquez-le dans GitHub lorsqu’il n’est plus nécessaire. ADT Studio conserve ce jeton localement sur cet appareil et ne le stocke pas dans le dossier du livre."
+
+#~ msgid "Security: use the shortest practical expiration, never share the token, and revoke it in GitHub when it is no longer needed. ADT Studio keeps this token only for the current browser session and does not store it in the book directory."
+#~ msgstr "Sécurité : utilisez la durée d’expiration pratique la plus courte, ne partagez jamais le jeton et révoquez-le dans GitHub lorsqu’il n’est plus nécessaire. ADT Studio conserve ce jeton uniquement pendant la session actuelle du navigateur et ne le stocke pas dans le dossier du livre."
+
 msgid "See examples"
 msgstr "Voir les exemples"
 
@@ -7786,6 +7951,10 @@ msgstr "Tout sélectionner"
 msgid "Select an item to edit its text — [[blank:…]] marks where a blank appears, so keep it to keep the blank."
 msgstr "Sélectionnez un élément pour modifier son texte : [[blank:…]] indique l'emplacement d'un blanc, conservez-le pour conserver le blanc."
 
+#. placeholder {0}: entry.text
+msgid "Select audio for {0}"
+msgstr "Sélectionner l’audio pour {0}"
+
 msgid "Select images to translate"
 msgstr "Sélectionner les images à traduire"
 
@@ -7810,8 +7979,17 @@ msgstr "Sélectionner un modèle..."
 msgid "Select the pages the quiz is written from, then choose where it appears using the buttons between pages."
 msgstr "Sélectionnez les pages sur lesquelles le quiz est basé, puis choisissez où il apparaît à l'aide des boutons entre les pages."
 
+#~ msgid "Select the repo scope. It covers repository creation, file publishing, and GitHub Pages configuration."
+#~ msgstr "Sélectionnez l’autorisation repo. Elle couvre la création du dépôt, la publication des fichiers et la configuration de GitHub Pages."
+
+msgid "Select this audio"
+msgstr "Sélectionner cet audio"
+
 msgid "Select up to 5 pages to use as visual references. The LLM will analyze them and generate a styleguide."
 msgstr "Sélectionnez jusqu'à 5 pages à utiliser comme références visuelles. Le LLM les analysera et générera un guide de style."
+
+msgid "Select visible audio"
+msgstr "Sélectionner les audios visibles"
 
 #~ msgid "Selected"
 #~ msgstr "Sélectionnée"
@@ -7869,8 +8047,11 @@ msgstr "Sessions"
 msgid "Sessions let different reviewers capture findings independently, including language-specific reviews."
 msgstr "Les sessions permettent à différents réviseurs de capturer leurs résultats indépendamment, y compris les révisions spécifiques à une langue."
 
-msgid "Set a Gemini API key to generate audio"
-msgstr "Définissez une clé API Gemini pour générer l'audio"
+#~ msgid "Set a Gemini API key to generate audio"
+#~ msgstr "Définissez une clé API Gemini pour générer l'audio"
+
+msgid "Set Administration to Read and write so ADT can configure the repository and create the GitHub Pages site."
+msgstr "Réglez Administration sur Lecture et écriture afin qu’ADT puisse configurer le dépôt et créer le site GitHub Pages."
 
 msgid "Set fonts for the whole book"
 msgstr "Définir les polices pour tout le livre"
@@ -7880,6 +8061,9 @@ msgstr "Définie manuellement"
 
 msgid "Set the editing language and choose output languages for the book."
 msgstr "Définissez la langue d'édition et choisissez les langues de sortie pour le livre."
+
+msgid "Set the selected speech provider's API key to generate audio"
+msgstr "Configurez la clé API du fournisseur vocal sélectionné pour générer l’audio"
 
 msgid "Set your API key first"
 msgstr "Configurez d'abord votre clé API"
@@ -8141,6 +8325,9 @@ msgstr "Aperçu de la parole"
 msgid "Speech Prompts"
 msgstr "Parole Invites"
 
+msgid "Speech regeneration views"
+msgstr "Vues de régénération vocale"
+
 msgid "Speech Settings"
 msgstr "Paramètres de la parole"
 
@@ -8398,6 +8585,9 @@ msgstr "Téléversé avec succès"
 
 msgid "Suggest improved translations when an entry needs attention"
 msgstr "Suggérer des traductions améliorées lorsqu'une entrée nécessite une attention"
+
+msgid "Suggested"
+msgstr "Suggéré"
 
 msgid "Suggested modification"
 msgstr "Modification suggérée"
@@ -8749,6 +8939,9 @@ msgstr "La révision de traduction enregistrée est obsolète. Relancez Réviser
 msgid "The section was edited after conversion — use \"Rebuild from page\" to refresh the steps."
 msgstr "La section a été modifiée après la conversion — utilisez « Reconstruire depuis la page » pour actualiser les étapes."
 
+msgid "The selected speech provider requires an API key."
+msgstr "Le fournisseur vocal sélectionné nécessite une clé API."
+
 msgid "The storyboard must be completed before generating {stageName}. Run the Storyboard stage first."
 msgstr "Le storyboard doit être complété avant de générer {stageName}. Exécutez d'abord l'étape du storyboard."
 
@@ -8760,6 +8953,9 @@ msgstr "La table des matières."
 
 msgid "The TOC lists the typed sections placed by Storyboard. Finish Storyboard before running this stage."
 msgstr "La table des matières liste les sections tapées placées par le Storyboard. Terminez le Storyboard avant d'exécuter cette étape."
+
+#~ msgid "The token needs repository contents, administration, and Pages permissions."
+#~ msgstr "Le jeton nécessite les autorisations de contenu du dépôt, d’administration et de Pages."
 
 msgid "The Water Cycle"
 msgstr "Le cycle de l'eau"
@@ -8817,6 +9013,9 @@ msgstr "Cette activité ne contient aucun texte ni aucune réponse adressable. R
 
 msgid "This archive can't be opened safely"
 msgstr "Cette archive ne peut pas être ouverte en toute sécurité"
+
+#~ msgid "This book asset will be included in the next commit."
+#~ msgstr "Cette ressource du livre sera incluse dans le prochain commit."
 
 msgid "This book has {pageCount} pages."
 msgstr "Ce livre comporte {pageCount} pages."
@@ -9105,6 +9304,9 @@ msgstr "Jetons totaux"
 msgid "Track reviewer progress and review findings captured from Preview."
 msgstr "Suivez la progression du réviseur et les résultats de révision capturés depuis l'aperçu."
 
+#~ msgid "Track the book's local edits, commits, publishing status, and GitHub metadata."
+#~ msgstr "Suivez les modifications locales, les commits, l’état de publication et les métadonnées GitHub du livre."
+
 msgid "Translate"
 msgstr "Traduire"
 
@@ -9320,6 +9522,9 @@ msgstr "Non catégorisé"
 
 msgid "Unchanged"
 msgstr "Inchangé"
+
+#~ msgid "Under Repository permissions, grant Contents, Administration, and Pages read and write access."
+#~ msgstr "Dans les autorisations du dépôt, accordez l’accès en lecture et écriture à Contents, Administration et Pages."
 
 msgid "Underline"
 msgstr "Souligné"
@@ -9612,6 +9817,9 @@ msgstr "Voir"
 #~ msgid "View all changes"
 #~ msgstr "Voir toutes les modifications"
 
+#~ msgid "View deployment"
+#~ msgstr "Voir le déploiement"
+
 msgid "View details"
 msgstr "Voir les détails"
 
@@ -9850,6 +10058,9 @@ msgstr "Surlignage mot à mot"
 msgid "words"
 msgstr "mots"
 
+#~ msgid "Workspace changes"
+#~ msgstr "Modifications de l’espace de travail"
+
 msgid "Wrap in group"
 msgstr "Encapsuler dans un groupe"
 
@@ -9935,50 +10146,3 @@ msgstr "Zoom avant"
 
 msgid "Zoom out"
 msgstr "Zoom arrière"
-
-#. placeholder {0}: selectedAudioIds.size
-msgid "{0} selected"
-msgstr "{0} sélectionnés"
-
-msgid "All audio"
-msgstr "Tous les fichiers audio"
-
-msgid "Clear visible selection"
-msgstr "Effacer la sélection visible"
-
-msgid "Git has not detected changed text entities for this view."
-msgstr "Git n’a détecté aucune entité de texte modifiée pour cette vue."
-
-msgid "No changed content needs speech regeneration"
-msgstr "Aucun contenu modifié ne nécessite de régénération vocale"
-
-msgid "Regenerate only the selected audio clips"
-msgstr "Régénérer uniquement les extraits audio sélectionnés"
-
-msgid "Regenerate selected"
-msgstr "Régénérer la sélection"
-
-msgid "Regenerate this audio clip"
-msgstr "Régénérer cet extrait audio"
-
-#. placeholder {0}: entry.text
-msgid "Select audio for {0}"
-msgstr "Sélectionner l’audio pour {0}"
-
-msgid "Select this audio"
-msgstr "Sélectionner cet audio"
-
-msgid "Select visible audio"
-msgstr "Sélectionner les audios visibles"
-
-msgid "Set the selected speech provider's API key to generate audio"
-msgstr "Configurez la clé API du fournisseur vocal sélectionné pour générer l’audio"
-
-msgid "Speech regeneration views"
-msgstr "Vues de régénération vocale"
-
-msgid "Suggested"
-msgstr "Suggéré"
-
-msgid "The selected speech provider requires an API key."
-msgstr "Le fournisseur vocal sélectionné nécessite une clé API."

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -9935,3 +9935,50 @@ msgstr "Zoom avant"
 
 msgid "Zoom out"
 msgstr "Zoom arrière"
+
+#. placeholder {0}: selectedAudioIds.size
+msgid "{0} selected"
+msgstr "{0} sélectionnés"
+
+msgid "All audio"
+msgstr "Tous les fichiers audio"
+
+msgid "Clear visible selection"
+msgstr "Effacer la sélection visible"
+
+msgid "Git has not detected changed text entities for this view."
+msgstr "Git n’a détecté aucune entité de texte modifiée pour cette vue."
+
+msgid "No changed content needs speech regeneration"
+msgstr "Aucun contenu modifié ne nécessite de régénération vocale"
+
+msgid "Regenerate only the selected audio clips"
+msgstr "Régénérer uniquement les extraits audio sélectionnés"
+
+msgid "Regenerate selected"
+msgstr "Régénérer la sélection"
+
+msgid "Regenerate this audio clip"
+msgstr "Régénérer cet extrait audio"
+
+#. placeholder {0}: entry.text
+msgid "Select audio for {0}"
+msgstr "Sélectionner l’audio pour {0}"
+
+msgid "Select this audio"
+msgstr "Sélectionner cet audio"
+
+msgid "Select visible audio"
+msgstr "Sélectionner les audios visibles"
+
+msgid "Set the selected speech provider's API key to generate audio"
+msgstr "Configurez la clé API du fournisseur vocal sélectionné pour générer l’audio"
+
+msgid "Speech regeneration views"
+msgstr "Vues de régénération vocale"
+
+msgid "Suggested"
+msgstr "Suggéré"
+
+msgid "The selected speech provider requires an API key."
+msgstr "Le fournisseur vocal sélectionné nécessite une clé API."

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -2964,6 +2964,9 @@ msgstr "TERMINÉ"
 #~ msgid "Downgrade"
 #~ msgstr "Rétrogradation"
 
+msgid "Done selecting"
+msgstr "Terminer la sélection"
+
 msgid "Download a full backup of this project"
 msgstr "Télécharger une sauvegarde complète de ce projet"
 
@@ -7950,6 +7953,9 @@ msgstr "Tout sélectionner"
 
 msgid "Select an item to edit its text — [[blank:…]] marks where a blank appears, so keep it to keep the blank."
 msgstr "Sélectionnez un élément pour modifier son texte : [[blank:…]] indique l'emplacement d'un blanc, conservez-le pour conserver le blanc."
+
+msgid "Select audio"
+msgstr "Sélectionner l’audio"
 
 #. placeholder {0}: entry.text
 msgid "Select audio for {0}"

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -2962,6 +2962,9 @@ msgstr "CONCLUÍDO"
 #~ msgid "Downgrade"
 #~ msgstr "Downgrade"
 
+msgid "Done selecting"
+msgstr "Concluir seleção"
+
 msgid "Download a full backup of this project"
 msgstr "Baixar um backup completo deste projeto"
 
@@ -7948,6 +7951,9 @@ msgstr "Selecionar tudo"
 
 msgid "Select an item to edit its text — [[blank:…]] marks where a blank appears, so keep it to keep the blank."
 msgstr "Selecione um item para editar seu texto: [[blank:…]] marca onde aparece uma lacuna, então mantenha-o para preservar a lacuna."
+
+msgid "Select audio"
+msgstr "Selecionar áudio"
 
 #. placeholder {0}: entry.text
 msgid "Select audio for {0}"

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -3821,8 +3821,8 @@ msgstr "Reunindo as evidências"
 msgid "Gemini"
 msgstr "Gemini"
 
-#~ msgid "Gemini API key is required to generate audio."
-#~ msgstr "É necessária uma chave de API do Gemini para gerar áudio."
+msgid "Gemini API key is required to generate audio."
+msgstr "É necessária uma chave de API do Gemini para gerar áudio."
 
 #~ msgid "Gemini generates each sentence in its own request, so its tone can drift between sentences. A lower temperature (e.g. 0.4) reduces that variation and a fixed seed makes delivery reproducible. Only affects languages routed to Gemini — OpenAI and Azure ignore these. Changing either value regenerates Gemini audio on the next run."
 #~ msgstr "O Gemini gera cada frase em sua própria requisição, então o tom pode variar entre as frases. Uma temperatura mais baixa (ex.: 0,4) reduz essa variação e uma semente fixa torna a leitura reproduzível. Afeta apenas os idiomas roteados para o Gemini — o OpenAI e o Azure ignoram esses valores. Alterar qualquer um deles regenera o áudio do Gemini na próxima execução."
@@ -3896,8 +3896,8 @@ msgstr "Gerar a partir das páginas"
 msgid "Generate global prompts"
 msgstr "Gerar prompts globais"
 
-#~ msgid "Generate missing Gemini audio"
-#~ msgstr "Gerar áudio faltante do Gemini"
+msgid "Generate missing Gemini audio"
+msgstr "Gerar o áudio Gemini ausente"
 
 msgid "Generate multiple-choice comprehension quizzes from the book's content. Create them automatically across the whole book, or add a single quiz from specific pages."
 msgstr "Gere questionários de compreensão de múltipla escolha a partir do conteúdo do livro. Crie-os automaticamente em todo o livro ou adicione um único questionário a partir de páginas específicas."
@@ -8051,8 +8051,8 @@ msgstr "Sessions"
 msgid "Sessions let different reviewers capture findings independently, including language-specific reviews."
 msgstr "Sessions let different reviewers capture findings independently, including language-specific reviews."
 
-#~ msgid "Set a Gemini API key to generate audio"
-#~ msgstr "Defina uma chave de API do Gemini para gerar áudio"
+msgid "Set a Gemini API key to generate audio"
+msgstr "Defina uma chave de API do Gemini para gerar áudio"
 
 msgid "Set Administration to Read and write so ADT can configure the repository and create the GitHub Pages site."
 msgstr "Defina Administração como Leitura e gravação para que o ADT possa configurar o repositório e criar o site do GitHub Pages."

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -243,6 +243,10 @@ msgstr "{0} questões"
 msgid "{0} sections"
 msgstr "{0} seções"
 
+#. placeholder {0}: selectedAudioIds.size
+msgid "{0} selected"
+msgstr "{0} selecionados"
+
 #. placeholder {0}: String(stale.length)
 msgid "{0} selected images are no longer in the storyboard."
 msgstr "{0} imagens selecionadas não estão mais no storyboard."
@@ -262,6 +266,10 @@ msgstr "{0} textos"
 #. placeholder {0}: outputLanguages.length
 msgid "{0} translations"
 msgstr "{0} traduções"
+
+#. placeholder {0}: changesQuery.data.changes.length
+#~ msgid "{0} unpublished file changes"
+#~ msgstr "{0} alterações de arquivo não publicadas"
 
 #. placeholder {0}: versions.length
 #~ msgid "{0} versions"
@@ -821,6 +829,9 @@ msgstr "Atividade: Múltipla escolha"
 msgid "Activity: Open-Ended Answer"
 msgstr "Atividade: Resposta aberta"
 
+#~ msgid "Activity: Ordering"
+#~ msgstr "Atividade: Ordenação"
+
 msgid "Activity: Other"
 msgstr "Atividade: Outra"
 
@@ -1203,6 +1214,9 @@ msgstr "Tudo"
 msgid "All {0} pages merged in"
 msgstr "As {0} páginas foram mescladas"
 
+msgid "All audio"
+msgstr "Todos os áudios"
+
 msgid "All categories"
 msgstr "Todas as categorias"
 
@@ -1259,6 +1273,9 @@ msgstr "Quantidade"
 
 msgid "An activity that does not fit the standard categories."
 msgstr "Uma atividade que não se enquadra nas categorias padrão."
+
+#~ msgid "An activity where learners arrange items into the correct order."
+#~ msgstr "Uma atividade em que os estudantes organizam itens na ordem correta."
 
 msgid "An activity where the learner underlines one or more words, phrases, or sentences directly in the text."
 msgstr "Uma atividade em que o aluno sublinha uma ou mais palavras, expressões ou frases diretamente no texto."
@@ -1654,6 +1671,9 @@ msgstr "O corpo do texto usa esta fonte hoje. Anexe uma fonte abaixo e atribua a
 msgid "Book"
 msgstr "Livro"
 
+#~ msgid "Book change history"
+#~ msgstr "Histórico de alterações do livro"
+
 msgid "Book coverage"
 msgstr "Cobertura do livro"
 
@@ -1671,6 +1691,9 @@ msgstr "Imagens do livro"
 
 msgid "Book info"
 msgstr "Informações do livro"
+
+#~ msgid "Book is published"
+#~ msgstr "O livro está publicado"
 
 msgid "Book Language"
 msgstr "Idioma do livro"
@@ -1929,6 +1952,9 @@ msgstr "Alterar o idioma do livro?"
 msgid "Change the picture for this term"
 msgstr "Alterar a imagem deste termo"
 
+#~ msgid "Changed files"
+#~ msgstr "Arquivos alterados"
+
 #~ msgid "Changes apply the next time you run Storyboard and Export."
 #~ msgstr "As alterações são aplicadas na próxima vez que você executar o Storyboard e a Exportação."
 
@@ -1973,6 +1999,9 @@ msgstr "Título do capítulo"
 
 msgid "Chart / Graph"
 msgstr "Gráfico / Tabela"
+
+#~ msgid "Check changes"
+#~ msgstr "Verificar alterações"
 
 #~ msgid "Check for updates"
 #~ msgstr "Verificar atualizações"
@@ -2085,6 +2114,9 @@ msgstr "Limpar modelo"
 msgid "Clear search"
 msgstr "Limpar busca"
 
+msgid "Clear visible selection"
+msgstr "Limpar seleção visível"
+
 msgid "Clear, descriptive captions for middle and high school readers."
 msgstr "Legendas claras e descritivas para leitores do ensino fundamental e médio."
 
@@ -2190,6 +2222,9 @@ msgstr "Comparar versões"
 msgid "Compared with fallback prompt."
 msgstr "Comparado com o prompt fallback."
 
+#~ msgid "Complete the guided setup before starting the publishing workflow."
+#~ msgstr "Conclua a configuração guiada antes de iniciar o fluxo de publicação."
+
 msgid "Completed"
 msgstr "Concluído"
 
@@ -2244,6 +2279,12 @@ msgstr "Configure cada etapa — extração, storyboard, layout — e deixe o AD
 msgid "Configure features to include in the export"
 msgstr "Configure as funcionalidades a incluir na exportação"
 
+#~ msgid "Configure GitHub publishing"
+#~ msgstr "Configurar publicação no GitHub"
+
+#~ msgid "Configure GitHub to start publishing"
+#~ msgstr "Configure o GitHub para começar a publicar"
+
 #~ msgid "Configure provider credentials and global prompt fallbacks used by ADT Studio."
 #~ msgstr "Configure as credenciais dos provedores e os prompts fallback globais usados pelo ADT Studio."
 
@@ -2258,6 +2299,12 @@ msgstr "Configurar vozes e sotaques"
 
 msgid "Confirm merge"
 msgstr "Confirmar mesclagem"
+
+#~ msgid "Confirm the destination below. Publishing will open the live workflow screen automatically."
+#~ msgstr "Confirme o destino abaixo. A publicação abrirá automaticamente a tela do fluxo ao vivo."
+
+#~ msgid "Connect an account and choose a repository before running this workflow."
+#~ msgstr "Conecte uma conta e escolha um repositório antes de executar este fluxo."
 
 msgid "Connect an AI provider"
 msgstr "Conecte um provedor de IA"
@@ -2282,6 +2329,9 @@ msgstr "Processamento de Conteúdo"
 
 msgid "Contents"
 msgstr "Conteúdo"
+
+msgid "Contents — Read and write; Administration — Read and write; Pages — Read and write; Metadata — Read-only."
+msgstr "Conteúdo — Leitura e gravação; Administração — Leitura e gravação; Pages — Leitura e gravação; Metadados — Somente leitura."
 
 msgid "Context"
 msgstr "Contexto"
@@ -2446,6 +2496,9 @@ msgstr "Create a reviewer session for this book."
 msgid "Create ADT"
 msgstr "Criar ADT"
 
+#~ msgid "Create classic token on GitHub"
+#~ msgstr "Criar token clássico no GitHub"
+
 msgid "Create descriptive captions for images to improve accessibility."
 msgstr "Cria legendas descritivas para imagens para melhorar a acessibilidade."
 
@@ -2454,6 +2507,9 @@ msgstr "Criar arquivo"
 
 msgid "Create files"
 msgstr "Criar arquivos"
+
+#~ msgid "Create fine-grained token on GitHub"
+#~ msgstr "Criar token de acesso refinado no GitHub"
 
 msgid "Create from scratch using your description"
 msgstr "Criar do zero usando sua descrição"
@@ -2469,6 +2525,9 @@ msgstr "Criar arquivo de prompt a partir do template"
 
 msgid "Create session"
 msgstr "Create session"
+
+#~ msgid "Create the destination repository first, then select its owner and that repository as the token resource."
+#~ msgstr "Primeiro crie o repositório de destino e depois selecione o proprietário e esse repositório como recurso do token."
 
 msgid "Created {created} prompt files for {normalizedTargetModel}."
 msgstr "Criados {created} arquivos de prompt para {normalizedTargetModel}."
@@ -2532,6 +2591,9 @@ msgstr "Atual (v{currentVersion})"
 
 msgid "Current book font"
 msgstr "Fonte atual do livro"
+
+#~ msgid "Current book workspace"
+#~ msgstr "Espaço de trabalho atual do livro"
 
 msgid "Current effective values"
 msgstr "Current effective values"
@@ -3053,6 +3115,9 @@ msgstr "Cada iteração é uma chamada LLM. Valores menores são mais rápidos e
 msgid "Each kind of pipeline task uses a compatible model. Image generation and speech use their own task-specific defaults."
 msgstr "Cada tipo de tarefa do pipeline usa um modelo compatível. A geração de imagens e de fala usa seus próprios padrões específicos por tarefa."
 
+#~ msgid "Each node updates live as ADT Studio publishes the book."
+#~ msgstr "Cada nó é atualizado ao vivo enquanto o ADT Studio publica o livro."
+
 msgid "Each polyp secretes a hard calcium carbonate skeleton. Over hundreds of years, millions of these skeletons build up into the massive reef structures we see today."
 msgstr "Cada pólipo secreta um esqueleto duro de carbonato de cálcio. Ao longo de centenas de anos, milhões desses esqueletos formam as enormes estruturas de recifes que vemos hoje."
 
@@ -3070,6 +3135,9 @@ msgstr "As etapas anteriores ainda não foram executadas"
 
 msgid "Early"
 msgstr "Iniciante"
+
+msgid "Easiest complete setup"
+msgstr "Configuração completa mais fácil"
 
 msgid "Easy Read"
 msgstr "Leitura Fácil"
@@ -3591,6 +3659,9 @@ msgstr "Filtra imagens decorativas ou sem conteúdo em cada página."
 msgid "Final Page"
 msgstr "Página Final"
 
+msgid "Fine-grained token for an existing repository"
+msgstr "Token de acesso refinado para um repositório existente"
+
 msgid "First images from the deep-field telescope."
 msgstr "Primeiras imagens do telescópio de campo profundo."
 
@@ -3747,8 +3818,8 @@ msgstr "Reunindo as evidências"
 msgid "Gemini"
 msgstr "Gemini"
 
-msgid "Gemini API key is required to generate audio."
-msgstr "É necessária uma chave de API do Gemini para gerar áudio."
+#~ msgid "Gemini API key is required to generate audio."
+#~ msgstr "É necessária uma chave de API do Gemini para gerar áudio."
 
 #~ msgid "Gemini generates each sentence in its own request, so its tone can drift between sentences. A lower temperature (e.g. 0.4) reduces that variation and a fixed seed makes delivery reproducible. Only affects languages routed to Gemini — OpenAI and Azure ignore these. Changing either value regenerates Gemini audio on the next run."
 #~ msgstr "O Gemini gera cada frase em sua própria requisição, então o tom pode variar entre as frases. Uma temperatura mais baixa (ex.: 0,4) reduz essa variação e uma semente fixa torna a leitura reproduzível. Afeta apenas os idiomas roteados para o Gemini — o OpenAI e o Azure ignoram esses valores. Alterar qualquer um deles regenera o áudio do Gemini na próxima execução."
@@ -3822,8 +3893,8 @@ msgstr "Gerar a partir das páginas"
 msgid "Generate global prompts"
 msgstr "Gerar prompts globais"
 
-msgid "Generate missing Gemini audio"
-msgstr "Gerar áudio faltante do Gemini"
+#~ msgid "Generate missing Gemini audio"
+#~ msgstr "Gerar áudio faltante do Gemini"
 
 msgid "Generate multiple-choice comprehension quizzes from the book's content. Create them automatically across the whole book, or add a single quiz from specific pages."
 msgstr "Gere questionários de compreensão de múltipla escolha a partir do conteúdo do livro. Crie-os automaticamente em todo o livro ou adicione um único questionário a partir de páginas específicas."
@@ -3919,6 +3990,12 @@ msgstr "Prompt de geração"
 
 msgid "Get started"
 msgstr "Começar"
+
+msgid "Git has not detected changed text entities for this view."
+msgstr "O Git não detectou entidades de texto alteradas nesta visualização."
+
+#~ msgid "Git publishing workflow"
+#~ msgstr "Fluxo de publicação Git"
 
 msgid "Global prompt reset to default."
 msgstr "Prompt global resetado para o padrão."
@@ -4552,6 +4629,9 @@ msgstr "Imagens grandes, fluxo narrativo. Melhor para livros ilustrados com voze
 #~ msgid "Last"
 #~ msgstr "Última"
 
+#~ msgid "Last activity"
+#~ msgstr "Última atividade"
+
 msgid "Last change"
 msgstr "Última alteração"
 
@@ -4560,6 +4640,12 @@ msgstr "Última modificação"
 
 #~ msgid "Last week"
 #~ msgstr "Semana passada"
+
+#~ msgid "Latest deployment"
+#~ msgstr "Implantação mais recente"
+
+#~ msgid "Latest GitHub changes synchronized."
+#~ msgstr "Alterações mais recentes do GitHub sincronizadas."
 
 msgid "Launch the app with"
 msgstr "Iniciar o aplicativo com"
@@ -4581,6 +4667,9 @@ msgstr "Layout espelhado nesta seção"
 
 msgid "Leading"
 msgstr "Entrelinha"
+
+#~ msgid "Learn how with a guided setup"
+#~ msgstr "Aprenda com uma configuração guiada"
 
 msgid "Least used"
 msgstr "Menos usado"
@@ -4732,6 +4821,9 @@ msgstr "Carregando livros..."
 msgid "Loading catalog..."
 msgstr "Carregando catálogo..."
 
+#~ msgid "Loading deployments"
+#~ msgstr "Carregando implantações"
+
 msgid "Loading Easy Read..."
 msgstr "Carregando Leitura Fácil..."
 
@@ -4824,6 +4916,12 @@ msgstr "Carregando..."
 
 msgid "Loading…"
 msgstr "Carregando…"
+
+#~ msgid "Local and GitHub changes need resolution before synchronization."
+#~ msgstr "As alterações locais e do GitHub precisam ser resolvidas antes da sincronização."
+
+#~ msgid "Local book is up to date."
+#~ msgstr "O livro local está atualizado."
 
 msgid "Localization"
 msgstr "Localização"
@@ -5364,6 +5462,9 @@ msgstr "Nenhuma legenda corresponde a esses filtros"
 msgid "No captions match your search"
 msgstr "Nenhuma legenda corresponde à sua pesquisa"
 
+msgid "No changed content needs speech regeneration"
+msgstr "Nenhum conteúdo alterado precisa de regeneração de voz"
+
 msgid "no changes"
 msgstr "sem alterações"
 
@@ -5679,8 +5780,14 @@ msgstr "ruído"
 msgid "None"
 msgstr "Nenhum"
 
+#~ msgid "Not committed yet"
+#~ msgstr "Ainda não confirmado"
+
 msgid "Not compatible with Fixed Layout"
 msgstr "Não compatível com Layout Fixo"
+
+#~ msgid "Not configured"
+#~ msgstr "Não configurado"
 
 msgid "Not detected"
 msgstr "Não detectado"
@@ -5854,6 +5961,9 @@ msgstr "Abrir pré-visualização da página {0}"
 
 msgid "Open Preview"
 msgstr "Open Preview"
+
+#~ msgid "Open public book"
+#~ msgstr "Abrir livro público"
 
 #. placeholder {0}: pullRequest.number
 msgid "Open pull request {0}"
@@ -6066,6 +6176,9 @@ msgstr "Empacote o livro para distribuição. Escolha um formato, decida o que v
 
 msgid "Package the finished book with every accessibility feature baked in — ready for a kid to open, listen, and read along."
 msgstr "Empacote o livro pronto com todos os recursos de acessibilidade integrados — pronto para uma criança abrir, ouvir e acompanhar a leitura."
+
+#~ msgid "Package, commit, push, host, and preview the accessible book without leaving ADT Studio."
+#~ msgstr "Empacote, confirme, publique, hospede e visualize o livro acessível sem sair do ADT Studio."
 
 msgid "Packaging"
 msgstr "Empacotando"
@@ -6642,11 +6755,20 @@ msgstr "Removido: {0}"
 msgid "PT"
 msgstr "PT"
 
+#~ msgid "Publish book"
+#~ msgstr "Publicar livro"
+
+#~ msgid "Publish with GitHub Pages"
+#~ msgstr "Publicar com GitHub Pages"
+
 msgid "published in"
 msgstr "publicado em"
 
 msgid "Publisher"
 msgstr "Editora"
+
+#~ msgid "Pull remote changes"
+#~ msgstr "Baixar alterações remotas"
 
 msgid "Pull requests"
 msgstr "Pull requests"
@@ -6893,6 +7015,9 @@ msgstr "Recomendado para"
 msgid "Recommended for {0}"
 msgstr "Recomendado para {0}"
 
+msgid "Recommended for creating a new repository"
+msgstr "Recomendado para criar um novo repositório"
+
 msgid "Record reviewer findings for the current page and save them to the active validation session."
 msgstr "Record reviewer findings for the current page and save them to the active validation session."
 
@@ -6935,11 +7060,24 @@ msgstr "Regenerar definição, variações e emoji"
 msgid "Regenerate Easy Read"
 msgstr "Regenerar Leitura Fácil"
 
+msgid "Regenerate only the selected audio clips"
+msgstr "Regenerar apenas os clipes de áudio selecionados"
+
+msgid "Regenerate selected"
+msgstr "Regenerar selecionados"
+
+#. placeholder {0}: selectedAudioIds.size
+#~ msgid "Regenerate selected ({0})"
+#~ msgstr "Regenerar selecionados ({0})"
+
 msgid "Regenerate selected images for each output language so that any text burned into them is shown in the target language."
 msgstr "Regenera as imagens selecionadas para cada idioma de saída para que qualquer texto fixo nelas seja exibido no idioma de destino."
 
 msgid "Regenerate this activity with AI (requires a saved state and an API key)"
 msgstr "Regenerar esta atividade com IA (requer um estado salvo e uma chave de API)"
+
+msgid "Regenerate this audio clip"
+msgstr "Regenerar este clipe de áudio"
 
 msgid "Region"
 msgstr "Região"
@@ -6964,6 +7102,12 @@ msgstr "Solte para enviar"
 
 msgid "Reload app"
 msgstr "Recarregar aplicativo"
+
+#~ msgid "Remote changes are available."
+#~ msgstr "Há alterações remotas disponíveis."
+
+#~ msgid "Remote changes available"
+#~ msgstr "Há alterações remotas disponíveis"
 
 msgid "Remove"
 msgstr "Remover"
@@ -7189,6 +7333,9 @@ msgstr "Revisar"
 #~ msgid "Review {selectedCount} selected"
 #~ msgstr "Revisar {selectedCount} selecionado(s)"
 
+#~ msgid "Review and publish"
+#~ msgstr "Revisar e publicar"
+
 msgid "Review and refine each simplified block side-by-side with the original before packaging."
 msgstr "Revise e refine cada bloco simplificado lado a lado com o original antes de empacotar."
 
@@ -7232,6 +7379,9 @@ msgstr "Rigor da revisão"
 
 msgid "Review style"
 msgstr "Estilo de revisão"
+
+#~ msgid "Review the most recent publishing workflow and open its public result."
+#~ msgstr "Revise o fluxo de publicação mais recente e abra seu resultado público."
 
 msgid "Review the project details below and confirm the import."
 msgstr "Revise os detalhes do projeto abaixo e confirme a importação."
@@ -7381,6 +7531,9 @@ msgstr "Executar Tradução"
 msgid "Run whole-book validation checks and configure accessibility assessment settings."
 msgstr "Run whole-book validation checks and configure accessibility assessment settings."
 
+#~ msgid "Run workflow"
+#~ msgstr "Executar fluxo"
+
 msgid "Run-only tags"
 msgstr "Run-only tags"
 
@@ -7447,6 +7600,9 @@ msgstr "Salvar atividade"
 msgid "Save activity (⌘S)"
 msgstr "Salvar atividade (⌘S)"
 
+#~ msgid "Save and publish"
+#~ msgstr "Salvar e publicar"
+
 msgid "Save changes"
 msgstr "Salvar alterações"
 
@@ -7467,6 +7623,9 @@ msgstr "Save checklist"
 
 msgid "Save failed"
 msgstr "Save failed"
+
+#~ msgid "Save or discard your edits before splitting"
+#~ msgstr "Salve ou descarte suas edições antes de dividir"
 
 msgid "Save or discard your edits first"
 msgstr "Salve ou descarte suas edições primeiro"
@@ -7685,6 +7844,12 @@ msgstr "seções"
 msgid "Sections"
 msgstr "Seções"
 
+msgid "Security: use the shortest practical expiration, never share the token, and revoke it in GitHub when it is no longer needed. ADT Studio keeps this token locally on this device and does not store it in the book directory."
+msgstr "Segurança: use a menor validade prática, nunca compartilhe o token e revogue-o no GitHub quando ele não for mais necessário. O ADT Studio mantém este token localmente neste dispositivo e não o armazena no diretório do livro."
+
+#~ msgid "Security: use the shortest practical expiration, never share the token, and revoke it in GitHub when it is no longer needed. ADT Studio keeps this token only for the current browser session and does not store it in the book directory."
+#~ msgstr "Segurança: use a menor validade prática, nunca compartilhe o token e revogue-o no GitHub quando não for mais necessário. O ADT Studio mantém esse token somente durante a sessão atual do navegador e não o armazena no diretório do livro."
+
 msgid "See examples"
 msgstr "Ver exemplos"
 
@@ -7784,6 +7949,10 @@ msgstr "Selecionar tudo"
 msgid "Select an item to edit its text — [[blank:…]] marks where a blank appears, so keep it to keep the blank."
 msgstr "Selecione um item para editar seu texto: [[blank:…]] marca onde aparece uma lacuna, então mantenha-o para preservar a lacuna."
 
+#. placeholder {0}: entry.text
+msgid "Select audio for {0}"
+msgstr "Selecionar áudio para {0}"
+
 msgid "Select images to translate"
 msgstr "Selecionar imagens para traduzir"
 
@@ -7808,8 +7977,17 @@ msgstr "Selecionar template..."
 msgid "Select the pages the quiz is written from, then choose where it appears using the buttons between pages."
 msgstr "Selecione as páginas em que o questionário se baseia e escolha onde ele aparece usando os botões entre as páginas."
 
+#~ msgid "Select the repo scope. It covers repository creation, file publishing, and GitHub Pages configuration."
+#~ msgstr "Selecione o escopo repo. Ele cobre a criação do repositório, a publicação de arquivos e a configuração do GitHub Pages."
+
+msgid "Select this audio"
+msgstr "Selecionar este áudio"
+
 msgid "Select up to 5 pages to use as visual references. The LLM will analyze them and generate a styleguide."
 msgstr "Selecione até 5 páginas para usar como referências visuais. O LLM irá analisá-las e gerar um guia de estilo."
+
+msgid "Select visible audio"
+msgstr "Selecionar áudios visíveis"
 
 #~ msgid "Selected"
 #~ msgstr "Selecionada"
@@ -7867,8 +8045,11 @@ msgstr "Sessions"
 msgid "Sessions let different reviewers capture findings independently, including language-specific reviews."
 msgstr "Sessions let different reviewers capture findings independently, including language-specific reviews."
 
-msgid "Set a Gemini API key to generate audio"
-msgstr "Defina uma chave de API do Gemini para gerar áudio"
+#~ msgid "Set a Gemini API key to generate audio"
+#~ msgstr "Defina uma chave de API do Gemini para gerar áudio"
+
+msgid "Set Administration to Read and write so ADT can configure the repository and create the GitHub Pages site."
+msgstr "Defina Administração como Leitura e gravação para que o ADT possa configurar o repositório e criar o site do GitHub Pages."
 
 msgid "Set fonts for the whole book"
 msgstr "Definir fontes do livro todo"
@@ -7878,6 +8059,9 @@ msgstr "Definida manualmente"
 
 msgid "Set the editing language and choose output languages for the book."
 msgstr "Defina o idioma de edição e escolha os idiomas de saída para o livro."
+
+msgid "Set the selected speech provider's API key to generate audio"
+msgstr "Configure a chave de API do provedor de voz selecionado para gerar áudio"
 
 msgid "Set your API key first"
 msgstr "Configure primeiro sua chave de API"
@@ -8139,6 +8323,9 @@ msgstr "Pré-visualização de Fala"
 msgid "Speech Prompts"
 msgstr "Prompts de fala"
 
+msgid "Speech regeneration views"
+msgstr "Visualizações de regeneração de voz"
+
 msgid "Speech Settings"
 msgstr "Configurações de Fala"
 
@@ -8396,6 +8583,9 @@ msgstr "Enviado com sucesso"
 
 msgid "Suggest improved translations when an entry needs attention"
 msgstr "Sugerir traduções melhoradas quando uma entrada precisar de atenção"
+
+msgid "Suggested"
+msgstr "Sugerido"
 
 msgid "Suggested modification"
 msgstr "Suggested modification"
@@ -8747,6 +8937,9 @@ msgstr "A revisão de tradução salva está desatualizada. Execute Revisar nova
 msgid "The section was edited after conversion — use \"Rebuild from page\" to refresh the steps."
 msgstr "A seção foi editada após a conversão — use «Reconstruir a partir da página» para atualizar as etapas."
 
+msgid "The selected speech provider requires an API key."
+msgstr "O provedor de voz selecionado exige uma chave de API."
+
 msgid "The storyboard must be completed before generating {stageName}. Run the Storyboard stage first."
 msgstr "O storyboard deve ser concluído antes de gerar {stageName}. Execute a etapa do Storyboard primeiro."
 
@@ -8758,6 +8951,9 @@ msgstr "O índice."
 
 msgid "The TOC lists the typed sections placed by Storyboard. Finish Storyboard before running this stage."
 msgstr "O índice lista as seções classificadas colocadas pelo Storyboard. Termine o Storyboard antes de executar esta etapa."
+
+#~ msgid "The token needs repository contents, administration, and Pages permissions."
+#~ msgstr "O token precisa de permissões de conteúdo do repositório, administração e Pages."
 
 msgid "The Water Cycle"
 msgstr "O Ciclo da Água"
@@ -8815,6 +9011,9 @@ msgstr "Esta atividade não tem textos nem respostas endereçáveis. Gere-a nova
 
 msgid "This archive can't be opened safely"
 msgstr "Este arquivo não pode ser aberto com segurança"
+
+#~ msgid "This book asset will be included in the next commit."
+#~ msgstr "Este recurso do livro será incluído no próximo commit."
 
 msgid "This book has {pageCount} pages."
 msgstr "Este livro tem {pageCount} páginas."
@@ -9103,6 +9302,9 @@ msgstr "Total de tokens"
 msgid "Track reviewer progress and review findings captured from Preview."
 msgstr "Track reviewer progress and review findings captured from Preview."
 
+#~ msgid "Track the book's local edits, commits, publishing status, and GitHub metadata."
+#~ msgstr "Acompanhe as edições locais, commits, status de publicação e metadados do GitHub do livro."
+
 msgid "Translate"
 msgstr "Traduzir"
 
@@ -9318,6 +9520,9 @@ msgstr "Uncategorized"
 
 msgid "Unchanged"
 msgstr "Inalterado"
+
+#~ msgid "Under Repository permissions, grant Contents, Administration, and Pages read and write access."
+#~ msgstr "Em Permissões do repositório, conceda acesso de leitura e gravação a Contents, Administration e Pages."
 
 msgid "Underline"
 msgstr "Sublinhado"
@@ -9610,6 +9815,9 @@ msgstr "Ver"
 #~ msgid "View all changes"
 #~ msgstr "Ver todas as alterações"
 
+#~ msgid "View deployment"
+#~ msgstr "Ver implantação"
+
 msgid "View details"
 msgstr "Ver detalhes"
 
@@ -9848,6 +10056,9 @@ msgstr "Destaque por palavra"
 msgid "words"
 msgstr "palavras"
 
+#~ msgid "Workspace changes"
+#~ msgstr "Alterações do espaço de trabalho"
+
 msgid "Wrap in group"
 msgstr "Envolver em grupo"
 
@@ -9933,50 +10144,3 @@ msgstr "Aproximar"
 
 msgid "Zoom out"
 msgstr "Afastar"
-
-#. placeholder {0}: selectedAudioIds.size
-msgid "{0} selected"
-msgstr "{0} selecionados"
-
-msgid "All audio"
-msgstr "Todos os áudios"
-
-msgid "Clear visible selection"
-msgstr "Limpar seleção visível"
-
-msgid "Git has not detected changed text entities for this view."
-msgstr "O Git não detectou entidades de texto alteradas nesta visualização."
-
-msgid "No changed content needs speech regeneration"
-msgstr "Nenhum conteúdo alterado precisa de regeneração de voz"
-
-msgid "Regenerate only the selected audio clips"
-msgstr "Regenerar apenas os clipes de áudio selecionados"
-
-msgid "Regenerate selected"
-msgstr "Regenerar selecionados"
-
-msgid "Regenerate this audio clip"
-msgstr "Regenerar este clipe de áudio"
-
-#. placeholder {0}: entry.text
-msgid "Select audio for {0}"
-msgstr "Selecionar áudio para {0}"
-
-msgid "Select this audio"
-msgstr "Selecionar este áudio"
-
-msgid "Select visible audio"
-msgstr "Selecionar áudios visíveis"
-
-msgid "Set the selected speech provider's API key to generate audio"
-msgstr "Configure a chave de API do provedor de voz selecionado para gerar áudio"
-
-msgid "Speech regeneration views"
-msgstr "Visualizações de regeneração de voz"
-
-msgid "Suggested"
-msgstr "Sugerido"
-
-msgid "The selected speech provider requires an API key."
-msgstr "O provedor de voz selecionado exige uma chave de API."

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -9933,3 +9933,50 @@ msgstr "Aproximar"
 
 msgid "Zoom out"
 msgstr "Afastar"
+
+#. placeholder {0}: selectedAudioIds.size
+msgid "{0} selected"
+msgstr "{0} selecionados"
+
+msgid "All audio"
+msgstr "Todos os áudios"
+
+msgid "Clear visible selection"
+msgstr "Limpar seleção visível"
+
+msgid "Git has not detected changed text entities for this view."
+msgstr "O Git não detectou entidades de texto alteradas nesta visualização."
+
+msgid "No changed content needs speech regeneration"
+msgstr "Nenhum conteúdo alterado precisa de regeneração de voz"
+
+msgid "Regenerate only the selected audio clips"
+msgstr "Regenerar apenas os clipes de áudio selecionados"
+
+msgid "Regenerate selected"
+msgstr "Regenerar selecionados"
+
+msgid "Regenerate this audio clip"
+msgstr "Regenerar este clipe de áudio"
+
+#. placeholder {0}: entry.text
+msgid "Select audio for {0}"
+msgstr "Selecionar áudio para {0}"
+
+msgid "Select this audio"
+msgstr "Selecionar este áudio"
+
+msgid "Select visible audio"
+msgstr "Selecionar áudios visíveis"
+
+msgid "Set the selected speech provider's API key to generate audio"
+msgstr "Configure a chave de API do provedor de voz selecionado para gerar áudio"
+
+msgid "Speech regeneration views"
+msgstr "Visualizações de regeneração de voz"
+
+msgid "Suggested"
+msgstr "Sugerido"
+
+msgid "The selected speech provider requires an API key."
+msgstr "O provedor de voz selecionado exige uma chave de API."

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -244,6 +244,10 @@ msgstr "{0} pyetje"
 msgid "{0} sections"
 msgstr "{0} seksione"
 
+#. placeholder {0}: selectedAudioIds.size
+msgid "{0} selected"
+msgstr "{0} të përzgjedhura"
+
 #. placeholder {0}: String(stale.length)
 msgid "{0} selected images are no longer in the storyboard."
 msgstr "{0} imazhe të zgjedhura nuk janë më në storyboard."
@@ -263,6 +267,10 @@ msgstr "{0} tekste"
 #. placeholder {0}: outputLanguages.length
 msgid "{0} translations"
 msgstr "{0} përkthime"
+
+#. placeholder {0}: changesQuery.data.changes.length
+#~ msgid "{0} unpublished file changes"
+#~ msgstr "{0} ndryshime skedarësh të papublikuara"
 
 #. placeholder {0}: versions.length
 #~ msgid "{0} versions"
@@ -822,6 +830,9 @@ msgstr "Aktivitet: Zgjedhje e Shumëfishtë"
 msgid "Activity: Open-Ended Answer"
 msgstr "Aktivitet: Përgjigje e Hapur"
 
+#~ msgid "Activity: Ordering"
+#~ msgstr "Aktivitet: Renditje"
+
 msgid "Activity: Other"
 msgstr "Aktivitet: Tjetër"
 
@@ -1204,6 +1215,9 @@ msgstr "Të gjitha"
 msgid "All {0} pages merged in"
 msgstr "Të {0} faqet janë bashkuar"
 
+msgid "All audio"
+msgstr "Të gjitha audiot"
+
 msgid "All categories"
 msgstr "Të gjitha kategoritë"
 
@@ -1260,6 +1274,9 @@ msgstr "Sasia"
 
 msgid "An activity that does not fit the standard categories."
 msgstr "Një aktivitet që nuk i përshtatet kategorive standarde."
+
+#~ msgid "An activity where learners arrange items into the correct order."
+#~ msgstr "Një aktivitet ku nxënësit i vendosin elementet në rendin e duhur."
 
 msgid "An activity where the learner underlines one or more words, phrases, or sentences directly in the text."
 msgstr "Një aktivitet ku nxënësi nënvizon një ose më shumë fjalë, fraza ose fjali drejtpërdrejt në tekst."
@@ -1655,6 +1672,9 @@ msgstr "Teksti kryesor përdor këtë font sot. Bashkëngjitni një font më pos
 msgid "Book"
 msgstr "Libër"
 
+#~ msgid "Book change history"
+#~ msgstr "Historiku i ndryshimeve të librit"
+
 msgid "Book coverage"
 msgstr "Mbulimi i librit"
 
@@ -1672,6 +1692,9 @@ msgstr "Figurat e librit"
 
 msgid "Book info"
 msgstr "Info libri"
+
+#~ msgid "Book is published"
+#~ msgstr "Libri është publikuar"
 
 msgid "Book Language"
 msgstr "Gjuha e librit"
@@ -1930,6 +1953,9 @@ msgstr "Të ndryshohet gjuha e librit?"
 msgid "Change the picture for this term"
 msgstr "Ndrysho figurën e këtij termi"
 
+#~ msgid "Changed files"
+#~ msgstr "Skedarë të ndryshuar"
+
 #~ msgid "Changes apply the next time you run Storyboard and Export."
 #~ msgstr "Ndryshimet zbatohen herën tjetër që ekzekutoni Storyboard dhe Eksportin."
 
@@ -1974,6 +2000,9 @@ msgstr "Titulli i kapitullit"
 
 msgid "Chart / Graph"
 msgstr "Tabelë / Grafik"
+
+#~ msgid "Check changes"
+#~ msgstr "Kontrollo ndryshimet"
 
 #~ msgid "Check for updates"
 #~ msgstr "Kontrollo për përditësime"
@@ -2086,6 +2115,9 @@ msgstr "Pastro modelin"
 msgid "Clear search"
 msgstr "Pastro kërkimin"
 
+msgid "Clear visible selection"
+msgstr "Pastro përzgjedhjen e dukshme"
+
 msgid "Clear, descriptive captions for middle and high school readers."
 msgstr "Përshkrime të qarta dhe përshkruese për lexues të shkollave të mesme."
 
@@ -2191,6 +2223,9 @@ msgstr "Krahaso versionet"
 msgid "Compared with fallback prompt."
 msgstr "Krahasuar me prompt-in fallback."
 
+#~ msgid "Complete the guided setup before starting the publishing workflow."
+#~ msgstr "Përfundoni konfigurimin e udhëzuar para se të nisni rrjedhën e publikimit."
+
 msgid "Completed"
 msgstr "Përfunduar"
 
@@ -2245,6 +2280,12 @@ msgstr "Konfiguroni çdo fazë — ekstraktim, storyboard, faqosje — pastaj l�
 msgid "Configure features to include in the export"
 msgstr "Konfiguroni funksionet për t'i përfshirë në eksportim"
 
+#~ msgid "Configure GitHub publishing"
+#~ msgstr "Konfiguro publikimin në GitHub"
+
+#~ msgid "Configure GitHub to start publishing"
+#~ msgstr "Konfiguroni GitHub-in për të filluar publikimin"
+
 #~ msgid "Configure provider credentials and global prompt fallbacks used by ADT Studio."
 #~ msgstr "Konfiguro kredencialet e ofruesve dhe promptet globale fallback që përdor ADT Studio."
 
@@ -2259,6 +2300,12 @@ msgstr "Konfiguroni zërat dhe thekset"
 
 msgid "Confirm merge"
 msgstr "Konfirmoni bashkimin"
+
+#~ msgid "Confirm the destination below. Publishing will open the live workflow screen automatically."
+#~ msgstr "Konfirmoni destinacionin më poshtë. Publikimi do ta hapë automatikisht ekranin e rrjedhës së drejtpërdrejtë."
+
+#~ msgid "Connect an account and choose a repository before running this workflow."
+#~ msgstr "Lidhni një llogari dhe zgjidhni një depo para se ta ekzekutoni këtë rrjedhë."
 
 msgid "Connect an AI provider"
 msgstr "Lidheni një ofrues AI"
@@ -2283,6 +2330,9 @@ msgstr "Përpunim Përmbajtjeje"
 
 msgid "Contents"
 msgstr "Përmbajtja"
+
+msgid "Contents — Read and write; Administration — Read and write; Pages — Read and write; Metadata — Read-only."
+msgstr "Përmbajtja — Lexim dhe shkrim; Administrimi — Lexim dhe shkrim; Pages — Lexim dhe shkrim; Metadata — Vetëm lexim."
 
 msgid "Context"
 msgstr "Konteksti"
@@ -2447,6 +2497,9 @@ msgstr "Krijoni një sesion rishikuesi për këtë libër."
 msgid "Create ADT"
 msgstr "Krijo ADT"
 
+#~ msgid "Create classic token on GitHub"
+#~ msgstr "Krijo token klasik në GitHub"
+
 msgid "Create descriptive captions for images to improve accessibility."
 msgstr "Krijoni përshkrime përshkruese për imazhet për të përmirësuar aksesueshmërinë."
 
@@ -2455,6 +2508,9 @@ msgstr "Krijo skedar"
 
 msgid "Create files"
 msgstr "Krijo skedarë"
+
+#~ msgid "Create fine-grained token on GitHub"
+#~ msgstr "Krijo token të detajuar në GitHub"
 
 msgid "Create from scratch using your description"
 msgstr "Krijo nga e para duke përdorur përshkrimin tuaj"
@@ -2470,6 +2526,9 @@ msgstr "Krijo skedar prompti nga shablloni"
 
 msgid "Create session"
 msgstr "Krijo sesion"
+
+#~ msgid "Create the destination repository first, then select its owner and that repository as the token resource."
+#~ msgstr "Fillimisht krijoni depon e destinacionit, pastaj zgjidhni pronarin dhe atë depo si burim të tokenit."
 
 msgid "Created {created} prompt files for {normalizedTargetModel}."
 msgstr "U krijuan {created} skedarë prompti për {normalizedTargetModel}."
@@ -2533,6 +2592,9 @@ msgstr "Aktual (v{currentVersion})"
 
 msgid "Current book font"
 msgstr "Fonti aktual i librit"
+
+#~ msgid "Current book workspace"
+#~ msgstr "Hapësira aktuale e punës së librit"
 
 msgid "Current effective values"
 msgstr "Vlerat aktuale efektive"
@@ -3054,6 +3116,9 @@ msgstr "Çdo iteracion është një thirrje LLM. Vlerat e ulëta janë më të s
 msgid "Each kind of pipeline task uses a compatible model. Image generation and speech use their own task-specific defaults."
 msgstr "Çdo lloj detyre në rrjedhën e punës përdor një model të përshtatshëm. Gjenerimi i imazheve dhe i të folurit përdorin modelet e veta të parazgjedhura sipas detyrës."
 
+#~ msgid "Each node updates live as ADT Studio publishes the book."
+#~ msgstr "Çdo nyje përditësohet drejtpërdrejt ndërsa ADT Studio publikon librin."
+
 msgid "Each polyp secretes a hard calcium carbonate skeleton. Over hundreds of years, millions of these skeletons build up into the massive reef structures we see today."
 msgstr "Çdo polip sekreton një skelet të fortë karbonati kalciumi. Gjatë qindra viteve, miliona prej këtyre skeletve grumbullohen duke formuar strukturat masive të rifeve që shohim sot."
 
@@ -3071,6 +3136,9 @@ msgstr "Fazat e mëhershme nuk janë ekzekutuar ende"
 
 msgid "Early"
 msgstr "Herët"
+
+msgid "Easiest complete setup"
+msgstr "Konfigurimi i plotë më i lehtë"
 
 msgid "Easy Read"
 msgstr "Easy Read"
@@ -3592,6 +3660,9 @@ msgstr "Filtron imazhet dekorative ose pa përmbajtje nga çdo faqe."
 msgid "Final Page"
 msgstr "Faqja e fundit"
 
+msgid "Fine-grained token for an existing repository"
+msgstr "Token i detajuar për një depo ekzistuese"
+
 msgid "First images from the deep-field telescope."
 msgstr "Imazhet e para nga teleskopi i fushës së thellë."
 
@@ -3748,8 +3819,8 @@ msgstr "Mbledhja e dëshmive"
 msgid "Gemini"
 msgstr "Gemini"
 
-msgid "Gemini API key is required to generate audio."
-msgstr "Çelësi API i Gemini është i nevojshëm për të gjeneruar audio."
+#~ msgid "Gemini API key is required to generate audio."
+#~ msgstr "Çelësi API i Gemini është i nevojshëm për të gjeneruar audio."
 
 #~ msgid "Gemini generates each sentence in its own request, so its tone can drift between sentences. A lower temperature (e.g. 0.4) reduces that variation and a fixed seed makes delivery reproducible. Only affects languages routed to Gemini — OpenAI and Azure ignore these. Changing either value regenerates Gemini audio on the next run."
 #~ msgstr "Gemini e gjeneron çdo fjali në kërkesën e vet, prandaj toni mund të ndryshojë nga një fjali te tjetra. Një temperaturë më e ulët (p.sh. 0.4) e zvogëlon këtë variacion dhe një farë e fiksuar e bën leximin të riprodhueshëm. Prek vetëm gjuhët e drejtuara te Gemini — OpenAI dhe Azure i shpërfillin. Ndryshimi i secilës vlerë e rigjeneron audion e Gemini në ekzekutimin e ardhshëm."
@@ -3823,8 +3894,8 @@ msgstr "Gjenero nga faqet"
 msgid "Generate global prompts"
 msgstr "Gjenero prompt-e globale"
 
-msgid "Generate missing Gemini audio"
-msgstr "Gjenero audion Gemini që mungon"
+#~ msgid "Generate missing Gemini audio"
+#~ msgstr "Gjenero audion Gemini që mungon"
 
 msgid "Generate multiple-choice comprehension quizzes from the book's content. Create them automatically across the whole book, or add a single quiz from specific pages."
 msgstr "Gjenero kuize me zgjedhje të shumëfishta nga përmbajtja e librit. Krijo ato automatikisht në të gjithë librin ose shto një kuiz të vetëm nga faqe specifike."
@@ -3920,6 +3991,12 @@ msgstr "Prompt Gjenerimi"
 
 msgid "Get started"
 msgstr "Filloni"
+
+msgid "Git has not detected changed text entities for this view."
+msgstr "Git nuk ka zbuluar entitete teksti të ndryshuara për këtë pamje."
+
+#~ msgid "Git publishing workflow"
+#~ msgstr "Rrjedha e publikimit Git"
 
 msgid "Global prompt reset to default."
 msgstr "Prompti global u resetua në parazgjedhje."
@@ -4553,6 +4630,9 @@ msgstr "Imazhe të mëdha, rrjedhje narrative. Më i miri për libra të ilustru
 #~ msgid "Last"
 #~ msgstr "I fundit"
 
+#~ msgid "Last activity"
+#~ msgstr "Aktiviteti i fundit"
+
 msgid "Last change"
 msgstr "Ndryshimi i fundit"
 
@@ -4561,6 +4641,12 @@ msgstr "Modifikuar së fundmi"
 
 #~ msgid "Last week"
 #~ msgstr "Java e kaluar"
+
+#~ msgid "Latest deployment"
+#~ msgstr "Publikimi më i fundit"
+
+#~ msgid "Latest GitHub changes synchronized."
+#~ msgstr "Ndryshimet më të fundit të GitHub u sinkronizuan."
 
 msgid "Launch the app with"
 msgstr "Hap aplikacionin me"
@@ -4582,6 +4668,9 @@ msgstr "Struktura u pasqyrua në këtë seksion"
 
 msgid "Leading"
 msgstr "Hapësira ndër-rreshta"
+
+#~ msgid "Learn how with a guided setup"
+#~ msgstr "Mësoni me konfigurimin e udhëzuar"
 
 msgid "Least used"
 msgstr "Më pak i përdorur"
@@ -4733,6 +4822,9 @@ msgstr "Duke ngarkuar librat..."
 msgid "Loading catalog..."
 msgstr "Duke ngarkuar katalogun..."
 
+#~ msgid "Loading deployments"
+#~ msgstr "Duke ngarkuar publikimet"
+
 msgid "Loading Easy Read..."
 msgstr "Duke ngarkuar Leximin e Lehtë..."
 
@@ -4825,6 +4917,12 @@ msgstr "Duke ngarkuar..."
 
 msgid "Loading…"
 msgstr "Duke ngarkuar…"
+
+#~ msgid "Local and GitHub changes need resolution before synchronization."
+#~ msgstr "Ndryshimet lokale dhe ato në GitHub duhet të zgjidhen para sinkronizimit."
+
+#~ msgid "Local book is up to date."
+#~ msgstr "Libri lokal është i përditësuar."
 
 msgid "Localization"
 msgstr "Lokalizim"
@@ -5365,6 +5463,9 @@ msgstr "Asnjë titull nuk përputhet me këta filtra"
 msgid "No captions match your search"
 msgstr "Asnjë titull nuk përputhet me kërkimin tuaj"
 
+msgid "No changed content needs speech regeneration"
+msgstr "Asnjë përmbajtje e ndryshuar nuk ka nevojë për rigjenerim të zërit"
+
 msgid "no changes"
 msgstr "pa ndryshime"
 
@@ -5680,8 +5781,14 @@ msgstr "zhurmë"
 msgid "None"
 msgstr "Asnjë"
 
+#~ msgid "Not committed yet"
+#~ msgstr "Ende pa commit"
+
 msgid "Not compatible with Fixed Layout"
 msgstr "I papajtueshëm me Paraqitjen e fiksuar"
+
+#~ msgid "Not configured"
+#~ msgstr "I pakonfiguruar"
 
 msgid "Not detected"
 msgstr "Nuk u zbulua"
@@ -5855,6 +5962,9 @@ msgstr "Hapni pamjen paraprake të faqes për {pageId}"
 
 msgid "Open Preview"
 msgstr "Hapni Pamjen Paraprake"
+
+#~ msgid "Open public book"
+#~ msgstr "Hap librin publik"
 
 #. placeholder {0}: pullRequest.number
 msgid "Open pull request {0}"
@@ -6067,6 +6177,9 @@ msgstr "Paketoni librin për shpërndarje. Zgjidhni një format, vendosni çfar�
 
 msgid "Package the finished book with every accessibility feature baked in — ready for a kid to open, listen, and read along."
 msgstr "Paketoni librin e përfunduar me të gjitha veçoritë e aksesueshmërisë të integruara — gati për t'u hapur, dëgjuar dhe lexuar nga një fëmijë."
+
+#~ msgid "Package, commit, push, host, and preview the accessible book without leaving ADT Studio."
+#~ msgstr "Paketoje, regjistroje, publikoje, hostoje dhe shikoje librin e qasshëm pa dalë nga ADT Studio."
 
 msgid "Packaging"
 msgstr "Paketimi"
@@ -6643,11 +6756,20 @@ msgstr "Shkurtuar: {reason}"
 msgid "PT"
 msgstr "PT"
 
+#~ msgid "Publish book"
+#~ msgstr "Publiko librin"
+
+#~ msgid "Publish with GitHub Pages"
+#~ msgstr "Publiko me GitHub Pages"
+
 msgid "published in"
 msgstr "botuar në"
 
 msgid "Publisher"
 msgstr "Botuesi"
+
+#~ msgid "Pull remote changes"
+#~ msgstr "Merr ndryshimet në distancë"
 
 msgid "Pull requests"
 msgstr "Pull request-e"
@@ -6894,6 +7016,9 @@ msgstr "I rekomanduar për"
 msgid "Recommended for {0}"
 msgstr "I rekomanduar për {0}"
 
+msgid "Recommended for creating a new repository"
+msgstr "Rekomandohet për krijimin e një depoje të re"
+
 msgid "Record reviewer findings for the current page and save them to the active validation session."
 msgstr "Regjistroni gjetjet e rishikuesit për faqen aktuale dhe ruajini në sesionin aktiv të validimit."
 
@@ -6936,11 +7061,24 @@ msgstr "Rigenero përkufizimin, variacionet dhe emoji"
 msgid "Regenerate Easy Read"
 msgstr "Rigenero Easy Read"
 
+msgid "Regenerate only the selected audio clips"
+msgstr "Rigjenero vetëm klipet e përzgjedhura të audios"
+
+msgid "Regenerate selected"
+msgstr "Rigjenero të përzgjedhurat"
+
+#. placeholder {0}: selectedAudioIds.size
+#~ msgid "Regenerate selected ({0})"
+#~ msgstr "Rigjenero të përzgjedhurat ({0})"
+
 msgid "Regenerate selected images for each output language so that any text burned into them is shown in the target language."
 msgstr "Rigenero imazhet e zgjedhura për çdo gjuhë dalëse, në mënyrë që çdo tekst i djegur mbi to të shfaqet në gjuhën e synuar."
 
 msgid "Regenerate this activity with AI (requires a saved state and an API key)"
 msgstr "Rigjeneroni këtë aktivitet me AI (kërkon gjendje të ruajtur dhe një çelës API)"
+
+msgid "Regenerate this audio clip"
+msgstr "Rigjenero këtë klip audio"
 
 msgid "Region"
 msgstr "Rajon"
@@ -6965,6 +7103,12 @@ msgstr "Lëshoni për të ngarkuar"
 
 msgid "Reload app"
 msgstr "Rinis aplikacionin"
+
+#~ msgid "Remote changes are available."
+#~ msgstr "Ka ndryshime në distancë."
+
+#~ msgid "Remote changes available"
+#~ msgstr "Ka ndryshime në distancë"
 
 msgid "Remove"
 msgstr "Hiq"
@@ -7190,6 +7334,9 @@ msgstr "Rishiko"
 #~ msgid "Review {selectedCount} selected"
 #~ msgstr "Rishiko {selectedCount} të zgjedhura"
 
+#~ msgid "Review and publish"
+#~ msgstr "Rishiko dhe publiko"
+
 msgid "Review and refine each simplified block side-by-side with the original before packaging."
 msgstr "Rishikoni dhe rafinoni çdo bllok të thjeshtëzuar krahas origjinalit përpara paketimit."
 
@@ -7233,6 +7380,9 @@ msgstr "Rreptësia e rishikimit"
 
 msgid "Review style"
 msgstr "Stili i rishikimit"
+
+#~ msgid "Review the most recent publishing workflow and open its public result."
+#~ msgstr "Rishiko rrjedhën më të fundit të publikimit dhe hap rezultatin e saj publik."
 
 msgid "Review the project details below and confirm the import."
 msgstr "Rishikoni detajet e projektit më poshtë dhe konfirmoni importimin."
@@ -7382,6 +7532,9 @@ msgstr "Ekzekuto Përkthimin"
 msgid "Run whole-book validation checks and configure accessibility assessment settings."
 msgstr "Ekzekutoni kontrollet e validimit të librit të plotë dhe konfiguroni cilësimet e vlerësimit të aksesueshmërisë."
 
+#~ msgid "Run workflow"
+#~ msgstr "Ekzekuto rrjedhën"
+
 msgid "Run-only tags"
 msgstr "Etiketa vetëm-ekzekutimi"
 
@@ -7448,6 +7601,9 @@ msgstr "Ruaj aktivitetin"
 msgid "Save activity (⌘S)"
 msgstr "Ruaj aktivitetin (⌘S)"
 
+#~ msgid "Save and publish"
+#~ msgstr "Ruaj dhe publiko"
+
 msgid "Save changes"
 msgstr "Ruaj ndryshimet"
 
@@ -7468,6 +7624,9 @@ msgstr "Ruaj listën e kontrollit"
 
 msgid "Save failed"
 msgstr "Ruajtja dështoi"
+
+#~ msgid "Save or discard your edits before splitting"
+#~ msgstr "Ruani ose hidhni poshtë ndryshimet para se të ndani"
 
 msgid "Save or discard your edits first"
 msgstr "Fillimisht ruani ose hidhni poshtë ndryshimet"
@@ -7686,6 +7845,12 @@ msgstr "seksione"
 msgid "Sections"
 msgstr "Seksione"
 
+msgid "Security: use the shortest practical expiration, never share the token, and revoke it in GitHub when it is no longer needed. ADT Studio keeps this token locally on this device and does not store it in the book directory."
+msgstr "Siguria: përdorni afatin më të shkurtër praktik, mos e ndani kurrë tokenin dhe revokojeni në GitHub kur nuk nevojitet më. ADT Studio e ruan këtë token lokalisht në këtë pajisje dhe nuk e ruan në dosjen e librit."
+
+#~ msgid "Security: use the shortest practical expiration, never share the token, and revoke it in GitHub when it is no longer needed. ADT Studio keeps this token only for the current browser session and does not store it in the book directory."
+#~ msgstr "Siguria: përdorni afatin më të shkurtër praktik, mos e ndani kurrë tokenin dhe revokojeni në GitHub kur të mos nevojitet më. ADT Studio e ruan këtë token vetëm gjatë sesionit aktual të shfletuesit dhe nuk e ruan në dosjen e librit."
+
 msgid "See examples"
 msgstr "Shiko shembuj"
 
@@ -7785,6 +7950,10 @@ msgstr "Zgjidhni të gjitha"
 msgid "Select an item to edit its text — [[blank:…]] marks where a blank appears, so keep it to keep the blank."
 msgstr "Zgjidhni një element për të redaktuar tekstin e tij — [[blank:…]] shënon vendin ku shfaqet një hapësirë bosh, prandaj ruajeni që të ruhet hapësira."
 
+#. placeholder {0}: entry.text
+msgid "Select audio for {0}"
+msgstr "Përzgjidh audion për {0}"
+
 msgid "Select images to translate"
 msgstr "Zgjidhni imazhet për të përkthyer"
 
@@ -7809,8 +7978,17 @@ msgstr "Zgjidhni shabllonin..."
 msgid "Select the pages the quiz is written from, then choose where it appears using the buttons between pages."
 msgstr "Zgjidhni faqet nga të cilat është shkruar kuizi, pastaj zgjidhni ku shfaqet duke përdorur butonat ndërmjet faqeve."
 
+#~ msgid "Select the repo scope. It covers repository creation, file publishing, and GitHub Pages configuration."
+#~ msgstr "Zgjidhni fushëveprimin repo. Ai mbulon krijimin e depos, publikimin e skedarëve dhe konfigurimin e GitHub Pages."
+
+msgid "Select this audio"
+msgstr "Përzgjidh këtë audio"
+
 msgid "Select up to 5 pages to use as visual references. The LLM will analyze them and generate a styleguide."
 msgstr "Zgjidhni deri në 5 faqe për t'i përdorur si referenca vizuale. LLM do t'i analizojë dhe do të gjenerojë një udhëzues stili."
+
+msgid "Select visible audio"
+msgstr "Përzgjidh audiot e dukshme"
 
 #~ msgid "Selected"
 #~ msgstr "I zgjedhur"
@@ -7868,8 +8046,11 @@ msgstr "Sesione"
 msgid "Sessions let different reviewers capture findings independently, including language-specific reviews."
 msgstr "Sesionet u lejojnë rishikuesve të ndryshëm të regjistrojnë gjetjet në mënyrë të pavarur, duke përfshirë rishikimet specifike për gjuhë."
 
-msgid "Set a Gemini API key to generate audio"
-msgstr "Vendosni një çelës API Gemini për të gjeneruar audio"
+#~ msgid "Set a Gemini API key to generate audio"
+#~ msgstr "Vendosni një çelës API Gemini për të gjeneruar audio"
+
+msgid "Set Administration to Read and write so ADT can configure the repository and create the GitHub Pages site."
+msgstr "Vendosni Administrimin në Lexim dhe shkrim që ADT të konfigurojë depon dhe të krijojë faqen GitHub Pages."
 
 msgid "Set fonts for the whole book"
 msgstr "Vendos fontet për të gjithë librin"
@@ -7879,6 +8060,9 @@ msgstr "Caktuar manualisht"
 
 msgid "Set the editing language and choose output languages for the book."
 msgstr "Vendosni gjuhën e redaktimit dhe zgjidhni gjuhët e daljes për librin."
+
+msgid "Set the selected speech provider's API key to generate audio"
+msgstr "Vendos çelësin API të ofruesit të përzgjedhur të zërit për të gjeneruar audio"
 
 msgid "Set your API key first"
 msgstr "Vendos fillimisht çelësin tënd të API-t"
@@ -8140,6 +8324,9 @@ msgstr "Parashikim i të Folurit"
 msgid "Speech Prompts"
 msgstr "Prompte të të Folurit"
 
+msgid "Speech regeneration views"
+msgstr "Pamjet e rigjenerimit të zërit"
+
 msgid "Speech Settings"
 msgstr "Cilësimet e të Folurit"
 
@@ -8397,6 +8584,9 @@ msgstr "Ngarkuar me sukses"
 
 msgid "Suggest improved translations when an entry needs attention"
 msgstr "Sugjero përkthime të përmirësuara kur një hyrje kërkon vëmendje"
+
+msgid "Suggested"
+msgstr "Të sugjeruara"
 
 msgid "Suggested modification"
 msgstr "Modifikim i sugjeruar"
@@ -8748,6 +8938,9 @@ msgstr "Rishikimi i ruajtur i përkthimit është i vjetëruar. Ekzekutoni Rishi
 msgid "The section was edited after conversion — use \"Rebuild from page\" to refresh the steps."
 msgstr "Seksioni u ndryshua pas konvertimit — përdor «Rindërto nga faqja» për të rifreskuar hapat."
 
+msgid "The selected speech provider requires an API key."
+msgstr "Ofruesi i përzgjedhur i zërit kërkon një çelës API."
+
 msgid "The storyboard must be completed before generating {stageName}. Run the Storyboard stage first."
 msgstr "Storyboard duhet të plotësohet para gjenerimit të {stageName}. Ekzekuto fazën Storyboard fillimisht."
 
@@ -8759,6 +8952,9 @@ msgstr "Tabela e përmbajtjes."
 
 msgid "The TOC lists the typed sections placed by Storyboard. Finish Storyboard before running this stage."
 msgstr "TOC liston seksionet e shtypura të vendosura nga Storyboard. Përfundo Storyboard para se të ekzekutosh këtë fazë."
+
+#~ msgid "The token needs repository contents, administration, and Pages permissions."
+#~ msgstr "Tokeni kërkon leje për përmbajtjen e depos, administrimin dhe Pages."
 
 msgid "The Water Cycle"
 msgstr "Cikli i Ujit"
@@ -8816,6 +9012,9 @@ msgstr "Ky aktivitet nuk ka tekste apo përgjigje të adresueshme. Rigjeneroni a
 
 msgid "This archive can't be opened safely"
 msgstr "Ky arkiv nuk mund të hapet në mënyrë të sigurt"
+
+#~ msgid "This book asset will be included in the next commit."
+#~ msgstr "Ky burim i librit do të përfshihet në commit-in e ardhshëm."
 
 msgid "This book has {pageCount} pages."
 msgstr "Ky libër ka {pageCount} faqe."
@@ -9104,6 +9303,9 @@ msgstr "Tokenë Gjithsej"
 msgid "Track reviewer progress and review findings captured from Preview."
 msgstr "Gjurmo progresin e rishikuesit dhe gjetjet e rishikimit të kaptura nga Paraparimimi."
 
+#~ msgid "Track the book's local edits, commits, publishing status, and GitHub metadata."
+#~ msgstr "Ndiqni redaktimet lokale, commit-et, statusin e publikimit dhe metadatat GitHub të librit."
+
 msgid "Translate"
 msgstr "Përkthe"
 
@@ -9319,6 +9521,9 @@ msgstr "Pa kategori"
 
 msgid "Unchanged"
 msgstr "I pandryshuar"
+
+#~ msgid "Under Repository permissions, grant Contents, Administration, and Pages read and write access."
+#~ msgstr "Te lejet e depos, jepni qasje leximi dhe shkrimi për Contents, Administration dhe Pages."
 
 msgid "Underline"
 msgstr "Nënvizim"
@@ -9611,6 +9816,9 @@ msgstr "Shiko"
 #~ msgid "View all changes"
 #~ msgstr "Shiko të gjitha ndryshimet"
 
+#~ msgid "View deployment"
+#~ msgstr "Shiko publikimin"
+
 msgid "View details"
 msgstr "Shiko detajet"
 
@@ -9849,6 +10057,9 @@ msgstr "Theksim në nivel fjale"
 msgid "words"
 msgstr "fjalë"
 
+#~ msgid "Workspace changes"
+#~ msgstr "Ndryshimet e hapësirës së punës"
+
 msgid "Wrap in group"
 msgstr "Mbështjell në grup"
 
@@ -9934,50 +10145,3 @@ msgstr "Zmadhim"
 
 msgid "Zoom out"
 msgstr "Zvogëlim"
-
-#. placeholder {0}: selectedAudioIds.size
-msgid "{0} selected"
-msgstr "{0} të përzgjedhura"
-
-msgid "All audio"
-msgstr "Të gjitha audiot"
-
-msgid "Clear visible selection"
-msgstr "Pastro përzgjedhjen e dukshme"
-
-msgid "Git has not detected changed text entities for this view."
-msgstr "Git nuk ka zbuluar entitete teksti të ndryshuara për këtë pamje."
-
-msgid "No changed content needs speech regeneration"
-msgstr "Asnjë përmbajtje e ndryshuar nuk ka nevojë për rigjenerim të zërit"
-
-msgid "Regenerate only the selected audio clips"
-msgstr "Rigjenero vetëm klipet e përzgjedhura të audios"
-
-msgid "Regenerate selected"
-msgstr "Rigjenero të përzgjedhurat"
-
-msgid "Regenerate this audio clip"
-msgstr "Rigjenero këtë klip audio"
-
-#. placeholder {0}: entry.text
-msgid "Select audio for {0}"
-msgstr "Përzgjidh audion për {0}"
-
-msgid "Select this audio"
-msgstr "Përzgjidh këtë audio"
-
-msgid "Select visible audio"
-msgstr "Përzgjidh audiot e dukshme"
-
-msgid "Set the selected speech provider's API key to generate audio"
-msgstr "Vendos çelësin API të ofruesit të përzgjedhur të zërit për të gjeneruar audio"
-
-msgid "Speech regeneration views"
-msgstr "Pamjet e rigjenerimit të zërit"
-
-msgid "Suggested"
-msgstr "Të sugjeruara"
-
-msgid "The selected speech provider requires an API key."
-msgstr "Ofruesi i përzgjedhur i zërit kërkon një çelës API."

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -9934,3 +9934,50 @@ msgstr "Zmadhim"
 
 msgid "Zoom out"
 msgstr "Zvogëlim"
+
+#. placeholder {0}: selectedAudioIds.size
+msgid "{0} selected"
+msgstr "{0} të përzgjedhura"
+
+msgid "All audio"
+msgstr "Të gjitha audiot"
+
+msgid "Clear visible selection"
+msgstr "Pastro përzgjedhjen e dukshme"
+
+msgid "Git has not detected changed text entities for this view."
+msgstr "Git nuk ka zbuluar entitete teksti të ndryshuara për këtë pamje."
+
+msgid "No changed content needs speech regeneration"
+msgstr "Asnjë përmbajtje e ndryshuar nuk ka nevojë për rigjenerim të zërit"
+
+msgid "Regenerate only the selected audio clips"
+msgstr "Rigjenero vetëm klipet e përzgjedhura të audios"
+
+msgid "Regenerate selected"
+msgstr "Rigjenero të përzgjedhurat"
+
+msgid "Regenerate this audio clip"
+msgstr "Rigjenero këtë klip audio"
+
+#. placeholder {0}: entry.text
+msgid "Select audio for {0}"
+msgstr "Përzgjidh audion për {0}"
+
+msgid "Select this audio"
+msgstr "Përzgjidh këtë audio"
+
+msgid "Select visible audio"
+msgstr "Përzgjidh audiot e dukshme"
+
+msgid "Set the selected speech provider's API key to generate audio"
+msgstr "Vendos çelësin API të ofruesit të përzgjedhur të zërit për të gjeneruar audio"
+
+msgid "Speech regeneration views"
+msgstr "Pamjet e rigjenerimit të zërit"
+
+msgid "Suggested"
+msgstr "Të sugjeruara"
+
+msgid "The selected speech provider requires an API key."
+msgstr "Ofruesi i përzgjedhur i zërit kërkon një çelës API."

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -3822,8 +3822,8 @@ msgstr "Mbledhja e dëshmive"
 msgid "Gemini"
 msgstr "Gemini"
 
-#~ msgid "Gemini API key is required to generate audio."
-#~ msgstr "Çelësi API i Gemini është i nevojshëm për të gjeneruar audio."
+msgid "Gemini API key is required to generate audio."
+msgstr "Kërkohet një çelës API Gemini për të gjeneruar audio."
 
 #~ msgid "Gemini generates each sentence in its own request, so its tone can drift between sentences. A lower temperature (e.g. 0.4) reduces that variation and a fixed seed makes delivery reproducible. Only affects languages routed to Gemini — OpenAI and Azure ignore these. Changing either value regenerates Gemini audio on the next run."
 #~ msgstr "Gemini e gjeneron çdo fjali në kërkesën e vet, prandaj toni mund të ndryshojë nga një fjali te tjetra. Një temperaturë më e ulët (p.sh. 0.4) e zvogëlon këtë variacion dhe një farë e fiksuar e bën leximin të riprodhueshëm. Prek vetëm gjuhët e drejtuara te Gemini — OpenAI dhe Azure i shpërfillin. Ndryshimi i secilës vlerë e rigjeneron audion e Gemini në ekzekutimin e ardhshëm."
@@ -3897,8 +3897,8 @@ msgstr "Gjenero nga faqet"
 msgid "Generate global prompts"
 msgstr "Gjenero prompt-e globale"
 
-#~ msgid "Generate missing Gemini audio"
-#~ msgstr "Gjenero audion Gemini që mungon"
+msgid "Generate missing Gemini audio"
+msgstr "Gjenero audion Gemini që mungon"
 
 msgid "Generate multiple-choice comprehension quizzes from the book's content. Create them automatically across the whole book, or add a single quiz from specific pages."
 msgstr "Gjenero kuize me zgjedhje të shumëfishta nga përmbajtja e librit. Krijo ato automatikisht në të gjithë librin ose shto një kuiz të vetëm nga faqe specifike."
@@ -8052,8 +8052,8 @@ msgstr "Sesione"
 msgid "Sessions let different reviewers capture findings independently, including language-specific reviews."
 msgstr "Sesionet u lejojnë rishikuesve të ndryshëm të regjistrojnë gjetjet në mënyrë të pavarur, duke përfshirë rishikimet specifike për gjuhë."
 
-#~ msgid "Set a Gemini API key to generate audio"
-#~ msgstr "Vendosni një çelës API Gemini për të gjeneruar audio"
+msgid "Set a Gemini API key to generate audio"
+msgstr "Vendosni një çelës API Gemini për të gjeneruar audio"
 
 msgid "Set Administration to Read and write so ADT can configure the repository and create the GitHub Pages site."
 msgstr "Vendosni Administrimin në Lexim dhe shkrim që ADT të konfigurojë depon dhe të krijojë faqen GitHub Pages."

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -2963,6 +2963,9 @@ msgstr "KRYER"
 #~ msgid "Downgrade"
 #~ msgstr "Kthim në version më të vjetër"
 
+msgid "Done selecting"
+msgstr "Përfundo përzgjedhjen"
+
 msgid "Download a full backup of this project"
 msgstr "Shkarko një kopje rezervë të plotë të këtij projekti"
 
@@ -7949,6 +7952,9 @@ msgstr "Zgjidhni të gjitha"
 
 msgid "Select an item to edit its text — [[blank:…]] marks where a blank appears, so keep it to keep the blank."
 msgstr "Zgjidhni një element për të redaktuar tekstin e tij — [[blank:…]] shënon vendin ku shfaqet një hapësirë bosh, prandaj ruajeni që të ruhet hapësira."
+
+msgid "Select audio"
+msgstr "Përzgjidh audion"
 
 #. placeholder {0}: entry.text
 msgid "Select audio for {0}"

--- a/config/speech_instructions.yaml
+++ b/config/speech_instructions.yaml
@@ -19,6 +19,11 @@ en-tz: |
 sw-tz: |
   Speak it in Tanzanian Swahili (Kiswahili cha Tanzania). Use the
   pronunciation and intonation typical of mainland Tanzania, not Kenyan Swahili.
+  Read numbers naturally in Tanzanian Swahili. Pronounce digits, decimals,
+  percentages, dates, times, fractions, measurements, and currency amounts as
+  complete Kiswahili words according to their meaning in the sentence; do not
+  use English number words. Keep mathematical operators and enumeration markers
+  clear and unambiguous.
   Speak in a cheerful and positive tone.
 pt: |
   Speak it in a European Portuguese (Portugal) accent. Use the pronunciation

--- a/packages/llm/src/__tests__/speech.test.ts
+++ b/packages/llm/src/__tests__/speech.test.ts
@@ -1,5 +1,41 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { createGeminiTTSSynthesizer, transcribeWithWhisper } from "../speech.js"
+import {
+  createAzureTTSSynthesizer,
+  createGeminiTTSSynthesizer,
+  transcribeWithWhisper,
+} from "../speech.js"
+
+describe("createAzureTTSSynthesizer", () => {
+  const fetchMock = vi.fn<typeof fetch>()
+
+  beforeEach(() => {
+    fetchMock.mockReset()
+    fetchMock.mockResolvedValue(new Response(new Uint8Array([1]), { status: 200 }))
+    vi.stubGlobal("fetch", fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("sets the SSML language from the selected voice for native number pronunciation", async () => {
+    const synth = createAzureTTSSynthesizer({
+      subscriptionKey: "test-key",
+      region: "eastus",
+    })
+
+    await synth.synthesize({
+      model: "azure",
+      voice: "sw-TZ-RehemaNeural",
+      input: "Ana vitabu 25.",
+      responseFormat: "mp3",
+    })
+
+    const request = fetchMock.mock.calls[0]?.[1]
+    expect(request?.body).toContain("xml:lang='sw-TZ'")
+    expect(request?.body).toContain("Ana vitabu 25.")
+  })
+})
 
 describe("createGeminiTTSSynthesizer", () => {
   const fetchMock = vi.fn<typeof fetch>()

--- a/packages/llm/src/speech.ts
+++ b/packages/llm/src/speech.ts
@@ -165,13 +165,19 @@ function buildAzureOutputFormat(
 }
 
 function buildSSML(voice: string, text: string): string {
+  // Azure voice names start with their BCP 47 locale (for example,
+  // "sw-TZ-RehemaNeural").  The document language affects how ambiguous
+  // tokens such as numerals, dates, and decimal separators are spoken, so it
+  // must agree with the selected voice instead of always being en-US.
+  const localeMatch = /^([a-z]{2,3}-[A-Z]{2})(?:-|$)/.exec(voice)
+  const locale = localeMatch?.[1] ?? "en-US"
   const escaped = text
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;")
     .replace(/'/g, "&apos;")
-  return `<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' xml:lang='en-US'><voice name='${voice}'>${escaped}</voice></speak>`
+  return `<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' xml:lang='${locale}'><voice name='${voice}'>${escaped}</voice></speak>`
 }
 
 function wrapPcmAsWave(

--- a/packages/pipeline/src/__tests__/speech.test.ts
+++ b/packages/pipeline/src/__tests__/speech.test.ts
@@ -4,6 +4,8 @@ import path from "node:path"
 import os from "node:os"
 import {
   stripEmojis,
+  prepareTextForSpeech,
+  prepareInstructionsForSpeech,
   isSpeakableText,
   resolveVoice,
   resolveInstructions,
@@ -41,6 +43,94 @@ describe("stripEmojis", () => {
 
   it("handles unicode text with emojis", () => {
     expect(stripEmojis("Hola 🌍 mundo")).toBe("Hola  mundo")
+  })
+})
+
+describe("prepareTextForSpeech", () => {
+  it("expands Tanzanian Swahili numbers and character ranges", () => {
+    expect(prepareTextForSpeech("Soma a-z na 25%.", "sw-TZ")).toBe(
+      "Soma a hadi z na asilimia ishirini na tano.",
+    )
+  })
+
+  it("speaks compact numeric ranges and spaced arithmetic unambiguously", () => {
+    expect(prepareTextForSpeech("Abakasi 1-6; 25 – 2 = 23", "sw-TZ")).toBe(
+      "Abakasi moja hadi sita; ishirini na tano toa mbili ni sawa na ishirini na tatu",
+    )
+  })
+
+  it("expands decimals digit by digit after the separator", () => {
+    expect(prepareTextForSpeech("1.05", "sw")).toBe("moja nukta sifuri tano")
+  })
+
+  it("speaks Roman numerals as their values in Kiswahili", () => {
+    expect(prepareTextForSpeech("Sura ya IV, XII na (xxi).", "sw-TZ")).toBe(
+      "Sura ya n-ne, kumi na mbili na (ishirini na moja).",
+    )
+  })
+
+  it("speaks Roman-numeral ranges semantically", () => {
+    expect(prepareTextForSpeech("Sura IV–VI", "sw-TZ")).toBe(
+      "Sura n-ne hadi sita",
+    )
+  })
+
+  it("does not mistake lowercase alphabetic labels for Roman numerals", () => {
+    expect(prepareTextForSpeech("Vipengele (c), (d), (i) na (l)", "sw-TZ")).toBe(
+      "Vipengele kipengele c, kipengele d, kipengele i na kipengele l",
+    )
+  })
+
+  it("gives isolated section letters Kiswahili context", () => {
+    expect(prepareTextForSpeech("(a) 4, (b) 14", "sw-TZ")).toBe(
+      "kipengele a n-ne, kipengele b kumi na n-ne",
+    )
+  })
+
+  it("speaks structural numbers as ordinal positions", () => {
+    expect(
+      prepareTextForSpeech(
+        "Mfano wa 1, Zoezi la 2, Swali la 3(a), Sura ya 4 na mwezi wa 12",
+        "sw-TZ",
+      ),
+    ).toBe(
+      "Mfano wa kwanza, Zoezi la pili, Swali la tatu kipengele a, Sura ya n-ne na mwezi wa kumi na mbili",
+    )
+  })
+
+  it("keeps quantities after non-structural connectors cardinal", () => {
+    expect(
+      prepareTextForSpeech("Thamani ya 8 na jumla ya 2", "sw-TZ"),
+    ).toBe("Thamani ya nane na jumla ya mbili")
+  })
+
+  it("leaves malformed Roman numerals unchanged", () => {
+    expect(prepareTextForSpeech("IIII na IC", "sw-TZ")).toBe("IIII na IC")
+  })
+
+  it("leaves other languages unchanged", () => {
+    expect(prepareTextForSpeech("a-z and 25", "en")).toBe("a-z and 25")
+  })
+
+  it("adds targeted phonetic guidance only to affected Swahili text", () => {
+    const prepared = prepareInstructionsForSpeech(
+      "Speak naturally.",
+      "kipengele a n-ne",
+      "sw-TZ",
+    )
+    expect(prepared).toContain("[ˈn̩.nɛ]")
+    expect(prepared).toContain("native Kiswahili vowel sounds")
+    expect(prepareInstructionsForSpeech("Speak naturally.", "moja", "sw-TZ")).toBe(
+      "Speak naturally.",
+    )
+  })
+
+  it("marks syllabic nasals in ordinary Swahili source words", () => {
+    const prepared = prepareTextForSpeech("Mmoja ana nne, wengine wanne.", "sw-TZ")
+    expect(prepared).toBe("M-moja ana n-ne, wengine wanne.")
+    const instructions = prepareInstructionsForSpeech("Speak naturally.", prepared, "sw-TZ")
+    expect(instructions).toContain("[m̩.ˈmɔ.dʒa]")
+    expect(instructions).toContain("[ˈn̩.nɛ]")
   })
 })
 
@@ -380,17 +470,18 @@ describe("generateSpeechFile", () => {
       ttsSynthesizer: mockSynthesizer,
     })
 
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       textId: "p001_t001",
       language: "en",
-      fileName: "p001_t001.mp3",
       voice: "alloy",
       model: "gpt-4o-mini-tts",
       cached: false,
     })
+    expect(result?.fileName).toMatch(/^p001_t001\.[a-f0-9]{12}\.mp3$/)
+    expect(result?.sourceHash).toMatch(/^[a-f0-9]{64}$/)
 
     // Verify file was written
-    const audioPath = path.join(bookDir, "audio", "en", "p001_t001.mp3")
+    const audioPath = path.join(bookDir, "audio", "en", result!.fileName)
     expect(fs.existsSync(audioPath)).toBe(true)
 
     // Verify cache was written
@@ -423,7 +514,7 @@ describe("generateSpeechFile", () => {
     })
 
     expect(result?.language).toBe("en-US")
-    expect(fs.existsSync(path.join(bookDir, "audio", "en-US", "p001_t001.mp3"))).toBe(true)
+    expect(fs.existsSync(path.join(bookDir, "audio", "en-US", result!.fileName))).toBe(true)
     expect(fs.readdirSync(path.join(bookDir, "audio"))).toContain("en-US")
   })
 
@@ -460,6 +551,46 @@ describe("generateSpeechFile", () => {
 
     expect(result!.cached).toBe(true)
     expect(mockSynthesize).toHaveBeenCalledTimes(1) // Not called again
+  })
+
+  it("synthesizes fresh audio when explicit regeneration bypasses the cache", async () => {
+    const original = await generateSpeechFile({
+      textId: "p001_t001",
+      text: "Hello world",
+      language: "en",
+      model: "gpt-4o-mini-tts",
+      voice: "alloy",
+      instructions: "Speak cheerfully.",
+      format: "mp3",
+      bookDir,
+      cacheDir,
+      ttsSynthesizer: mockSynthesizer,
+    })
+
+    mockSynthesize.mockResolvedValueOnce(
+      new Uint8Array(Buffer.from("fresh-audio-data"))
+    )
+    const result = await generateSpeechFile({
+      textId: "p001_t001",
+      text: "Hello world",
+      language: "en",
+      model: "gpt-4o-mini-tts",
+      voice: "alloy",
+      instructions: "Speak cheerfully.",
+      format: "mp3",
+      bookDir,
+      cacheDir,
+      ttsSynthesizer: mockSynthesizer,
+      forceRegenerate: true,
+    })
+
+    expect(result?.cached).toBe(false)
+    expect(mockSynthesize).toHaveBeenCalledTimes(2)
+    expect(result?.fileName).not.toBe(original?.fileName)
+    expect(fs.readFileSync(path.join(bookDir, "audio", "en", result!.fileName), "utf8"))
+      .toBe("fresh-audio-data")
+    expect(fs.readFileSync(path.join(bookDir, "audio", "en", original!.fileName), "utf8"))
+      .toBe("fake-audio-data")
   })
 
   it("only acquires the optional rate limiter when a real synth call is needed", async () => {

--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -186,6 +186,8 @@ export {
   type ResolvedGeminiTtsRateLimit,
   isSpeakableText,
   stripEmojis,
+  prepareTextForSpeech,
+  prepareInstructionsForSpeech,
   loadVoicesConfig,
   loadSpeechInstructions,
   computeSpeechCacheKey,

--- a/packages/pipeline/src/speech.ts
+++ b/packages/pipeline/src/speech.ts
@@ -36,6 +36,187 @@ export function stripEmojis(text: string): string {
   return text.replace(EMOJI_RE, "")
 }
 
+const SWAHILI_UNITS = [
+  "sifuri", "moja", "mbili", "tatu", "n-ne", "tano",
+  "sita", "saba", "nane", "tisa",
+] as const
+const SWAHILI_TENS = [
+  "", "kumi", "ishirini", "thelathini", "arobaini",
+  "hamsini", "sitini", "sabini", "themanini", "tisini",
+] as const
+const SWAHILI_SCALES = [
+  { value: 1_000_000_000_000, name: "trilioni" },
+  { value: 1_000_000_000, name: "bilioni" },
+  { value: 1_000_000, name: "milioni" },
+  { value: 1_000, name: "elfu" },
+  { value: 100, name: "mia" },
+] as const
+
+function swahiliIntegerWords(value: number): string {
+  if (value < 10) return SWAHILI_UNITS[value]!
+  if (value < 100) {
+    const tens = SWAHILI_TENS[Math.floor(value / 10)]!
+    const remainder = value % 10
+    return remainder === 0 ? tens : `${tens} na ${SWAHILI_UNITS[remainder]}`
+  }
+  for (const scale of SWAHILI_SCALES) {
+    if (value >= scale.value) {
+      const count = Math.floor(value / scale.value)
+      const remainder = value % scale.value
+      const prefix = `${scale.name} ${swahiliIntegerWords(count)}`
+      return remainder === 0 ? prefix : `${prefix} na ${swahiliIntegerWords(remainder)}`
+    }
+  }
+  return String(value)
+}
+
+function swahiliNumberWords(token: string): string {
+  const compact = token.replace(/\s/g, "")
+  const normalized = /^\d{1,3}(?:,\d{3})+$/.test(compact)
+    ? compact.replace(/,/g, "")
+    : compact
+  const parts = normalized.split(/[.,]/)
+  const whole = parts[0] ?? "0"
+  const fraction = parts[1]
+  const wholeWords =
+    whole.length > 1 && whole.startsWith("0")
+      ? [...whole].map((digit) => SWAHILI_UNITS[Number(digit)]).join(" ")
+      : swahiliIntegerWords(Number(whole))
+  if (fraction === undefined) return wholeWords
+  const separator = normalized.includes(",") ? "koma" : "nukta"
+  return `${wholeWords} ${separator} ${[...fraction]
+    .map((digit) => SWAHILI_UNITS[Number(digit)])
+    .join(" ")}`
+}
+
+const ROMAN_VALUE: Record<string, number> = {
+  I: 1, V: 5, X: 10, L: 50, C: 100, D: 500, M: 1_000,
+}
+
+function romanNumeralValue(token: string): number | null {
+  const roman = token.toUpperCase()
+  // Canonical Roman numerals only. This rejects arbitrary words made solely
+  // from Roman letters and malformed forms such as IIII or IC.
+  if (!/^(?=[MDCLXVI]+$)M{0,3}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})$/.test(roman)) {
+    return null
+  }
+  let total = 0
+  for (let index = 0; index < roman.length; index++) {
+    const current = ROMAN_VALUE[roman[index]!]!
+    const next = ROMAN_VALUE[roman[index + 1]!] ?? 0
+    total += current < next ? -current : current
+  }
+  return total || null
+}
+
+function swahiliRomanWords(token: string): string {
+  const value = romanNumeralValue(token)
+  return value === null ? token : swahiliIntegerWords(value)
+}
+
+const SWAHILI_ORDINAL_CONTEXT_RE = new RegExp(
+  String.raw`\b(mfano|zoezi|swali|sura|sehemu|hatua|ukurasa|darasa|mwezi|safu|mstari|jedwali|kielelezo|picha|aya|kipengele|kifungu|somo)\s+(ya|wa|la|cha|vya|za)\s+(\d+)\b`,
+  "gi",
+)
+
+function swahiliOrdinalWords(token: string): string {
+  const value = Number(token)
+  if (value === 1) return "kwanza"
+  if (value === 2) return "pili"
+  return swahiliIntegerWords(value)
+}
+
+/**
+ * Convert ambiguous written tokens into deterministic, language-native TTS
+ * input without changing the catalog text displayed to the reader.
+ */
+export function prepareTextForSpeech(text: string, language: string): string {
+  if (getBaseLanguage(language) !== "sw") return text
+
+  return text
+    // Pronunciation lexicon for initial syllabic nasals. These separators are
+    // TTS-only syllable boundaries; the visible catalog text is untouched.
+    .replace(/\bmmoja\b/gi, (word) => `${word[0]}-${word.slice(1)}`)
+    .replace(/\bnne\b/gi, (word) => `${word[0]}-${word.slice(1)}`)
+    // Digits following structural nouns are positions, not quantities:
+    // "Mfano wa 1" means "Mfano wa kwanza", while a phrase such as
+    // "thamani ya 8" remains cardinal because it is not a structural label.
+    .replace(
+      SWAHILI_ORDINAL_CONTEXT_RE,
+      (_match, noun: string, connector: string, number: string) =>
+        `${noun} ${connector} ${swahiliOrdinalWords(number)}`,
+    )
+    // Roman ranges must be resolved before the generic character-range rule.
+    .replace(/\b([IVXLCDM]{1,12})\s*[-–—]\s*([IVXLCDM]{1,12})\b/g, (_match, from: string, to: string) => {
+      const fromValue = romanNumeralValue(from)
+      const toValue = romanNumeralValue(to)
+      return fromValue === null || toValue === null
+        ? _match
+        : `${swahiliIntegerWords(fromValue)} hadi ${swahiliIntegerWords(toValue)}`
+    })
+    // Multi-character uppercase numerals are unambiguous. A single numeral is
+    // converted only in list/heading notation such as (V) or X., avoiding math
+    // variables and ordinary alphabetic labels such as lowercase (c).
+    .replace(/\b[IVXLCDM]{2,12}\b/g, (token) => swahiliRomanWords(token))
+    .replace(/\(([IVXLCDM])\)|\b([IVXLCDM])(?=[.)])/g, (_match, wrapped: string | undefined, suffixed: string | undefined) => {
+      const token = (wrapped ?? suffixed)!
+      const words = swahiliRomanWords(token)
+      return wrapped ? `(${words})` : words
+    })
+    .replace(/\(([ivxlcdm]{2,12})\)|\b([ivxlcdm]{2,12})(?=[.)])/g, (match, wrapped: string | undefined, suffixed: string | undefined) => {
+      const token = (wrapped ?? suffixed)!
+      const value = romanNumeralValue(token)
+      if (value === null) return match
+      const words = swahiliIntegerWords(value)
+      return wrapped ? `(${words})` : words
+    })
+    // A bare parenthesized letter is an enumeration/section label, not an
+    // English word. Give it Kiswahili structural context so OpenAI keeps the
+    // selected accent instead of switching to an English alphabet reading.
+    // Multi-letter Roman numerals were already handled above.
+    .replace(/\(([a-z])\)/g, " kipengele $1")
+    // A compact dash is a range; spaced mathematical dashes remain subtraction.
+    .replace(/\b([A-Za-z])\s*[-–—]\s*([A-Za-z])\b/g, "$1 hadi $2")
+    .replace(/\b(\d+)\s*[-–—](?=\d)(\d+)\b/g, "$1 hadi $2")
+    .replace(/(\d+(?:[.,]\d+)?)\s*%/g, "asilimia $1")
+    .replace(/\b\d+(?:[.,]\d+)?\b/g, (token) => swahiliNumberWords(token))
+    .replace(/\s[-–—]\s/g, " toa ")
+    .replace(/\s\+\s/g, " jumlisha ")
+    .replace(/\s[×*]\s/g, " zidisha kwa ")
+    .replace(/\s[÷/]\s/g, " gawanya kwa ")
+    .replace(/\s=\s/g, " ni sawa na ")
+    .replace(/\s{2,}/g, " ")
+    .trim()
+}
+
+/** Add phonetic direction only when the prepared transcript needs it. */
+export function prepareInstructionsForSpeech(
+  instructions: string,
+  preparedText: string,
+  language: string,
+): string {
+  if (getBaseLanguage(language) !== "sw") return instructions
+  const additions: string[] = []
+  if (/\bkipengele [a-z]\b/.test(preparedText)) {
+    additions.push(
+      "Pronounce enumeration letters with native Kiswahili vowel sounds; never use English alphabet names or an English accent.",
+    )
+  }
+  if (/\bn-ne\b/.test(preparedText)) {
+    additions.push(
+      'Pronounce "n-ne" as Tanzanian Kiswahili [ˈn̩.nɛ], with the first syllabic n clearly stressed and audible. Do not reduce it to "ne" and do not speak the hyphen.',
+    )
+  }
+  if (/\bm-moja\b/i.test(preparedText)) {
+    additions.push(
+      'Pronounce "m-moja" as Tanzanian Kiswahili [m̩.ˈmɔ.dʒa]: the first m is its own syllable, stress "mo", and do not speak the hyphen.',
+    )
+  }
+  return additions.length > 0
+    ? [instructions.trim(), ...additions].filter(Boolean).join("\n")
+    : instructions
+}
+
 // ---------------------------------------------------------------------------
 // Speakable text check
 // ---------------------------------------------------------------------------
@@ -273,7 +454,11 @@ export function computeSpeechCacheKey(data: {
           ...(geminiSeed !== undefined ? { geminiSeed } : {}),
         }
       : {}
-  const json = JSON.stringify({ ...base, ...gemini })
+  // Azure SSML v2 derives xml:lang from the selected voice. Include the
+  // synthesis revision so audio cached under the old hard-coded en-US SSML is
+  // regenerated instead of silently reused.
+  const synthesisRevision = base.provider === "azure" ? { synthesisRevision: 2 } : {}
+  const json = JSON.stringify({ ...base, ...gemini, ...synthesisRevision })
   return crypto.createHash("sha256").update(json).digest("hex")
 }
 
@@ -321,6 +506,10 @@ export interface GenerateSpeechFileOptions {
    *  Undefined → not sent; Gemini uses its own defaults (sampling disabled). */
   geminiTemperature?: number
   geminiSeed?: number
+  /** Skip an existing LLM-level cache entry and synthesize fresh audio. Use
+   * only for an explicit user-requested regeneration; normal pipeline runs
+   * must continue to benefit from deterministic cache reuse. */
+  forceRegenerate?: boolean
   /** Run cancellation — aborts the rate-limiter wait and the TTS request. */
   signal?: AbortSignal
 }
@@ -348,12 +537,18 @@ export async function generateSpeechFile(
     provider,
     geminiTemperature,
     geminiSeed,
+    forceRegenerate = false,
     signal,
   } = options
 
   // Strip emojis and validate
-  const sanitized = stripEmojis(text).trim()
+  const sanitized = prepareTextForSpeech(stripEmojis(text).trim(), language)
   if (!isSpeakableText(sanitized)) return null
+  const preparedInstructions = prepareInstructionsForSpeech(
+    instructions,
+    sanitized,
+    language,
+  )
 
   const safeTextId = assertSafeSegment(textId, SAFE_TEXT_ID_RE, "text id")
   const safeFormat = assertSafeSegment(
@@ -371,13 +566,16 @@ export async function generateSpeechFile(
     text: sanitized,
     voice,
     model,
-    instructions,
+    instructions: preparedInstructions,
     provider,
     geminiTemperature,
     geminiSeed,
   })
 
-  const fileName = `${safeTextId}.${safeFormat}`
+  const versionSuffix = forceRegenerate
+    ? `${hash.slice(0, 12)}-${Date.now().toString(36)}-${crypto.randomBytes(4).toString("hex")}`
+    : hash.slice(0, 12)
+  const fileName = `${safeTextId}.${versionSuffix}.${safeFormat}`
   const audioRoot = path.resolve(bookDir, "audio")
   const audioDir = path.resolve(audioRoot, normalizedLanguage)
   assertWithinBase(audioRoot, audioDir, "audio directory")
@@ -386,9 +584,12 @@ export async function generateSpeechFile(
 
   // Check cache
   const cacheRoot = path.resolve(cacheDir, "tts")
-  const cachePath = path.resolve(cacheRoot, `${hash}.${safeFormat}`)
+  const cacheName = forceRegenerate
+    ? `${hash}-${Date.now().toString(36)}-${crypto.randomBytes(4).toString("hex")}.${safeFormat}`
+    : `${hash}.${safeFormat}`
+  const cachePath = path.resolve(cacheRoot, cacheName)
   assertWithinBase(cacheRoot, cachePath, "cache file")
-  if (fs.existsSync(cachePath)) {
+  if (!forceRegenerate && fs.existsSync(cachePath)) {
     fs.mkdirSync(audioDir, { recursive: true })
     fs.copyFileSync(cachePath, outputPath)
     return {
@@ -399,6 +600,7 @@ export async function generateSpeechFile(
       model,
       cached: true,
       provider,
+      sourceHash: hash,
     }
   }
 
@@ -410,7 +612,7 @@ export async function generateSpeechFile(
     voice,
     input: sanitized,
     responseFormat: safeFormat,
-    instructions: instructions || undefined,
+    instructions: preparedInstructions || undefined,
     temperature: geminiTemperature,
     seed: geminiSeed,
     signal,
@@ -434,6 +636,7 @@ export async function generateSpeechFile(
     model,
     cached: false,
     provider,
+    sourceHash: hash,
   }
 }
 
@@ -578,10 +781,23 @@ export async function generatePageSpeechFiles(
   const results: SpeechFileEntry[] = []
   for (const range of ranges) {
     signal?.throwIfAborted()
+    const entry = usable.find((candidate) => candidate.id === range.id)
+    if (!entry) continue
+    const sourceHash = computeSpeechCacheKey({
+      text: entry.text,
+      voice,
+      model,
+      instructions,
+      provider,
+      geminiTemperature,
+      geminiSeed,
+    })
     // A short edge fade guarantees zero-amplitude slice edges (belt-and-braces
     // with the silence-snap above) so back-to-back playback has no clicks.
     const slice = sliceWav(pageBytes, range.start, range.end, PAGE_SLICE_FADE_MS)
-    const fileName = `${range.id}.${safeFormat}`
+    // Page-batched clips follow the same entity-versioning rule as clips made
+    // one at a time: changed source text creates a new immutable asset.
+    const fileName = `${range.id}.${sourceHash.slice(0, 12)}.${safeFormat}`
     const outputPath = path.resolve(audioDir, fileName)
     assertWithinBase(audioDir, outputPath, "audio file")
     // Only write when the bytes actually change, so an unchanged slice keeps its
@@ -590,7 +806,16 @@ export async function generatePageSpeechFiles(
     if (!fs.existsSync(outputPath) || !fs.readFileSync(outputPath).equals(slice)) {
       fs.writeFileSync(outputPath, slice)
     }
-    results.push({ textId: range.id, language: normalizedLanguage, fileName, voice, model, cached, provider })
+    results.push({
+      textId: range.id,
+      language: normalizedLanguage,
+      fileName,
+      voice,
+      model,
+      cached,
+      provider,
+      sourceHash,
+    })
   }
   return results
 }

--- a/packages/types/src/speech.ts
+++ b/packages/types/src/speech.ts
@@ -106,6 +106,8 @@ export const SpeechFileEntry = z.object({
   model: z.string(),
   cached: z.boolean(),
   provider: z.string().optional(),
+  /** Deterministic hash of the spoken text, voice, model, and instructions. */
+  sourceHash: z.string().optional(),
 })
 export type SpeechFileEntry = z.infer<typeof SpeechFileEntry>
 


### PR DESCRIPTION
## Summary

Split from #707 as requested.

- Regenerates one clip or an explicit selection without rerunning all Speech.
- Uses versioned, content-hashed files so regeneration never overwrites prior audio/cache artifacts.
- Persists edited source/translation text as a new entity version.
- Preserves regenerated page-batched clips during later full runs.
- Invalidates stale timestamps and reports partial selection failures.
- Prevents untranslated source text from using a target-language voice.
- Moves checkboxes into explicit selection mode and adds change-driven suggestions.
- Fixes Swahili thousands parsing.

Closes #696
Supersedes the Speech portion of #707.

## Verification

- build, typecheck, lint, strict i18n compile passed
- 101/101 focused Speech/API/stage-runner tests passed
- Full suite: 2,345/2,346 passed; one unrelated part-service test exceeded the 5-second timeout only under parallel load
- Isolated part-service rerun: 14/14 passed