### PR TITLE
fix(sectioning): keep textbook cover and credits pages on by default

### DIFF
--- a/apps/studio/src/components/wizard/constants.ts
+++ b/apps/studio/src/components/wizard/constants.ts
@@ -344,7 +344,10 @@ export const PRESETS: PresetConfig[] = [
       // (config.yaml uses bare `header`/`footer`/`page_number`). The `_text`
       // suffixed variants never match, so header/footer would leak in unpruned.
       pruned_role_types: ["header", "footer", "page_number", "watermark"],
-      pruned_section_types: ["back_cover", "credits", "inside_cover"],
+      // Textbooks keep the cover pages (inside/inner cover, back cover) and the
+      // credits page on by default — they carry publisher/ISBN and
+      // contributor/funding info worth retaining.
+      pruned_section_types: [],
       image_filters: { min_stddev: 2 },
     },
   },


### PR DESCRIPTION
The textbook wizard preset no longer prunes `back_cover`, `credits`, or `inside_cover` by default, so text books keep their cover pages and credits (which carry publisher/ISBN and contributor/funding info) unless the user opts to prune them. This is the preset's full replacement for the global default, so an empty `pruned_section_types` list means nothing in the front/back matter gets flagged `isPruned` for textbook books. Storybook, reference, and the global/custom defaults are unchanged, and users can still toggle any of these sections off per book in Sectioning settings.