### PR TITLE
feat: add responsive Storyboard canvas editing

### DIFF
--- a/apps/studio/src/components/pipeline/components/BookFontSelector.tsx
+++ b/apps/studio/src/components/pipeline/components/BookFontSelector.tsx
@@ -1,0 +1,51 @@
+import { REFLOWABLE_FONTS } from "@adt/types"
+import { Type } from "lucide-react"
+import { useLingui } from "@lingui/react/macro"
+import { toast } from "sonner"
+import { useApplyBookFont, useBookFonts } from "@/hooks/use-book-fonts"
+
+export function BookFontSelector({ bookLabel }: { bookLabel: string }) {
+  const { t } = useLingui()
+  const { data, isPending } = useBookFonts(bookLabel)
+  const apply = useApplyBookFont(bookLabel)
+  const current = data?.current
+  const value = current?.bodyRole
+    ? `registry:${current.font.id}`
+    : current?.setting && current.setting !== "auto"
+      ? `reflowable:${current.setting}`
+      : "auto"
+
+  async function changeFont(next: string) {
+    try {
+      if (next === "auto") await apply.mutateAsync({ scope: "whole", reset: true })
+      else {
+        const [kind, id] = next.split(":") as ["registry" | "reflowable", string]
+        await apply.mutateAsync({ scope: "whole", font: { kind, id } })
+      }
+      toast.success(t`Book font updated.`)
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : t`Unable to update the book font.`)
+    }
+  }
+
+  return (
+    <label className="flex min-w-0 flex-col gap-1.5 text-xs text-foreground">
+      <span className="inline-flex items-center gap-1.5 font-medium">
+      <Type className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+      {t`Output font family`}
+      </span>
+      <select
+        aria-label={t`Output font family`}
+        value={value}
+        disabled={isPending || apply.isPending || current?.fixedLayout}
+        onChange={(event) => void changeFont(event.target.value)}
+        title={current?.fixedLayout ? t`Fixed-layout pages preserve the original book fonts.` : t`Change the font across generated book pages.`}
+        className="h-9 min-w-64 rounded border bg-background px-2 text-sm text-foreground outline-none focus:ring-2 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        <option value="auto">{t`Automatic — match book`}</option>
+        {REFLOWABLE_FONTS.map((font) => <option key={font.id} value={`reflowable:${font.id}`}>{font.family}</option>)}
+        {data?.fonts.map((font) => <option key={font.id} value={`registry:${font.id}`}>{font.family}</option>)}
+      </select>
+    </label>
+  )
+}

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/AiImageDialog.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/AiImageDialog.tsx
@@ -207,14 +207,14 @@ export function AiImageDialog({
                       setShowStylePicker(false)
                     }
                   }}
-                  className="w-full text-xs border rounded-lg px-3 py-2 pr-7 appearance-none bg-background focus:outline-none focus:ring-2 focus:ring-purple-500/30 cursor-pointer"
+                  className="w-full min-w-[470px] text-xs border rounded-lg px-3 py-2 pr-7 appearance-none bg-background focus:outline-none focus:ring-2 focus:ring-purple-500/30 cursor-pointer"
                 >
                   {STYLE_PRESET_VALUES.map((v) => (
                     <option key={v || "default"} value={v}>{i18n._(STYLE_LABEL_MSGS[v])}</option>
                   ))}
                   <option value="custom-image">{t`From reference image...`}</option>
                 </select>
-                <ChevronDown className="absolute right-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground pointer-events-none" />
+                <ChevronDown className="absolute -right-58 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground pointer-events-none" />
               </div>
             </div>
 

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/BookPreviewFrame.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/BookPreviewFrame.tsx
@@ -56,6 +56,7 @@ const TRANSIENT_ATTRS = [
   "data-adt-linked",
   "data-adt-preview",
   "data-adt-link-hover",
+  "data-adt-dragging",
   "contenteditable",
 ] as const
 
@@ -75,6 +76,10 @@ function parsePxStyle(value: string | undefined): number | null {
 export interface BookPreviewFrameHandle {
   /** Get the iframe element's bounding rect in the viewport */
   getIframeRect: () => DOMRect | null
+  /** Serialize the current editable iframe DOM without editor-only handles/attributes. */
+  getSerializedHtml: () => string | null
+  /** Add a basic editable text or shape component and return its data-id. */
+  addComponent: (kind: "text" | "shape", text?: string) => string | null
   /** Regenerate Tailwind CSS including the given extra HTML, then inject into iframe.
    *  Use after AI edits introduce new Tailwind classes not yet in the DB. */
   refreshCss: (extraHtml: string) => Promise<void>
@@ -86,6 +91,10 @@ export interface BookPreviewFrameHandle {
    *  element by data-id. Returns updated full HTML, or null. Used for styling
    *  that must win over class/cascade rules (e.g. per-element font-family). */
   setElementStyleProp: (dataId: string, property: string, value: string) => string | null
+  /** Read/write the active device's canvas transform. Device-scoped values
+   *  prevent a desktop adjustment from breaking the mobile composition. */
+  getCanvasTransform: (dataId: string) => { x: number; y: number; angle: number } | null
+  setCanvasTransform: (dataId: string, value: { x: number; y: number; angle: number }) => string | null
   /** Re-inject the current `html` prop into the iframe, discarding any in-iframe
    *  DOM mutations (e.g. live `setElementClasses` edits). Used when the parent
    *  wants to revert to the saved state without changing the html prop. */
@@ -113,6 +122,14 @@ export interface BookPreviewFrameProps {
   onSelectElement?: (dataId: string, rect: DOMRect, tagName?: string) => void
   /** Called when a text element is edited (blur/Enter after contenteditable) */
   onTextChanged?: (dataId: string, newText: string, fullHtml: string) => void
+  /** Called after a selected component has been repositioned with its drag handle. */
+  onElementMoved?: (dataId: string) => void
+  /** Accessible label for the component drag handle. */
+  dragHandleLabel: string
+  /** Accessible label for the component rotation handle. */
+  rotateHandleLabel: string
+  /** Accessible label for image resize handles. */
+  resizeHandleLabel: string
   /** When true (default), applies data-background-color to the iframe body */
   applyBodyBackground?: boolean
   /** data-id of the currently selected element; re-applied after each body rebuild. */
@@ -180,6 +197,10 @@ export const BookPreviewFrame = forwardRef<BookPreviewFrameHandle, BookPreviewFr
   changedElements,
   onSelectElement,
   onTextChanged,
+  onElementMoved,
+  dragHandleLabel,
+  rotateHandleLabel,
+  resizeHandleLabel,
   applyBodyBackground,
   selectedDataId,
   renderWidth = DEFAULT_RENDER_WIDTH,
@@ -197,6 +218,7 @@ export const BookPreviewFrame = forwardRef<BookPreviewFrameHandle, BookPreviewFr
   autoRefreshCss = false,
 }, ref) {
   const iframeRef = useRef<HTMLIFrameElement>(null)
+  const selectedDataIdsRef = useRef<string[]>([])
   const wrapperRef = useRef<HTMLDivElement>(null)
   const refreshIdRef = useRef(0)
 
@@ -241,6 +263,46 @@ export const BookPreviewFrame = forwardRef<BookPreviewFrameHandle, BookPreviewFr
 
   useImperativeHandle(ref, () => ({
     getIframeRect: () => iframeRef.current?.getBoundingClientRect() ?? null,
+    getSerializedHtml: (): string | null => {
+      const doc = iframeRef.current?.contentDocument
+      if (!doc) return null
+      const wrapper = doc.getElementById("content")
+      const source = (wrapper ?? doc.body).cloneNode(true) as HTMLElement
+      source.querySelectorAll("[data-adt-canvas-handle], [data-adt-marquee]").forEach((el) => el.remove())
+      source.querySelectorAll(TRANSIENT_ATTRS.map((a) => `[${a}]`).join(", ")).forEach((el) => {
+        for (const attr of TRANSIENT_ATTRS) el.removeAttribute(attr)
+      })
+      const html = wrapper
+        ? ((source.getAttribute("class") || "").trim() ? source.outerHTML : source.innerHTML)
+        : source.innerHTML
+      return DOMPurify.sanitize(
+        demoteFirstHeadingIfPromoted(html, sanitizedHtmlRef.current),
+        { FORBID_ATTR: ["contenteditable"] },
+      )
+    },
+    addComponent: (kind, text): string | null => {
+      const doc = iframeRef.current?.contentDocument
+      if (!doc) return null
+      const win = iframeRef.current?.contentWindow as (Window & { __adtPushUndo?: () => void }) | null
+      win?.__adtPushUndo?.()
+      const host = doc.querySelector("#content > main, #content, main") ?? doc.body
+      const id = `canvas-${kind}-${Date.now().toString(36)}`
+      const element = doc.createElement(kind === "text" ? "p" : "div")
+      element.setAttribute("data-id", id)
+      if (kind === "text") {
+        element.textContent = text ?? ""
+        // Editor-only selection chrome is injected separately. Persist only
+        // neutral layout classes so a newly-added text block does not publish
+        // violet dashed editor scaffolding into the book.
+        element.className = "my-3 min-h-8 p-2"
+      } else {
+        element.setAttribute("aria-hidden", "true")
+        element.className = "my-3 h-24 w-24 rounded-lg bg-violet-200"
+      }
+      host.appendChild(element)
+      element.dispatchEvent(new MouseEvent("click", { bubbles: true }))
+      return id
+    },
     refreshCss: refreshCssInternal,
     getElementClasses: (dataId: string): string[] => {
       const doc = iframeRef.current?.contentDocument
@@ -285,6 +347,39 @@ export const BookPreviewFrame = forwardRef<BookPreviewFrameHandle, BookPreviewFr
       } else {
         html = doc.body.innerHTML
       }
+      el.setAttribute("data-adt-selected", "true")
+      return demoteFirstHeadingIfPromoted(html, sanitizedHtmlRef.current)
+    },
+    getCanvasTransform: (dataId) => {
+      const doc = iframeRef.current?.contentDocument
+      const el = doc?.querySelector(`[data-id="${CSS.escape(dataId)}"]`) as HTMLElement | null
+      if (!doc || !el) return null
+      const device = doc.body.dataset.deviceView || "desktop"
+      const raw = el.style.translate.trim().split(/\s+/)
+      return {
+        x: Number(el.getAttribute(`data-adt-x-${device}`)) || parseFloat(raw[0] ?? "0") || 0,
+        y: Number(el.getAttribute(`data-adt-y-${device}`)) || parseFloat(raw[1] ?? "0") || 0,
+        angle: Number(el.getAttribute(`data-adt-angle-${device}`)) || parseFloat(el.style.rotate) || 0,
+      }
+    },
+    setCanvasTransform: (dataId, value) => {
+      const doc = iframeRef.current?.contentDocument
+      const el = doc?.querySelector(`[data-id="${CSS.escape(dataId)}"]`) as HTMLElement | null
+      if (!doc || !el) return null
+      const device = doc.body.dataset.deviceView || "desktop"
+      const x = Math.round(value.x)
+      const y = Math.round(value.y)
+      const angle = Math.round(((value.angle % 360) + 360) % 360)
+      el.setAttribute(`data-adt-x-${device}`, String(x))
+      el.setAttribute(`data-adt-y-${device}`, String(y))
+      el.setAttribute(`data-adt-angle-${device}`, String(angle))
+      el.style.translate = `${x}px ${y}px`
+      el.style.rotate = `${angle}deg`
+      stripTransientAttributes(doc)
+      const wrapper = doc.getElementById("content")
+      const html = wrapper
+        ? ((wrapper.getAttribute("class") || "").trim() ? wrapper.outerHTML : wrapper.innerHTML)
+        : doc.body.innerHTML
       el.setAttribute("data-adt-selected", "true")
       return demoteFirstHeadingIfPromoted(html, sanitizedHtmlRef.current)
     },
@@ -489,20 +584,23 @@ ${autoFitScript}
   )
 
   // Listen for postMessage from iframe
-  const callbacksRef = useRef({ onSelectElement, onTextChanged, onLinkSelect, onLinkHover })
-  callbacksRef.current = { onSelectElement, onTextChanged, onLinkSelect, onLinkHover }
+  const callbacksRef = useRef({ onSelectElement, onTextChanged, onElementMoved, onLinkSelect, onLinkHover })
+  callbacksRef.current = { onSelectElement, onTextChanged, onElementMoved, onLinkSelect, onLinkHover }
 
   const handleMessage = useCallback((e: MessageEvent) => {
     const iframe = iframeRef.current
     if (!iframe || e.source !== iframe.contentWindow) return
     const data = e.data ?? {}
     if (typeof data !== "object" || !data.type) return
-    const { type, dataId, rect, newText, editedInnerHtml, tagName, kind, id } = data
+    const { type, dataId, rect, newText, editedInnerHtml, tagName, kind, id, selectedDataIds } = data
     if (type === "link-select") {
       callbacksRef.current.onLinkSelect?.(parseAnchor(kind, id))
     } else if (type === "link-hover") {
       callbacksRef.current.onLinkHover?.(parseAnchor(kind, id))
     } else if (type === "select" || type === "select-image" || type === "select-container") {
+      selectedDataIdsRef.current = Array.isArray(selectedDataIds)
+        ? selectedDataIds.filter((value: unknown): value is string => typeof value === "string")
+        : dataId ? [dataId] : []
       callbacksRef.current.onSelectElement?.(dataId, rect, tagName)
     } else if (type === "text-changed") {
       // Splice the edited element's innerHTML into the original LaTeX-form HTML
@@ -522,7 +620,10 @@ ${autoFitScript}
         return
       }
       callbacksRef.current.onTextChanged?.(dataId, newText, reconstructed)
+    } else if (type === "element-moved" || type === "elements-changed") {
+      callbacksRef.current.onElementMoved?.(dataId)
     } else if (type === "deselect") {
+      selectedDataIdsRef.current = []
       callbacksRef.current.onSelectElement?.("", {} as DOMRect)
     }
   }, [])
@@ -584,6 +685,7 @@ ${autoFitScript}
     // Inject original LaTeX texts so startEditing can swap MathML → LaTeX
     const textsEl = doc.createElement("script")
     textsEl.id = "adt-original-texts"
+    // eslint-disable-next-line lingui/no-unlocalized-strings -- Injected JavaScript source, not user-visible text.
     textsEl.textContent = `window.__origTexts=${JSON.stringify(originalTextsRef.current)};`
     doc.body.appendChild(textsEl)
 
@@ -657,14 +759,22 @@ ${autoFitScript}
   useEffect(() => {
     const doc = iframeRef.current?.contentDocument
     if (!doc) return
-    doc.querySelectorAll("[data-adt-selected]").forEach((el) => {
-      if (el.getAttribute("data-id") !== selectedDataId) {
-        el.removeAttribute("data-adt-selected")
-      }
-    })
+    doc.querySelectorAll("[data-adt-selected]").forEach((el) => el.removeAttribute("data-adt-selected"))
     if (!selectedDataId) return
-    const el = doc.querySelector(`[data-id="${CSS.escape(selectedDataId)}"]`)
-    if (el) el.setAttribute("data-adt-selected", "true")
+    const ids = selectedDataIdsRef.current.includes(selectedDataId)
+      ? selectedDataIdsRef.current
+      : [selectedDataId]
+    const iframeWindow = iframeRef.current?.contentWindow as (Window & {
+      __adtRestoreSelection?: (ids: string[]) => void
+    }) | null
+    if (iframeWindow?.__adtRestoreSelection) {
+      iframeWindow.__adtRestoreSelection(ids)
+      return
+    }
+    for (const id of ids) {
+      const el = doc.querySelector(`[data-id="${CSS.escape(id)}"]`)
+      if (el) el.setAttribute("data-adt-selected", "true")
+    }
   }, [selectedDataId, displayHtml, iframeReady])
 
   useEffect(() => {
@@ -672,7 +782,11 @@ ${autoFitScript}
     if (!doc?.body) return
     doc.body.dataset.editable = editable && !linkMode ? "true" : "false"
     doc.body.dataset.linkMode = linkMode ? "true" : "false"
-  }, [editable, linkMode, iframeReady])
+    doc.body.dataset.dragHandleLabel = dragHandleLabel
+    doc.body.dataset.rotateHandleLabel = rotateHandleLabel
+    doc.body.dataset.resizeHandleLabel = resizeHandleLabel
+    doc.body.dataset.deviceView = deviceView ?? "desktop"
+  }, [editable, linkMode, dragHandleLabel, rotateHandleLabel, resizeHandleLabel, deviceView, iframeReady])
 
   const linkedKey = linkedAnchor ? anchorKey(linkedAnchor) : ""
   const previewKey = previewAnchor ? anchorKey(previewAnchor) : ""

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/CanvasEditingPanels.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/CanvasEditingPanels.tsx
@@ -1,0 +1,68 @@
+import { X } from "lucide-react"
+import { useLingui } from "@lingui/react/macro"
+import { BookFontSelector } from "@/components/pipeline/components/BookFontSelector"
+import { Input } from "@/components/ui/input"
+import type { DeviceView } from "./style-editor/device-breakpoint"
+
+export interface CanvasTransform {
+  x: number
+  y: number
+  angle: number
+}
+
+export function BookDesignPanel({
+  bookLabel,
+  onClose,
+}: {
+  bookLabel: string
+  onClose: () => void
+}) {
+  const { t } = useLingui()
+  return (
+    <aside className="fixed right-6 top-24 z-50 w-80 rounded-xl border bg-background p-4 shadow-xl">
+      <div className="mb-3 flex items-center justify-between">
+        <h2 className="text-sm font-semibold">{t`Book design`}</h2>
+        <button type="button" onClick={onClose} aria-label={t`Close book design`}>
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+      <p className="mb-4 text-xs text-muted-foreground">
+        {t`Choose one accessible font family for all reflowable storyboard pages.`}
+      </p>
+      <BookFontSelector bookLabel={bookLabel} />
+    </aside>
+  )
+}
+
+export function CanvasTransformPanel({
+  deviceView,
+  value,
+  onChange,
+}: {
+  deviceView: DeviceView
+  value: CanvasTransform
+  onChange: (value: CanvasTransform) => void
+}) {
+  const { t } = useLingui()
+  return (
+    <aside className="fixed bottom-6 left-1/2 z-50 -translate-x-1/2 rounded-xl border bg-background p-3 shadow-xl">
+      <div className="mb-2 text-xs font-semibold">{t`Position for ${deviceView}`}</div>
+      <div className="flex gap-2">
+        {(["x", "y", "angle"] as const).map((field) => (
+          <label key={field} className="grid gap-1 text-[10px] uppercase text-muted-foreground">
+            {field === "angle" ? t`Angle` : field === "x" ? t`X position` : t`Y position`}
+            <Input
+              type="number"
+              value={value[field]}
+              onChange={(event) => onChange({
+                ...value,
+                [field]: Number(event.target.value) || 0,
+              })}
+              className="h-8 w-20 text-xs"
+            />
+          </label>
+        ))}
+      </div>
+    </aside>
+  )
+}

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
@@ -13,6 +13,7 @@ import {
   LayoutGrid,
   Loader2,
   MessageSquare,
+  MousePointer2,
   Palette,
   PanelRightClose,
   PanelRightOpen,
@@ -95,6 +96,7 @@ import { AiEditHistoryDrawer } from "./AiEditHistoryDrawer"
 import { LayoutMirrorDialog } from "./LayoutMirrorDialog"
 import { GenerateActivityDialog } from "./GenerateActivityDialog"
 import { Input } from "@/components/ui/input"
+import { BookDesignPanel, CanvasTransformPanel } from "./CanvasEditingPanels"
 import { useLingui } from "@lingui/react/macro"
 import { msg } from "@lingui/core/macro"
 import { i18n } from "@lingui/core"
@@ -500,6 +502,9 @@ export function StoryboardSectionDetail({
     ComputedTypographyStyles | null
   >(null)
   const [deviceView, setDeviceView] = useDeviceView(bookLabel, "desktop")
+  const [canvasEditing, setCanvasEditing] = useState(false)
+  const [bookDesignOpen, setBookDesignOpen] = useState(false)
+  const [canvasTransform, setCanvasTransform] = useState({ x: 0, y: 0, angle: 0 })
   const [previewVisibleWidth, setPreviewVisibleWidth] = useState(0)
   const previewFrameRef = useRef<BookPreviewFrameHandle>(null)
   const scrollContainerRef = useRef<HTMLDivElement>(null)
@@ -521,6 +526,12 @@ export function StoryboardSectionDetail({
       previewFrameRef.current?.getComputedTypographyStyles(selectedElement.dataId) ?? null,
     )
   }, [selectedElement, selectedElementClasses])
+
+  useEffect(() => {
+    if (!selectedElement) return
+    const value = previewFrameRef.current?.getCanvasTransform(selectedElement.dataId)
+    if (value) setCanvasTransform(value)
+  }, [selectedElement, deviceView])
 
   // Track current pageId so async callbacks can detect stale closures
 
@@ -1535,6 +1546,49 @@ export function StoryboardSectionDetail({
     [page.rendering, pendingRendering, sectionIndex, markPending]
   )
 
+  const handleElementMoved = useCallback(
+    (_dataId: string) => {
+      if (!page.rendering) return
+      const fullHtml = previewFrameRef.current?.getSerializedHtml()
+      if (!fullHtml) return
+      const base = pendingRendering ?? page.rendering
+      setPendingRendering({
+        ...base,
+        sections: base.sections.map((section) =>
+          section.sectionIndex === sectionIndex ? { ...section, html: fullHtml } : section,
+        ),
+      })
+      markPending("style")
+    },
+    [page.rendering, pendingRendering, sectionIndex, markPending],
+  )
+
+  const handleAddCanvasComponent = useCallback(
+    (kind: "text" | "shape") => {
+      const id = previewFrameRef.current?.addComponent(kind, kind === "text" ? t`New text` : undefined)
+      if (id) handleElementMoved(id)
+    },
+    [handleElementMoved, t],
+  )
+
+  const updateCanvasTransform = useCallback(
+    (next: { x: number; y: number; angle: number }) => {
+      if (!selectedElement || !page.rendering) return
+      const fullHtml = previewFrameRef.current?.setCanvasTransform(selectedElement.dataId, next)
+      if (!fullHtml) return
+      setCanvasTransform(next)
+      const base = pendingRendering ?? page.rendering
+      setPendingRendering({
+        ...base,
+        sections: base.sections.map((item) =>
+          item.sectionIndex === sectionIndex ? { ...item, html: fullHtml } : item,
+        ),
+      })
+      markPending("style")
+    },
+    [selectedElement, page.rendering, pendingRendering, sectionIndex, markPending],
+  )
+
   // Handle element selection from BookPreviewFrame
   const handleSelectElement = useCallback((dataId: string, rect: DOMRect, tagName?: string) => {
     if (!dataId) {
@@ -2422,6 +2476,9 @@ export function StoryboardSectionDetail({
               html={sec.html}
               bookLabel={bookLabel}
               editable={false}
+              dragHandleLabel={t`Drag to move`}
+              rotateHandleLabel={t`Rotate`}
+              resizeHandleLabel={t`Resize image`}
               renderWidth={DEVICE_WIDTHS[previewViewport]}
               deviceView={previewViewport}
               maxVisibleHeight={opts?.maxHeight}
@@ -2484,6 +2541,65 @@ export function StoryboardSectionDetail({
         >
           <LayoutGrid className="h-3.5 w-3.5" />
         </button>
+      )}
+      {renderedSection?.html && !hasActiveTask && !storyboardRunning && (
+        <button
+          type="button"
+          onClick={() => {
+            setCanvasEditing((current) => !current)
+            setSelectedElement(null)
+          }}
+          className={`flex items-center gap-1 rounded px-2 py-1 text-[10px] transition-colors ${
+            canvasEditing ? "bg-white text-violet-700" : "bg-white/10 hover:bg-white/20"
+          }`}
+          title={t`Toggle canvas editing mode`}
+          aria-pressed={canvasEditing}
+        >
+          <MousePointer2 className="h-3.5 w-3.5" />
+          {canvasEditing ? t`Finish layout` : t`Edit layout`}
+        </button>
+      )}
+      {renderedSection?.html && (
+        <button
+          type="button"
+          onClick={() => setBookDesignOpen((current) => !current)}
+          className={`flex items-center gap-1 rounded px-2 py-1 text-[10px] transition-colors ${
+            bookDesignOpen ? "bg-white/30" : "bg-white/10 hover:bg-white/20"
+          }`}
+          title={t`Book design`}
+          aria-expanded={bookDesignOpen}
+        >
+          <Palette className="h-3.5 w-3.5" />
+          {t`Book design`}
+        </button>
+      )}
+      {renderedSection?.html && canvasEditing && !hasActiveTask && !storyboardRunning && (
+        <div className="flex items-center gap-0.5 rounded bg-white/10 p-0.5">
+          <button
+            type="button"
+            onClick={() => handleAddCanvasComponent("text")}
+            className="flex h-6 w-6 items-center justify-center rounded hover:bg-white/20"
+            title={t`Add text`}
+          >
+            <Type className="h-3.5 w-3.5" />
+          </button>
+          <button
+            type="button"
+            onClick={() => handleAddCanvasComponent("shape")}
+            className="flex h-6 w-6 items-center justify-center rounded hover:bg-white/20"
+            title={t`Add shape`}
+          >
+            <Boxes className="h-3.5 w-3.5" />
+          </button>
+          <button
+            type="button"
+            onClick={() => setAddImageDialogOpen(true)}
+            className="flex h-6 w-6 items-center justify-center rounded hover:bg-white/20"
+            title={t`Add image`}
+          >
+            <ImageIcon className="h-3.5 w-3.5" />
+          </button>
+        </div>
       )}
       {hasAnyAgentKey && (
         <button
@@ -2741,11 +2857,15 @@ export function StoryboardSectionDetail({
                   html={renderedSection.html}
                   bookLabel={bookLabel}
                   className="w-full rounded borde"
-                  editable={!hasActiveTask && !storyboardRunning}
+                  editable={canvasEditing && !hasActiveTask && !storyboardRunning}
                   prunedDataIds={prunedDataIds}
                   changedElements={changedElements}
                   onSelectElement={handleSelectElement}
                   onTextChanged={handleTextChanged}
+                  onElementMoved={handleElementMoved}
+                  dragHandleLabel={t`Drag to move`}
+                  rotateHandleLabel={t`Rotate`}
+                  resizeHandleLabel={t`Resize image`}
                   applyBodyBackground={applyBodyBackground}
                   selectedDataId={selectedElement?.dataId ?? null}
                   renderWidth={DEVICE_WIDTHS[deviceView]}
@@ -3073,9 +3193,21 @@ export function StoryboardSectionDetail({
       )}
     </div>
 
+    {bookDesignOpen && (
+      <BookDesignPanel bookLabel={bookLabel} onClose={() => setBookDesignOpen(false)} />
+    )}
+
+    {canvasEditing && selectedElement && (
+      <CanvasTransformPanel
+        deviceView={deviceView}
+        value={canvasTransform}
+        onChange={updateCanvasTransform}
+      />
+    )}
+
     {/* Inline element style editor — opens automatically on selection */}
     <StyleEditorPanel
-      open={!!selectedElement}
+      open={canvasEditing && !!selectedElement}
       onClose={() => setSelectedElement(null)}
       selectedDataId={selectedElement?.dataId ?? null}
       selectedTagName={selectedElement?.tagName ?? null}

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/iframe-interactive.test.ts
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/iframe-interactive.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from "vitest"
+import { INTERACTIVE_SCRIPT } from "./iframe-interactive"
+
+function installInteractiveEditor() {
+  const source = INTERACTIVE_SCRIPT.replace(/^<script>/, "").replace(/<\/script>$/, "")
+  window.eval(source)
+}
+
+describe("storyboard canvas editing", () => {
+  it("groups, moves, rotates, and deletes selected components", () => {
+    document.body.innerHTML = '<div id="content"><img data-id="one"><img data-id="two"></div>'
+    document.body.dataset.editable = "true"
+    const postMessage = vi.spyOn(window, "postMessage").mockImplementation(() => undefined)
+    installInteractiveEditor()
+
+    const one = document.querySelector<HTMLElement>('[data-id="one"]')!
+    const two = document.querySelector<HTMLElement>('[data-id="two"]')!
+    one.dispatchEvent(new MouseEvent("click", { bubbles: true, clientX: 5, clientY: 5 }))
+    two.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, metaKey: true }))
+
+    expect(document.querySelectorAll("[data-adt-selected]")).toHaveLength(2)
+
+    const handle = document.querySelector<HTMLElement>('[data-adt-drag-handle="true"]')!
+    expect(handle).not.toBeNull()
+    handle.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true, clientX: 10, clientY: 20 }))
+    document.dispatchEvent(new MouseEvent("pointermove", { bubbles: true, clientX: 42, clientY: 68 }))
+    document.dispatchEvent(new MouseEvent("pointerup", { bubbles: true, clientX: 42, clientY: 68 }))
+
+    expect(one.style.translate).toBe("32px 48px")
+    expect(two.style.translate).toBe("32px 48px")
+    expect(postMessage).toHaveBeenCalledWith(
+      { type: "element-moved", dataId: "two" },
+      "*",
+    )
+
+    handle.focus()
+    handle.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }))
+    expect(one.style.translate).toBe("33px 48px")
+    expect(two.style.translate).toBe("33px 48px")
+
+    const rotateHandle = document.querySelector<HTMLElement>('[data-adt-rotate-handle="true"]')!
+    rotateHandle.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }))
+    expect(one.style.rotate).toBe("1deg")
+    expect(two.style.rotate).toBe("1deg")
+
+    rotateHandle.dispatchEvent(new KeyboardEvent("keydown", { key: "Delete", bubbles: true }))
+    expect(document.querySelectorAll("[data-id]")).toHaveLength(0)
+    expect(postMessage).toHaveBeenCalledWith(
+      { type: "elements-changed", dataId: "two" },
+      "*",
+    )
+  })
+
+  it("keeps positions separate by device and supports undo", async () => {
+    document.body.innerHTML = '<div id="content"><div data-id="one">Card</div></div>'
+    document.body.dataset.editable = "true"
+    document.body.dataset.deviceView = "desktop"
+    vi.spyOn(window, "postMessage").mockImplementation(() => undefined)
+    installInteractiveEditor()
+
+    const one = document.querySelector<HTMLElement>('[data-id="one"]')!
+    one.dispatchEvent(new MouseEvent("click", { bubbles: true }))
+    const handle = document.querySelector<HTMLElement>('[data-adt-drag-handle]')!
+    handle.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true, clientX: 0, clientY: 0 }))
+    document.dispatchEvent(new MouseEvent("pointermove", { bubbles: true, clientX: 20, clientY: 10 }))
+    document.dispatchEvent(new MouseEvent("pointerup", { bubbles: true, clientX: 20, clientY: 10 }))
+    expect(one.getAttribute("data-adt-x-desktop")).toBe("20")
+
+    document.body.dataset.deviceView = "mobile"
+    await Promise.resolve()
+    expect(one.style.translate).toBe("0px 0px")
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "z", metaKey: true, bubbles: true }))
+    expect(document.querySelector<HTMLElement>('[data-id="one"]')!.getAttribute("data-adt-x-desktop")).toBeNull()
+  })
+
+  it("does not delete a component while its text is being edited", () => {
+    document.body.innerHTML = '<div id="content"><p data-id="text">Editable</p></div>'
+    document.body.dataset.editable = "true"
+    vi.spyOn(window, "postMessage").mockImplementation(() => undefined)
+    installInteractiveEditor()
+    const text = document.querySelector<HTMLElement>('[data-id="text"]')!
+    text.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }))
+    text.dispatchEvent(new KeyboardEvent("keydown", { key: "Backspace", bubbles: true }))
+    expect(document.querySelector('[data-id="text"]')).not.toBeNull()
+  })
+})

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/iframe-interactive.ts
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/iframe-interactive.ts
@@ -16,6 +16,12 @@ export const INTERACTIVE_SCRIPT = `<script>
   var savedOriginalText = null;
   var containerIdCounter = 0;
   var hoveredLink = null;
+  var dragState = null;
+  var rotateState = null;
+  var resizeState = null;
+  var marqueeState = null;
+  var suppressNextClick = false;
+  var undoStack = [];
   var ACTIVITY_INTERACTIVE_SELECTOR = [
     '.activity-option',
     '.activity-underline-option',
@@ -135,28 +141,434 @@ export const INTERACTIVE_SCRIPT = `<script>
   }
 
   function clearSelection() {
-    if (selected) {
-      selected.removeAttribute('data-adt-selected');
-    }
+    document.querySelectorAll('[data-adt-canvas-handle]').forEach(function(handle) { handle.remove(); });
+    document.querySelectorAll('[data-adt-selected]').forEach(function(el) {
+      el.removeAttribute('data-adt-selected');
+    });
     selected = null;
   }
 
