### PR TITLE
feat(storyboard): add position & transform controls to element style editor

### DIFF
--- a/apps/studio/src/components/pipeline/stages/storyboard/components/style-editor/class-maps/index.ts
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/style-editor/class-maps/index.ts
@@ -36,3 +36,11 @@ export {
   shadowClassMap,
 } from "./appearance"
 export { objectFitClassMap, objectPositionClassMap } from "./image-fit"
+export {
+  positionClassMap,
+  insetClassMap,
+  rotateClassMap,
+  translateXClassMap,
+  translateYClassMap,
+  scaleClassMap,
+} from "./position"

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/style-editor/class-maps/position.test.ts
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/style-editor/class-maps/position.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest"
+import {
+  positionClassMap,
+  insetClassMap,
+  rotateClassMap,
+  translateXClassMap,
+  translateYClassMap,
+  scaleClassMap,
+} from "./position"
+
+describe("positionClassMap", () => {
+  it("reads the CSS position keyword", () => {
+    expect(positionClassMap.fromClasses(["p-4", "absolute"])).toBe("absolute")
+    expect(positionClassMap.fromClasses(["flex"])).toBeNull()
+  })
+
+  it("emits nothing for the default static", () => {
+    expect(positionClassMap.toClasses("static")).toEqual([])
+    expect(positionClassMap.toClasses("relative")).toEqual(["relative"])
+  })
+})
+
+describe("insetClassMap", () => {
+  it("reads per-side, axis and all-sides forms including negatives", () => {
+    expect(insetClassMap.fromClasses(["top-4"])).toEqual({ t: 16, r: 0, b: 0, l: 0 })
+    expect(insetClassMap.fromClasses(["-left-2"])).toEqual({ t: 0, r: 0, b: 0, l: -8 })
+    expect(insetClassMap.fromClasses(["inset-x-4"])).toEqual({ t: 0, r: 16, b: 0, l: 16 })
+    expect(insetClassMap.fromClasses(["inset-2"])).toEqual({ t: 8, r: 8, b: 8, l: 8 })
+    expect(insetClassMap.fromClasses(["top-[13px]"])).toEqual({ t: 13, r: 0, b: 0, l: 0 })
+  })
+
+  it("writes the most compact form", () => {
+    expect(insetClassMap.toClasses({ t: 0, r: 0, b: 0, l: 0 })).toEqual([])
+    expect(insetClassMap.toClasses({ t: 8, r: 8, b: 8, l: 8 })).toEqual(["inset-2"])
+    expect(insetClassMap.toClasses({ t: 16, r: 8, b: 16, l: 8 })).toEqual([
+      "inset-x-2",
+      "inset-y-4",
+    ])
+    expect(insetClassMap.toClasses({ t: 16, r: 0, b: 0, l: -8 })).toEqual([
+      "top-4",
+      "-left-2",
+    ])
+    expect(insetClassMap.toClasses({ t: 13, r: 0, b: 0, l: 0 })).toEqual(["top-[13px]"])
+  })
+
+  it("round-trips arbitrary and off-scale values", () => {
+    const value = { t: 5, r: -13, b: 0, l: 0 }
+    expect(insetClassMap.fromClasses(insetClassMap.toClasses(value))).toEqual(value)
+  })
+})
+
+describe("rotateClassMap", () => {
+  it("reads and normalizes rotation to 0..359", () => {
+    expect(rotateClassMap.fromClasses(["rotate-90"])).toBe(90)
+    expect(rotateClassMap.fromClasses(["-rotate-90"])).toBe(270)
+    expect(rotateClassMap.fromClasses(["rotate-[270deg]"])).toBe(270)
+    expect(rotateClassMap.fromClasses(["flex"])).toBeNull()
+  })
+
+  it("emits readable classes for the quarter turns", () => {
+    expect(rotateClassMap.toClasses(0)).toEqual([])
+    expect(rotateClassMap.toClasses(90)).toEqual(["rotate-90"])
+    expect(rotateClassMap.toClasses(180)).toEqual(["rotate-180"])
+    expect(rotateClassMap.toClasses(270)).toEqual(["-rotate-90"])
+    // wraps past a full turn
+    expect(rotateClassMap.toClasses(360)).toEqual([])
+    expect(rotateClassMap.toClasses(-90)).toEqual(["-rotate-90"])
+  })
+
+  it("does not match 3D rotate utilities", () => {
+    expect(rotateClassMap.matches("rotate-x-45")).toBe(false)
+    expect(rotateClassMap.matches("rotate-90")).toBe(true)
+  })
+})
+
+describe("translate maps", () => {
+  it("read and write signed offsets", () => {
+    expect(translateXClassMap.fromClasses(["translate-x-4"])).toBe(16)
+    expect(translateXClassMap.fromClasses(["-translate-x-2"])).toBe(-8)
+    expect(translateXClassMap.toClasses(0)).toEqual([])
+    expect(translateXClassMap.toClasses(16)).toEqual(["translate-x-4"])
+    expect(translateXClassMap.toClasses(-8)).toEqual(["-translate-x-2"])
+    expect(translateYClassMap.toClasses(13)).toEqual(["translate-y-[13px]"])
+  })
+
+  it("ignores the other axis", () => {
+    expect(translateXClassMap.fromClasses(["translate-y-4"])).toBeNull()
+  })
+})
+
+describe("scaleClassMap", () => {
+  it("reads token and arbitrary scales as percentages", () => {
+    expect(scaleClassMap.fromClasses(["scale-110"])).toBe(110)
+    expect(scaleClassMap.fromClasses(["scale-[1.7]"])).toBe(170)
+    expect(scaleClassMap.fromClasses(["scale-x-50"])).toBeNull()
+  })
+
+  it("emits nothing for 100% and tokens where available", () => {
+    expect(scaleClassMap.toClasses(100)).toEqual([])
+    expect(scaleClassMap.toClasses(110)).toEqual(["scale-110"])
+    expect(scaleClassMap.toClasses(170)).toEqual(["scale-[1.7]"])
+  })
+})

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/style-editor/class-maps/position.test.ts
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/style-editor/class-maps/position.test.ts
@@ -47,6 +47,29 @@ describe("insetClassMap", () => {
     const value = { t: 5, r: -13, b: 0, l: 0 }
     expect(insetClassMap.fromClasses(insetClassMap.toClasses(value))).toEqual(value)
   })
