### PR TITLE
Fix rotated raster extraction for PDF image placements

### DIFF
--- a/apps/api/src/routes/books.test.ts
+++ b/apps/api/src/routes/books.test.ts
@@ -1500,8 +1500,22 @@ describe("GET /books/:label/images/:imageId", () => {
 
     expect(res.status).toBe(200)
     expect(res.headers.get("Content-Type")).toBe("image/png")
+    expect(res.headers.get("Cache-Control")).toBe("private, no-cache")
+    expect(res.headers.get("ETag")).toBe('"abc123"')
     const buf = await res.arrayBuffer()
     expect(Buffer.from(buf).toString()).toBe("fake-png-data")
+  })
+
+  it("returns 304 when the extracted image hash is unchanged", async () => {
+    createBookWithImage("img-book-etag")
+    const app = createBookRoutes(tmpDir)
+    const res = await app.request("/books/img-book-etag/images/img-book-etag_p1_page", {
+      headers: { "If-None-Match": '"abc123"' },
+    })
+
+    expect(res.status).toBe(304)
+    expect(res.headers.get("Cache-Control")).toBe("private, no-cache")
+    expect(res.headers.get("ETag")).toBe('"abc123"')
   })
 
   it("returns 404 for nonexistent image", async () => {

--- a/apps/api/src/routes/books.test.ts
+++ b/apps/api/src/routes/books.test.ts
@@ -1452,7 +1452,7 @@ describe("GET /books/:label/export-adt", () => {
 })
 
 describe("GET /books/:label/images/:imageId", () => {
-  function createBookWithImage(label: string): void {
+  function createBookWithImage(label: string, hash = "abc123"): void {
     const storage = createBookStorage(label, tmpDir)
     try {
       storage.putExtractedPage({
@@ -1463,7 +1463,7 @@ describe("GET /books/:label/images/:imageId", () => {
           imageId: `${label}_p1_page`,
           buffer: Buffer.from("fake-png-data"),
           format: "png" as const,
-          hash: "abc123",
+          hash,
           width: 800,
           height: 600,
         },
@@ -1516,6 +1516,20 @@ describe("GET /books/:label/images/:imageId", () => {
     expect(res.status).toBe(304)
     expect(res.headers.get("Cache-Control")).toBe("private, no-cache")
     expect(res.headers.get("ETag")).toBe('"abc123"')
+  })
+
+  it("does not return 304 for a legacy image with an empty hash", async () => {
+    createBookWithImage("img-book-empty-hash", "")
+    const app = createBookRoutes(tmpDir)
+    const res = await app.request(
+      "/books/img-book-empty-hash/images/img-book-empty-hash_p1_page",
+      { headers: { "If-None-Match": '""' } }
+    )
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get("Cache-Control")).toBe("private, no-cache")
+    expect(res.headers.get("ETag")).toBeNull()
+    expect(Buffer.from(await res.arrayBuffer()).toString()).toBe("fake-png-data")
   })
 
   it("returns 404 for nonexistent image", async () => {

--- a/apps/api/src/routes/books.ts
+++ b/apps/api/src/routes/books.ts
@@ -842,9 +842,9 @@ export function createBookRoutes(
     const db = openBookDb(dbPath)
     try {
       const rows = db.all(
-        "SELECT path FROM images WHERE image_id = ?",
+        "SELECT path, hash FROM images WHERE image_id = ?",
         [imageId]
-      ) as Array<{ path: string }>
+      ) as Array<{ path: string; hash: string }>
 
       if (rows.length === 0) {
         throw new HTTPException(404, {
@@ -871,12 +871,21 @@ export function createBookRoutes(
         })
       }
 
+      // Extract reruns intentionally reuse stable image IDs while replacing
+      // their bytes. Require revalidation so Chromium cannot show a previous
+      // extraction for up to 24 hours under the same URL.
+      const etag = `"${rows[0].hash}"`
+      c.header("Cache-Control", "private, no-cache")
+      c.header("ETag", etag)
+      if (c.req.header("If-None-Match") === etag) {
+        return c.body(null, 304)
+      }
+
       const imageBuffer = fs.readFileSync(imagePath)
       const ext = path.extname(imagePath).toLowerCase()
       const contentType =
         ext === ".jpg" || ext === ".jpeg" ? "image/jpeg" : "image/png"
       c.header("Content-Type", contentType)
-      c.header("Cache-Control", "public, max-age=86400")
       return c.body(imageBuffer)
     } finally {
       db.close()

--- a/apps/api/src/routes/books.ts
+++ b/apps/api/src/routes/books.ts
@@ -874,11 +874,13 @@ export function createBookRoutes(
       // Extract reruns intentionally reuse stable image IDs while replacing
       // their bytes. Require revalidation so Chromium cannot show a previous
       // extraction for up to 24 hours under the same URL.
-      const etag = `"${rows[0].hash}"`
       c.header("Cache-Control", "private, no-cache")
-      c.header("ETag", etag)
-      if (c.req.header("If-None-Match") === etag) {
-        return c.body(null, 304)
+      if (rows[0].hash) {
+        const etag = `"${rows[0].hash}"`
+        c.header("ETag", etag)
+        if (c.req.header("If-None-Match") === etag) {
+          return c.body(null, 304)
+        }
       }
 
       const imageBuffer = fs.readFileSync(imagePath)

--- a/packages/pdf/src/__tests__/create-test-pdf.ts
+++ b/packages/pdf/src/__tests__/create-test-pdf.ts
@@ -261,6 +261,52 @@ Q
 }
 
 /**
+ * Create a PDF whose rectangular raster is stored landscape but painted with
+ * the same off-diagonal quarter-turn CTM used by InDesign in the real-world
+ * certificate regression fixture.
+ */
+export function createQuarterTurnRasterTestPdf(): Buffer {
+  const doc = new mupdf.PDFDocument();
+  const imgW = 20;
+  const imgH = 10;
+  const pixmap = new mupdf.Pixmap(mupdf.ColorSpace.DeviceRGB, [0, 0, imgW, imgH], false);
+  const samples = pixmap.getPixels();
+
+  for (let y = 0; y < imgH; y++) {
+    for (let x = 0; x < imgW; x++) {
+      const i = (y * imgW + x) * 3;
+      const left = x < imgW / 2;
+      const top = y < imgH / 2;
+      const rgb = top
+        ? (left ? [255, 0, 0] : [0, 255, 0])
+        : (left ? [0, 0, 255] : [255, 255, 0]);
+      samples[i] = rgb[0];
+      samples[i + 1] = rgb[1];
+      samples[i + 2] = rgb[2];
+    }
+  }
+
+  const image = new mupdf.Image(pixmap);
+  const imgObj = doc.addImage(image);
+  const xobjects = doc.newDictionary();
+  xobjects.put("Im1", imgObj);
+  const resourcesDict = doc.newDictionary();
+  resourcesDict.put("XObject", xobjects);
+  const resources = doc.addObject(resourcesDict);
+
+  const stream = `
+q
+0 -200 100 0 100 300 cm
+/Im1 Do
+Q
+`;
+  const buf = new mupdf.Buffer();
+  buf.writeLine(stream);
+  doc.insertPage(-1, doc.addPage([0, 0, 612, 792], 0, resources, buf));
+  return Buffer.from(doc.saveToBuffer("").asUint8Array());
+}
+
+/**
  * Create a 1-page PDF with a raster image, overlapping vector, AND nearby text label.
  * The text "Figure 1" is placed just below the image+vector figure.
  * Used to verify text label absorption expands the figure group bbox.

--- a/packages/pdf/src/__tests__/extract-raster-flip-e2e.test.ts
+++ b/packages/pdf/src/__tests__/extract-raster-flip-e2e.test.ts
@@ -1,20 +1,21 @@
 import { describe, expect, it } from "vitest";
 import { PNG } from "pngjs";
 import { extractPdf } from "../extract.js";
-import { createMirroredRasterTestPdf } from "./create-test-pdf.js";
+import {
+  createMirroredRasterTestPdf,
+  createQuarterTurnRasterTestPdf,
+} from "./create-test-pdf.js";
 
 /**
- * End-to-end regression test for the raster flip pipeline.
+ * End-to-end regression test for the raster orientation pipeline.
  *
  * Unlike the unit tests in `flip-utils.test.ts` and
  * `extract-raster-placement.test.ts` (which feed hand-authored CTM arrays
  * directly to internal functions) and the `raven.pdf` snapshot test in
  * `extract-raven.test.ts` (whose fixture contains no mirrored images, making
- * the flip pass a no-op there), this test parses a real PDF content stream
- * containing a `cm` with a negative scale and asserts the *extracted pixel
- * data* has the mirror correctly baked in (matching what the PDF actually
- * renders). This is the scenario from #590 that no other test exercises
- * end-to-end.
+ * the orientation pass a no-op there), this test parses real PDF content
+ * streams and asserts the *extracted pixel data* has each discrete CTM
+ * orientation correctly baked in.
  */
 describe("extractPdf — mirrored raster image (end-to-end)", () => {
   it("bakes a horizontal mirror into the extracted pixels", async () => {
@@ -25,10 +26,9 @@ describe("extractPdf — mirrored raster image (end-to-end)", () => {
     expect(rasters).toHaveLength(1);
 
     const image = rasters[0];
-    // flipTransform is cleared once applied (see applyFlipsToRasterImages),
-    // so by the time extraction finishes it's undefined again — the pixel
+    // orientationTransform is cleared once extraction finishes — the pixel
     // buffer itself is the source of truth here.
-    expect(image.flipTransform).toBeUndefined();
+    expect(image.orientationTransform).toBeUndefined();
 
     // The embedded XObject bytes are left=red/right=blue, but the page's
     // negative-X `cm` mirrors it visually when rendered. The flip pass must
@@ -49,7 +49,7 @@ describe("extractPdf — mirrored raster image (end-to-end)", () => {
     expect(rasters).toHaveLength(1);
 
     const image = rasters[0];
-    expect(image.flipTransform).toBeUndefined();
+    expect(image.orientationTransform).toBeUndefined();
 
     // The embedded XObject bytes are top=red/bottom=blue, but the page's
     // negative-Y `cm` mirrors it visually when rendered. The flip pass must
@@ -59,6 +59,23 @@ describe("extractPdf — mirrored raster image (end-to-end)", () => {
     const bottomPixel = pixelAt(png, 0, png.height - 1);
     expect(topPixel).toEqual([0, 0, 255]);
     expect(bottomPixel).toEqual([255, 0, 0]);
+  });
+
+  it("bakes an off-diagonal 90-degree CTM into the extracted pixels", async () => {
+    const pdfBuffer = createQuarterTurnRasterTestPdf();
+    const result = await extractPdf({ pdfBuffer });
+
+    const rasters = result.pages[0].images.filter((i) => i.renderMethod === "raster");
+    expect(rasters).toHaveLength(1);
+
+    const image = rasters[0];
+    expect(image.width).toBe(10);
+    expect(image.height).toBe(20);
+
+    const png = PNG.sync.read(image.buffer);
+    expect(pixelAt(png, 0, 0)).toEqual([0, 0, 255]);
+    expect(pixelAt(png, png.width - 1, 0)).toEqual([255, 0, 0]);
+    expect(pixelAt(png, 0, png.height - 1)).toEqual([255, 255, 0]);
   });
 });
 

--- a/packages/pdf/src/__tests__/extract-raster-placement.test.ts
+++ b/packages/pdf/src/__tests__/extract-raster-placement.test.ts
@@ -53,8 +53,8 @@ describe("stampRasterPlacementsFromOps", () => {
 
     expect(imageA.streamSeqno).toBe(11);
     expect(imageB.streamSeqno).toBe(10);
-    expect(imageA.flipTransform).toEqual({ flipHorizontal: true, flipVertical: false });
-    expect(imageB.flipTransform).toEqual({ flipHorizontal: false, flipVertical: true });
+    expect(imageA.orientationTransform).toBe("flip-horizontal");
+    expect(imageB.orientationTransform).toBe("flip-vertical");
   });
 
   it("falls back to stream order for same-dimension images without digests", () => {
@@ -69,7 +69,18 @@ describe("stampRasterPlacementsFromOps", () => {
 
     expect(first.streamSeqno).toBe(20);
     expect(second.streamSeqno).toBe(21);
-    expect(first.flipTransform).toEqual({ flipHorizontal: true, flipVertical: false });
-    expect(second.flipTransform).toEqual({ flipHorizontal: false, flipVertical: false });
+    expect(first.orientationTransform).toBe("flip-horizontal");
+    expect(second.orientationTransform).toBe("identity");
+  });
+
+  it("does not consume a digest-bearing candidate for a known non-matching op", () => {
+    const survivor = makeRaster("pg001_im002", "digest-b");
+    const filteredOp = makeImageOp(30, "digest-a", [-1, 0, 0, 1, 0, 0]);
+    const survivorOp = makeImageOp(31, "digest-b", [1, 0, 0, 1, 0, 0]);
+
+    _testing.stampRasterPlacementsFromOps([survivor], [filteredOp, survivorOp]);
+
+    expect(survivor.streamSeqno).toBe(31);
+    expect(survivor.orientationTransform).toBe("identity");
   });
 });

--- a/packages/pdf/src/__tests__/flip-utils.test.ts
+++ b/packages/pdf/src/__tests__/flip-utils.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it, vi } from "vitest";
 import { PNG } from "pngjs";
 import jpeg from "jpeg-js";
 import {
-  applyFlipsToRasterImages,
-  detectFlipFromCurrentTransformationMatrix,
+  applyOrientationTransformsToRasterImages,
+  detectOrientationFromCurrentTransformationMatrix,
   flipImageBufferHorizontal,
   flipImageBufferVertical,
 } from "../flip-utils.js";
@@ -60,30 +60,68 @@ function createFourPixelPng(): Buffer {
   return PNG.sync.write(png);
 }
 
+function createSixPixelPng(): Buffer {
+  const png = new PNG({ width: 2, height: 3 });
+  const colors = [
+    [255, 0, 0], [0, 255, 0],
+    [0, 0, 255], [255, 255, 0],
+    [0, 255, 255], [255, 0, 255],
+  ];
+  colors.forEach((color, index) => {
+    const offset = index * 4;
+    png.data[offset] = color[0];
+    png.data[offset + 1] = color[1];
+    png.data[offset + 2] = color[2];
+    png.data[offset + 3] = 255;
+  });
+  return PNG.sync.write(png);
+}
+
 function rgbaAt(buffer: Buffer, x: number, y: number): [number, number, number, number] {
   const { data, width } = PNG.sync.read(buffer);
   const idx = (y * width + x) * 4;
   return [data[idx], data[idx + 1], data[idx + 2], data[idx + 3]];
 }
 
-describe("detectFlipFromCurrentTransformationMatrix", () => {
-  it("detects horizontal and vertical flip from CTM signs", () => {
-    expect(detectFlipFromCurrentTransformationMatrix([-1, 0, 0, 1, 0, 0])).toEqual({
-      flipHorizontal: true,
-      flipVertical: false,
-    });
-    expect(detectFlipFromCurrentTransformationMatrix([1, 0, 0, -1, 0, 0])).toEqual({
-      flipHorizontal: false,
-      flipVertical: true,
-    });
-    expect(detectFlipFromCurrentTransformationMatrix([-1, 0, 0, -1, 0, 0])).toEqual({
-      flipHorizontal: true,
-      flipVertical: true,
-    });
-    expect(detectFlipFromCurrentTransformationMatrix([1, 0, 0, 1, 0, 0])).toEqual({
-      flipHorizontal: false,
-      flipVertical: false,
-    });
+describe("detectOrientationFromCurrentTransformationMatrix", () => {
+  it("detects all right-angle rotations and reflections", () => {
+    expect(detectOrientationFromCurrentTransformationMatrix([1, 0, 0, 1, 0, 0])).toBe("identity");
+    expect(detectOrientationFromCurrentTransformationMatrix([-1, 0, 0, 1, 0, 0])).toBe("flip-horizontal");
+    expect(detectOrientationFromCurrentTransformationMatrix([1, 0, 0, -1, 0, 0])).toBe("flip-vertical");
+    expect(detectOrientationFromCurrentTransformationMatrix([-1, 0, 0, -1, 0, 0])).toBe("rotate-180");
+    expect(detectOrientationFromCurrentTransformationMatrix([0, 1, -1, 0, 0, 0])).toBe("rotate-90-clockwise");
+    expect(detectOrientationFromCurrentTransformationMatrix([0, -1, 1, 0, 0, 0])).toBe("rotate-90-counterclockwise");
+    expect(detectOrientationFromCurrentTransformationMatrix([0, 1, 1, 0, 0, 0])).toBe("transpose");
+    expect(detectOrientationFromCurrentTransformationMatrix([0, -1, -1, 0, 0, 0])).toBe("anti-transpose");
+  });
+
+  it("normalizes non-uniform scale and tolerates tiny axis residue", () => {
+    expect(
+      detectOrientationFromCurrentTransformationMatrix([
+        0.000001,
+        -459.851837,
+        325.1875,
+        -0.000001,
+        130.14,
+        674.28,
+      ]),
+    ).toBe("rotate-90-counterclockwise");
+  });
+
+  it("rejects arbitrary rotations, skew, and degenerate matrices", () => {
+    const angle = Math.PI / 4;
+    expect(
+      detectOrientationFromCurrentTransformationMatrix([
+        Math.cos(angle),
+        Math.sin(angle),
+        -Math.sin(angle),
+        Math.cos(angle),
+        0,
+        0,
+      ]),
+    ).toBeNull();
+    expect(detectOrientationFromCurrentTransformationMatrix([1, 0.2, 0, 1, 0, 0])).toBeNull();
+    expect(detectOrientationFromCurrentTransformationMatrix([0, 0, 0, 1, 0, 0])).toBeNull();
   });
 });
 
@@ -135,36 +173,52 @@ describe("buffer flips", () => {
   });
 });
 
-describe("applyFlipsToRasterImages", () => {
+describe("applyOrientationTransformsToRasterImages", () => {
   it("applies the pre-stamped flip transform", () => {
     const sourceA = createTwoPixelPng([255, 0, 0], [0, 0, 255]);
     const sourceB = createTwoPixelPng([0, 255, 0], [255, 255, 0]);
     const imageA = makeRasterImage("im001", sourceA, "digest-a");
     const imageB = makeRasterImage("im002", sourceB, "digest-b");
-    imageA.flipTransform = { flipHorizontal: true, flipVertical: false };
-    imageB.flipTransform = { flipHorizontal: false, flipVertical: false };
+    imageA.orientationTransform = "flip-horizontal";
+    imageB.orientationTransform = "identity";
 
-    applyFlipsToRasterImages([imageA, imageB]);
+    applyOrientationTransformsToRasterImages([imageA, imageB]);
 
     expect(imageA.buffer.equals(sourceA)).toBe(false);
     expect(imageB.buffer.equals(sourceB)).toBe(true);
   });
 
-  it("clears flipTransform after applying, so an accidental second call is a no-op", () => {
+  it("bakes a quarter-turn into pixels and swaps dimensions", () => {
+    const source = createSixPixelPng();
+    const image = makeRasterImage("im001", source);
+    image.width = 2;
+    image.height = 3;
+    image.orientationTransform = "rotate-90-counterclockwise";
+
+    applyOrientationTransformsToRasterImages([image]);
+
+    expect(image.width).toBe(3);
+    expect(image.height).toBe(2);
+    expect(rgbaAt(image.buffer, 0, 0)).toEqual([0, 255, 0, 255]);
+    expect(rgbaAt(image.buffer, 2, 0)).toEqual([255, 0, 255, 255]);
+    expect(rgbaAt(image.buffer, 0, 1)).toEqual([255, 0, 0, 255]);
+  });
+
+  it("clears orientationTransform after applying, so an accidental second call is a no-op", () => {
     const source = createTwoPixelPng([255, 0, 0], [0, 0, 255]);
     const image = makeRasterImage("im001", source);
-    image.flipTransform = { flipHorizontal: true, flipVertical: false };
+    image.orientationTransform = "flip-horizontal";
 
-    applyFlipsToRasterImages([image]);
+    applyOrientationTransformsToRasterImages([image]);
     const afterFirstCall = Buffer.from(image.buffer);
-    expect(image.flipTransform).toBeUndefined();
+    expect(image.orientationTransform).toBeUndefined();
     expect(afterFirstCall.equals(source)).toBe(false);
 
     // A caller re-invoking on the same array (without re-stamping
-    // flipTransform) must be a no-op, not a silent double-flip (which for
+    // orientationTransform) must be a no-op, not a silent double-flip (which for
     // H+H would revert to the original, and for any other combination would
     // corrupt the image).
-    applyFlipsToRasterImages([image]);
+    applyOrientationTransformsToRasterImages([image]);
 
     expect(image.buffer.equals(afterFirstCall)).toBe(true);
   });
@@ -173,7 +227,7 @@ describe("applyFlipsToRasterImages", () => {
     const source = createTwoPixelPng([255, 0, 0], [0, 0, 255]);
     const image = makeRasterImage("im001", source);
 
-    applyFlipsToRasterImages([image]);
+    applyOrientationTransformsToRasterImages([image]);
 
     expect(image.buffer.equals(source)).toBe(true);
   });
@@ -190,9 +244,9 @@ describe("applyFlipsToRasterImages", () => {
 
     const image = makeRasterImage("im001", Buffer.from([0xff, 0xd8]));
     image.format = "jpeg";
-    image.flipTransform = { flipHorizontal: true, flipVertical: true };
+    image.orientationTransform = "rotate-180";
 
-    applyFlipsToRasterImages([image]);
+    applyOrientationTransformsToRasterImages([image]);
 
     expect(decodeSpy).toHaveBeenCalledTimes(1);
     expect(encodeSpy).toHaveBeenCalledTimes(1);
@@ -207,13 +261,13 @@ describe("applyFlipsToRasterImages", () => {
     const malformedJpeg = Buffer.from([0xff, 0xd8, 0xff, 0x00]); // truncated/invalid JPEG
     const badImage = makeRasterImage("im001", malformedJpeg);
     badImage.format = "jpeg";
-    badImage.flipTransform = { flipHorizontal: true, flipVertical: false };
+    badImage.orientationTransform = "flip-horizontal";
 
     const goodSource = createTwoPixelPng([255, 0, 0], [0, 0, 255]);
     const goodImage = makeRasterImage("im002", goodSource);
-    goodImage.flipTransform = { flipHorizontal: true, flipVertical: false };
+    goodImage.orientationTransform = "flip-horizontal";
 
-    expect(() => applyFlipsToRasterImages([badImage, goodImage])).not.toThrow();
+    expect(() => applyOrientationTransformsToRasterImages([badImage, goodImage])).not.toThrow();
 
     // Malformed image is left exactly as-is (original orientation kept).
     expect(badImage.buffer.equals(malformedJpeg)).toBe(true);

--- a/packages/pdf/src/extract.ts
+++ b/packages/pdf/src/extract.ts
@@ -38,9 +38,9 @@ import {
 import type { DrawItem, PositionedTextOutput } from "@adt/types";
 import { classifyFontCategoryByName } from "@adt/types";
 import {
-  detectFlipFromCurrentTransformationMatrix,
-  applyFlipsToRasterImages,
-  type ImageFlipTransform,
+  detectOrientationFromCurrentTransformationMatrix,
+  applyOrientationTransformsToRasterImages,
+  type ImageOrientationTransform,
 } from "./flip-utils.js";
 
 // ============================================================================
@@ -145,17 +145,17 @@ export interface ExtractedImage {
    * as the recorder's `ImageStreamOp.contentDigest` so the two compare equal.
    * Transient: not persisted to the images table.
    *
-   * STALE AFTER FLIP: hashes the pre-flip pixels. Only read during the
-   * placement-matching pass, which runs before `applyFlipsToRasterImages` —
+   * STALE AFTER ORIENTATION: hashes the original pixels. Only read during the
+   * placement-matching pass, which runs before the orientation transform —
    * do not reuse it downstream to reason about the image's current pixels.
    */
   pixelDigest?: string;
   /**
-   * Flip transform derived from the EXACT draw op matched to this image by
-   * `stampRasterPlacementsFromOps`. Transient: used by `applyFlipsToRasterImages`
-   * to avoid re-matching stream ops in a second pass.
+   * Right-angle orientation derived from the EXACT draw op matched to this
+   * image by `stampRasterPlacementsFromOps`. Transient: baked into the image
+   * pixels after placement matching.
    */
-  flipTransform?: ImageFlipTransform;
+  orientationTransform?: ImageOrientationTransform;
   /**
    * Geometry bboxes of this vector figure's constituent SVG shapes, in the
    * same coordinate space as recorder ops (page coords + spread xOffset).
@@ -846,10 +846,10 @@ async function extractPage(doc: MupdfDocument, pageIndex: number, vectorTextGrou
     pageBounds,
     0,
     0,
-    hasDuplicateDimensions(rasterImages),
+    hasDuplicateDimensions(allRasterImages),
   );
-  stampRasterPlacementsFromOps(rasterImages, recorder.ops);
-  applyFlipsToRasterImages(rasterImages);
+  stampRasterPlacementsFromOps(allRasterImages, recorder.ops);
+  applyOrientationTransformsToRasterImages(rasterImages);
 
   // Reuse the StructuredText already built above — no extra pass. Build
   // positioned text at fixed-layout quality (spacing cleanup on) so the data is
@@ -1069,8 +1069,8 @@ function hasDuplicateDimensions(images: ExtractedImage[]): boolean {
 
 /**
  * Match each `fillImage` / `fillImageMask` op to an extracted raster XObject,
- * stamping the matched raster's `streamSeqno`, `bounds`, and `flipTransform`
- * (derived from the op's CTM).
+ * stamping the matched raster's `streamSeqno`, `bounds`, and discrete
+ * orientation (derived from the op's CTM).
  *
  * Matching keys on native pixel dimensions. When a dimension bucket holds more
  * than one image the match is ambiguous: a page that can see several same-size
@@ -1099,7 +1099,9 @@ function stampRasterPlacementsFromOps(
     if (!candidates || candidates.length === 0) continue;
     let matched: ExtractedImage | undefined;
     // Disambiguate same-dimension candidates by pixel content when available.
-    if (candidates.length > 1 && op.contentDigest) {
+    // Check even a single remaining candidate: an earlier op may belong to an
+    // image that was omitted by a caller, and must not steal a known non-match.
+    if (op.contentDigest) {
       const idx = candidates.findIndex(
         (c) => c.pixelDigest !== undefined && c.pixelDigest === op.contentDigest,
       );
@@ -1112,6 +1114,7 @@ function stampRasterPlacementsFromOps(
         // that a later digest-bearing op still needs to match.
         const undigested = candidates.findIndex((c) => c.pixelDigest === undefined);
         if (undigested >= 0) matched = candidates.splice(undigested, 1)[0];
+        else continue;
       }
     }
     // Unambiguous bucket, or no digest match — pair in stream order.
@@ -1119,7 +1122,16 @@ function stampRasterPlacementsFromOps(
     if (!matched) continue;
     matched.streamSeqno = op.seqno;
     matched.bounds = bboxToImageBounds(op.bbox);
-    matched.flipTransform = detectFlipFromCurrentTransformationMatrix(op.currentTransformationMatrix);
+    const orientation = detectOrientationFromCurrentTransformationMatrix(
+      op.currentTransformationMatrix,
+    );
+    if (orientation) {
+      matched.orientationTransform = orientation;
+    } else {
+      console.warn(
+        `[pdf] unsupported image orientation for ${matched.imageId}; keeping original pixels`,
+      );
+    }
     const clipD = selectImageClipPath(op);
     if (clipD) matched.clipPath = clipD;
     if (op.blendMode && op.blendMode !== "Normal") {
@@ -1653,7 +1665,7 @@ async function extractSpreadPage(
     leftBounds,
     0,
     0,
-    hasDuplicateDimensions(leftRaster),
+    hasDuplicateDimensions(allLeftRaster),
   );
   const leftMaxSeqno = leftRecorder.ops.reduce(
     (m, o) => Math.max(m, o.seqno),
@@ -1664,15 +1676,15 @@ async function extractSpreadPage(
     rightBounds,
     leftPageWidthPt,
     leftMaxSeqno + 1,
-    hasDuplicateDimensions(rightRaster),
+    hasDuplicateDimensions(allRightRaster),
   );
   const ops: StreamOp[] = [...leftRecorder.ops, ...rightRecorder.ops];
   // Rasters: stamp per page so dim-tied images on different pages don't
   // pair across the spread boundary.
-  stampRasterPlacementsFromOps(leftRaster, leftRecorder.ops);
-  applyFlipsToRasterImages(leftRaster);
-  stampRasterPlacementsFromOps(rightRaster, rightRecorder.ops);
-  applyFlipsToRasterImages(rightRaster);
+  stampRasterPlacementsFromOps(allLeftRaster, leftRecorder.ops);
+  applyOrientationTransformsToRasterImages(leftRaster);
+  stampRasterPlacementsFromOps(allRightRaster, rightRecorder.ops);
+  applyOrientationTransformsToRasterImages(rightRaster);
 
   // Reuse the per-page StructuredText already built above — no extra pass.
   const paragraphData = parsePageParagraphsSpread(leftPage, rightPage, leftStext, rightStext, 2, true);

--- a/packages/pdf/src/flip-utils.ts
+++ b/packages/pdf/src/flip-utils.ts
@@ -1,174 +1,221 @@
 /**
- * Image Flip Transform Utilities
+ * Image orientation utilities.
  *
- * Detects and applies current transformation matrix (CTM) based flip transformations
- * to raster images extracted from PDFs. Handles both JPEG and PNG formats.
+ * PDF image XObjects store raw pixels separately from the CTM used when the
+ * image is painted. Extracted assets therefore need the CTM's discrete
+ * orientation baked into their pixels so they match the rendered page.
  */
 
 import { createHash } from "crypto";
-import { PNG } from "pngjs";
 import jpeg from "jpeg-js";
+import { PNG } from "pngjs";
+import type { ExtractedImage, ImageFormat } from "./extract.js";
 import { decodePng } from "./png-utils.js";
-import type { ExtractedImage } from "./extract.js";
 
-/**
- * Hash a buffer to a 16-character hex string.
- * Avoids circular dependency by defining locally instead of importing from extract.
- */
 function hashBuffer(buf: Buffer): string {
   return createHash("sha256").update(buf).digest("hex").slice(0, 16);
 }
 
 /**
- * Detect if image needs horizontal/vertical flip based on current transformation matrix.
- * Negative X scale (a < 0) = horizontal flip; negative Y scale (d < 0) = vertical flip.
- * Scope: axis-aligned flips only. This intentionally ignores b/c (rotation/skew)
- * terms from the CTM; suitable for current storybook inputs, but not a full
- * affine-orientation solver for arbitrary rotations.
+ * The eight axis-aligned symmetries of a rectangle. Rotation names describe
+ * the pixel operation in the extractor's top-left/y-down image space.
  */
-export interface ImageFlipTransform {
-  flipHorizontal: boolean;
-  flipVertical: boolean;
+export type ImageOrientationTransform =
+  | "identity"
+  | "flip-horizontal"
+  | "flip-vertical"
+  | "rotate-180"
+  | "rotate-90-clockwise"
+  | "rotate-90-counterclockwise"
+  | "transpose"
+  | "anti-transpose";
+
+type AxisComponent = -1 | 0 | 1;
+type OrientationMatrix = readonly [
+  AxisComponent,
+  AxisComponent,
+  AxisComponent,
+  AxisComponent,
+];
+
+/** Matrix maps source pixel coordinates to oriented output coordinates. */
+const ORIENTATION_MATRICES: Record<ImageOrientationTransform, OrientationMatrix> = {
+  identity: [1, 0, 0, 1],
+  "flip-horizontal": [-1, 0, 0, 1],
+  "flip-vertical": [1, 0, 0, -1],
+  "rotate-180": [-1, 0, 0, -1],
+  "rotate-90-clockwise": [0, -1, 1, 0],
+  "rotate-90-counterclockwise": [0, 1, -1, 0],
+  transpose: [0, 1, 1, 0],
+  "anti-transpose": [0, -1, -1, 0],
+};
+
+const MATRIX_TO_ORIENTATION = new Map<string, ImageOrientationTransform>(
+  Object.entries(ORIENTATION_MATRICES).map(([orientation, matrix]) => [
+    matrix.join(","),
+    orientation as ImageOrientationTransform,
+  ]),
+);
+
+// InDesign and similar tools sometimes leave tiny floating-point residues in
+// otherwise exact quarter-turn matrices. Accept those, but do not silently
+// reinterpret a genuinely arbitrary rotation or skew as a flip.
+const AXIS_SNAP_TOLERANCE = 1e-4;
+
+function snapAxisComponent(value: number): AxisComponent | null {
+  if (Math.abs(value) <= AXIS_SNAP_TOLERANCE) return 0;
+  if (Math.abs(value - 1) <= AXIS_SNAP_TOLERANCE) return 1;
+  if (Math.abs(value + 1) <= AXIS_SNAP_TOLERANCE) return -1;
+  return null;
 }
 
-export function detectFlipFromCurrentTransformationMatrix(currentTransformationMatrix: number[]): ImageFlipTransform {
-  const [a, , , d] = currentTransformationMatrix; // [a, b, c, d, e, f]
+/**
+ * Detect the discrete orientation encoded in a PDF image CTM.
+ *
+ * The two CTM basis vectors are normalized independently so non-uniform scale
+ * does not affect orientation. Returns `null` for degenerate, skewed, or
+ * arbitrary-angle matrices; those require general affine resampling rather
+ * than a lossless right-angle pixel permutation.
+ */
+export function detectOrientationFromCurrentTransformationMatrix(
+  currentTransformationMatrix: number[],
+): ImageOrientationTransform | null {
+  const [a, b, c, d] = currentTransformationMatrix;
+  if (![a, b, c, d].every(Number.isFinite)) return null;
+
+  const xLength = Math.hypot(a, b);
+  const yLength = Math.hypot(c, d);
+  if (xLength === 0 || yLength === 0) return null;
+
+  const m00 = snapAxisComponent(a / xLength);
+  const m01 = snapAxisComponent(c / yLength);
+  const m10 = snapAxisComponent(b / xLength);
+  const m11 = snapAxisComponent(d / yLength);
+  if (m00 === null || m01 === null || m10 === null || m11 === null) return null;
+
+  const matrix: OrientationMatrix = [m00, m01, m10, m11];
+  return MATRIX_TO_ORIENTATION.get(matrix.join(",")) ?? null;
+}
+
+interface OrientedPixels {
+  data: Buffer;
+  width: number;
+  height: number;
+}
+
+function orientRgbaPixels(
+  data: Uint8Array,
+  width: number,
+  height: number,
+  orientation: ImageOrientationTransform,
+): OrientedPixels {
+  const [m00, m01, m10, m11] = ORIENTATION_MATRICES[orientation];
+  const swapsAxes = m00 === 0;
+  const outputWidth = swapsAxes ? height : width;
+  const outputHeight = swapsAxes ? width : height;
+  const oriented = Buffer.alloc(outputWidth * outputHeight * 4);
+
+  // Negative matrix terms produce negative raw coordinates. Translate the
+  // transformed pixel lattice back to a zero-based output rectangle.
+  const offsetX = (m00 < 0 ? width - 1 : 0) + (m01 < 0 ? height - 1 : 0);
+  const offsetY = (m10 < 0 ? width - 1 : 0) + (m11 < 0 ? height - 1 : 0);
+
+  for (let sourceY = 0; sourceY < height; sourceY++) {
+    for (let sourceX = 0; sourceX < width; sourceX++) {
+      const outputX = m00 * sourceX + m01 * sourceY + offsetX;
+      const outputY = m10 * sourceX + m11 * sourceY + offsetY;
+      const sourceIndex = (sourceY * width + sourceX) * 4;
+      const outputIndex = (outputY * outputWidth + outputX) * 4;
+      oriented.set(data.subarray(sourceIndex, sourceIndex + 4), outputIndex);
+    }
+  }
+
+  return { data: oriented, width: outputWidth, height: outputHeight };
+}
+
+function orientImageBuffer(
+  buffer: Buffer,
+  format: ImageFormat,
+  orientation: ImageOrientationTransform,
+): { buffer: Buffer; width: number; height: number } {
+  if (format === "jpeg") {
+    const decoded = jpeg.decode(buffer, { useTArray: true });
+    const oriented = orientRgbaPixels(
+      decoded.data,
+      decoded.width,
+      decoded.height,
+      orientation,
+    );
+    const encoded = jpeg.encode(
+      { data: oriented.data, width: oriented.width, height: oriented.height },
+      90,
+    );
+    return {
+      buffer: Buffer.from(encoded.data),
+      width: oriented.width,
+      height: oriented.height,
+    };
+  }
+
+  const decoded = decodePng(buffer);
+  const oriented = orientRgbaPixels(
+    decoded.data,
+    decoded.width,
+    decoded.height,
+    orientation,
+  );
+  const png = new PNG({ width: oriented.width, height: oriented.height });
+  png.data = oriented.data;
   return {
-    flipHorizontal: a < 0, // Negative X scale
-    flipVertical: d < 0,   // Negative Y scale
+    buffer: PNG.sync.write(png),
+    width: oriented.width,
+    height: oriented.height,
   };
 }
 
-/**
- * Flip an image buffer along one or both axes in a single decode/encode pass.
- * Handles both JPEG and PNG formats.
- *
- * Decoding once and applying both axes together (rather than chaining two
- * single-axis flips) matters most for JPEG: each decode+encode round-trip is
- * lossy (generational loss) and CPU-costly, so a 180° placement — both flags
- * set, the common case for upside-down scans — must not pay that cost twice.
- */
-function flipImageBuffer(
-  buffer: Buffer,
-  format: string,
-  { flipHorizontal, flipVertical }: ImageFlipTransform
-): Buffer {
-  if (!flipHorizontal && !flipVertical) return buffer;
+/** Thin compatibility helpers used by focused pixel tests. */
+export function flipImageBufferHorizontal(buffer: Buffer, format: ImageFormat): Buffer {
+  return orientImageBuffer(buffer, format, "flip-horizontal").buffer;
+}
 
-  if (format === "jpeg") {
-    const decoded = jpeg.decode(buffer, { useTArray: true });
-    const { width, height } = decoded;
-    const flipped = Buffer.alloc(decoded.data.length);
-
-    for (let y = 0; y < height; y++) {
-      const srcY = flipVertical ? height - 1 - y : y;
-      for (let x = 0; x < width; x++) {
-        const srcX = flipHorizontal ? width - 1 - x : x;
-        const srcIdx = (srcY * width + srcX) * 4;
-        const dstIdx = (y * width + x) * 4;
-        flipped[dstIdx] = decoded.data[srcIdx];
-        flipped[dstIdx + 1] = decoded.data[srcIdx + 1];
-        flipped[dstIdx + 2] = decoded.data[srcIdx + 2];
-        flipped[dstIdx + 3] = decoded.data[srcIdx + 3];
-      }
-    }
-
-    const encoded = jpeg.encode(
-      { data: flipped, width, height },
-      90 // Maintain quality
-    );
-    return Buffer.from(encoded.data);
-  }
-
-  if (format === "png") {
-    const { data, width, height } = decodePng(buffer);
-    const flipped = Buffer.alloc(data.length);
-
-    for (let y = 0; y < height; y++) {
-      const srcY = flipVertical ? height - 1 - y : y;
-      for (let x = 0; x < width; x++) {
-        const srcX = flipHorizontal ? width - 1 - x : x;
-        const srcIdx = (srcY * width + srcX) * 4;
-        const dstIdx = (y * width + x) * 4;
-        flipped[dstIdx] = data[srcIdx];
-        flipped[dstIdx + 1] = data[srcIdx + 1];
-        flipped[dstIdx + 2] = data[srcIdx + 2];
-        flipped[dstIdx + 3] = data[srcIdx + 3];
-      }
-    }
-
-    const png = new PNG({ width, height });
-    png.data = flipped;
-    return PNG.sync.write(png);
-  }
-
-  return buffer; // Unknown format
+export function flipImageBufferVertical(buffer: Buffer, format: ImageFormat): Buffer {
+  return orientImageBuffer(buffer, format, "flip-vertical").buffer;
 }
 
 /**
- * Flip image buffer horizontally (left-right mirror).
+ * Bake pre-stamped CTM orientations into extracted raster images in-place.
+ * Quarter turns also update the stored native dimensions.
  *
- * JPEG tradeoff: this path decodes to RGBA, flips pixels, then re-encodes at
- * quality 90. That is lossy for already-compressed JPEGs (generational loss),
- * even though geometric flip can be represented losslessly in JPEG.
- * Chosen intentionally for now to keep a pure JS/TS dependency-light path.
+ * JPEG transforms remain lossy because jpeg-js decodes to RGBA and re-encodes
+ * at quality 90. A single transform always uses exactly one decode/encode pass.
  */
-export function flipImageBufferHorizontal(buffer: Buffer, format: string): Buffer {
-  return flipImageBuffer(buffer, format, { flipHorizontal: true, flipVertical: false });
-}
-
-/**
- * Flip image buffer vertically (top-bottom mirror).
- *
- * JPEG tradeoff: this path decodes to RGBA, flips pixels, then re-encodes at
- * quality 90. That is lossy for already-compressed JPEGs (generational loss).
- */
-export function flipImageBufferVertical(buffer: Buffer, format: string): Buffer {
-  return flipImageBuffer(buffer, format, { flipHorizontal: false, flipVertical: true });
-}
-
-/**
- * Apply CTM-based flip transforms to raster images.
- * Updates image buffers and hashes in-place.
- *
- * Flip direction is pre-stamped per image by `stampRasterPlacementsFromOps`
- * during the consuming op->image match pass.
- */
-export function applyFlipsToRasterImages(
-  images: ExtractedImage[]
+export function applyOrientationTransformsToRasterImages(
+  images: ExtractedImage[],
 ): void {
-  if (images.length === 0) return;
-
   for (const image of images) {
-    const { flipHorizontal, flipVertical } = image.flipTransform ?? {
-      flipHorizontal: false,
-      flipVertical: false,
-    };
-    if (!flipHorizontal && !flipVertical) continue;
+    const orientation = image.orientationTransform;
+    if (!orientation || orientation === "identity") {
+      image.orientationTransform = undefined;
+      continue;
+    }
 
     try {
-      // Single decode/encode pass for both axes — avoids double generational
-      // loss + double CPU cost on 180° placements (both flags set).
-      const flippedBuf = flipImageBuffer(image.buffer, image.format, { flipHorizontal, flipVertical });
-
-      // Update the image with the flipped buffer and recalculate hash
-      image.buffer = flippedBuf;
-      image.hash = hashBuffer(flippedBuf);
-      // Clear the transform so a second call over the same array (not done
-      // today, but not guaranteed by any caller) is a no-op instead of
-      // silently double-flipping (H+H reverts to original; any other
-      // combination corrupts the image).
-      image.flipTransform = undefined;
+      const oriented = orientImageBuffer(image.buffer, image.format, orientation);
+      image.buffer = oriented.buffer;
+      image.width = oriented.width;
+      image.height = oriented.height;
+      image.hash = hashBuffer(oriented.buffer);
     } catch (err) {
-      // Leave the image unflipped rather than failing the whole page/book.
-      // jpeg-js is stricter than mupdf (no arithmetic coding, 12-bit, or
-      // truncated streams, plus its own maxMemoryUsageInMB guard) and, via
-      // the canRawExtract fast path, is the first thing to ever decode these
-      // raw DCTDecode bytes.
+      // Preserve the previous availability behavior: one unusual JPEG must not
+      // abort the whole page/book. The warning makes the degraded orientation
+      // discoverable in server logs.
       console.warn(
-        `[pdf] flip failed for ${image.imageId}, keeping original orientation:`,
-        err instanceof Error ? err.message : err
+        `[pdf] orientation transform failed for ${image.imageId}, keeping original pixels:`,
+        err instanceof Error ? err.message : err,
       );
+    } finally {
+      // Prevent an accidental second call from applying the transform twice.
+      image.orientationTransform = undefined;
     }
   }
 }

--- a/packages/storage/src/__tests__/book-storage.test.ts
+++ b/packages/storage/src/__tests__/book-storage.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, afterEach, vi } from "vitest"
+import { createHash } from "node:crypto"
 import fs from "node:fs"
 import os from "node:os"
 import path from "node:path"
@@ -315,10 +316,14 @@ describe("createBookStorage", () => {
 
     const db = openBookDb(paths.dbPath)
     const rows = db.all(
-      "SELECT width, height FROM images WHERE image_id = ?",
+      "SELECT hash, width, height FROM images WHERE image_id = ?",
       ["pg001_im001_tr_es"]
-    ) as Array<{ width: number; height: number }>
-    expect(rows).toEqual([{ width: 200, height: 150 }])
+    ) as Array<{ hash: string; width: number; height: number }>
+    const expectedHash = createHash("sha256")
+      .update(Buffer.from("second"))
+      .digest("hex")
+      .slice(0, 16)
+    expect(rows).toEqual([{ hash: expectedHash, width: 200, height: 150 }])
     db.close()
     storage.close()
   })

--- a/packages/storage/src/book-storage.ts
+++ b/packages/storage/src/book-storage.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto"
 import fs from "node:fs"
 import path from "node:path"
 import type sqlite from "node-sqlite3-wasm"
@@ -201,7 +202,7 @@ export function createBookStorage(label: string, booksRoot: string): Storage {
           cropId,
           input.pageId,
           `images/${filename}`,
-          "",
+          hashBuffer(input.buffer),
           input.width,
           input.height,
           "crop",
@@ -235,7 +236,7 @@ export function createBookStorage(label: string, booksRoot: string): Storage {
           segId,
           input.pageId,
           `images/${filename}`,
-          "",
+          hashBuffer(input.buffer),
           input.width,
           input.height,
           "segment",
@@ -268,7 +269,7 @@ export function createBookStorage(label: string, booksRoot: string): Storage {
           newImageId,
           input.pageId,
           `images/${filename}`,
-          "",
+          hashBuffer(input.buffer),
           input.width,
           input.height,
           "translate",
@@ -622,6 +623,10 @@ function writeImage(
       image.bounds?.height ?? null,
     ]
   )
+}
+
+function hashBuffer(buffer: Buffer): string {
+  return createHash("sha256").update(buffer).digest("hex").slice(0, 16)
 }
 
 function ensureWithinRoot(target: string, root: string): void {


### PR DESCRIPTION
Fixes raster extraction when PDF image placement uses quarter-turn or reflected CTMs by baking all eight right-angle orientations into output pixels and updating dimensions and hashes.

It also makes operation-to-raster matching digest-safe across vector filtering and adds ETag revalidation so re-extraction cannot display stale image assets.

Regression coverage includes orientation units, raster placement matching, synthetic-PDF end-to-end extraction, and API cache behavior.

Validation passed for 175 PDF tests, 104 focused tests, build, and typecheck.