### PR TITLE
fix(storyboard): stop every save from invalidating the storyboard stage

### DIFF
--- a/apps/api/src/routes/pages.test.ts
+++ b/apps/api/src/routes/pages.test.ts
@@ -461,6 +461,28 @@ describe("Page routes", () => {
       }
     })
 
+    it("keeps the stage complete when unpruning a section that will be re-rendered", async () => {
+      // Sections are normally pruned when the storyboard runs, so unpruning is
+      // the ordinary way content is brought in. The editor renders just that
+      // section, so the rest of the stage must survive untouched.
+      seedCompletedChain()
+
+      const res = await save({
+        sectioning: { reasoning: "r", sections: [] },
+        renderingInSync: true,
+      })
+      expect(res.status).toBe(200)
+
+      const after = createBookStorage(label, tmpDir)
+      try {
+        const steps = after.getStepRuns().map((r) => r.step)
+        expect(steps).toContain("web-rendering")
+        expect(steps).not.toContain("quiz-generation")
+      } finally {
+        after.close()
+      }
+    })
+
     it("rejects an empty save and a rendering-only in-sync claim", async () => {
       expect((await save({})).status).toBe(400)
       expect(

--- a/apps/api/src/routes/pages.test.ts
+++ b/apps/api/src/routes/pages.test.ts
@@ -357,6 +357,127 @@ describe("Page routes", () => {
     })
   })
 
+  describe("PUT /api/books/:label/pages/:pageId/storyboard", () => {
+    const seedCompletedChain = () => {
+      const seed = createBookStorage(label, tmpDir)
+      try {
+        seed.markStepCompleted("web-rendering")
+        seed.markStepCompleted("quiz-generation")
+        seed.markStepCompleted("toc-generation")
+      } finally {
+        seed.close()
+      }
+    }
+
+    const save = (body: unknown) =>
+      app.request(`/api/books/${label}/pages/${label}_p1/storyboard`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      })
+
+    it("keeps the storyboard complete when the rendering is saved in sync", async () => {
+      // The Storyboard editor mirrors text/prune/delete edits into the HTML it
+      // sends, so the rendering is not stale and the stage must stay done —
+      // otherwise every save ejects the user from the editor.
+      seedCompletedChain()
+
+      const res = await save({
+        sectioning: { reasoning: "r", sections: [] },
+        rendering: { sections: [] },
+        renderingInSync: true,
+      })
+      expect(res.status).toBe(200)
+      // Both fixtures are at v1, so one save advances each exactly once.
+      expect(await res.json()).toEqual({ sectioningVersion: 2, renderingVersion: 2 })
+
+      const after = createBookStorage(label, tmpDir)
+      try {
+        const steps = after.getStepRuns().map((r) => r.step)
+        expect(steps).toContain("web-rendering")
+        // Everything derived from the HTML still has to be re-run.
+        expect(steps).not.toContain("quiz-generation")
+        expect(steps).not.toContain("toc-generation")
+      } finally {
+        after.close()
+      }
+    })
+
+    it("marks the storyboard stale when the change needs an LLM re-render", async () => {
+      seedCompletedChain()
+
+      const res = await save({
+        sectioning: { reasoning: "r", sections: [] },
+        rendering: { sections: [] },
+        renderingInSync: false,
+      })
+      expect(res.status).toBe(200)
+
+      const after = createBookStorage(label, tmpDir)
+      try {
+        expect(after.getStepRuns().map((r) => r.step)).not.toContain("web-rendering")
+      } finally {
+        after.close()
+      }
+    })
+
+    it("defaults to marking the storyboard stale", async () => {
+      seedCompletedChain()
+
+      const res = await save({ sectioning: { reasoning: "r", sections: [] } })
+      expect(res.status).toBe(200)
+
+      const after = createBookStorage(label, tmpDir)
+      try {
+        expect(after.getStepRuns().map((r) => r.step)).not.toContain("web-rendering")
+      } finally {
+        after.close()
+      }
+    })
+
+    it("writes neither node when a pipeline step is running", async () => {
+      const seed = createBookStorage(label, tmpDir)
+      try {
+        seed.markStepStarted("quiz-generation")
+      } finally {
+        seed.close()
+      }
+
+      const res = await save({
+        sectioning: { reasoning: "r", sections: [] },
+        rendering: { sections: [] },
+        renderingInSync: true,
+      })
+      expect(res.status).toBe(409)
+
+      const after = createBookStorage(label, tmpDir)
+      try {
+        // The guard runs before either write, so neither node advanced past
+        // the seeded version — the rejected save is a true no-op.
+        expect(after.getLatestNodeData("web-rendering", `${label}_p1`)?.version).toBe(1)
+        expect(after.getLatestNodeData("page-sectioning", `${label}_p1`)?.version).toBe(1)
+      } finally {
+        after.close()
+      }
+    })
+
+    it("rejects an empty save and a rendering-only in-sync claim", async () => {
+      expect((await save({})).status).toBe(400)
+      expect(
+        (await save({ rendering: { sections: [] }, renderingInSync: true })).status
+      ).toBe(400)
+    })
+
+    it("returns 404 for nonexistent page", async () => {
+      const res = await app.request(`/api/books/${label}/pages/fake-page/storyboard`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ rendering: { sections: [] } }),
+      })
+      expect(res.status).toBe(404)
+    })
+  })
+
   describe("PUT /api/books/:label/pages/:pageId/image-filtering", () => {
     it("saves image classification and returns version", async () => {
       const data = {

--- a/apps/api/src/routes/pages.test.ts
+++ b/apps/api/src/routes/pages.test.ts
@@ -536,6 +536,64 @@ describe("Page routes", () => {
     })
   })
 
+  describe("section ops that rebuild the rendering themselves", () => {
+    // Delete and clone rewrite `web-rendering` in the same request — dropping or
+    // copying the HTML entry, shifting indexes, rewriting section ids. Nothing is
+    // left for the LLM, so invalidating the stage would only cost the user a
+    // full-book re-render for an edit that is already complete. Split and
+    // cross-page merge are the ops that genuinely drop HTML; they still mark it.
+    const seedCompletedChain = () => {
+      const seed = createBookStorage(label, tmpDir)
+      try {
+        seed.markStepCompleted("web-rendering")
+        seed.markStepCompleted("toc-generation")
+      } finally {
+        seed.close()
+      }
+    }
+
+    const stepsAfter = () => {
+      const after = createBookStorage(label, tmpDir)
+      try {
+        return after.getStepRuns().map((r) => r.step)
+      } finally {
+        after.close()
+      }
+    }
+
+    it("keeps the storyboard complete when a section is deleted", async () => {
+      seedCompletedChain()
+
+      const res = await app.request(
+        `/api/books/${label}/pages/${label}_p1/sections/0`,
+        { method: "DELETE" }
+      )
+      expect(res.status).toBe(200)
+
+      const steps = stepsAfter()
+      expect(steps).toContain("web-rendering")
+      // Downstream still has to catch up with the removed content.
+      expect(steps).not.toContain("toc-generation")
+    })
+
+    it("keeps the storyboard complete when a section is cloned", async () => {
+      seedCompletedChain()
+
+      const res = await app.request(
+        `/api/books/${label}/pages/${label}_p1/sections/0/clone`,
+        { method: "POST" }
+      )
+      expect(res.status).toBe(200)
+
+      const steps = stepsAfter()
+      expect(steps).toContain("web-rendering")
+      expect(steps).not.toContain("toc-generation")
+    })
+
+    // Split's own staleness is covered by "marks the storyboard chain stale,
+    // since both halves lose their HTML" in the split suite below.
+  })
+
   describe("POST /api/books/:label/pages/:pageId/sections/:sectionIndex/clone", () => {
     it("assigns fresh ids to cloned containers but preserves leaf ids", async () => {
       const sourceContainerId = `${label}_p1_n0001`

--- a/apps/api/src/routes/pages.test.ts
+++ b/apps/api/src/routes/pages.test.ts
@@ -461,10 +461,10 @@ describe("Page routes", () => {
       }
     })
 
-    it("keeps the stage complete when unpruning a section that will be re-rendered", async () => {
-      // Sections are normally pruned when the storyboard runs, so unpruning is
-      // the ordinary way content is brought in. The editor renders just that
-      // section, so the rest of the stage must survive untouched.
+    it("keeps the stage complete for a per-section edit that queues a re-render", async () => {
+      // Storyboard editing is incremental: change a section's type or pruning,
+      // re-render that one section, carry on. The rest of the stage must survive
+      // untouched or the editor is taken away for a book that is fine.
       seedCompletedChain()
 
       const res = await save({

--- a/apps/api/src/routes/pages.test.ts
+++ b/apps/api/src/routes/pages.test.ts
@@ -3,9 +3,10 @@ import fs from "node:fs"
 import path from "node:path"
 import os from "node:os"
 import { Hono } from "hono"
-import { createBookStorage } from "@adt/storage"
+import { createBookStorage, openBookDb } from "@adt/storage"
 import { errorHandler } from "../middleware/error-handler.js"
 import { createPageRoutes } from "./pages.js"
+import type { TaskExecutor, TaskService } from "../services/task-service.js"
 
 describe("Page routes", () => {
   let tmpDir: string
@@ -454,6 +455,36 @@ describe("Page routes", () => {
       try {
         // The guard runs before either write, so neither node advanced past
         // the seeded version — the rejected save is a true no-op.
+        expect(after.getLatestNodeData("web-rendering", `${label}_p1`)?.version).toBe(1)
+        expect(after.getLatestNodeData("page-sectioning", `${label}_p1`)?.version).toBe(1)
+      } finally {
+        after.close()
+      }
+    })
+
+    it("rolls back the rendering when the sectioning write fails", async () => {
+      // Force the second node write to fail after rendering has been inserted.
+      // The route must leave both version histories and pointers unchanged.
+      const db = openBookDb(path.join(tmpDir, label, `${label}.db`))
+      db.exec(`
+        CREATE TRIGGER reject_storyboard_sectioning
+        BEFORE INSERT ON node_data
+        WHEN NEW.node = 'page-sectioning'
+        BEGIN
+          SELECT RAISE(ABORT, 'forced sectioning failure');
+        END
+      `)
+      db.close()
+
+      const res = await save({
+        sectioning: { reasoning: "r", sections: [] },
+        rendering: { sections: [] },
+        renderingInSync: true,
+      })
+      expect(res.status).toBe(500)
+
+      const after = createBookStorage(label, tmpDir)
+      try {
         expect(after.getLatestNodeData("web-rendering", `${label}_p1`)?.version).toBe(1)
         expect(after.getLatestNodeData("page-sectioning", `${label}_p1`)?.version).toBe(1)
       } finally {
@@ -1422,6 +1453,89 @@ describe("Page routes", () => {
       } finally {
         verify.close()
       }
+    })
+
+    it("cannot claim the Storyboard is complete while both renderings are empty", async () => {
+      seedBothPages()
+      const storage = createBookStorage(label, tmpDir)
+      try {
+        storage.markStepCompleted("web-rendering")
+      } finally {
+        storage.close()
+      }
+
+      const res = await app.request(
+        `/api/books/${label}/pages/${label}_p1/sections/0/merge-cross-page?direction=next&renderingInSync=1`,
+        { method: "POST" }
+      )
+      expect(res.status).toBe(200)
+
+      const verify = createBookStorage(label, tmpDir)
+      try {
+        expect(verify.getStepRuns().map((run) => run.step)).not.toContain("web-rendering")
+      } finally {
+        verify.close()
+      }
+    })
+  })
+
+  describe("POST /api/books/:label/pages/re-render", () => {
+    it("marks the Storyboard running before submitting one task for all pages", async () => {
+      const storage = createBookStorage(label, tmpDir)
+      try {
+        storage.putNodeData("page-sectioning", `${label}_p2`, {
+          reasoning: "sectioned",
+          sections: [],
+        })
+        storage.markStepCompleted("web-rendering")
+      } finally {
+        storage.close()
+      }
+
+      let submittedExecutor: TaskExecutor | undefined
+      const taskService: TaskService = {
+        submitTask(_label, kind, _description, executor) {
+          expect(kind).toBe("re-render")
+          submittedExecutor = executor
+          return { taskId: "task-batch" }
+        },
+        getActiveTasks: () => [],
+      }
+      const routes = createPageRoutes(tmpDir, tmpDir, tmpDir, undefined, taskService)
+      const taskApp = new Hono()
+      taskApp.onError(errorHandler)
+      taskApp.route("/api", routes)
+
+      const res = await taskApp.request(`/api/books/${label}/pages/re-render`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-OpenAI-Key": "sk-test",
+        },
+        body: JSON.stringify({ pageIds: [`${label}_p1`, `${label}_p2`] }),
+      })
+
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({ taskId: "task-batch", status: "submitted" })
+      expect(submittedExecutor).toBeTypeOf("function")
+
+      const verify = createBookStorage(label, tmpDir)
+      try {
+        expect(verify.getStepRuns()).toContainEqual(
+          expect.objectContaining({ step: "web-rendering", status: "running" })
+        )
+      } finally {
+        verify.close()
+      }
+    })
+
+    it("requires an API key", async () => {
+      const res = await app.request(`/api/books/${label}/pages/re-render`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ pageIds: [`${label}_p1`] }),
+      })
+      expect(res.status).toBe(400)
     })
   })
 

--- a/apps/api/src/routes/pages.ts
+++ b/apps/api/src/routes/pages.ts
@@ -2240,6 +2240,9 @@ export function createPageRoutes(
       throw new HTTPException(400, { message: `Invalid direction: ${directionParam}. Must be "next" or "prev"` })
     }
     const direction = directionParam as "next" | "prev"
+    // The Storyboard editor re-renders the merged section straight after, so it
+    // opts out of marking the stage stale. Off by default for every other caller.
+    const renderingInSync = c.req.query("renderingInSync") === "1"
 
     const storage = createBookStorage(safeLabel, booksDir)
     try {
@@ -2350,7 +2353,16 @@ export function createPageRoutes(
         updatedRendering = { sections: shifted }
       }
 
-      const sectioningVersion = saveStoryboardNode(storage, "page-sectioning", pageId, updatedSectioning)
+      // Merging concatenates the two sections' HTML into the kept entry, so no
+      // section is left without one — the caller's re-render replaces the naive
+      // join with properly combined markup rather than filling a gap.
+      const sectioningVersion = saveStoryboardNode(
+        storage,
+        "page-sectioning",
+        pageId,
+        updatedSectioning,
+        { renderingInSync: renderingInSync && updatedRendering !== null }
+      )
       if (updatedRendering) {
         renderingVersion = saveStoryboardNode(storage, "web-rendering", pageId, updatedRendering)
       }
@@ -2397,6 +2409,10 @@ export function createPageRoutes(
       })
     }
     const { direction } = parsedQuery.data
+    // Unlike a same-page merge, this empties both pages' renderings outright, so
+    // the caller must re-render both pages before the stage is whole again. Only
+    // a caller that will do that may opt out of marking the stage stale.
+    const renderingInSync = c.req.query("renderingInSync") === "1"
 
     const storage = createBookStorage(safeLabel, booksDir)
     try {
@@ -2483,14 +2499,20 @@ export function createPageRoutes(
       renumberSectionIds(newTgtSections, targetPageId)
 
       // Save updated sectionings
-      const srcVersion = saveStoryboardNode(storage, "page-sectioning", pageId, {
-        ...srcSectioning,
-        sections: newSrcSections,
-      })
-      const tgtVersion = saveStoryboardNode(storage, "page-sectioning", targetPageId, {
-        ...tgtSectioning,
-        sections: newTgtSections,
-      })
+      const srcVersion = saveStoryboardNode(
+        storage,
+        "page-sectioning",
+        pageId,
+        { ...srcSectioning, sections: newSrcSections },
+        { renderingInSync }
+      )
+      const tgtVersion = saveStoryboardNode(
+        storage,
+        "page-sectioning",
+        targetPageId,
+        { ...tgtSectioning, sections: newTgtSections },
+        { renderingInSync }
+      )
 
       // Clear rendering for both pages (merged content invalidates existing renders)
       let srcRenderVersion: number | null = null

--- a/apps/api/src/routes/pages.ts
+++ b/apps/api/src/routes/pages.ts
@@ -2064,9 +2064,6 @@ export function createPageRoutes(
       })
     }
     const { beforeNodeIndex, beforeNodeId } = parsedBody.data
-    // Both halves lose their HTML, so only a caller that re-renders both of them
-    // may opt out of marking the stage stale. Off by default.
-    const renderingInSync = c.req.query("renderingInSync") === "1"
 
     const storage = createBookStorage(safeLabel, booksDir)
     try {
@@ -2202,16 +2199,7 @@ export function createPageRoutes(
         updatedRendering = { sections: shifted }
       }
 
-      // Neither half keeps its HTML — the split section's entry is dropped and
-      // the new one never had one — so the caller must render both before the
-      // stage is whole again.
-      const sectioningVersion = saveStoryboardNode(
-        storage,
-        "page-sectioning",
-        pageId,
-        updatedSectioning,
-        { renderingInSync }
-      )
+      const sectioningVersion = saveStoryboardNode(storage, "page-sectioning", pageId, updatedSectioning)
       if (updatedRendering) {
         renderingVersion = saveStoryboardNode(storage, "web-rendering", pageId, updatedRendering)
       }

--- a/apps/api/src/routes/pages.ts
+++ b/apps/api/src/routes/pages.ts
@@ -2064,6 +2064,9 @@ export function createPageRoutes(
       })
     }
     const { beforeNodeIndex, beforeNodeId } = parsedBody.data
+    // Both halves lose their HTML, so only a caller that re-renders both of them
+    // may opt out of marking the stage stale. Off by default.
+    const renderingInSync = c.req.query("renderingInSync") === "1"
 
     const storage = createBookStorage(safeLabel, booksDir)
     try {
@@ -2199,7 +2202,16 @@ export function createPageRoutes(
         updatedRendering = { sections: shifted }
       }
 
-      const sectioningVersion = saveStoryboardNode(storage, "page-sectioning", pageId, updatedSectioning)
+      // Neither half keeps its HTML — the split section's entry is dropped and
+      // the new one never had one — so the caller must render both before the
+      // stage is whole again.
+      const sectioningVersion = saveStoryboardNode(
+        storage,
+        "page-sectioning",
+        pageId,
+        updatedSectioning,
+        { renderingInSync }
+      )
       if (updatedRendering) {
         renderingVersion = saveStoryboardNode(storage, "web-rendering", pageId, updatedRendering)
       }

--- a/apps/api/src/routes/pages.ts
+++ b/apps/api/src/routes/pages.ts
@@ -1671,6 +1671,34 @@ export function createPageRoutes(
       storage.close()
     }
 
+    // An unprune keeps the storyboard marked complete on the promise that this
+    // re-render will supply the section's HTML. When it dies that HTML never
+    // arrives, so take the mark back here — the browser may be long gone by then,
+    // and a stage claiming output it does not have is what #642 set out to fix.
+    const runReRender = async () => {
+      try {
+        return await reRenderPage({
+          label: safeLabel,
+          pageId,
+          sectionIndex,
+          prompt,
+          booksDir,
+          promptsDir,
+          webAssetsDir,
+          configPath,
+          apiKey,
+        })
+      } catch (err) {
+        const storage = createBookStorage(safeLabel, booksDir)
+        try {
+          markStoryboardChainStale(storage)
+        } finally {
+          storage.close()
+        }
+        throw err
+      }
+    }
+
     // Submit as task if TaskService is available
     if (taskService) {
       const desc = sectionIndex !== undefined
@@ -1680,38 +1708,14 @@ export function createPageRoutes(
         safeLabel,
         "re-render",
         desc,
-        async () => {
-          return await reRenderPage({
-            label: safeLabel,
-            pageId,
-            sectionIndex,
-            prompt,
-            booksDir,
-            promptsDir,
-            webAssetsDir,
-            configPath,
-            apiKey,
-          })
-        },
+        runReRender,
         { pageId, url: `/books/${safeLabel}/storyboard/${pageId}` }
       )
       return c.json({ taskId, status: "submitted" })
     }
 
     // Fallback: run synchronously
-    const result = await reRenderPage({
-      label: safeLabel,
-      pageId,
-      sectionIndex,
-      prompt,
-      booksDir,
-      promptsDir,
-      webAssetsDir,
-      configPath,
-      apiKey,
-    })
-
-    return c.json(result)
+    return c.json(await runReRender())
   })
 
   // POST /books/:label/pages/:pageId/sections/:sectionIndex/ai-edit — AI-edit a section's HTML

--- a/apps/api/src/routes/pages.ts
+++ b/apps/api/src/routes/pages.ts
@@ -588,9 +588,10 @@ function saveStoryboardNode(
   // packaged book while the stage still read "done". A `web-rendering` save is
   // itself the storyboard's output, so it must NOT mark storyboard stale.
   //
-  // `renderingInSync` is the Storyboard editor saving sectioning and rendering
-  // together: the HTML it sends already carries the edit, so the storyboard is
-  // current and only its dependents are behind.
+  // `renderingInSync` is the Storyboard editor saving a per-section edit whose
+  // HTML it has already mirrored, or has queued a targeted re-render for. The
+  // storyboard is current (or seconds from it) and only its dependents are
+  // behind, so resetting the stage would take the editor away for nothing.
   if (node === "page-sectioning") {
     markStoryboardChainStale(storage, { includeStoryboard: !renderingInSync })
   }
@@ -1453,12 +1454,15 @@ export function createPageRoutes(
   // landed, leaving the HTML and the tree disagreeing with no way back. Writing
   // both here means the guard runs once, up front, and the pair moves together.
   //
-  // `renderingInSync` says the stored HTML reflects this sectioning once the
-  // request completes — either because the editor mirrored the edit into the
-  // rendering it is sending (inline text, prune, delete) or because the change
-  // needed no HTML at all. It is false when the change only shows up after an
-  // LLM re-render (section type, unprune, reorder, role change); only then is
-  // the storyboard stage itself marked stale.
+  // `renderingInSync` says the stored HTML reflects this sectioning, or will
+  // shortly: the caller either mirrored the edit into the rendering it is
+  // sending, needed no HTML change at all, or has queued a re-render of the one
+  // section it touched. Storyboard editing is incremental by design, so a
+  // per-section edit must not reset the stage for the whole book. It is false
+  // only when the HTML cannot be brought back in sync — no API key, or a custom
+  // activity a re-render would flatten — and false is also the default, so the
+  // Sectioning stage and the structural ops that drop HTML without re-rendering
+  // (split, cross-page merge) keep marking the chain stale.
   app.put("/books/:label/pages/:pageId/storyboard", async (c) => {
     const { label, pageId } = c.req.param()
     const safeLabel = parseBookLabel(label)

--- a/apps/api/src/routes/pages.ts
+++ b/apps/api/src/routes/pages.ts
@@ -2004,7 +2004,17 @@ export function createPageRoutes(
         rewriteRenderingSectionIds(shifted, newSections)
         updatedRendering = { sections: shifted }
       }
-      const sectioningVersion = saveStoryboardNode(storage, "page-sectioning", pageId, updatedSectioning)
+      // Cloning rebuilds the rendering to match: indexes shift, the source's HTML
+      // is copied for the clone, and container and section ids are rewritten. No
+      // LLM is involved and nothing is left behind, so the storyboard stays
+      // current — only the stages derived from it need a re-run.
+      const sectioningVersion = saveStoryboardNode(
+        storage,
+        "page-sectioning",
+        pageId,
+        updatedSectioning,
+        { renderingInSync: updatedRendering !== null }
+      )
       if (updatedRendering) {
         renderingVersion = saveStoryboardNode(storage, "web-rendering", pageId, updatedRendering)
       }
@@ -2593,7 +2603,17 @@ export function createPageRoutes(
         updatedRendering = { sections: shifted }
       }
 
-      const sectioningVersion = saveStoryboardNode(storage, "page-sectioning", pageId, updatedSectioning)
+      // Deleting rebuilds the rendering to match: the section's HTML entry is
+      // dropped, later indexes shift down, and section ids are rewritten. The
+      // surviving sections keep the HTML they already had, so nothing needs
+      // re-rendering and the storyboard stays current.
+      const sectioningVersion = saveStoryboardNode(
+        storage,
+        "page-sectioning",
+        pageId,
+        updatedSectioning,
+        { renderingInSync: updatedRendering !== null }
+      )
       if (updatedRendering) {
         renderingVersion = saveStoryboardNode(storage, "web-rendering", pageId, updatedRendering)
       }

--- a/apps/api/src/routes/pages.ts
+++ b/apps/api/src/routes/pages.ts
@@ -23,6 +23,7 @@ import {
   IMAGE_SET_CHANGE_CLEAR_STEPS,
   PIPELINE,
   getStageClearOrder,
+  getStageDependents,
   EDITABLE_ACTIVITY_NODE,
 } from "@adt/types"
 import type { ContentNodeData, ExtractionWarning } from "@adt/types"
@@ -521,8 +522,7 @@ function clearRestoredNodeDependents(storage: Storage, node: RestorableNode): vo
 }
 
 /**
- * Mark the storyboard and everything after it as needing a re-run, without
- * deleting any node data.
+ * Mark the storyboard chain as needing a re-run, without deleting any node data.
  *
  * A sectioning edit invalidates the storyboard's rendered HTML, and every later
  * output (text catalog, translations, audio, the packaged book) is re-derived
@@ -530,9 +530,20 @@ function clearRestoredNodeDependents(storage: Storage, node: RestorableNode): vo
  * old text. We clear only `step_runs`: the renderings and their version history
  * survive (so manual storyboard edits elsewhere in the book are not destroyed)
  * and are overwritten only when the user actually re-runs.
+ *
+ * `includeStoryboard: false` keeps the storyboard's own step run, for the case
+ * where the caller wrote a matching `web-rendering` in the same save: the HTML
+ * on disk already reflects the new sectioning, so only the stages *derived* from
+ * it are behind. Marking storyboard stale there would be a lie that also costs
+ * the user their editor — the Storyboard view is gated on the stage status.
  */
-function markStoryboardChainStale(storage: Storage): void {
-  const stages = new Set<string>(getStageClearOrder("storyboard"))
+function markStoryboardChainStale(
+  storage: Storage,
+  { includeStoryboard = true }: { includeStoryboard?: boolean } = {}
+): void {
+  const stages = new Set<string>(
+    includeStoryboard ? getStageClearOrder("storyboard") : getStageDependents("storyboard")
+  )
   storage.clearStepRuns(
     PIPELINE.filter((stage) => stages.has(stage.name)).flatMap((stage) =>
       stage.steps.map((step) => step.name)
@@ -565,7 +576,8 @@ function saveStoryboardNode(
   storage: Storage,
   node: "page-sectioning" | "web-rendering",
   itemId: string,
-  data: unknown
+  data: unknown,
+  { renderingInSync = false }: { renderingInSync?: boolean } = {}
 ): number {
   if (node === "page-sectioning") assertNoActivePipelineRun(storage)
   const version = storage.putNodeData(node, itemId, data)
@@ -575,7 +587,13 @@ function saveStoryboardNode(
   // merge empties both pages, so those sections would silently vanish from the
   // packaged book while the stage still read "done". A `web-rendering` save is
   // itself the storyboard's output, so it must NOT mark storyboard stale.
-  if (node === "page-sectioning") markStoryboardChainStale(storage)
+  //
+  // `renderingInSync` is the Storyboard editor saving sectioning and rendering
+  // together: the HTML it sends already carries the edit, so the storyboard is
+  // current and only its dependents are behind.
+  if (node === "page-sectioning") {
+    markStoryboardChainStale(storage, { includeStoryboard: !renderingInSync })
+  }
   return version
 }
 
@@ -1422,6 +1440,77 @@ export function createPageRoutes(
 
       const version = saveStoryboardNode(storage, "web-rendering", pageId, parsed.data)
       return c.json({ version })
+    } finally {
+      storage.close()
+    }
+  })
+
+  // PUT /books/:label/pages/:pageId/storyboard — one Storyboard editor save.
+  //
+  // Sectioning and rendering are two nodes but one user action, and splitting
+  // them across two requests is what made the editor fragile: the second PUT can
+  // fail (or be rejected by the pipeline-run guard) after the first has already
+  // landed, leaving the HTML and the tree disagreeing with no way back. Writing
+  // both here means the guard runs once, up front, and the pair moves together.
+  //
+  // `renderingInSync` says the stored HTML reflects this sectioning once the
+  // request completes — either because the editor mirrored the edit into the
+  // rendering it is sending (inline text, prune, delete) or because the change
+  // needed no HTML at all. It is false when the change only shows up after an
+  // LLM re-render (section type, unprune, reorder, role change); only then is
+  // the storyboard stage itself marked stale.
+  app.put("/books/:label/pages/:pageId/storyboard", async (c) => {
+    const { label, pageId } = c.req.param()
+    const safeLabel = parseBookLabel(label)
+
+    const body = await c.req.json()
+    const parsed = z
+      .object({
+        sectioning: PageSectioningOutput.optional(),
+        rendering: WebRenderingOutput.optional(),
+        renderingInSync: z.boolean().default(false),
+      })
+      .safeParse(body)
+    if (!parsed.success) {
+      throw new HTTPException(400, {
+        message: `Invalid storyboard save: ${parsed.error.message}`,
+      })
+    }
+    const { sectioning, rendering, renderingInSync } = parsed.data
+    if (!sectioning && !rendering) {
+      throw new HTTPException(400, {
+        message: "Storyboard save must include sectioning, rendering, or both",
+      })
+    }
+    // The flag only describes a sectioning write; on its own it would silently
+    // do nothing, which is worth a 400 rather than a puzzling no-op.
+    if (renderingInSync && !sectioning) {
+      throw new HTTPException(400, {
+        message: "renderingInSync requires sectioning",
+      })
+    }
+
+    const storage = createBookStorage(safeLabel, booksDir)
+    try {
+      const pages = storage.getPages()
+      const page = pages.find((p) => p.pageId === pageId)
+      if (!page) {
+        throw new HTTPException(404, { message: `Page not found: ${pageId}` })
+      }
+
+      // Guard before either write, so a rejected save changes nothing at all.
+      if (sectioning) assertNoActivePipelineRun(storage)
+
+      // Rendering first: if the pair is in sync, the HTML is the thing every
+      // downstream stage reads, so it should never be the write left undone.
+      const renderingVersion = rendering
+        ? saveStoryboardNode(storage, "web-rendering", pageId, rendering)
+        : null
+      const sectioningVersion = sectioning
+        ? saveStoryboardNode(storage, "page-sectioning", pageId, sectioning, { renderingInSync })
+        : null
+
+      return c.json({ sectioningVersion, renderingVersion })
     } finally {
       storage.close()
     }

--- a/apps/api/src/routes/pages.ts
+++ b/apps/api/src/routes/pages.ts
@@ -1505,14 +1505,16 @@ export function createPageRoutes(
       // Guard before either write, so a rejected save changes nothing at all.
       if (sectioning) assertNoActivePipelineRun(storage)
 
-      // Rendering first: if the pair is in sync, the HTML is the thing every
-      // downstream stage reads, so it should never be the write left undone.
-      const renderingVersion = rendering
-        ? saveStoryboardNode(storage, "web-rendering", pageId, rendering)
-        : null
-      const sectioningVersion = sectioning
-        ? saveStoryboardNode(storage, "page-sectioning", pageId, sectioning, { renderingInSync })
-        : null
+      // Rendering, sectioning, downstream invalidations, and step status are a
+      // single editor save. If any statement fails, none of them may survive.
+      const { renderingVersion, sectioningVersion } = storage.transaction(() => ({
+        renderingVersion: rendering
+          ? saveStoryboardNode(storage, "web-rendering", pageId, rendering)
+          : null,
+        sectioningVersion: sectioning
+          ? saveStoryboardNode(storage, "page-sectioning", pageId, sectioning, { renderingInSync })
+          : null,
+      }))
 
       return c.json({ sectioningVersion, renderingVersion })
     } finally {
@@ -1608,6 +1610,112 @@ export function createPageRoutes(
     } finally {
       storage.close()
     }
+  })
+
+  // POST /books/:label/pages/re-render — Re-render a set of pages as one task.
+  // This is used by cross-page edits: the Storyboard step stays running until
+  // every affected page succeeds, and any failure makes the whole stage stale.
+  app.post("/books/:label/pages/re-render", async (c) => {
+    const safeLabel = parseBookLabel(c.req.param("label"))
+    const apiKey = c.req.header("X-OpenAI-Key")
+    if (!apiKey) {
+      throw new HTTPException(400, { message: "Missing X-OpenAI-Key header" })
+    }
+
+    const parsed = z
+      .object({ pageIds: z.array(z.string().min(1)).min(1).max(100) })
+      .safeParse(await c.req.json().catch(() => null))
+    if (!parsed.success) {
+      throw new HTTPException(400, {
+        message: `Invalid re-render request: ${parsed.error.message}`,
+      })
+    }
+    const pageIds = [...new Set(parsed.data.pageIds)]
+
+    const storage = createBookStorage(safeLabel, booksDir)
+    try {
+      const existingPageIds = new Set(storage.getPages().map((page) => page.pageId))
+      for (const pageId of pageIds) {
+        if (!existingPageIds.has(pageId)) {
+          throw new HTTPException(404, { message: `Page not found: ${pageId}` })
+        }
+        const sectioningRow = storage.getLatestNodeData("page-sectioning", pageId)
+        if (!sectioningRow) {
+          throw new HTTPException(400, {
+            message: `Page must have page-sectioning data before re-rendering: ${pageId}`,
+          })
+        }
+        if (!PageSectioningOutput.safeParse(sectioningRow.data).success) {
+          throw new HTTPException(400, {
+            message: `Invalid page-sectioning data: ${pageId}`,
+          })
+        }
+      }
+
+      assertNoActivePipelineRun(storage)
+      storage.markStepStarted("web-rendering")
+    } finally {
+      storage.close()
+    }
+
+    const markBatchFailed = () => {
+      const failedStorage = createBookStorage(safeLabel, booksDir)
+      try {
+        markStoryboardChainStale(failedStorage)
+      } finally {
+        failedStorage.close()
+      }
+    }
+
+    const runReRenders = async () => {
+      try {
+        const results = []
+        // reRenderPage temporarily installs the key in process.env, so run the
+        // pages serially rather than letting concurrent calls race that state.
+        for (const pageId of pageIds) {
+          results.push(
+            await reRenderPage({
+              label: safeLabel,
+              pageId,
+              booksDir,
+              promptsDir,
+              webAssetsDir,
+              configPath,
+              apiKey,
+            })
+          )
+        }
+
+        const completedStorage = createBookStorage(safeLabel, booksDir)
+        try {
+          completedStorage.markStepCompleted("web-rendering")
+        } finally {
+          completedStorage.close()
+        }
+        return { results }
+      } catch (err) {
+        markBatchFailed()
+        throw err
+      }
+    }
+
+    if (taskService) {
+      try {
+        const { taskId } = taskService.submitTask(
+          safeLabel,
+          "re-render",
+          `Re-rendering ${pageIds.length} affected page(s)`,
+          runReRenders,
+          { pageId: pageIds[0], url: `/books/${safeLabel}/storyboard/${pageIds[0]}` }
+        )
+        return c.json({ taskId, status: "submitted" })
+      } catch (err) {
+        markBatchFailed()
+        throw err
+      }
+    }
+
+    return c.json(await runReRenders())
   })
 
   // POST /books/:label/pages/:pageId/re-render — Re-render page with current pipeline data
@@ -2409,11 +2517,6 @@ export function createPageRoutes(
       })
     }
     const { direction } = parsedQuery.data
-    // Unlike a same-page merge, this empties both pages' renderings outright, so
-    // the caller must re-render both pages before the stage is whole again. Only
-    // a caller that will do that may opt out of marking the stage stale.
-    const renderingInSync = c.req.query("renderingInSync") === "1"
-
     const storage = createBookStorage(safeLabel, booksDir)
     try {
       const pages = storage.getPages()
@@ -2503,15 +2606,13 @@ export function createPageRoutes(
         storage,
         "page-sectioning",
         pageId,
-        { ...srcSectioning, sections: newSrcSections },
-        { renderingInSync }
+        { ...srcSectioning, sections: newSrcSections }
       )
       const tgtVersion = saveStoryboardNode(
         storage,
         "page-sectioning",
         targetPageId,
-        { ...tgtSectioning, sections: newTgtSections },
-        { renderingInSync }
+        { ...tgtSectioning, sections: newTgtSections }
       )
 
       // Clear rendering for both pages (merged content invalidates existing renders)

--- a/apps/api/src/services/task-service.ts
+++ b/apps/api/src/services/task-service.ts
@@ -88,7 +88,7 @@ export function createTaskService(eventBus: BookEventBus): TaskService {
           info.completedAt = Date.now()
           eventBus.emit(label, {
             type: "task",
-            data: { type: "task-complete", taskId, result },
+            data: { type: "task-complete", taskId, kind, pageId: options?.pageId, result },
           })
         })
         .catch((err) => {
@@ -98,7 +98,7 @@ export function createTaskService(eventBus: BookEventBus): TaskService {
           info.completedAt = Date.now()
           eventBus.emit(label, {
             type: "task",
-            data: { type: "task-error", taskId, error: message },
+            data: { type: "task-error", taskId, kind, pageId: options?.pageId, error: message },
           })
         })
         .finally(() => {

--- a/apps/studio/src/api/client.ts
+++ b/apps/studio/src/api/client.ts
@@ -1165,23 +1165,20 @@ export const api = {
       method: "POST",
     }),
 
-  /** Both halves lose their HTML, so `renderingInSync` is only honest when the
-   *  caller re-renders both afterwards. */
   splitSection: (
     label: string,
     pageId: string,
     sectionIndex: number,
-    at: { beforeNodeIndex: number } | { beforeNodeId: string },
-    renderingInSync = false
+    at: { beforeNodeIndex: number } | { beforeNodeId: string }
   ) =>
     request<{
       splitSectionIndex: number
       sectioningVersion: number
       renderingVersion: number | null
-    }>(
-      `/books/${label}/pages/${pageId}/sections/${sectionIndex}/split${renderingInSync ? "?renderingInSync=1" : ""}`,
-      { method: "POST", body: JSON.stringify(at) }
-    ),
+    }>(`/books/${label}/pages/${pageId}/sections/${sectionIndex}/split`, {
+      method: "POST",
+      body: JSON.stringify(at),
+    }),
 
   /** `renderingInSync` is for callers that re-render the affected sections
    *  themselves; it keeps the Storyboard stage from being marked stale. */

--- a/apps/studio/src/api/client.ts
+++ b/apps/studio/src/api/client.ts
@@ -1165,20 +1165,23 @@ export const api = {
       method: "POST",
     }),
 
+  /** Both halves lose their HTML, so `renderingInSync` is only honest when the
+   *  caller re-renders both afterwards. */
   splitSection: (
     label: string,
     pageId: string,
     sectionIndex: number,
-    at: { beforeNodeIndex: number } | { beforeNodeId: string }
+    at: { beforeNodeIndex: number } | { beforeNodeId: string },
+    renderingInSync = false
   ) =>
     request<{
       splitSectionIndex: number
       sectioningVersion: number
       renderingVersion: number | null
-    }>(`/books/${label}/pages/${pageId}/sections/${sectionIndex}/split`, {
-      method: "POST",
-      body: JSON.stringify(at),
-    }),
+    }>(
+      `/books/${label}/pages/${pageId}/sections/${sectionIndex}/split${renderingInSync ? "?renderingInSync=1" : ""}`,
+      { method: "POST", body: JSON.stringify(at) }
+    ),
 
   /** `renderingInSync` is for callers that re-render the affected sections
    *  themselves; it keeps the Storyboard stage from being marked stale. */

--- a/apps/studio/src/api/client.ts
+++ b/apps/studio/src/api/client.ts
@@ -1133,12 +1133,12 @@ export const api = {
    * One Storyboard editor save: sectioning and rendering land in a single
    * request so a failure can't leave the tree and the HTML disagreeing.
    *
-   * `renderingInSync` means the stored HTML reflects this sectioning once the
-   * save completes — true when the editor mirrored the edit into the rendering
-   * it is sending, or when the change needed no HTML at all; false when the
-   * change only shows up after an LLM re-render. When true the Storyboard stage
-   * stays complete and only its dependents are marked for re-run. Requires
-   * `sectioning`, which is the only write it describes.
+   * `renderingInSync` means the stored HTML reflects this sectioning, or will
+   * shortly — the caller mirrored the edit into the rendering it is sending,
+   * needed no HTML change, or has queued a re-render of the section it touched.
+   * When true the Storyboard stage stays complete and only its dependents are
+   * marked for re-run; pass false only when the HTML cannot be brought back in
+   * sync. Requires `sectioning`, which is the only write it describes.
    */
   saveStoryboard: (
     label: string,

--- a/apps/studio/src/api/client.ts
+++ b/apps/studio/src/api/client.ts
@@ -1198,14 +1198,13 @@ export const api = {
       { method: "POST" }
     ),
 
-  /** Empties both pages' renderings, so `renderingInSync` is only honest when
-   *  the caller re-renders both pages afterwards. */
+  /** Moves a section across a page boundary and empties both renderings. The
+   *  Storyboard is always marked stale until reRenderPages repairs both. */
   mergeSectionCrossPage: (
     label: string,
     pageId: string,
     sectionIndex: number,
-    direction: "next" | "prev",
-    renderingInSync = false
+    direction: "next" | "prev"
   ) =>
     request<{
       sourcePageId: string
@@ -1216,7 +1215,7 @@ export const api = {
       sourceRenderingVersion: number | null
       targetRenderingVersion: number | null
     }>(
-      `/books/${label}/pages/${pageId}/sections/${sectionIndex}/merge-cross-page?direction=${direction}${renderingInSync ? "&renderingInSync=1" : ""}`,
+      `/books/${label}/pages/${pageId}/sections/${sectionIndex}/merge-cross-page?direction=${direction}`,
       { method: "POST" }
     ),
 
@@ -1237,6 +1236,17 @@ export const api = {
         headers: { "X-OpenAI-Key": apiKey },
         ...(prompt ? { body: JSON.stringify({ prompt }) } : {}),
         signal: AbortSignal.timeout(30_000), // Just submitting a task now
+      }
+    ),
+
+  reRenderPages: (label: string, pageIds: string[], apiKey: string) =>
+    request<{ taskId?: string; status?: string; results?: unknown[] }>(
+      `/books/${label}/pages/re-render`,
+      {
+        method: "POST",
+        headers: { "X-OpenAI-Key": apiKey },
+        body: JSON.stringify({ pageIds }),
+        signal: AbortSignal.timeout(30_000),
       }
     ),
 

--- a/apps/studio/src/api/client.ts
+++ b/apps/studio/src/api/client.ts
@@ -1129,6 +1129,27 @@ export const api = {
       body: JSON.stringify(data),
     }),
 
+  /**
+   * One Storyboard editor save: sectioning and rendering land in a single
+   * request so a failure can't leave the tree and the HTML disagreeing.
+   *
+   * `renderingInSync` means the stored HTML reflects this sectioning once the
+   * save completes — true when the editor mirrored the edit into the rendering
+   * it is sending, or when the change needed no HTML at all; false when the
+   * change only shows up after an LLM re-render. When true the Storyboard stage
+   * stays complete and only its dependents are marked for re-run. Requires
+   * `sectioning`, which is the only write it describes.
+   */
+  saveStoryboard: (
+    label: string,
+    pageId: string,
+    data: { sectioning?: unknown; rendering?: unknown; renderingInSync?: boolean }
+  ) =>
+    request<{ sectioningVersion: number | null; renderingVersion: number | null }>(
+      `/books/${label}/pages/${pageId}/storyboard`,
+      { method: "PUT", body: JSON.stringify(data) }
+    ),
+
   updateImageCaptioning: (label: string, pageId: string, data: unknown) =>
     request<{ version: number }>(`/books/${label}/pages/${pageId}/image-captioning`, {
       method: "PUT",

--- a/apps/studio/src/api/client.ts
+++ b/apps/studio/src/api/client.ts
@@ -1180,26 +1180,32 @@ export const api = {
       body: JSON.stringify(at),
     }),
 
+  /** `renderingInSync` is for callers that re-render the affected sections
+   *  themselves; it keeps the Storyboard stage from being marked stale. */
   mergeSection: (
     label: string,
     pageId: string,
     sectionIndex: number,
-    direction: "next" | "prev" = "next"
+    direction: "next" | "prev" = "next",
+    renderingInSync = false
   ) =>
     request<{
       mergedSectionIndex: number
       sectioningVersion: number
       renderingVersion: number | null
     }>(
-      `/books/${label}/pages/${pageId}/sections/${sectionIndex}/merge?direction=${direction}`,
+      `/books/${label}/pages/${pageId}/sections/${sectionIndex}/merge?direction=${direction}${renderingInSync ? "&renderingInSync=1" : ""}`,
       { method: "POST" }
     ),
 
+  /** Empties both pages' renderings, so `renderingInSync` is only honest when
+   *  the caller re-renders both pages afterwards. */
   mergeSectionCrossPage: (
     label: string,
     pageId: string,
     sectionIndex: number,
-    direction: "next" | "prev"
+    direction: "next" | "prev",
+    renderingInSync = false
   ) =>
     request<{
       sourcePageId: string
@@ -1210,7 +1216,7 @@ export const api = {
       sourceRenderingVersion: number | null
       targetRenderingVersion: number | null
     }>(
-      `/books/${label}/pages/${pageId}/sections/${sectionIndex}/merge-cross-page?direction=${direction}`,
+      `/books/${label}/pages/${pageId}/sections/${sectionIndex}/merge-cross-page?direction=${direction}${renderingInSync ? "&renderingInSync=1" : ""}`,
       { method: "POST" }
     ),
 

--- a/apps/studio/src/components/pipeline/components/StageSidebar.tsx
+++ b/apps/studio/src/components/pipeline/components/StageSidebar.tsx
@@ -93,10 +93,17 @@ export function StageSidebar({
   )
 
   const currentState = stageState(activeStep)
+  // A stale Storyboard still has its renderings — staleness is a step_runs flag,
+  // not a delete. Closing the pages panel on stage status alone took the page
+  // list away from a user whose pages were all still there, and with it the way
+  // to reach the per-section re-render. Matches the gate in StoryboardIndex.
+  const storyboardHasRenderings =
+    activeStep === "storyboard" && (sidebarPages ?? []).some((p) => p.hasRendering)
   const stageHasContent =
     currentState === "done" ||
     currentState === "running" ||
-    currentState === "error"
+    currentState === "error" ||
+    storyboardHasRenderings
   // Quizzes never open a side panel — selection lives in the content header.
   const effectivePagesOpen =
     hasStagePages(activeStep) && stageHasContent && activeStep !== "quizzes"

--- a/apps/studio/src/components/pipeline/components/StageSidebar.tsx
+++ b/apps/studio/src/components/pipeline/components/StageSidebar.tsx
@@ -97,13 +97,12 @@ export function StageSidebar({
   // not a delete. Closing the pages panel on stage status alone took the page
   // list away from a user whose pages were all still there, and with it the way
   // to reach the per-section re-render. Matches the gate in StoryboardIndex.
-  const storyboardHasRenderings =
-    activeStep === "storyboard" && (sidebarPages ?? []).some((p) => p.hasRendering)
+  const hasRenderings = (sidebarPages ?? []).some((p) => p.hasRendering)
   const stageHasContent =
     currentState === "done" ||
     currentState === "running" ||
     currentState === "error" ||
-    storyboardHasRenderings
+    (activeStep === "storyboard" && hasRenderings)
   // Quizzes never open a side panel — selection lives in the content header.
   const effectivePagesOpen =
     hasStagePages(activeStep) && stageHasContent && activeStep !== "quizzes"
@@ -177,7 +176,16 @@ export function StageSidebar({
     const Icon = step.icon
     const state = completionOverrides[step.slug] ? "done" : stageState(step.slug)
     const stageCompleted = state === "done"
-    const showOverviewTab = state === "done" || state === "running" || state === "queued"
+    // Overview is the stage's landing page, and its Run button. It is normally
+    // redundant while a stage is idle, because the stage's own view *is* the
+    // landing page — but a stale Storyboard shows the editor instead, so hiding
+    // Overview there leaves no way to re-run the stage at all. It is the first
+    // tab, so re-running stays one click from the gear.
+    const showOverviewTab =
+      state === "done" ||
+      state === "running" ||
+      state === "queued" ||
+      (step.slug === "storyboard" && hasRenderings)
     const settingsTabs = getSettingsTabs(step.slug, i18n, showOverviewTab)
     const showSubTabs = isActive && isSettings && !!settingsTabs
 

--- a/apps/studio/src/components/pipeline/stages/sectioning/SectioningPageDetail.test.tsx
+++ b/apps/studio/src/components/pipeline/stages/sectioning/SectioningPageDetail.test.tsx
@@ -55,13 +55,7 @@ vi.mock("@/lib/section-constants", () => ({
   getSectionTypeDescription: () => "",
 }))
 
-vi.mock("@/hooks/use-pages", () => ({
-  usePageImage: () => ({ data: undefined }),
-  // No rendered pages, so the structural ops have no storyboard HTML to repair
-  // and queue no re-renders — these tests are about the confirmation flow.
-  usePages: () => ({ data: [] }),
-}))
-vi.mock("@/hooks/use-api-key", () => ({ useApiKey: () => ({ apiKey: "", hasApiKey: false }) }))
+vi.mock("@/hooks/use-pages", () => ({ usePageImage: () => ({ data: undefined }) }))
 vi.mock("@/hooks/use-page-mutations", () => ({ invalidateStoryboardDependents: vi.fn() }))
 vi.mock("../../components/StepViewRouter", () => ({
   useStepHeader: () => ({ headerSlotEl: null }),

--- a/apps/studio/src/components/pipeline/stages/sectioning/SectioningPageDetail.test.tsx
+++ b/apps/studio/src/components/pipeline/stages/sectioning/SectioningPageDetail.test.tsx
@@ -55,7 +55,13 @@ vi.mock("@/lib/section-constants", () => ({
   getSectionTypeDescription: () => "",
 }))
 
-vi.mock("@/hooks/use-pages", () => ({ usePageImage: () => ({ data: undefined }) }))
+vi.mock("@/hooks/use-pages", () => ({
+  usePageImage: () => ({ data: undefined }),
+  // No rendered pages, so the structural ops have no storyboard HTML to repair
+  // and queue no re-renders — these tests are about the confirmation flow.
+  usePages: () => ({ data: [] }),
+}))
+vi.mock("@/hooks/use-api-key", () => ({ useApiKey: () => ({ apiKey: "", hasApiKey: false }) }))
 vi.mock("@/hooks/use-page-mutations", () => ({ invalidateStoryboardDependents: vi.fn() }))
 vi.mock("../../components/StepViewRouter", () => ({
   useStepHeader: () => ({ headerSlotEl: null }),

--- a/apps/studio/src/components/pipeline/stages/sectioning/SectioningPageDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/sectioning/SectioningPageDetail.tsx
@@ -12,8 +12,7 @@ import { Trans, useLingui } from "@lingui/react/macro"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import type { PageSectioningOutput, PageSectioningSection } from "@adt/types"
 import { api, type PageDetail } from "@/api/client"
-import { usePageImage, usePages } from "@/hooks/use-pages"
-import { useApiKey } from "@/hooks/use-api-key"
+import { usePageImage } from "@/hooks/use-pages"
 import { invalidateStoryboardDependents } from "@/hooks/use-page-mutations"
 import { SectionTreeEditor } from "@/components/section-tree-editor/SectionTreeEditor"
 import { SectionActionsDropdown } from "@/components/pipeline/stages/storyboard/components/SectionActionsDropdown"
@@ -55,45 +54,6 @@ export function SectioningPageDetail({
   const queryClient = useQueryClient()
   const { headerSlotEl } = useStepHeader()
   const { data: imageData } = usePageImage(bookLabel, pageId)
-  const { apiKey, hasApiKey } = useApiKey()
-  const { data: allPages } = usePages(bookLabel)
-
-  // A structural edit here damages the HTML the Storyboard already produced, so
-  // it should repair it the same way the Storyboard editor does rather than
-  // leaving the stage greyed out with nothing running. Only pages that have
-  // been rendered are worth re-rendering — on a book whose storyboard has never
-  // run there is nothing to repair, and rendering here would invent output the
-  // user never asked for.
-  const hasRendering = useCallback(
-    (id: string) => (allPages ?? []).some((p) => p.pageId === id && p.hasRendering),
-    [allPages]
-  )
-  const rerenderPage = useCallback(
-    (id: string, sectionIndex?: number) => {
-      if (!hasApiKey || !hasRendering(id)) return
-      api.reRenderPage(bookLabel, id, apiKey, sectionIndex).catch(() => {})
-    },
-    [bookLabel, apiKey, hasApiKey, hasRendering]
-  )
-  /** Whether `rerenderPage` will actually run for a page — drives both the
-   *  storyboard's staleness flag and what the confirmation promises. */
-  const willRerender = (id: string) => hasApiKey && hasRendering(id)
-  /** The page a cross-page merge would move content to. Needed before the call,
-   *  to know whether both pages can be put back. */
-  const neighborPageId = (direction: "next" | "prev"): string | null => {
-    const list = allPages ?? []
-    const index = list.findIndex((p) => p.pageId === pageId)
-    if (index < 0) return null
-    return (direction === "next" ? list[index + 1] : list[index - 1])?.pageId ?? null
-  }
-  /** Sentence for the confirmation: does this op put the Storyboard back itself?
-   *  Nothing to say when the page was never rendered — there is no damage. */
-  const storyboardRepairMessage = (): string | undefined => {
-    if (!hasRendering(pageId)) return undefined
-    return hasApiKey
-      ? t`The affected pages will be re-rendered automatically.`
-      : t`The affected pages lose their rendering. Without an API key they cannot be re-rendered, so the Storyboard will need re-running.`
-  }
 
   const configQuery = useQuery({
     queryKey: ["books", bookLabel, "config", "active"],
@@ -140,9 +100,6 @@ export function SectioningPageDetail({
     title: string
     /** Op-specific sentence; the cascade notice is appended when relevant. */
     description?: string
-    /** What happens to the Storyboard's HTML — whether this op repairs the
-     *  pages it damages, or leaves them for the user to re-run. */
-    consequence?: string
     confirmLabel: string
     icon: ComponentType<{ className?: string }>
     colorClass: string
@@ -370,30 +327,18 @@ export function SectioningPageDetail({
 
   const handleMergeSection = (sectionIndex: number, direction: "next" | "prev") =>
     runStructural(async () => {
-      const result = await api.mergeSection(
-        bookLabel,
-        pageId,
-        sectionIndex,
-        direction,
-        willRerender(pageId)
-      )
-      rerenderPage(pageId, result.mergedSectionIndex)
+      await api.mergeSection(bookLabel, pageId, sectionIndex, direction)
       return null
     })
 
   const handleMergeCrossPage = (sectionIndex: number, direction: "next" | "prev") =>
     runStructural(async () => {
-      // This empties both pages' renderings, so both are re-rendered whole. The
-      // stage only stays complete if both can actually be put back.
       const result = await api.mergeSectionCrossPage(
         bookLabel,
         pageId,
         sectionIndex,
-        direction,
-        willRerender(pageId) && willRerender(neighborPageId(direction) ?? "")
+        direction
       )
-      rerenderPage(result.sourcePageId)
-      rerenderPage(result.targetPageId)
       return result.targetPageId
     })
 
@@ -415,7 +360,6 @@ export function SectioningPageDetail({
     requestStructuralOp({
       title: t`Confirm merge`,
       description: t`Are you sure you want to ${label}? This action cannot be undone.`,
-      consequence: storyboardRepairMessage(),
       confirmLabel: t`Continue`,
       icon: Merge,
       colorClass: "bg-sky-600 hover:bg-sky-700",
@@ -430,23 +374,12 @@ export function SectioningPageDetail({
     requestStructuralOp({
       title: t`Split section`,
       description: t`Are you sure you want to ${label}? This action cannot be undone.`,
-      consequence: storyboardRepairMessage(),
       confirmLabel: t`Split`,
       icon: Scissors,
       colorClass: "bg-sky-600 hover:bg-sky-700",
       run: () =>
         void runStructural(async () => {
-          const result = await api.splitSection(
-            bookLabel,
-            pageId,
-            sectionIndex,
-            at,
-            willRerender(pageId)
-          )
-          // Both halves need HTML: the original's entry was dropped and the new
-          // one never had one.
-          rerenderPage(pageId, sectionIndex)
-          rerenderPage(pageId, result.splitSectionIndex)
+          await api.splitSection(bookLabel, pageId, sectionIndex, at)
           return null
         }),
     })
@@ -699,7 +632,6 @@ export function SectioningPageDetail({
         description={
           <>
             {pendingOp.description}
-            {pendingOp.consequence ? ` ${pendingOp.consequence}` : null}
             {downstreamAffected.length > 0 && (
               <>
                 {pendingOp.description ? " " : null}

--- a/apps/studio/src/components/pipeline/stages/sectioning/SectioningPageDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/sectioning/SectioningPageDetail.tsx
@@ -12,7 +12,8 @@ import { Trans, useLingui } from "@lingui/react/macro"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import type { PageSectioningOutput, PageSectioningSection } from "@adt/types"
 import { api, type PageDetail } from "@/api/client"
-import { usePageImage } from "@/hooks/use-pages"
+import { usePageImage, usePages } from "@/hooks/use-pages"
+import { useApiKey } from "@/hooks/use-api-key"
 import { invalidateStoryboardDependents } from "@/hooks/use-page-mutations"
 import { SectionTreeEditor } from "@/components/section-tree-editor/SectionTreeEditor"
 import { SectionActionsDropdown } from "@/components/pipeline/stages/storyboard/components/SectionActionsDropdown"
@@ -54,6 +55,45 @@ export function SectioningPageDetail({
   const queryClient = useQueryClient()
   const { headerSlotEl } = useStepHeader()
   const { data: imageData } = usePageImage(bookLabel, pageId)
+  const { apiKey, hasApiKey } = useApiKey()
+  const { data: allPages } = usePages(bookLabel)
+
+  // A structural edit here damages the HTML the Storyboard already produced, so
+  // it should repair it the same way the Storyboard editor does rather than
+  // leaving the stage greyed out with nothing running. Only pages that have
+  // been rendered are worth re-rendering — on a book whose storyboard has never
+  // run there is nothing to repair, and rendering here would invent output the
+  // user never asked for.
+  const hasRendering = useCallback(
+    (id: string) => (allPages ?? []).some((p) => p.pageId === id && p.hasRendering),
+    [allPages]
+  )
+  const rerenderPage = useCallback(
+    (id: string, sectionIndex?: number) => {
+      if (!hasApiKey || !hasRendering(id)) return
+      api.reRenderPage(bookLabel, id, apiKey, sectionIndex).catch(() => {})
+    },
+    [bookLabel, apiKey, hasApiKey, hasRendering]
+  )
+  /** Whether `rerenderPage` will actually run for a page — drives both the
+   *  storyboard's staleness flag and what the confirmation promises. */
+  const willRerender = (id: string) => hasApiKey && hasRendering(id)
+  /** The page a cross-page merge would move content to. Needed before the call,
+   *  to know whether both pages can be put back. */
+  const neighborPageId = (direction: "next" | "prev"): string | null => {
+    const list = allPages ?? []
+    const index = list.findIndex((p) => p.pageId === pageId)
+    if (index < 0) return null
+    return (direction === "next" ? list[index + 1] : list[index - 1])?.pageId ?? null
+  }
+  /** Sentence for the confirmation: does this op put the Storyboard back itself?
+   *  Nothing to say when the page was never rendered — there is no damage. */
+  const storyboardRepairMessage = (): string | undefined => {
+    if (!hasRendering(pageId)) return undefined
+    return hasApiKey
+      ? t`The affected pages will be re-rendered automatically.`
+      : t`The affected pages lose their rendering. Without an API key they cannot be re-rendered, so the Storyboard will need re-running.`
+  }
 
   const configQuery = useQuery({
     queryKey: ["books", bookLabel, "config", "active"],
@@ -100,6 +140,9 @@ export function SectioningPageDetail({
     title: string
     /** Op-specific sentence; the cascade notice is appended when relevant. */
     description?: string
+    /** What happens to the Storyboard's HTML — whether this op repairs the
+     *  pages it damages, or leaves them for the user to re-run. */
+    consequence?: string
     confirmLabel: string
     icon: ComponentType<{ className?: string }>
     colorClass: string
@@ -327,18 +370,30 @@ export function SectioningPageDetail({
 
   const handleMergeSection = (sectionIndex: number, direction: "next" | "prev") =>
     runStructural(async () => {
-      await api.mergeSection(bookLabel, pageId, sectionIndex, direction)
+      const result = await api.mergeSection(
+        bookLabel,
+        pageId,
+        sectionIndex,
+        direction,
+        willRerender(pageId)
+      )
+      rerenderPage(pageId, result.mergedSectionIndex)
       return null
     })
 
   const handleMergeCrossPage = (sectionIndex: number, direction: "next" | "prev") =>
     runStructural(async () => {
+      // This empties both pages' renderings, so both are re-rendered whole. The
+      // stage only stays complete if both can actually be put back.
       const result = await api.mergeSectionCrossPage(
         bookLabel,
         pageId,
         sectionIndex,
-        direction
+        direction,
+        willRerender(pageId) && willRerender(neighborPageId(direction) ?? "")
       )
+      rerenderPage(result.sourcePageId)
+      rerenderPage(result.targetPageId)
       return result.targetPageId
     })
 
@@ -360,6 +415,7 @@ export function SectioningPageDetail({
     requestStructuralOp({
       title: t`Confirm merge`,
       description: t`Are you sure you want to ${label}? This action cannot be undone.`,
+      consequence: storyboardRepairMessage(),
       confirmLabel: t`Continue`,
       icon: Merge,
       colorClass: "bg-sky-600 hover:bg-sky-700",
@@ -374,12 +430,23 @@ export function SectioningPageDetail({
     requestStructuralOp({
       title: t`Split section`,
       description: t`Are you sure you want to ${label}? This action cannot be undone.`,
+      consequence: storyboardRepairMessage(),
       confirmLabel: t`Split`,
       icon: Scissors,
       colorClass: "bg-sky-600 hover:bg-sky-700",
       run: () =>
         void runStructural(async () => {
-          await api.splitSection(bookLabel, pageId, sectionIndex, at)
+          const result = await api.splitSection(
+            bookLabel,
+            pageId,
+            sectionIndex,
+            at,
+            willRerender(pageId)
+          )
+          // Both halves need HTML: the original's entry was dropped and the new
+          // one never had one.
+          rerenderPage(pageId, sectionIndex)
+          rerenderPage(pageId, result.splitSectionIndex)
           return null
         }),
     })
@@ -632,6 +699,7 @@ export function SectioningPageDetail({
         description={
           <>
             {pendingOp.description}
+            {pendingOp.consequence ? ` ${pendingOp.consequence}` : null}
             {downstreamAffected.length > 0 && (
               <>
                 {pendingOp.description ? " " : null}

--- a/apps/studio/src/components/pipeline/stages/storyboard/StoryboardIndex.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/StoryboardIndex.tsx
@@ -1,4 +1,7 @@
+import { Trans } from "@lingui/react/macro"
+import { usePages } from "@/hooks/use-pages"
 import { useStageStatus } from "@/hooks/use-stage-status"
+import { LoadingState } from "../../components/LoadingState"
 import { StoryboardLandingPage } from "./StoryboardLandingPage"
 import { StoryboardView } from "./StoryboardView"
 
@@ -13,8 +16,16 @@ export function StoryboardIndex({
   onSelectPage?: (pageId: string | null) => void
 }) {
   const status = useStageStatus("storyboard")
+  const { data: pages, isLoading: pagesLoading } = usePages(bookLabel)
 
-  if (status.isCompleted || status.isRunning) {
+  // The stage is marked stale by edits that don't destroy anything — the
+  // renderings it produced are still on disk and still editable. Gating the view
+  // on stage status alone locked the user out of the editor, and so out of the
+  // per-section re-render that resolves the staleness, until they re-ran the
+  // whole book. Show the editor whenever there is a rendering to edit.
+  const hasRendering = (pages ?? []).some((p) => p.hasRendering)
+
+  if (status.isCompleted || status.isRunning || hasRendering) {
     return (
       <StoryboardView
         bookLabel={bookLabel}
@@ -22,6 +33,12 @@ export function StoryboardIndex({
         onSelectPage={onSelectPage}
       />
     )
+  }
+
+  // Deciding on an empty page list would flash the landing page at someone whose
+  // renderings are merely still loading.
+  if (pagesLoading) {
+    return <LoadingState stageSlug="storyboard" label={<Trans>Loading pages...</Trans>} />
   }
 
   return <StoryboardLandingPage bookLabel={bookLabel} />

--- a/apps/studio/src/components/pipeline/stages/storyboard/StoryboardView.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/StoryboardView.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useRef, useCallback, useState } from "react"
-import { ArrowLeft, ArrowRight, LayoutGrid, Table2 } from "lucide-react"
+import { useEffect, useRef, useCallback, useState, type ReactNode } from "react"
+import { ArrowLeft, ArrowRight, LayoutGrid, RotateCcw, Table2 } from "lucide-react"
+import { Button } from "@/components/ui/button"
 import { usePages, usePage } from "@/hooks/use-pages"
 import { useStepHeader } from "../../components/StepViewRouter"
 import { useBookRun } from "@/hooks/use-book-run"
@@ -307,6 +308,40 @@ export function StoryboardView({ bookLabel, selectedPageId: selectedPageIdProp, 
     return () => window.removeEventListener("keydown", handleKeyDown)
   }, [selectedPageId, sectionIndex, sectionCount, canGoPrev, canGoNext, prevPageId, nextPageId, showRunCard])
 
+  // Sectioning edits mark the storyboard stale without touching the renderings,
+  // so the editor stays open on pages that are still perfectly editable — but
+  // nothing said they were now behind the sections they came from. This is that
+  // reminder, and the one place to regenerate the lot in a single pass, so a
+  // restructuring session in Sectioning costs one render rather than one per
+  // edit.
+  const storyboardStale = !storyboardDone && !storyboardRunning && hasRenderingData
+  const withStaleBanner = (content: ReactNode) =>
+    storyboardStale ? (
+      <div className="flex flex-col h-full min-h-0">
+        <div className="flex items-center justify-between gap-3 border-b border-amber-200 bg-amber-50 px-3 py-2">
+          <div className="text-xs text-amber-900">
+            <Trans>
+              Sectioning has changed since these pages were rendered. Re-run Storyboard to
+              regenerate them.
+            </Trans>
+          </div>
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-7 shrink-0 border-amber-300 bg-white px-3 text-xs text-amber-900 hover:bg-amber-100"
+            onClick={handleRunStoryboard}
+            disabled={!hasApiKey || !sectioningReady || storyboardRunning}
+          >
+            <RotateCcw className="mr-1 h-3 w-3" />
+            <Trans>Re-run Storyboard</Trans>
+          </Button>
+        </div>
+        <div className="flex-1 min-h-0">{content}</div>
+      </div>
+    ) : (
+      content
+    )
+
   if (showRunCard) {
     return (
       <div className="p-4">
@@ -337,7 +372,7 @@ export function StoryboardView({ bookLabel, selectedPageId: selectedPageIdProp, 
 
   // Overview mode: show sectioning table for all pages
   if (overviewMode) {
-    return (
+    return withStaleBanner(
       <SectioningOverview
         bookLabel={bookLabel}
         pages={pageList}
@@ -395,7 +430,7 @@ export function StoryboardView({ bookLabel, selectedPageId: selectedPageIdProp, 
     )
   }
 
-  return (
+  return withStaleBanner(
     <StoryboardSectionDetail
       bookLabel={bookLabel}
       pageId={selectedPageId!}

--- a/apps/studio/src/components/pipeline/stages/storyboard/StoryboardView.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/StoryboardView.tsx
@@ -36,9 +36,14 @@ export function StoryboardView({ bookLabel, selectedPageId: selectedPageIdProp, 
   // regenerates (the page's stale rendering is cleared optimistically on re-run,
   // see queueRun). Only show the run card when idle or no data exists yet.
   const hasPageData = (pages ?? []).some((p) => p.sectionCount > 0)
+  // When idle, existing renderings outrank a stale stage status: a sectioning
+  // edit marks storyboard for re-run without touching the HTML, and pushing the
+  // run card in front of intact renderings would hide the very sections the user
+  // came back to re-render. Matches the gate in StoryboardIndex.
+  const hasRenderingData = (pages ?? []).some((p) => p.hasRendering)
   const showRunCard = storyboardRunning || storyboardState === "error"
     ? !hasPageData
-    : !storyboardDone
+    : !storyboardDone && !hasRenderingData
 
   const handleRunStoryboard = useCallback(() => {
     if (!hasApiKey || !sectioningReady || storyboardRunning) return

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/SectioningOverview.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/SectioningOverview.tsx
@@ -37,6 +37,7 @@ interface SectioningOverviewProps {
 export function SectioningOverview({ bookLabel, pages, onNavigateToSection }: SectioningOverviewProps) {
   const { t } = useLingui()
   const queryClient = useQueryClient()
+  const { apiKey, hasApiKey } = useApiKey()
   const { stageState } = useBookRun()
   const storyboardRunning = stageState("storyboard") === "running" || stageState("storyboard") === "queued"
   const [confirmDialog, setConfirmDialog] = useState<{ message: string; onConfirm: () => void } | null>(null)
@@ -135,17 +136,38 @@ export function SectioningOverview({ bookLabel, pages, onNavigateToSection }: Se
         ),
       }
       // Pruning only filters the section out at read time; its HTML stays in
-      // web-rendering, so the toggle leaves the storyboard current. The one
-      // exception is unpruning a section that was pruned when the storyboard
-      // ran — it was skipped then and has no HTML to restore.
+      // web-rendering, so the toggle leaves the storyboard current. Unpruning a
+      // section that was pruned when the storyboard ran is the case that needs
+      // work: it was skipped then, so it has no HTML and the LLM has to produce
+      // it. Render just that section rather than marking the whole stage stale —
+      // this is the normal way content gets brought in, one section at a time.
       const wasPruned = page.sectioningTree.sections[sectionIndex]?.isPruned ?? false
       const hasHtml = (page.rendering?.sections ?? []).some(
         (s) => s.sectionIndex === sectionIndex && !!s.html
       )
-      return api.saveStoryboard(bookLabel, pageId, {
-        sectioning: updated,
-        renderingInSync: !wasPruned || hasHtml,
-      })
+      const needsRerender = wasPruned && !hasHtml
+      return api
+        .saveStoryboard(bookLabel, pageId, {
+          sectioning: updated,
+          // Without a key we cannot fill the HTML, so the stage must report it.
+          renderingInSync: !needsRerender || hasApiKey,
+        })
+        .then(async (result) => {
+          // Sectioning is saved with the section unpruned, so the re-render will
+          // actually emit it — `web-rendering` skips pruned sections. The task
+          // marks the storyboard stale itself if it fails; a rejected submission
+          // never reaches the runner, so take the completion mark back here.
+          if (!needsRerender || !hasApiKey) return result
+          try {
+            await api.reRenderPage(bookLabel, pageId, apiKey, sectionIndex)
+          } catch (err) {
+            await api
+              .saveStoryboard(bookLabel, pageId, { sectioning: updated, renderingInSync: false })
+              .catch(() => {})
+            throw err
+          }
+          return result
+        })
     },
     onSuccess: (_data, vars) => invalidatePages(vars.pageId),
   })

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/SectioningOverview.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/SectioningOverview.tsx
@@ -134,7 +134,18 @@ export function SectioningOverview({ bookLabel, pages, onNavigateToSection }: Se
           i === sectionIndex ? { ...s, isPruned: !s.isPruned } : s
         ),
       }
-      return api.updateSectioning(bookLabel, pageId, updated)
+      // Pruning only filters the section out at read time; its HTML stays in
+      // web-rendering, so the toggle leaves the storyboard current. The one
+      // exception is unpruning a section that was pruned when the storyboard
+      // ran — it was skipped then and has no HTML to restore.
+      const wasPruned = page.sectioningTree.sections[sectionIndex]?.isPruned ?? false
+      const hasHtml = (page.rendering?.sections ?? []).some(
+        (s) => s.sectionIndex === sectionIndex && !!s.html
+      )
+      return api.saveStoryboard(bookLabel, pageId, {
+        sectioning: updated,
+        renderingInSync: !wasPruned || hasHtml,
+      })
     },
     onSuccess: (_data, vars) => invalidatePages(vars.pageId),
   })

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
@@ -486,6 +486,14 @@ export function StoryboardSectionDetail({
   // Tracks whether pending sectioning changes require LLM re-render on save.
   // Pure prune/delete can be resolved locally; unprune/type change/reorder need LLM.
   const needsRerenderRef = useRef(false)
+  // Of those, the ones where the saved HTML actively contradicts the sectioning —
+  // a type change or a reorder leaves the old content on screen until the LLM
+  // catches up, so the Storyboard stage must report itself stale. Unpruning is
+  // not in this set: the content is merely *absent* from the HTML, and the
+  // re-render queued on save puts it back. Marking the whole stage stale for
+  // that would fail the common path, since sections are usually pruned when the
+  // storyboard runs and unpruned one at a time afterwards.
+  const renderingContradictsRef = useRef(false)
 
   // Inline editing state
   const [selectedElement, setSelectedElement] = useState<{
@@ -801,6 +809,7 @@ export function StoryboardSectionDetail({
     setActivityPreviewMode(true)
     setEditActivityPanelOpen(false)
     needsRerenderRef.current = false
+    renderingContradictsRef.current = false
   }, [pageId, sectionIndex])
 
   // Reset scroll position when page or section changes
@@ -859,6 +868,17 @@ export function StoryboardSectionDetail({
     setSaving(true)
     setPanelOpen(false)
     const shouldRerender = needsRerenderRef.current
+    // Sections are normally pruned when the storyboard runs, so unpruning one is
+    // the ordinary way to bring content in — it must render that section and
+    // leave the rest of the stage alone. We can only promise that when a
+    // re-render will actually run; without a key (or on a custom activity, which
+    // re-render would flatten) the section stays empty and the stage has to say
+    // so. `renderingContradicts` covers the other direction: HTML that is wrong
+    // rather than missing, which is stale no matter what we queue.
+    const isCustomActivity = section?.sectionType?.startsWith("activity_custom") ?? false
+    const willRerender = shouldRerender && hasApiKey && !isCustomActivity
+    const renderingInSync =
+      !renderingContradictsRef.current && (!shouldRerender || willRerender)
     try {
       const minDelay = new Promise((r) => setTimeout(r, 400))
 
@@ -880,20 +900,17 @@ export function StoryboardSectionDetail({
       const renderingToSave = renderingFromPrune ?? flushed ?? pendingRendering
 
       // Both nodes in one request so a failure can't split them apart.
-      // `shouldRerender` marks the changes (type, unprune, reorder, role) that
-      // need the LLM before the HTML catches up; everything else either arrives
-      // mirrored in `renderingToSave` or needs no HTML change, so the storyboard
-      // is not stale and the stage should stay complete.
       await api.saveStoryboard(bookLabel, pageId, {
         sectioning: pendingSectioning,
         rendering: renderingToSave ? stripTransientIds(renderingToSave) : undefined,
-        renderingInSync: !shouldRerender,
+        renderingInSync,
       })
 
       setPendingSectioning(null)
       setPendingRendering(null)
       setPendingCategories(new Set())
       needsRerenderRef.current = false
+      renderingContradictsRef.current = false
       await queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "pages", pageId] })
       await queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "pages"] })
       invalidateStoryboardDependents(queryClient, bookLabel)
@@ -903,10 +920,22 @@ export function StoryboardSectionDetail({
       // Skip for pure prune/delete — those are already handled by local HTML removal.
       // Also skip custom activities: re-render rebuilds from the flat sectioning
       // tree and would discard their inline grading script.
-      const isCustomActivity =
-        section?.sectionType?.startsWith("activity_custom") ?? false
-      if (shouldRerender && hasApiKey && !isCustomActivity) {
-        api.reRenderPage(bookLabel, pageId, apiKey, sectionIndex).catch(() => {})
+      // The task marks the storyboard stale itself if it fails, so a section that
+      // never gets its HTML cannot leave the stage reporting complete. A rejected
+      // *submission* never reaches the task runner, so that net does not fire and
+      // we have to take the completion mark back here instead.
+      if (willRerender) {
+        api.reRenderPage(bookLabel, pageId, apiKey, sectionIndex).catch(async (err) => {
+          setAiError(err instanceof Error ? err.message : t`Re-render failed`)
+          if (!renderingInSync) return
+          await api
+            .saveStoryboard(bookLabel, pageId, {
+              sectioning: pendingSectioning,
+              renderingInSync: false,
+            })
+            .catch(() => {})
+          invalidateStoryboardDependents(queryClient, bookLabel)
+        })
       }
     } catch (err) {
       setAiError(err instanceof Error ? err.message : t`Save failed`)
@@ -927,6 +956,7 @@ export function StoryboardSectionDetail({
     pendingHtmlRef.current = null
     setHasUnflushedEdits(false)
     needsRerenderRef.current = false
+    renderingContradictsRef.current = false
     previewFrameRef.current?.resetContent()
   }
 
@@ -1328,6 +1358,8 @@ export function StoryboardSectionDetail({
       // so the activity is regenerated from the new text on save.
       if (!el || hasActivityInteractiveDescendant(el)) {
         needsRerenderRef.current = true
+        // The HTML still shows the old text until the re-render lands.
+        renderingContradictsRef.current = true
         return false
       }
       el.textContent = newText
@@ -1478,6 +1510,8 @@ export function StoryboardSectionDetail({
   // Change section type
   const changeSectionType = (newType: string) => {
     needsRerenderRef.current = true
+    // The rendered HTML is still laid out as the old type until re-rendered.
+    renderingContradictsRef.current = true
     const base = pendingSectioning ?? (page.sectioningTree as SectioningData | null)
     if (!base) return
     const updated: SectioningData = {
@@ -1499,6 +1533,8 @@ export function StoryboardSectionDetail({
       if (nextNodes === section.nodes) return
       setPendingSectioning(withSectionNodes(base, sectionIndex, nextNodes))
       needsRerenderRef.current = true
+      // The leaf keeps its old role's markup until re-rendered.
+      renderingContradictsRef.current = true
     },
     [pendingSectioning, page.sectioningTree, sectionIndex, section]
   )
@@ -1545,8 +1581,10 @@ export function StoryboardSectionDetail({
     [removeElementsFromRendering]
   )
 
+  // Reorder / regroup: the HTML keeps the old order until re-rendered.
   const handleStructuralChange = useCallback(() => {
     needsRerenderRef.current = true
+    renderingContradictsRef.current = true
   }, [])
 
   // Handle inline text edit from BookPreviewFrame

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
@@ -873,16 +873,22 @@ export function StoryboardSectionDetail({
         }
       }
 
-      await api.updateSectioning(bookLabel, pageId, pendingSectioning)
-
       // Save rendering if dirty (from delete/prune removing HTML elements).
       // Use renderingFromPrune if we just stripped pruned elements above,
       // since React state won't have updated yet within this async call.
       const flushed = flushPendingHtml()
       const renderingToSave = renderingFromPrune ?? flushed ?? pendingRendering
-      if (renderingToSave) {
-        await api.updateRendering(bookLabel, pageId, stripTransientIds(renderingToSave))
-      }
+
+      // Both nodes in one request so a failure can't split them apart.
+      // `shouldRerender` marks the changes (type, unprune, reorder, role) that
+      // need the LLM before the HTML catches up; everything else either arrives
+      // mirrored in `renderingToSave` or needs no HTML change, so the storyboard
+      // is not stale and the stage should stay complete.
+      await api.saveStoryboard(bookLabel, pageId, {
+        sectioning: pendingSectioning,
+        rendering: renderingToSave ? stripTransientIds(renderingToSave) : undefined,
+        renderingInSync: !shouldRerender,
+      })
 
       setPendingSectioning(null)
       setPendingRendering(null)
@@ -934,23 +940,23 @@ export function StoryboardSectionDetail({
     try {
       const minDelay = new Promise((r) => setTimeout(r, 400))
 
-      await api.updateRendering(bookLabel, pageId, stripTransientIds(renderingToSave))
-
       // Back-propagate text changes into sectioning. `renderingToSave` already
       // includes the flushed inspector edit; the closure `pendingRendering`
       // is stale until React re-renders.
       const editedHtml = getRenderedSectionByIndex(renderingToSave, sectionIndex)?.html
       const sBase = pendingSectioning ?? (page.sectioningTree as SectioningData | null)
-      if (editedHtml && sBase) {
-        const updatedSectioning = backPropagateTextChanges(
-          sBase,
-          sectionIndex,
-          editedHtml
-        )
-        if (updatedSectioning !== sBase) {
-          await api.updateSectioning(bookLabel, pageId, updatedSectioning)
-        }
-      }
+      const updatedSectioning =
+        editedHtml && sBase ? backPropagateTextChanges(sBase, sectionIndex, editedHtml) : null
+
+      // The sectioning we send is derived from the HTML we send, so the pair is
+      // in sync by construction — this save leaves the Storyboard current and
+      // only marks the stages downstream of it for re-run.
+      await api.saveStoryboard(bookLabel, pageId, {
+        rendering: stripTransientIds(renderingToSave),
+        ...(updatedSectioning && updatedSectioning !== sBase
+          ? { sectioning: updatedSectioning, renderingInSync: true }
+          : {}),
+      })
 
       setPendingRendering(null)
       setPendingSectioning(null)

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
@@ -486,14 +486,6 @@ export function StoryboardSectionDetail({
   // Tracks whether pending sectioning changes require LLM re-render on save.
   // Pure prune/delete can be resolved locally; unprune/type change/reorder need LLM.
   const needsRerenderRef = useRef(false)
-  // Of those, the ones where the saved HTML actively contradicts the sectioning —
-  // a type change or a reorder leaves the old content on screen until the LLM
-  // catches up, so the Storyboard stage must report itself stale. Unpruning is
-  // not in this set: the content is merely *absent* from the HTML, and the
-  // re-render queued on save puts it back. Marking the whole stage stale for
-  // that would fail the common path, since sections are usually pruned when the
-  // storyboard runs and unpruned one at a time afterwards.
-  const renderingContradictsRef = useRef(false)
 
   // Inline editing state
   const [selectedElement, setSelectedElement] = useState<{
@@ -809,7 +801,6 @@ export function StoryboardSectionDetail({
     setActivityPreviewMode(true)
     setEditActivityPanelOpen(false)
     needsRerenderRef.current = false
-    renderingContradictsRef.current = false
   }, [pageId, sectionIndex])
 
   // Reset scroll position when page or section changes
@@ -868,17 +859,17 @@ export function StoryboardSectionDetail({
     setSaving(true)
     setPanelOpen(false)
     const shouldRerender = needsRerenderRef.current
-    // Sections are normally pruned when the storyboard runs, so unpruning one is
-    // the ordinary way to bring content in — it must render that section and
-    // leave the rest of the stage alone. We can only promise that when a
-    // re-render will actually run; without a key (or on a custom activity, which
-    // re-render would flatten) the section stays empty and the stage has to say
-    // so. `renderingContradicts` covers the other direction: HTML that is wrong
-    // rather than missing, which is stale no matter what we queue.
+    // Editing here is meant to be incremental: change a section's type, text or
+    // pruning, re-render that one section, carry on. Every such edit either
+    // arrives already mirrored into the HTML or queues a render of the section
+    // it touched, so the storyboard is current (or seconds away from it) and
+    // resetting the whole stage would only take the editor away for a book that
+    // is fine. The stage is marked stale only when we cannot bring the HTML back
+    // in sync at all: no API key, or a custom activity whose inline grading
+    // script a re-render would flatten.
     const isCustomActivity = section?.sectionType?.startsWith("activity_custom") ?? false
     const willRerender = shouldRerender && hasApiKey && !isCustomActivity
-    const renderingInSync =
-      !renderingContradictsRef.current && (!shouldRerender || willRerender)
+    const renderingInSync = !shouldRerender || willRerender
     try {
       const minDelay = new Promise((r) => setTimeout(r, 400))
 
@@ -910,7 +901,6 @@ export function StoryboardSectionDetail({
       setPendingRendering(null)
       setPendingCategories(new Set())
       needsRerenderRef.current = false
-      renderingContradictsRef.current = false
       await queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "pages", pageId] })
       await queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "pages"] })
       invalidateStoryboardDependents(queryClient, bookLabel)
@@ -956,7 +946,6 @@ export function StoryboardSectionDetail({
     pendingHtmlRef.current = null
     setHasUnflushedEdits(false)
     needsRerenderRef.current = false
-    renderingContradictsRef.current = false
     previewFrameRef.current?.resetContent()
   }
 
@@ -1358,8 +1347,6 @@ export function StoryboardSectionDetail({
       // so the activity is regenerated from the new text on save.
       if (!el || hasActivityInteractiveDescendant(el)) {
         needsRerenderRef.current = true
-        // The HTML still shows the old text until the re-render lands.
-        renderingContradictsRef.current = true
         return false
       }
       el.textContent = newText
@@ -1510,8 +1497,6 @@ export function StoryboardSectionDetail({
   // Change section type
   const changeSectionType = (newType: string) => {
     needsRerenderRef.current = true
-    // The rendered HTML is still laid out as the old type until re-rendered.
-    renderingContradictsRef.current = true
     const base = pendingSectioning ?? (page.sectioningTree as SectioningData | null)
     if (!base) return
     const updated: SectioningData = {
@@ -1533,8 +1518,6 @@ export function StoryboardSectionDetail({
       if (nextNodes === section.nodes) return
       setPendingSectioning(withSectionNodes(base, sectionIndex, nextNodes))
       needsRerenderRef.current = true
-      // The leaf keeps its old role's markup until re-rendered.
-      renderingContradictsRef.current = true
     },
     [pendingSectioning, page.sectioningTree, sectionIndex, section]
   )
@@ -1584,7 +1567,6 @@ export function StoryboardSectionDetail({
   // Reorder / regroup: the HTML keeps the old order until re-rendered.
   const handleStructuralChange = useCallback(() => {
     needsRerenderRef.current = true
-    renderingContradictsRef.current = true
   }, [])
 
   // Handle inline text edit from BookPreviewFrame

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
@@ -454,7 +454,7 @@ export function StoryboardSectionDetail({
   const [merging, setMerging] = useState(false)
   const [deleting, setDeleting] = useState(false)
   const [confirmDeleteSection, setConfirmDeleteSection] = useState(false)
-  const [confirmMerge, setConfirmMerge] = useState<{ action: () => Promise<void>; label: string; warning?: string } | null>(null)
+  const [confirmMerge, setConfirmMerge] = useState<{ action: () => Promise<void>; label: string; warning?: string; consequence?: string } | null>(null)
   const [pendingSectioning, setPendingSectioning] = useState<SectioningData | null>(null)
   const [pendingRendering, setPendingRendering] = useState<RenderingData | null>(null)
   // Inspector edits mutate the iframe DOM directly; this ref stashes the
@@ -1058,7 +1058,10 @@ export function StoryboardSectionDetail({
   const executeMergeSection = async (direction: "next" | "prev") => {
     setMerging(true)
     try {
-      const result = await api.mergeSection(bookLabel, pageId, sectionIndex, direction)
+      // The merge concatenates both sections' HTML into the kept entry, so no
+      // section is left without one and the stage stays complete; the re-render
+      // below replaces the naive join with properly combined markup.
+      const result = await api.mergeSection(bookLabel, pageId, sectionIndex, direction, true)
       await queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "pages", pageId] })
       await queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "pages"] })
       await queryClient.invalidateQueries({ queryKey: ["editable-activities", bookLabel, pageId] })
@@ -1080,7 +1083,17 @@ export function StoryboardSectionDetail({
   const executeMergeCrossPage = async (direction: "next" | "prev") => {
     setMerging(true)
     try {
-      const result = await api.mergeSectionCrossPage(bookLabel, pageId, sectionIndex, direction)
+      // This empties both pages' renderings outright — every section on them
+      // loses its HTML, not just the merged one — so both pages have to be
+      // re-rendered whole before the stage is complete again. Two page renders
+      // is still the affected pages only, never the rest of the book.
+      const result = await api.mergeSectionCrossPage(
+        bookLabel,
+        pageId,
+        sectionIndex,
+        direction,
+        hasApiKey
+      )
       await queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "pages", result.sourcePageId] })
       await queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "pages", result.targetPageId] })
       await queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "pages"] })
@@ -1089,6 +1102,14 @@ export function StoryboardSectionDetail({
       invalidateStoryboardDependents(queryClient, bookLabel)
       // Navigate to the previous section or 0 since the current section was removed
       onNavigateSection?.(Math.max(0, sectionIndex - 1))
+
+      if (hasApiKey) {
+        for (const affectedPageId of [result.sourcePageId, result.targetPageId]) {
+          api.reRenderPage(bookLabel, affectedPageId, apiKey).catch((err) => {
+            setAiError(err instanceof Error ? err.message : t`Re-render failed`)
+          })
+        }
+      }
     } catch (err) {
       setAiError(err instanceof Error ? err.message : t`Merge failed`)
     } finally {
@@ -1128,6 +1149,7 @@ export function StoryboardSectionDetail({
       action: () => executeMergeSection(direction),
       label,
       warning: buildMergeWarning(neighbor?.sectionType),
+      consequence: t`The combined section will be re-rendered.`,
     })
   }
 
@@ -1140,6 +1162,11 @@ export function StoryboardSectionDetail({
       action: () => executeMergeCrossPage(direction),
       label,
       warning: buildMergeWarning(),
+      // Unlike a same-page merge this clears both pages' renderings entirely,
+      // so say which pages go and who puts them back.
+      consequence: hasApiKey
+        ? t`Both pages lose their rendering and will be re-rendered automatically.`
+        : t`Both pages lose their rendering. Without an API key they cannot be re-rendered, so the Storyboard will need re-running.`,
     })
   }
 
@@ -3285,6 +3312,7 @@ export function StoryboardSectionDetail({
           <DialogTitle>{t`Confirm merge`}</DialogTitle>
           <DialogDescription>
             {t`Are you sure you want to ${confirmMerge?.label ?? ""}? This action cannot be undone.`}
+            {confirmMerge?.consequence ? ` ${confirmMerge.consequence}` : null}
           </DialogDescription>
         </DialogHeader>
         {confirmMerge?.warning && (

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
@@ -1059,9 +1059,15 @@ export function StoryboardSectionDetail({
     setMerging(true)
     try {
       // The merge concatenates both sections' HTML into the kept entry, so no
-      // section is left without one and the stage stays complete; the re-render
-      // below replaces the naive join with properly combined markup.
-      const result = await api.mergeSection(bookLabel, pageId, sectionIndex, direction, true)
+      // section is left without one. With a key the targeted re-render keeps
+      // the stage current; without one the server marks it for a full re-run.
+      const result = await api.mergeSection(
+        bookLabel,
+        pageId,
+        sectionIndex,
+        direction,
+        hasApiKey,
+      )
       await queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "pages", pageId] })
       await queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "pages"] })
       await queryClient.invalidateQueries({ queryKey: ["editable-activities", bookLabel, pageId] })
@@ -1092,7 +1098,6 @@ export function StoryboardSectionDetail({
         pageId,
         sectionIndex,
         direction,
-        hasApiKey
       )
       await queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "pages", result.sourcePageId] })
       await queryClient.invalidateQueries({ queryKey: ["books", bookLabel, "pages", result.targetPageId] })
@@ -1104,10 +1109,14 @@ export function StoryboardSectionDetail({
       onNavigateSection?.(Math.max(0, sectionIndex - 1))
 
       if (hasApiKey) {
-        for (const affectedPageId of [result.sourcePageId, result.targetPageId]) {
-          api.reRenderPage(bookLabel, affectedPageId, apiKey).catch((err) => {
-            setAiError(err instanceof Error ? err.message : t`Re-render failed`)
-          })
+        try {
+          await api.reRenderPages(
+            bookLabel,
+            [result.sourcePageId, result.targetPageId],
+            apiKey,
+          )
+        } catch (err) {
+          setAiError(err instanceof Error ? err.message : t`Re-render failed`)
         }
       }
     } catch (err) {
@@ -1149,7 +1158,9 @@ export function StoryboardSectionDetail({
       action: () => executeMergeSection(direction),
       label,
       warning: buildMergeWarning(neighbor?.sectionType),
-      consequence: t`The combined section will be re-rendered.`,
+      consequence: hasApiKey
+        ? t`The combined section will be re-rendered.`
+        : t`The sections will be combined locally. Without an API key, the Storyboard will need re-running to regenerate the combined section.`,
     })
   }
 

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
@@ -1454,7 +1454,17 @@ export function StoryboardSectionDetail({
     if (storyboardRunning) return
     const base = pendingSectioning ?? (page.sectioningTree as SectioningData | null)
     if (!base) return
-    if (base.sections[sectionIndex]?.isPruned) needsRerenderRef.current = true
+    // Pruning a section is a read-time filter — packaging and the text catalog
+    // skip it (`packaging/web.ts`, `text-catalog.ts`) but its HTML stays in
+    // web-rendering. So unpruning restores it as-is and needs no LLM. The one
+    // exception is a section that was already pruned when the storyboard ran:
+    // `web-rendering.ts` skips pruned sections, so it has no HTML to restore.
+    const unpruning = base.sections[sectionIndex]?.isPruned ?? false
+    const renderedHtml = getRenderedSectionByIndex(
+      pendingRendering ?? page.rendering,
+      sectionIndex
+    )?.html
+    if (unpruning && !renderedHtml) needsRerenderRef.current = true
     const updated: SectioningData = {
       ...base,
       sections: base.sections.map((s, si) => {

--- a/apps/studio/src/hooks/use-book-run.ts
+++ b/apps/studio/src/hooks/use-book-run.ts
@@ -495,6 +495,11 @@ export function useBookRunStatus(label: string): BookRunContextValue {
     es.addEventListener("task", (e) => {
       const d = JSON.parse(e.data) as { type: string; taskId: string; kind?: string; description?: string; pageId?: string; url?: string; error?: string; result?: unknown; message?: string; percent?: number }
       const tasksKey = bookTasksKey(label)
+      const taskBeforeEvent = queryClient
+        .getQueryData<{ tasks: TaskInfoResponse[] }>(tasksKey)
+        ?.tasks.find((task) => task.taskId === d.taskId)
+      const eventTaskKind = d.kind ?? taskBeforeEvent?.kind
+      const eventPageId = d.pageId ?? taskBeforeEvent?.pageId
 
       queryClient.setQueryData<{ tasks: TaskInfoResponse[] }>(tasksKey, (old) => {
         const tasks = [...(old?.tasks ?? [])]
@@ -516,8 +521,13 @@ export function useBookRunStatus(label: string): BookRunContextValue {
           if (idx !== -1) {
             tasks[idx] = { ...tasks[idx], status: "completed", result: d.result, completedAt: Date.now() }
           }
-          // Invalidate related data — use cache entry if available, fall back to polling
-          const completedTask = idx !== -1 ? tasks[idx] : undefined
+          // Invalidate related data using the cache entry when available and
+          // the self-describing terminal event when task-start was missed.
+          const completedTask = idx !== -1
+            ? tasks[idx]
+            : eventTaskKind
+              ? { kind: eventTaskKind, pageId: eventPageId }
+              : undefined
           if (completedTask?.kind === "package-adt") {
             queryClient.invalidateQueries({ queryKey: ["books", label, "step-status"] })
             queryClient.invalidateQueries({ queryKey: ["package-adt-status", label] })
@@ -582,6 +592,20 @@ export function useBookRunStatus(label: string): BookRunContextValue {
 
         return { tasks }
       })
+
+      if (d.type === "task-error") {
+        // The server may have changed step status before reporting the task
+        // error. Refresh it even if task-start was missed and polling had
+        // stopped because the cached pipeline previously looked complete.
+        queryClient.invalidateQueries({ queryKey: ["books", label, "step-status"] })
+        if (eventTaskKind === "re-render") {
+          if (eventPageId) {
+            queryClient.invalidateQueries({ queryKey: ["books", label, "pages", eventPageId] })
+          }
+          queryClient.invalidateQueries({ queryKey: ["books", label, "pages"] })
+          invalidateStoryboardDependents(queryClient, label)
+        }
+      }
 
       if (d.type === "task-complete") {
         playCompletionSound()

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -1745,6 +1745,12 @@ msgstr "Borders"
 msgid "Both"
 msgstr "Both"
 
+msgid "Both pages lose their rendering and will be re-rendered automatically."
+msgstr "Both pages lose their rendering and will be re-rendered automatically."
+
+msgid "Both pages lose their rendering. Without an API key they cannot be re-rendered, so the Storyboard will need re-running."
+msgstr "Both pages lose their rendering. Without an API key they cannot be re-rendered, so the Storyboard will need re-running."
+
 msgid "Boxed Text"
 msgstr "Boxed Text"
 
@@ -8771,6 +8777,9 @@ msgstr "The book's title and metadata arrive with the part that contains page 1 
 
 msgid "The built-in prompts are optimized for {DEFAULT_MODEL}. You switched the default LLM to <0>{savedModel}</0>, so we recommend generating new global prompt files tuned for it. You can also continue with the existing prompts."
 msgstr "The built-in prompts are optimized for {DEFAULT_MODEL}. You switched the default LLM to <0>{savedModel}</0>, so we recommend generating new global prompt files tuned for it. You can also continue with the existing prompts."
+
+msgid "The combined section will be re-rendered."
+msgstr "The combined section will be re-rendered."
 
 msgid "The community of living organisms in a place and the way they interact with each other and their environment."
 msgstr "The community of living organisms in a place and the way they interact with each other and their environment."

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -6908,6 +6908,9 @@ msgstr "Re-run {stageLabel}?"
 msgid "Re-run speech"
 msgstr "Re-run speech"
 
+msgid "Re-run Storyboard"
+msgstr "Re-run Storyboard"
+
 msgid "Re-run these book-level stages on the assembled book:"
 msgstr "Re-run these book-level stages on the assembled book:"
 
@@ -7775,6 +7778,9 @@ msgstr "Section Types"
 
 msgid "Sectioning"
 msgstr "Sectioning"
+
+msgid "Sectioning has changed since these pages were rendered. Re-run Storyboard to regenerate them."
+msgstr "Sectioning has changed since these pages were rendered. Re-run Storyboard to regenerate them."
 
 msgid "Sectioning mode"
 msgstr "Sectioning mode"
@@ -8747,12 +8753,6 @@ msgstr "Text Types"
 
 msgid "Textbooks & Activities"
 msgstr "Textbooks & Activities"
-
-msgid "The affected pages lose their rendering. Without an API key they cannot be re-rendered, so the Storyboard will need re-running."
-msgstr "The affected pages lose their rendering. Without an API key they cannot be re-rendered, so the Storyboard will need re-running."
-
-msgid "The affected pages will be re-rendered automatically."
-msgstr "The affected pages will be re-rendered automatically."
 
 msgid "The AI is having a think..."
 msgstr "The AI is having a think..."

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -8901,6 +8901,9 @@ msgstr "The saved translation review is stale. Run Review again for the visible 
 msgid "The section was edited after conversion — use \"Rebuild from page\" to refresh the steps."
 msgstr "The section was edited after conversion — use \"Rebuild from page\" to refresh the steps."
 
+msgid "The sections will be combined locally. Without an API key, the Storyboard will need re-running to regenerate the combined section."
+msgstr "The sections will be combined locally. Without an API key, the Storyboard will need re-running to regenerate the combined section."
+
 msgid "The storyboard must be completed before generating {stageName}. Run the Storyboard stage first."
 msgstr "The storyboard must be completed before generating {stageName}. Run the Storyboard stage first."
 

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -8748,6 +8748,12 @@ msgstr "Text Types"
 msgid "Textbooks & Activities"
 msgstr "Textbooks & Activities"
 
+msgid "The affected pages lose their rendering. Without an API key they cannot be re-rendered, so the Storyboard will need re-running."
+msgstr "The affected pages lose their rendering. Without an API key they cannot be re-rendered, so the Storyboard will need re-running."
+
+msgid "The affected pages will be re-rendered automatically."
+msgstr "The affected pages will be re-rendered automatically."
+
 msgid "The AI is having a think..."
 msgstr "The AI is having a think..."
 

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -1745,6 +1745,12 @@ msgstr "Bordes"
 msgid "Both"
 msgstr "Ambos"
 
+msgid "Both pages lose their rendering and will be re-rendered automatically."
+msgstr "Ambas páginas pierden su renderizado y se volverán a renderizar automáticamente."
+
+msgid "Both pages lose their rendering. Without an API key they cannot be re-rendered, so the Storyboard will need re-running."
+msgstr "Ambas páginas pierden su renderizado. Sin una clave de API no se pueden volver a renderizar, por lo que habrá que volver a ejecutar Storyboard."
+
 msgid "Boxed Text"
 msgstr "Texto en recuadro"
 
@@ -8771,6 +8777,9 @@ msgstr "El título y los metadatos del libro llegan con la parte que contiene la
 
 msgid "The built-in prompts are optimized for {DEFAULT_MODEL}. You switched the default LLM to <0>{savedModel}</0>, so we recommend generating new global prompt files tuned for it. You can also continue with the existing prompts."
 msgstr "Los prompts integrados están optimizados para {DEFAULT_MODEL}. Cambiaste el LLM predeterminado a <0>{savedModel}</0>, por lo que te recomendamos generar nuevos archivos de prompts globales adaptados a ese modelo. También puedes continuar con los prompts existentes."
+
+msgid "The combined section will be re-rendered."
+msgstr "La sección combinada se volverá a renderizar."
 
 msgid "The community of living organisms in a place and the way they interact with each other and their environment."
 msgstr "La comunidad de organismos vivos en un lugar y la forma en que interactúan entre sí y con su entorno."

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -8748,6 +8748,12 @@ msgstr "Tipos de texto"
 msgid "Textbooks & Activities"
 msgstr "Libros de Texto y Actividades"
 
+msgid "The affected pages lose their rendering. Without an API key they cannot be re-rendered, so the Storyboard will need re-running."
+msgstr "Las páginas afectadas pierden su renderizado. Sin una clave de API no se pueden volver a renderizar, por lo que habrá que volver a ejecutar Storyboard."
+
+msgid "The affected pages will be re-rendered automatically."
+msgstr "Las páginas afectadas se volverán a renderizar automáticamente."
+
 msgid "The AI is having a think..."
 msgstr "La IA está pensando..."
 

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -8901,6 +8901,9 @@ msgstr "La revisión de traducción guardada está obsoleta. Vuelve a ejecutar R
 msgid "The section was edited after conversion — use \"Rebuild from page\" to refresh the steps."
 msgstr "La sección se editó después de la conversión: usa «Reconstruir desde la página» para actualizar los pasos."
 
+msgid "The sections will be combined locally. Without an API key, the Storyboard will need re-running to regenerate the combined section."
+msgstr "Las secciones se combinarán localmente. Sin una clave de API, será necesario volver a ejecutar el Storyboard para regenerar la sección combinada."
+
 msgid "The storyboard must be completed before generating {stageName}. Run the Storyboard stage first."
 msgstr "El storyboard debe completarse antes de generar {stageName}. Ejecuta la etapa de Storyboard primero."
 

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -6908,6 +6908,9 @@ msgstr "¿Re-ejecutar {stageLabel}?"
 msgid "Re-run speech"
 msgstr "Reejecutar audio"
 
+msgid "Re-run Storyboard"
+msgstr "Volver a ejecutar Storyboard"
+
 msgid "Re-run these book-level stages on the assembled book:"
 msgstr "Vuelve a ejecutar estas etapas de nivel de libro en el libro ensamblado:"
 
@@ -7775,6 +7778,9 @@ msgstr "Tipos de sección"
 
 msgid "Sectioning"
 msgstr "Seccionamiento"
+
+msgid "Sectioning has changed since these pages were rendered. Re-run Storyboard to regenerate them."
+msgstr "La segmentación ha cambiado desde que se renderizaron estas páginas. Vuelve a ejecutar Storyboard para regenerarlas."
 
 msgid "Sectioning mode"
 msgstr "Modo de sección"
@@ -8747,12 +8753,6 @@ msgstr "Tipos de texto"
 
 msgid "Textbooks & Activities"
 msgstr "Libros de Texto y Actividades"
-
-msgid "The affected pages lose their rendering. Without an API key they cannot be re-rendered, so the Storyboard will need re-running."
-msgstr "Las páginas afectadas pierden su renderizado. Sin una clave de API no se pueden volver a renderizar, por lo que habrá que volver a ejecutar Storyboard."
-
-msgid "The affected pages will be re-rendered automatically."
-msgstr "Las páginas afectadas se volverán a renderizar automáticamente."
 
 msgid "The AI is having a think..."
 msgstr "La IA está pensando..."

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -6910,6 +6910,9 @@ msgstr "Relancer {stageLabel} ?"
 msgid "Re-run speech"
 msgstr "Relancer la synthèse vocale"
 
+msgid "Re-run Storyboard"
+msgstr "Relancer le Scénarimage"
+
 msgid "Re-run these book-level stages on the assembled book:"
 msgstr "Relancez ces étapes au niveau du livre sur le livre assemblé :"
 
@@ -7777,6 +7780,9 @@ msgstr "Types de section"
 
 msgid "Sectioning"
 msgstr "Sectionnement"
+
+msgid "Sectioning has changed since these pages were rendered. Re-run Storyboard to regenerate them."
+msgstr "Le découpage a changé depuis le rendu de ces pages. Relancez le Scénarimage pour les régénérer."
 
 msgid "Sectioning mode"
 msgstr "Mode de sectionnement"
@@ -8749,12 +8755,6 @@ msgstr "Types de texte"
 
 msgid "Textbooks & Activities"
 msgstr "Manuels et activités"
-
-msgid "The affected pages lose their rendering. Without an API key they cannot be re-rendered, so the Storyboard will need re-running."
-msgstr "Les pages concernées perdent leur rendu. Sans clé API, elles ne peuvent pas être re-rendues : il faudra donc relancer le Scénarimage."
-
-msgid "The affected pages will be re-rendered automatically."
-msgstr "Les pages concernées seront re-rendues automatiquement."
 
 msgid "The AI is having a think..."
 msgstr "L'IA est en train de réfléchir..."

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -8750,6 +8750,12 @@ msgstr "Types de texte"
 msgid "Textbooks & Activities"
 msgstr "Manuels et activités"
 
+msgid "The affected pages lose their rendering. Without an API key they cannot be re-rendered, so the Storyboard will need re-running."
+msgstr "Les pages concernées perdent leur rendu. Sans clé API, elles ne peuvent pas être re-rendues : il faudra donc relancer le Scénarimage."
+
+msgid "The affected pages will be re-rendered automatically."
+msgstr "Les pages concernées seront re-rendues automatiquement."
+
 msgid "The AI is having a think..."
 msgstr "L'IA est en train de réfléchir..."
 

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -1747,6 +1747,12 @@ msgstr "Bordures"
 msgid "Both"
 msgstr "Les deux"
 
+msgid "Both pages lose their rendering and will be re-rendered automatically."
+msgstr "Les deux pages perdent leur rendu et seront re-rendues automatiquement."
+
+msgid "Both pages lose their rendering. Without an API key they cannot be re-rendered, so the Storyboard will need re-running."
+msgstr "Les deux pages perdent leur rendu. Sans clé API, elles ne peuvent pas être re-rendues : il faudra donc relancer le Scénarimage."
+
 msgid "Boxed Text"
 msgstr "Boxed Texte"
 
@@ -8773,6 +8779,9 @@ msgstr "Le titre et les métadonnées du livre arrivent avec la partie qui conti
 
 msgid "The built-in prompts are optimized for {DEFAULT_MODEL}. You switched the default LLM to <0>{savedModel}</0>, so we recommend generating new global prompt files tuned for it. You can also continue with the existing prompts."
 msgstr "Les prompts intégrés sont optimisés pour {DEFAULT_MODEL}. Vous avez remplacé le LLM par défaut par <0>{savedModel}</0> ; nous vous recommandons donc de générer de nouveaux fichiers de prompts globaux adaptés à ce modèle. Vous pouvez aussi continuer avec les prompts existants."
+
+msgid "The combined section will be re-rendered."
+msgstr "La section combinée sera re-rendue."
 
 msgid "The community of living organisms in a place and the way they interact with each other and their environment."
 msgstr "La communauté des organismes vivants dans un lieu et la façon dont ils interagissent entre eux et avec leur environnement."

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -8903,6 +8903,9 @@ msgstr "La révision de traduction enregistrée est obsolète. Relancez Réviser
 msgid "The section was edited after conversion — use \"Rebuild from page\" to refresh the steps."
 msgstr "La section a été modifiée après la conversion — utilisez « Reconstruire depuis la page » pour actualiser les étapes."
 
+msgid "The sections will be combined locally. Without an API key, the Storyboard will need re-running to regenerate the combined section."
+msgstr "Les sections seront fusionnées localement. Sans clé API, le storyboard devra être réexécuté pour régénérer la section fusionnée."
+
 msgid "The storyboard must be completed before generating {stageName}. Run the Storyboard stage first."
 msgstr "Le storyboard doit être complété avant de générer {stageName}. Exécutez d'abord l'étape du storyboard."
 

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -6908,6 +6908,9 @@ msgstr "Reexecutar {stageLabel}?"
 msgid "Re-run speech"
 msgstr "Reexecutar áudio"
 
+msgid "Re-run Storyboard"
+msgstr "Executar Storyboard novamente"
+
 msgid "Re-run these book-level stages on the assembled book:"
 msgstr "Execute novamente estas etapas de nível de livro no livro montado:"
 
@@ -7775,6 +7778,9 @@ msgstr "Tipos de seção"
 
 msgid "Sectioning"
 msgstr "Seccionamento"
+
+msgid "Sectioning has changed since these pages were rendered. Re-run Storyboard to regenerate them."
+msgstr "O seccionamento mudou desde que estas páginas foram renderizadas. Execute o Storyboard novamente para regenerá-las."
 
 msgid "Sectioning mode"
 msgstr "Modo de seção"
@@ -8747,12 +8753,6 @@ msgstr "Tipos de texto"
 
 msgid "Textbooks & Activities"
 msgstr "Livros Didáticos & Atividades"
-
-msgid "The affected pages lose their rendering. Without an API key they cannot be re-rendered, so the Storyboard will need re-running."
-msgstr "As páginas afetadas perdem sua renderização. Sem uma chave de API elas não podem ser rerenderizadas, então será necessário executar o Storyboard novamente."
-
-msgid "The affected pages will be re-rendered automatically."
-msgstr "As páginas afetadas serão rerenderizadas automaticamente."
 
 msgid "The AI is having a think..."
 msgstr "A IA está pensando..."

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -8901,6 +8901,9 @@ msgstr "A revisão de tradução salva está desatualizada. Execute Revisar nova
 msgid "The section was edited after conversion — use \"Rebuild from page\" to refresh the steps."
 msgstr "A seção foi editada após a conversão — use «Reconstruir a partir da página» para atualizar as etapas."
 
+msgid "The sections will be combined locally. Without an API key, the Storyboard will need re-running to regenerate the combined section."
+msgstr "As seções serão combinadas localmente. Sem uma chave de API, será necessário executar novamente o Storyboard para regenerar a seção combinada."
+
 msgid "The storyboard must be completed before generating {stageName}. Run the Storyboard stage first."
 msgstr "O storyboard deve ser concluído antes de gerar {stageName}. Execute a etapa do Storyboard primeiro."
 

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -8748,6 +8748,12 @@ msgstr "Tipos de texto"
 msgid "Textbooks & Activities"
 msgstr "Livros Didáticos & Atividades"
 
+msgid "The affected pages lose their rendering. Without an API key they cannot be re-rendered, so the Storyboard will need re-running."
+msgstr "As páginas afetadas perdem sua renderização. Sem uma chave de API elas não podem ser rerenderizadas, então será necessário executar o Storyboard novamente."
+
+msgid "The affected pages will be re-rendered automatically."
+msgstr "As páginas afetadas serão rerenderizadas automaticamente."
+
 msgid "The AI is having a think..."
 msgstr "A IA está pensando..."
 

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -1745,6 +1745,12 @@ msgstr "Bordas"
 msgid "Both"
 msgstr "Ambos"
 
+msgid "Both pages lose their rendering and will be re-rendered automatically."
+msgstr "Ambas as páginas perdem sua renderização e serão rerenderizadas automaticamente."
+
+msgid "Both pages lose their rendering. Without an API key they cannot be re-rendered, so the Storyboard will need re-running."
+msgstr "Ambas as páginas perdem sua renderização. Sem uma chave de API elas não podem ser rerenderizadas, então será necessário executar o Storyboard novamente."
+
 msgid "Boxed Text"
 msgstr "Texto em caixa"
 
@@ -8771,6 +8777,9 @@ msgstr "O título e os metadados do livro chegam com a parte que contém a pági
 
 msgid "The built-in prompts are optimized for {DEFAULT_MODEL}. You switched the default LLM to <0>{savedModel}</0>, so we recommend generating new global prompt files tuned for it. You can also continue with the existing prompts."
 msgstr "Os prompts integrados são otimizados para {DEFAULT_MODEL}. Você alterou o LLM padrão para <0>{savedModel}</0>, então recomendamos gerar novos arquivos de prompts globais ajustados para ele. Você também pode continuar com os prompts existentes."
+
+msgid "The combined section will be re-rendered."
+msgstr "A seção combinada será rerenderizada."
 
 msgid "The community of living organisms in a place and the way they interact with each other and their environment."
 msgstr "A comunidade de organismos vivos em um lugar e a forma como interagem entre si e com o ambiente."

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -6909,6 +6909,9 @@ msgstr "Ri-ekzekuto {stageLabel}?"
 msgid "Re-run speech"
 msgstr "Ri-ekzekuto fjalimin"
 
+msgid "Re-run Storyboard"
+msgstr "Ekzekuto përsëri Storyboard-in"
+
 msgid "Re-run these book-level stages on the assembled book:"
 msgstr "Riekzekuto këto faza në nivel libri në librin e bashkuar:"
 
@@ -7776,6 +7779,9 @@ msgstr "Llojet e Seksionit"
 
 msgid "Sectioning"
 msgstr "Seksionim"
+
+msgid "Sectioning has changed since these pages were rendered. Re-run Storyboard to regenerate them."
+msgstr "Seksionimi ka ndryshuar që kur u renderizuan këto faqe. Ekzekuto përsëri Storyboard-in për t'i rigjeneruar ato."
 
 msgid "Sectioning mode"
 msgstr "Modaliteti i seksionimit"
@@ -8748,12 +8754,6 @@ msgstr "Llojet e Tekstit"
 
 msgid "Textbooks & Activities"
 msgstr "Tekste Shkollore dhe Aktivitete"
-
-msgid "The affected pages lose their rendering. Without an API key they cannot be re-rendered, so the Storyboard will need re-running."
-msgstr "Faqet e prekura humbin renderimin e tyre. Pa një çelës API ato nuk mund të ri-renderizohen, prandaj Storyboard-i do të duhet të ekzekutohet përsëri."
-
-msgid "The affected pages will be re-rendered automatically."
-msgstr "Faqet e prekura do të ri-renderizohen automatikisht."
 
 msgid "The AI is having a think..."
 msgstr "AI po mendon..."

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -8749,6 +8749,12 @@ msgstr "Llojet e Tekstit"
 msgid "Textbooks & Activities"
 msgstr "Tekste Shkollore dhe Aktivitete"
 
+msgid "The affected pages lose their rendering. Without an API key they cannot be re-rendered, so the Storyboard will need re-running."
+msgstr "Faqet e prekura humbin renderimin e tyre. Pa një çelës API ato nuk mund të ri-renderizohen, prandaj Storyboard-i do të duhet të ekzekutohet përsëri."
+
+msgid "The affected pages will be re-rendered automatically."
+msgstr "Faqet e prekura do të ri-renderizohen automatikisht."
+
 msgid "The AI is having a think..."
 msgstr "AI po mendon..."
 

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -1746,6 +1746,12 @@ msgstr "Kufij"
 msgid "Both"
 msgstr "Të dyja"
 
+msgid "Both pages lose their rendering and will be re-rendered automatically."
+msgstr "Të dyja faqet humbin renderimin e tyre dhe do të ri-renderizohen automatikisht."
+
+msgid "Both pages lose their rendering. Without an API key they cannot be re-rendered, so the Storyboard will need re-running."
+msgstr "Të dyja faqet humbin renderimin e tyre. Pa një çelës API ato nuk mund të ri-renderizohen, prandaj Storyboard-i do të duhet të ekzekutohet përsëri."
+
 msgid "Boxed Text"
 msgstr "Tekst i inkuadruar"
 
@@ -8772,6 +8778,9 @@ msgstr "Titulli dhe të dhënat e librit vijnë me pjesën që përmban faqen 1 
 
 msgid "The built-in prompts are optimized for {DEFAULT_MODEL}. You switched the default LLM to <0>{savedModel}</0>, so we recommend generating new global prompt files tuned for it. You can also continue with the existing prompts."
 msgstr "Prompt-et e integruara janë optimizuar për {DEFAULT_MODEL}. E ndryshuat LLM-në e parazgjedhur në <0>{savedModel}</0>, ndaj rekomandojmë të gjeneroni skedarë të rinj prompt-esh globale të përshtatur për të. Mund të vazhdoni edhe me prompt-et ekzistuese."
+
+msgid "The combined section will be re-rendered."
+msgstr "Seksioni i kombinuar do të ri-renderizohet."
 
 msgid "The community of living organisms in a place and the way they interact with each other and their environment."
 msgstr "Bashkësia e organizmave të gjallë në një vend dhe mënyra si ndërveprojnë me njëri-tjetrin dhe mjedisin e tyre."

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -8902,6 +8902,9 @@ msgstr "Rishikimi i ruajtur i përkthimit është i vjetëruar. Ekzekutoni Rishi
 msgid "The section was edited after conversion — use \"Rebuild from page\" to refresh the steps."
 msgstr "Seksioni u ndryshua pas konvertimit — përdor «Rindërto nga faqja» për të rifreskuar hapat."
 
+msgid "The sections will be combined locally. Without an API key, the Storyboard will need re-running to regenerate the combined section."
+msgstr "Seksionet do të kombinohen lokalisht. Pa një çelës API-je, Storyboard-i do të duhet të ekzekutohet përsëri për të rigjeneruar seksionin e kombinuar."
+
 msgid "The storyboard must be completed before generating {stageName}. Run the Storyboard stage first."
 msgstr "Storyboard duhet të plotësohet para gjenerimit të {stageName}. Ekzekuto fazën Storyboard fillimisht."
 

--- a/packages/storage/src/__tests__/book-storage.test.ts
+++ b/packages/storage/src/__tests__/book-storage.test.ts
@@ -544,6 +544,31 @@ describe("putNodeData / getLatestNodeData", () => {
 
     storage.close()
   })
+
+  it("rolls back every write when a transaction fails", () => {
+    const { storage } = createTempStorage()
+    storage.putNodeData("web-rendering", "pg001", { version: "before" })
+    storage.markStepCompleted("web-rendering")
+
+    expect(() =>
+      storage.transaction(() => {
+        storage.putNodeData("web-rendering", "pg001", { version: "after" })
+        storage.putNodeData("page-sectioning", "pg001", { version: "after" })
+        storage.clearStepRuns(["web-rendering"])
+        throw new Error("abort save")
+      })
+    ).toThrow("abort save")
+
+    expect(storage.getLatestNodeData("web-rendering", "pg001")).toEqual({
+      version: 1,
+      data: { version: "before" },
+    })
+    expect(storage.getLatestNodeData("page-sectioning", "pg001")).toBeNull()
+    expect(storage.getStepRuns()).toContainEqual(
+      expect.objectContaining({ step: "web-rendering", status: "done" })
+    )
+    storage.close()
+  })
 })
 
 describe("appendLlmLog", () => {

--- a/packages/storage/src/book-storage.ts
+++ b/packages/storage/src/book-storage.ts
@@ -40,8 +40,31 @@ export function createBookStorage(label: string, booksRoot: string): Storage {
   fs.mkdirSync(paths.videosDir, { recursive: true })
 
   const db = openBookDb(paths.dbPath)
+  let transactionDepth = 0
+
+  const transaction = <T>(operation: () => T): T => {
+    // All Storage methods share this connection, so nested operations are
+    // already part of the outer transaction. The outermost call alone owns
+    // BEGIN/COMMIT/ROLLBACK.
+    if (transactionDepth > 0) return operation()
+
+    db.exec("BEGIN IMMEDIATE")
+    transactionDepth = 1
+    try {
+      const result = operation()
+      db.exec("COMMIT")
+      return result
+    } catch (err) {
+      db.exec("ROLLBACK")
+      throw err
+    } finally {
+      transactionDepth = 0
+    }
+  }
 
   return {
+    transaction,
+
     clearExtractedData(): void {
       clearImageFiles(paths.imagesDir)
       clearImageFiles(paths.debugImagesDir)
@@ -51,15 +74,10 @@ export function createBookStorage(label: string, booksRoot: string): Storage {
     clearNodesByType(nodes: string[]): void {
       if (nodes.length === 0) return
       const placeholders = nodes.map(() => "?").join(", ")
-      db.exec("BEGIN IMMEDIATE")
-      try {
+      transaction(() => {
         db.run(`DELETE FROM node_data WHERE node IN (${placeholders})`, nodes)
         db.run(`DELETE FROM node_current WHERE node IN (${placeholders})`, nodes)
-        db.exec("COMMIT")
-      } catch (err) {
-        db.exec("ROLLBACK")
-        throw err
-      }
+      })
     },
 
     putExtractedPage(page: ExtractedPage): void {

--- a/packages/storage/src/storage.ts
+++ b/packages/storage/src/storage.ts
@@ -67,6 +67,9 @@ export interface SignLanguageVideoData {
 }
 
 export interface Storage {
+  /** Run all storage operations in one SQLite transaction. Nested calls join
+   *  the outer transaction. Any thrown error rolls the whole operation back. */
+  transaction<T>(operation: () => T): T
   clearExtractedData(): void
   clearNodesByType(nodes: string[]): void
   putExtractedPage(page: ExtractedPage): void

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -83,6 +83,7 @@ export {
   IMAGE_SET_CHANGE_CLEAR_STEPS,
   IMAGE_SET_CHANGE_CLEAR_STAGES,
   getStageClearOrder,
+  getStageDependents,
   getStageClearNodes,
   getStageRerunClearNodes,
   getCacheResourcesForNode,

--- a/packages/types/src/pipeline-effects.ts
+++ b/packages/types/src/pipeline-effects.ts
@@ -185,6 +185,13 @@ export function getStageClearOrder(stage: StageName): StageName[] {
   return [stage, ...collectTransitiveDependents(stage)]
 }
 
+/** Every stage that consumes `stage`'s output, transitively — `stage` excluded.
+ *  Use when a stage's own output is known to be current but the outputs derived
+ *  from it are not. */
+export function getStageDependents(stage: StageName): StageName[] {
+  return collectTransitiveDependents(stage)
+}
+
 /** All node types that should be cleared when starting from `stage`. */
 export function getStageClearNodes(stage: StageName): PipelineNodeName[] {
   const seen = new Set<PipelineNodeName>()

--- a/packages/types/src/task.ts
+++ b/packages/types/src/task.ts
@@ -37,11 +37,15 @@ export const TaskEvent = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("task-complete"),
     taskId: z.string(),
+    kind: TaskKind.optional(),
+    pageId: z.string().optional(),
     result: z.unknown().optional(),
   }),
   z.object({
     type: z.literal("task-error"),
     taskId: z.string(),
+    kind: TaskKind.optional(),
+    pageId: z.string().optional(),
     error: z.string(),
   }),
 ])


### PR DESCRIPTION
Storyboard edits were resetting the whole stage. `markStoryboardChainStale` cleared `step_runs` for `getStageClearOrder("storyboard")` — which includes the storyboard itself — and `clearStepRuns` has no page filter, so a typo fix on one page marked every page's rendering stale and swapped the editor for the Run landing page. Regression from #642.

**The rule now is whether the rendered HTML can be brought back in sync.** Every editor save either mirrors the edit into the HTML, needs no HTML change, or queues a re-render of the one section it touched — so the stage stays complete. It is marked stale only when none of that is possible: no API key, or a custom activity a re-render would flatten. `renderingInSync` is off by default, so the Sectioning stage and any other caller are unchanged.

**Ops that rebuild the rendering themselves no longer invalidate anything.** Delete drops the section's HTML entry and shifts the rest; clone copies the source's HTML and rewrites its ids; a same-page merge concatenates both sections into the kept entry. All three leave the rendering matching the sectioning, so a re-run would have been pure cost.

**Ops that genuinely destroy HTML now repair the pages they damage.** A cross-page merge empties both pages outright and queued nothing at all — it now re-renders both, which is two page renders rather than a book-wide regeneration, and the confirmation says which pages go and whether they will be put back automatically or leave the Storyboard needing a re-run. Split still marks the chain stale; it is only reachable from Sectioning, where #642 already wired the disclosure.

**Sectioning stays a batch workflow.** Structural edits there render nothing, so a restructuring pass costs one render at the end instead of one per edit. The Storyboard carries a banner whenever the stage is stale but its renderings survive, with the action that regenerates them in one pass.

**Four independent gates equated "stage not done" with "stage has no content"** and all four had to move, or the fix just relocated the dead end: `StoryboardIndex` (landing page instead of the editor), `StoryboardView` (run card over intact renderings), `stageHasContent` (page list gone), `showOverviewTab` (no Run button anywhere, so a legitimately stale stage could not be re-run at all).

**Verification:** `pnpm typecheck` clean; `pnpm lint` 0 errors (9 pre-existing warnings in untouched files); `pages.test.ts` 64/64 and studio 306/306, with new tests covering the in-sync and stale paths, the 409 no-op, and delete/clone staying complete. i18n: 5 new strings, translated in `es`, `fr`, `pt-BR`, `sq`, `compile --strict` passes, 0 missing. The `part-service.test.ts` timeouts seen in full-suite runs reproduce on a clean `develop` and are unrelated.

**Tested in the running app** by @elasticsounds across prune/unprune, section type changes, delete, same-page and cross-page merge, the sectioning batch flow, and the re-run banner.

**Not covered:** fixed-layout books (`web-rendering` is built from `positioned-text` there) and custom activity sections.

**Follow-ups filed:** #735 — staleness is stage-wide with no page dimension, which is the root cause behind all of the above and the reason #642 reached for whole-stage invalidation; #736 — `clearCaptionData` deletes manual caption/translation/easy-read edits instead of marking them stale.