+
+  it("only matches px-representable insets, leaving other utilities untouched", () => {
+    // Tailwind v4 ring/shadow utilities that share the `inset-` prefix
+    expect(insetClassMap.matches("inset-ring-2")).toBe(false)
+    expect(insetClassMap.matches("inset-shadow-sm")).toBe(false)
+    expect(insetClassMap.matches("-inset-ring-2")).toBe(false)
+    // fraction / keyword insets the px control can't represent (centering idiom)
+    expect(insetClassMap.matches("top-1/2")).toBe(false)
+    expect(insetClassMap.matches("left-1/2")).toBe(false)
+    expect(insetClassMap.matches("inset-auto")).toBe(false)
+    expect(insetClassMap.matches("top-full")).toBe(false)
+    // px-representable insets are matched
+    expect(insetClassMap.matches("inset-4")).toBe(true)
+    expect(insetClassMap.matches("top-[13px]")).toBe(true)
+    expect(insetClassMap.matches("-left-2")).toBe(true)
+    // an unrepresentable utility alongside a px offset must survive untouched
+    expect(insetClassMap.fromClasses(["inset-ring-2", "top-1/2", "top-4"])).toEqual({
+      t: 16,
+      r: 0,
+      b: 0,
+      l: 0,
+    })
+  })
 })
 
 describe("rotateClassMap", () => {
@@ -85,6 +108,14 @@ describe("translate maps", () => {
 
   it("ignores the other axis", () => {
     expect(translateXClassMap.fromClasses(["translate-y-4"])).toBeNull()
+  })
+
+  it("leaves fraction / keyword translates untouched", () => {
+    expect(translateXClassMap.matches("-translate-x-1/2")).toBe(false)
+    expect(translateXClassMap.matches("translate-x-full")).toBe(false)
+    expect(translateYClassMap.matches("-translate-y-1/2")).toBe(false)
+    expect(translateXClassMap.matches("translate-x-4")).toBe(true)
+    expect(translateXClassMap.matches("-translate-x-[13px]")).toBe(true)
   })
 })
 

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/style-editor/class-maps/position.ts
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/style-editor/class-maps/position.ts
@@ -1,0 +1,243 @@
+/* eslint-disable lingui/no-unlocalized-strings -- Tailwind class identifiers, not user copy */
+
+import type { BoxValue } from "../controls/BoxInput"
+import type { ClassMap } from "./types"
+
+// Tailwind v3.4 / v4 default spacing scale, px ↔ token. Shared by the inset
+// (top/right/bottom/left) and translate maps. Off-scale values fall back to
+// arbitrary classes (`top-[13px]`). The sign is always carried by a `-`
+// prefix on the utility (`-top-4`), so these helpers only deal in magnitudes.
+const SPACING_TOKENS: ReadonlyArray<readonly [number, string]> = [
+  [0, "0"], [2, "0.5"], [4, "1"], [6, "1.5"], [8, "2"], [10, "2.5"],
+  [12, "3"], [14, "3.5"], [16, "4"], [20, "5"], [24, "6"], [28, "7"],
+  [32, "8"], [36, "9"], [40, "10"], [44, "11"], [48, "12"], [56, "14"],
+  [64, "16"], [80, "20"], [96, "24"], [112, "28"], [128, "32"], [144, "36"],
+  [160, "40"], [176, "44"], [192, "48"], [208, "52"], [224, "56"], [240, "60"],
+  [256, "64"], [288, "72"], [320, "80"], [384, "96"],
+]
+const PX_TO_TOKEN = new Map<number, string>(SPACING_TOKENS)
+const TOKEN_TO_PX = new Map<string, number>(
+  SPACING_TOKENS.map(([px, token]) => [token, px])
+)
+
+/** Positive magnitude px → Tailwind spacing token (or arbitrary `[Npx]`). */
+function pxToToken(px: number): string {
+  const exact = PX_TO_TOKEN.get(px)
+  if (exact !== undefined) return exact
+  return `[${px}px]`
+}
+
+/** Tailwind spacing token → px. Handles the scale plus arbitrary `[Npx]`/
+ *  `[Nrem]` (which may carry their own sign). Returns null for anything else
+ *  (fractions like `1/2`, `full`, `auto`), which the numeric controls skip. */
+function tokenToPx(token: string): number | null {
+  const fromTable = TOKEN_TO_PX.get(token)
+  if (fromTable !== undefined) return fromTable
+  const arbitrary = token.match(/^\[(-?[\d.]+)(px|rem)\]$/)
+  if (!arbitrary) return null
+  const n = Number(arbitrary[1])
+  if (!Number.isFinite(n)) return null
+  return arbitrary[2] === "rem" ? n * 16 : n
+}
+
+// ---------------------------------------------------------------------------
+// position — the CSS `position` property (static/relative/absolute/fixed/sticky)
+// ---------------------------------------------------------------------------
+
+const POSITION_VALUES = ["static", "relative", "absolute", "fixed", "sticky"]
+
+export const positionClassMap: ClassMap<string> = {
+  matches: (cls) => POSITION_VALUES.includes(cls),
+  fromClasses(classes) {
+    let last: string | null = null
+    for (const cls of classes) {
+      if (POSITION_VALUES.includes(cls)) last = cls
+    }
+    return last
+  },
+  // `static` is the CSS default, so emit nothing for it (removes any class).
+  toClasses(value) {
+    return value && value !== "static" ? [value] : []
+  },
+}
+
+// ---------------------------------------------------------------------------
+// inset — top/right/bottom/left offsets, in px, negatives allowed. Reads the
+// full cascade (`inset-*`, `inset-x-*`, `inset-y-*`, and per-side) and writes
+// the most compact form.
+// ---------------------------------------------------------------------------
+
+const INSET_RE = /^(-?)(inset-x|inset-y|inset|top|right|bottom|left)-(.+)$/
+
+function insetClass(name: string, px: number): string {
+  const sign = px < 0 ? "-" : ""
+  return `${sign}${name}-${pxToToken(Math.abs(px))}`
+}
+
+export const insetClassMap: ClassMap<BoxValue> = {
+  matches: (cls) => INSET_RE.test(cls),
+
+  fromClasses(classes) {
+    let result: BoxValue | null = null
+    for (const cls of classes) {
+      const m = cls.match(INSET_RE)
+      if (!m) continue
+      const [, sign, side, token] = m
+      const magnitude = tokenToPx(token)
+      if (magnitude === null) continue
+      const px = sign === "-" ? -magnitude : magnitude
+      if (!result) result = { t: 0, r: 0, b: 0, l: 0 }
+      switch (side) {
+        case "inset":
+          result.t = px
+          result.r = px
+          result.b = px
+          result.l = px
+          break
+        case "inset-x":
+          result.l = px
+          result.r = px
+          break
+        case "inset-y":
+          result.t = px
+          result.b = px
+          break
+        case "top":
+          result.t = px
+          break
+        case "right":
+          result.r = px
+          break
+        case "bottom":
+          result.b = px
+          break
+        case "left":
+          result.l = px
+          break
+      }
+    }
+    return result
+  },
+
+  toClasses(value) {
+    const { t, r, b, l } = value
+    if (t === 0 && r === 0 && b === 0 && l === 0) return []
+    if (t === r && r === b && b === l) return [insetClass("inset", t)]
+    if (t === b && l === r) {
+      const parts: string[] = []
+      if (l !== 0 || r !== 0) parts.push(insetClass("inset-x", l))
+      if (t !== 0 || b !== 0) parts.push(insetClass("inset-y", t))
+      return parts
+    }
+    const parts: string[] = []
+    if (t !== 0) parts.push(insetClass("top", t))
+    if (r !== 0) parts.push(insetClass("right", r))
+    if (b !== 0) parts.push(insetClass("bottom", b))
+    if (l !== 0) parts.push(insetClass("left", l))
+    return parts
+  },
+}
+
+// ---------------------------------------------------------------------------
+// rotate — degrees, normalized to 0..359. Multiples of 90 use the readable
+// Tailwind classes (`rotate-90`, `rotate-180`, `-rotate-90`); anything else
+// falls back to an arbitrary `rotate-[Ndeg]`.
+// ---------------------------------------------------------------------------
+
+const ROTATE_RE = /^(-?)rotate-(\[[^\]]+\]|\d+(?:\.\d+)?)$/
+
+function normalizeDeg(deg: number): number {
+  return ((Math.round(deg) % 360) + 360) % 360
+}
+
+export const rotateClassMap: ClassMap<number> = {
+  matches: (cls) => ROTATE_RE.test(cls),
+  fromClasses(classes) {
+    let last: number | null = null
+    for (const cls of classes) {
+      const m = cls.match(ROTATE_RE)
+      if (!m) continue
+      const [, sign, token] = m
+      let n: number | null = null
+      const arbitrary = token.match(/^\[(-?[\d.]+)deg\]$/)
+      if (arbitrary) n = Number(arbitrary[1])
+      else if (/^\d+(?:\.\d+)?$/.test(token)) n = Number(token)
+      if (n === null || !Number.isFinite(n)) continue
+      last = normalizeDeg(sign === "-" ? -n : n)
+    }
+    return last
+  },
+  toClasses(value) {
+    const d = normalizeDeg(value)
+    if (d === 0) return []
+    if (d === 90) return ["rotate-90"]
+    if (d === 180) return ["rotate-180"]
+    if (d === 270) return ["-rotate-90"]
+    return [`rotate-[${d}deg]`]
+  },
+}
+
+// ---------------------------------------------------------------------------
+// translate — X/Y transform offsets in px, negatives allowed. Compose with
+// rotate/scale because every Tailwind transform utility emits the full
+// `transform` chain.
+// ---------------------------------------------------------------------------
+
+function makeTranslateClassMap(axis: "x" | "y"): ClassMap<number> {
+  const re = new RegExp(`^(-?)translate-${axis}-(.+)$`)
+  return {
+    matches: (cls) => re.test(cls),
+    fromClasses(classes) {
+      let last: number | null = null
+      for (const cls of classes) {
+        const m = cls.match(re)
+        if (!m) continue
+        const magnitude = tokenToPx(m[2])
+        if (magnitude === null) continue
+        last = m[1] === "-" ? -magnitude : magnitude
+      }
+      return last
+    },
+    toClasses(value) {
+      if (value === 0) return []
+      const sign = value < 0 ? "-" : ""
+      return [`${sign}translate-${axis}-${pxToToken(Math.abs(value))}`]
+    },
+  }
+}
+
+export const translateXClassMap = makeTranslateClassMap("x")
+export const translateYClassMap = makeTranslateClassMap("y")
+
+// ---------------------------------------------------------------------------
+// scale — uniform scale as a percentage (100 = no scaling). Known Tailwind
+// steps use their token (`scale-110`); others fall back to `scale-[1.7]`.
+// ---------------------------------------------------------------------------
+
+const SCALE_TOKENS = new Set([0, 50, 75, 90, 95, 100, 105, 110, 125, 150])
+const SCALE_RE = /^scale-(\[[^\]]+\]|\d+)$/
+
+export const scaleClassMap: ClassMap<number> = {
+  matches: (cls) => SCALE_RE.test(cls),
+  fromClasses(classes) {
+    let last: number | null = null
+    for (const cls of classes) {
+      const m = cls.match(SCALE_RE)
+      if (!m) continue
+      const token = m[1]
+      const arbitrary = token.match(/^\[([\d.]+)\]$/)
+      if (arbitrary) {
+        const n = Number(arbitrary[1])
+        if (Number.isFinite(n)) last = Math.round(n * 100)
+      } else if (/^\d+$/.test(token)) {
+        last = Number(token)
+      }
+    }
+    return last
+  },
+  toClasses(value) {
+    if (value === 100) return []
+    if (SCALE_TOKENS.has(value)) return [`scale-${value}`]
+    return [`scale-[${value / 100}]`]
+  },
+}

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/style-editor/class-maps/position.ts
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/style-editor/class-maps/position.ts
@@ -69,13 +69,24 @@ export const positionClassMap: ClassMap<string> = {
 
 const INSET_RE = /^(-?)(inset-x|inset-y|inset|top|right|bottom|left)-(.+)$/
 
+// Only match inset utilities this px control can actually represent (spacing
+// tokens and arbitrary px/rem). Utilities we can't model — Tailwind v4's
+// `inset-ring-*`/`inset-shadow-*`, and fraction/keyword insets like `top-1/2`
+// or `left-auto` used by the centered-absolute idiom — are left untouched so
+// editing a px offset never silently strips them.
+function insetToken(cls: string): string | null {
+  const m = cls.match(INSET_RE)
+  if (!m || tokenToPx(m[3]) === null) return null
+  return m[3]
+}
+
 function insetClass(name: string, px: number): string {
   const sign = px < 0 ? "-" : ""
   return `${sign}${name}-${pxToToken(Math.abs(px))}`
 }
 
 export const insetClassMap: ClassMap<BoxValue> = {
-  matches: (cls) => INSET_RE.test(cls),
+  matches: (cls) => insetToken(cls) !== null,
 
   fromClasses(classes) {
     let result: BoxValue | null = null
@@ -186,7 +197,12 @@ export const rotateClassMap: ClassMap<number> = {
 function makeTranslateClassMap(axis: "x" | "y"): ClassMap<number> {
   const re = new RegExp(`^(-?)translate-${axis}-(.+)$`)
   return {
-    matches: (cls) => re.test(cls),
+    // Only match px-representable translates; leave `translate-x-full`,
+    // `translate-x-1/2` (centering idiom), etc. untouched on edit.
+    matches: (cls) => {
+      const m = cls.match(re)
+      return m !== null && tokenToPx(m[2]) !== null
+    },
     fromClasses(classes) {
       let last: number | null = null
       for (const cls of classes) {

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/style-editor/element-types.ts
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/style-editor/element-types.ts
@@ -47,12 +47,14 @@ export type SectionKey =
   | "spacing"
   | "sizing"
   | "layout"
+  | "position"
   | "borders"
   | "imageFit"
 
 export const ALL_SECTION_KEYS: ReadonlyArray<SectionKey> = [
   "layout",
   "sizing",
+  "position",
   "spacing",
   "typography",
   "appearance",
@@ -60,9 +62,18 @@ export const ALL_SECTION_KEYS: ReadonlyArray<SectionKey> = [
   "imageFit",
 ]
 
+// `position` (offset + rotate + transform) applies to every element type —
+// text, images and containers alike — so it's included in each set.
 const VISIBLE_SECTIONS: Record<ElementType, ReadonlySet<SectionKey>> = {
-  text: new Set(["typography", "appearance", "spacing", "sizing"]),
-  image: new Set(["imageFit", "sizing", "spacing", "borders", "appearance"]),
+  text: new Set(["typography", "appearance", "spacing", "sizing", "position"]),
+  image: new Set([
+    "imageFit",
+    "sizing",
+    "spacing",
+    "borders",
+    "appearance",
+    "position",
+  ]),
   container: new Set([
     "layout",
     "spacing",
@@ -70,6 +81,7 @@ const VISIBLE_SECTIONS: Record<ElementType, ReadonlySet<SectionKey>> = {
     "appearance",
     "borders",
     "typography",
+    "position",
   ]),
   interactive: new Set([
     "typography",
@@ -78,9 +90,24 @@ const VISIBLE_SECTIONS: Record<ElementType, ReadonlySet<SectionKey>> = {
     "sizing",
     "layout",
     "borders",
+    "position",
   ]),
-  list: new Set(["typography", "spacing", "layout", "sizing", "appearance"]),
-  media: new Set(["imageFit", "sizing", "spacing", "borders", "appearance"]),
+  list: new Set([
+    "typography",
+    "spacing",
+    "layout",
+    "sizing",
+    "appearance",
+    "position",
+  ]),
+  media: new Set([
+    "imageFit",
+    "sizing",
+    "spacing",
+    "borders",
+    "appearance",
+    "position",
+  ]),
 }
 
 export function isSectionVisible(

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/style-editor/sections/Position.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/style-editor/sections/Position.tsx
@@ -109,7 +109,10 @@ export function PositionSection() {
       <StyleLabel label={<Trans>Scale</Trans>} override={scale.override}>
         <NumericInput
           value={scale.value}
-          onCommit={scale.setValue}
+          // Clearing the field commits 0; treat 0 (and negatives) as "no
+          // scaling" (100%) rather than `scale-0`, which would make the
+          // element vanish.
+          onCommit={(n) => scale.setValue(n <= 0 ? 100 : n)}
           inputMode="numeric"
           suffix="%"
         />

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/style-editor/sections/Position.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/style-editor/sections/Position.tsx
@@ -1,0 +1,119 @@
+import { RotateCcw, RotateCw } from "lucide-react"
+import { Trans, useLingui } from "@lingui/react/macro"
+import { cn } from "@/lib/utils"
+import { StyleLabel } from "../controls/StyleLabel"
+import { Section } from "../controls/Section"
+import { Select, type SelectOption } from "../controls/Select"
+import { BoxInput, type BoxValue } from "../controls/BoxInput"
+import { NumericInput } from "../controls/NumericInput"
+import {
+  positionClassMap,
+  insetClassMap,
+  rotateClassMap,
+  translateXClassMap,
+  translateYClassMap,
+  scaleClassMap,
+} from "../class-maps"
+import { useElementStyles } from "../use-element-styles"
+
+// CSS position keywords double as their own labels — technical identifiers,
+// not translatable copy (mirrors the display options in the Layout section).
+const POSITION_OPTIONS: ReadonlyArray<SelectOption<string>> = [
+  "static",
+  "relative",
+  "absolute",
+  "fixed",
+  "sticky",
+].map((v) => ({ value: v, label: v }))
+
+// Axis abbreviations for the translate fields — technical identifiers, not copy.
+const AXIS = { x: "X", y: "Y" } as const
+
+const ZERO_BOX: BoxValue = { t: 0, r: 0, b: 0, l: 0 }
+
+const iconButtonClass = cn(
+  "inline-flex h-8 shrink-0 items-center justify-center gap-1.5 rounded-md bg-muted/60 px-2.5 text-muted-foreground outline-none",
+  "hover:bg-muted hover:text-foreground transition-colors cursor-pointer",
+  "focus-visible:bg-background focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-violet-500"
+)
+
+export function PositionSection() {
+  const { t } = useLingui()
+  const position = useElementStyles(positionClassMap, "static")
+  const inset = useElementStyles(insetClassMap, ZERO_BOX)
+  const rotate = useElementStyles(rotateClassMap, 0)
+  const translateX = useElementStyles(translateXClassMap, 0)
+  const translateY = useElementStyles(translateYClassMap, 0)
+  const scale = useElementStyles(scaleClassMap, 100)
+
+  return (
+    <Section title={<Trans>Position</Trans>}>
+      <StyleLabel label={<Trans>Position</Trans>} override={position.override}>
+        <Select
+          value={position.value}
+          onChange={position.setValue}
+          options={POSITION_OPTIONS}
+        />
+      </StyleLabel>
+
+      <StyleLabel label={<Trans>Offset</Trans>} override={inset.override}>
+        <BoxInput value={inset.value} onChange={inset.setValue} />
+      </StyleLabel>
+
+      <StyleLabel label={<Trans>Rotate</Trans>} override={rotate.override}>
+        <div className="flex w-full items-center gap-1.5">
+          <button
+            type="button"
+            title={t`Rotate 90° counter-clockwise`}
+            aria-label={t`Rotate 90° counter-clockwise`}
+            onClick={() => rotate.setValue(rotate.value - 90)}
+            className={iconButtonClass}
+          >
+            <RotateCcw className="h-3.5 w-3.5" />
+          </button>
+          <button
+            type="button"
+            title={t`Rotate 90° clockwise`}
+            aria-label={t`Rotate 90° clockwise`}
+            onClick={() => rotate.setValue(rotate.value + 90)}
+            className={cn(iconButtonClass, "flex-1")}
+          >
+            <RotateCw className="h-3.5 w-3.5" />
+            <span className="tabular-nums text-[12px] text-foreground">
+              {rotate.value}&deg;
+            </span>
+          </button>
+        </div>
+      </StyleLabel>
+
+      <StyleLabel
+        label={<Trans context="CSS transform">Translate</Trans>}
+        override={translateX.override ?? translateY.override}
+      >
+        <div className="grid w-full grid-cols-2 gap-1.5">
+          <NumericInput
+            value={translateX.value}
+            onCommit={translateX.setValue}
+            inputMode="numeric"
+            suffix={AXIS.x}
+          />
+          <NumericInput
+            value={translateY.value}
+            onCommit={translateY.setValue}
+            inputMode="numeric"
+            suffix={AXIS.y}
+          />
+        </div>
+      </StyleLabel>
+
+      <StyleLabel label={<Trans>Scale</Trans>} override={scale.override}>
+        <NumericInput
+          value={scale.value}
+          onCommit={scale.setValue}
+          inputMode="numeric"
+          suffix="%"
+        />
+      </StyleLabel>
+    </Section>
+  )
+}

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/style-editor/sections/index.ts
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/style-editor/sections/index.ts
@@ -5,6 +5,7 @@ import { AppearanceSection } from "./Appearance"
 import { SpacingSection } from "./Spacing"
 import { SizingSection } from "./Sizing"
 import { LayoutSection } from "./Layout"
+import { PositionSection } from "./Position"
 import { BordersSection } from "./Borders"
 import { ImageFitSection } from "./ImageFit"
 
@@ -14,6 +15,7 @@ export const SECTION_COMPONENTS: Record<SectionKey, ComponentType> = {
   spacing: SpacingSection,
   sizing: SizingSection,
   layout: LayoutSection,
+  position: PositionSection,
   borders: BordersSection,
   imageFit: ImageFitSection,
 }
@@ -24,6 +26,7 @@ export {
   SpacingSection,
   SizingSection,
   LayoutSection,
+  PositionSection,
   BordersSection,
   ImageFitSection,
 }

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -5854,6 +5854,9 @@ msgstr "of"
 msgid "Off"
 msgstr "Off"
 
+msgid "Offset"
+msgstr "Offset"
+
 #~ msgid "Older"
 #~ msgstr "Older"
 
@@ -7399,6 +7402,15 @@ msgstr "Rising ocean temperatures cause coral bleaching - when stressed corals e
 msgid "Role"
 msgstr "Role"
 
+msgid "Rotate"
+msgstr "Rotate"
+
+msgid "Rotate 90° clockwise"
+msgstr "Rotate 90° clockwise"
+
+msgid "Rotate 90° counter-clockwise"
+msgstr "Rotate 90° counter-clockwise"
+
 msgid "Row"
 msgstr "Row"
 
@@ -7603,6 +7615,9 @@ msgstr "Saving..."
 
 msgid "Saving…"
 msgstr "Saving…"
+
+msgid "Scale"
+msgstr "Scale"
 
 msgid "Scene 04"
 msgstr "Scene 04"
@@ -9245,6 +9260,10 @@ msgstr "Total Tokens"
 msgid "Track reviewer progress and review findings captured from Preview."
 msgstr "Track reviewer progress and review findings captured from Preview."
 
+msgid "Translate"
+msgstr "Translate"
+
+msgctxt "CSS transform"
 msgid "Translate"
 msgstr "Translate"
 

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -5854,6 +5854,9 @@ msgstr "of"
 msgid "Off"
 msgstr "Apagado"
 
+msgid "Offset"
+msgstr "Desplazamiento"
+
 #~ msgid "Older"
 #~ msgstr "Anterior"
 
@@ -7399,6 +7402,15 @@ msgstr "El aumento de las temperaturas oceánicas causa el blanqueamiento de cor
 msgid "Role"
 msgstr "Rol"
 
+msgid "Rotate"
+msgstr "Rotar"
+
+msgid "Rotate 90° clockwise"
+msgstr "Rotar 90° en sentido horario"
+
+msgid "Rotate 90° counter-clockwise"
+msgstr "Rotar 90° en sentido antihorario"
+
 msgid "Row"
 msgstr "Fila"
 
@@ -7603,6 +7615,9 @@ msgstr "Guardando..."
 
 msgid "Saving…"
 msgstr "Guardando…"
+
+msgid "Scale"
+msgstr "Escala"
 
 msgid "Scene 04"
 msgstr "Escena 04"
@@ -9247,6 +9262,10 @@ msgstr "Track reviewer progress and review findings captured from Preview."
 
 msgid "Translate"
 msgstr "Traducir"
+
+msgctxt "CSS transform"
+msgid "Translate"
+msgstr "Trasladar"
 
 msgid "Translate text in images"
 msgstr "Traducir texto en imágenes"

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -5856,6 +5856,9 @@ msgstr "sur"
 msgid "Off"
 msgstr "Désactivé"
 
+msgid "Offset"
+msgstr "Décalage"
+
 #~ msgid "Older"
 #~ msgstr "Plus ancienne"
 
@@ -7401,6 +7404,15 @@ msgstr "La hausse des températures océaniques provoque le blanchissement des c
 msgid "Role"
 msgstr "Rôle"
 
+msgid "Rotate"
+msgstr "Pivoter"
+
+msgid "Rotate 90° clockwise"
+msgstr "Pivoter de 90° dans le sens horaire"
+
+msgid "Rotate 90° counter-clockwise"
+msgstr "Pivoter de 90° dans le sens antihoraire"
+
 msgid "Row"
 msgstr "Ligne"
 
@@ -7605,6 +7617,9 @@ msgstr "Enregistrement..."
 
 msgid "Saving…"
 msgstr "Enregistrement…"
+
+msgid "Scale"
+msgstr "Échelle"
 
 msgid "Scene 04"
 msgstr "Scène 04"
@@ -9249,6 +9264,10 @@ msgstr "Suivez la progression du réviseur et les résultats de révision captur
 
 msgid "Translate"
 msgstr "Traduire"
+
+msgctxt "CSS transform"
+msgid "Translate"
+msgstr "Translation"
 
 msgid "Translate text in images"
 msgstr "Traduire le texte dans les images"

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -5854,6 +5854,9 @@ msgstr "of"
 msgid "Off"
 msgstr "Desligado"
 
+msgid "Offset"
+msgstr "Deslocamento"
+
 #~ msgid "Older"
 #~ msgstr "Mais antiga"
 
@@ -7399,6 +7402,15 @@ msgstr "O aumento das temperaturas dos oceanos causa o branqueamento dos corais 
 msgid "Role"
 msgstr "Função"
 
+msgid "Rotate"
+msgstr "Girar"
+
+msgid "Rotate 90° clockwise"
+msgstr "Girar 90° no sentido horário"
+
+msgid "Rotate 90° counter-clockwise"
+msgstr "Girar 90° no sentido anti-horário"
+
 msgid "Row"
 msgstr "Linha"
 
@@ -7603,6 +7615,9 @@ msgstr "Salvando..."
 
 msgid "Saving…"
 msgstr "Salvando…"
+
+msgid "Scale"
+msgstr "Escala"
 
 msgid "Scene 04"
 msgstr "Cena 04"
@@ -9247,6 +9262,10 @@ msgstr "Track reviewer progress and review findings captured from Preview."
 
 msgid "Translate"
 msgstr "Traduzir"
+
+msgctxt "CSS transform"
+msgid "Translate"
+msgstr "Transladar"
 
 msgid "Translate text in images"
 msgstr "Traduzir texto em imagens"

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -5855,6 +5855,9 @@ msgstr "nga"
 msgid "Off"
 msgstr "Joaktiv"
 
+msgid "Offset"
+msgstr "Zhvendosje"
+
 #~ msgid "Older"
 #~ msgstr "Më i vjetër"
 
@@ -7400,6 +7403,15 @@ msgstr "Rritja e temperaturave të oqeanit shkakton zbardhjen e koraleve - kur k
 msgid "Role"
 msgstr "Rol"
 
+msgid "Rotate"
+msgstr "Rrotullo"
+
+msgid "Rotate 90° clockwise"
+msgstr "Rrotullo 90° në kahun orar"
+
+msgid "Rotate 90° counter-clockwise"
+msgstr "Rrotullo 90° në kahun kundërorar"
+
 msgid "Row"
 msgstr "Rresht"
 
@@ -7604,6 +7616,9 @@ msgstr "Duke ruajtur..."
 
 msgid "Saving…"
 msgstr "Po ruhet…"
+
+msgid "Scale"
+msgstr "Shkallë"
 
 msgid "Scene 04"
 msgstr "Skena 04"
@@ -9248,6 +9263,10 @@ msgstr "Gjurmo progresin e rishikuesit dhe gjetjet e rishikimit të kaptura nga 
 
 msgid "Translate"
 msgstr "Përkthe"
+
+msgctxt "CSS transform"
+msgid "Translate"
+msgstr "Translim"
 
 msgid "Translate text in images"
 msgstr "Përkthe tekstin në imazhe"


### PR DESCRIPTION
Adds a **Position** section to the storyboard element style editor, visible for every element type (text, images, containers, links, lists, media). It exposes the CSS `position` classes plus top/right/bottom/left offsets to move elements, a rotate button that cycles 90° per press (`rotate-90`/`rotate-180`/`-rotate-90`), and translate/scale transform controls. Everything is built on the existing `ClassMap`/`useElementStyles` pattern, so edits are responsive-breakpoint aware and recompiled into the live preview. New round-trip tests cover the class maps, and all 6 new strings are fully translated for es, fr, pt-BR, and sq (0 missing). Verified with `pnpm typecheck`, `pnpm --filter @adt/studio lint` (0 errors), and the style-editor vitest suite (13 passing).