### PR TITLE
feat(sectioning): add auto-pruned watermark text type

### DIFF
--- a/apps/studio/src/components/wizard/constants.ts
+++ b/apps/studio/src/components/wizard/constants.ts
@@ -343,7 +343,7 @@ export const PRESETS: PresetConfig[] = [
       // Role keys must match the actual `role_types` the sectioning LLM assigns
       // (config.yaml uses bare `header`/`footer`/`page_number`). The `_text`
       // suffixed variants never match, so header/footer would leak in unpruned.
-      pruned_role_types: ["header", "footer", "page_number"],
+      pruned_role_types: ["header", "footer", "page_number", "watermark"],
       pruned_section_types: ["back_cover", "credits", "inside_cover"],
       image_filters: { min_stddev: 2 },
     },
@@ -419,7 +419,7 @@ export const PRESETS: PresetConfig[] = [
       // (config.yaml uses bare `header`/`footer`/`page_number`). The `_text`
       // suffixed variants never match, so header/footer would leak into the
       // two-column-story layout unpruned.
-      pruned_role_types: ["header", "footer", "page_number"],
+      pruned_role_types: ["header", "footer", "page_number", "watermark"],
       pruned_section_types: [
         "back_cover",
         "credits",
@@ -509,7 +509,7 @@ export const PRESETS: PresetConfig[] = [
       // Role keys must match the actual `role_types` the sectioning LLM assigns
       // (config.yaml uses bare `header`/`footer`/`page_number`). The `_text`
       // suffixed variants never match, so header/footer would leak in unpruned.
-      pruned_role_types: ["header", "footer", "page_number"],
+      pruned_role_types: ["header", "footer", "page_number", "watermark"],
       pruned_section_types: [
         "back_cover",
         "credits",

--- a/config.yaml
+++ b/config.yaml
@@ -67,6 +67,13 @@ role_types:
   footer: A running footer.
   quote: A quoted passage.
   book_metadata: Publisher, copyright, ISBN, edition, or author metadata.
+  watermark: >
+    Decorative, status, or usage-restriction overlay text stamped across the
+    page — e.g. "DRAFT", "SAMPLE", "SPECIMEN", "CONFIDENTIAL", "FOR ONLINE
+    READING ONLY", a copyright/ownership stamp, or a repeated diagonal label.
+    Often faint/semi-transparent, tinted, and rotated diagonally, and may run
+    across or behind the real content (repeating identically on every page).
+    Not part of the reading content.
 
 section_types:
   front_cover: >
@@ -315,6 +322,7 @@ pruned_role_types:
   - header
   - footer
   - page_number
+  - watermark
 
 pruned_section_types:
   - back_cover

--- a/packages/pipeline/src/render-llm.ts
+++ b/packages/pipeline/src/render-llm.ts
@@ -307,7 +307,12 @@ function collectLeafDataIdOrder(nodes: RenderNode[]): string[] {
 // (single dots are normal punctuation).
 const TEXTBOOK_BLANK_RE = /_+|\.{3,}/g
 const PLACEHOLDER_MARKER_RE = /\[placeholder:[^\]]+\]/g
-const OPTIONAL_TEXT_ROLES = new Set(["footer", "header", "page_number"])
+const OPTIONAL_TEXT_ROLES = new Set([
+  "footer",
+  "header",
+  "page_number",
+  "watermark",
+])
 
 /** True if the leaf's text is nothing but textbook blank placeholders
  * (`___`, `...`, `[placeholder:...]`) and inert separators (whitespace,

--- a/prompts/page_sectioning.liquid
+++ b/prompts/page_sectioning.liquid
@@ -140,6 +140,7 @@ Use these to disambiguate activity types:
 9. Poetry / verse: `preformatted` per stanza; each line is a `role: "text"` leaf.
 10. Fill-in-the-blank placeholders: when a word appears as a placeholder (dotted, underlined, inside blanks, or styled like `..word..` / `___word___`), wrap the placeholder as `[placeholder:word]` within the leaf's text. Only do this when the word is visually styled as a fill-in blank.
 11. Page numbers, running headers, and running footers become leaves with role `page_number` / `header` / `footer` — typically in their own tiny section or appended to an existing section based on location.
+12. Watermark overlays — decorative, status, or usage-restriction text stamped across the page (e.g. "DRAFT", "SAMPLE", "SPECIMEN", "CONFIDENTIAL", "FOR ONLINE READING ONLY", a copyright/ownership stamp, or a repeated diagonal label) — become a single leaf with role `watermark`. They are typically faint / semi-transparent, tinted, and rotated diagonally, and often repeat identically on every page. A watermark commonly runs across or behind the real content: do NOT merge its words into the headings, paragraphs, table cells, or table-of-contents entries it overlaps, and do NOT treat it as a `caption`/`label` — pull it out as its own separate `watermark` leaf carrying the full phrase. It is not part of the reading content.
 
 ## Section partition rules
 


### PR DESCRIPTION
Adds `watermark` as a sectioning role ("text type") that is pruned by default in the global `config.yaml` and in every wizard preset (textbook, storybook, reference; `custom` inherits the global default), so watermark leaves get `isPruned` at sectioning time and are excluded downstream from rendering, TTS, and the text catalog with no per-role code. Hardens the sectioning prompt to catch usage-restriction overlays such as the Tanzanian textbooks' faint diagonal "FOR ONLINE READING ONLY" stamp — pulling it into a single separate `watermark` leaf instead of merging it into the headings/TOC entries it crosses. Also adds `watermark` to render-llm's `OPTIONAL_TEXT_ROLES` so a dropped watermark never fails render validation. The role auto-appears in the Sectioning "Text Types" editor (with a prune toggle) since that UI is config-driven, and `role_types`/`pruned_role_types` are already fingerprinted so reruns recompute. Verified: `pnpm typecheck` clean, `pnpm lint` 0 errors, and the affected pipeline tests pass.