### PR TITLE
Fix: Windows Signing

### DIFF
--- a/apps/desktop/electron-builder.js
+++ b/apps/desktop/electron-builder.js
@@ -90,6 +90,7 @@ const config = {
       publisherName: [
         "Núcleo de Excelência em Tecnologias Sociais - NEES",
         "UNICEF",
+        "Elias Constantopedos"
       ],
       sign: "./scripts/sign-windows.js",
     },

--- a/apps/desktop/scripts/sign-windows.js
+++ b/apps/desktop/scripts/sign-windows.js
@@ -1,9 +1,10 @@
 const { spawnSync } = require("node:child_process");
 const path = require("node:path");
 
+// TODO: replace to use enviroment variables
 const TRUSTED_SIGNING_KEYSTORE = "eus.codesigning.azure.net";
 // <TrustedSigningAccount>/<CertificateProfile> — see Azure Portal.
-const TRUSTED_SIGNING_ALIAS = "NEES/neespnld";
+const TRUSTED_SIGNING_ALIAS = "adtnees/adtnees";
 
 module.exports = async function (configuration) {
   const skipTargets = new Set(


### PR DESCRIPTION
## Fix Windows code signing configuration

### What changed

This branch updates the Windows code-signing setup for the Electron desktop app.

- **`apps/desktop/scripts/sign-windows.js`**
  - Changed the Azure Trusted Signing alias from `NEES/neespnld` to `adtnees/adtnees`, pointing the signing script at the correct Trusted Signing account and certificate profile.
  - Added a TODO to move these values into environment variables.

- **`apps/desktop/electron-builder.js`**
  - Added `"Elias Constantopedos"` to the `publisherName` list in the Windows build config, so signatures issued under that publisher name pass installer verification.