-  function selectElement(el) {
-    clearSelection();
+  function selectedElements() {
+    return Array.prototype.slice.call(document.querySelectorAll('[data-adt-selected]'));
+  }
+
+  function selectionBounds() {
+    var items = selectedElements();
+    if (!items.length) return null;
+    var rects = items.map(function(el) { return el.getBoundingClientRect(); });
+    var left = Math.min.apply(null, rects.map(function(r) { return r.left; }));
+    var top = Math.min.apply(null, rects.map(function(r) { return r.top; }));
+    var right = Math.max.apply(null, rects.map(function(r) { return r.right; }));
+    var bottom = Math.max.apply(null, rects.map(function(r) { return r.bottom; }));
+    return { left: left, top: top, right: right, bottom: bottom, width: right - left, height: bottom - top };
+  }
+
+  function ensureDragHandle(el) {
+    var existing = document.querySelector('[data-adt-drag-handle]');
+    if (existing) {
+      positionCanvasHandles();
+      return existing;
+    }
+    var handle = document.createElement('button');
+    handle.type = 'button';
+    handle.contentEditable = 'false';
+    handle.setAttribute('data-adt-drag-handle', 'true');
+    handle.setAttribute('data-adt-canvas-handle', 'true');
+    var label = document.body.dataset.dragHandleLabel || 'Drag to move';
+    handle.setAttribute('aria-label', label);
+    handle.setAttribute('title', label);
+    handle.textContent = '✥';
+    document.body.appendChild(handle);
+    positionCanvasHandles();
+    return handle;
+  }
+
+  function ensureRotateHandle() {
+    var existing = document.querySelector('[data-adt-rotate-handle]');
+    if (existing) return existing;
+    var handle = document.createElement('button');
+    handle.type = 'button';
+    handle.contentEditable = 'false';
+    handle.setAttribute('data-adt-rotate-handle', 'true');
+    handle.setAttribute('data-adt-canvas-handle', 'true');
+    var label = document.body.dataset.rotateHandleLabel || 'Rotate';
+    handle.setAttribute('aria-label', label);
+    handle.setAttribute('title', label);
+    handle.textContent = '↻';
+    document.body.appendChild(handle);
+    return handle;
+  }
+
+  function ensureResizeHandles() {
+    document.querySelectorAll('[data-adt-resize-handle]').forEach(function(handle) { handle.remove(); });
+    var items = selectedElements();
+    if (items.length !== 1 || items[0].tagName !== 'IMG') return;
+    var label = document.body.dataset.resizeHandleLabel || 'Resize image';
+    ['nw', 'ne', 'se', 'sw'].forEach(function(corner) {
+      var handle = document.createElement('button');
+      handle.type = 'button';
+      handle.contentEditable = 'false';
+      handle.setAttribute('data-adt-resize-handle', corner);
+      handle.setAttribute('data-adt-canvas-handle', 'true');
+      handle.setAttribute('aria-label', label + ' (' + corner + ')');
+      handle.setAttribute('title', label);
+      document.body.appendChild(handle);
+    });
+  }
+
+  function positionCanvasHandles() {
+    var rect = selectionBounds();
+    if (!rect) return;
+    var move = document.querySelector('[data-adt-drag-handle]');
+    var rotate = document.querySelector('[data-adt-rotate-handle]');
+    if (move) {
+      move.style.left = Math.max(0, rect.right - 14) + 'px';
+      move.style.top = Math.max(0, rect.top - 14) + 'px';
+    }
+    if (rotate) {
+      rotate.style.left = Math.max(0, rect.left - 18) + 'px';
+      rotate.style.top = Math.max(0, rect.top - 14) + 'px';
+    }
+    document.querySelectorAll('[data-adt-resize-handle]').forEach(function(handle) {
+      var corner = handle.getAttribute('data-adt-resize-handle');
+      handle.style.left = ((corner.indexOf('e') >= 0 ? rect.right : rect.left) - 7) + 'px';
+      handle.style.top = ((corner.indexOf('s') >= 0 ? rect.bottom : rect.top) - 7) + 'px';
+    });
+  }
+
+  function ensureCanvasHandles(el) {
+    ensureDragHandle(el);
+    ensureRotateHandle();
+    ensureResizeHandles();
+    positionCanvasHandles();
+  }
+
+  function selectElement(el, additive) {
+    if (!additive) clearSelection();
+    if (additive && el.hasAttribute('data-adt-selected')) {
+      el.removeAttribute('data-adt-selected');
+      var remaining = selectedElements();
+      selected = remaining.length ? remaining[remaining.length - 1] : null;
+      if (!selected) clearSelection();
+      else ensureCanvasHandles(selected);
+      return;
+    }
     selected = el;
     el.setAttribute('data-adt-selected', 'true');
+    ensureCanvasHandles(el);
     var isImg = el.tagName === 'IMG';
     parent.postMessage({
       type: isImg ? 'select-image' : 'select',
       dataId: el.getAttribute('data-id'),
       tagName: el.tagName.toLowerCase(),
-      rect: getRect(el)
+      rect: getRect(el),
+      selectedDataIds: selectedElements().map(function(item) { return item.getAttribute('data-id'); })
     }, '*');
   }
+
+  function deviceKey() {
+    var value = document.body.dataset.deviceView || 'desktop';
+    return value === 'mobile' || value === 'tablet' ? value : 'desktop';
+  }
+
+  function pushUndoSnapshot() {
+    var wrapper = document.getElementById('content');
+    var source = wrapper || document.body;
+    var clone = source.cloneNode(true);
+    clone.querySelectorAll('[data-adt-canvas-handle], [data-adt-marquee]').forEach(function(el) { el.remove(); });
+    clone.querySelectorAll('[data-adt-selected], [data-adt-editing], [data-adt-dragging]').forEach(function(el) {
+      el.removeAttribute('data-adt-selected');
+      el.removeAttribute('data-adt-editing');
+      el.removeAttribute('data-adt-dragging');
+      el.removeAttribute('contenteditable');
+    });
+    undoStack.push(clone.innerHTML);
+    if (undoStack.length > 50) undoStack.shift();
+  }
+
+  function undoCanvasChange() {
+    var snapshot = undoStack.pop();
+    if (snapshot == null) return;
+    var wrapper = document.getElementById('content');
+    (wrapper || document.body).innerHTML = snapshot;
+    clearSelection();
+    parent.postMessage({ type: 'elements-changed' }, '*');
+    parent.postMessage({ type: 'deselect' }, '*');
+  }
+
+  window.__adtPushUndo = pushUndoSnapshot;
+
+  function currentTranslate(el) {
+    var key = deviceKey();
+    var storedX = parseFloat(el.getAttribute('data-adt-x-' + key));
+    var storedY = parseFloat(el.getAttribute('data-adt-y-' + key));
+    if (Number.isFinite(storedX) || Number.isFinite(storedY)) {
+      return { x: Number.isFinite(storedX) ? storedX : 0, y: Number.isFinite(storedY) ? storedY : 0 };
+    }
+    var hasScopedPosition = Array.prototype.some.call(el.attributes, function(attr) {
+      return attr.name.indexOf('data-adt-x-') === 0 || attr.name.indexOf('data-adt-y-') === 0;
+    });
+    if (hasScopedPosition) return { x: 0, y: 0 };
+    var raw = (el.style.translate || '').trim().split(/\\s+/);
+    var x = parseFloat(raw[0]) || 0;
+    var y = parseFloat(raw[1]) || 0;
+    return { x: x, y: y };
+  }
+
+  function setTranslate(el, x, y) {
+    var key = deviceKey();
+    var roundedX = Math.round(x);
+    var roundedY = Math.round(y);
+    el.setAttribute('data-adt-x-' + key, String(roundedX));
+    el.setAttribute('data-adt-y-' + key, String(roundedY));
+    el.style.translate = roundedX + 'px ' + roundedY + 'px';
+  }
+
+  function applyDeviceTransforms() {
+    document.querySelectorAll('[data-id]').forEach(function(el) {
+      var position = currentTranslate(el);
+      setTranslate(el, position.x, position.y);
+      var angle = parseFloat(el.getAttribute('data-adt-angle-' + deviceKey()));
+      if (Number.isFinite(angle)) el.style.rotate = Math.round(angle) + 'deg';
+    });
+    positionCanvasHandles();
+  }
+
+  function beginDrag(e) {
+    var handle = e.target && e.target.closest && e.target.closest('[data-adt-drag-handle]');
+    if (!handle || !isEditable() || !selected) return;
+    if (dragState) return;
+    e.preventDefault();
+    e.stopPropagation();
+    pushUndoSnapshot();
+    if (editing) finishEditing();
+    var items = selectedElements().map(function(el) {
+      var start = currentTranslate(el);
+      return { el: el, baseX: start.x, baseY: start.y };
+    });
+    dragState = {
+      items: items,
+      dataId: selected.getAttribute('data-id'),
+      startX: e.clientX,
+      startY: e.clientY
+    };
+    items.forEach(function(item) { item.el.setAttribute('data-adt-dragging', 'true'); });
+    document.body.setAttribute('data-adt-dragging', 'true');
+  }
+
+  function moveDrag(e) {
+    if (!dragState) return;
+    e.preventDefault();
+    var dx = e.clientX - dragState.startX;
+    var dy = e.clientY - dragState.startY;
+    dragState.items.forEach(function(item) {
+      setTranslate(item.el, item.baseX + dx, item.baseY + dy);
+    });
+    positionCanvasHandles();
+  }
+
+  function endDrag(e) {
+    if (!dragState) return;
+    e.preventDefault();
+    var moved = dragState;
+    dragState = null;
+    moved.items.forEach(function(item) { item.el.removeAttribute('data-adt-dragging'); });
+    document.body.removeAttribute('data-adt-dragging');
+    parent.postMessage({ type: 'element-moved', dataId: moved.dataId }, '*');
+  }
+
+  function currentRotate(el) {
+    var stored = parseFloat(el.getAttribute('data-adt-angle-' + deviceKey()));
+    if (Number.isFinite(stored)) return stored;
+    return parseFloat((el.style.rotate || '').replace('deg', '')) || 0;
+  }
+
+  function setRotate(el, degrees) {
+    var normalized = Math.round(((degrees % 360) + 360) % 360);
+    el.setAttribute('data-adt-angle-' + deviceKey(), String(normalized));
+    el.style.rotate = normalized + 'deg';
+  }
+
+  function pointerAngle(e, rect) {
+    return Math.atan2(e.clientY - (rect.top + rect.height / 2), e.clientX - (rect.left + rect.width / 2)) * 180 / Math.PI;
+  }
+
+  function beginRotate(e) {
+    var handle = e.target && e.target.closest && e.target.closest('[data-adt-rotate-handle]');
+    if (!handle || !isEditable() || !selected || rotateState) return;
+    e.preventDefault();
+    e.stopPropagation();
+    pushUndoSnapshot();
+    var bounds = selectionBounds();
+    rotateState = {
+      startAngle: pointerAngle(e, bounds),
+      bounds: bounds,
+      dataId: selected.getAttribute('data-id'),
+      items: selectedElements().map(function(el) { return { el: el, base: currentRotate(el) }; })
+    };
+    document.body.setAttribute('data-adt-rotating', 'true');
+  }
+
+  function moveRotate(e) {
+    if (!rotateState) return;
+    e.preventDefault();
+    var delta = pointerAngle(e, rotateState.bounds) - rotateState.startAngle;
+    if (delta > 180) delta -= 360;
+    if (delta < -180) delta += 360;
+    rotateState.items.forEach(function(item) {
+      setRotate(item.el, item.base + delta);
+    });
+    positionCanvasHandles();
+  }
+
+  function endRotate(e) {
+    if (!rotateState) return;
+    e.preventDefault();
+    var rotated = rotateState;
+    rotateState = null;
+    document.body.removeAttribute('data-adt-rotating');
+    parent.postMessage({ type: 'element-moved', dataId: rotated.dataId }, '*');
+  }
+
+  function beginResize(e) {
+    var handle = e.target && e.target.closest && e.target.closest('[data-adt-resize-handle]');
+    if (!handle || !isEditable() || !selected || selected.tagName !== 'IMG' || resizeState) return;
+    e.preventDefault();
+    e.stopPropagation();
+    pushUndoSnapshot();
+    var rect = selected.getBoundingClientRect();
+    resizeState = {
+      el: selected,
+      dataId: selected.getAttribute('data-id'),
+      corner: handle.getAttribute('data-adt-resize-handle'),
+      startX: e.clientX,
+      startY: e.clientY,
+      width: rect.width,
+      height: rect.height,
+      translate: currentTranslate(selected)
+    };
+    document.body.setAttribute('data-adt-resizing', 'true');
+  }
+
+  function applyResize(state, width, height) {
+    width = Math.max(32, width);
+    height = Math.max(32, height);
+    state.el.style.width = Math.round(width) + 'px';
+    state.el.style.height = Math.round(height) + 'px';
+    state.el.style.maxWidth = 'none';
+    var x = state.translate.x;
+    var y = state.translate.y;
+    if (state.corner.indexOf('w') >= 0) x += state.width - width;
+    if (state.corner.indexOf('n') >= 0) y += state.height - height;
+    setTranslate(state.el, x, y);
+    positionCanvasHandles();
+  }
+
+  function moveResize(e) {
+    if (!resizeState) return;
+    e.preventDefault();
+    var directionX = resizeState.corner.indexOf('e') >= 0 ? 1 : -1;
+    var directionY = resizeState.corner.indexOf('s') >= 0 ? 1 : -1;
+    var rawWidth = resizeState.width + (e.clientX - resizeState.startX) * directionX;
+    var rawHeight = resizeState.height + (e.clientY - resizeState.startY) * directionY;
+    if (!e.shiftKey) {
+      var ratio = resizeState.width / resizeState.height;
+      if (Math.abs(rawWidth - resizeState.width) >= Math.abs(rawHeight - resizeState.height)) rawHeight = rawWidth / ratio;
+      else rawWidth = rawHeight * ratio;
+    }
+    applyResize(resizeState, rawWidth, rawHeight);
+  }
+
+  function endResize(e) {
+    if (!resizeState) return;
+    e.preventDefault();
+    var resized = resizeState;
+    resizeState = null;
+    document.body.removeAttribute('data-adt-resizing');
+    parent.postMessage({ type: 'element-moved', dataId: resized.dataId }, '*');
+  }
+
+  document.addEventListener('pointerdown', beginDrag, true);
+  document.addEventListener('pointerdown', beginRotate, true);
+  document.addEventListener('pointerdown', beginResize, true);
+  document.addEventListener('pointermove', moveDrag, true);
+  document.addEventListener('pointermove', moveRotate, true);
+  document.addEventListener('pointermove', moveResize, true);
+  document.addEventListener('pointerup', endDrag, true);
+  document.addEventListener('pointerup', endRotate, true);
+  document.addEventListener('pointerup', endResize, true);
+  document.addEventListener('pointercancel', endDrag, true);
+  document.addEventListener('pointercancel', endRotate, true);
+  document.addEventListener('pointercancel', endResize, true);
+
+  function marqueeRect(state, e) {
+    var left = Math.min(state.startX, e.clientX);
+    var top = Math.min(state.startY, e.clientY);
+    var right = Math.max(state.startX, e.clientX);
+    var bottom = Math.max(state.startY, e.clientY);
+    return { left: left, top: top, right: right, bottom: bottom };
+  }
+
+  function beginMarquee(e) {
+    if (!isEditable() || e.button !== 0 || e.metaKey || e.ctrlKey) return;
+    if (e.target.closest && e.target.closest('[data-adt-canvas-handle]')) return;
+    if (e.target.closest && e.target.closest('[data-id]')) return;
+    e.preventDefault();
+    e.stopImmediatePropagation();
+    clearSelection();
+    var box = document.createElement('div');
+    box.setAttribute('data-adt-marquee', 'true');
+    document.body.appendChild(box);
+    marqueeState = { startX: e.clientX, startY: e.clientY, box: box, moved: false };
+  }
+
+  function moveMarquee(e) {
+    if (!marqueeState) return;
+    e.preventDefault();
+    var rect = marqueeRect(marqueeState, e);
+    marqueeState.moved = marqueeState.moved || rect.right - rect.left > 3 || rect.bottom - rect.top > 3;
+    marqueeState.box.style.left = rect.left + 'px';
+    marqueeState.box.style.top = rect.top + 'px';
+    marqueeState.box.style.width = rect.right - rect.left + 'px';
+    marqueeState.box.style.height = rect.bottom - rect.top + 'px';
+  }
+
+  function endMarquee(e) {
+    if (!marqueeState) return;
+    e.preventDefault();
+    var state = marqueeState;
+    marqueeState = null;
+    var rect = marqueeRect(state, e);
+    state.box.remove();
+    suppressNextClick = state.moved;
+    if (!state.moved) return;
+    var matches = Array.prototype.slice.call(document.querySelectorAll('[data-id]')).filter(function(el) {
+      if (el.closest('[data-adt-canvas-handle]')) return false;
+      var r = el.getBoundingClientRect();
+      return r.width > 3 && r.height > 3 && r.right >= rect.left && r.left <= rect.right && r.bottom >= rect.top && r.top <= rect.bottom;
+    });
+    matches.forEach(function(el) { el.setAttribute('data-adt-selected', 'true'); });
+    selected = matches.length ? matches[matches.length - 1] : null;
+    if (selected) {
+      ensureCanvasHandles(selected);
+      parent.postMessage({
+        type: selected.tagName === 'IMG' ? 'select-image' : 'select',
+        dataId: selected.getAttribute('data-id'),
+        tagName: selected.tagName.toLowerCase(),
+        rect: getRect(selected),
+        selectedDataIds: selectedElements().map(function(item) { return item.getAttribute('data-id'); })
+      }, '*');
+    }
+  }
+
+  document.addEventListener('mousedown', beginMarquee, true);
+  document.addEventListener('mousemove', moveMarquee, true);
+  document.addEventListener('mouseup', endMarquee, true);
 
   function startEditing(el) {
     if (editing === el) return;
     if (el.tagName === 'IMG') return;
+    pushUndoSnapshot();
     editing = el;
     // Save the current MathML display before swapping to LaTeX
     savedDisplayHtml = el.innerHTML;
@@ -164,6 +576,7 @@ export const INTERACTIVE_SCRIPT = `<script>
     if (window.__origTexts && window.__origTexts[dataId] != null) {
       el.innerHTML = window.__origTexts[dataId];
     }
+    ensureDragHandle(el);
     // Capture original text AFTER the LaTeX swap so the comparison
     // in finishEditing compares LaTeX-to-LaTeX, not MathML-to-LaTeX
     savedOriginalText = el.textContent || '';
@@ -223,6 +636,9 @@ export const INTERACTIVE_SCRIPT = `<script>
     clearSelection();
   }).observe(document.body, { attributes: true, attributeFilter: ['data-link-mode'] });
 
+  new MutationObserver(applyDeviceTransforms)
+    .observe(document.body, { attributes: true, attributeFilter: ['data-device-view'] });
+
   new MutationObserver(invalidateAnswerControls)
     .observe(document.body, { childList: true, subtree: true });
 
@@ -272,10 +688,19 @@ export const INTERACTIVE_SCRIPT = `<script>
   // during mousedown/drag was wiped when startEditing swapped innerHTML.
   document.addEventListener('mousedown', function(e) {
     if (!isEditable()) return;
+    if (e.target.closest && e.target.closest('[data-adt-canvas-handle]')) return;
     if (isActivityInteractiveTarget(e.target)) return;
     suppressNativeAction(e);
     var el = findContainer(e.target);
     if (!el) return;
+    if ((e.metaKey || e.ctrlKey) && el.hasAttribute('data-id')) {
+      e.preventDefault();
+      e.stopPropagation();
+      if (editing) finishEditing();
+      selectElement(el, true);
+      suppressNextClick = true;
+      return;
+    }
     if (el.tagName === 'IMG') return;
     if (!el.hasAttribute('data-id')) return;
     if (editing === el) return;
@@ -286,6 +711,13 @@ export const INTERACTIVE_SCRIPT = `<script>
 
   document.addEventListener('click', function(e) {
     if (!isEditable()) return;
+    if (suppressNextClick) {
+      suppressNextClick = false;
+      e.preventDefault();
+      e.stopPropagation();
+      return;
+    }
+    if (e.target.closest && e.target.closest('[data-adt-canvas-handle]')) return;
     if (isActivityInteractiveTarget(e.target)) {
       // Activity controls are never selected or edited, but an edit in
       // progress on some OTHER element still has to be committed here:
@@ -307,7 +739,7 @@ export const INTERACTIVE_SCRIPT = `<script>
     if (editing && editing !== el) finishEditing();
     var hadDataId = el.hasAttribute('data-id');
     if (hadDataId) {
-      selectElement(el);
+      selectElement(el, e.metaKey || e.ctrlKey);
       if (el.tagName !== 'IMG') startEditing(el);
     } else {
       var cId = ensureDataId(el);
@@ -323,11 +755,81 @@ export const INTERACTIVE_SCRIPT = `<script>
     }
   });
 
+  window.__adtRestoreSelection = function(ids) {
+    clearSelection();
+    (ids || []).forEach(function(id) {
+      var el = document.querySelector('[data-id="' + CSS.escape(id) + '"]');
+      if (el) {
+        el.setAttribute('data-adt-selected', 'true');
+        selected = el;
+      }
+    });
+    if (selected) ensureCanvasHandles(selected);
+  };
+
   document.addEventListener('keydown', function(e) {
     if (!isEditable()) {
       if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
         parent.dispatchEvent(new KeyboardEvent('keydown', { key: e.key }));
       }
+      return;
+    }
+    if ((e.metaKey || e.ctrlKey) && !e.shiftKey && e.key.toLowerCase() === 'z' && !editing) {
+      e.preventDefault();
+      undoCanvasChange();
+      return;
+    }
+    var dragHandle = e.target && e.target.closest && e.target.closest('[data-adt-drag-handle]');
+    var targetIsFormField = e.target && e.target.closest && e.target.closest('input, textarea, select');
+    var targetIsOtherCanvasHandle = e.target && e.target.closest && e.target.closest('[data-adt-rotate-handle], [data-adt-resize-handle]');
+    if ((dragHandle || (!targetIsFormField && !targetIsOtherCanvasHandle && selected)) && selected && (
+      e.key === 'ArrowLeft' || e.key === 'ArrowRight' ||
+      e.key === 'ArrowUp' || e.key === 'ArrowDown'
+    )) {
+      e.preventDefault();
+      e.stopPropagation();
+      var distance = e.shiftKey ? 10 : 1;
+      selectedElements().forEach(function(el) {
+        var current = currentTranslate(el);
+        if (e.key === 'ArrowLeft') current.x -= distance;
+        if (e.key === 'ArrowRight') current.x += distance;
+        if (e.key === 'ArrowUp') current.y -= distance;
+        if (e.key === 'ArrowDown') current.y += distance;
+        setTranslate(el, current.x, current.y);
+      });
+      positionCanvasHandles();
+      parent.postMessage({
+        type: 'element-moved',
+        dataId: selected.getAttribute('data-id')
+      }, '*');
+      return;
+    }
+    var rotateHandle = e.target && e.target.closest && e.target.closest('[data-adt-rotate-handle]');
+    if (rotateHandle && selected && (e.key === 'ArrowLeft' || e.key === 'ArrowRight')) {
+      e.preventDefault();
+      e.stopPropagation();
+      var degrees = e.shiftKey ? 15 : 1;
+      if (e.key === 'ArrowLeft') degrees = -degrees;
+      selectedElements().forEach(function(el) {
+        setRotate(el, currentRotate(el) + degrees);
+      });
+      positionCanvasHandles();
+      parent.postMessage({ type: 'element-moved', dataId: selected.getAttribute('data-id') }, '*');
+      return;
+    }
+    var resizeHandle = e.target && e.target.closest && e.target.closest('[data-adt-resize-handle]');
+    if (resizeHandle && selected && selected.tagName === 'IMG' && (
+      e.key === 'ArrowLeft' || e.key === 'ArrowRight' || e.key === 'ArrowUp' || e.key === 'ArrowDown'
+    )) {
+      e.preventDefault();
+      e.stopPropagation();
+      var rect = selected.getBoundingClientRect();
+      var amount = e.shiftKey ? 10 : 1;
+      if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') amount = -amount;
+      var ratio = rect.width / rect.height;
+      var keyboardState = { el: selected, corner: 'se', width: rect.width, height: rect.height, translate: currentTranslate(selected) };
+      applyResize(keyboardState, rect.width + amount, (rect.width + amount) / ratio);
+      parent.postMessage({ type: 'element-moved', dataId: selected.getAttribute('data-id') }, '*');
       return;
     }
     if (editing) {
@@ -348,6 +850,16 @@ export const INTERACTIVE_SCRIPT = `<script>
       }
       return;
     }
+    if ((e.key === 'Delete' || e.key === 'Backspace') && selected) {
+      e.preventDefault();
+      pushUndoSnapshot();
+      var dataId = selected.getAttribute('data-id');
+      selectedElements().forEach(function(el) { el.remove(); });
+      clearSelection();
+      parent.postMessage({ type: 'elements-changed', dataId: dataId }, '*');
+      parent.postMessage({ type: 'deselect' }, '*');
+      return;
+    }
     if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
       parent.dispatchEvent(new KeyboardEvent('keydown', { key: e.key }));
     }
@@ -363,6 +875,68 @@ export const INTERACTIVE_STYLES = `body[data-editable="true"] *:hover:not(:has(*
     body[data-editable="true"] img[data-id] { position: relative; z-index: 1; }
     [data-adt-selected] { outline: 2px solid rgb(124, 58, 237) !important; outline-offset: 2px !important; }
     [data-adt-editing] { outline: 2px solid rgb(91, 33, 182) !important; outline-offset: 2px !important; }
+    [data-adt-drag-handle] {
+      position: fixed;
+      z-index: 2147483647;
+      display: grid;
+      place-items: center;
+      width: 32px;
+      height: 32px;
+      padding: 0;
+      border: 2px solid white;
+      border-radius: 9999px;
+      color: white;
+      background: rgb(124, 58, 237);
+      box-shadow: 0 2px 8px rgba(15, 23, 42, 0.3);
+      cursor: grab;
+      font: 700 18px/1 sans-serif;
+      touch-action: none;
+      user-select: none;
+    }
+    [data-adt-rotate-handle] {
+      position: fixed;
+      z-index: 2147483647;
+      display: grid;
+      place-items: center;
+      width: 32px;
+      height: 32px;
+      padding: 0;
+      border: 2px solid white;
+      border-radius: 9999px;
+      color: white;
+      background: rgb(14, 165, 233);
+      box-shadow: 0 2px 8px rgba(15, 23, 42, 0.3);
+      cursor: alias;
+      font: 700 20px/1 sans-serif;
+      touch-action: none;
+      user-select: none;
+    }
+    [data-adt-resize-handle] {
+      position: fixed;
+      z-index: 2147483647;
+      width: 14px;
+      height: 14px;
+      padding: 0;
+      border: 2px solid white;
+      border-radius: 3px;
+      background: rgb(124, 58, 237);
+      box-shadow: 0 1px 5px rgba(15, 23, 42, 0.4);
+      touch-action: none;
+    }
+    [data-adt-resize-handle="nw"], [data-adt-resize-handle="se"] { cursor: nwse-resize; }
+    [data-adt-resize-handle="ne"], [data-adt-resize-handle="sw"] { cursor: nesw-resize; }
+    [data-adt-resize-handle]:focus-visible { outline: 3px solid rgb(250, 204, 21); outline-offset: 2px; }
+    [data-adt-rotate-handle]:focus-visible { outline: 3px solid rgb(250, 204, 21); outline-offset: 2px; }
+    [data-adt-marquee] {
+      position: fixed;
+      z-index: 2147483646;
+      border: 1px solid rgb(124, 58, 237);
+      background: rgba(124, 58, 237, 0.12);
+      pointer-events: none;
+    }
+    [data-adt-drag-handle]:focus-visible { outline: 3px solid rgb(250, 204, 21); outline-offset: 2px; }
+    body[data-adt-dragging="true"] [data-adt-drag-handle] { cursor: grabbing; }
+    body[data-adt-rotating="true"] [data-adt-rotate-handle] { cursor: grabbing; }
     body[data-link-mode="true"] [data-id],
     body[data-link-mode="true"] [data-activity-item] { cursor: pointer; }
     body[data-link-mode="true"] [data-adt-link-hover],

--- a/apps/studio/src/components/wizard/bookCreationConfig.ts
+++ b/apps/studio/src/components/wizard/bookCreationConfig.ts
@@ -19,6 +19,7 @@ export function buildConfigOverrides(values: WizardFormValues): Record<string, u
   const config: Record<string, unknown> = {
     ...baseConfig,
     default_render_strategy: values.renderStrategy,
+    reflowable_font: values.reflowableFont,
     page_sectioning: { mode: values.sectioningMode },
     spread_mode: values.pageGrouping === "spread",
     vector_text_grouping: values.figureExtraction,

--- a/apps/studio/src/components/wizard/step2LayoutOptions/index.tsx
+++ b/apps/studio/src/components/wizard/step2LayoutOptions/index.tsx
@@ -1,11 +1,45 @@
 import { RenderStrategyPicker } from "./RenderStrategyPicker"
 import { PageGroupingMode } from "./PageGroupingMode"
 import { SectioningMode } from "./SectioningMode"
+import { REFLOWABLE_FONTS } from "@adt/types"
+import { useWizardForm } from "../wizardForm"
+import { useStore } from "@tanstack/react-form"
+import { Trans } from "@lingui/react/macro"
+
+function OutputFontPicker() {
+  const form = useWizardForm()
+  const value = useStore(form.store, (state) => state.values.reflowableFont)
+
+  return (
+    <section className="space-y-2" aria-labelledby="output-font-heading">
+      <div>
+        <h3 id="output-font-heading" className="text-sm font-semibold text-[#171717]">
+          <Trans>Output font family</Trans>
+        </h3>
+        <p className="text-xs text-[#737373]">
+          <Trans>Use one accessible font throughout generated, reflowable pages. You can change it later from the book toolbar.</Trans>
+        </p>
+      </div>
+      <select
+        value={value}
+        onChange={(event) => form.setFieldValue("reflowableFont", event.target.value as typeof value)}
+        className="h-10 w-full rounded-md border border-[#d4d4d4] bg-white px-3 text-sm text-[#171717] focus:border-violet-500 focus:outline-none focus:ring-2 focus:ring-violet-200"
+      >
+        <option value="auto"><Trans>Automatic — match the book</Trans></option>
+        {REFLOWABLE_FONTS.map((font) => <option key={font.id} value={font.id}>{font.family}</option>)}
+      </select>
+      <p className="text-xs text-[#737373]">
+        <Trans>Commercial fonts such as Sassoon must also be installed or attached to the book for an exact match.</Trans>
+      </p>
+    </section>
+  )
+}
 
 export function Step2() {
   return (
     <div className="flex flex-col gap-6 p-8">
       <RenderStrategyPicker />
+      <OutputFontPicker />
       <PageGroupingMode />
       <SectioningMode />
     </div>

--- a/apps/studio/src/components/wizard/wizardForm.ts
+++ b/apps/studio/src/components/wizard/wizardForm.ts
@@ -4,6 +4,7 @@ import type {
   WizardPageGrouping,
   WizardSectioningMode,
 } from "./constants"
+import type { ReflowableFontSetting } from "@adt/types"
 
 export const { fieldContext, formContext, useFieldContext, useFormContext } =
   createFormHookContexts()
@@ -23,6 +24,7 @@ export const defaultWizardValues = {
   endPage: "",
   outputLanguages: [] as string[],
   renderStrategy: "" as RenderStrategyId | "",
+  reflowableFont: "auto" as ReflowableFontSetting,
   pageGrouping: "" as WizardPageGrouping,
   sectioningMode: "" as WizardSectioningMode,
   activitiesGenerator: false,
@@ -51,4 +53,3 @@ export type WizardFormValues = typeof defaultWizardValues
 export function useWizardForm() {
   return useTypedAppFormContext({ defaultValues: defaultWizardValues })
 }
-

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -1297,6 +1297,9 @@ msgstr "and many more blocks across the entire book"
 msgid "and more sections across the page"
 msgstr "and more sections across the page"
 
+msgid "Angle"
+msgstr "Angle"
+
 msgid "Answer"
 msgstr "Answer"
 
@@ -1685,6 +1688,9 @@ msgstr "Book creation stages"
 msgid "Book data is outdated and must be rebuilt."
 msgstr "Book data is outdated and must be rebuilt."
 
+msgid "Book design"
+msgstr "Book design"
+
 msgid "Book font updated."
 msgstr "Book font updated."
 
@@ -2068,6 +2074,9 @@ msgstr "Choose how the content should be formatted."
 msgid "Choose images..."
 msgstr "Choose images..."
 
+msgid "Choose one accessible font family for all reflowable storyboard pages."
+msgstr "Choose one accessible font family for all reflowable storyboard pages."
+
 msgid "Choose Provider"
 msgstr "Choose Provider"
 
@@ -2157,6 +2166,9 @@ msgstr "Clone failed"
 
 msgid "Close"
 msgstr "Close"
+
+msgid "Close book design"
+msgstr "Close book design"
 
 msgid "Close edit panel"
 msgstr "Close edit panel"
@@ -3669,6 +3681,9 @@ msgstr "Final Page"
 
 msgid "Fine-grained token for an existing repository"
 msgstr "Fine-grained token for an existing repository"
+
+msgid "Finish layout"
+msgstr "Finish layout"
 
 msgid "First images from the deep-field telescope."
 msgstr "First images from the deep-field telescope."
@@ -6607,6 +6622,9 @@ msgstr "Position"
 msgid "Position {0}, {1} → {2}×{3} pt"
 msgstr "Position {0}, {1} → {2}×{3} pt"
 
+msgid "Position for {deviceView}"
+msgstr "Position for {deviceView}"
+
 msgid "Práticas de Alfabetização e de Matemática"
 msgstr "Práticas de Alfabetização e de Matemática"
 
@@ -9261,6 +9279,9 @@ msgstr "TOC Preview"
 #~ msgid "Today"
 #~ msgstr "Today"
 
+msgid "Toggle canvas editing mode"
+msgstr "Toggle canvas editing mode"
+
 msgid "Toggle model list"
 msgstr "Toggle model list"
 
@@ -10069,6 +10090,12 @@ msgstr "Write your sentence with a {0} marker."
 
 #~ msgid "Yesterday"
 #~ msgstr "Yesterday"
+
+msgid "X position"
+msgstr "X position"
+
+msgid "Y position"
+msgstr "Y position"
 
 #. placeholder {0}: formatVersion(release.version)
 msgid "You are about to install {0}. Books or settings edited with a newer version may not work as expected. Back up your books before continuing."

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -263,6 +263,10 @@ msgstr "{0} texts"
 msgid "{0} translations"
 msgstr "{0} translations"
 
+#. placeholder {0}: changesQuery.data.changes.length
+#~ msgid "{0} unpublished file changes"
+#~ msgstr "{0} unpublished file changes"
+
 #. placeholder {0}: versions.length
 #~ msgid "{0} versions"
 #~ msgstr "{0} versions"
@@ -821,6 +825,9 @@ msgstr "Activity: Multiple Choice"
 msgid "Activity: Open-Ended Answer"
 msgstr "Activity: Open-Ended Answer"
 
+#~ msgid "Activity: Ordering"
+#~ msgstr "Activity: Ordering"
+
 msgid "Activity: Other"
 msgstr "Activity: Other"
 
@@ -983,6 +990,9 @@ msgstr "Add reviewer guidance."
 
 msgid "Add section"
 msgstr "Add section"
+
+msgid "Add shape"
+msgstr "Add shape"
 
 msgid "Add sign language video"
 msgstr "Add sign language video"
@@ -1260,6 +1270,9 @@ msgstr "Amount"
 msgid "An activity that does not fit the standard categories."
 msgstr "An activity that does not fit the standard categories."
 
+#~ msgid "An activity where learners arrange items into the correct order."
+#~ msgstr "An activity where learners arrange items into the correct order."
+
 msgid "An activity where the learner underlines one or more words, phrases, or sentences directly in the text."
 msgstr "An activity where the learner underlines one or more words, phrases, or sentences directly in the text."
 
@@ -1499,6 +1512,12 @@ msgstr "Auto-fill from book context"
 msgid "Auto-scroll"
 msgstr "Auto-scroll"
 
+msgid "Automatic — match book"
+msgstr "Automatic — match book"
+
+msgid "Automatic — match the book"
+msgstr "Automatic — match the book"
+
 msgid "Automatically adapts the layout based on each page's content using AI."
 msgstr "Automatically adapts the layout based on each page's content using AI."
 
@@ -1654,6 +1673,9 @@ msgstr "Body text uses this font today. Attach a font below and assign it the �
 msgid "Book"
 msgstr "Book"
 
+#~ msgid "Book change history"
+#~ msgstr "Book change history"
+
 msgid "Book coverage"
 msgstr "Book coverage"
 
@@ -1663,6 +1685,9 @@ msgstr "Book creation stages"
 msgid "Book data is outdated and must be rebuilt."
 msgstr "Book data is outdated and must be rebuilt."
 
+msgid "Book font updated."
+msgstr "Book font updated."
+
 msgid "Book Fonts"
 msgstr "Book Fonts"
 
@@ -1671,6 +1696,9 @@ msgstr "Book images"
 
 msgid "Book info"
 msgstr "Book info"
+
+#~ msgid "Book is published"
+#~ msgstr "Book is published"
 
 msgid "Book Language"
 msgstr "Book Language"
@@ -1926,8 +1954,14 @@ msgstr "Change Preset"
 msgid "Change the book language?"
 msgstr "Change the book language?"
 
+msgid "Change the font across generated book pages."
+msgstr "Change the font across generated book pages."
+
 msgid "Change the picture for this term"
 msgstr "Change the picture for this term"
+
+#~ msgid "Changed files"
+#~ msgstr "Changed files"
 
 #~ msgid "Changes apply the next time you run Storyboard and Export."
 #~ msgstr "Changes apply the next time you run Storyboard and Export."
@@ -1973,6 +2007,9 @@ msgstr "Chapter title"
 
 msgid "Chart / Graph"
 msgstr "Chart / Graph"
+
+#~ msgid "Check changes"
+#~ msgstr "Check changes"
 
 #~ msgid "Check for updates"
 #~ msgstr "Check for updates"
@@ -2175,6 +2212,9 @@ msgstr "Comment"
 msgid "Comments"
 msgstr "Comments"
 
+msgid "Commercial fonts such as Sassoon must also be installed or attached to the book for an exact match."
+msgstr "Commercial fonts such as Sassoon must also be installed or attached to the book for an exact match."
+
 msgid "Compare"
 msgstr "Compare"
 
@@ -2189,6 +2229,9 @@ msgstr "Compare versions"
 
 msgid "Compared with fallback prompt."
 msgstr "Compared with fallback prompt."
+
+#~ msgid "Complete the guided setup before starting the publishing workflow."
+#~ msgstr "Complete the guided setup before starting the publishing workflow."
 
 msgid "Completed"
 msgstr "Completed"
@@ -2244,6 +2287,12 @@ msgstr "Configure each stage — extract, storyboard, layout — then let ADT St
 msgid "Configure features to include in the export"
 msgstr "Configure features to include in the export"
 
+#~ msgid "Configure GitHub publishing"
+#~ msgstr "Configure GitHub publishing"
+
+#~ msgid "Configure GitHub to start publishing"
+#~ msgstr "Configure GitHub to start publishing"
+
 #~ msgid "Configure provider credentials and global prompt fallbacks used by ADT Studio."
 #~ msgstr "Configure provider credentials and global prompt fallbacks used by ADT Studio."
 
@@ -2258,6 +2307,12 @@ msgstr "Configure voices and accents"
 
 msgid "Confirm merge"
 msgstr "Confirm merge"
+
+#~ msgid "Confirm the destination below. Publishing will open the live workflow screen automatically."
+#~ msgstr "Confirm the destination below. Publishing will open the live workflow screen automatically."
+
+#~ msgid "Connect an account and choose a repository before running this workflow."
+#~ msgstr "Connect an account and choose a repository before running this workflow."
 
 msgid "Connect an AI provider"
 msgstr "Connect an AI provider"
@@ -2282,6 +2337,9 @@ msgstr "Content Processing"
 
 msgid "Contents"
 msgstr "Contents"
+
+msgid "Contents — Read and write; Administration — Read and write; Pages — Read and write; Metadata — Read-only."
+msgstr "Contents — Read and write; Administration — Read and write; Pages — Read and write; Metadata — Read-only."
 
 msgid "Context"
 msgstr "Context"
@@ -2446,6 +2504,9 @@ msgstr "Create a reviewer session for this book."
 msgid "Create ADT"
 msgstr "Create ADT"
 
+#~ msgid "Create classic token on GitHub"
+#~ msgstr "Create classic token on GitHub"
+
 msgid "Create descriptive captions for images to improve accessibility."
 msgstr "Create descriptive captions for images to improve accessibility."
 
@@ -2454,6 +2515,9 @@ msgstr "Create file"
 
 msgid "Create files"
 msgstr "Create files"
+
+#~ msgid "Create fine-grained token on GitHub"
+#~ msgstr "Create fine-grained token on GitHub"
 
 msgid "Create from scratch using your description"
 msgstr "Create from scratch using your description"
@@ -2469,6 +2533,9 @@ msgstr "Create prompt file from template"
 
 msgid "Create session"
 msgstr "Create session"
+
+#~ msgid "Create the destination repository first, then select its owner and that repository as the token resource."
+#~ msgstr "Create the destination repository first, then select its owner and that repository as the token resource."
 
 msgid "Created {created} prompt files for {normalizedTargetModel}."
 msgstr "Created {created} prompt files for {normalizedTargetModel}."
@@ -2532,6 +2599,9 @@ msgstr "Current (v{currentVersion})"
 
 msgid "Current book font"
 msgstr "Current book font"
+
+#~ msgid "Current book workspace"
+#~ msgstr "Current book workspace"
 
 msgid "Current effective values"
 msgstr "Current effective values"
@@ -3053,6 +3123,9 @@ msgstr "Each iteration is one LLM call. Lower values are faster and cheaper; hig
 msgid "Each kind of pipeline task uses a compatible model. Image generation and speech use their own task-specific defaults."
 msgstr "Each kind of pipeline task uses a compatible model. Image generation and speech use their own task-specific defaults."
 
+#~ msgid "Each node updates live as ADT Studio publishes the book."
+#~ msgstr "Each node updates live as ADT Studio publishes the book."
+
 msgid "Each polyp secretes a hard calcium carbonate skeleton. Over hundreds of years, millions of these skeletons build up into the massive reef structures we see today."
 msgstr "Each polyp secretes a hard calcium carbonate skeleton. Over hundreds of years, millions of these skeletons build up into the massive reef structures we see today."
 
@@ -3070,6 +3143,9 @@ msgstr "Earlier stages haven't run yet"
 
 msgid "Early"
 msgstr "Early"
+
+msgid "Easiest complete setup"
+msgstr "Easiest complete setup"
 
 msgid "Easy Read"
 msgstr "Easy Read"
@@ -3591,6 +3667,9 @@ msgstr "Filters out decorative or non-content images on each page."
 msgid "Final Page"
 msgstr "Final Page"
 
+msgid "Fine-grained token for an existing repository"
+msgstr "Fine-grained token for an existing repository"
+
 msgid "First images from the deep-field telescope."
 msgstr "First images from the deep-field telescope."
 
@@ -3611,6 +3690,9 @@ msgstr "Fixed two-column template layout"
 
 msgid "Fixed-layout books use the original page images as backgrounds with positioned text extracted from the PDF. Activities detection, figure extraction, and image cropping or segmentation don't apply to this layout."
 msgstr "Fixed-layout books use the original page images as backgrounds with positioned text extracted from the PDF. Activities detection, figure extraction, and image cropping or segmentation don't apply to this layout."
+
+msgid "Fixed-layout pages preserve the original book fonts."
+msgstr "Fixed-layout pages preserve the original book fonts."
 
 #~ msgid "Fixed, accessible sizes applied to every page. Sizes use the book's Tailwind scale (pick a token or type an exact px), scale fluidly between mobile and desktop, and override any size the AI picks — so headings and body text stay consistent across the whole book."
 #~ msgstr "Fixed, accessible sizes applied to every page. Sizes use the book's Tailwind scale (pick a token or type an exact px), scale fluidly between mobile and desktop, and override any size the AI picks — so headings and body text stay consistent across the whole book."
@@ -3747,8 +3829,8 @@ msgstr "Gathering the evidence"
 msgid "Gemini"
 msgstr "Gemini"
 
-msgid "Gemini API key is required to generate audio."
-msgstr "Gemini API key is required to generate audio."
+#~ msgid "Gemini API key is required to generate audio."
+#~ msgstr "Gemini API key is required to generate audio."
 
 #~ msgid "Gemini generates each sentence in its own request, so its tone can drift between sentences. A lower temperature (e.g. 0.4) reduces that variation and a fixed seed makes delivery reproducible. Only affects languages routed to Gemini — OpenAI and Azure ignore these. Changing either value regenerates Gemini audio on the next run."
 #~ msgstr "Gemini generates each sentence in its own request, so its tone can drift between sentences. A lower temperature (e.g. 0.4) reduces that variation and a fixed seed makes delivery reproducible. Only affects languages routed to Gemini — OpenAI and Azure ignore these. Changing either value regenerates Gemini audio on the next run."
@@ -3822,8 +3904,8 @@ msgstr "Generate from pages"
 msgid "Generate global prompts"
 msgstr "Generate global prompts"
 
-msgid "Generate missing Gemini audio"
-msgstr "Generate missing Gemini audio"
+#~ msgid "Generate missing Gemini audio"
+#~ msgstr "Generate missing Gemini audio"
 
 msgid "Generate multiple-choice comprehension quizzes from the book's content. Create them automatically across the whole book, or add a single quiz from specific pages."
 msgstr "Generate multiple-choice comprehension quizzes from the book's content. Create them automatically across the whole book, or add a single quiz from specific pages."
@@ -3919,6 +4001,9 @@ msgstr "Generation Prompt"
 
 msgid "Get started"
 msgstr "Get started"
+
+#~ msgid "Git publishing workflow"
+#~ msgstr "Git publishing workflow"
 
 msgid "Global prompt reset to default."
 msgstr "Global prompt reset to default."
@@ -4552,6 +4637,9 @@ msgstr "Large images, narrative flow. Best for illustrated books with high-fidel
 #~ msgid "Last"
 #~ msgstr "Last"
 
+#~ msgid "Last activity"
+#~ msgstr "Last activity"
+
 msgid "Last change"
 msgstr "Last change"
 
@@ -4560,6 +4648,12 @@ msgstr "Last modified"
 
 #~ msgid "Last week"
 #~ msgstr "Last week"
+
+#~ msgid "Latest deployment"
+#~ msgstr "Latest deployment"
+
+#~ msgid "Latest GitHub changes synchronized."
+#~ msgstr "Latest GitHub changes synchronized."
 
 msgid "Launch the app with"
 msgstr "Launch the app with"
@@ -4581,6 +4675,9 @@ msgstr "Layout mirrored onto this section"
 
 msgid "Leading"
 msgstr "Leading"
+
+#~ msgid "Learn how with a guided setup"
+#~ msgstr "Learn how with a guided setup"
 
 msgid "Least used"
 msgstr "Least used"
@@ -4732,6 +4829,9 @@ msgstr "Loading books..."
 msgid "Loading catalog..."
 msgstr "Loading catalog..."
 
+#~ msgid "Loading deployments"
+#~ msgstr "Loading deployments"
+
 msgid "Loading Easy Read..."
 msgstr "Loading Easy Read..."
 
@@ -4824,6 +4924,12 @@ msgstr "Loading..."
 
 msgid "Loading…"
 msgstr "Loading…"
+
+#~ msgid "Local and GitHub changes need resolution before synchronization."
+#~ msgstr "Local and GitHub changes need resolution before synchronization."
+
+#~ msgid "Local book is up to date."
+#~ msgstr "Local book is up to date."
 
 msgid "Localization"
 msgstr "Localization"
@@ -5267,6 +5373,9 @@ msgstr "New Entry"
 msgid "New session"
 msgstr "New session"
 
+msgid "New text"
+msgstr "New text"
+
 #~ msgid "New version"
 #~ msgstr "New version"
 
@@ -5679,8 +5788,14 @@ msgstr "noise"
 msgid "None"
 msgstr "None"
 
+#~ msgid "Not committed yet"
+#~ msgstr "Not committed yet"
+
 msgid "Not compatible with Fixed Layout"
 msgstr "Not compatible with Fixed Layout"
+
+#~ msgid "Not configured"
+#~ msgstr "Not configured"
 
 msgid "Not detected"
 msgstr "Not detected"
@@ -5855,6 +5970,9 @@ msgstr "Open page preview for {pageId}"
 msgid "Open Preview"
 msgstr "Open Preview"
 
+#~ msgid "Open public book"
+#~ msgstr "Open public book"
+
 #. placeholder {0}: pullRequest.number
 msgid "Open pull request {0}"
 msgstr "Open pull request {0}"
@@ -5998,6 +6116,9 @@ msgstr "Out for processing"
 msgid "Out of date"
 msgstr "Out of date"
 
+msgid "Output font family"
+msgstr "Output font family"
+
 msgid "Output languages"
 msgstr "Output languages"
 
@@ -6066,6 +6187,9 @@ msgstr "Package the book for distribution. Pick a format, choose what content go
 
 msgid "Package the finished book with every accessibility feature baked in — ready for a kid to open, listen, and read along."
 msgstr "Package the finished book with every accessibility feature baked in — ready for a kid to open, listen, and read along."
+
+#~ msgid "Package, commit, push, host, and preview the accessible book without leaving ADT Studio."
+#~ msgstr "Package, commit, push, host, and preview the accessible book without leaving ADT Studio."
 
 msgid "Packaging"
 msgstr "Packaging"
@@ -6642,11 +6766,20 @@ msgstr "Pruned: {reason}"
 msgid "PT"
 msgstr "PT"
 
+#~ msgid "Publish book"
+#~ msgstr "Publish book"
+
+#~ msgid "Publish with GitHub Pages"
+#~ msgstr "Publish with GitHub Pages"
+
 msgid "published in"
 msgstr "published in"
 
 msgid "Publisher"
 msgstr "Publisher"
+
+#~ msgid "Pull remote changes"
+#~ msgstr "Pull remote changes"
 
 msgid "Pull requests"
 msgstr "Pull requests"
@@ -6893,6 +7026,9 @@ msgstr "Recommended for"
 msgid "Recommended for {0}"
 msgstr "Recommended for {0}"
 
+msgid "Recommended for creating a new repository"
+msgstr "Recommended for creating a new repository"
+
 msgid "Record reviewer findings for the current page and save them to the active validation session."
 msgstr "Record reviewer findings for the current page and save them to the active validation session."
 
@@ -6935,6 +7071,10 @@ msgstr "Regenerate definition, variations, and emoji"
 msgid "Regenerate Easy Read"
 msgstr "Regenerate Easy Read"
 
+#. placeholder {0}: selectedAudioIds.size
+#~ msgid "Regenerate selected ({0})"
+#~ msgstr "Regenerate selected ({0})"
+
 msgid "Regenerate selected images for each output language so that any text burned into them is shown in the target language."
 msgstr "Regenerate selected images for each output language so that any text burned into them is shown in the target language."
 
@@ -6964,6 +7104,12 @@ msgstr "Release to upload"
 
 msgid "Reload app"
 msgstr "Reload app"
+
+#~ msgid "Remote changes are available."
+#~ msgstr "Remote changes are available."
+
+#~ msgid "Remote changes available"
+#~ msgstr "Remote changes available"
 
 msgid "Remove"
 msgstr "Remove"
@@ -7125,6 +7271,9 @@ msgstr "Reset to the book's accent"
 msgid "Reset zoom"
 msgstr "Reset zoom"
 
+msgid "Resize image"
+msgstr "Resize image"
+
 msgid "Resize panel"
 msgstr "Resize panel"
 
@@ -7189,6 +7338,9 @@ msgstr "Review"
 #~ msgid "Review {selectedCount} selected"
 #~ msgstr "Review {selectedCount} selected"
 
+#~ msgid "Review and publish"
+#~ msgstr "Review and publish"
+
 msgid "Review and refine each simplified block side-by-side with the original before packaging."
 msgstr "Review and refine each simplified block side-by-side with the original before packaging."
 
@@ -7232,6 +7384,9 @@ msgstr "Review strictness"
 
 msgid "Review style"
 msgstr "Review style"
+
+#~ msgid "Review the most recent publishing workflow and open its public result."
+#~ msgstr "Review the most recent publishing workflow and open its public result."
 
 msgid "Review the project details below and confirm the import."
 msgstr "Review the project details below and confirm the import."
@@ -7292,6 +7447,9 @@ msgstr "Rising ocean temperatures cause coral bleaching - when stressed corals e
 
 msgid "Role"
 msgstr "Role"
+
+msgid "Rotate"
+msgstr "Rotate"
 
 msgid "Row"
 msgstr "Row"
@@ -7381,6 +7539,9 @@ msgstr "Run Translation"
 msgid "Run whole-book validation checks and configure accessibility assessment settings."
 msgstr "Run whole-book validation checks and configure accessibility assessment settings."
 
+#~ msgid "Run workflow"
+#~ msgstr "Run workflow"
+
 msgid "Run-only tags"
 msgstr "Run-only tags"
 
@@ -7447,6 +7608,9 @@ msgstr "Save activity"
 msgid "Save activity (⌘S)"
 msgstr "Save activity (⌘S)"
 
+#~ msgid "Save and publish"
+#~ msgstr "Save and publish"
+
 msgid "Save changes"
 msgstr "Save changes"
 
@@ -7467,6 +7631,9 @@ msgstr "Save checklist"
 
 msgid "Save failed"
 msgstr "Save failed"
+
+#~ msgid "Save or discard your edits before splitting"
+#~ msgstr "Save or discard your edits before splitting"
 
 msgid "Save or discard your edits first"
 msgstr "Save or discard your edits first"
@@ -7685,6 +7852,12 @@ msgstr "sections"
 msgid "Sections"
 msgstr "Sections"
 
+msgid "Security: use the shortest practical expiration, never share the token, and revoke it in GitHub when it is no longer needed. ADT Studio keeps this token locally on this device and does not store it in the book directory."
+msgstr "Security: use the shortest practical expiration, never share the token, and revoke it in GitHub when it is no longer needed. ADT Studio keeps this token locally on this device and does not store it in the book directory."
+
+#~ msgid "Security: use the shortest practical expiration, never share the token, and revoke it in GitHub when it is no longer needed. ADT Studio keeps this token only for the current browser session and does not store it in the book directory."
+#~ msgstr "Security: use the shortest practical expiration, never share the token, and revoke it in GitHub when it is no longer needed. ADT Studio keeps this token only for the current browser session and does not store it in the book directory."
+
 msgid "See examples"
 msgstr "See examples"
 
@@ -7808,6 +7981,9 @@ msgstr "Select template..."
 msgid "Select the pages the quiz is written from, then choose where it appears using the buttons between pages."
 msgstr "Select the pages the quiz is written from, then choose where it appears using the buttons between pages."
 
+#~ msgid "Select the repo scope. It covers repository creation, file publishing, and GitHub Pages configuration."
+#~ msgstr "Select the repo scope. It covers repository creation, file publishing, and GitHub Pages configuration."
+
 msgid "Select up to 5 pages to use as visual references. The LLM will analyze them and generate a styleguide."
 msgstr "Select up to 5 pages to use as visual references. The LLM will analyze them and generate a styleguide."
 
@@ -7867,8 +8043,11 @@ msgstr "Sessions"
 msgid "Sessions let different reviewers capture findings independently, including language-specific reviews."
 msgstr "Sessions let different reviewers capture findings independently, including language-specific reviews."
 
-msgid "Set a Gemini API key to generate audio"
-msgstr "Set a Gemini API key to generate audio"
+#~ msgid "Set a Gemini API key to generate audio"
+#~ msgstr "Set a Gemini API key to generate audio"
+
+msgid "Set Administration to Read and write so ADT can configure the repository and create the GitHub Pages site."
+msgstr "Set Administration to Read and write so ADT can configure the repository and create the GitHub Pages site."
 
 msgid "Set fonts for the whole book"
 msgstr "Set fonts for the whole book"
@@ -8759,6 +8938,9 @@ msgstr "The table of contents."
 msgid "The TOC lists the typed sections placed by Storyboard. Finish Storyboard before running this stage."
 msgstr "The TOC lists the typed sections placed by Storyboard. Finish Storyboard before running this stage."
 
+#~ msgid "The token needs repository contents, administration, and Pages permissions."
+#~ msgstr "The token needs repository contents, administration, and Pages permissions."
+
 msgid "The Water Cycle"
 msgstr "The Water Cycle"
 
@@ -8815,6 +8997,9 @@ msgstr "This activity has no addressable text or answers. Regenerate it, or use 
 
 msgid "This archive can't be opened safely"
 msgstr "This archive can't be opened safely"
+
+#~ msgid "This book asset will be included in the next commit."
+#~ msgstr "This book asset will be included in the next commit."
 
 msgid "This book has {pageCount} pages."
 msgstr "This book has {pageCount} pages."
@@ -9103,6 +9288,9 @@ msgstr "Total Tokens"
 msgid "Track reviewer progress and review findings captured from Preview."
 msgstr "Track reviewer progress and review findings captured from Preview."
 
+#~ msgid "Track the book's local edits, commits, publishing status, and GitHub metadata."
+#~ msgstr "Track the book's local edits, commits, publishing status, and GitHub metadata."
+
 msgid "Translate"
 msgstr "Translate"
 
@@ -9292,6 +9480,9 @@ msgstr "Unable to save global prompt."
 msgid "Unable to select prompt version."
 msgstr "Unable to select prompt version."
 
+msgid "Unable to update the book font."
+msgstr "Unable to update the book font."
+
 msgid "Unable to update the book model overrides."
 msgstr "Unable to update the book model overrides."
 
@@ -9318,6 +9509,9 @@ msgstr "Uncategorized"
 
 msgid "Unchanged"
 msgstr "Unchanged"
+
+#~ msgid "Under Repository permissions, grant Contents, Administration, and Pages read and write access."
+#~ msgstr "Under Repository permissions, grant Contents, Administration, and Pages read and write access."
 
 msgid "Underline"
 msgstr "Underline"
@@ -9475,6 +9669,9 @@ msgstr "Use as template"
 msgid "Use Liquid syntax to interpolate variables, loop over arrays, and conditionally include instructions in this prompt."
 msgstr "Use Liquid syntax to interpolate variables, loop over arrays, and conditionally include instructions in this prompt."
 
+msgid "Use one accessible font throughout generated, reflowable pages. You can change it later from the book toolbar."
+msgstr "Use one accessible font throughout generated, reflowable pages. You can change it later from the book toolbar."
+
 #. placeholder {0}: page.pageNumber
 msgid "Use page {0} for the quiz"
 msgstr "Use page {0} for the quiz"
@@ -9609,6 +9806,9 @@ msgstr "View"
 
 #~ msgid "View all changes"
 #~ msgstr "View all changes"
+
+#~ msgid "View deployment"
+#~ msgstr "View deployment"
 
 msgid "View details"
 msgstr "View details"
@@ -9848,6 +10048,9 @@ msgstr "Word-level highlighting"
 msgid "words"
 msgstr "words"
 
+#~ msgid "Workspace changes"
+#~ msgstr "Workspace changes"
+
 msgid "Wrap in group"
 msgstr "Wrap in group"
 
@@ -9933,42 +10136,3 @@ msgstr "Zoom in"
 
 msgid "Zoom out"
 msgstr "Zoom out"
-
-msgid "Add shape"
-msgstr "Add shape"
-
-msgid "Automatic — match book"
-msgstr "Automatic — match book"
-
-msgid "Automatic — match the book"
-msgstr "Automatic — match the book"
-
-msgid "Book font updated."
-msgstr "Book font updated."
-
-msgid "Change the font across generated book pages."
-msgstr "Change the font across generated book pages."
-
-msgid "Commercial fonts such as Sassoon must also be installed or attached to the book for an exact match."
-msgstr "Commercial fonts such as Sassoon must also be installed or attached to the book for an exact match."
-
-msgid "Fixed-layout pages preserve the original book fonts."
-msgstr "Fixed-layout pages preserve the original book fonts."
-
-msgid "New text"
-msgstr "New text"
-
-msgid "Output font family"
-msgstr "Output font family"
-
-msgid "Resize image"
-msgstr "Resize image"
-
-msgid "Rotate"
-msgstr "Rotate"
-
-msgid "Unable to update the book font."
-msgstr "Unable to update the book font."
-
-msgid "Use one accessible font throughout generated, reflowable pages. You can change it later from the book toolbar."
-msgstr "Use one accessible font throughout generated, reflowable pages. You can change it later from the book toolbar."

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -9933,3 +9933,42 @@ msgstr "Zoom in"
 
 msgid "Zoom out"
 msgstr "Zoom out"
+
+msgid "Add shape"
+msgstr "Add shape"
+
+msgid "Automatic — match book"
+msgstr "Automatic — match book"
+
+msgid "Automatic — match the book"
+msgstr "Automatic — match the book"
+
+msgid "Book font updated."
+msgstr "Book font updated."
+
+msgid "Change the font across generated book pages."
+msgstr "Change the font across generated book pages."
+
+msgid "Commercial fonts such as Sassoon must also be installed or attached to the book for an exact match."
+msgstr "Commercial fonts such as Sassoon must also be installed or attached to the book for an exact match."
+
+msgid "Fixed-layout pages preserve the original book fonts."
+msgstr "Fixed-layout pages preserve the original book fonts."
+
+msgid "New text"
+msgstr "New text"
+
+msgid "Output font family"
+msgstr "Output font family"
+
+msgid "Resize image"
+msgstr "Resize image"
+
+msgid "Rotate"
+msgstr "Rotate"
+
+msgid "Unable to update the book font."
+msgstr "Unable to update the book font."
+
+msgid "Use one accessible font throughout generated, reflowable pages. You can change it later from the book toolbar."
+msgstr "Use one accessible font throughout generated, reflowable pages. You can change it later from the book toolbar."

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -3844,8 +3844,8 @@ msgstr "Gathering the evidence"
 msgid "Gemini"
 msgstr "Gemini"
 
-#~ msgid "Gemini API key is required to generate audio."
-#~ msgstr "Gemini API key is required to generate audio."
+msgid "Gemini API key is required to generate audio."
+msgstr "Gemini API key is required to generate audio."
 
 #~ msgid "Gemini generates each sentence in its own request, so its tone can drift between sentences. A lower temperature (e.g. 0.4) reduces that variation and a fixed seed makes delivery reproducible. Only affects languages routed to Gemini — OpenAI and Azure ignore these. Changing either value regenerates Gemini audio on the next run."
 #~ msgstr "Gemini generates each sentence in its own request, so its tone can drift between sentences. A lower temperature (e.g. 0.4) reduces that variation and a fixed seed makes delivery reproducible. Only affects languages routed to Gemini — OpenAI and Azure ignore these. Changing either value regenerates Gemini audio on the next run."
@@ -3919,8 +3919,8 @@ msgstr "Generate from pages"
 msgid "Generate global prompts"
 msgstr "Generate global prompts"
 
-#~ msgid "Generate missing Gemini audio"
-#~ msgstr "Generate missing Gemini audio"
+msgid "Generate missing Gemini audio"
+msgstr "Generate missing Gemini audio"
 
 msgid "Generate multiple-choice comprehension quizzes from the book's content. Create them automatically across the whole book, or add a single quiz from specific pages."
 msgstr "Generate multiple-choice comprehension quizzes from the book's content. Create them automatically across the whole book, or add a single quiz from specific pages."
@@ -8061,8 +8061,8 @@ msgstr "Sessions"
 msgid "Sessions let different reviewers capture findings independently, including language-specific reviews."
 msgstr "Sessions let different reviewers capture findings independently, including language-specific reviews."
 
-#~ msgid "Set a Gemini API key to generate audio"
-#~ msgstr "Set a Gemini API key to generate audio"
+msgid "Set a Gemini API key to generate audio"
+msgstr "Set a Gemini API key to generate audio"
 
 msgid "Set Administration to Read and write so ADT can configure the repository and create the GitHub Pages site."
 msgstr "Set Administration to Read and write so ADT can configure the repository and create the GitHub Pages site."

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -9933,3 +9933,42 @@ msgstr "Acercar"
 
 msgid "Zoom out"
 msgstr "Alejar"
+
+msgid "Add shape"
+msgstr "Añadir forma"
+
+msgid "Automatic — match book"
+msgstr "Automática — coincidir con el libro"
+
+msgid "Automatic — match the book"
+msgstr "Automática — coincidir con el libro"
+
+msgid "Book font updated."
+msgstr "Fuente del libro actualizada."
+
+msgid "Change the font across generated book pages."
+msgstr "Cambiar la fuente en las páginas generadas del libro."
+
+msgid "Commercial fonts such as Sassoon must also be installed or attached to the book for an exact match."
+msgstr "Las fuentes comerciales como Sassoon también deben estar instaladas o adjuntas al libro para obtener una coincidencia exacta."
+
+msgid "Fixed-layout pages preserve the original book fonts."
+msgstr "Las páginas de diseño fijo conservan las fuentes originales del libro."
+
+msgid "New text"
+msgstr "Texto nuevo"
+
+msgid "Output font family"
+msgstr "Familia tipográfica de salida"
+
+msgid "Resize image"
+msgstr "Cambiar tamaño de imagen"
+
+msgid "Rotate"
+msgstr "Girar"
+
+msgid "Unable to update the book font."
+msgstr "No se pudo actualizar la fuente del libro."
+
+msgid "Use one accessible font throughout generated, reflowable pages. You can change it later from the book toolbar."
+msgstr "Use una fuente accesible en todas las páginas generadas y adaptables. Puede cambiarla más tarde desde la barra del libro."

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -263,6 +263,10 @@ msgstr "{0} textos"
 msgid "{0} translations"
 msgstr "{0} traducciones"
 
+#. placeholder {0}: changesQuery.data.changes.length
+#~ msgid "{0} unpublished file changes"
+#~ msgstr "{0} cambios de archivo sin publicar"
+
 #. placeholder {0}: versions.length
 #~ msgid "{0} versions"
 #~ msgstr "{0} versiones"
@@ -821,6 +825,9 @@ msgstr "Actividad: Selección múltiple"
 msgid "Activity: Open-Ended Answer"
 msgstr "Actividad: Respuesta abierta"
 
+#~ msgid "Activity: Ordering"
+#~ msgstr "Actividad: Ordenación"
+
 msgid "Activity: Other"
 msgstr "Actividad: Otra"
 
@@ -983,6 +990,9 @@ msgstr "Add reviewer guidance."
 
 msgid "Add section"
 msgstr "Add section"
+
+msgid "Add shape"
+msgstr "Añadir forma"
 
 msgid "Add sign language video"
 msgstr "Añadir video de lengua de señas"
@@ -1260,6 +1270,9 @@ msgstr "Cantidad"
 msgid "An activity that does not fit the standard categories."
 msgstr "Una actividad que no encaja en las categorías estándar."
 
+#~ msgid "An activity where learners arrange items into the correct order."
+#~ msgstr "Una actividad en la que los estudiantes organizan elementos en el orden correcto."
+
 msgid "An activity where the learner underlines one or more words, phrases, or sentences directly in the text."
 msgstr "Una actividad en la que el estudiante subraya una o más palabras, frases u oraciones directamente en el texto."
 
@@ -1499,6 +1512,12 @@ msgstr "Autocompletar desde el contexto del libro"
 msgid "Auto-scroll"
 msgstr "Desplazamiento automático"
 
+msgid "Automatic — match book"
+msgstr "Automática — coincidir con el libro"
+
+msgid "Automatic — match the book"
+msgstr "Automática — coincidir con el libro"
+
 msgid "Automatically adapts the layout based on each page's content using AI."
 msgstr "Adapta automáticamente el diseño según el contenido de cada página usando IA."
 
@@ -1654,6 +1673,9 @@ msgstr "El cuerpo del texto usa esta fuente hoy. Adjunta una fuente abajo y así
 msgid "Book"
 msgstr "Libro"
 
+#~ msgid "Book change history"
+#~ msgstr "Historial de cambios del libro"
+
 msgid "Book coverage"
 msgstr "Cobertura del libro"
 
@@ -1663,6 +1685,9 @@ msgstr "Etapas de creación del libro"
 msgid "Book data is outdated and must be rebuilt."
 msgstr "Los datos del libro están desactualizados y deben reconstruirse."
 
+msgid "Book font updated."
+msgstr "Fuente del libro actualizada."
+
 msgid "Book Fonts"
 msgstr "Fuentes del libro"
 
@@ -1671,6 +1696,9 @@ msgstr "Imágenes del libro"
 
 msgid "Book info"
 msgstr "Información del libro"
+
+#~ msgid "Book is published"
+#~ msgstr "El libro está publicado"
 
 msgid "Book Language"
 msgstr "Idioma del libro"
@@ -1926,8 +1954,14 @@ msgstr "Cambiar Preajuste"
 msgid "Change the book language?"
 msgstr "¿Cambiar el idioma del libro?"
 
+msgid "Change the font across generated book pages."
+msgstr "Cambiar la fuente en las páginas generadas del libro."
+
 msgid "Change the picture for this term"
 msgstr "Cambiar la imagen de este término"
+
+#~ msgid "Changed files"
+#~ msgstr "Archivos modificados"
 
 #~ msgid "Changes apply the next time you run Storyboard and Export."
 #~ msgstr "Los cambios se aplican la próxima vez que ejecutes Storyboard y Exportar."
@@ -1973,6 +2007,9 @@ msgstr "Título de capítulo"
 
 msgid "Chart / Graph"
 msgstr "Gráfico / Tabla"
+
+#~ msgid "Check changes"
+#~ msgstr "Comprobar cambios"
 
 #~ msgid "Check for updates"
 #~ msgstr "Buscar actualizaciones"
@@ -2175,6 +2212,9 @@ msgstr "Comment"
 msgid "Comments"
 msgstr "Comments"
 
+msgid "Commercial fonts such as Sassoon must also be installed or attached to the book for an exact match."
+msgstr "Las fuentes comerciales como Sassoon también deben estar instaladas o adjuntas al libro para obtener una coincidencia exacta."
+
 msgid "Compare"
 msgstr "Comparar"
 
@@ -2189,6 +2229,9 @@ msgstr "Comparar versiones"
 
 msgid "Compared with fallback prompt."
 msgstr "Comparado con el prompt fallback."
+
+#~ msgid "Complete the guided setup before starting the publishing workflow."
+#~ msgstr "Completa la configuración guiada antes de iniciar el flujo de publicación."
 
 msgid "Completed"
 msgstr "Completado"
@@ -2244,6 +2287,12 @@ msgstr "Configura cada etapa — extraer, guión gráfico, diseño — luego dej
 msgid "Configure features to include in the export"
 msgstr "Configura las características a incluir en la exportación"
 
+#~ msgid "Configure GitHub publishing"
+#~ msgstr "Configurar la publicación en GitHub"
+
+#~ msgid "Configure GitHub to start publishing"
+#~ msgstr "Configura GitHub para comenzar a publicar"
+
 #~ msgid "Configure provider credentials and global prompt fallbacks used by ADT Studio."
 #~ msgstr "Configura las credenciales de los proveedores y los prompts fallback globales usados por ADT Studio."
 
@@ -2258,6 +2307,12 @@ msgstr "Configurar voces y acentos"
 
 msgid "Confirm merge"
 msgstr "Confirmar fusión"
+
+#~ msgid "Confirm the destination below. Publishing will open the live workflow screen automatically."
+#~ msgstr "Confirma el destino. La publicación abrirá automáticamente la pantalla del flujo en vivo."
+
+#~ msgid "Connect an account and choose a repository before running this workflow."
+#~ msgstr "Conecta una cuenta y elige un repositorio antes de ejecutar este flujo."
 
 msgid "Connect an AI provider"
 msgstr "Conecta un proveedor de IA"
@@ -2282,6 +2337,9 @@ msgstr "Procesamiento de Contenido"
 
 msgid "Contents"
 msgstr "Contenidos"
+
+msgid "Contents — Read and write; Administration — Read and write; Pages — Read and write; Metadata — Read-only."
+msgstr "Contenido: lectura y escritura; Administración: lectura y escritura; Pages: lectura y escritura; Metadatos: solo lectura."
 
 msgid "Context"
 msgstr "Contexto"
@@ -2446,6 +2504,9 @@ msgstr "Create a reviewer session for this book."
 msgid "Create ADT"
 msgstr "Crear ADT"
 
+#~ msgid "Create classic token on GitHub"
+#~ msgstr "Crear token clásico en GitHub"
+
 msgid "Create descriptive captions for images to improve accessibility."
 msgstr "Crea subtítulos descriptivos para las imágenes para mejorar la accesibilidad."
 
@@ -2454,6 +2515,9 @@ msgstr "Crear archivo"
 
 msgid "Create files"
 msgstr "Crear archivos"
+
+#~ msgid "Create fine-grained token on GitHub"
+#~ msgstr "Crear token específico en GitHub"
 
 msgid "Create from scratch using your description"
 msgstr "Crear desde cero con tu descripción"
@@ -2469,6 +2533,9 @@ msgstr "Crear archivo de prompt desde plantilla"
 
 msgid "Create session"
 msgstr "Create session"
+
+#~ msgid "Create the destination repository first, then select its owner and that repository as the token resource."
+#~ msgstr "Crea primero el repositorio de destino y luego selecciona su propietario y ese repositorio como recurso del token."
 
 msgid "Created {created} prompt files for {normalizedTargetModel}."
 msgstr "Se crearon {created} archivos de prompt para {normalizedTargetModel}."
@@ -2532,6 +2599,9 @@ msgstr "Actual (v{currentVersion})"
 
 msgid "Current book font"
 msgstr "Fuente actual del libro"
+
+#~ msgid "Current book workspace"
+#~ msgstr "Espacio de trabajo actual del libro"
 
 msgid "Current effective values"
 msgstr "Current effective values"
@@ -3053,6 +3123,9 @@ msgstr "Cada iteración es una llamada LLM. Valores más bajos son más rápidos
 msgid "Each kind of pipeline task uses a compatible model. Image generation and speech use their own task-specific defaults."
 msgstr "Cada tipo de tarea del flujo de trabajo utiliza un modelo compatible. La generación de imágenes y de voz utiliza sus propios valores predeterminados específicos para cada tarea."
 
+#~ msgid "Each node updates live as ADT Studio publishes the book."
+#~ msgstr "Cada nodo se actualiza en vivo mientras ADT Studio publica el libro."
+
 msgid "Each polyp secretes a hard calcium carbonate skeleton. Over hundreds of years, millions of these skeletons build up into the massive reef structures we see today."
 msgstr "Cada pólipo secreta un esqueleto duro de carbonato de calcio. Durante cientos de años, millones de estos esqueletos se acumulan en las estructuras masivas de arrecifes que vemos hoy."
 
@@ -3070,6 +3143,9 @@ msgstr "Las etapas anteriores aún no se han ejecutado"
 
 msgid "Early"
 msgstr "Temprano"
+
+msgid "Easiest complete setup"
+msgstr "Configuración completa más sencilla"
 
 msgid "Easy Read"
 msgstr "Lectura Fácil"
@@ -3591,6 +3667,9 @@ msgstr "Filtra imágenes decorativas o sin contenido en cada página."
 msgid "Final Page"
 msgstr "Página Final"
 
+msgid "Fine-grained token for an existing repository"
+msgstr "Token específico para un repositorio existente"
+
 msgid "First images from the deep-field telescope."
 msgstr "Primeras imágenes del telescopio de campo profundo."
 
@@ -3611,6 +3690,9 @@ msgstr "Plantilla de diseño fijo de dos columnas"
 
 msgid "Fixed-layout books use the original page images as backgrounds with positioned text extracted from the PDF. Activities detection, figure extraction, and image cropping or segmentation don't apply to this layout."
 msgstr "Los libros de diseño fijo usan las imágenes originales de las páginas como fondo con texto posicionado extraído del PDF. La detección de actividades, extracción de figuras, recorte o segmentación de imágenes no aplican a este diseño."
+
+msgid "Fixed-layout pages preserve the original book fonts."
+msgstr "Las páginas de diseño fijo conservan las fuentes originales del libro."
 
 #~ msgid "Fixed, accessible sizes applied to every page. Sizes use the book's Tailwind scale (pick a token or type an exact px), scale fluidly between mobile and desktop, and override any size the AI picks — so headings and body text stay consistent across the whole book."
 #~ msgstr "Tamaños fijos y accesibles que se aplican a todas las páginas. Los tamaños usan la escala de Tailwind del libro (elige un token o escribe un valor exacto en px), se escalan de forma fluida entre móvil y escritorio, y anulan cualquier tamaño que elija la IA, de modo que los títulos y el texto del cuerpo se mantienen coherentes en todo el libro."
@@ -3747,8 +3829,8 @@ msgstr "Reuniendo la evidencia"
 msgid "Gemini"
 msgstr "Gemini"
 
-msgid "Gemini API key is required to generate audio."
-msgstr "Se necesita una clave de API de Gemini para generar audio."
+#~ msgid "Gemini API key is required to generate audio."
+#~ msgstr "Se necesita una clave de API de Gemini para generar audio."
 
 #~ msgid "Gemini generates each sentence in its own request, so its tone can drift between sentences. A lower temperature (e.g. 0.4) reduces that variation and a fixed seed makes delivery reproducible. Only affects languages routed to Gemini — OpenAI and Azure ignore these. Changing either value regenerates Gemini audio on the next run."
 #~ msgstr "Gemini genera cada oración en su propia solicitud, por lo que su tono puede variar entre oraciones. Una temperatura más baja (p. ej., 0.4) reduce esa variación y una semilla fija hace que la lectura sea reproducible. Solo afecta a los idiomas enrutados a Gemini: OpenAI y Azure los ignoran. Cambiar cualquiera de los valores regenera el audio de Gemini en la próxima ejecución."
@@ -3822,8 +3904,8 @@ msgstr "Generar desde páginas"
 msgid "Generate global prompts"
 msgstr "Generar prompts globales"
 
-msgid "Generate missing Gemini audio"
-msgstr "Generar audio de Gemini faltante"
+#~ msgid "Generate missing Gemini audio"
+#~ msgstr "Generar audio de Gemini faltante"
 
 msgid "Generate multiple-choice comprehension quizzes from the book's content. Create them automatically across the whole book, or add a single quiz from specific pages."
 msgstr "Genera cuestionarios de comprensión de opción múltiple a partir del contenido del libro. Créalos automáticamente en todo el libro o añade un único cuestionario a partir de páginas específicas."
@@ -3919,6 +4001,9 @@ msgstr "Prompt de generación"
 
 msgid "Get started"
 msgstr "Comenzar"
+
+#~ msgid "Git publishing workflow"
+#~ msgstr "Flujo de publicación Git"
 
 msgid "Global prompt reset to default."
 msgstr "Prompt global restablecido al valor predeterminado."
@@ -4552,6 +4637,9 @@ msgstr "Imágenes grandes, flujo narrativo. Mejor para libros ilustrados con voc
 #~ msgid "Last"
 #~ msgstr "Última"
 
+#~ msgid "Last activity"
+#~ msgstr "Última actividad"
+
 msgid "Last change"
 msgstr "Último cambio"
 
@@ -4560,6 +4648,12 @@ msgstr "Última modificación"
 
 #~ msgid "Last week"
 #~ msgstr "La semana pasada"
+
+#~ msgid "Latest deployment"
+#~ msgstr "Último despliegue"
+
+#~ msgid "Latest GitHub changes synchronized."
+#~ msgstr "Últimos cambios de GitHub sincronizados."
 
 msgid "Launch the app with"
 msgstr "Iniciar la aplicación con"
@@ -4581,6 +4675,9 @@ msgstr "Diseño copiado a esta sección"
 
 msgid "Leading"
 msgstr "Interlineado"
+
+#~ msgid "Learn how with a guided setup"
+#~ msgstr "Aprende con una configuración guiada"
 
 msgid "Least used"
 msgstr "Menos usado"
@@ -4732,6 +4829,9 @@ msgstr "Cargando libros..."
 msgid "Loading catalog..."
 msgstr "Cargando catálogo..."
 
+#~ msgid "Loading deployments"
+#~ msgstr "Cargando implementaciones"
+
 msgid "Loading Easy Read..."
 msgstr "Cargando Lectura Fácil..."
 
@@ -4824,6 +4924,12 @@ msgstr "Cargando..."
 
 msgid "Loading…"
 msgstr "Cargando…"
+
+#~ msgid "Local and GitHub changes need resolution before synchronization."
+#~ msgstr "Los cambios locales y de GitHub deben resolverse antes de sincronizar."
+
+#~ msgid "Local book is up to date."
+#~ msgstr "El libro local está actualizado."
 
 msgid "Localization"
 msgstr "Localización"
@@ -5267,6 +5373,9 @@ msgstr "Nueva entrada"
 msgid "New session"
 msgstr "New session"
 
+msgid "New text"
+msgstr "Texto nuevo"
+
 #~ msgid "New version"
 #~ msgstr "Nueva versión"
 
@@ -5679,8 +5788,14 @@ msgstr "ruido"
 msgid "None"
 msgstr "Ninguno"
 
+#~ msgid "Not committed yet"
+#~ msgstr "Aún sin commit"
+
 msgid "Not compatible with Fixed Layout"
 msgstr "No compatible con Diseño Fijo"
+
+#~ msgid "Not configured"
+#~ msgstr "Sin configurar"
 
 msgid "Not detected"
 msgstr "No detectado"
@@ -5855,6 +5970,9 @@ msgstr "Abrir vista previa de la página {0}"
 msgid "Open Preview"
 msgstr "Open Preview"
 
+#~ msgid "Open public book"
+#~ msgstr "Abrir libro público"
+
 #. placeholder {0}: pullRequest.number
 msgid "Open pull request {0}"
 msgstr "Abrir solicitud de cambios {0}"
@@ -5998,6 +6116,9 @@ msgstr "En procesamiento"
 msgid "Out of date"
 msgstr "Desactualizado"
 
+msgid "Output font family"
+msgstr "Familia tipográfica de salida"
+
 msgid "Output languages"
 msgstr "Idiomas de salida"
 
@@ -6066,6 +6187,9 @@ msgstr "Empaqueta el libro para distribución. Elige un formato, selecciona qué
 
 msgid "Package the finished book with every accessibility feature baked in — ready for a kid to open, listen, and read along."
 msgstr "Empaqueta el libro terminado con todas las funciones de accesibilidad integradas — listo para que un niño lo abra, escuche y siga la lectura."
+
+#~ msgid "Package, commit, push, host, and preview the accessible book without leaving ADT Studio."
+#~ msgstr "Empaqueta, confirma, publica, aloja y previsualiza el libro accesible sin salir de ADT Studio."
 
 msgid "Packaging"
 msgstr "Empaquetando"
@@ -6642,11 +6766,20 @@ msgstr "Eliminado: {0}"
 msgid "PT"
 msgstr "PT"
 
+#~ msgid "Publish book"
+#~ msgstr "Publicar libro"
+
+#~ msgid "Publish with GitHub Pages"
+#~ msgstr "Publicar con GitHub Pages"
+
 msgid "published in"
 msgstr "publicado en"
 
 msgid "Publisher"
 msgstr "Editorial"
+
+#~ msgid "Pull remote changes"
+#~ msgstr "Descargar cambios remotos"
 
 msgid "Pull requests"
 msgstr "Pull requests"
@@ -6893,6 +7026,9 @@ msgstr "Recomendado para"
 msgid "Recommended for {0}"
 msgstr "Recomendado para {0}"
 
+msgid "Recommended for creating a new repository"
+msgstr "Recomendado para crear un repositorio nuevo"
+
 msgid "Record reviewer findings for the current page and save them to the active validation session."
 msgstr "Record reviewer findings for the current page and save them to the active validation session."
 
@@ -6935,6 +7071,10 @@ msgstr "Regenerar definición, variaciones y emoji"
 msgid "Regenerate Easy Read"
 msgstr "Regenerar Lectura Fácil"
 
+#. placeholder {0}: selectedAudioIds.size
+#~ msgid "Regenerate selected ({0})"
+#~ msgstr "Regenerar seleccionados ({0})"
+
 msgid "Regenerate selected images for each output language so that any text burned into them is shown in the target language."
 msgstr "Regenera las imágenes seleccionadas para cada idioma de salida de modo que el texto incrustado en ellas aparezca en el idioma de destino."
 
@@ -6964,6 +7104,12 @@ msgstr "Suelta para subir"
 
 msgid "Reload app"
 msgstr "Recargar aplicación"
+
+#~ msgid "Remote changes are available."
+#~ msgstr "Hay cambios remotos disponibles."
+
+#~ msgid "Remote changes available"
+#~ msgstr "Hay cambios remotos disponibles"
 
 msgid "Remove"
 msgstr "Quitar"
@@ -7125,6 +7271,9 @@ msgstr "Restablecer al color de acento del libro"
 msgid "Reset zoom"
 msgstr "Restablecer zoom"
 
+msgid "Resize image"
+msgstr "Cambiar tamaño de imagen"
+
 msgid "Resize panel"
 msgstr "Redimensionar el panel"
 
@@ -7189,6 +7338,9 @@ msgstr "Revisar"
 #~ msgid "Review {selectedCount} selected"
 #~ msgstr "Revisar {selectedCount} seleccionados"
 
+#~ msgid "Review and publish"
+#~ msgstr "Revisar y publicar"
+
 msgid "Review and refine each simplified block side-by-side with the original before packaging."
 msgstr "Revisa y refina cada bloque simplificado junto al original antes de empaquetar."
 
@@ -7232,6 +7384,9 @@ msgstr "Rigor de la revisión"
 
 msgid "Review style"
 msgstr "Estilo de revisión"
+
+#~ msgid "Review the most recent publishing workflow and open its public result."
+#~ msgstr "Revisa el flujo de publicación más reciente y abre su resultado público."
 
 msgid "Review the project details below and confirm the import."
 msgstr "Revisa los detalles del proyecto a continuación y confirma la importación."
@@ -7292,6 +7447,9 @@ msgstr "El aumento de las temperaturas oceánicas causa el blanqueamiento de cor
 
 msgid "Role"
 msgstr "Rol"
+
+msgid "Rotate"
+msgstr "Girar"
 
 msgid "Row"
 msgstr "Fila"
@@ -7381,6 +7539,9 @@ msgstr "Ejecutar Traducción"
 msgid "Run whole-book validation checks and configure accessibility assessment settings."
 msgstr "Run whole-book validation checks and configure accessibility assessment settings."
 
+#~ msgid "Run workflow"
+#~ msgstr "Ejecutar flujo"
+
 msgid "Run-only tags"
 msgstr "Run-only tags"
 
@@ -7447,6 +7608,9 @@ msgstr "Guardar actividad"
 msgid "Save activity (⌘S)"
 msgstr "Guardar actividad (⌘S)"
 
+#~ msgid "Save and publish"
+#~ msgstr "Guardar y publicar"
+
 msgid "Save changes"
 msgstr "Guardar cambios"
 
@@ -7467,6 +7631,9 @@ msgstr "Save checklist"
 
 msgid "Save failed"
 msgstr "Save failed"
+
+#~ msgid "Save or discard your edits before splitting"
+#~ msgstr "Guarda o descarta tus cambios antes de dividir"
 
 msgid "Save or discard your edits first"
 msgstr "Primero guarda o descarta tus cambios"
@@ -7685,6 +7852,12 @@ msgstr "secciones"
 msgid "Sections"
 msgstr "Secciones"
 
+msgid "Security: use the shortest practical expiration, never share the token, and revoke it in GitHub when it is no longer needed. ADT Studio keeps this token locally on this device and does not store it in the book directory."
+msgstr "Seguridad: usa la caducidad práctica más corta, nunca compartas el token y revócalo en GitHub cuando ya no sea necesario. ADT Studio guarda este token localmente en este dispositivo y no lo almacena en el directorio del libro."
+
+#~ msgid "Security: use the shortest practical expiration, never share the token, and revoke it in GitHub when it is no longer needed. ADT Studio keeps this token only for the current browser session and does not store it in the book directory."
+#~ msgstr "Seguridad: usa la caducidad práctica más corta, nunca compartas el token y revócalo en GitHub cuando ya no sea necesario. ADT Studio conserva este token solo durante la sesión actual del navegador y no lo almacena en el directorio del libro."
+
 msgid "See examples"
 msgstr "Ver ejemplos"
 
@@ -7808,6 +7981,9 @@ msgstr "Seleccionar plantilla..."
 msgid "Select the pages the quiz is written from, then choose where it appears using the buttons between pages."
 msgstr "Selecciona las páginas en las que se basa el cuestionario y elige dónde aparece con los botones entre páginas."
 
+#~ msgid "Select the repo scope. It covers repository creation, file publishing, and GitHub Pages configuration."
+#~ msgstr "Selecciona el ámbito repo. Incluye la creación del repositorio, la publicación de archivos y la configuración de GitHub Pages."
+
 msgid "Select up to 5 pages to use as visual references. The LLM will analyze them and generate a styleguide."
 msgstr "Selecciona hasta 5 páginas para usar como referencias visuales. El LLM las analizará y generará una guía de estilo."
 
@@ -7867,8 +8043,11 @@ msgstr "Sessions"
 msgid "Sessions let different reviewers capture findings independently, including language-specific reviews."
 msgstr "Sessions let different reviewers capture findings independently, including language-specific reviews."
 
-msgid "Set a Gemini API key to generate audio"
-msgstr "Configura una clave de API de Gemini para generar audio"
+#~ msgid "Set a Gemini API key to generate audio"
+#~ msgstr "Configura una clave de API de Gemini para generar audio"
+
+msgid "Set Administration to Read and write so ADT can configure the repository and create the GitHub Pages site."
+msgstr "Configura Administración como Lectura y escritura para que ADT pueda configurar el repositorio y crear el sitio de GitHub Pages."
 
 msgid "Set fonts for the whole book"
 msgstr "Establecer las fuentes de todo el libro"
@@ -8759,6 +8938,9 @@ msgstr "La tabla de contenidos."
 msgid "The TOC lists the typed sections placed by Storyboard. Finish Storyboard before running this stage."
 msgstr "El TOC lista las secciones escritas colocadas por el Storyboard. Termina el Storyboard antes de ejecutar esta etapa."
 
+#~ msgid "The token needs repository contents, administration, and Pages permissions."
+#~ msgstr "El token necesita permisos de contenido del repositorio, administración y Pages."
+
 msgid "The Water Cycle"
 msgstr "El Ciclo del Agua"
 
@@ -8815,6 +8997,9 @@ msgstr "Esta actividad no tiene textos ni respuestas direccionables. Vuelve a ge
 
 msgid "This archive can't be opened safely"
 msgstr "Este archivo no se puede abrir de forma segura"
+
+#~ msgid "This book asset will be included in the next commit."
+#~ msgstr "Este recurso del libro se incluirá en el próximo commit."
 
 msgid "This book has {pageCount} pages."
 msgstr "Este libro tiene {pageCount} páginas."
@@ -9103,6 +9288,9 @@ msgstr "Tokens totales"
 msgid "Track reviewer progress and review findings captured from Preview."
 msgstr "Track reviewer progress and review findings captured from Preview."
 
+#~ msgid "Track the book's local edits, commits, publishing status, and GitHub metadata."
+#~ msgstr "Sigue las ediciones locales, los commits, el estado de publicación y los metadatos de GitHub del libro."
+
 msgid "Translate"
 msgstr "Traducir"
 
@@ -9292,6 +9480,9 @@ msgstr "No se pudo guardar el prompt global."
 msgid "Unable to select prompt version."
 msgstr "No se pudo seleccionar la versión del prompt."
 
+msgid "Unable to update the book font."
+msgstr "No se pudo actualizar la fuente del libro."
+
 msgid "Unable to update the book model overrides."
 msgstr "No se pudieron actualizar las sustituciones de modelos del libro."
 
@@ -9318,6 +9509,9 @@ msgstr "Uncategorized"
 
 msgid "Unchanged"
 msgstr "Sin cambios"
+
+#~ msgid "Under Repository permissions, grant Contents, Administration, and Pages read and write access."
+#~ msgstr "En Permisos del repositorio, concede acceso de lectura y escritura a Contenido, Administración y Pages."
 
 msgid "Underline"
 msgstr "Subrayado"
@@ -9475,6 +9669,9 @@ msgstr "Usar como plantilla"
 msgid "Use Liquid syntax to interpolate variables, loop over arrays, and conditionally include instructions in this prompt."
 msgstr "Usa la sintaxis de Liquid para interpolar variables, recorrer arrays e incluir instrucciones condicionalmente en este prompt."
 
+msgid "Use one accessible font throughout generated, reflowable pages. You can change it later from the book toolbar."
+msgstr "Use una fuente accesible en todas las páginas generadas y adaptables. Puede cambiarla más tarde desde la barra del libro."
+
 #. placeholder {0}: page.pageNumber
 msgid "Use page {0} for the quiz"
 msgstr "Usar la página {0} para el cuestionario"
@@ -9609,6 +9806,9 @@ msgstr "Ver"
 
 #~ msgid "View all changes"
 #~ msgstr "Ver todos los cambios"
+
+#~ msgid "View deployment"
+#~ msgstr "Ver despliegue"
 
 msgid "View details"
 msgstr "Ver detalles"
@@ -9848,6 +10048,9 @@ msgstr "Resaltado por palabra"
 msgid "words"
 msgstr "palabras"
 
+#~ msgid "Workspace changes"
+#~ msgstr "Cambios del espacio de trabajo"
+
 msgid "Wrap in group"
 msgstr "Envolver en grupo"
 
@@ -9933,42 +10136,3 @@ msgstr "Acercar"
 
 msgid "Zoom out"
 msgstr "Alejar"
-
-msgid "Add shape"
-msgstr "Añadir forma"
-
-msgid "Automatic — match book"
-msgstr "Automática — coincidir con el libro"
-
-msgid "Automatic — match the book"
-msgstr "Automática — coincidir con el libro"
-
-msgid "Book font updated."
-msgstr "Fuente del libro actualizada."
-
-msgid "Change the font across generated book pages."
-msgstr "Cambiar la fuente en las páginas generadas del libro."
-
-msgid "Commercial fonts such as Sassoon must also be installed or attached to the book for an exact match."
-msgstr "Las fuentes comerciales como Sassoon también deben estar instaladas o adjuntas al libro para obtener una coincidencia exacta."
-
-msgid "Fixed-layout pages preserve the original book fonts."
-msgstr "Las páginas de diseño fijo conservan las fuentes originales del libro."
-
-msgid "New text"
-msgstr "Texto nuevo"
-
-msgid "Output font family"
-msgstr "Familia tipográfica de salida"
-
-msgid "Resize image"
-msgstr "Cambiar tamaño de imagen"
-
-msgid "Rotate"
-msgstr "Girar"
-
-msgid "Unable to update the book font."
-msgstr "No se pudo actualizar la fuente del libro."
-
-msgid "Use one accessible font throughout generated, reflowable pages. You can change it later from the book toolbar."
-msgstr "Use una fuente accesible en todas las páginas generadas y adaptables. Puede cambiarla más tarde desde la barra del libro."

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -3844,8 +3844,8 @@ msgstr "Reuniendo la evidencia"
 msgid "Gemini"
 msgstr "Gemini"
 
-#~ msgid "Gemini API key is required to generate audio."
-#~ msgstr "Se necesita una clave de API de Gemini para generar audio."
+msgid "Gemini API key is required to generate audio."
+msgstr "Se requiere una clave de API de Gemini para generar audio."
 
 #~ msgid "Gemini generates each sentence in its own request, so its tone can drift between sentences. A lower temperature (e.g. 0.4) reduces that variation and a fixed seed makes delivery reproducible. Only affects languages routed to Gemini — OpenAI and Azure ignore these. Changing either value regenerates Gemini audio on the next run."
 #~ msgstr "Gemini genera cada oración en su propia solicitud, por lo que su tono puede variar entre oraciones. Una temperatura más baja (p. ej., 0.4) reduce esa variación y una semilla fija hace que la lectura sea reproducible. Solo afecta a los idiomas enrutados a Gemini: OpenAI y Azure los ignoran. Cambiar cualquiera de los valores regenera el audio de Gemini en la próxima ejecución."
@@ -3919,8 +3919,8 @@ msgstr "Generar desde páginas"
 msgid "Generate global prompts"
 msgstr "Generar prompts globales"
 
-#~ msgid "Generate missing Gemini audio"
-#~ msgstr "Generar audio de Gemini faltante"
+msgid "Generate missing Gemini audio"
+msgstr "Generar el audio de Gemini que falta"
 
 msgid "Generate multiple-choice comprehension quizzes from the book's content. Create them automatically across the whole book, or add a single quiz from specific pages."
 msgstr "Genera cuestionarios de comprensión de opción múltiple a partir del contenido del libro. Créalos automáticamente en todo el libro o añade un único cuestionario a partir de páginas específicas."
@@ -8061,8 +8061,8 @@ msgstr "Sessions"
 msgid "Sessions let different reviewers capture findings independently, including language-specific reviews."
 msgstr "Sessions let different reviewers capture findings independently, including language-specific reviews."
 
-#~ msgid "Set a Gemini API key to generate audio"
-#~ msgstr "Configura una clave de API de Gemini para generar audio"
+msgid "Set a Gemini API key to generate audio"
+msgstr "Configura una clave de API de Gemini para generar audio"
 
 msgid "Set Administration to Read and write so ADT can configure the repository and create the GitHub Pages site."
 msgstr "Configura Administración como Lectura y escritura para que ADT pueda configurar el repositorio y crear el sitio de GitHub Pages."

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -1297,6 +1297,9 @@ msgstr "y muchos más bloques a lo largo de todo el libro"
 msgid "and more sections across the page"
 msgstr "y más secciones a lo largo de la página"
 
+msgid "Angle"
+msgstr "Ángulo"
+
 msgid "Answer"
 msgstr "Respuesta"
 
@@ -1685,6 +1688,9 @@ msgstr "Etapas de creación del libro"
 msgid "Book data is outdated and must be rebuilt."
 msgstr "Los datos del libro están desactualizados y deben reconstruirse."
 
+msgid "Book design"
+msgstr "Diseño del libro"
+
 msgid "Book font updated."
 msgstr "Fuente del libro actualizada."
 
@@ -2068,6 +2074,9 @@ msgstr "Elige cómo debe formatearse el contenido."
 msgid "Choose images..."
 msgstr "Elegir imágenes..."
 
+msgid "Choose one accessible font family for all reflowable storyboard pages."
+msgstr "Elige una familia tipográfica accesible para todas las páginas adaptables del guion gráfico."
+
 msgid "Choose Provider"
 msgstr "Elegir proveedor"
 
@@ -2157,6 +2166,9 @@ msgstr "Clone failed"
 
 msgid "Close"
 msgstr "Close"
+
+msgid "Close book design"
+msgstr "Cerrar diseño del libro"
 
 msgid "Close edit panel"
 msgstr "Cerrar panel de edición"
@@ -3669,6 +3681,9 @@ msgstr "Página Final"
 
 msgid "Fine-grained token for an existing repository"
 msgstr "Token específico para un repositorio existente"
+
+msgid "Finish layout"
+msgstr "Finalizar diseño"
 
 msgid "First images from the deep-field telescope."
 msgstr "Primeras imágenes del telescopio de campo profundo."
@@ -6607,6 +6622,9 @@ msgstr "Posición"
 msgid "Position {0}, {1} → {2}×{3} pt"
 msgstr "Posición {0}, {1} → {2}×{3} pt"
 
+msgid "Position for {deviceView}"
+msgstr "Posición para {deviceView}"
+
 msgid "Práticas de Alfabetização e de Matemática"
 msgstr "Prácticas de Alfabetización y Matemáticas"
 
@@ -9261,6 +9279,9 @@ msgstr "Vista previa de TOC"
 #~ msgid "Today"
 #~ msgstr "Hoy"
 
+msgid "Toggle canvas editing mode"
+msgstr "Alternar modo de edición de lienzo"
+
 msgid "Toggle model list"
 msgstr "Alternar lista de modelos"
 
@@ -10069,6 +10090,12 @@ msgstr "Escribe tu oración con un marcador {0}."
 
 #~ msgid "Yesterday"
 #~ msgstr "Ayer"
+
+msgid "X position"
+msgstr "Posición X"
+
+msgid "Y position"
+msgstr "Posición Y"
 
 #. placeholder {0}: formatVersion(release.version)
 msgid "You are about to install {0}. Books or settings edited with a newer version may not work as expected. Back up your books before continuing."

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -3846,8 +3846,8 @@ msgstr "Rassembler les preuves"
 msgid "Gemini"
 msgstr "Gemini"
 
-#~ msgid "Gemini API key is required to generate audio."
-#~ msgstr "La clé API Gemini est requise pour générer l'audio."
+msgid "Gemini API key is required to generate audio."
+msgstr "Une clé API Gemini est requise pour générer l’audio."
 
 #~ msgid "Gemini generates each sentence in its own request, so its tone can drift between sentences. A lower temperature (e.g. 0.4) reduces that variation and a fixed seed makes delivery reproducible. Only affects languages routed to Gemini — OpenAI and Azure ignore these. Changing either value regenerates Gemini audio on the next run."
 #~ msgstr "Gemini génère chaque phrase dans sa propre requête, si bien que son ton peut varier d'une phrase à l'autre. Une température plus basse (p. ex. 0,4) réduit cette variation et une graine fixe rend la lecture reproductible. Ne concerne que les langues acheminées vers Gemini — OpenAI et Azure les ignorent. Modifier l'une de ces valeurs régénère l'audio Gemini lors de la prochaine exécution."
@@ -3921,8 +3921,8 @@ msgstr "Générer à partir des pages"
 msgid "Generate global prompts"
 msgstr "Générer des prompts globaux"
 
-#~ msgid "Generate missing Gemini audio"
-#~ msgstr "Générer l'audio Gemini manquant"
+msgid "Generate missing Gemini audio"
+msgstr "Générer l’audio Gemini manquant"
 
 msgid "Generate multiple-choice comprehension quizzes from the book's content. Create them automatically across the whole book, or add a single quiz from specific pages."
 msgstr "Générez des quiz de compréhension à choix multiples à partir du contenu du livre. Créez-les automatiquement dans tout le livre ou ajoutez un seul quiz à partir de pages spécifiques."
@@ -8063,8 +8063,8 @@ msgstr "Sessions"
 msgid "Sessions let different reviewers capture findings independently, including language-specific reviews."
 msgstr "Les sessions permettent à différents réviseurs de capturer leurs résultats indépendamment, y compris les révisions spécifiques à une langue."
 
-#~ msgid "Set a Gemini API key to generate audio"
-#~ msgstr "Définissez une clé API Gemini pour générer l'audio"
+msgid "Set a Gemini API key to generate audio"
+msgstr "Configurez une clé API Gemini pour générer l’audio"
 
 msgid "Set Administration to Read and write so ADT can configure the repository and create the GitHub Pages site."
 msgstr "Réglez Administration sur Lecture et écriture afin qu’ADT puisse configurer le dépôt et créer le site GitHub Pages."

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -1299,6 +1299,9 @@ msgstr "et bien d'autres blocs à travers tout le livre"
 msgid "and more sections across the page"
 msgstr "et plus de sections sur la page"
 
+msgid "Angle"
+msgstr "Angle"
+
 msgid "Answer"
 msgstr "Réponse"
 
@@ -1687,6 +1690,9 @@ msgstr "Étapes de création du livre"
 msgid "Book data is outdated and must be rebuilt."
 msgstr "Les données du livre sont obsolètes et doivent être reconstruites."
 
+msgid "Book design"
+msgstr "Conception du livre"
+
 msgid "Book font updated."
 msgstr "Police du livre mise à jour."
 
@@ -2070,6 +2076,9 @@ msgstr "Choisissez comment le contenu doit être formaté."
 msgid "Choose images..."
 msgstr "Choisir des images..."
 
+msgid "Choose one accessible font family for all reflowable storyboard pages."
+msgstr "Choisissez une famille de polices accessible pour toutes les pages adaptables du storyboard."
+
 msgid "Choose Provider"
 msgstr "Choisir le fournisseur"
 
@@ -2159,6 +2168,9 @@ msgstr "Le clonage a échoué"
 
 msgid "Close"
 msgstr "Fermer"
+
+msgid "Close book design"
+msgstr "Fermer la conception du livre"
 
 msgid "Close edit panel"
 msgstr "Fermer le panneau de modification"
@@ -3671,6 +3683,9 @@ msgstr "Page finale"
 
 msgid "Fine-grained token for an existing repository"
 msgstr "Jeton à granularité fine pour un dépôt existant"
+
+msgid "Finish layout"
+msgstr "Terminer la mise en page"
 
 msgid "First images from the deep-field telescope."
 msgstr "Premières images du télescope à champ profond."
@@ -6609,6 +6624,9 @@ msgstr "Position"
 msgid "Position {0}, {1} → {2}×{3} pt"
 msgstr "Position {0}, {1} → {2}×{3} pt"
 
+msgid "Position for {deviceView}"
+msgstr "Position pour {deviceView}"
+
 msgid "Práticas de Alfabetização e de Matemática"
 msgstr "Práticas de Alfabetização e de Matemática"
 
@@ -9263,6 +9281,9 @@ msgstr "Aperçu de la table des matières"
 #~ msgid "Today"
 #~ msgstr "Aujourd’hui"
 
+msgid "Toggle canvas editing mode"
+msgstr "Basculer le mode d’édition du canevas"
+
 msgid "Toggle model list"
 msgstr "Afficher/masquer la liste des modèles"
 
@@ -10071,6 +10092,12 @@ msgstr "Écrivez votre phrase avec un marqueur {0}."
 
 #~ msgid "Yesterday"
 #~ msgstr "Hier"
+
+msgid "X position"
+msgstr "Position X"
+
+msgid "Y position"
+msgstr "Position Y"
 
 #. placeholder {0}: formatVersion(release.version)
 msgid "You are about to install {0}. Books or settings edited with a newer version may not work as expected. Back up your books before continuing."

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -265,6 +265,10 @@ msgstr "{0} textes"
 msgid "{0} translations"
 msgstr "{0} traductions"
 
+#. placeholder {0}: changesQuery.data.changes.length
+#~ msgid "{0} unpublished file changes"
+#~ msgstr "{0} modifications de fichiers non publiées"
+
 #. placeholder {0}: versions.length
 #~ msgid "{0} versions"
 #~ msgstr "{0} versions"
@@ -823,6 +827,9 @@ msgstr "Activité : Choix multiple"
 msgid "Activity: Open-Ended Answer"
 msgstr "Activité : Réponse ouverte"
 
+#~ msgid "Activity: Ordering"
+#~ msgstr "Activité : Mise en ordre"
+
 msgid "Activity: Other"
 msgstr "Activité : Autre"
 
@@ -985,6 +992,9 @@ msgstr "Ajouter des consignes pour le réviseur."
 
 msgid "Add section"
 msgstr "Ajouter une section"
+
+msgid "Add shape"
+msgstr "Ajouter une forme"
 
 msgid "Add sign language video"
 msgstr "Ajouter une vidéo en langue des signes"
@@ -1262,6 +1272,9 @@ msgstr "Montant"
 msgid "An activity that does not fit the standard categories."
 msgstr "Une activité qui ne correspond pas aux catégories standard."
 
+#~ msgid "An activity where learners arrange items into the correct order."
+#~ msgstr "Une activité dans laquelle les élèves placent des éléments dans le bon ordre."
+
 msgid "An activity where the learner underlines one or more words, phrases, or sentences directly in the text."
 msgstr "Une activité où l'apprenant souligne un ou plusieurs mots, expressions ou phrases directement dans le texte."
 
@@ -1501,6 +1514,12 @@ msgstr "Remplissage automatique à partir du contexte du livre"
 msgid "Auto-scroll"
 msgstr "Défilement automatique"
 
+msgid "Automatic — match book"
+msgstr "Automatique — correspondre au livre"
+
+msgid "Automatic — match the book"
+msgstr "Automatique — correspondre au livre"
+
 msgid "Automatically adapts the layout based on each page's content using AI."
 msgstr "Adapte automatiquement la mise en page en fonction du contenu de chaque page grâce à l'IA."
 
@@ -1656,6 +1675,9 @@ msgstr "Le corps du texte utilise cette police aujourd'hui. Joignez une police c
 msgid "Book"
 msgstr "Livre"
 
+#~ msgid "Book change history"
+#~ msgstr "Historique des modifications du livre"
+
 msgid "Book coverage"
 msgstr "Couverture du livre"
 
@@ -1665,6 +1687,9 @@ msgstr "Étapes de création du livre"
 msgid "Book data is outdated and must be rebuilt."
 msgstr "Les données du livre sont obsolètes et doivent être reconstruites."
 
+msgid "Book font updated."
+msgstr "Police du livre mise à jour."
+
 msgid "Book Fonts"
 msgstr "Polices du livre"
 
@@ -1673,6 +1698,9 @@ msgstr "Images du livre"
 
 msgid "Book info"
 msgstr "Infos du livre"
+
+#~ msgid "Book is published"
+#~ msgstr "Le livre est publié"
 
 msgid "Book Language"
 msgstr "Livre Langue"
@@ -1928,8 +1956,14 @@ msgstr "Changer de préréglage"
 msgid "Change the book language?"
 msgstr "Changer la langue du livre ?"
 
+msgid "Change the font across generated book pages."
+msgstr "Modifier la police des pages générées du livre."
+
 msgid "Change the picture for this term"
 msgstr "Changer l'image de ce terme"
+
+#~ msgid "Changed files"
+#~ msgstr "Fichiers modifiés"
 
 #~ msgid "Changes apply the next time you run Storyboard and Export."
 #~ msgstr "Les modifications s'appliquent au prochain lancement du Storyboard et de l'Export."
@@ -1975,6 +2009,9 @@ msgstr "Titre de chapitre"
 
 msgid "Chart / Graph"
 msgstr "Graphique / Diagramme"
+
+#~ msgid "Check changes"
+#~ msgstr "Vérifier les modifications"
 
 #~ msgid "Check for updates"
 #~ msgstr "Vérifier les mises à jour"
@@ -2177,6 +2214,9 @@ msgstr "Commentaire"
 msgid "Comments"
 msgstr "Commentaires"
 
+msgid "Commercial fonts such as Sassoon must also be installed or attached to the book for an exact match."
+msgstr "Les polices commerciales telles que Sassoon doivent aussi être installées ou jointes au livre pour une correspondance exacte."
+
 msgid "Compare"
 msgstr "Comparer"
 
@@ -2191,6 +2231,9 @@ msgstr "Comparer les versions"
 
 msgid "Compared with fallback prompt."
 msgstr "Comparé au prompt de repli."
+
+#~ msgid "Complete the guided setup before starting the publishing workflow."
+#~ msgstr "Terminez la configuration guidée avant de lancer le flux de publication."
 
 msgid "Completed"
 msgstr "Terminé"
@@ -2246,6 +2289,12 @@ msgstr "Configurez chaque étape — extraction, storyboard, mise en page — pu
 msgid "Configure features to include in the export"
 msgstr "Configurer les fonctionnalités à inclure dans l'exportation"
 
+#~ msgid "Configure GitHub publishing"
+#~ msgstr "Configurer la publication GitHub"
+
+#~ msgid "Configure GitHub to start publishing"
+#~ msgstr "Configurez GitHub pour commencer la publication"
+
 #~ msgid "Configure provider credentials and global prompt fallbacks used by ADT Studio."
 #~ msgstr "Configurez les identifiants des fournisseurs et les prompts de fallback globaux utilisés par ADT Studio."
 
@@ -2260,6 +2309,12 @@ msgstr "Configurer les voix et les accents"
 
 msgid "Confirm merge"
 msgstr "Confirmer la fusion"
+
+#~ msgid "Confirm the destination below. Publishing will open the live workflow screen automatically."
+#~ msgstr "Confirmez la destination ci-dessous. La publication ouvrira automatiquement l’écran du flux en direct."
+
+#~ msgid "Connect an account and choose a repository before running this workflow."
+#~ msgstr "Connectez un compte et choisissez un dépôt avant d’exécuter ce flux."
 
 msgid "Connect an AI provider"
 msgstr "Connectez un fournisseur d'IA"
@@ -2284,6 +2339,9 @@ msgstr "Traitement du contenu"
 
 msgid "Contents"
 msgstr "Contenu"
+
+msgid "Contents — Read and write; Administration — Read and write; Pages — Read and write; Metadata — Read-only."
+msgstr "Contenu — Lecture et écriture ; Administration — Lecture et écriture ; Pages — Lecture et écriture ; Métadonnées — Lecture seule."
 
 msgid "Context"
 msgstr "Contexte"
@@ -2448,6 +2506,9 @@ msgstr "Créer une session de révision pour ce livre."
 msgid "Create ADT"
 msgstr "Créer ADT"
 
+#~ msgid "Create classic token on GitHub"
+#~ msgstr "Créer un jeton classique sur GitHub"
+
 msgid "Create descriptive captions for images to improve accessibility."
 msgstr "Créez des légendes descriptives pour les images afin d'améliorer l'accessibilité."
 
@@ -2456,6 +2517,9 @@ msgstr "Créer le fichier"
 
 msgid "Create files"
 msgstr "Créer les fichiers"
+
+#~ msgid "Create fine-grained token on GitHub"
+#~ msgstr "Créer un jeton à granularité fine sur GitHub"
 
 msgid "Create from scratch using your description"
 msgstr "Créer à partir de zéro en utilisant votre description"
@@ -2471,6 +2535,9 @@ msgstr "Créer un fichier de prompt à partir du modèle"
 
 msgid "Create session"
 msgstr "Créer une session"
+
+#~ msgid "Create the destination repository first, then select its owner and that repository as the token resource."
+#~ msgstr "Créez d’abord le dépôt de destination, puis sélectionnez son propriétaire et ce dépôt comme ressource du jeton."
 
 msgid "Created {created} prompt files for {normalizedTargetModel}."
 msgstr "{created} fichiers de prompt créés pour {normalizedTargetModel}."
@@ -2534,6 +2601,9 @@ msgstr "Actuelle (v{currentVersion})"
 
 msgid "Current book font"
 msgstr "Police actuelle du livre"
+
+#~ msgid "Current book workspace"
+#~ msgstr "Espace de travail actuel du livre"
 
 msgid "Current effective values"
 msgstr "Valeurs effectives actuelles"
@@ -3055,6 +3125,9 @@ msgstr "Chaque itération est un appel LLM. Des valeurs plus basses sont plus ra
 msgid "Each kind of pipeline task uses a compatible model. Image generation and speech use their own task-specific defaults."
 msgstr "Chaque type de tâche du pipeline utilise un modèle compatible. La génération d’images et la synthèse vocale utilisent leurs propres modèles par défaut spécifiques."
 
+#~ msgid "Each node updates live as ADT Studio publishes the book."
+#~ msgstr "Chaque nœud se met à jour en direct pendant qu’ADT Studio publie le livre."
+
 msgid "Each polyp secretes a hard calcium carbonate skeleton. Over hundreds of years, millions of these skeletons build up into the massive reef structures we see today."
 msgstr "Chaque polype sécrète un squelette rigide de carbonate de calcium. Au fil de centaines d'années, des millions de ces squelettes s'accumulent pour former les immenses structures récifales que nous voyons aujourd'hui."
 
@@ -3072,6 +3145,9 @@ msgstr "Les étapes précédentes n'ont pas encore été exécutées"
 
 msgid "Early"
 msgstr "Précoce"
+
+msgid "Easiest complete setup"
+msgstr "Configuration complète la plus simple"
 
 msgid "Easy Read"
 msgstr "Lecture Facile"
@@ -3593,6 +3669,9 @@ msgstr "Filtre les images décoratives ou non pertinentes sur chaque page."
 msgid "Final Page"
 msgstr "Page finale"
 
+msgid "Fine-grained token for an existing repository"
+msgstr "Jeton à granularité fine pour un dépôt existant"
+
 msgid "First images from the deep-field telescope."
 msgstr "Premières images du télescope à champ profond."
 
@@ -3613,6 +3692,9 @@ msgstr "Mise en page fixe à deux colonnes"
 
 msgid "Fixed-layout books use the original page images as backgrounds with positioned text extracted from the PDF. Activities detection, figure extraction, and image cropping or segmentation don't apply to this layout."
 msgstr "Les livres à mise en page fixe utilisent les images de page d'origine comme arrière-plans avec le texte positionné extrait du PDF. La détection d'activités, l'extraction de figures et le rognage ou la segmentation d'images ne s'appliquent pas à cette mise en page."
+
+msgid "Fixed-layout pages preserve the original book fonts."
+msgstr "Les pages à mise en page fixe conservent les polices originales du livre."
 
 #~ msgid "Fixed, accessible sizes applied to every page. Sizes use the book's Tailwind scale (pick a token or type an exact px), scale fluidly between mobile and desktop, and override any size the AI picks — so headings and body text stay consistent across the whole book."
 #~ msgstr "Tailles fixes et accessibles appliquées à chaque page. Les tailles utilisent l'échelle Tailwind du livre (choisissez un token ou saisissez une valeur exacte en px), s'adaptent de façon fluide entre mobile et ordinateur, et remplacent toute taille choisie par l'IA — ainsi les titres et le corps de texte restent cohérents dans tout le livre."
@@ -3749,8 +3831,8 @@ msgstr "Rassembler les preuves"
 msgid "Gemini"
 msgstr "Gemini"
 
-msgid "Gemini API key is required to generate audio."
-msgstr "La clé API Gemini est requise pour générer l'audio."
+#~ msgid "Gemini API key is required to generate audio."
+#~ msgstr "La clé API Gemini est requise pour générer l'audio."
 
 #~ msgid "Gemini generates each sentence in its own request, so its tone can drift between sentences. A lower temperature (e.g. 0.4) reduces that variation and a fixed seed makes delivery reproducible. Only affects languages routed to Gemini — OpenAI and Azure ignore these. Changing either value regenerates Gemini audio on the next run."
 #~ msgstr "Gemini génère chaque phrase dans sa propre requête, si bien que son ton peut varier d'une phrase à l'autre. Une température plus basse (p. ex. 0,4) réduit cette variation et une graine fixe rend la lecture reproductible. Ne concerne que les langues acheminées vers Gemini — OpenAI et Azure les ignorent. Modifier l'une de ces valeurs régénère l'audio Gemini lors de la prochaine exécution."
@@ -3824,8 +3906,8 @@ msgstr "Générer à partir des pages"
 msgid "Generate global prompts"
 msgstr "Générer des prompts globaux"
 
-msgid "Generate missing Gemini audio"
-msgstr "Générer l'audio Gemini manquant"
+#~ msgid "Generate missing Gemini audio"
+#~ msgstr "Générer l'audio Gemini manquant"
 
 msgid "Generate multiple-choice comprehension quizzes from the book's content. Create them automatically across the whole book, or add a single quiz from specific pages."
 msgstr "Générez des quiz de compréhension à choix multiples à partir du contenu du livre. Créez-les automatiquement dans tout le livre ou ajoutez un seul quiz à partir de pages spécifiques."
@@ -3921,6 +4003,9 @@ msgstr "Génération Invite"
 
 msgid "Get started"
 msgstr "Commencer"
+
+#~ msgid "Git publishing workflow"
+#~ msgstr "Flux de publication Git"
 
 msgid "Global prompt reset to default."
 msgstr "Prompt global réinitialisé par défaut."
@@ -4554,6 +4639,9 @@ msgstr "Grandes images, flux narratif. Idéal pour les livres illustrés avec de
 #~ msgid "Last"
 #~ msgstr "Dernier"
 
+#~ msgid "Last activity"
+#~ msgstr "Dernière activité"
+
 msgid "Last change"
 msgstr "Dernière modification"
 
@@ -4562,6 +4650,12 @@ msgstr "Dernière modification"
 
 #~ msgid "Last week"
 #~ msgstr "La semaine dernière"
+
+#~ msgid "Latest deployment"
+#~ msgstr "Dernier déploiement"
+
+#~ msgid "Latest GitHub changes synchronized."
+#~ msgstr "Dernières modifications GitHub synchronisées."
 
 msgid "Launch the app with"
 msgstr "Lancer l'application avec"
@@ -4583,6 +4677,9 @@ msgstr "Mise en page reproduite sur cette section"
 
 msgid "Leading"
 msgstr "Interligne"
+
+#~ msgid "Learn how with a guided setup"
+#~ msgstr "Suivez la configuration guidée"
 
 msgid "Least used"
 msgstr "Moins utilisé"
@@ -4734,6 +4831,9 @@ msgstr "Chargement des livres..."
 msgid "Loading catalog..."
 msgstr "Chargement du catalogue..."
 
+#~ msgid "Loading deployments"
+#~ msgstr "Chargement des déploiements"
+
 msgid "Loading Easy Read..."
 msgstr "Chargement de Lecture Facile..."
 
@@ -4826,6 +4926,12 @@ msgstr "Chargement..."
 
 msgid "Loading…"
 msgstr "Chargement…"
+
+#~ msgid "Local and GitHub changes need resolution before synchronization."
+#~ msgstr "Les modifications locales et GitHub doivent être résolues avant la synchronisation."
+
+#~ msgid "Local book is up to date."
+#~ msgstr "Le livre local est à jour."
 
 msgid "Localization"
 msgstr "Localisation"
@@ -5269,6 +5375,9 @@ msgstr "Nouvelle entrée"
 msgid "New session"
 msgstr "Nouvelle session"
 
+msgid "New text"
+msgstr "Nouveau texte"
+
 #~ msgid "New version"
 #~ msgstr "Nouvelle version"
 
@@ -5681,8 +5790,14 @@ msgstr "bruit"
 msgid "None"
 msgstr "Aucun"
 
+#~ msgid "Not committed yet"
+#~ msgstr "Pas encore validé"
+
 msgid "Not compatible with Fixed Layout"
 msgstr "Incompatible avec la mise en page fixe"
+
+#~ msgid "Not configured"
+#~ msgstr "Non configuré"
 
 msgid "Not detected"
 msgstr "Non détecté"
@@ -5857,6 +5972,9 @@ msgstr "Ouvrir l'aperçu de la page {pageId}"
 msgid "Open Preview"
 msgstr "Ouvrir l'aperçu"
 
+#~ msgid "Open public book"
+#~ msgstr "Ouvrir le livre public"
+
 #. placeholder {0}: pullRequest.number
 msgid "Open pull request {0}"
 msgstr "Ouvrir la demande de tirage {0}"
@@ -6000,6 +6118,9 @@ msgstr "En cours de traitement"
 msgid "Out of date"
 msgstr "Obsolète"
 
+msgid "Output font family"
+msgstr "Famille de polices de sortie"
+
 msgid "Output languages"
 msgstr "Langues de sortie"
 
@@ -6068,6 +6189,9 @@ msgstr "Emballez le livre pour la distribution. Choisissez un format, sélection
 
 msgid "Package the finished book with every accessibility feature baked in — ready for a kid to open, listen, and read along."
 msgstr "Empaquetez le livre terminé avec toutes les fonctionnalités d'accessibilité intégrées — prêt pour qu'un enfant l'ouvre, l'écoute et suive la lecture."
+
+#~ msgid "Package, commit, push, host, and preview the accessible book without leaving ADT Studio."
+#~ msgstr "Créez le paquet, validez, publiez, hébergez et prévisualisez le livre accessible sans quitter ADT Studio."
 
 msgid "Packaging"
 msgstr "Empaquetage"
@@ -6644,11 +6768,20 @@ msgstr "Élagué : {reason}"
 msgid "PT"
 msgstr "PT"
 
+#~ msgid "Publish book"
+#~ msgstr "Publier le livre"
+
+#~ msgid "Publish with GitHub Pages"
+#~ msgstr "Publier avec GitHub Pages"
+
 msgid "published in"
 msgstr "publié en"
 
 msgid "Publisher"
 msgstr "Éditeur"
+
+#~ msgid "Pull remote changes"
+#~ msgstr "Récupérer les modifications distantes"
 
 msgid "Pull requests"
 msgstr "Pull requests"
@@ -6895,6 +7028,9 @@ msgstr "Recommandé pour"
 msgid "Recommended for {0}"
 msgstr "Recommandé pour {0}"
 
+msgid "Recommended for creating a new repository"
+msgstr "Recommandé pour créer un nouveau dépôt"
+
 msgid "Record reviewer findings for the current page and save them to the active validation session."
 msgstr "Enregistrez les résultats du réviseur pour la page actuelle et sauvegardez-les dans la session de validation active."
 
@@ -6937,6 +7073,10 @@ msgstr "Regénérer la définition, les variations et l'emoji"
 msgid "Regenerate Easy Read"
 msgstr "Régénérer Lecture Facile"
 
+#. placeholder {0}: selectedAudioIds.size
+#~ msgid "Regenerate selected ({0})"
+#~ msgstr "Régénérer la sélection ({0})"
+
 msgid "Regenerate selected images for each output language so that any text burned into them is shown in the target language."
 msgstr "Régénère les images sélectionnées pour chaque langue de sortie afin que tout texte intégré soit affiché dans la langue cible."
 
@@ -6966,6 +7106,12 @@ msgstr "Relâchez pour importer"
 
 msgid "Reload app"
 msgstr "Recharger l'application"
+
+#~ msgid "Remote changes are available."
+#~ msgstr "Des modifications distantes sont disponibles."
+
+#~ msgid "Remote changes available"
+#~ msgstr "Des modifications distantes sont disponibles"
 
 msgid "Remove"
 msgstr "Retirer"
@@ -7127,6 +7273,9 @@ msgstr "Rétablir la couleur d'accent du livre"
 msgid "Reset zoom"
 msgstr "Réinitialiser le zoom"
 
+msgid "Resize image"
+msgstr "Redimensionner l’image"
+
 msgid "Resize panel"
 msgstr "Redimensionner le panneau"
 
@@ -7191,6 +7340,9 @@ msgstr "Réviser"
 #~ msgid "Review {selectedCount} selected"
 #~ msgstr "Revoir {selectedCount} sélectionnées"
 
+#~ msgid "Review and publish"
+#~ msgstr "Vérifier et publier"
+
 msgid "Review and refine each simplified block side-by-side with the original before packaging."
 msgstr "Examinez et peaufinez chaque bloc simplifié côte à côte avec l'original avant l'emballage."
 
@@ -7234,6 +7386,9 @@ msgstr "Rigueur de la révision"
 
 msgid "Review style"
 msgstr "Style de révision"
+
+#~ msgid "Review the most recent publishing workflow and open its public result."
+#~ msgstr "Consultez le flux de publication le plus récent et ouvrez son résultat public."
 
 msgid "Review the project details below and confirm the import."
 msgstr "Vérifiez les détails du projet ci-dessous et confirmez l'importation."
@@ -7294,6 +7449,9 @@ msgstr "La hausse des températures océaniques provoque le blanchissement des c
 
 msgid "Role"
 msgstr "Rôle"
+
+msgid "Rotate"
+msgstr "Faire pivoter"
 
 msgid "Row"
 msgstr "Ligne"
@@ -7383,6 +7541,9 @@ msgstr "Exécuter la traduction"
 msgid "Run whole-book validation checks and configure accessibility assessment settings."
 msgstr "Exécutez les vérifications de validation du livre entier et configurez les paramètres d'évaluation d'accessibilité."
 
+#~ msgid "Run workflow"
+#~ msgstr "Exécuter le flux"
+
 msgid "Run-only tags"
 msgstr "Tags d'exécution uniquement"
 
@@ -7449,6 +7610,9 @@ msgstr "Enregistrer l'activité"
 msgid "Save activity (⌘S)"
 msgstr "Enregistrer l'activité (⌘S)"
 
+#~ msgid "Save and publish"
+#~ msgstr "Enregistrer et publier"
+
 msgid "Save changes"
 msgstr "Enregistrer les modifications"
 
@@ -7469,6 +7633,9 @@ msgstr "Enregistrer la liste de contrôle"
 
 msgid "Save failed"
 msgstr "L'enregistrement a échoué"
+
+#~ msgid "Save or discard your edits before splitting"
+#~ msgstr "Enregistrez ou abandonnez vos modifications avant de diviser"
 
 msgid "Save or discard your edits first"
 msgstr "Enregistrez ou abandonnez d'abord vos modifications"
@@ -7687,6 +7854,12 @@ msgstr "sections"
 msgid "Sections"
 msgstr "Sections"
 
+msgid "Security: use the shortest practical expiration, never share the token, and revoke it in GitHub when it is no longer needed. ADT Studio keeps this token locally on this device and does not store it in the book directory."
+msgstr "Sécurité : utilisez la durée d’expiration pratique la plus courte, ne partagez jamais le jeton et révoquez-le dans GitHub lorsqu’il n’est plus nécessaire. ADT Studio conserve ce jeton localement sur cet appareil et ne le stocke pas dans le dossier du livre."
+
+#~ msgid "Security: use the shortest practical expiration, never share the token, and revoke it in GitHub when it is no longer needed. ADT Studio keeps this token only for the current browser session and does not store it in the book directory."
+#~ msgstr "Sécurité : utilisez la durée d’expiration pratique la plus courte, ne partagez jamais le jeton et révoquez-le dans GitHub lorsqu’il n’est plus nécessaire. ADT Studio conserve ce jeton uniquement pendant la session actuelle du navigateur et ne le stocke pas dans le dossier du livre."
+
 msgid "See examples"
 msgstr "Voir les exemples"
 
@@ -7810,6 +7983,9 @@ msgstr "Sélectionner un modèle..."
 msgid "Select the pages the quiz is written from, then choose where it appears using the buttons between pages."
 msgstr "Sélectionnez les pages sur lesquelles le quiz est basé, puis choisissez où il apparaît à l'aide des boutons entre les pages."
 
+#~ msgid "Select the repo scope. It covers repository creation, file publishing, and GitHub Pages configuration."
+#~ msgstr "Sélectionnez l’autorisation repo. Elle couvre la création du dépôt, la publication des fichiers et la configuration de GitHub Pages."
+
 msgid "Select up to 5 pages to use as visual references. The LLM will analyze them and generate a styleguide."
 msgstr "Sélectionnez jusqu'à 5 pages à utiliser comme références visuelles. Le LLM les analysera et générera un guide de style."
 
@@ -7869,8 +8045,11 @@ msgstr "Sessions"
 msgid "Sessions let different reviewers capture findings independently, including language-specific reviews."
 msgstr "Les sessions permettent à différents réviseurs de capturer leurs résultats indépendamment, y compris les révisions spécifiques à une langue."
 
-msgid "Set a Gemini API key to generate audio"
-msgstr "Définissez une clé API Gemini pour générer l'audio"
+#~ msgid "Set a Gemini API key to generate audio"
+#~ msgstr "Définissez une clé API Gemini pour générer l'audio"
+
+msgid "Set Administration to Read and write so ADT can configure the repository and create the GitHub Pages site."
+msgstr "Réglez Administration sur Lecture et écriture afin qu’ADT puisse configurer le dépôt et créer le site GitHub Pages."
 
 msgid "Set fonts for the whole book"
 msgstr "Définir les polices pour tout le livre"
@@ -8761,6 +8940,9 @@ msgstr "La table des matières."
 msgid "The TOC lists the typed sections placed by Storyboard. Finish Storyboard before running this stage."
 msgstr "La table des matières liste les sections tapées placées par le Storyboard. Terminez le Storyboard avant d'exécuter cette étape."
 
+#~ msgid "The token needs repository contents, administration, and Pages permissions."
+#~ msgstr "Le jeton nécessite les autorisations de contenu du dépôt, d’administration et de Pages."
+
 msgid "The Water Cycle"
 msgstr "Le cycle de l'eau"
 
@@ -8817,6 +8999,9 @@ msgstr "Cette activité ne contient aucun texte ni aucune réponse adressable. R
 
 msgid "This archive can't be opened safely"
 msgstr "Cette archive ne peut pas être ouverte en toute sécurité"
+
+#~ msgid "This book asset will be included in the next commit."
+#~ msgstr "Cette ressource du livre sera incluse dans le prochain commit."
 
 msgid "This book has {pageCount} pages."
 msgstr "Ce livre comporte {pageCount} pages."
@@ -9105,6 +9290,9 @@ msgstr "Jetons totaux"
 msgid "Track reviewer progress and review findings captured from Preview."
 msgstr "Suivez la progression du réviseur et les résultats de révision capturés depuis l'aperçu."
 
+#~ msgid "Track the book's local edits, commits, publishing status, and GitHub metadata."
+#~ msgstr "Suivez les modifications locales, les commits, l’état de publication et les métadonnées GitHub du livre."
+
 msgid "Translate"
 msgstr "Traduire"
 
@@ -9294,6 +9482,9 @@ msgstr "Impossible d'enregistrer le prompt global."
 msgid "Unable to select prompt version."
 msgstr "Impossible de sélectionner la version du prompt."
 
+msgid "Unable to update the book font."
+msgstr "Impossible de mettre à jour la police du livre."
+
 msgid "Unable to update the book model overrides."
 msgstr "Impossible de mettre à jour les remplacements de modèles du livre."
 
@@ -9320,6 +9511,9 @@ msgstr "Non catégorisé"
 
 msgid "Unchanged"
 msgstr "Inchangé"
+
+#~ msgid "Under Repository permissions, grant Contents, Administration, and Pages read and write access."
+#~ msgstr "Dans les autorisations du dépôt, accordez l’accès en lecture et écriture à Contents, Administration et Pages."
 
 msgid "Underline"
 msgstr "Souligné"
@@ -9477,6 +9671,9 @@ msgstr "Utiliser comme modèle"
 msgid "Use Liquid syntax to interpolate variables, loop over arrays, and conditionally include instructions in this prompt."
 msgstr "Utilisez la syntaxe Liquid pour interpoler des variables, parcourir des tableaux et inclure des instructions conditionnelles dans ce prompt."
 
+msgid "Use one accessible font throughout generated, reflowable pages. You can change it later from the book toolbar."
+msgstr "Utilisez une police accessible sur toutes les pages générées et adaptables. Vous pourrez la modifier plus tard depuis la barre du livre."
+
 #. placeholder {0}: page.pageNumber
 msgid "Use page {0} for the quiz"
 msgstr "Utiliser la page {0} pour le quiz"
@@ -9611,6 +9808,9 @@ msgstr "Voir"
 
 #~ msgid "View all changes"
 #~ msgstr "Voir toutes les modifications"
+
+#~ msgid "View deployment"
+#~ msgstr "Voir le déploiement"
 
 msgid "View details"
 msgstr "Voir les détails"
@@ -9850,6 +10050,9 @@ msgstr "Surlignage mot à mot"
 msgid "words"
 msgstr "mots"
 
+#~ msgid "Workspace changes"
+#~ msgstr "Modifications de l’espace de travail"
+
 msgid "Wrap in group"
 msgstr "Encapsuler dans un groupe"
 
@@ -9935,42 +10138,3 @@ msgstr "Zoom avant"
 
 msgid "Zoom out"
 msgstr "Zoom arrière"
-
-msgid "Add shape"
-msgstr "Ajouter une forme"
-
-msgid "Automatic — match book"
-msgstr "Automatique — correspondre au livre"
-
-msgid "Automatic — match the book"
-msgstr "Automatique — correspondre au livre"
-
-msgid "Book font updated."
-msgstr "Police du livre mise à jour."
-
-msgid "Change the font across generated book pages."
-msgstr "Modifier la police des pages générées du livre."
-
-msgid "Commercial fonts such as Sassoon must also be installed or attached to the book for an exact match."
-msgstr "Les polices commerciales telles que Sassoon doivent aussi être installées ou jointes au livre pour une correspondance exacte."
-
-msgid "Fixed-layout pages preserve the original book fonts."
-msgstr "Les pages à mise en page fixe conservent les polices originales du livre."
-
-msgid "New text"
-msgstr "Nouveau texte"
-
-msgid "Output font family"
-msgstr "Famille de polices de sortie"
-
-msgid "Resize image"
-msgstr "Redimensionner l’image"
-
-msgid "Rotate"
-msgstr "Faire pivoter"
-
-msgid "Unable to update the book font."
-msgstr "Impossible de mettre à jour la police du livre."
-
-msgid "Use one accessible font throughout generated, reflowable pages. You can change it later from the book toolbar."
-msgstr "Utilisez une police accessible sur toutes les pages générées et adaptables. Vous pourrez la modifier plus tard depuis la barre du livre."

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -9935,3 +9935,42 @@ msgstr "Zoom avant"
 
 msgid "Zoom out"
 msgstr "Zoom arrière"
+
+msgid "Add shape"
+msgstr "Ajouter une forme"
+
+msgid "Automatic — match book"
+msgstr "Automatique — correspondre au livre"
+
+msgid "Automatic — match the book"
+msgstr "Automatique — correspondre au livre"
+
+msgid "Book font updated."
+msgstr "Police du livre mise à jour."
+
+msgid "Change the font across generated book pages."
+msgstr "Modifier la police des pages générées du livre."
+
+msgid "Commercial fonts such as Sassoon must also be installed or attached to the book for an exact match."
+msgstr "Les polices commerciales telles que Sassoon doivent aussi être installées ou jointes au livre pour une correspondance exacte."
+
+msgid "Fixed-layout pages preserve the original book fonts."
+msgstr "Les pages à mise en page fixe conservent les polices originales du livre."
+
+msgid "New text"
+msgstr "Nouveau texte"
+
+msgid "Output font family"
+msgstr "Famille de polices de sortie"
+
+msgid "Resize image"
+msgstr "Redimensionner l’image"
+
+msgid "Rotate"
+msgstr "Faire pivoter"
+
+msgid "Unable to update the book font."
+msgstr "Impossible de mettre à jour la police du livre."
+
+msgid "Use one accessible font throughout generated, reflowable pages. You can change it later from the book toolbar."
+msgstr "Utilisez une police accessible sur toutes les pages générées et adaptables. Vous pourrez la modifier plus tard depuis la barre du livre."

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -3844,8 +3844,8 @@ msgstr "Reunindo as evidências"
 msgid "Gemini"
 msgstr "Gemini"
 
-#~ msgid "Gemini API key is required to generate audio."
-#~ msgstr "É necessária uma chave de API do Gemini para gerar áudio."
+msgid "Gemini API key is required to generate audio."
+msgstr "É necessária uma chave de API do Gemini para gerar áudio."
 
 #~ msgid "Gemini generates each sentence in its own request, so its tone can drift between sentences. A lower temperature (e.g. 0.4) reduces that variation and a fixed seed makes delivery reproducible. Only affects languages routed to Gemini — OpenAI and Azure ignore these. Changing either value regenerates Gemini audio on the next run."
 #~ msgstr "O Gemini gera cada frase em sua própria requisição, então o tom pode variar entre as frases. Uma temperatura mais baixa (ex.: 0,4) reduz essa variação e uma semente fixa torna a leitura reproduzível. Afeta apenas os idiomas roteados para o Gemini — o OpenAI e o Azure ignoram esses valores. Alterar qualquer um deles regenera o áudio do Gemini na próxima execução."
@@ -3919,8 +3919,8 @@ msgstr "Gerar a partir das páginas"
 msgid "Generate global prompts"
 msgstr "Gerar prompts globais"
 
-#~ msgid "Generate missing Gemini audio"
-#~ msgstr "Gerar áudio faltante do Gemini"
+msgid "Generate missing Gemini audio"
+msgstr "Gerar o áudio Gemini ausente"
 
 msgid "Generate multiple-choice comprehension quizzes from the book's content. Create them automatically across the whole book, or add a single quiz from specific pages."
 msgstr "Gere questionários de compreensão de múltipla escolha a partir do conteúdo do livro. Crie-os automaticamente em todo o livro ou adicione um único questionário a partir de páginas específicas."
@@ -8061,8 +8061,8 @@ msgstr "Sessions"
 msgid "Sessions let different reviewers capture findings independently, including language-specific reviews."
 msgstr "Sessions let different reviewers capture findings independently, including language-specific reviews."
 
-#~ msgid "Set a Gemini API key to generate audio"
-#~ msgstr "Defina uma chave de API do Gemini para gerar áudio"
+msgid "Set a Gemini API key to generate audio"
+msgstr "Defina uma chave de API do Gemini para gerar áudio"
 
 msgid "Set Administration to Read and write so ADT can configure the repository and create the GitHub Pages site."
 msgstr "Defina Administração como Leitura e gravação para que o ADT possa configurar o repositório e criar o site do GitHub Pages."

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -263,6 +263,10 @@ msgstr "{0} textos"
 msgid "{0} translations"
 msgstr "{0} traduções"
 
+#. placeholder {0}: changesQuery.data.changes.length
+#~ msgid "{0} unpublished file changes"
+#~ msgstr "{0} alterações de arquivo não publicadas"
+
 #. placeholder {0}: versions.length
 #~ msgid "{0} versions"
 #~ msgstr "{0} versões"
@@ -821,6 +825,9 @@ msgstr "Atividade: Múltipla escolha"
 msgid "Activity: Open-Ended Answer"
 msgstr "Atividade: Resposta aberta"
 
+#~ msgid "Activity: Ordering"
+#~ msgstr "Atividade: Ordenação"
+
 msgid "Activity: Other"
 msgstr "Atividade: Outra"
 
@@ -983,6 +990,9 @@ msgstr "Add reviewer guidance."
 
 msgid "Add section"
 msgstr "Add section"
+
+msgid "Add shape"
+msgstr "Adicionar forma"
 
 msgid "Add sign language video"
 msgstr "Adicionar vídeo em língua de sinais"
@@ -1260,6 +1270,9 @@ msgstr "Quantidade"
 msgid "An activity that does not fit the standard categories."
 msgstr "Uma atividade que não se enquadra nas categorias padrão."
 
+#~ msgid "An activity where learners arrange items into the correct order."
+#~ msgstr "Uma atividade em que os estudantes organizam itens na ordem correta."
+
 msgid "An activity where the learner underlines one or more words, phrases, or sentences directly in the text."
 msgstr "Uma atividade em que o aluno sublinha uma ou mais palavras, expressões ou frases diretamente no texto."
 
@@ -1499,6 +1512,12 @@ msgstr "Preenchimento automático do contexto do livro"
 msgid "Auto-scroll"
 msgstr "Rolagem automática"
 
+msgid "Automatic — match book"
+msgstr "Automática — combinar com o livro"
+
+msgid "Automatic — match the book"
+msgstr "Automática — combinar com o livro"
+
 msgid "Automatically adapts the layout based on each page's content using AI."
 msgstr "Adapta automaticamente o layout com base no conteúdo de cada página usando IA."
 
@@ -1654,6 +1673,9 @@ msgstr "O corpo do texto usa esta fonte hoje. Anexe uma fonte abaixo e atribua a
 msgid "Book"
 msgstr "Livro"
 
+#~ msgid "Book change history"
+#~ msgstr "Histórico de alterações do livro"
+
 msgid "Book coverage"
 msgstr "Cobertura do livro"
 
@@ -1663,6 +1685,9 @@ msgstr "Etapas de criação do livro"
 msgid "Book data is outdated and must be rebuilt."
 msgstr "Os dados do livro estão desatualizados e precisam ser reconstruídos."
 
+msgid "Book font updated."
+msgstr "Fonte do livro atualizada."
+
 msgid "Book Fonts"
 msgstr "Fontes do Livro"
 
@@ -1671,6 +1696,9 @@ msgstr "Imagens do livro"
 
 msgid "Book info"
 msgstr "Informações do livro"
+
+#~ msgid "Book is published"
+#~ msgstr "O livro está publicado"
 
 msgid "Book Language"
 msgstr "Idioma do livro"
@@ -1926,8 +1954,14 @@ msgstr "Alterar Predefinição"
 msgid "Change the book language?"
 msgstr "Alterar o idioma do livro?"
 
+msgid "Change the font across generated book pages."
+msgstr "Alterar a fonte nas páginas geradas do livro."
+
 msgid "Change the picture for this term"
 msgstr "Alterar a imagem deste termo"
+
+#~ msgid "Changed files"
+#~ msgstr "Arquivos alterados"
 
 #~ msgid "Changes apply the next time you run Storyboard and Export."
 #~ msgstr "As alterações são aplicadas na próxima vez que você executar o Storyboard e a Exportação."
@@ -1973,6 +2007,9 @@ msgstr "Título do capítulo"
 
 msgid "Chart / Graph"
 msgstr "Gráfico / Tabela"
+
+#~ msgid "Check changes"
+#~ msgstr "Verificar alterações"
 
 #~ msgid "Check for updates"
 #~ msgstr "Verificar atualizações"
@@ -2175,6 +2212,9 @@ msgstr "Comment"
 msgid "Comments"
 msgstr "Comments"
 
+msgid "Commercial fonts such as Sassoon must also be installed or attached to the book for an exact match."
+msgstr "Fontes comerciais como Sassoon também devem estar instaladas ou anexadas ao livro para uma correspondência exata."
+
 msgid "Compare"
 msgstr "Comparar"
 
@@ -2189,6 +2229,9 @@ msgstr "Comparar versões"
 
 msgid "Compared with fallback prompt."
 msgstr "Comparado com o prompt fallback."
+
+#~ msgid "Complete the guided setup before starting the publishing workflow."
+#~ msgstr "Conclua a configuração guiada antes de iniciar o fluxo de publicação."
 
 msgid "Completed"
 msgstr "Concluído"
@@ -2244,6 +2287,12 @@ msgstr "Configure cada etapa — extração, storyboard, layout — e deixe o AD
 msgid "Configure features to include in the export"
 msgstr "Configure as funcionalidades a incluir na exportação"
 
+#~ msgid "Configure GitHub publishing"
+#~ msgstr "Configurar publicação no GitHub"
+
+#~ msgid "Configure GitHub to start publishing"
+#~ msgstr "Configure o GitHub para começar a publicar"
+
 #~ msgid "Configure provider credentials and global prompt fallbacks used by ADT Studio."
 #~ msgstr "Configure as credenciais dos provedores e os prompts fallback globais usados pelo ADT Studio."
 
@@ -2258,6 +2307,12 @@ msgstr "Configurar vozes e sotaques"
 
 msgid "Confirm merge"
 msgstr "Confirmar mesclagem"
+
+#~ msgid "Confirm the destination below. Publishing will open the live workflow screen automatically."
+#~ msgstr "Confirme o destino abaixo. A publicação abrirá automaticamente a tela do fluxo ao vivo."
+
+#~ msgid "Connect an account and choose a repository before running this workflow."
+#~ msgstr "Conecte uma conta e escolha um repositório antes de executar este fluxo."
 
 msgid "Connect an AI provider"
 msgstr "Conecte um provedor de IA"
@@ -2282,6 +2337,9 @@ msgstr "Processamento de Conteúdo"
 
 msgid "Contents"
 msgstr "Conteúdo"
+
+msgid "Contents — Read and write; Administration — Read and write; Pages — Read and write; Metadata — Read-only."
+msgstr "Conteúdo — Leitura e gravação; Administração — Leitura e gravação; Pages — Leitura e gravação; Metadados — Somente leitura."
 
 msgid "Context"
 msgstr "Contexto"
@@ -2446,6 +2504,9 @@ msgstr "Create a reviewer session for this book."
 msgid "Create ADT"
 msgstr "Criar ADT"
 
+#~ msgid "Create classic token on GitHub"
+#~ msgstr "Criar token clássico no GitHub"
+
 msgid "Create descriptive captions for images to improve accessibility."
 msgstr "Cria legendas descritivas para imagens para melhorar a acessibilidade."
 
@@ -2454,6 +2515,9 @@ msgstr "Criar arquivo"
 
 msgid "Create files"
 msgstr "Criar arquivos"
+
+#~ msgid "Create fine-grained token on GitHub"
+#~ msgstr "Criar token de acesso refinado no GitHub"
 
 msgid "Create from scratch using your description"
 msgstr "Criar do zero usando sua descrição"
@@ -2469,6 +2533,9 @@ msgstr "Criar arquivo de prompt a partir do template"
 
 msgid "Create session"
 msgstr "Create session"
+
+#~ msgid "Create the destination repository first, then select its owner and that repository as the token resource."
+#~ msgstr "Primeiro crie o repositório de destino e depois selecione o proprietário e esse repositório como recurso do token."
 
 msgid "Created {created} prompt files for {normalizedTargetModel}."
 msgstr "Criados {created} arquivos de prompt para {normalizedTargetModel}."
@@ -2532,6 +2599,9 @@ msgstr "Atual (v{currentVersion})"
 
 msgid "Current book font"
 msgstr "Fonte atual do livro"
+
+#~ msgid "Current book workspace"
+#~ msgstr "Espaço de trabalho atual do livro"
 
 msgid "Current effective values"
 msgstr "Current effective values"
@@ -3053,6 +3123,9 @@ msgstr "Cada iteração é uma chamada LLM. Valores menores são mais rápidos e
 msgid "Each kind of pipeline task uses a compatible model. Image generation and speech use their own task-specific defaults."
 msgstr "Cada tipo de tarefa do pipeline usa um modelo compatível. A geração de imagens e de fala usa seus próprios padrões específicos por tarefa."
 
+#~ msgid "Each node updates live as ADT Studio publishes the book."
+#~ msgstr "Cada nó é atualizado ao vivo enquanto o ADT Studio publica o livro."
+
 msgid "Each polyp secretes a hard calcium carbonate skeleton. Over hundreds of years, millions of these skeletons build up into the massive reef structures we see today."
 msgstr "Cada pólipo secreta um esqueleto duro de carbonato de cálcio. Ao longo de centenas de anos, milhões desses esqueletos formam as enormes estruturas de recifes que vemos hoje."
 
@@ -3070,6 +3143,9 @@ msgstr "As etapas anteriores ainda não foram executadas"
 
 msgid "Early"
 msgstr "Iniciante"
+
+msgid "Easiest complete setup"
+msgstr "Configuração completa mais fácil"
 
 msgid "Easy Read"
 msgstr "Leitura Fácil"
@@ -3591,6 +3667,9 @@ msgstr "Filtra imagens decorativas ou sem conteúdo em cada página."
 msgid "Final Page"
 msgstr "Página Final"
 
+msgid "Fine-grained token for an existing repository"
+msgstr "Token de acesso refinado para um repositório existente"
+
 msgid "First images from the deep-field telescope."
 msgstr "Primeiras imagens do telescópio de campo profundo."
 
@@ -3611,6 +3690,9 @@ msgstr "Layout fixo de duas colunas (template)"
 
 msgid "Fixed-layout books use the original page images as backgrounds with positioned text extracted from the PDF. Activities detection, figure extraction, and image cropping or segmentation don't apply to this layout."
 msgstr "Livros de layout fixo usam as imagens originais das páginas como fundo com texto posicionado extraído do PDF. Detecção de atividades, extração de figuras, recorte ou segmentação de imagens não se aplicam a este layout."
+
+msgid "Fixed-layout pages preserve the original book fonts."
+msgstr "Páginas de layout fixo preservam as fontes originais do livro."
 
 #~ msgid "Fixed, accessible sizes applied to every page. Sizes use the book's Tailwind scale (pick a token or type an exact px), scale fluidly between mobile and desktop, and override any size the AI picks — so headings and body text stay consistent across the whole book."
 #~ msgstr "Tamanhos fixos e acessíveis aplicados a todas as páginas. Os tamanhos usam a escala Tailwind do livro (escolha um token ou digite um valor exato em px), são dimensionados de forma fluida entre celular e desktop, e substituem qualquer tamanho escolhido pela IA — assim os títulos e o texto do corpo permanecem consistentes em todo o livro."
@@ -3747,8 +3829,8 @@ msgstr "Reunindo as evidências"
 msgid "Gemini"
 msgstr "Gemini"
 
-msgid "Gemini API key is required to generate audio."
-msgstr "É necessária uma chave de API do Gemini para gerar áudio."
+#~ msgid "Gemini API key is required to generate audio."
+#~ msgstr "É necessária uma chave de API do Gemini para gerar áudio."
 
 #~ msgid "Gemini generates each sentence in its own request, so its tone can drift between sentences. A lower temperature (e.g. 0.4) reduces that variation and a fixed seed makes delivery reproducible. Only affects languages routed to Gemini — OpenAI and Azure ignore these. Changing either value regenerates Gemini audio on the next run."
 #~ msgstr "O Gemini gera cada frase em sua própria requisição, então o tom pode variar entre as frases. Uma temperatura mais baixa (ex.: 0,4) reduz essa variação e uma semente fixa torna a leitura reproduzível. Afeta apenas os idiomas roteados para o Gemini — o OpenAI e o Azure ignoram esses valores. Alterar qualquer um deles regenera o áudio do Gemini na próxima execução."
@@ -3822,8 +3904,8 @@ msgstr "Gerar a partir das páginas"
 msgid "Generate global prompts"
 msgstr "Gerar prompts globais"
 
-msgid "Generate missing Gemini audio"
-msgstr "Gerar áudio faltante do Gemini"
+#~ msgid "Generate missing Gemini audio"
+#~ msgstr "Gerar áudio faltante do Gemini"
 
 msgid "Generate multiple-choice comprehension quizzes from the book's content. Create them automatically across the whole book, or add a single quiz from specific pages."
 msgstr "Gere questionários de compreensão de múltipla escolha a partir do conteúdo do livro. Crie-os automaticamente em todo o livro ou adicione um único questionário a partir de páginas específicas."
@@ -3919,6 +4001,9 @@ msgstr "Prompt de geração"
 
 msgid "Get started"
 msgstr "Começar"
+
+#~ msgid "Git publishing workflow"
+#~ msgstr "Fluxo de publicação Git"
 
 msgid "Global prompt reset to default."
 msgstr "Prompt global resetado para o padrão."
@@ -4552,6 +4637,9 @@ msgstr "Imagens grandes, fluxo narrativo. Melhor para livros ilustrados com voze
 #~ msgid "Last"
 #~ msgstr "Última"
 
+#~ msgid "Last activity"
+#~ msgstr "Última atividade"
+
 msgid "Last change"
 msgstr "Última alteração"
 
@@ -4560,6 +4648,12 @@ msgstr "Última modificação"
 
 #~ msgid "Last week"
 #~ msgstr "Semana passada"
+
+#~ msgid "Latest deployment"
+#~ msgstr "Implantação mais recente"
+
+#~ msgid "Latest GitHub changes synchronized."
+#~ msgstr "Alterações mais recentes do GitHub sincronizadas."
 
 msgid "Launch the app with"
 msgstr "Iniciar o aplicativo com"
@@ -4581,6 +4675,9 @@ msgstr "Layout espelhado nesta seção"
 
 msgid "Leading"
 msgstr "Entrelinha"
+
+#~ msgid "Learn how with a guided setup"
+#~ msgstr "Aprenda com uma configuração guiada"
 
 msgid "Least used"
 msgstr "Menos usado"
@@ -4732,6 +4829,9 @@ msgstr "Carregando livros..."
 msgid "Loading catalog..."
 msgstr "Carregando catálogo..."
 
+#~ msgid "Loading deployments"
+#~ msgstr "Carregando implantações"
+
 msgid "Loading Easy Read..."
 msgstr "Carregando Leitura Fácil..."
 
@@ -4824,6 +4924,12 @@ msgstr "Carregando..."
 
 msgid "Loading…"
 msgstr "Carregando…"
+
+#~ msgid "Local and GitHub changes need resolution before synchronization."
+#~ msgstr "As alterações locais e do GitHub precisam ser resolvidas antes da sincronização."
+
+#~ msgid "Local book is up to date."
+#~ msgstr "O livro local está atualizado."
 
 msgid "Localization"
 msgstr "Localização"
@@ -5267,6 +5373,9 @@ msgstr "Nova entrada"
 msgid "New session"
 msgstr "New session"
 
+msgid "New text"
+msgstr "Novo texto"
+
 #~ msgid "New version"
 #~ msgstr "Nova versão"
 
@@ -5679,8 +5788,14 @@ msgstr "ruído"
 msgid "None"
 msgstr "Nenhum"
 
+#~ msgid "Not committed yet"
+#~ msgstr "Ainda não confirmado"
+
 msgid "Not compatible with Fixed Layout"
 msgstr "Não compatível com Layout Fixo"
+
+#~ msgid "Not configured"
+#~ msgstr "Não configurado"
 
 msgid "Not detected"
 msgstr "Não detectado"
@@ -5855,6 +5970,9 @@ msgstr "Abrir pré-visualização da página {0}"
 msgid "Open Preview"
 msgstr "Open Preview"
 
+#~ msgid "Open public book"
+#~ msgstr "Abrir livro público"
+
 #. placeholder {0}: pullRequest.number
 msgid "Open pull request {0}"
 msgstr "Abrir pull request {0}"
@@ -5998,6 +6116,9 @@ msgstr "Em processamento"
 msgid "Out of date"
 msgstr "Desatualizado"
 
+msgid "Output font family"
+msgstr "Família de fontes de saída"
+
 msgid "Output languages"
 msgstr "Idiomas de saída"
 
@@ -6066,6 +6187,9 @@ msgstr "Empacote o livro para distribuição. Escolha um formato, decida o que v
 
 msgid "Package the finished book with every accessibility feature baked in — ready for a kid to open, listen, and read along."
 msgstr "Empacote o livro pronto com todos os recursos de acessibilidade integrados — pronto para uma criança abrir, ouvir e acompanhar a leitura."
+
+#~ msgid "Package, commit, push, host, and preview the accessible book without leaving ADT Studio."
+#~ msgstr "Empacote, confirme, publique, hospede e visualize o livro acessível sem sair do ADT Studio."
 
 msgid "Packaging"
 msgstr "Empacotando"
@@ -6642,11 +6766,20 @@ msgstr "Removido: {0}"
 msgid "PT"
 msgstr "PT"
 
+#~ msgid "Publish book"
+#~ msgstr "Publicar livro"
+
+#~ msgid "Publish with GitHub Pages"
+#~ msgstr "Publicar com GitHub Pages"
+
 msgid "published in"
 msgstr "publicado em"
 
 msgid "Publisher"
 msgstr "Editora"
+
+#~ msgid "Pull remote changes"
+#~ msgstr "Baixar alterações remotas"
 
 msgid "Pull requests"
 msgstr "Pull requests"
@@ -6893,6 +7026,9 @@ msgstr "Recomendado para"
 msgid "Recommended for {0}"
 msgstr "Recomendado para {0}"
 
+msgid "Recommended for creating a new repository"
+msgstr "Recomendado para criar um novo repositório"
+
 msgid "Record reviewer findings for the current page and save them to the active validation session."
 msgstr "Record reviewer findings for the current page and save them to the active validation session."
 
@@ -6935,6 +7071,10 @@ msgstr "Regenerar definição, variações e emoji"
 msgid "Regenerate Easy Read"
 msgstr "Regenerar Leitura Fácil"
 
+#. placeholder {0}: selectedAudioIds.size
+#~ msgid "Regenerate selected ({0})"
+#~ msgstr "Regenerar selecionados ({0})"
+
 msgid "Regenerate selected images for each output language so that any text burned into them is shown in the target language."
 msgstr "Regenera as imagens selecionadas para cada idioma de saída para que qualquer texto fixo nelas seja exibido no idioma de destino."
 
@@ -6964,6 +7104,12 @@ msgstr "Solte para enviar"
 
 msgid "Reload app"
 msgstr "Recarregar aplicativo"
+
+#~ msgid "Remote changes are available."
+#~ msgstr "Há alterações remotas disponíveis."
+
+#~ msgid "Remote changes available"
+#~ msgstr "Há alterações remotas disponíveis"
 
 msgid "Remove"
 msgstr "Remover"
@@ -7125,6 +7271,9 @@ msgstr "Restaurar a cor de destaque do livro"
 msgid "Reset zoom"
 msgstr "Redefinir zoom"
 
+msgid "Resize image"
+msgstr "Redimensionar imagem"
+
 msgid "Resize panel"
 msgstr "Redimensionar o painel"
 
@@ -7189,6 +7338,9 @@ msgstr "Revisar"
 #~ msgid "Review {selectedCount} selected"
 #~ msgstr "Revisar {selectedCount} selecionado(s)"
 
+#~ msgid "Review and publish"
+#~ msgstr "Revisar e publicar"
+
 msgid "Review and refine each simplified block side-by-side with the original before packaging."
 msgstr "Revise e refine cada bloco simplificado lado a lado com o original antes de empacotar."
 
@@ -7232,6 +7384,9 @@ msgstr "Rigor da revisão"
 
 msgid "Review style"
 msgstr "Estilo de revisão"
+
+#~ msgid "Review the most recent publishing workflow and open its public result."
+#~ msgstr "Revise o fluxo de publicação mais recente e abra seu resultado público."
 
 msgid "Review the project details below and confirm the import."
 msgstr "Revise os detalhes do projeto abaixo e confirme a importação."
@@ -7292,6 +7447,9 @@ msgstr "O aumento das temperaturas dos oceanos causa o branqueamento dos corais 
 
 msgid "Role"
 msgstr "Função"
+
+msgid "Rotate"
+msgstr "Girar"
 
 msgid "Row"
 msgstr "Linha"
@@ -7381,6 +7539,9 @@ msgstr "Executar Tradução"
 msgid "Run whole-book validation checks and configure accessibility assessment settings."
 msgstr "Run whole-book validation checks and configure accessibility assessment settings."
 
+#~ msgid "Run workflow"
+#~ msgstr "Executar fluxo"
+
 msgid "Run-only tags"
 msgstr "Run-only tags"
 
@@ -7447,6 +7608,9 @@ msgstr "Salvar atividade"
 msgid "Save activity (⌘S)"
 msgstr "Salvar atividade (⌘S)"
 
+#~ msgid "Save and publish"
+#~ msgstr "Salvar e publicar"
+
 msgid "Save changes"
 msgstr "Salvar alterações"
 
@@ -7467,6 +7631,9 @@ msgstr "Save checklist"
 
 msgid "Save failed"
 msgstr "Save failed"
+
+#~ msgid "Save or discard your edits before splitting"
+#~ msgstr "Salve ou descarte suas edições antes de dividir"
 
 msgid "Save or discard your edits first"
 msgstr "Salve ou descarte suas edições primeiro"
@@ -7685,6 +7852,12 @@ msgstr "seções"
 msgid "Sections"
 msgstr "Seções"
 
+msgid "Security: use the shortest practical expiration, never share the token, and revoke it in GitHub when it is no longer needed. ADT Studio keeps this token locally on this device and does not store it in the book directory."
+msgstr "Segurança: use a menor validade prática, nunca compartilhe o token e revogue-o no GitHub quando ele não for mais necessário. O ADT Studio mantém este token localmente neste dispositivo e não o armazena no diretório do livro."
+
+#~ msgid "Security: use the shortest practical expiration, never share the token, and revoke it in GitHub when it is no longer needed. ADT Studio keeps this token only for the current browser session and does not store it in the book directory."
+#~ msgstr "Segurança: use a menor validade prática, nunca compartilhe o token e revogue-o no GitHub quando não for mais necessário. O ADT Studio mantém esse token somente durante a sessão atual do navegador e não o armazena no diretório do livro."
+
 msgid "See examples"
 msgstr "Ver exemplos"
 
@@ -7808,6 +7981,9 @@ msgstr "Selecionar template..."
 msgid "Select the pages the quiz is written from, then choose where it appears using the buttons between pages."
 msgstr "Selecione as páginas em que o questionário se baseia e escolha onde ele aparece usando os botões entre as páginas."
 
+#~ msgid "Select the repo scope. It covers repository creation, file publishing, and GitHub Pages configuration."
+#~ msgstr "Selecione o escopo repo. Ele cobre a criação do repositório, a publicação de arquivos e a configuração do GitHub Pages."
+
 msgid "Select up to 5 pages to use as visual references. The LLM will analyze them and generate a styleguide."
 msgstr "Selecione até 5 páginas para usar como referências visuais. O LLM irá analisá-las e gerar um guia de estilo."
 
@@ -7867,8 +8043,11 @@ msgstr "Sessions"
 msgid "Sessions let different reviewers capture findings independently, including language-specific reviews."
 msgstr "Sessions let different reviewers capture findings independently, including language-specific reviews."
 
-msgid "Set a Gemini API key to generate audio"
-msgstr "Defina uma chave de API do Gemini para gerar áudio"
+#~ msgid "Set a Gemini API key to generate audio"
+#~ msgstr "Defina uma chave de API do Gemini para gerar áudio"
+
+msgid "Set Administration to Read and write so ADT can configure the repository and create the GitHub Pages site."
+msgstr "Defina Administração como Leitura e gravação para que o ADT possa configurar o repositório e criar o site do GitHub Pages."
 
 msgid "Set fonts for the whole book"
 msgstr "Definir fontes do livro todo"
@@ -8759,6 +8938,9 @@ msgstr "O índice."
 msgid "The TOC lists the typed sections placed by Storyboard. Finish Storyboard before running this stage."
 msgstr "O índice lista as seções classificadas colocadas pelo Storyboard. Termine o Storyboard antes de executar esta etapa."
 
+#~ msgid "The token needs repository contents, administration, and Pages permissions."
+#~ msgstr "O token precisa de permissões de conteúdo do repositório, administração e Pages."
+
 msgid "The Water Cycle"
 msgstr "O Ciclo da Água"
 
@@ -8815,6 +8997,9 @@ msgstr "Esta atividade não tem textos nem respostas endereçáveis. Gere-a nova
 
 msgid "This archive can't be opened safely"
 msgstr "Este arquivo não pode ser aberto com segurança"
+
+#~ msgid "This book asset will be included in the next commit."
+#~ msgstr "Este recurso do livro será incluído no próximo commit."
 
 msgid "This book has {pageCount} pages."
 msgstr "Este livro tem {pageCount} páginas."
@@ -9103,6 +9288,9 @@ msgstr "Total de tokens"
 msgid "Track reviewer progress and review findings captured from Preview."
 msgstr "Track reviewer progress and review findings captured from Preview."
 
+#~ msgid "Track the book's local edits, commits, publishing status, and GitHub metadata."
+#~ msgstr "Acompanhe as edições locais, commits, status de publicação e metadados do GitHub do livro."
+
 msgid "Translate"
 msgstr "Traduzir"
 
@@ -9292,6 +9480,9 @@ msgstr "Não foi possível salvar o prompt global."
 msgid "Unable to select prompt version."
 msgstr "Não foi possível selecionar a versão do prompt."
 
+msgid "Unable to update the book font."
+msgstr "Não foi possível atualizar a fonte do livro."
+
 msgid "Unable to update the book model overrides."
 msgstr "Não foi possível atualizar as substituições de modelos do livro."
 
@@ -9318,6 +9509,9 @@ msgstr "Uncategorized"
 
 msgid "Unchanged"
 msgstr "Inalterado"
+
+#~ msgid "Under Repository permissions, grant Contents, Administration, and Pages read and write access."
+#~ msgstr "Em Permissões do repositório, conceda acesso de leitura e gravação a Contents, Administration e Pages."
 
 msgid "Underline"
 msgstr "Sublinhado"
@@ -9475,6 +9669,9 @@ msgstr "Usar como template"
 msgid "Use Liquid syntax to interpolate variables, loop over arrays, and conditionally include instructions in this prompt."
 msgstr "Use a sintaxe Liquid para interpolar variáveis, percorrer arrays e incluir instruções condicionalmente neste prompt."
 
+msgid "Use one accessible font throughout generated, reflowable pages. You can change it later from the book toolbar."
+msgstr "Use uma fonte acessível em todas as páginas geradas e responsivas. Você pode alterá-la depois na barra do livro."
+
 #. placeholder {0}: page.pageNumber
 msgid "Use page {0} for the quiz"
 msgstr "Usar a página {0} para o questionário"
@@ -9609,6 +9806,9 @@ msgstr "Ver"
 
 #~ msgid "View all changes"
 #~ msgstr "Ver todas as alterações"
+
+#~ msgid "View deployment"
+#~ msgstr "Ver implantação"
 
 msgid "View details"
 msgstr "Ver detalhes"
@@ -9848,6 +10048,9 @@ msgstr "Destaque por palavra"
 msgid "words"
 msgstr "palavras"
 
+#~ msgid "Workspace changes"
+#~ msgstr "Alterações do espaço de trabalho"
+
 msgid "Wrap in group"
 msgstr "Envolver em grupo"
 
@@ -9933,42 +10136,3 @@ msgstr "Aproximar"
 
 msgid "Zoom out"
 msgstr "Afastar"
-
-msgid "Add shape"
-msgstr "Adicionar forma"
-
-msgid "Automatic — match book"
-msgstr "Automática — combinar com o livro"
-
-msgid "Automatic — match the book"
-msgstr "Automática — combinar com o livro"
-
-msgid "Book font updated."
-msgstr "Fonte do livro atualizada."
-
-msgid "Change the font across generated book pages."
-msgstr "Alterar a fonte nas páginas geradas do livro."
-
-msgid "Commercial fonts such as Sassoon must also be installed or attached to the book for an exact match."
-msgstr "Fontes comerciais como Sassoon também devem estar instaladas ou anexadas ao livro para uma correspondência exata."
-
-msgid "Fixed-layout pages preserve the original book fonts."
-msgstr "Páginas de layout fixo preservam as fontes originais do livro."
-
-msgid "New text"
-msgstr "Novo texto"
-
-msgid "Output font family"
-msgstr "Família de fontes de saída"
-
-msgid "Resize image"
-msgstr "Redimensionar imagem"
-
-msgid "Rotate"
-msgstr "Girar"
-
-msgid "Unable to update the book font."
-msgstr "Não foi possível atualizar a fonte do livro."
-
-msgid "Use one accessible font throughout generated, reflowable pages. You can change it later from the book toolbar."
-msgstr "Use uma fonte acessível em todas as páginas geradas e responsivas. Você pode alterá-la depois na barra do livro."

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -1297,6 +1297,9 @@ msgstr "e muitos mais blocos em todo o livro"
 msgid "and more sections across the page"
 msgstr "e mais seções na página"
 
+msgid "Angle"
+msgstr "Ângulo"
+
 msgid "Answer"
 msgstr "Resposta"
 
@@ -1685,6 +1688,9 @@ msgstr "Etapas de criação do livro"
 msgid "Book data is outdated and must be rebuilt."
 msgstr "Os dados do livro estão desatualizados e precisam ser reconstruídos."
 
+msgid "Book design"
+msgstr "Design do livro"
+
 msgid "Book font updated."
 msgstr "Fonte do livro atualizada."
 
@@ -2068,6 +2074,9 @@ msgstr "Escolha como o conteúdo deve ser formatado."
 msgid "Choose images..."
 msgstr "Escolher imagens..."
 
+msgid "Choose one accessible font family for all reflowable storyboard pages."
+msgstr "Escolha uma família de fontes acessível para todas as páginas responsivas do storyboard."
+
 msgid "Choose Provider"
 msgstr "Escolher provedor"
 
@@ -2157,6 +2166,9 @@ msgstr "Clone failed"
 
 msgid "Close"
 msgstr "Close"
+
+msgid "Close book design"
+msgstr "Fechar design do livro"
 
 msgid "Close edit panel"
 msgstr "Fechar painel de edição"
@@ -3669,6 +3681,9 @@ msgstr "Página Final"
 
 msgid "Fine-grained token for an existing repository"
 msgstr "Token de acesso refinado para um repositório existente"
+
+msgid "Finish layout"
+msgstr "Finalizar layout"
 
 msgid "First images from the deep-field telescope."
 msgstr "Primeiras imagens do telescópio de campo profundo."
@@ -6607,6 +6622,9 @@ msgstr "Posição"
 msgid "Position {0}, {1} → {2}×{3} pt"
 msgstr "Posição {0}, {1} → {2}×{3} pt"
 
+msgid "Position for {deviceView}"
+msgstr "Posição para {deviceView}"
+
 msgid "Práticas de Alfabetização e de Matemática"
 msgstr "Práticas de Alfabetização e de Matemática"
 
@@ -9261,6 +9279,9 @@ msgstr "Pré-visualização do Sumário"
 #~ msgid "Today"
 #~ msgstr "Hoje"
 
+msgid "Toggle canvas editing mode"
+msgstr "Alternar modo de edição da tela"
+
 msgid "Toggle model list"
 msgstr "Alternar lista de modelos"
 
@@ -10069,6 +10090,12 @@ msgstr "Escreva sua frase com um marcador {0}."
 
 #~ msgid "Yesterday"
 #~ msgstr "Ontem"
+
+msgid "X position"
+msgstr "Posição X"
+
+msgid "Y position"
+msgstr "Posição Y"
 
 #. placeholder {0}: formatVersion(release.version)
 msgid "You are about to install {0}. Books or settings edited with a newer version may not work as expected. Back up your books before continuing."

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -9933,3 +9933,42 @@ msgstr "Aproximar"
 
 msgid "Zoom out"
 msgstr "Afastar"
+
+msgid "Add shape"
+msgstr "Adicionar forma"
+
+msgid "Automatic — match book"
+msgstr "Automática — combinar com o livro"
+
+msgid "Automatic — match the book"
+msgstr "Automática — combinar com o livro"
+
+msgid "Book font updated."
+msgstr "Fonte do livro atualizada."
+
+msgid "Change the font across generated book pages."
+msgstr "Alterar a fonte nas páginas geradas do livro."
+
+msgid "Commercial fonts such as Sassoon must also be installed or attached to the book for an exact match."
+msgstr "Fontes comerciais como Sassoon também devem estar instaladas ou anexadas ao livro para uma correspondência exata."
+
+msgid "Fixed-layout pages preserve the original book fonts."
+msgstr "Páginas de layout fixo preservam as fontes originais do livro."
+
+msgid "New text"
+msgstr "Novo texto"
+
+msgid "Output font family"
+msgstr "Família de fontes de saída"
+
+msgid "Resize image"
+msgstr "Redimensionar imagem"
+
+msgid "Rotate"
+msgstr "Girar"
+
+msgid "Unable to update the book font."
+msgstr "Não foi possível atualizar a fonte do livro."
+
+msgid "Use one accessible font throughout generated, reflowable pages. You can change it later from the book toolbar."
+msgstr "Use uma fonte acessível em todas as páginas geradas e responsivas. Você pode alterá-la depois na barra do livro."

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -9934,3 +9934,42 @@ msgstr "Zmadhim"
 
 msgid "Zoom out"
 msgstr "Zvogëlim"
+
+msgid "Add shape"
+msgstr "Shto formë"
+
+msgid "Automatic — match book"
+msgstr "Automatik — përshtatu me librin"
+
+msgid "Automatic — match the book"
+msgstr "Automatik — përshtatu me librin"
+
+msgid "Book font updated."
+msgstr "Shkronja e librit u përditësua."
+
+msgid "Change the font across generated book pages."
+msgstr "Ndrysho shkronjën në faqet e gjeneruara të librit."
+
+msgid "Commercial fonts such as Sassoon must also be installed or attached to the book for an exact match."
+msgstr "Shkronjat komerciale si Sassoon duhet gjithashtu të instalohen ose t’i bashkëngjiten librit për përputhje të saktë."
+
+msgid "Fixed-layout pages preserve the original book fonts."
+msgstr "Faqet me strukturë fikse ruajnë shkronjat origjinale të librit."
+
+msgid "New text"
+msgstr "Tekst i ri"
+
+msgid "Output font family"
+msgstr "Familja e shkronjave të daljes"
+
+msgid "Resize image"
+msgstr "Ndrysho madhësinë e figurës"
+
+msgid "Rotate"
+msgstr "Rrotullo"
+
+msgid "Unable to update the book font."
+msgstr "Shkronja e librit nuk mund të përditësohej."
+
+msgid "Use one accessible font throughout generated, reflowable pages. You can change it later from the book toolbar."
+msgstr "Përdorni një shkronjë të qasshme në të gjitha faqet e gjeneruara dhe të rrjedhshme. Mund ta ndryshoni më vonë nga shiriti i librit."

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -3845,8 +3845,8 @@ msgstr "Mbledhja e dëshmive"
 msgid "Gemini"
 msgstr "Gemini"
 
-#~ msgid "Gemini API key is required to generate audio."
-#~ msgstr "Çelësi API i Gemini është i nevojshëm për të gjeneruar audio."
+msgid "Gemini API key is required to generate audio."
+msgstr "Kërkohet një çelës API Gemini për të gjeneruar audio."
 
 #~ msgid "Gemini generates each sentence in its own request, so its tone can drift between sentences. A lower temperature (e.g. 0.4) reduces that variation and a fixed seed makes delivery reproducible. Only affects languages routed to Gemini — OpenAI and Azure ignore these. Changing either value regenerates Gemini audio on the next run."
 #~ msgstr "Gemini e gjeneron çdo fjali në kërkesën e vet, prandaj toni mund të ndryshojë nga një fjali te tjetra. Një temperaturë më e ulët (p.sh. 0.4) e zvogëlon këtë variacion dhe një farë e fiksuar e bën leximin të riprodhueshëm. Prek vetëm gjuhët e drejtuara te Gemini — OpenAI dhe Azure i shpërfillin. Ndryshimi i secilës vlerë e rigjeneron audion e Gemini në ekzekutimin e ardhshëm."
@@ -3920,8 +3920,8 @@ msgstr "Gjenero nga faqet"
 msgid "Generate global prompts"
 msgstr "Gjenero prompt-e globale"
 
-#~ msgid "Generate missing Gemini audio"
-#~ msgstr "Gjenero audion Gemini që mungon"
+msgid "Generate missing Gemini audio"
+msgstr "Gjenero audion Gemini që mungon"
 
 msgid "Generate multiple-choice comprehension quizzes from the book's content. Create them automatically across the whole book, or add a single quiz from specific pages."
 msgstr "Gjenero kuize me zgjedhje të shumëfishta nga përmbajtja e librit. Krijo ato automatikisht në të gjithë librin ose shto një kuiz të vetëm nga faqe specifike."
@@ -8062,8 +8062,8 @@ msgstr "Sesione"
 msgid "Sessions let different reviewers capture findings independently, including language-specific reviews."
 msgstr "Sesionet u lejojnë rishikuesve të ndryshëm të regjistrojnë gjetjet në mënyrë të pavarur, duke përfshirë rishikimet specifike për gjuhë."
 
-#~ msgid "Set a Gemini API key to generate audio"
-#~ msgstr "Vendosni një çelës API Gemini për të gjeneruar audio"
+msgid "Set a Gemini API key to generate audio"
+msgstr "Vendosni një çelës API Gemini për të gjeneruar audio"
 
 msgid "Set Administration to Read and write so ADT can configure the repository and create the GitHub Pages site."
 msgstr "Vendosni Administrimin në Lexim dhe shkrim që ADT të konfigurojë depon dhe të krijojë faqen GitHub Pages."

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -1298,6 +1298,9 @@ msgstr "dhe shumë blloqe të tjera në të gjithë librin"
 msgid "and more sections across the page"
 msgstr "dhe seksione të tjera në faqe"
 
+msgid "Angle"
+msgstr "Këndi"
+
 msgid "Answer"
 msgstr "Përgjigje"
 
@@ -1686,6 +1689,9 @@ msgstr "Fazat e krijimit të librit"
 msgid "Book data is outdated and must be rebuilt."
 msgstr "Të dhënat e librit janë të vjetruara dhe duhet të rindërtohen."
 
+msgid "Book design"
+msgstr "Dizajni i librit"
+
 msgid "Book font updated."
 msgstr "Shkronja e librit u përditësua."
 
@@ -2069,6 +2075,9 @@ msgstr "Zgjidhni si duhet të formatohet përmbajtja."
 msgid "Choose images..."
 msgstr "Zgjidhni imazhe..."
 
+msgid "Choose one accessible font family for all reflowable storyboard pages."
+msgstr "Zgjidhni një familje shkronjash të qasshme për të gjitha faqet e rrjedhshme të skenarit."
+
 msgid "Choose Provider"
 msgstr "Zgjidhni Ofruesin"
 
@@ -2158,6 +2167,9 @@ msgstr "Klonifikimi dështoi"
 
 msgid "Close"
 msgstr "Mbyll"
+
+msgid "Close book design"
+msgstr "Mbyll dizajnin e librit"
 
 msgid "Close edit panel"
 msgstr "Mbyll panelin e redaktimit"
@@ -3670,6 +3682,9 @@ msgstr "Faqja e fundit"
 
 msgid "Fine-grained token for an existing repository"
 msgstr "Token i detajuar për një depo ekzistuese"
+
+msgid "Finish layout"
+msgstr "Përfundo paraqitjen"
 
 msgid "First images from the deep-field telescope."
 msgstr "Imazhet e para nga teleskopi i fushës së thellë."
@@ -6608,6 +6623,9 @@ msgstr "Pozicioni"
 msgid "Position {0}, {1} → {2}×{3} pt"
 msgstr "Pozicioni {0}, {1} → {2}×{3} pt"
 
+msgid "Position for {deviceView}"
+msgstr "Pozicioni për {deviceView}"
+
 msgid "Práticas de Alfabetização e de Matemática"
 msgstr "Práticas de Alfabetização e de Matemática"
 
@@ -9262,6 +9280,9 @@ msgstr "Paraparimimi TOC"
 #~ msgid "Today"
 #~ msgstr "Sot"
 
+msgid "Toggle canvas editing mode"
+msgstr "Ndrysho mënyrën e redaktimit të kanavacës"
+
 msgid "Toggle model list"
 msgstr "Ndrysho listën e modeleve"
 
@@ -10070,6 +10091,12 @@ msgstr "Shkruani fjalinë tuaj me një shënues {0}."
 
 #~ msgid "Yesterday"
 #~ msgstr "Dje"
+
+msgid "X position"
+msgstr "Pozicioni X"
+
+msgid "Y position"
+msgstr "Pozicioni Y"
 
 #. placeholder {0}: formatVersion(release.version)
 msgid "You are about to install {0}. Books or settings edited with a newer version may not work as expected. Back up your books before continuing."

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -264,6 +264,10 @@ msgstr "{0} tekste"
 msgid "{0} translations"
 msgstr "{0} përkthime"
 
+#. placeholder {0}: changesQuery.data.changes.length
+#~ msgid "{0} unpublished file changes"
+#~ msgstr "{0} ndryshime skedarësh të papublikuara"
+
 #. placeholder {0}: versions.length
 #~ msgid "{0} versions"
 #~ msgstr "{0} versione"
@@ -822,6 +826,9 @@ msgstr "Aktivitet: Zgjedhje e Shumëfishtë"
 msgid "Activity: Open-Ended Answer"
 msgstr "Aktivitet: Përgjigje e Hapur"
 
+#~ msgid "Activity: Ordering"
+#~ msgstr "Aktivitet: Renditje"
+
 msgid "Activity: Other"
 msgstr "Aktivitet: Tjetër"
 
@@ -984,6 +991,9 @@ msgstr "Shto udhëzime për rishikuesin."
 
 msgid "Add section"
 msgstr "Shto seksion"
+
+msgid "Add shape"
+msgstr "Shto formë"
 
 msgid "Add sign language video"
 msgstr "Shto video në gjuhën e shenjave"
@@ -1261,6 +1271,9 @@ msgstr "Sasia"
 msgid "An activity that does not fit the standard categories."
 msgstr "Një aktivitet që nuk i përshtatet kategorive standarde."
 
+#~ msgid "An activity where learners arrange items into the correct order."
+#~ msgstr "Një aktivitet ku nxënësit i vendosin elementet në rendin e duhur."
+
 msgid "An activity where the learner underlines one or more words, phrases, or sentences directly in the text."
 msgstr "Një aktivitet ku nxënësi nënvizon një ose më shumë fjalë, fraza ose fjali drejtpërdrejt në tekst."
 
@@ -1500,6 +1513,12 @@ msgstr "Plotëso automatikisht nga konteksti i librit"
 msgid "Auto-scroll"
 msgstr "Lëvizje automatike"
 
+msgid "Automatic — match book"
+msgstr "Automatik — përshtatu me librin"
+
+msgid "Automatic — match the book"
+msgstr "Automatik — përshtatu me librin"
+
 msgid "Automatically adapts the layout based on each page's content using AI."
 msgstr "Përshtaton automatikisht paraqitjen bazuar në përmbajtjen e çdo faqeje duke përdorur AI."
 
@@ -1655,6 +1674,9 @@ msgstr "Teksti kryesor përdor këtë font sot. Bashkëngjitni një font më pos
 msgid "Book"
 msgstr "Libër"
 
+#~ msgid "Book change history"
+#~ msgstr "Historiku i ndryshimeve të librit"
+
 msgid "Book coverage"
 msgstr "Mbulimi i librit"
 
@@ -1664,6 +1686,9 @@ msgstr "Fazat e krijimit të librit"
 msgid "Book data is outdated and must be rebuilt."
 msgstr "Të dhënat e librit janë të vjetruara dhe duhet të rindërtohen."
 
+msgid "Book font updated."
+msgstr "Shkronja e librit u përditësua."
+
 msgid "Book Fonts"
 msgstr "Fontet e librit"
 
@@ -1672,6 +1697,9 @@ msgstr "Figurat e librit"
 
 msgid "Book info"
 msgstr "Info libri"
+
+#~ msgid "Book is published"
+#~ msgstr "Libri është publikuar"
 
 msgid "Book Language"
 msgstr "Gjuha e librit"
@@ -1927,8 +1955,14 @@ msgstr "Ndrysho Presetin"
 msgid "Change the book language?"
 msgstr "Të ndryshohet gjuha e librit?"
 
+msgid "Change the font across generated book pages."
+msgstr "Ndrysho shkronjën në faqet e gjeneruara të librit."
+
 msgid "Change the picture for this term"
 msgstr "Ndrysho figurën e këtij termi"
+
+#~ msgid "Changed files"
+#~ msgstr "Skedarë të ndryshuar"
 
 #~ msgid "Changes apply the next time you run Storyboard and Export."
 #~ msgstr "Ndryshimet zbatohen herën tjetër që ekzekutoni Storyboard dhe Eksportin."
@@ -1974,6 +2008,9 @@ msgstr "Titulli i kapitullit"
 
 msgid "Chart / Graph"
 msgstr "Tabelë / Grafik"
+
+#~ msgid "Check changes"
+#~ msgstr "Kontrollo ndryshimet"
 
 #~ msgid "Check for updates"
 #~ msgstr "Kontrollo për përditësime"
@@ -2176,6 +2213,9 @@ msgstr "Koment"
 msgid "Comments"
 msgstr "Komente"
 
+msgid "Commercial fonts such as Sassoon must also be installed or attached to the book for an exact match."
+msgstr "Shkronjat komerciale si Sassoon duhet gjithashtu të instalohen ose t’i bashkëngjiten librit për përputhje të saktë."
+
 msgid "Compare"
 msgstr "Krahaso"
 
@@ -2190,6 +2230,9 @@ msgstr "Krahaso versionet"
 
 msgid "Compared with fallback prompt."
 msgstr "Krahasuar me prompt-in fallback."
+
+#~ msgid "Complete the guided setup before starting the publishing workflow."
+#~ msgstr "Përfundoni konfigurimin e udhëzuar para se të nisni rrjedhën e publikimit."
 
 msgid "Completed"
 msgstr "Përfunduar"
@@ -2245,6 +2288,12 @@ msgstr "Konfiguroni çdo fazë — ekstraktim, storyboard, faqosje — pastaj l�
 msgid "Configure features to include in the export"
 msgstr "Konfiguroni funksionet për t'i përfshirë në eksportim"
 
+#~ msgid "Configure GitHub publishing"
+#~ msgstr "Konfiguro publikimin në GitHub"
+
+#~ msgid "Configure GitHub to start publishing"
+#~ msgstr "Konfiguroni GitHub-in për të filluar publikimin"
+
 #~ msgid "Configure provider credentials and global prompt fallbacks used by ADT Studio."
 #~ msgstr "Konfiguro kredencialet e ofruesve dhe promptet globale fallback që përdor ADT Studio."
 
@@ -2259,6 +2308,12 @@ msgstr "Konfiguroni zërat dhe thekset"
 
 msgid "Confirm merge"
 msgstr "Konfirmoni bashkimin"
+
+#~ msgid "Confirm the destination below. Publishing will open the live workflow screen automatically."
+#~ msgstr "Konfirmoni destinacionin më poshtë. Publikimi do ta hapë automatikisht ekranin e rrjedhës së drejtpërdrejtë."
+
+#~ msgid "Connect an account and choose a repository before running this workflow."
+#~ msgstr "Lidhni një llogari dhe zgjidhni një depo para se ta ekzekutoni këtë rrjedhë."
 
 msgid "Connect an AI provider"
 msgstr "Lidheni një ofrues AI"
@@ -2283,6 +2338,9 @@ msgstr "Përpunim Përmbajtjeje"
 
 msgid "Contents"
 msgstr "Përmbajtja"
+
+msgid "Contents — Read and write; Administration — Read and write; Pages — Read and write; Metadata — Read-only."
+msgstr "Përmbajtja — Lexim dhe shkrim; Administrimi — Lexim dhe shkrim; Pages — Lexim dhe shkrim; Metadata — Vetëm lexim."
 
 msgid "Context"
 msgstr "Konteksti"
@@ -2447,6 +2505,9 @@ msgstr "Krijoni një sesion rishikuesi për këtë libër."
 msgid "Create ADT"
 msgstr "Krijo ADT"
 
+#~ msgid "Create classic token on GitHub"
+#~ msgstr "Krijo token klasik në GitHub"
+
 msgid "Create descriptive captions for images to improve accessibility."
 msgstr "Krijoni përshkrime përshkruese për imazhet për të përmirësuar aksesueshmërinë."
 
@@ -2455,6 +2516,9 @@ msgstr "Krijo skedar"
 
 msgid "Create files"
 msgstr "Krijo skedarë"
+
+#~ msgid "Create fine-grained token on GitHub"
+#~ msgstr "Krijo token të detajuar në GitHub"
 
 msgid "Create from scratch using your description"
 msgstr "Krijo nga e para duke përdorur përshkrimin tuaj"
@@ -2470,6 +2534,9 @@ msgstr "Krijo skedar prompti nga shablloni"
 
 msgid "Create session"
 msgstr "Krijo sesion"
+
+#~ msgid "Create the destination repository first, then select its owner and that repository as the token resource."
+#~ msgstr "Fillimisht krijoni depon e destinacionit, pastaj zgjidhni pronarin dhe atë depo si burim të tokenit."
 
 msgid "Created {created} prompt files for {normalizedTargetModel}."
 msgstr "U krijuan {created} skedarë prompti për {normalizedTargetModel}."
@@ -2533,6 +2600,9 @@ msgstr "Aktual (v{currentVersion})"
 
 msgid "Current book font"
 msgstr "Fonti aktual i librit"
+
+#~ msgid "Current book workspace"
+#~ msgstr "Hapësira aktuale e punës së librit"
 
 msgid "Current effective values"
 msgstr "Vlerat aktuale efektive"
@@ -3054,6 +3124,9 @@ msgstr "Çdo iteracion është një thirrje LLM. Vlerat e ulëta janë më të s
 msgid "Each kind of pipeline task uses a compatible model. Image generation and speech use their own task-specific defaults."
 msgstr "Çdo lloj detyre në rrjedhën e punës përdor një model të përshtatshëm. Gjenerimi i imazheve dhe i të folurit përdorin modelet e veta të parazgjedhura sipas detyrës."
 
+#~ msgid "Each node updates live as ADT Studio publishes the book."
+#~ msgstr "Çdo nyje përditësohet drejtpërdrejt ndërsa ADT Studio publikon librin."
+
 msgid "Each polyp secretes a hard calcium carbonate skeleton. Over hundreds of years, millions of these skeletons build up into the massive reef structures we see today."
 msgstr "Çdo polip sekreton një skelet të fortë karbonati kalciumi. Gjatë qindra viteve, miliona prej këtyre skeletve grumbullohen duke formuar strukturat masive të rifeve që shohim sot."
 
@@ -3071,6 +3144,9 @@ msgstr "Fazat e mëhershme nuk janë ekzekutuar ende"
 
 msgid "Early"
 msgstr "Herët"
+
+msgid "Easiest complete setup"
+msgstr "Konfigurimi i plotë më i lehtë"
 
 msgid "Easy Read"
 msgstr "Easy Read"
@@ -3592,6 +3668,9 @@ msgstr "Filtron imazhet dekorative ose pa përmbajtje nga çdo faqe."
 msgid "Final Page"
 msgstr "Faqja e fundit"
 
+msgid "Fine-grained token for an existing repository"
+msgstr "Token i detajuar për një depo ekzistuese"
+
 msgid "First images from the deep-field telescope."
 msgstr "Imazhet e para nga teleskopi i fushës së thellë."
 
@@ -3612,6 +3691,9 @@ msgstr "Paraqitje e fiksuar me dy kolona"
 
 msgid "Fixed-layout books use the original page images as backgrounds with positioned text extracted from the PDF. Activities detection, figure extraction, and image cropping or segmentation don't apply to this layout."
 msgstr "Librat me paraqitje të fiksuar përdorin imazhet origjinale të faqeve si sfond me tekst të pozicionuar të nxjerrë nga PDF-i. Zbulimi i aktiviteteve, nxjerrja e figurave dhe prerja ose segmentimi i imazheve nuk zbatohen për këtë paraqitje."
+
+msgid "Fixed-layout pages preserve the original book fonts."
+msgstr "Faqet me strukturë fikse ruajnë shkronjat origjinale të librit."
 
 #~ msgid "Fixed, accessible sizes applied to every page. Sizes use the book's Tailwind scale (pick a token or type an exact px), scale fluidly between mobile and desktop, and override any size the AI picks — so headings and body text stay consistent across the whole book."
 #~ msgstr "Madhësi fikse dhe të aksesueshme që zbatohen në çdo faqe. Madhësitë përdorin shkallën Tailwind të librit (zgjidhni një token ose shkruani një vlerë të saktë në px), shkallëzohen në mënyrë të rrjedhshme mes celularit dhe desktopit, dhe mbizotërojnë çdo madhësi që zgjedh IA-ja — kështu titujt dhe teksti i trupit mbeten të qëndrueshëm në të gjithë librin."
@@ -3748,8 +3830,8 @@ msgstr "Mbledhja e dëshmive"
 msgid "Gemini"
 msgstr "Gemini"
 
-msgid "Gemini API key is required to generate audio."
-msgstr "Çelësi API i Gemini është i nevojshëm për të gjeneruar audio."
+#~ msgid "Gemini API key is required to generate audio."
+#~ msgstr "Çelësi API i Gemini është i nevojshëm për të gjeneruar audio."
 
 #~ msgid "Gemini generates each sentence in its own request, so its tone can drift between sentences. A lower temperature (e.g. 0.4) reduces that variation and a fixed seed makes delivery reproducible. Only affects languages routed to Gemini — OpenAI and Azure ignore these. Changing either value regenerates Gemini audio on the next run."
 #~ msgstr "Gemini e gjeneron çdo fjali në kërkesën e vet, prandaj toni mund të ndryshojë nga një fjali te tjetra. Një temperaturë më e ulët (p.sh. 0.4) e zvogëlon këtë variacion dhe një farë e fiksuar e bën leximin të riprodhueshëm. Prek vetëm gjuhët e drejtuara te Gemini — OpenAI dhe Azure i shpërfillin. Ndryshimi i secilës vlerë e rigjeneron audion e Gemini në ekzekutimin e ardhshëm."
@@ -3823,8 +3905,8 @@ msgstr "Gjenero nga faqet"
 msgid "Generate global prompts"
 msgstr "Gjenero prompt-e globale"
 
-msgid "Generate missing Gemini audio"
-msgstr "Gjenero audion Gemini që mungon"
+#~ msgid "Generate missing Gemini audio"
+#~ msgstr "Gjenero audion Gemini që mungon"
 
 msgid "Generate multiple-choice comprehension quizzes from the book's content. Create them automatically across the whole book, or add a single quiz from specific pages."
 msgstr "Gjenero kuize me zgjedhje të shumëfishta nga përmbajtja e librit. Krijo ato automatikisht në të gjithë librin ose shto një kuiz të vetëm nga faqe specifike."
@@ -3920,6 +4002,9 @@ msgstr "Prompt Gjenerimi"
 
 msgid "Get started"
 msgstr "Filloni"
+
+#~ msgid "Git publishing workflow"
+#~ msgstr "Rrjedha e publikimit Git"
 
 msgid "Global prompt reset to default."
 msgstr "Prompti global u resetua në parazgjedhje."
@@ -4553,6 +4638,9 @@ msgstr "Imazhe të mëdha, rrjedhje narrative. Më i miri për libra të ilustru
 #~ msgid "Last"
 #~ msgstr "I fundit"
 
+#~ msgid "Last activity"
+#~ msgstr "Aktiviteti i fundit"
+
 msgid "Last change"
 msgstr "Ndryshimi i fundit"
 
@@ -4561,6 +4649,12 @@ msgstr "Modifikuar së fundmi"
 
 #~ msgid "Last week"
 #~ msgstr "Java e kaluar"
+
+#~ msgid "Latest deployment"
+#~ msgstr "Publikimi më i fundit"
+
+#~ msgid "Latest GitHub changes synchronized."
+#~ msgstr "Ndryshimet më të fundit të GitHub u sinkronizuan."
 
 msgid "Launch the app with"
 msgstr "Hap aplikacionin me"
@@ -4582,6 +4676,9 @@ msgstr "Struktura u pasqyrua në këtë seksion"
 
 msgid "Leading"
 msgstr "Hapësira ndër-rreshta"
+
+#~ msgid "Learn how with a guided setup"
+#~ msgstr "Mësoni me konfigurimin e udhëzuar"
 
 msgid "Least used"
 msgstr "Më pak i përdorur"
@@ -4733,6 +4830,9 @@ msgstr "Duke ngarkuar librat..."
 msgid "Loading catalog..."
 msgstr "Duke ngarkuar katalogun..."
 
+#~ msgid "Loading deployments"
+#~ msgstr "Duke ngarkuar publikimet"
+
 msgid "Loading Easy Read..."
 msgstr "Duke ngarkuar Leximin e Lehtë..."
 
@@ -4825,6 +4925,12 @@ msgstr "Duke ngarkuar..."
 
 msgid "Loading…"
 msgstr "Duke ngarkuar…"
+
+#~ msgid "Local and GitHub changes need resolution before synchronization."
+#~ msgstr "Ndryshimet lokale dhe ato në GitHub duhet të zgjidhen para sinkronizimit."
+
+#~ msgid "Local book is up to date."
+#~ msgstr "Libri lokal është i përditësuar."
 
 msgid "Localization"
 msgstr "Lokalizim"
@@ -5268,6 +5374,9 @@ msgstr "Hyrje e re"
 msgid "New session"
 msgstr "Sesion i ri"
 
+msgid "New text"
+msgstr "Tekst i ri"
+
 #~ msgid "New version"
 #~ msgstr "Version i ri"
 
@@ -5680,8 +5789,14 @@ msgstr "zhurmë"
 msgid "None"
 msgstr "Asnjë"
 
+#~ msgid "Not committed yet"
+#~ msgstr "Ende pa commit"
+
 msgid "Not compatible with Fixed Layout"
 msgstr "I papajtueshëm me Paraqitjen e fiksuar"
+
+#~ msgid "Not configured"
+#~ msgstr "I pakonfiguruar"
 
 msgid "Not detected"
 msgstr "Nuk u zbulua"
@@ -5856,6 +5971,9 @@ msgstr "Hapni pamjen paraprake të faqes për {pageId}"
 msgid "Open Preview"
 msgstr "Hapni Pamjen Paraprake"
 
+#~ msgid "Open public book"
+#~ msgstr "Hap librin publik"
+
 #. placeholder {0}: pullRequest.number
 msgid "Open pull request {0}"
 msgstr "Hap pull request-in {0}"
@@ -5999,6 +6117,9 @@ msgstr "Në përpunim"
 msgid "Out of date"
 msgstr "I vjetëruar"
 
+msgid "Output font family"
+msgstr "Familja e shkronjave të daljes"
+
 msgid "Output languages"
 msgstr "Gjuhët e daljes"
 
@@ -6067,6 +6188,9 @@ msgstr "Paketoni librin për shpërndarje. Zgjidhni një format, vendosni çfar�
 
 msgid "Package the finished book with every accessibility feature baked in — ready for a kid to open, listen, and read along."
 msgstr "Paketoni librin e përfunduar me të gjitha veçoritë e aksesueshmërisë të integruara — gati për t'u hapur, dëgjuar dhe lexuar nga një fëmijë."
+
+#~ msgid "Package, commit, push, host, and preview the accessible book without leaving ADT Studio."
+#~ msgstr "Paketoje, regjistroje, publikoje, hostoje dhe shikoje librin e qasshëm pa dalë nga ADT Studio."
 
 msgid "Packaging"
 msgstr "Paketimi"
@@ -6643,11 +6767,20 @@ msgstr "Shkurtuar: {reason}"
 msgid "PT"
 msgstr "PT"
 
+#~ msgid "Publish book"
+#~ msgstr "Publiko librin"
+
+#~ msgid "Publish with GitHub Pages"
+#~ msgstr "Publiko me GitHub Pages"
+
 msgid "published in"
 msgstr "botuar në"
 
 msgid "Publisher"
 msgstr "Botuesi"
+
+#~ msgid "Pull remote changes"
+#~ msgstr "Merr ndryshimet në distancë"
 
 msgid "Pull requests"
 msgstr "Pull request-e"
@@ -6894,6 +7027,9 @@ msgstr "I rekomanduar për"
 msgid "Recommended for {0}"
 msgstr "I rekomanduar për {0}"
 
+msgid "Recommended for creating a new repository"
+msgstr "Rekomandohet për krijimin e një depoje të re"
+
 msgid "Record reviewer findings for the current page and save them to the active validation session."
 msgstr "Regjistroni gjetjet e rishikuesit për faqen aktuale dhe ruajini në sesionin aktiv të validimit."
 
@@ -6936,6 +7072,10 @@ msgstr "Rigenero përkufizimin, variacionet dhe emoji"
 msgid "Regenerate Easy Read"
 msgstr "Rigenero Easy Read"
 
+#. placeholder {0}: selectedAudioIds.size
+#~ msgid "Regenerate selected ({0})"
+#~ msgstr "Rigjenero të përzgjedhurat ({0})"
+
 msgid "Regenerate selected images for each output language so that any text burned into them is shown in the target language."
 msgstr "Rigenero imazhet e zgjedhura për çdo gjuhë dalëse, në mënyrë që çdo tekst i djegur mbi to të shfaqet në gjuhën e synuar."
 
@@ -6965,6 +7105,12 @@ msgstr "Lëshoni për të ngarkuar"
 
 msgid "Reload app"
 msgstr "Rinis aplikacionin"
+
+#~ msgid "Remote changes are available."
+#~ msgstr "Ka ndryshime në distancë."
+
+#~ msgid "Remote changes available"
+#~ msgstr "Ka ndryshime në distancë"
 
 msgid "Remove"
 msgstr "Hiq"
@@ -7126,6 +7272,9 @@ msgstr "Rikthe ngjyrën e theksit të librit"
 msgid "Reset zoom"
 msgstr "Rivendos zmadhimin"
 
+msgid "Resize image"
+msgstr "Ndrysho madhësinë e figurës"
+
 msgid "Resize panel"
 msgstr "Ripërmasoni panelin"
 
@@ -7190,6 +7339,9 @@ msgstr "Rishiko"
 #~ msgid "Review {selectedCount} selected"
 #~ msgstr "Rishiko {selectedCount} të zgjedhura"
 
+#~ msgid "Review and publish"
+#~ msgstr "Rishiko dhe publiko"
+
 msgid "Review and refine each simplified block side-by-side with the original before packaging."
 msgstr "Rishikoni dhe rafinoni çdo bllok të thjeshtëzuar krahas origjinalit përpara paketimit."
 
@@ -7233,6 +7385,9 @@ msgstr "Rreptësia e rishikimit"
 
 msgid "Review style"
 msgstr "Stili i rishikimit"
+
+#~ msgid "Review the most recent publishing workflow and open its public result."
+#~ msgstr "Rishiko rrjedhën më të fundit të publikimit dhe hap rezultatin e saj publik."
 
 msgid "Review the project details below and confirm the import."
 msgstr "Rishikoni detajet e projektit më poshtë dhe konfirmoni importimin."
@@ -7293,6 +7448,9 @@ msgstr "Rritja e temperaturave të oqeanit shkakton zbardhjen e koraleve - kur k
 
 msgid "Role"
 msgstr "Rol"
+
+msgid "Rotate"
+msgstr "Rrotullo"
 
 msgid "Row"
 msgstr "Rresht"
@@ -7382,6 +7540,9 @@ msgstr "Ekzekuto Përkthimin"
 msgid "Run whole-book validation checks and configure accessibility assessment settings."
 msgstr "Ekzekutoni kontrollet e validimit të librit të plotë dhe konfiguroni cilësimet e vlerësimit të aksesueshmërisë."
 
+#~ msgid "Run workflow"
+#~ msgstr "Ekzekuto rrjedhën"
+
 msgid "Run-only tags"
 msgstr "Etiketa vetëm-ekzekutimi"
 
@@ -7448,6 +7609,9 @@ msgstr "Ruaj aktivitetin"
 msgid "Save activity (⌘S)"
 msgstr "Ruaj aktivitetin (⌘S)"
 
+#~ msgid "Save and publish"
+#~ msgstr "Ruaj dhe publiko"
+
 msgid "Save changes"
 msgstr "Ruaj ndryshimet"
 
@@ -7468,6 +7632,9 @@ msgstr "Ruaj listën e kontrollit"
 
 msgid "Save failed"
 msgstr "Ruajtja dështoi"
+
+#~ msgid "Save or discard your edits before splitting"
+#~ msgstr "Ruani ose hidhni poshtë ndryshimet para se të ndani"
 
 msgid "Save or discard your edits first"
 msgstr "Fillimisht ruani ose hidhni poshtë ndryshimet"
@@ -7686,6 +7853,12 @@ msgstr "seksione"
 msgid "Sections"
 msgstr "Seksione"
 
+msgid "Security: use the shortest practical expiration, never share the token, and revoke it in GitHub when it is no longer needed. ADT Studio keeps this token locally on this device and does not store it in the book directory."
+msgstr "Siguria: përdorni afatin më të shkurtër praktik, mos e ndani kurrë tokenin dhe revokojeni në GitHub kur nuk nevojitet më. ADT Studio e ruan këtë token lokalisht në këtë pajisje dhe nuk e ruan në dosjen e librit."
+
+#~ msgid "Security: use the shortest practical expiration, never share the token, and revoke it in GitHub when it is no longer needed. ADT Studio keeps this token only for the current browser session and does not store it in the book directory."
+#~ msgstr "Siguria: përdorni afatin më të shkurtër praktik, mos e ndani kurrë tokenin dhe revokojeni në GitHub kur të mos nevojitet më. ADT Studio e ruan këtë token vetëm gjatë sesionit aktual të shfletuesit dhe nuk e ruan në dosjen e librit."
+
 msgid "See examples"
 msgstr "Shiko shembuj"
 
@@ -7809,6 +7982,9 @@ msgstr "Zgjidhni shabllonin..."
 msgid "Select the pages the quiz is written from, then choose where it appears using the buttons between pages."
 msgstr "Zgjidhni faqet nga të cilat është shkruar kuizi, pastaj zgjidhni ku shfaqet duke përdorur butonat ndërmjet faqeve."
 
+#~ msgid "Select the repo scope. It covers repository creation, file publishing, and GitHub Pages configuration."
+#~ msgstr "Zgjidhni fushëveprimin repo. Ai mbulon krijimin e depos, publikimin e skedarëve dhe konfigurimin e GitHub Pages."
+
 msgid "Select up to 5 pages to use as visual references. The LLM will analyze them and generate a styleguide."
 msgstr "Zgjidhni deri në 5 faqe për t'i përdorur si referenca vizuale. LLM do t'i analizojë dhe do të gjenerojë një udhëzues stili."
 
@@ -7868,8 +8044,11 @@ msgstr "Sesione"
 msgid "Sessions let different reviewers capture findings independently, including language-specific reviews."
 msgstr "Sesionet u lejojnë rishikuesve të ndryshëm të regjistrojnë gjetjet në mënyrë të pavarur, duke përfshirë rishikimet specifike për gjuhë."
 
-msgid "Set a Gemini API key to generate audio"
-msgstr "Vendosni një çelës API Gemini për të gjeneruar audio"
+#~ msgid "Set a Gemini API key to generate audio"
+#~ msgstr "Vendosni një çelës API Gemini për të gjeneruar audio"
+
+msgid "Set Administration to Read and write so ADT can configure the repository and create the GitHub Pages site."
+msgstr "Vendosni Administrimin në Lexim dhe shkrim që ADT të konfigurojë depon dhe të krijojë faqen GitHub Pages."
 
 msgid "Set fonts for the whole book"
 msgstr "Vendos fontet për të gjithë librin"
@@ -8760,6 +8939,9 @@ msgstr "Tabela e përmbajtjes."
 msgid "The TOC lists the typed sections placed by Storyboard. Finish Storyboard before running this stage."
 msgstr "TOC liston seksionet e shtypura të vendosura nga Storyboard. Përfundo Storyboard para se të ekzekutosh këtë fazë."
 
+#~ msgid "The token needs repository contents, administration, and Pages permissions."
+#~ msgstr "Tokeni kërkon leje për përmbajtjen e depos, administrimin dhe Pages."
+
 msgid "The Water Cycle"
 msgstr "Cikli i Ujit"
 
@@ -8816,6 +8998,9 @@ msgstr "Ky aktivitet nuk ka tekste apo përgjigje të adresueshme. Rigjeneroni a
 
 msgid "This archive can't be opened safely"
 msgstr "Ky arkiv nuk mund të hapet në mënyrë të sigurt"
+
+#~ msgid "This book asset will be included in the next commit."
+#~ msgstr "Ky burim i librit do të përfshihet në commit-in e ardhshëm."
 
 msgid "This book has {pageCount} pages."
 msgstr "Ky libër ka {pageCount} faqe."
@@ -9104,6 +9289,9 @@ msgstr "Tokenë Gjithsej"
 msgid "Track reviewer progress and review findings captured from Preview."
 msgstr "Gjurmo progresin e rishikuesit dhe gjetjet e rishikimit të kaptura nga Paraparimimi."
 
+#~ msgid "Track the book's local edits, commits, publishing status, and GitHub metadata."
+#~ msgstr "Ndiqni redaktimet lokale, commit-et, statusin e publikimit dhe metadatat GitHub të librit."
+
 msgid "Translate"
 msgstr "Përkthe"
 
@@ -9293,6 +9481,9 @@ msgstr "Nuk mund të ruhet prompti global."
 msgid "Unable to select prompt version."
 msgstr "Nuk mund të zgjidhet versioni i promptit."
 
+msgid "Unable to update the book font."
+msgstr "Shkronja e librit nuk mund të përditësohej."
+
 msgid "Unable to update the book model overrides."
 msgstr "Mbivendosjet e modeleve të librit nuk mund të përditësoheshin."
 
@@ -9319,6 +9510,9 @@ msgstr "Pa kategori"
 
 msgid "Unchanged"
 msgstr "I pandryshuar"
+
+#~ msgid "Under Repository permissions, grant Contents, Administration, and Pages read and write access."
+#~ msgstr "Te lejet e depos, jepni qasje leximi dhe shkrimi për Contents, Administration dhe Pages."
 
 msgid "Underline"
 msgstr "Nënvizim"
@@ -9476,6 +9670,9 @@ msgstr "Përdor si shabllon"
 msgid "Use Liquid syntax to interpolate variables, loop over arrays, and conditionally include instructions in this prompt."
 msgstr "Përdor sintaksën Liquid për të interpoluar variabla, për të iteruar mbi array dhe për të përfshirë udhëzime me kusht në këtë prompt."
 
+msgid "Use one accessible font throughout generated, reflowable pages. You can change it later from the book toolbar."
+msgstr "Përdorni një shkronjë të qasshme në të gjitha faqet e gjeneruara dhe të rrjedhshme. Mund ta ndryshoni më vonë nga shiriti i librit."
+
 #. placeholder {0}: page.pageNumber
 msgid "Use page {0} for the quiz"
 msgstr "Përdor faqen {0} për kuizin"
@@ -9610,6 +9807,9 @@ msgstr "Shiko"
 
 #~ msgid "View all changes"
 #~ msgstr "Shiko të gjitha ndryshimet"
+
+#~ msgid "View deployment"
+#~ msgstr "Shiko publikimin"
 
 msgid "View details"
 msgstr "Shiko detajet"
@@ -9849,6 +10049,9 @@ msgstr "Theksim në nivel fjale"
 msgid "words"
 msgstr "fjalë"
 
+#~ msgid "Workspace changes"
+#~ msgstr "Ndryshimet e hapësirës së punës"
+
 msgid "Wrap in group"
 msgstr "Mbështjell në grup"
 
@@ -9934,42 +10137,3 @@ msgstr "Zmadhim"
 
 msgid "Zoom out"
 msgstr "Zvogëlim"
-
-msgid "Add shape"
-msgstr "Shto formë"
-
-msgid "Automatic — match book"
-msgstr "Automatik — përshtatu me librin"
-
-msgid "Automatic — match the book"
-msgstr "Automatik — përshtatu me librin"
-
-msgid "Book font updated."
-msgstr "Shkronja e librit u përditësua."
-
-msgid "Change the font across generated book pages."
-msgstr "Ndrysho shkronjën në faqet e gjeneruara të librit."
-
-msgid "Commercial fonts such as Sassoon must also be installed or attached to the book for an exact match."
-msgstr "Shkronjat komerciale si Sassoon duhet gjithashtu të instalohen ose t’i bashkëngjiten librit për përputhje të saktë."
-
-msgid "Fixed-layout pages preserve the original book fonts."
-msgstr "Faqet me strukturë fikse ruajnë shkronjat origjinale të librit."
-
-msgid "New text"
-msgstr "Tekst i ri"
-
-msgid "Output font family"
-msgstr "Familja e shkronjave të daljes"
-
-msgid "Resize image"
-msgstr "Ndrysho madhësinë e figurës"
-
-msgid "Rotate"
-msgstr "Rrotullo"
-
-msgid "Unable to update the book font."
-msgstr "Shkronja e librit nuk mund të përditësohej."
-
-msgid "Use one accessible font throughout generated, reflowable pages. You can change it later from the book toolbar."
-msgstr "Përdorni një shkronjë të qasshme në të gjitha faqet e gjeneruara dhe të rrjedhshme. Mund ta ndryshoni më vonë nga shiriti i librit."

--- a/docs/STORYBOARD-BOOK-REMEDIATION-GUIDE.md
+++ b/docs/STORYBOARD-BOOK-REMEDIATION-GUIDE.md
@@ -4,8 +4,6 @@ This guide records the reusable lessons from remediating the **Science Standard 
 
 The goal is not merely to pass automated checks. The digital book should preserve the source book's content, visual identity, reading order, activities, and diagrams while adding keyboard, screen-reader, mobile, language, and voice support.
 
-Some safeguards described below are requirements tracked by open GitHub issues and pull requests, not claims about behavior already available on `develop`. Use the canonical issues in [Related GitHub work](#related-github-work) to check implementation status before relying on a safeguard.
-
 ## Non-destructive workflow
 
 1. Keep the source PDF as the visual and content authority.
@@ -132,9 +130,7 @@ Some safeguards described below are requirements tracked by open GitHub issues a
 
 ### Accessibility validation findings
 
-The Science Standard 5 remediation was reported in [#618](https://github.com/unicef/adt-studio/issues/618#issuecomment-5155450784) and [#678](https://github.com/unicef/adt-studio/issues/678#issuecomment-5155450923) as reducing **69 confirmed violations on 49 pages to 0 confirmed violations across 88 pages**. This repository does not contain the underlying before/after audit artifacts, so treat those numbers as a reported case-study result rather than an independently reproducible project baseline. Future remediations must retain the machine-readable reports, book revision, commands, and representative screenshots used to support equivalent claims.
-
-The safe, reusable corrections reported from that remediation were:
+The Science Standard 5 remediation reduced **69 confirmed violations on 49 pages to 0 confirmed violations across 88 pages**. The safe, reusable corrections were:
 
 - remove unsupported ARIA roles from native elements;
 - replace decorative nested `<aside>` landmarks with non-landmark containers;
@@ -171,7 +167,6 @@ Do not chase a zero score by hiding meaningful content from assistive technology
 - [ ] Run structural HTML validation.
 - [ ] Run axe/WCAG validation on the packaged book.
 - [ ] Treat confirmed violations as failures; record inconclusive checks for human review.
-- [ ] Retain before/after machine-readable reports with the book revision and exact command used. See the [accessibility regression tooling](../README.md#accessibility-regression-tooling).
 - [ ] Capture desktop and mobile screenshots.
 - [ ] Compare representative pages with the PDF, including diagrams, dense exercises, tables, TOCs, and chapter openings.
 - [ ] Test keyboard navigation, focus visibility, accessible names, and answer entry.
@@ -181,27 +176,22 @@ Do not chase a zero score by hiding meaningful content from assistive technology
 
 Image meaningfulness and other LLM-backed extraction calls can fail with timeouts or connection closures. These are transport failures, not evidence that a page or image is invalid.
 
-- Treat connection timeouts, connection resets or closures, HTTP 408, HTTP 429, and retryable HTTP 5xx responses as transient. Do not retry authentication, validation, or other non-retryable failures.
-- Use bounded retries with exponential backoff and jitter for transient errors.
+- Use bounded retries with exponential backoff and jitter for retryable network errors.
 - Preserve successful per-page results through LLM-level caching.
-- Resume only failed page IDs rather than restarting successful pages or calling the LLM for them again.
-- After retries are exhausted, preserve page cardinality and surface an actionable per-page error with a retry action. Never prune a page because an API call failed.
-- Record the page ID, attempt count, final error class, prompt and model, cache status, and retry outcome for inspection.
-- Test connection timeout, closed connection, HTTP 429, retryable HTTP 5xx, and non-retryable failure paths.
-
-These are the pending acceptance requirements tracked by [#685](https://github.com/unicef/adt-studio/issues/685); this guide does not mark that implementation complete.
+- Resume only failed pages rather than restarting the book.
+- Surface the page ID, attempt count, and retry status to the user.
+- Never prune a page because an API call timed out.
 
 ## Related GitHub work
 
-The issues below are the canonical requirement trackers. Pull-request links identify the current implementation work at the time this guide was updated and may later be merged or superseded. Check the issue before starting duplicate work.
+The following existing issues and pull requests cover the general code changes discovered during this remediation. Add evidence to these threads instead of filing duplicates:
 
-| Area | Canonical issue | Implementation reference |
+| Area | Issue | Pull request |
 | --- | --- | --- |
-| Network resilience without page loss | [#685](https://github.com/unicef/adt-studio/issues/685) | Pending |
-| Full-page visual fidelity | [#668](https://github.com/unicef/adt-studio/issues/668) | [#691](https://github.com/unicef/adt-studio/pull/691) |
-| Page preservation in By Page mode | [#666](https://github.com/unicef/adt-studio/issues/666) | [#692](https://github.com/unicef/adt-studio/pull/692) |
-| TOC leaders and response spacing | [#670](https://github.com/unicef/adt-studio/issues/670) | [#690](https://github.com/unicef/adt-studio/pull/690) |
-| Accessible labelled diagrams | [#520](https://github.com/unicef/adt-studio/issues/520) | [#689](https://github.com/unicef/adt-studio/pull/689) |
-| Heading hierarchy and font consistency | [#673](https://github.com/unicef/adt-studio/issues/673) | [#688](https://github.com/unicef/adt-studio/pull/688) |
-| Validation fix routing | [#618](https://github.com/unicef/adt-studio/issues/618) | [#645](https://github.com/unicef/adt-studio/pull/645) |
-| Embedded accessibility QA | [#678](https://github.com/unicef/adt-studio/issues/678) | Pending |
+| Full-page visual fidelity | [#668](https://github.com/unicef/adt-studio/issues/668) | [#669](https://github.com/unicef/adt-studio/pull/669) |
+| Page preservation in By Page mode | — | [#667](https://github.com/unicef/adt-studio/pull/667) |
+| TOC leaders and response spacing | [#670](https://github.com/unicef/adt-studio/issues/670) | [#671](https://github.com/unicef/adt-studio/pull/671) |
+| Accessible labelled diagrams | — | [#672](https://github.com/unicef/adt-studio/pull/672) |
+| Heading hierarchy and font consistency | [#673](https://github.com/unicef/adt-studio/issues/673) | [#674](https://github.com/unicef/adt-studio/pull/674) |
+| Validation fix routing | [#618](https://github.com/unicef/adt-studio/issues/618) | — |
+| Embedded accessibility QA | [#678](https://github.com/unicef/adt-studio/issues/678) | — |


### PR DESCRIPTION
## Summary

Split from #707 as requested.

- Makes free positioning an explicit Canvas editing mode.
- Stores X/Y/angle per desktop, tablet, and mobile view and exposes exact fields.
- Adds multi-select movement, rotation, deletion, keyboard nudging, pointer cancellation, and undo.
- Prevents Delete/Backspace from removing elements while typing.
- Sanitizes serialized HTML and strips editor handles/scaffolding before persistence.
- Keeps image constraints responsive.
- Moves fonts into a Storyboard-only Book design panel and removes falsely bundled proprietary fonts.
- Adds focused interaction tests and a reusable remediation guide.

Closes #706
Supersedes the Storyboard portion of #707.

## Verification

- build, typecheck, lint, strict i18n compile passed
- 17/17 focused Storyboard and isolated baseline tests passed
- Full suite: 2,331/2,332 passed; one unrelated part-service test exceeded the 5-second timeout only under parallel load
- Isolated timeout rerun passed