### PR TITLE
fix(storyboard): preserve heading hierarchy through AI edits

### DIFF
--- a/apps/api/src/routes/debug.test.ts
+++ b/apps/api/src/routes/debug.test.ts
@@ -26,6 +26,7 @@ describe("Debug routes", () => {
             promptName: "classify-text",
             modelId: "gpt-4o",
             cacheHit: false,
+            success: true,
             durationMs: 1200,
             usage: { inputTokens: 500, outputTokens: 200 },
             validationErrors: [],
@@ -38,6 +39,7 @@ describe("Debug routes", () => {
             promptName: "classify-text",
             modelId: "gpt-4o",
             cacheHit: true,
+            success: true,
             durationMs: 50,
             usage: { inputTokens: 500, outputTokens: 200 },
           },
@@ -49,6 +51,7 @@ describe("Debug routes", () => {
             promptName: "section-page",
             modelId: "gpt-4o",
             cacheHit: false,
+            success: false,
             durationMs: 2000,
             usage: { inputTokens: 1000, outputTokens: 500 },
             validationErrors: ["Invalid section type"],
@@ -61,6 +64,7 @@ describe("Debug routes", () => {
             promptName: "extract-metadata",
             modelId: "gpt-4o",
             cacheHit: false,
+            success: true,
             durationMs: 3000,
             usage: { inputTokens: 2000, outputTokens: 300 },
           },
@@ -253,6 +257,8 @@ describe("Debug routes", () => {
       expect(textStep).toBeDefined()
       expect(textStep.calls).toBe(3)
       expect(textStep.cacheHits).toBe(1)
+      expect(textStep.errorCount).toBe(1)
+      expect(body.totals.errorCount).toBe(1)
     })
 
     it("returns null pipeline run timing", async () => {

--- a/apps/api/src/routes/debug.ts
+++ b/apps/api/src/routes/debug.ts
@@ -106,7 +106,12 @@ export function createDebugRoutes(
           COALESCE(SUM(json_extract(data, '$.usage.inputTokens')), 0) as inputTokens,
           COALESCE(SUM(json_extract(data, '$.usage.outputTokens')), 0) as outputTokens,
           ROUND(AVG(json_extract(data, '$.durationMs')), 0) as avgDurationMs,
-          SUM(CASE WHEN json_array_length(json_extract(data, '$.validationErrors')) > 0 THEN 1 ELSE 0 END) as errorCount
+          SUM(CASE
+            WHEN json_extract(data, '$.success') = 0 THEN 1
+            WHEN json_extract(data, '$.success') IS NULL
+              AND json_array_length(json_extract(data, '$.validationErrors')) > 0 THEN 1
+            ELSE 0
+          END) as errorCount
         FROM llm_log
         GROUP BY step
         ORDER BY step

--- a/apps/api/src/services/page-edit-service.test.ts
+++ b/apps/api/src/services/page-edit-service.test.ts
@@ -354,6 +354,67 @@ describe("page-edit-service", () => {
 
     it.each([
       {
+        name: "generic markup",
+        invalidHtml: `<section><div class="text-4xl" data-id="section-title">Section title</div></section>`,
+      },
+      {
+        name: "a changed level",
+        invalidHtml: `<section><h3 class="adt-h2" data-id="section-title">Section title</h3></section>`,
+      },
+      {
+        name: "a local font-size override",
+        invalidHtml: `<section><h2 class="adt-h2 text-4xl" data-id="section-title">Section title</h2></section>`,
+      },
+    ])("rejects $name and accepts a hierarchy-preserving AI edit", async ({ invalidHtml }) => {
+      const currentHtml = `<section><h2 class="adt-h2" data-id="section-title">Section title</h2></section>`
+      const validHtml = `<section class="bg-blue-50"><h2 class="adt-h2 text-blue-700 mt-4" data-id="section-title">Section title</h2></section>`
+      let rejectionErrors: string[] = []
+
+      llmMocks.generateObject.mockImplementation(async (opts: unknown) => {
+        const editOptions = opts as {
+          validate?: (result: unknown, context: Record<string, unknown>) => {
+            valid: boolean
+            errors: string[]
+          }
+          maxRetries?: number
+        }
+        expect(editOptions.maxRetries).toBe(3)
+        const rejected = editOptions.validate?.(
+          { reasoning: "Changed the background", content: invalidHtml },
+          {},
+        )
+        expect(rejected?.valid).toBe(false)
+        rejectionErrors = rejected?.errors ?? []
+
+        const accepted = editOptions.validate?.(
+          { reasoning: "Changed the background", content: validHtml },
+          {},
+        )
+        expect(accepted?.valid).toBe(true)
+        return {
+          object: { reasoning: "Changed the background", content: validHtml },
+        } as never
+      })
+
+      const result = await aiEditSection({
+        label,
+        pageId: `${label}_p1`,
+        sectionIndex: 0,
+        instruction: "Change the background color and add spacing",
+        currentHtml,
+        booksDir: tmpDir,
+        promptsDir: tmpDir,
+        configPath: path.resolve(process.cwd(), "config.yaml"),
+        apiKey: "test-key",
+      })
+
+      expect(rejectionErrors).toContainEqual(expect.stringContaining("Sectioning"))
+      expect(result.html).toBe(validHtml)
+      expect(result.html).toContain('<h2 class="adt-h2 text-blue-700 mt-4"')
+    })
+
+    it.each([
+      {
         name: "uses page_sectioning.model when configured",
         defaultModelId: "openai:gpt-4.1",
         pageSectioningModelId: "openai:gpt-4o",

--- a/apps/api/src/services/page-edit-service.ts
+++ b/apps/api/src/services/page-edit-service.ts
@@ -3,7 +3,7 @@ import path from "node:path"
 import { createBookStorage } from "@adt/storage"
 import { createLLMModel, createPromptEngine } from "@adt/llm"
 import type { LLMModel } from "@adt/llm"
-import { renderPage, buildRenderStrategyResolver, buildBookFontsPromptContext, readTypography, buildTypographyCss, collectReferencedImageIds, collectSourcePageImages, createTemplateEngine, loadBookConfig, createScreenshotRenderer, runVisualReviewLoop, DEFAULT_VISUAL_REVIEW_MODEL_ID, buildScreenshotHtml, SCREENSHOT_VIEWPORTS, inspectOrderingActivityHtml } from "@adt/pipeline"
+import { renderPage, buildRenderStrategyResolver, buildBookFontsPromptContext, readTypography, buildTypographyCss, collectReferencedImageIds, collectSourcePageImages, createTemplateEngine, loadBookConfig, createScreenshotRenderer, runVisualReviewLoop, DEFAULT_VISUAL_REVIEW_MODEL_ID, buildScreenshotHtml, SCREENSHOT_VIEWPORTS, inspectOrderingActivityHtml, validateRetainedHeadingHierarchy } from "@adt/pipeline"
 import type { VisualRefinementDeps } from "@adt/pipeline"
 import { PageSectioningOutput, WebRenderingOutput, webRenderingLLMSchema, editVerifyLLMSchema, DEFAULT_LLM_MODEL_ID } from "@adt/types"
 import { loadStyleguideContent } from "./styleguide.js"
@@ -361,6 +361,7 @@ export async function aiEditSection(
       if (!cleanedHtml.includes("<section")) {
         errors.push("Result must contain a <section> element")
       }
+      errors.push(...validateRetainedHeadingHierarchy(currentHtml, cleanedHtml))
       if (originalOrdering.isOrdering) {
         const ordering = inspectOrderingActivityHtml(cleanedHtml)
         if (!ordering.isOrdering) {

--- a/apps/studio/src/api/client.ts
+++ b/apps/studio/src/api/client.ts
@@ -609,6 +609,8 @@ export interface LlmLogEntry {
     requestedPromptName?: string
     modelId: string
     cacheHit: boolean
+    /** Final status of this individual attempt. Older log entries may omit it. */
+    success?: boolean
     durationMs: number
     usage?: { inputTokens: number; outputTokens: number }
     validationErrors?: string[]

--- a/apps/studio/src/components/debug/LlmLogsTab.tsx
+++ b/apps/studio/src/components/debug/LlmLogsTab.tsx
@@ -41,7 +41,12 @@ function formatSeconds(ms: number): string {
 }
 
 function getStatus(entry: LlmLogEntry): RowStatus {
-  if (entry.data.validationErrors && entry.data.validationErrors.length > 0) return "error"
+  if (entry.data.success === false) return "error"
+  if (
+    entry.data.success === undefined &&
+    entry.data.validationErrors &&
+    entry.data.validationErrors.length > 0
+  ) return "error"
   if (entry.data.cacheHit) return "cached"
   return "success"
 }
@@ -231,7 +236,7 @@ function LogDetail({ data, label }: { data: LlmLogEntry["data"]; label: string }
           </div>
         )}
 
-        {data.validationErrors && data.validationErrors.length > 0 && (
+        {data.success !== true && data.validationErrors && data.validationErrors.length > 0 && (
           <div>
             <div className="font-medium text-destructive mb-1 flex items-center gap-1">
               <AlertTriangle className="h-3 w-3" />

--- a/packages/llm/src/__tests__/client.test.ts
+++ b/packages/llm/src/__tests__/client.test.ts
@@ -264,4 +264,51 @@ describe("createLLMModel validation retries", () => {
       },
     ])
   })
+
+  it("logs validation retries as individual attempts without carrying errors or usage forward", async () => {
+    openaiProviderMock.mockReturnValue({ provider: "openai" })
+    generateObjectMock
+      .mockResolvedValueOnce({
+        object: { value: "invalid" },
+        usage: { promptTokens: 10, completionTokens: 2 },
+      })
+      .mockResolvedValueOnce({
+        object: { value: "valid" },
+        usage: { promptTokens: 20, completionTokens: 3 },
+      })
+
+    const onLog = vi.fn()
+    const llm = createLLMModel({
+      modelId: "openai:gpt-4.1",
+      onLog,
+    })
+    const result = await llm.generateObject<{ value: string }>({
+      schema: z.object({ value: z.string() }),
+      messages: [{ role: "user", content: "Return a value" }],
+      maxRetries: 1,
+      validate: (value) =>
+        value.value === "valid"
+          ? { valid: true, errors: [] }
+          : { valid: false, errors: ["Value must be valid."] },
+      log: {
+        taskType: "test-step",
+        promptName: "test-prompt",
+      },
+    })
+
+    expect(result.usage).toEqual({ inputTokens: 30, outputTokens: 5 })
+    expect(onLog).toHaveBeenCalledTimes(2)
+    expect(onLog.mock.calls[0]?.[0]).toMatchObject({
+      success: false,
+      errorCount: 1,
+      validationErrors: ["Value must be valid."],
+      usage: { inputTokens: 10, outputTokens: 2 },
+    })
+    expect(onLog.mock.calls[1]?.[0]).toMatchObject({
+      success: true,
+      errorCount: 0,
+      usage: { inputTokens: 20, outputTokens: 3 },
+    })
+    expect(onLog.mock.calls[1]?.[0].validationErrors).toBeUndefined()
+  })
 })

--- a/packages/llm/src/client.ts
+++ b/packages/llm/src/client.ts
@@ -112,6 +112,8 @@ export function createLLMModel(options: CreateLLMModelOptions): LLMModel {
           : opts.log?.requestedPromptName
 
       for (let attempt = 0; attempt <= maxRetries; attempt++) {
+        const attemptStartedAt = Date.now()
+        const attemptUsage: TokenUsage = { inputTokens: 0, outputTokens: 0 }
         const hash = computeHash({
           modelId,
           mode: opts.mode,
@@ -142,6 +144,8 @@ export function createLLMModel(options: CreateLLMModelOptions): LLMModel {
                 externalSignal
               )
               result = generated.object
+              attemptUsage.inputTokens += generated.usage.inputTokens
+              attemptUsage.outputTokens += generated.usage.outputTokens
               totalUsage.inputTokens += generated.usage.inputTokens
               totalUsage.outputTokens += generated.usage.outputTokens
               lastCacheHit = false
@@ -159,6 +163,8 @@ export function createLLMModel(options: CreateLLMModelOptions): LLMModel {
               externalSignal
             )
             result = generated.object
+            attemptUsage.inputTokens += generated.usage.inputTokens
+            attemptUsage.outputTokens += generated.usage.outputTokens
             totalUsage.inputTokens += generated.usage.inputTokens
             totalUsage.outputTokens += generated.usage.outputTokens
             lastCacheHit = false
@@ -191,14 +197,14 @@ export function createLLMModel(options: CreateLLMModelOptions): LLMModel {
                   modelId,
                   cacheHit: lastCacheHit,
                   success: false,
-                  errorCount: allErrors.length,
+                  errorCount: check.errors.length,
                   attempt,
-                  durationMs: Date.now() - t0,
+                  durationMs: Date.now() - attemptStartedAt,
                   usage:
-                    totalUsage.inputTokens > 0 || totalUsage.outputTokens > 0
-                      ? totalUsage
+                    attemptUsage.inputTokens > 0 || attemptUsage.outputTokens > 0
+                      ? attemptUsage
                       : undefined,
-                  validationErrors: allErrors.length > 0 ? allErrors : undefined,
+                  validationErrors: check.errors,
                   messages: sanitizeMessages(
                     buildLogMessages(system, currentMessages, null)
                   ),
@@ -235,14 +241,13 @@ export function createLLMModel(options: CreateLLMModelOptions): LLMModel {
               modelId,
               cacheHit: lastCacheHit,
               success: true,
-              errorCount: allErrors.length,
+              errorCount: 0,
               attempt,
-              durationMs: Date.now() - t0,
+              durationMs: Date.now() - attemptStartedAt,
               usage:
-                totalUsage.inputTokens > 0 || totalUsage.outputTokens > 0
-                  ? totalUsage
+                attemptUsage.inputTokens > 0 || attemptUsage.outputTokens > 0
+                  ? attemptUsage
                   : undefined,
-              validationErrors: allErrors.length > 0 ? allErrors : undefined,
               messages: sanitizeMessages(
                 buildLogMessages(system, currentMessages, result)
               ),
@@ -286,14 +291,14 @@ export function createLLMModel(options: CreateLLMModelOptions): LLMModel {
                 modelId,
                 cacheHit: false,
                 success: false,
-                errorCount: allErrors.length,
+                errorCount: 1,
                 attempt,
-                durationMs: Date.now() - t0,
+                durationMs: Date.now() - attemptStartedAt,
                 usage:
-                  totalUsage.inputTokens > 0 || totalUsage.outputTokens > 0
-                    ? totalUsage
+                  attemptUsage.inputTokens > 0 || attemptUsage.outputTokens > 0
+                    ? attemptUsage
                     : undefined,
-                validationErrors: allErrors,
+                validationErrors: [errMsg],
                 messages: sanitizeMessages(
                   buildLogMessages(system, currentMessages, null)
                 ),
@@ -325,14 +330,14 @@ export function createLLMModel(options: CreateLLMModelOptions): LLMModel {
               modelId,
               cacheHit: false,
               success: false,
-              errorCount: allErrors.length,
+              errorCount: 1,
               attempt,
-              durationMs: Date.now() - t0,
+              durationMs: Date.now() - attemptStartedAt,
               usage:
-                totalUsage.inputTokens > 0 || totalUsage.outputTokens > 0
-                  ? totalUsage
+                attemptUsage.inputTokens > 0 || attemptUsage.outputTokens > 0
+                  ? attemptUsage
                   : undefined,
-              validationErrors: allErrors,
+              validationErrors: [errMsg],
               messages: sanitizeMessages(
                 buildLogMessages(system, currentMessages, null)
               ),

--- a/packages/pipeline/src/__tests__/book-outline.test.ts
+++ b/packages/pipeline/src/__tests__/book-outline.test.ts
@@ -3,7 +3,11 @@ import { PNG } from "pngjs"
 import { describe, expect, it } from "vitest"
 import { createPromptEngine } from "@adt/llm"
 import type { GenerateObjectOptions, LLMModel, Message } from "@adt/llm"
-import type { BookOutlineOutput, PositionedTextOutput } from "@adt/types"
+import type {
+  BookOutlineOutput,
+  BookOutlineProposalOutput,
+  PositionedTextOutput,
+} from "@adt/types"
 import {
   BOOK_OUTLINE_CHUNK_PAGE_LIMIT,
   buildBookOutlineConfig,
@@ -12,6 +16,8 @@ import {
 } from "../book-outline.js"
 import {
   BOOK_OUTLINE_MAX_PAGE_TEXT_CHARS,
+  BOOK_OUTLINE_MAX_POSITIONED_PAGE_TEXT_CHARS,
+  BOOK_OUTLINE_MAX_CANDIDATES_PER_PAGE,
   buildBookOutlineEvidence,
   buildHeadingCandidates,
   buildProofSheets,
@@ -65,6 +71,80 @@ function positionedText(): PositionedTextOutput {
   }
 }
 
+function positionedHeadings(
+  lines: Array<{
+    text: string
+    left?: number
+    top?: number
+    fontSize?: number
+    fontWeight?: number
+  }>,
+): PositionedTextOutput {
+  return {
+    pageWidth: 600,
+    pageHeight: 800,
+    renderWidth: 1200,
+    renderHeight: 1600,
+    drawItems: lines.map((line, index) => ({
+      kind: "paragraph" as const,
+      textId: `tx${String(index + 1).padStart(3, "0")}`,
+      top: line.top ?? 40 + index * 40,
+      left: line.left ?? 60,
+      lineHeight: line.fontSize ?? 16,
+      text: line.text,
+      segments: [{
+        text: line.text,
+        style: {
+          "font-size": `${line.fontSize ?? 16}px`,
+          "font-weight": String(line.fontWeight ?? 400),
+        },
+      }],
+    })),
+  }
+}
+
+function tocGuidedEvidence(): BookOutlineEvidence {
+  return buildBookOutlineEvidence(
+    [
+      {
+        pageId: "pg001",
+        pageNumber: 1,
+        text: "SUMÁRIO\nCAPÍTULO 1 Experiências vividas\nLinguagem formal e informal\nCurrículo profissional\nMedidas de comprimento",
+        imageBase64: pngBase64(),
+        positionedText: positionedHeadings([
+          { text: "SUMÁRIO", left: 60, fontSize: 24, fontWeight: 700 },
+          {
+            text: "CAPÍTULO 1 Experiências vividas ................ 9",
+            left: 60,
+            fontSize: 18,
+            fontWeight: 700,
+          },
+          { text: "Linguagem formal e informal ................ 18", left: 90 },
+          { text: "Currículo profissional ..................... 19", left: 90 },
+          { text: "Medidas de comprimento ..................... 22", left: 90 },
+        ]),
+      },
+      ...[
+        "EXPERIÊNCIAS VIVIDAS",
+        "LINGUAGEM FORMAL E INFORMAL",
+        "CURRÍCULO PROFISSIONAL",
+        "MEDIDAS DE COMPRIMENTO",
+      ].map((text, index) => ({
+        pageId: `pg00${index + 2}`,
+        pageNumber: index + 2,
+        text,
+        imageBase64: pngBase64(),
+        positionedText: positionedHeadings([{
+          text,
+          fontSize: index === 0 ? 28 : 20,
+          fontWeight: 700,
+        }]),
+      })),
+    ],
+    null,
+  )
+}
+
 function evidence(): BookOutlineEvidence {
   return buildBookOutlineEvidence(
     [
@@ -114,6 +194,20 @@ function output(): BookOutlineOutput {
   }
 }
 
+function proposal(book = output()): BookOutlineProposalOutput {
+  return {
+    reasoning: book.reasoning.slice(0, 600),
+    styleClusters: book.styleClusters.map((cluster) => ({ ...cluster })),
+    entries: book.entries.map((entry) => ({
+      sourceCandidateIds: [...entry.sourceCandidateIds],
+      level: entry.level,
+      kind: entry.kind,
+      styleClusterId: entry.styleClusterId,
+      confidence: entry.confidence,
+    })),
+  }
+}
+
 function messageText(message: Message): string {
   if (typeof message.content === "string") return message.content
   return message.content
@@ -144,7 +238,7 @@ describe("book outline evidence", () => {
       fontWeight: 700,
       centered: true,
       topRatio: 0.05,
-      widthRatio: 2 / 3,
+      widthRatio: 0.667,
     })
     expect(candidates[0].headingLikelihood).toBeGreaterThan(candidates[1].headingLikelihood)
   })
@@ -165,6 +259,8 @@ describe("book outline evidence", () => {
     expect(sheets[1].pageIds).toEqual(["pg5"])
     const rendered = PNG.sync.read(Buffer.from(sheets[0].imageBase64, "base64"))
     expect({ width: rendered.width, height: rendered.height }).toEqual({ width: 26, height: 30 })
+    const partial = PNG.sync.read(Buffer.from(sheets[1].imageBase64, "base64"))
+    expect({ width: partial.width, height: partial.height }).toEqual({ width: 26, height: 16 })
   })
 
   it("bounds OCR fallback candidates and oversized page text", () => {
@@ -175,7 +271,7 @@ describe("book outline evidence", () => {
       [{ pageId: "pg001", pageNumber: 1, text, imageBase64: pngBase64() }],
       null,
     )
-    expect(candidates).toHaveLength(40)
+    expect(candidates).toHaveLength(BOOK_OUTLINE_MAX_CANDIDATES_PER_PAGE)
 
     const oversized = `${"a".repeat(7_000)}${"b".repeat(7_000)}`
     const bounded = buildBookOutlineEvidence(
@@ -186,14 +282,100 @@ describe("book outline evidence", () => {
     expect(bounded.pages[0].text).toContain("middle of page text omitted")
     expect(bounded.pages[0].text.startsWith("a")).toBe(true)
     expect(bounded.pages[0].text.endsWith("b")).toBe(true)
+
+    const positioned = buildBookOutlineEvidence(
+      [{
+        pageId: "pg002",
+        pageNumber: 2,
+        text: oversized,
+        imageBase64: pngBase64(),
+        positionedText: positionedText(),
+      }],
+      null,
+    )
+    expect(positioned.pages[0].text).toHaveLength(
+      BOOK_OUTLINE_MAX_POSITIONED_PAGE_TEXT_CHARS,
+    )
+  })
+
+  it("drops table-of-contents navigation rows and their page numbers from evidence", () => {
+    const candidates = buildHeadingCandidates(
+      [{
+        pageId: "pg001",
+        pageNumber: 1,
+        text: [
+          "SUMÁRIO",
+          "Capítulo um ........................ 9",
+          "Tema A ............................. 10",
+          "Tema B ............................. 14",
+          "9",
+          "10",
+          "14",
+        ].join("\n"),
+        imageBase64: pngBase64(),
+      }],
+      null,
+    )
+
+    expect(candidates.map((candidate) => candidate.text)).toEqual(["SUMÁRIO"])
+  })
+
+  it("preserves TOC indentation as compact hierarchy evidence", () => {
+    const bookEvidence = tocGuidedEvidence()
+
+    expect(
+      bookEvidence.candidates
+        .filter((candidate) => candidate.pageId === "pg001")
+        .map((candidate) => candidate.text),
+    ).toEqual(["SUMÁRIO"])
+    expect(bookEvidence.tocHierarchy).toEqual([
+      expect.objectContaining({
+        title: "CAPÍTULO 1 Experiências vividas",
+        suggestedLevel: 1,
+        confidence: 0.98,
+      }),
+      expect.objectContaining({
+        title: "Linguagem formal e informal",
+        suggestedLevel: 2,
+        confidence: 0.98,
+      }),
+      expect.objectContaining({
+        title: "Currículo profissional",
+        suggestedLevel: 2,
+        confidence: 0.98,
+      }),
+      expect.objectContaining({
+        title: "Medidas de comprimento",
+        suggestedLevel: 2,
+        confidence: 0.98,
+      }),
+    ])
   })
 })
 
 describe("book outline generation", () => {
-  it("inherits the configured OpenAI default model", () => {
+  it("uses the fast mini model for the shipped OpenAI default", () => {
     expect(
       buildBookOutlineConfig({
         default_model: "openai:gpt-5.4",
+        structure_types: {},
+        role_types: {},
+      }).modelId,
+    ).toBe("openai:gpt-5.4-mini")
+  })
+
+  it("keeps non-default and explicit outline model selections", () => {
+    expect(
+      buildBookOutlineConfig({
+        default_model: "google:gemini-2.5-flash",
+        structure_types: {},
+        role_types: {},
+      }).modelId,
+    ).toBe("google:gemini-2.5-flash")
+    expect(
+      buildBookOutlineConfig({
+        default_model: "openai:gpt-5.4",
+        book_outline: { model: "openai:gpt-5.4" },
         structure_types: {},
         role_types: {},
       }).modelId,
@@ -205,7 +387,7 @@ describe("book outline generation", () => {
     const llm: LLMModel = {
       generateObject: async <T>(options: GenerateObjectOptions) => {
         captured = options
-        const result = output()
+        const result = proposal()
         expect(options.validate?.(result, options.context ?? {})).toEqual({ valid: true, errors: [] })
         return { object: result as T }
       },
@@ -228,6 +410,43 @@ describe("book outline generation", () => {
     expect((captured?.context?.proof_sheets as unknown[])).toHaveLength(1)
   })
 
+  it("keeps a 20-page book in one outline call", async () => {
+    const mediumEvidence = buildBookOutlineEvidence(
+      Array.from({ length: 20 }, (_, index) => ({
+        pageId: `pg${String(index + 1).padStart(3, "0")}`,
+        pageNumber: index + 1,
+        text: `Chapter ${index + 1}`,
+        imageBase64: pngBase64(),
+        positionedText: positionedText(),
+      })),
+      null,
+    )
+    const calls: GenerateObjectOptions[] = []
+    const llm: LLMModel = {
+      generateObject: async <T>(options: GenerateObjectOptions) => {
+        calls.push(options)
+        return {
+          object: {
+            reasoning: "No headings needed for this call-count test.",
+            entries: [],
+            styleClusters: [],
+          } as T,
+        }
+      },
+    }
+
+    await generateBookOutline(
+      mediumEvidence,
+      buildBookOutlineConfig({ structure_types: {}, role_types: {} }),
+      llm,
+    )
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0].prompt).toBe("book_outline")
+    expect((calls[0].context?.pages as unknown[])).toHaveLength(20)
+    expect((calls[0].context?.proof_sheets as unknown[])).toHaveLength(1)
+  })
+
   it("chunks long books and globally synthesizes only compact proposals", async () => {
     const longEvidence = buildBookOutlineEvidence(
       Array.from({ length: BOOK_OUTLINE_CHUNK_PAGE_LIMIT * 2 + 1 }, (_, index) => ({
@@ -240,13 +459,12 @@ describe("book outline generation", () => {
       null,
     )
     const calls: GenerateObjectOptions[] = []
-    const proposals: BookOutlineOutput[] = []
+    const proposals: BookOutlineProposalOutput[] = []
     const llm: LLMModel = {
       generateObject: async <T>(options: GenerateObjectOptions) => {
         calls.push(options)
         if (options.prompt === "book_outline_synthesis") {
-          let nextId = 1
-          const combined: BookOutlineOutput = {
+          const combined: BookOutlineProposalOutput = {
             reasoning: "Normalized all deterministic chunks.",
             styleClusters: [
               { styleClusterId: "chapter-style", description: "Chapter title", level: 1 },
@@ -254,7 +472,6 @@ describe("book outline generation", () => {
             entries: proposals.flatMap((proposal) =>
               proposal.entries.map((entry) => ({
                 ...entry,
-                outlineId: `outline-${String(nextId++).padStart(3, "0")}`,
                 styleClusterId: "chapter-style",
               })),
             ),
@@ -272,22 +489,17 @@ describe("book outline generation", () => {
           pageId: string
           text: string
         }>
-        const proposal: BookOutlineOutput = {
+        const proposal: BookOutlineProposalOutput = {
           reasoning: "Provisional chunk headings.",
           styleClusters: [
             { styleClusterId: "chapter-style", description: "Chapter title", level: 1 },
           ],
-          entries: pages.map((page, index) => {
+          entries: pages.map((page) => {
             const candidate = candidates.find((item) => item.pageId === page.pageId)!
             return {
-              outlineId: `outline-${String(index + 1).padStart(3, "0")}`,
-              title: candidate.text,
+              sourceCandidateIds: [candidate.candidateId],
               level: 1,
               kind: "chapter" as const,
-              pageId: page.pageId,
-              pageNumber: page.pageNumber,
-              sourceCandidateIds: [candidate.candidateId],
-              parentId: null,
               styleClusterId: "chapter-style",
               confidence: 0.9,
             }
@@ -328,7 +540,7 @@ describe("book outline generation", () => {
   it("rejects invented candidate references", async () => {
     const llm: LLMModel = {
       generateObject: async <T>(options: GenerateObjectOptions) => {
-        const invalid = output()
+        const invalid = proposal()
         invalid.entries[0].sourceCandidateIds = ["invented"]
         const validation = options.validate?.(invalid, options.context ?? {})
         expect(validation?.valid).toBe(false)
@@ -337,30 +549,175 @@ describe("book outline generation", () => {
       },
     }
 
-    await generateBookOutline(
+    await expect(generateBookOutline(
       evidence(),
       buildBookOutlineConfig({ structure_types: {}, role_types: {} }),
       llm,
-    )
+    )).rejects.toThrow("unknown candidate")
   })
 
-  it("rejects rewritten outline titles", async () => {
+  it("derives exact outline titles from source candidates", async () => {
     const llm: LLMModel = {
       generateObject: async <T>(options: GenerateObjectOptions) => {
-        const invalid = output()
-        invalid.entries[0].title = "A rewritten chapter name"
-        const validation = options.validate?.(invalid, options.context ?? {})
-        expect(validation?.valid).toBe(false)
-        expect(validation?.errors.join(" ")).toContain("title must exactly match")
-        return { object: invalid as T }
+        const compact = proposal()
+        const validation = options.validate?.(compact, options.context ?? {})
+        expect(validation?.valid).toBe(true)
+        return { object: compact as T }
       },
     }
 
-    await generateBookOutline(
+    const result = await generateBookOutline(
       evidence(),
       buildBookOutlineConfig({ structure_types: {}, role_types: {} }),
       llm,
     )
+    expect(result.entries[0].title).toBe("Chapter One")
+  })
+
+  it("derives a valid parent tree from entry order and semantic levels", async () => {
+    const parentEvidence = buildBookOutlineEvidence(
+      [{
+        pageId: "pg001",
+        pageNumber: 1,
+        text: "Chapter\nSection\nSubsection\nPeer section",
+        imageBase64: pngBase64(),
+      }],
+      null,
+    )
+    const compact: BookOutlineProposalOutput = {
+      reasoning: "Ordered semantic levels define the hierarchy.",
+      styleClusters: [
+        { styleClusterId: "h1", description: "Chapter", level: 1 },
+        { styleClusterId: "h2", description: "Section", level: 2 },
+        { styleClusterId: "h3", description: "Subsection", level: 3 },
+      ],
+      entries: [1, 2, 3, 2].map((level, index) => ({
+        sourceCandidateIds: [`pg001_hc${String(index + 1).padStart(3, "0")}`],
+        level,
+        kind: level === 1 ? "chapter" as const : "section" as const,
+        styleClusterId: `h${level}`,
+        confidence: 0.9,
+      })),
+    }
+    const llm: LLMModel = {
+      generateObject: async <T>(options: GenerateObjectOptions) => {
+        expect(options.validate?.(compact, options.context ?? {})).toEqual({
+          valid: true,
+          errors: [],
+        })
+        return { object: compact as T }
+      },
+    }
+
+    const result = await generateBookOutline(
+      parentEvidence,
+      buildBookOutlineConfig({ structure_types: {}, role_types: {} }),
+      llm,
+    )
+    expect(result.entries.map((entry) => entry.parentId)).toEqual([
+      null,
+      "outline-001",
+      "outline-002",
+      "outline-001",
+    ])
+  })
+
+  it("anchors matching in-book headings to the TOC hierarchy before deriving parents", async () => {
+    const bookEvidence = tocGuidedEvidence()
+    const compact: BookOutlineProposalOutput = {
+      reasoning: "Visual size alone made later topic headings look top-level.",
+      styleClusters: [
+        { styleClusterId: "display", description: "Large red heading", level: 1 },
+      ],
+      entries: [
+        { candidateId: "pg002_hc001", level: 1, kind: "chapter" as const },
+        { candidateId: "pg003_hc001", level: 1, kind: "section" as const },
+        { candidateId: "pg004_hc001", level: 1, kind: "section" as const },
+        { candidateId: "pg005_hc001", level: 1, kind: "section" as const },
+      ].map(({ candidateId, level, kind }) => ({
+        sourceCandidateIds: [candidateId],
+        level,
+        kind,
+        styleClusterId: "display",
+        confidence: 0.9,
+      })),
+    }
+    const llm: LLMModel = {
+      generateObject: async <T>(options: GenerateObjectOptions) => {
+        expect(options.context?.toc_hierarchy).toEqual(bookEvidence.tocHierarchy)
+        expect(options.validate?.(compact, options.context ?? {})).toEqual({
+          valid: true,
+          errors: [],
+        })
+        return { object: compact as T }
+      },
+    }
+
+    const result = await generateBookOutline(
+      bookEvidence,
+      buildBookOutlineConfig({ structure_types: {}, role_types: {} }),
+      llm,
+    )
+
+    expect(result.entries.map((entry) => entry.level)).toEqual([1, 2, 2, 2])
+    expect(result.entries.map((entry) => entry.parentId)).toEqual([
+      null,
+      "outline-001",
+      "outline-001",
+      "outline-001",
+    ])
+    expect(result.reasoning).toContain("3 deterministic TOC hierarchy corrections")
+  })
+
+  it("splits a visual style reused at different semantic levels without retrying", async () => {
+    const llm: LLMModel = {
+      generateObject: async <T>(options: GenerateObjectOptions) => {
+        const mismatched = proposal()
+        mismatched.entries.push({
+          ...mismatched.entries[0],
+          level: 2,
+          kind: "section",
+          sourceCandidateIds: ["pg001_hc002"],
+        })
+
+        const validation = options.validate?.(mismatched, options.context ?? {})
+        expect(validation?.valid).toBe(true)
+        return { object: mismatched as T }
+      },
+    }
+
+    const result = await generateBookOutline(
+      evidence(),
+      buildBookOutlineConfig({ structure_types: {}, role_types: {} }),
+      llm,
+    )
+    expect(result.entries[1].level).toBe(2)
+    expect(result.entries[1].styleClusterId).toBe("chapter-style-level-2")
+    expect(result.styleClusters).toContainEqual({
+      styleClusterId: "chapter-style-level-2",
+      description: "Large centered title (level 2 variant)",
+      level: 2,
+    })
+  })
+
+  it("corrects a cluster declaration when all entries agree on another level", async () => {
+    const llm: LLMModel = {
+      generateObject: async <T>(options: GenerateObjectOptions) => {
+        const mismatched = proposal()
+        mismatched.entries[0].level = 2
+        const validation = options.validate?.(mismatched, options.context ?? {})
+        expect(validation?.valid).toBe(true)
+        return { object: mismatched as T }
+      },
+    }
+
+    const result = await generateBookOutline(
+      evidence(),
+      buildBookOutlineConfig({ structure_types: {}, role_types: {} }),
+      llm,
+    )
+    expect(result.entries[0].level).toBe(2)
+    expect(result.styleClusters[0].level).toBe(2)
   })
 
   it("returns page entries with their ancestor and style context", () => {
@@ -395,9 +752,11 @@ describe("book outline generation", () => {
   it("renders all evidence plus a proof-sheet image in the OpenAI prompt", async () => {
     const promptEngine = createPromptEngine(path.join(process.cwd(), "prompts"))
     const bookEvidence = evidence()
+    const tocHierarchy = tocGuidedEvidence().tocHierarchy
     const messages = await promptEngine.renderPrompt("book_outline", {
       pages: bookEvidence.pages,
       candidates: bookEvidence.candidates,
+      toc_hierarchy: tocHierarchy,
       proof_sheets: bookEvidence.proofSheets.map((sheet) => ({
         sheet_id: sheet.sheetId,
         page_ids: sheet.pageIds,
@@ -415,16 +774,22 @@ describe("book outline generation", () => {
 
     expect(text).toContain("Chapter One")
     expect(text).toContain("pg001_hc001")
+    expect(text).toContain("candidate_id | page_id | page_number")
     expect(text).toContain("proof-001 pages: pg001")
+    expect(text).toContain("TOC navigation rows are links/list items")
+    expect(text).toContain("Compact table-of-contents hierarchy guide")
+    expect(text).toContain("Linguagem formal e informal")
     expect(imageParts).toHaveLength(1)
   })
 
   it("renders the bounded chunk and compact synthesis prompts", async () => {
     const promptEngine = createPromptEngine(path.join(process.cwd(), "prompts"))
     const bookEvidence = evidence()
+    const tocHierarchy = tocGuidedEvidence().tocHierarchy
     const chunkMessages = await promptEngine.renderPrompt("book_outline_chunk", {
       pages: bookEvidence.pages,
       candidates: bookEvidence.candidates,
+      toc_hierarchy: tocHierarchy,
       proof_sheets: bookEvidence.proofSheets.map((sheet) => ({
         sheet_id: sheet.sheetId,
         page_ids: sheet.pageIds,
@@ -433,7 +798,10 @@ describe("book outline generation", () => {
       })),
       type_scale: bookEvidence.typeScale,
     })
-    expect(chunkMessages.map(messageText).join("\n")).toContain("deterministic page chunk")
+    const chunkText = chunkMessages.map(messageText).join("\n")
+    expect(chunkText).toContain("deterministic page chunk")
+    expect(chunkText).toContain("exclude every TOC navigation row")
+    expect(chunkText).toContain("every entry level equals its referenced style cluster level")
 
     const synthesisMessages = await promptEngine.renderPrompt("book_outline_synthesis", {
       chunks: [{
@@ -442,10 +810,13 @@ describe("book outline generation", () => {
         entries: output().entries,
         style_clusters: output().styleClusters,
       }],
+      toc_hierarchy: tocHierarchy,
       type_scale: bookEvidence.typeScale,
     })
     const synthesisText = synthesisMessages.map(messageText).join("\n")
     expect(synthesisText).toContain("final book-structure analyst")
     expect(synthesisText).toContain("pg001_hc001")
+    expect(synthesisText).toContain("Never restore table-of-contents navigation rows")
+    expect(synthesisText).toContain("every entry level equals its referenced style cluster level")
   })
 })

--- a/packages/pipeline/src/__tests__/page-sectioning.test.ts
+++ b/packages/pipeline/src/__tests__/page-sectioning.test.ts
@@ -1,5 +1,7 @@
+import path from "node:path"
 import { describe, expect, it } from "vitest"
 import type { AppConfig } from "@adt/types"
+import { createPromptEngine } from "@adt/llm"
 import type {
   GenerateObjectOptions,
   GenerateObjectResult,
@@ -221,6 +223,38 @@ describe("buildPageSectioningConfig", () => {
       page_sectioning: { mode: "page" },
     }
     expect(buildPageSectioningConfig(appConfig).mode).toBe("page")
+  })
+})
+
+describe("page sectioning prompt", () => {
+  it("makes outline-linked role assignment override wording and visual heuristics", async () => {
+    const promptEngine = createPromptEngine(path.join(process.cwd(), "prompts"))
+    const messages = await promptEngine.renderPrompt("page_sectioning", {
+      structure_types: [],
+      role_types: [],
+      section_types: [],
+      book_outline: {
+        entries: [{
+          outlineId: "outline-001",
+          title: "CAPÍTULO 1",
+          level: 2,
+          kind: "chapter",
+          styleClusterId: "toc-chapter",
+        }],
+        ancestors: [],
+      },
+      mode: "page",
+    })
+    const text = messages
+      .flatMap((message) => typeof message.content === "string"
+        ? [message.content]
+        : message.content.filter((part) => part.type === "text").map((part) => part.text))
+      .join("\n")
+
+    expect(text).toContain("role mapping is mechanical")
+    expect(text).toContain("still uses `section_heading`")
+    expect(text).toContain("TOC navigation rows are list/link content")
+    expect(text).toContain("never `chapter_title`")
   })
 })
 

--- a/packages/pipeline/src/__tests__/validate-typography-hierarchy.test.ts
+++ b/packages/pipeline/src/__tests__/validate-typography-hierarchy.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest"
-import { validateTypographyHierarchy } from "../validate-typography-hierarchy.js"
+import {
+  validateRetainedHeadingHierarchy,
+  validateTypographyHierarchy,
+} from "../validate-typography-hierarchy.js"
 
 describe("validateTypographyHierarchy", () => {
   it("accepts authoritative H1/H2/H3 role mappings", () => {
@@ -87,5 +90,59 @@ describe("validateTypographyHierarchy", () => {
       [{ text_id: "heading", text_type: "heading", heading_level: 4 }],
       { allowNonHeadingFontSizes: true },
     )).toContainEqual(expect.stringContaining("font-size utility"))
+  })
+})
+
+describe("validateRetainedHeadingHierarchy", () => {
+  const directHeading = `<section><h2 class="adt-h2" data-id="section-title">Section title</h2></section>`
+  const splitHeading = `<section><h2 class="adt-h2"><span data-id="split-title">Split title</span></h2></section>`
+
+  it("preserves direct and descendant heading IDs through visual edits", () => {
+    expect(validateRetainedHeadingHierarchy(
+      directHeading,
+      `<section class="bg-slate-50"><h2 class="adt-h2 text-blue-700 mt-4" data-id="section-title">Section title</h2></section>`,
+    )).toEqual([])
+    expect(validateRetainedHeadingHierarchy(splitHeading, splitHeading)).toEqual([])
+  })
+
+  it.each([
+    {
+      name: "a generic element",
+      edited: `<section><div class="text-4xl" data-id="section-title">Section title</div></section>`,
+      expected: "semantic <h1> through <h6>",
+    },
+    {
+      name: "a different tag/class pairing",
+      edited: `<section><h3 class="adt-h2" data-id="section-title">Section title</h3></section>`,
+      expected: `<h2 class="adt-h2">`,
+    },
+    {
+      name: "a font-size utility",
+      edited: `<section><h2 class="adt-h2 text-4xl" data-id="section-title">Section title</h2></section>`,
+      expected: "font-size utility",
+    },
+    {
+      name: "an inline font override",
+      edited: `<section><h2 class="adt-h2" style="font: 2rem sans-serif" data-id="section-title">Section title</h2></section>`,
+      expected: "inline font/font-size",
+    },
+  ])("rejects a retained heading changed to $name", ({ edited, expected }) => {
+    const errors = validateRetainedHeadingHierarchy(directHeading, edited)
+    expect(errors).toContainEqual(expect.stringContaining(expected))
+    expect(errors).toContainEqual(expect.stringContaining("Change heading rank in Sectioning"))
+  })
+
+  it("allows intentional removal of the heading element", () => {
+    expect(validateRetainedHeadingHierarchy(
+      directHeading,
+      `<section><p data-id="body">Remaining text</p></section>`,
+    )).toEqual([])
+  })
+
+  it("allows non-heading activity control sizes", () => {
+    expect(validateRetainedHeadingHierarchy(
+      directHeading,
+      `<section><h2 class="adt-h2" data-id="section-title">Section title</h2><button class="text-sm">Choice</button></section>`,
+    )).toEqual([])
   })
 })

--- a/packages/pipeline/src/__tests__/validate-typography-hierarchy.test.ts
+++ b/packages/pipeline/src/__tests__/validate-typography-hierarchy.test.ts
@@ -109,12 +109,17 @@ describe("validateRetainedHeadingHierarchy", () => {
     {
       name: "a generic element",
       edited: `<section><div class="text-4xl" data-id="section-title">Section title</div></section>`,
-      expected: "semantic <h1> through <h6>",
+      expected: "semantic <h2>",
     },
     {
       name: "a different tag/class pairing",
       edited: `<section><h3 class="adt-h2" data-id="section-title">Section title</h3></section>`,
-      expected: `<h2 class="adt-h2">`,
+      expected: "must remain <h2>",
+    },
+    {
+      name: "a removed type-scale class",
+      edited: `<section><h2 class="font-bold" data-id="section-title">Section title</h2></section>`,
+      expected: "adt-h2",
     },
     {
       name: "a font-size utility",
@@ -144,5 +149,49 @@ describe("validateRetainedHeadingHierarchy", () => {
       directHeading,
       `<section><h2 class="adt-h2" data-id="section-title">Section title</h2><button class="text-sm">Choice</button></section>`,
     )).toEqual([])
+  })
+
+  it("ignores font sizing outside the retained heading subtree", () => {
+    expect(validateRetainedHeadingHierarchy(
+      directHeading,
+      `<style>.activity-control { font-size: 0.875rem }</style><section class="text-sm"><h2 class="adt-h2" data-id="section-title">Section title</h2><button class="activity-control text-sm">Choice</button></section>`,
+    )).toEqual([])
+  })
+
+  it("keeps legacy headings editable without forcing a typography migration", () => {
+    const legacyHeading = `<section><h1 class="text-5xl font-bold" data-id="legacy-title">Legacy title</h1></section>`
+
+    expect(validateRetainedHeadingHierarchy(
+      legacyHeading,
+      `<section class="bg-blue-50"><h1 class="text-5xl font-bold" data-id="legacy-title">Legacy title</h1></section>`,
+    )).toEqual([])
+    expect(validateRetainedHeadingHierarchy(
+      legacyHeading,
+      `<section><h1 class="adt-h1 font-bold" data-id="legacy-title">Legacy title</h1></section>`,
+    )).toEqual([])
+  })
+
+  it("still preserves legacy semantic rank and rejects conflicting hierarchy classes", () => {
+    const legacyHeading = `<section><h1 class="text-5xl font-bold" data-id="legacy-title">Legacy title</h1></section>`
+
+    expect(validateRetainedHeadingHierarchy(
+      legacyHeading,
+      `<section><h2 class="text-5xl font-bold" data-id="legacy-title">Legacy title</h2></section>`,
+    )).toContainEqual(expect.stringContaining("must remain <h1>"))
+    expect(validateRetainedHeadingHierarchy(
+      legacyHeading,
+      `<section><h1 class="adt-h2 font-bold" data-id="legacy-title">Legacy title</h1></section>`,
+    )).toContainEqual(expect.stringContaining("different level"))
+  })
+
+  it("rejects size overrides on descendants of a current heading", () => {
+    expect(validateRetainedHeadingHierarchy(
+      directHeading,
+      `<section><h2 class="adt-h2" data-id="section-title"><span class="text-xl">Section title</span></h2></section>`,
+    )).toContainEqual(expect.stringContaining("font-size utility"))
+    expect(validateRetainedHeadingHierarchy(
+      directHeading,
+      `<section><h2 class="adt-h2" data-id="section-title"><style>.word { font-size: 2rem }</style>Section title</h2></section>`,
+    )).toContainEqual(expect.stringContaining("nested <style>"))
   })
 })

--- a/packages/pipeline/src/__tests__/web-rendering-prompts.test.ts
+++ b/packages/pipeline/src/__tests__/web-rendering-prompts.test.ts
@@ -110,10 +110,10 @@ describe("web rendering reading-order prompts", () => {
     })
     const prompt = messages.map(messageText).join("\n")
 
-    expect(prompt).toContain("Heading roles are authoritative")
-    expect(prompt).toContain('`chapter_title` → semantic `<h1 class="adt-h1">`')
-    expect(prompt).toContain('`section_heading` → `<h2 class="adt-h2">`')
-    expect(prompt).toContain('`subheading` → `<h3 class="adt-h3">`')
+    expect(prompt).toContain("A supplied `heading_level=N` is authoritative")
+    expect(prompt).toContain('`chapter_title` as `<h1 class="adt-h1">`')
+    expect(prompt).toContain('`section_heading` as `<h2 class="adt-h2">`')
+    expect(prompt).toContain('`subheading` as `<h3 class="adt-h3">`')
   })
 
   for (const promptName of HTML_RENDER_PROMPTS) {
@@ -126,9 +126,11 @@ describe("web rendering reading-order prompts", () => {
 
       expect(prompt).toContain("## BOOK-WIDE HEADING HIERARCHY")
       expect(prompt).toContain('chapter_title` as `<h1 class="adt-h1">')
-      expect(prompt).toContain("Never apply `text-*` or inline `font-size` overrides to a heading")
+      expect(prompt).toContain("Never apply `text-*` or inline `font`/`font-size` overrides to a heading")
 
-      for (const match of prompt.matchAll(/<h([1-6])\b[^>]*class="([^"]*)"/g)) {
+      const headingExamples = [...prompt.matchAll(/<h([1-6])\b[^>]*class="([^"]*)"/g)]
+      expect(headingExamples.map((match) => match[1])).toEqual(["1", "2", "3"])
+      for (const match of headingExamples) {
         const [, level, classNames] = match
         const classes = classNames.split(/\s+/)
         expect(classes, match[0]).toContain(`adt-h${level}`)
@@ -151,9 +153,42 @@ describe("web rendering reading-order prompts", () => {
     const prompt = messages.map(messageText).join("\n")
 
     expect(prompt).toContain("must keep the same native `<h1>` through `<h6>` tag")
-    expect(prompt).toContain("matching `adt-h1` through `adt-h6` class")
+    expect(prompt).toContain("already uses the matching `adt-h1` through `adt-h6` class")
+    expect(prompt).toContain("Do not migrate or otherwise rewrite that legacy typography")
     expect(prompt).toContain("must make the hierarchy change in Sectioning")
     expect(prompt).toContain("Intentional removal of the entire heading remains allowed")
+  })
+
+  it("keeps styleguide and visual-review prompts subordinate to outline typography", async () => {
+    const [styleguideMessages, reviewMessages, flexibleMessages] = await Promise.all([
+      promptEngine.renderPrompt("styleguide_generation", {
+        page_images: [],
+        book_fonts: [],
+        typography: [{ className: "adt-h4", label: "Heading level 4", mobilePx: 19, desktopPx: 28 }],
+      }),
+      promptEngine.renderPrompt("visual_review", {
+        nodes,
+        section_type: "text_only",
+        has_merged_content: false,
+        viewports: [{ label: "Desktop", width: 1280, tailwind_prefix: "" }],
+      }),
+      promptEngine.renderPrompt("visual_review_flexible", {
+        nodes,
+        section_type: "text_only",
+        has_merged_content: false,
+        user_instructions: "Change the background",
+        viewports: [{ label: "Desktop", width: 1280, tailwind_prefix: "" }],
+      }),
+    ])
+    const styleguidePrompt = styleguideMessages.map(messageText).join("\n")
+    const reviewPrompt = reviewMessages.map(messageText).join("\n")
+    const flexiblePrompt = flexibleMessages.map(messageText).join("\n")
+
+    expect(styleguidePrompt).toContain("do not assign every activity title to H2")
+    expect(styleguidePrompt).toContain("selected later from the authoritative outline")
+    expect(reviewPrompt).toContain("`adt-h1` through `adt-h6`")
+    expect(flexiblePrompt).toContain("existing semantic `adt-*` type-scale classes and heading ranks remain fixed")
+    expect(flexiblePrompt).toContain("Never add a `text-*` size utility")
   })
 
   it("requires right-aligned page numbers and dotted leaders for TOC pages", async () => {

--- a/packages/pipeline/src/__tests__/web-rendering-prompts.test.ts
+++ b/packages/pipeline/src/__tests__/web-rendering-prompts.test.ts
@@ -22,6 +22,23 @@ const nodes = [
   },
 ]
 
+const HTML_RENDER_PROMPTS = [
+  "web_generation_html",
+  "web_generation_html_overlay",
+  "activity_multiple_choice",
+  "activity_multi_select",
+  "activity_underline_text",
+  "activity_true_false",
+  "activity_fill_in_the_blank",
+  "activity_fill_in_a_table",
+  "activity_matching",
+  "activity_sorting",
+  "activity_ordering",
+  "activity_open_ended_answer",
+] as const
+
+const FONT_SIZE_UTILITY_RE = /^(?:[a-z-]+:)*!?text-(?:xs|sm|base|lg|xl|[2-9]xl|\[)/
+
 function messageText(message: Message | undefined): string {
   if (!message) return ""
   if (typeof message.content === "string") return message.content
@@ -97,6 +114,46 @@ describe("web rendering reading-order prompts", () => {
     expect(prompt).toContain('`chapter_title` → semantic `<h1 class="adt-h1">`')
     expect(prompt).toContain('`section_heading` → `<h2 class="adt-h2">`')
     expect(prompt).toContain('`subheading` → `<h3 class="adt-h3">`')
+  })
+
+  for (const promptName of HTML_RENDER_PROMPTS) {
+    it(`${promptName} receives consistent book-wide heading rules`, async () => {
+      const messages = await promptEngine.renderPrompt(
+        promptName,
+        generationContext(),
+      )
+      const prompt = messages.map(messageText).join("\n")
+
+      expect(prompt).toContain("## BOOK-WIDE HEADING HIERARCHY")
+      expect(prompt).toContain('chapter_title` as `<h1 class="adt-h1">')
+      expect(prompt).toContain("Never apply `text-*` or inline `font-size` overrides to a heading")
+
+      for (const match of prompt.matchAll(/<h([1-6])\b[^>]*class="([^"]*)"/g)) {
+        const [, level, classNames] = match
+        const classes = classNames.split(/\s+/)
+        expect(classes, match[0]).toContain(`adt-h${level}`)
+        expect(classes.some((className) => FONT_SIZE_UTILITY_RE.test(className)), match[0]).toBe(false)
+      }
+
+      expect(prompt).not.toMatch(
+        /(?:heading|title)[^\n]*\b(?:[a-z-]+:)*!?text-(?:xs|sm|base|lg|xl|[2-9]xl|\[)/i,
+      )
+    })
+  }
+
+  it("requires AI edits to preserve retained heading semantics", async () => {
+    const messages = await promptEngine.renderPrompt("html_edit", {
+      instruction: "Change the background color",
+      current_html: `<section><h2 class="adt-h2" data-id="title">Title</h2></section>`,
+      screenshots: [],
+      previous_attempt_failure: "",
+    })
+    const prompt = messages.map(messageText).join("\n")
+
+    expect(prompt).toContain("must keep the same native `<h1>` through `<h6>` tag")
+    expect(prompt).toContain("matching `adt-h1` through `adt-h6` class")
+    expect(prompt).toContain("must make the hierarchy change in Sectioning")
+    expect(prompt).toContain("Intentional removal of the entire heading remains allowed")
   })
 
   it("requires right-aligned page numbers and dotted leaders for TOC pages", async () => {

--- a/packages/pipeline/src/book-outline-evidence.ts
+++ b/packages/pipeline/src/book-outline-evidence.ts
@@ -34,20 +34,37 @@ export interface BookOutlineProofSheet {
   imageBase64: string
 }
 
+/**
+ * Compact evidence-only hierarchy recovered from table-of-contents rows.
+ * These rows guide matching in-book headings but are never outline entries.
+ */
+export interface TocHierarchyEntryEvidence {
+  tocPageId: string
+  tocPageNumber: number
+  title: string
+  suggestedLevel: number
+  indentRatio: number | null
+  confidence: number
+}
+
 export interface BookOutlineEvidence {
   pages: Array<{ pageId: string; pageNumber: number; text: string }>
   candidates: HeadingCandidateEvidence[]
+  tocHierarchy: TocHierarchyEntryEvidence[]
   proofSheets: BookOutlineProofSheet[]
   typeScale: TypeScale | null
 }
 
 /** Keep each page's prompt contribution bounded without discarding both ends. */
 export const BOOK_OUTLINE_MAX_PAGE_TEXT_CHARS = 12_000
+/** Positioned candidates already carry the page's useful text and typography. */
+export const BOOK_OUTLINE_MAX_POSITIONED_PAGE_TEXT_CHARS = 600
+export const BOOK_OUTLINE_MAX_CANDIDATES_PER_PAGE = 16
 
-function boundedPageText(text: string): string {
-  if (text.length <= BOOK_OUTLINE_MAX_PAGE_TEXT_CHARS) return text
+function boundedPageText(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text
   const marker = "\n\n[... middle of page text omitted for outline input ...]\n\n"
-  const available = BOOK_OUTLINE_MAX_PAGE_TEXT_CHARS - marker.length
+  const available = maxChars - marker.length
   const leading = Math.ceil(available / 2)
   const trailing = Math.floor(available / 2)
   return `${text.slice(0, leading)}${marker}${text.slice(-trailing)}`
@@ -67,6 +84,19 @@ interface GroupedParagraph {
   order: number
 }
 
+interface RankedParagraph {
+  group: GroupedParagraph
+  text: string
+  likelihood: number
+}
+
+interface RawTocHierarchyEntry {
+  tocPageId: string
+  tocPageNumber: number
+  title: string
+  indentRatio: number | null
+}
+
 function parseCssNumber(value: string | undefined): number | null {
   if (!value) return null
   if (value.trim().toLowerCase() === "bold") return 700
@@ -78,11 +108,82 @@ function normalizedText(value: string): string {
   return value.replace(/\s+/g, " ").trim()
 }
 
+function rounded(value: number | null, digits: number): number | null {
+  if (value === null) return null
+  const factor = 10 ** digits
+  return Math.round(value * factor) / factor
+}
+
 function isMostlyUppercase(text: string): boolean {
   const letters = [...text].filter((char) => char.toLocaleLowerCase() !== char.toLocaleUpperCase())
   if (letters.length < 3) return false
   const uppercase = letters.filter((char) => char === char.toLocaleUpperCase()).length
   return uppercase / letters.length >= 0.8
+}
+
+function parseTocRow(text: string): string | null {
+  const match = text.match(/^(.*?)\s*\.{4,}\s*(?:(?:\d{1,4}|[ivxlcdm]{1,8})\s*)?$/i)
+  const title = match?.[1]?.replace(/\s+/g, " ").trim() ?? ""
+  return title.length > 0 ? title : null
+}
+
+function normalizedTocIndentBands(entries: RawTocHierarchyEntry[]): number[] {
+  const indents = [...new Set(
+    entries.flatMap((entry) => entry.indentRatio === null ? [] : [entry.indentRatio]),
+  )].sort((a, b) => a - b)
+  if (indents.length === 0) return []
+
+  // Treat a large horizontal jump as a new TOC column rather than a deeper
+  // hierarchy level, then compare indentation within each column.
+  const bandStarts: number[] = [indents[0]]
+  for (let index = 1; index < indents.length; index++) {
+    if (indents[index] - indents[index - 1] > 0.2) {
+      bandStarts.push(indents[index])
+    }
+  }
+  return entries.map((entry) => {
+    if (entry.indentRatio === null) return Number.NaN
+    const bandStart = [...bandStarts]
+      .reverse()
+      .find((start) => start <= entry.indentRatio!) ?? bandStarts[0]
+    return rounded(entry.indentRatio - bandStart, 3) ?? 0
+  })
+}
+
+function buildTocHierarchy(rawEntries: RawTocHierarchyEntry[]): TocHierarchyEntryEvidence[] {
+  const normalizedIndents = normalizedTocIndentBands(rawEntries)
+  const clusters: number[] = []
+  for (const indent of [...normalizedIndents].filter(Number.isFinite).sort((a, b) => a - b)) {
+    const current = clusters.at(-1)
+    if (current === undefined || indent - current > 0.025) {
+      clusters.push(indent)
+    }
+  }
+
+  return rawEntries.map((entry, index) => {
+    const indent = normalizedIndents[index]
+    const clusterIndex = Number.isFinite(indent)
+      ? clusters.reduce(
+          (best, candidate, candidateIndex) =>
+            Math.abs(candidate - indent) < Math.abs(clusters[best] - indent)
+              ? candidateIndex
+              : best,
+          0,
+        )
+      : 0
+    return {
+      ...entry,
+      suggestedLevel: Math.min(6, clusterIndex + 1),
+      // Multiple indentation bands make the relationship authoritative enough
+      // for deterministic matching. Flat/OCR-only TOCs remain prompt guidance.
+      confidence: clusters.length > 1 && Number.isFinite(indent) ? 0.98 : 0.45,
+    }
+  })
+}
+
+interface BuiltHeadingEvidence {
+  candidates: HeadingCandidateEvidence[]
+  tocHierarchy: TocHierarchyEntryEvidence[]
 }
 
 /**
@@ -92,12 +193,13 @@ function isMostlyUppercase(text: string): boolean {
  * decided are headings. OCR-only pages retain every line because no local
  * typography signal can safely rank one above another.
  */
-export function buildHeadingCandidates(
+function buildHeadingEvidence(
   pages: BookOutlineEvidencePage[],
   typeScale: TypeScale | null,
-  maxPerPage = 40,
-): HeadingCandidateEvidence[] {
+  maxPerPage = BOOK_OUTLINE_MAX_CANDIDATES_PER_PAGE,
+): BuiltHeadingEvidence {
   const output: HeadingCandidateEvidence[] = []
+  const rawTocHierarchy: RawTocHierarchyEntry[] = []
 
   for (const page of pages) {
     const positioned = page.positionedText
@@ -173,7 +275,7 @@ export function buildHeadingCandidates(
     }
 
     const bodyPx = typeScale?.bodyPx ?? null
-    const ranked = [...groups.values()].map((group) => {
+    const allRanked: RankedParagraph[] = [...groups.values()].map((group) => {
       const text = normalizedText(group.text.join(" "))
       const ratio = bodyPx && group.maxFontSize ? group.maxFontSize / bodyPx : null
       let likelihood = 0
@@ -185,6 +287,38 @@ export function buildHeadingCandidates(
       if (positioned && group.top / Math.max(1, positioned.pageHeight) <= 0.2) likelihood += 0.3
       if (text.length > 220) likelihood -= 1
       return { group, text, likelihood }
+    })
+
+    // A TOC's navigation rows are links/list items, not headings in the
+    // document's semantic outline. They also dominate candidate and output
+    // tokens on textbook front matter. Long dot leaders are a strong,
+    // language-independent signal; once a page has several, discard their
+    // separate terminal page-number blocks too. Keep the page's own heading
+    // (for example "Contents" / "Sumário").
+    const hasDotLeader = (text: string) => /\.{4,}/.test(text)
+    const likelyTableOfContents =
+      allRanked.filter(({ text }) => hasDotLeader(text)).length >= 3
+    if (likelyTableOfContents) {
+      for (const { group, text } of allRanked) {
+        const title = parseTocRow(text)
+        if (!title) continue
+        rawTocHierarchy.push({
+          tocPageId: page.pageId,
+          tocPageNumber: page.pageNumber,
+          title,
+          indentRatio: positioned
+            ? rounded(group.left / Math.max(1, positioned.pageWidth), 3)
+            : null,
+        })
+      }
+    }
+    const ranked = allRanked.filter(({ text }) => {
+      if (hasDotLeader(text)) return false
+      if (
+        likelyTableOfContents &&
+        /^(?:\d{1,4}|[ivxlcdm]{1,8})$/i.test(text.trim())
+      ) return false
+      return true
     })
 
     // Keep the strongest blocks when a page is unusually dense, then restore
@@ -202,25 +336,49 @@ export function buildHeadingCandidates(
         pageNumber: page.pageNumber,
         text,
         sourceTextIds: group.textIds,
-        fontSizePx: group.maxFontSize,
-        fontWeight: group.maxFontWeight,
+        fontSizePx: rounded(group.maxFontSize, 2),
+        fontWeight: rounded(group.maxFontWeight, 0),
         fontFamily: group.fontFamily,
         color: group.color,
-        topRatio: positioned ? group.top / Math.max(1, positioned.pageHeight) : null,
-        leftRatio: positioned ? group.left / Math.max(1, positioned.pageWidth) : null,
+        topRatio: positioned
+          ? rounded(group.top / Math.max(1, positioned.pageHeight), 3)
+          : null,
+        leftRatio: positioned
+          ? rounded(group.left / Math.max(1, positioned.pageWidth), 3)
+          : null,
         widthRatio:
           positioned && group.width !== null
-            ? group.width / Math.max(1, positioned.pageWidth)
+            ? rounded(group.width / Math.max(1, positioned.pageWidth), 3)
             : null,
         centered: group.centered,
         sizeToBodyRatio:
-          bodyPx && group.maxFontSize ? group.maxFontSize / bodyPx : null,
+          bodyPx && group.maxFontSize
+            ? rounded(group.maxFontSize / bodyPx, 3)
+            : null,
         headingLikelihood: Math.round(Math.max(0, likelihood) * 100) / 100,
       })
     })
   }
 
-  return output
+  return {
+    candidates: output,
+    tocHierarchy: buildTocHierarchy(rawTocHierarchy),
+  }
+}
+
+export function buildHeadingCandidates(
+  pages: BookOutlineEvidencePage[],
+  typeScale: TypeScale | null,
+  maxPerPage = BOOK_OUTLINE_MAX_CANDIDATES_PER_PAGE,
+): HeadingCandidateEvidence[] {
+  return buildHeadingEvidence(pages, typeScale, maxPerPage).candidates
+}
+
+export function buildTocHierarchyEvidence(
+  pages: BookOutlineEvidencePage[],
+  typeScale: TypeScale | null,
+): TocHierarchyEntryEvidence[] {
+  return buildHeadingEvidence(pages, typeScale).tocHierarchy
 }
 
 function resizeInto(
@@ -263,17 +421,18 @@ export function buildProofSheets(
   } = {},
 ): BookOutlineProofSheet[] {
   const columns = options.columns ?? 4
-  const rows = options.rows ?? 4
-  const cellWidth = options.cellWidth ?? 300
-  const cellHeight = options.cellHeight ?? 400
+  const rows = options.rows ?? 6
+  const cellWidth = options.cellWidth ?? 240
+  const cellHeight = options.cellHeight ?? 320
   const gap = options.gap ?? 8
   const perSheet = columns * rows
   const sheets: BookOutlineProofSheet[] = []
 
   for (let start = 0; start < pages.length; start += perSheet) {
     const chunk = pages.slice(start, start + perSheet)
+    const usedRows = Math.max(1, Math.ceil(chunk.length / columns))
     const width = columns * cellWidth + (columns + 1) * gap
-    const height = rows * cellHeight + (rows + 1) * gap
+    const height = usedRows * cellHeight + (usedRows + 1) * gap
     const sheet = new PNG({ width, height, fill: true })
     sheet.data.fill(255)
 
@@ -306,13 +465,20 @@ export function buildBookOutlineEvidence(
   pages: BookOutlineEvidencePage[],
   typeScale: TypeScale | null,
 ): BookOutlineEvidence {
+  const headingEvidence = buildHeadingEvidence(pages, typeScale)
   return {
-    pages: pages.map(({ pageId, pageNumber, text }) => ({
+    pages: pages.map(({ pageId, pageNumber, text, positionedText }) => ({
       pageId,
       pageNumber,
-      text: boundedPageText(text),
+      text: boundedPageText(
+        text,
+        positionedText
+          ? BOOK_OUTLINE_MAX_POSITIONED_PAGE_TEXT_CHARS
+          : BOOK_OUTLINE_MAX_PAGE_TEXT_CHARS,
+      ),
     })),
-    candidates: buildHeadingCandidates(pages, typeScale),
+    candidates: headingEvidence.candidates,
+    tocHierarchy: headingEvidence.tocHierarchy,
     proofSheets: buildProofSheets(pages),
     typeScale,
   }

--- a/packages/pipeline/src/book-outline.ts
+++ b/packages/pipeline/src/book-outline.ts
@@ -1,5 +1,6 @@
 import {
   BookOutlineOutput,
+  BookOutlineProposalOutput,
   DEFAULT_LLM_MAX_RETRIES,
   DEFAULT_LLM_MODEL_ID,
   type AppConfig,
@@ -12,11 +13,12 @@ import type { BookOutlineEvidence } from "./book-outline-evidence.js"
 
 export const BOOK_OUTLINE_NODE = "book-outline"
 export const BOOK_OUTLINE_ITEM = "book"
-export const BOOK_OUTLINE_CHUNK_PAGE_LIMIT = 16
+export const BOOK_OUTLINE_CHUNK_PAGE_LIMIT = 24
 
 const BOOK_OUTLINE_CHUNK_PROMPT = "book_outline_chunk"
 const BOOK_OUTLINE_SYNTHESIS_PROMPT = "book_outline_synthesis"
 const BOOK_OUTLINE_CHUNK_MAX_TOKENS = 16_384
+const DEFAULT_OPENAI_BOOK_OUTLINE_MODEL_ID = "openai:gpt-5.4-mini"
 
 export interface BookOutlineConfig {
   promptName: string
@@ -33,12 +35,190 @@ export interface PageOutlineContext {
 
 export function buildBookOutlineConfig(appConfig: AppConfig): BookOutlineConfig {
   const config = appConfig.book_outline
+  const inheritedModel = appConfig.default_model ?? DEFAULT_LLM_MODEL_ID
   return {
     promptName: config?.prompt ?? "book_outline",
-    modelId: config?.model ?? appConfig.default_model ?? DEFAULT_LLM_MODEL_ID,
+    // Whole-book hierarchy is a bounded classification/extraction task, not a
+    // frontier-model task. Keep non-OpenAI selections intact, but use the fast
+    // multimodal mini variant for the shipped OpenAI default. A per-step model
+    // override remains authoritative when a book genuinely needs the full model.
+    modelId: config?.model ?? (
+      inheritedModel === DEFAULT_LLM_MODEL_ID
+        ? DEFAULT_OPENAI_BOOK_OUTLINE_MODEL_ID
+        : inheritedModel
+    ),
     maxRetries: config?.max_retries ?? DEFAULT_LLM_MAX_RETRIES,
     timeoutMs: (config?.timeout ?? 300) * 1000,
   }
+}
+
+function outlineIdForIndex(index: number): string {
+  return `outline-${String(index + 1).padStart(3, "0")}`
+}
+
+function normalizedHeadingKey(value: string): string {
+  return value
+    .normalize("NFKD")
+    .replace(/\p{M}/gu, "")
+    .toLocaleLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+}
+
+function headingKeyVariants(value: string): Set<string> {
+  const normalized = normalizedHeadingKey(value)
+  const variants = new Set([normalized])
+  // Match a TOC row such as "CAPÍTULO 1 Experiências..." to the visible
+  // chapter opener "EXPERIÊNCIAS..." without depending on one language.
+  variants.add(
+    normalized.replace(
+      /^[\p{L}]+\s+(?:\d+|[ivxlcdm]+)\s+/u,
+      "",
+    ),
+  )
+  variants.add(normalized.replace(/^(?:\d+|[ivxlcdm]+)\s+/u, ""))
+  variants.delete("")
+  return variants
+}
+
+function tocLevelForTitle(title: string, evidence: BookOutlineEvidence): number | null {
+  const titleKeys = headingKeyVariants(title)
+  const matchingLevels = new Set(
+    evidence.tocHierarchy
+      .filter((entry) => entry.confidence >= 0.9)
+      .filter((entry) => {
+        const tocKeys = headingKeyVariants(entry.title)
+        return [...titleKeys].some((key) => tocKeys.has(key))
+      })
+      .map((entry) => entry.suggestedLevel),
+  )
+  return matchingLevels.size === 1 ? [...matchingLevels][0] : null
+}
+
+function proposalToOutline(
+  proposal: BookOutlineProposalOutput,
+  evidence: BookOutlineEvidence,
+): { outline: BookOutlineOutput | null; errors: string[] } {
+  const errors: string[] = []
+  const candidates = new Map(
+    evidence.candidates.map((candidate) => [candidate.candidateId, candidate]),
+  )
+  const candidateOrder = new Map(
+    evidence.candidates.map((candidate, index) => [candidate.candidateId, index]),
+  )
+  const entries: BookOutlineEntry[] = []
+  let adjustedTocLevels = 0
+
+  proposal.entries.forEach((entry, index) => {
+    const sourceCandidates = entry.sourceCandidateIds.flatMap((candidateId) => {
+      const candidate = candidates.get(candidateId)
+      if (!candidate) {
+        errors.push(
+          `Outline proposal entry ${index} references unknown candidate "${candidateId}".`,
+        )
+        return []
+      }
+      return [candidate]
+    })
+    if (sourceCandidates.length !== entry.sourceCandidateIds.length) return
+
+    const first = sourceCandidates[0]
+    if (sourceCandidates.some((candidate) => candidate.pageId !== first.pageId)) {
+      errors.push(`Outline proposal entry ${index} combines candidates from different pages.`)
+      return
+    }
+    const title = sourceCandidates
+      .sort(
+        (a, b) =>
+          (candidateOrder.get(a.candidateId) ?? 0) -
+          (candidateOrder.get(b.candidateId) ?? 0),
+      )
+      .map((candidate) => candidate.text)
+      .join(" ")
+      .replace(/\s+/g, " ")
+      .trim()
+    const tocLevel = tocLevelForTitle(title, evidence)
+    const level = tocLevel ?? entry.level
+    if (tocLevel !== null && tocLevel !== entry.level) adjustedTocLevels++
+
+    let parentId: string | null = null
+    for (let previous = entries.length - 1; previous >= 0; previous--) {
+      if (entries[previous].level < level) {
+        parentId = entries[previous].outlineId
+        break
+      }
+    }
+
+    entries.push({
+      outlineId: outlineIdForIndex(index),
+      title,
+      level,
+      kind: entry.kind,
+      pageId: first.pageId,
+      pageNumber: first.pageNumber,
+      sourceCandidateIds: [...entry.sourceCandidateIds],
+      parentId,
+      styleClusterId: entry.styleClusterId,
+      confidence: entry.confidence,
+    })
+  })
+
+  if (errors.length > 0 || entries.length !== proposal.entries.length) {
+    return { outline: null, errors }
+  }
+  const tocNote = adjustedTocLevels > 0
+    ? ` Applied ${adjustedTocLevels} deterministic TOC hierarchy correction${adjustedTocLevels === 1 ? "" : "s"}.`
+    : ""
+  const reasoning = tocNote
+    ? `${proposal.reasoning.slice(0, Math.max(0, 600 - tocNote.length))}${tocNote}`
+    : proposal.reasoning.slice(0, 600)
+  return {
+    outline: {
+      reasoning,
+      entries,
+      styleClusters: proposal.styleClusters.map((cluster) => ({ ...cluster })),
+    },
+    errors: [],
+  }
+}
+
+function validateBookOutlineProposal(
+  raw: unknown,
+  evidence: BookOutlineEvidence,
+): ValidationResult {
+  const parsed = BookOutlineProposalOutput.safeParse(raw)
+  if (!parsed.success) {
+    return {
+      valid: false,
+      errors: parsed.error.issues.map((issue) => `${issue.path.join(".")}: ${issue.message}`),
+    }
+  }
+  const converted = proposalToOutline(parsed.data, evidence)
+  if (!converted.outline) return { valid: false, errors: converted.errors }
+
+  // Deterministic cleanup is applied again after generation. At validation
+  // time only its validity matters; the compact proposal remains the model's
+  // response and the stored entity is the expanded authoritative outline.
+  const validation = validateBookOutline(converted.outline, evidence)
+  return validation.valid
+    ? { valid: true, errors: [] }
+    : validation
+}
+
+function finalizeBookOutlineProposal(
+  proposal: BookOutlineProposalOutput,
+  evidence: BookOutlineEvidence,
+): BookOutlineOutput {
+  const converted = proposalToOutline(proposal, evidence)
+  if (!converted.outline) {
+    throw new Error(`Invalid book outline proposal: ${converted.errors.join(" ")}`)
+  }
+  const validation = validateBookOutline(converted.outline, evidence)
+  if (!validation.valid) {
+    throw new Error(`Invalid expanded book outline: ${validation.errors.join(" ")}`)
+  }
+  return (validation.cleaned as BookOutlineOutput | undefined) ?? converted.outline
 }
 
 function validateBookOutline(
@@ -54,7 +234,12 @@ function validateBookOutline(
   }
 
   const errors: string[] = []
-  const output = parsed.data
+  let cleaned = false
+  const output: BookOutlineOutput = {
+    ...parsed.data,
+    entries: parsed.data.entries.map((entry) => ({ ...entry })),
+    styleClusters: parsed.data.styleClusters.map((cluster) => ({ ...cluster })),
+  }
   const pages = new Map(evidence.pages.map((page) => [page.pageId, page]))
   const candidates = new Map(evidence.candidates.map((candidate) => [candidate.candidateId, candidate]))
   const candidateOrder = new Map(
@@ -70,6 +255,55 @@ function validateBookOutline(
       errors.push(`Duplicate styleClusterId "${cluster.styleClusterId}".`)
     }
     clusters.set(cluster.styleClusterId, cluster)
+  }
+
+  // A cluster/entry level mismatch does not require another semantic pass.
+  // Preserve the model's hierarchy and split a reused visual style into one
+  // cluster per semantic level, which is exactly the representation the
+  // schema requires. If every use agrees on a level other than the cluster's
+  // declared level, simply correct the unused declaration.
+  if (clusters.size === output.styleClusters.length) {
+    const usedLevels = new Map<string, Set<number>>()
+    for (const entry of output.entries) {
+      if (!clusters.has(entry.styleClusterId)) continue
+      const levels = usedLevels.get(entry.styleClusterId) ?? new Set<number>()
+      levels.add(entry.level)
+      usedLevels.set(entry.styleClusterId, levels)
+    }
+
+    for (const [clusterId, levels] of usedLevels) {
+      const cluster = clusters.get(clusterId)!
+      if (!levels.has(cluster.level)) {
+        cluster.level = levels.values().next().value!
+        cleaned = true
+      }
+      if (levels.size === 1) {
+        const [usedLevel] = levels
+        cluster.level = usedLevel
+        continue
+      }
+
+      for (const level of levels) {
+        if (level === cluster.level) continue
+        const baseId = `${clusterId}-level-${level}`
+        let derivedId = baseId
+        let suffix = 2
+        while (clusters.has(derivedId)) derivedId = `${baseId}-${suffix++}`
+        const derived: BookOutlineStyleCluster = {
+          styleClusterId: derivedId,
+          description: `${cluster.description} (level ${level} variant)`,
+          level,
+        }
+        output.styleClusters.push(derived)
+        clusters.set(derivedId, derived)
+        for (const entry of output.entries) {
+          if (entry.styleClusterId === clusterId && entry.level === level) {
+            entry.styleClusterId = derivedId
+          }
+        }
+        cleaned = true
+      }
+    }
   }
 
   for (const entry of output.entries) {
@@ -120,10 +354,11 @@ function validateBookOutline(
         .replace(/\s+/g, " ")
         .trim()
       if (entry.title.replace(/\s+/g, " ").trim() !== visibleTitle) {
-        errors.push(
-          `Outline entry "${entry.outlineId}" title must exactly match its source candidates: ` +
-            `"${visibleTitle}".`,
-        )
+        // Candidate text is authoritative and this correction contains no
+        // semantic judgment. Repair it locally instead of paying for another
+        // complete multimodal outline call.
+        entry.title = visibleTitle
+        cleaned = true
       }
     }
 
@@ -157,13 +392,19 @@ function validateBookOutline(
     entryIds.add(entry.outlineId)
   }
 
-  return { valid: errors.length === 0, errors }
+  if (errors.length > 0) return { valid: false, errors }
+  return {
+    valid: true,
+    errors: [],
+    ...(cleaned && { cleaned: output }),
+  }
 }
 
 function promptContext(evidence: BookOutlineEvidence): Record<string, unknown> {
   return {
     pages: evidence.pages,
     candidates: evidence.candidates,
+    toc_hierarchy: evidence.tocHierarchy,
     proof_sheets: evidence.proofSheets.map((sheet) => ({
       sheet_id: sheet.sheetId,
       page_ids: sheet.pageIds,
@@ -182,7 +423,10 @@ function evidenceChunk(
   return {
     pages,
     candidates: evidence.candidates.filter((candidate) => pageIds.has(candidate.pageId)),
-    // Default proof sheets contain 16 pages, matching the chunk boundary. Keep
+    // The compact TOC is book-wide guidance. Every chunk needs it so later
+    // chapter pages retain the hierarchy established in the front matter.
+    tocHierarchy: evidence.tocHierarchy,
+    // Default proof sheets contain 24 pages, matching the chunk boundary. Keep
     // only sheets wholly represented by this request so visual evidence never
     // leaks in from a neighboring chunk.
     proofSheets: evidence.proofSheets.filter((sheet) =>
@@ -200,11 +444,11 @@ async function generateOutlinePass(
   taskType: string,
   maxTokens: number,
 ): Promise<BookOutlineOutput> {
-  const result = await llmModel.generateObject<BookOutlineOutput>({
-    schema: BookOutlineOutput,
+  const result = await llmModel.generateObject<BookOutlineProposalOutput>({
+    schema: BookOutlineProposalOutput,
     prompt,
     context: promptContext(evidence),
-    validate: (raw) => validateBookOutline(raw, evidence),
+    validate: (raw) => validateBookOutlineProposal(raw, evidence),
     maxRetries: config.maxRetries,
     maxTokens,
     timeoutMs: config.timeoutMs,
@@ -214,7 +458,7 @@ async function generateOutlinePass(
     },
   })
 
-  return result.object
+  return finalizeBookOutlineProposal(result.object, evidence)
 }
 
 /**
@@ -239,36 +483,57 @@ export async function generateBookOutline(
     )
   }
 
-  const chunks: Array<{
+  const chunkSpecs: Array<{
     chunkId: string
     pageNumbers: number[]
-    output: BookOutlineOutput
+    evidence: BookOutlineEvidence
   }> = []
 
   for (let start = 0; start < evidence.pages.length; start += BOOK_OUTLINE_CHUNK_PAGE_LIMIT) {
     const pages = evidence.pages.slice(start, start + BOOK_OUTLINE_CHUNK_PAGE_LIMIT)
     const chunk = evidenceChunk(evidence, pages)
-    const chunkNumber = chunks.length + 1
-    const prompt = config.promptName === "book_outline"
-      ? BOOK_OUTLINE_CHUNK_PROMPT
-      : config.promptName
-    const output = await generateOutlinePass(
-      chunk,
-      config,
-      llmModel,
-      prompt,
-      "book-outline",
-      BOOK_OUTLINE_CHUNK_MAX_TOKENS,
-    )
-    chunks.push({
+    const chunkNumber = chunkSpecs.length + 1
+    chunkSpecs.push({
       chunkId: `chunk-${String(chunkNumber).padStart(3, "0")}`,
       pageNumbers: pages.map((page) => page.pageNumber),
-      output,
+      evidence: chunk,
     })
   }
 
-  const result = await llmModel.generateObject<BookOutlineOutput>({
-    schema: BookOutlineOutput,
+  const chunks: Array<{
+    chunkId: string
+    pageNumbers: number[]
+    output: BookOutlineOutput
+  }> = []
+  const prompt = config.promptName === "book_outline"
+    ? BOOK_OUTLINE_CHUNK_PROMPT
+    : config.promptName
+
+  // Chunk calls are independent. A small bound cuts wall-clock time for long
+  // books without flooding the provider or making retry spikes unbounded.
+  for (let start = 0; start < chunkSpecs.length; start += 2) {
+    const batch = chunkSpecs.slice(start, start + 2)
+    const outputs = await Promise.all(batch.map((chunk) =>
+      generateOutlinePass(
+        chunk.evidence,
+        config,
+        llmModel,
+        prompt,
+        "book-outline",
+        BOOK_OUTLINE_CHUNK_MAX_TOKENS,
+      )
+    ))
+    batch.forEach((chunk, index) => {
+      chunks.push({
+        chunkId: chunk.chunkId,
+        pageNumbers: chunk.pageNumbers,
+        output: outputs[index],
+      })
+    })
+  }
+
+  const result = await llmModel.generateObject<BookOutlineProposalOutput>({
+    schema: BookOutlineProposalOutput,
     prompt: BOOK_OUTLINE_SYNTHESIS_PROMPT,
     context: {
       chunks: chunks.map((chunk) => ({
@@ -277,9 +542,10 @@ export async function generateBookOutline(
         entries: chunk.output.entries,
         style_clusters: chunk.output.styleClusters,
       })),
+      toc_hierarchy: evidence.tocHierarchy,
       type_scale: evidence.typeScale,
     },
-    validate: (raw) => validateBookOutline(raw, evidence),
+    validate: (raw) => validateBookOutlineProposal(raw, evidence),
     maxRetries: config.maxRetries,
     maxTokens: 32_768,
     timeoutMs: config.timeoutMs,
@@ -289,7 +555,7 @@ export async function generateBookOutline(
     },
   })
 
-  return result.object
+  return finalizeBookOutlineProposal(result.object, evidence)
 }
 
 export function readBookOutline(storage: Storage): BookOutlineOutput | null {

--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -175,6 +175,7 @@ export {
   type GenerateTocOptions,
 } from "./toc-generation.js"
 export { validateSectionHtml } from "./validate-html.js"
+export { validateRetainedHeadingHierarchy } from "./validate-typography-hierarchy.js"
 export {
   generateQuiz,
   generateAllQuizzes,

--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -79,11 +79,13 @@ export {
 export {
   buildBookOutlineEvidence,
   buildHeadingCandidates,
+  buildTocHierarchyEvidence,
   buildProofSheets,
   type BookOutlineEvidence,
   type BookOutlineEvidencePage,
   type HeadingCandidateEvidence,
   type BookOutlineProofSheet,
+  type TocHierarchyEntryEvidence,
 } from "./book-outline-evidence.js"
 export {
   renderPage,

--- a/packages/pipeline/src/validate-typography-hierarchy.ts
+++ b/packages/pipeline/src/validate-typography-hierarchy.ts
@@ -170,3 +170,56 @@ export function validateTypographyHierarchy(
 
   return [...new Set(errors)]
 }
+
+/**
+ * Preserve the semantic level of headings that survive an HTML edit.
+ *
+ * Heading data IDs may live on the heading itself or on descendants when a
+ * heading is split into styled spans. IDs intentionally removed by the edit
+ * are omitted from validation so the existing AI-edit deletion policy remains
+ * unchanged.
+ */
+export function validateRetainedHeadingHierarchy(
+  originalHtml: string,
+  editedHtml: string,
+): string[] {
+  const originalRoot = parseDocument(originalHtml) as unknown as HtmlNode
+  const editedRoot = parseDocument(editedHtml) as unknown as HtmlNode
+  const retainedHeadings: LeafText[] = []
+  const seenIds = new Set<string>()
+
+  walk(originalRoot, (node) => {
+    const level = /^h([1-6])$/.exec(node.name ?? "")?.[1]
+    if (!level) return
+
+    walk(node, (descendant) => {
+      const textId = descendant.attribs?.["data-id"]
+      if (
+        !textId ||
+        seenIds.has(textId) ||
+        closestHeading(descendant) !== node ||
+        !findByDataId(editedRoot, textId)
+      ) {
+        return
+      }
+      seenIds.add(textId)
+      retainedHeadings.push({
+        text_id: textId,
+        text_type: "heading",
+        heading_level: Number(level),
+      })
+    })
+  })
+
+  if (retainedHeadings.length === 0) return []
+
+  const errors = validateTypographyHierarchy(editedHtml, retainedHeadings, {
+    allowNonHeadingFontSizes: true,
+  })
+  if (errors.length === 0) return []
+
+  return [
+    ...errors,
+    "AI editing must preserve each retained heading's semantic tag and matching adt-h* class. Change heading rank in Sectioning instead.",
+  ]
+}

--- a/packages/pipeline/src/validate-typography-hierarchy.ts
+++ b/packages/pipeline/src/validate-typography-hierarchy.ts
@@ -1,4 +1,5 @@
 import { parseDocument } from "htmlparser2"
+import { headingLevelForRole } from "@adt/types"
 
 interface HtmlNode {
   name?: string
@@ -13,12 +14,6 @@ interface LeafText {
   text_type: string
   heading_level?: number
 }
-
-const ROLE_HEADING_LEVEL = {
-  chapter_title: 1,
-  section_heading: 2,
-  subheading: 3,
-} as const
 
 const STANDARD_TEXT_SIZE_RE = /^text-(?:xs|sm|base|lg|xl|[2-9]xl)$/
 const ARBITRARY_TEXT_SIZE_RE = /^(?:length:|(?:calc|clamp|min|max|var)\(|-?(?:\d|\.\d)|.*(?:px|r?em|vw|vh|vmin|vmax|ch|ex|%).*|(?:xx?-small|small|medium|large|x-large|xx-large|xxx-large|smaller|larger)|.*font-?size.*)$/i
@@ -84,6 +79,38 @@ function hasClass(node: HtmlNode, className: string): boolean {
   return (node.attribs?.class?.split(/\s+/) ?? []).includes(className)
 }
 
+function headingSubtreeErrors(heading: HtmlNode, expectedLevel: number): string[] {
+  const expectedClass = `adt-h${expectedLevel}`
+  const errors: string[] = []
+  const scaleClasses = headingClasses(heading)
+
+  if (!hasClass(heading, expectedClass) || scaleClasses.length !== 1) {
+    errors.push(`Retained <h${expectedLevel}> must keep exactly one matching "${expectedClass}" class.`)
+  }
+
+  walk(heading, (node) => {
+    const classes = node.attribs?.class ?? ""
+    if (node !== heading && headingClasses(node).length > 0) {
+      errors.push("Book-wide adt-h* typography classes may only appear on the semantic heading element.")
+    }
+    if (classes.split(/\s+/).some(isFontSizeUtility)) {
+      errors.push(`Retained headings must not use a font-size utility: "${classes}".`)
+    }
+    if (/(?:^|;)\s*font(?:-size)?\s*:/i.test(node.attribs?.style ?? "")) {
+      errors.push("Retained headings must not use inline font/font-size; use the book-wide adt-h* class.")
+    }
+    if (node.name === "style" && /\bfont(?:-size)?\s*:/i.test(textContent(node))) {
+      errors.push("Retained headings must not define font/font-size rules in a nested <style> block.")
+    }
+  })
+
+  return [...new Set(errors)]
+}
+
+function hasStrictHeadingTypography(heading: HtmlNode, level: number): boolean {
+  return headingSubtreeErrors(heading, level).length === 0
+}
+
 export interface TypographyHierarchyOptions {
   /** Activity/overlay controls may size non-heading UI text independently. */
   allowNonHeadingFontSizes?: boolean
@@ -125,8 +152,7 @@ export function validateTypographyHierarchy(
   })
 
   for (const leaf of leafTexts) {
-    const roleLevel =
-      ROLE_HEADING_LEVEL[leaf.text_type as keyof typeof ROLE_HEADING_LEVEL]
+    const roleLevel = headingLevelForRole(leaf.text_type)
     const expectedLevel = leaf.heading_level ?? roleLevel
     const isLegacyHeading = leaf.text_type === "heading"
     if (!expectedLevel && !isLegacyHeading) continue
@@ -172,7 +198,9 @@ export function validateTypographyHierarchy(
 }
 
 /**
- * Preserve the semantic level of headings that survive an HTML edit.
+ * Preserve the semantic level of headings that survive an HTML edit. Current
+ * adt-h* headings retain the full type-scale contract, while older headings
+ * keep their semantic tag without being migrated by an unrelated edit.
  *
  * Heading data IDs may live on the heading itself or on descendants when a
  * heading is split into styled spans. IDs intentionally removed by the edit
@@ -185,12 +213,14 @@ export function validateRetainedHeadingHierarchy(
 ): string[] {
   const originalRoot = parseDocument(originalHtml) as unknown as HtmlNode
   const editedRoot = parseDocument(editedHtml) as unknown as HtmlNode
-  const retainedHeadings: LeafText[] = []
+  const errors: string[] = []
   const seenIds = new Set<string>()
 
   walk(originalRoot, (node) => {
-    const level = /^h([1-6])$/.exec(node.name ?? "")?.[1]
-    if (!level) return
+    const levelText = /^h([1-6])$/.exec(node.name ?? "")?.[1]
+    if (!levelText) return
+    const level = Number(levelText)
+    const originalIsStrict = hasStrictHeadingTypography(node, level)
 
     walk(node, (descendant) => {
       const textId = descendant.attribs?.["data-id"]
@@ -203,23 +233,37 @@ export function validateRetainedHeadingHierarchy(
         return
       }
       seenIds.add(textId)
-      retainedHeadings.push({
-        text_id: textId,
-        text_type: "heading",
-        heading_level: Number(level),
-      })
+      const editedHeading = closestHeading(findByDataId(editedRoot, textId))
+      if (!editedHeading) {
+        errors.push(`Heading "${textId}" must remain inside semantic <h${level}> markup.`)
+        return
+      }
+
+      if (editedHeading.name !== `h${level}`) {
+        errors.push(`Heading "${textId}" must remain <h${level}>; found <${editedHeading.name ?? "unknown"}>.`)
+        return
+      }
+
+      if (originalIsStrict) {
+        errors.push(...headingSubtreeErrors(editedHeading, level))
+        return
+      }
+
+      // Older renderings may predate the adt-h* type scale. Preserve their
+      // semantic tag without forcing an unrelated AI edit to migrate their
+      // typography. Adopting the correct class is fine; introducing a
+      // conflicting hierarchy class is not.
+      const scaleClasses = headingClasses(editedHeading)
+      if (scaleClasses.some((className) => className !== `adt-h${level}`)) {
+        errors.push(`Heading "${textId}" must not introduce an adt-h* class for a different level.`)
+      }
     })
   })
 
-  if (retainedHeadings.length === 0) return []
-
-  const errors = validateTypographyHierarchy(editedHtml, retainedHeadings, {
-    allowNonHeadingFontSizes: true,
-  })
   if (errors.length === 0) return []
 
   return [
-    ...errors,
-    "AI editing must preserve each retained heading's semantic tag and matching adt-h* class. Change heading rank in Sectioning instead.",
+    ...new Set(errors),
+    "AI editing must preserve each retained heading's semantic tag. Current adt-h* headings must also keep their matching book-wide class and size. Change heading rank in Sectioning or book-wide size in Fonts instead.",
   ]
 }

--- a/packages/types/src/book-outline.ts
+++ b/packages/types/src/book-outline.ts
@@ -67,6 +67,28 @@ export const BookOutlineOutput = z.object({
 })
 export type BookOutlineOutput = z.infer<typeof BookOutlineOutput>
 
+/**
+ * Compact LLM-only proposal. Exact titles, page references, sequential IDs,
+ * and parent IDs are derived from candidate IDs after generation so the model
+ * spends tokens only on semantic decisions.
+ */
+export const BookOutlineProposalEntry = z.object({
+  sourceCandidateIds: z.array(z.string().min(1)).min(1),
+  level: HeadingLevel,
+  kind: HeadingKind,
+  styleClusterId: z.string().min(1),
+  confidence: z.number().min(0).max(1),
+})
+export type BookOutlineProposalEntry = z.infer<typeof BookOutlineProposalEntry>
+
+export const BookOutlineProposalOutput = z.object({
+  /** Prompted to be concise; truncated deterministically after generation. */
+  reasoning: z.string(),
+  entries: z.array(BookOutlineProposalEntry),
+  styleClusters: z.array(BookOutlineStyleCluster),
+})
+export type BookOutlineProposalOutput = z.infer<typeof BookOutlineProposalOutput>
+
 /** A heading assignment currently present in a page-sectioning tree. */
 export const BookOutlineAppliedHeading = z.object({
   outlineEntryId: z.string(),

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -227,6 +227,8 @@ export {
   BookOutlineStyleCluster,
   BookOutlineEntry,
   BookOutlineOutput,
+  BookOutlineProposalEntry,
+  BookOutlineProposalOutput,
   BookOutlineAppliedHeading,
   BookOutlineAuditResponse,
 } from "./book-outline.js"

--- a/prompts/_render_fidelity.liquid
+++ b/prompts/_render_fidelity.liquid
@@ -26,6 +26,8 @@ Each text leaf in the content tree is shown as `role id=<data-id> "<text>"`. The
 
 ## BOOK-WIDE HEADING HIERARCHY
 
-- Heading roles and `heading_level` values are authoritative. Render `chapter_title` as `<h1 class="adt-h1">`, `section_heading` as `<h2 class="adt-h2">`, and `subheading` as `<h3 class="adt-h3">`.
-- Render a generic `heading` with a supplied level N as `<hN class="adt-hN">`, supporting levels 1 through 6. Put its supplied `data-id` on the heading or a descendant.
-- Never apply `text-*` or inline `font-size` overrides to a heading. Its book-wide `adt-h1` through `adt-h6` class owns its size. Local sizing remains available for non-heading activity controls and decorative UI text.
+- A leaf is a document heading only when its role is `chapter_title`, `section_heading`, `subheading`, or `heading`, or when it carries `heading_level`. Words such as “title” or “category heading” do not promote an instruction, label, or activity control into the document outline.
+- A supplied `heading_level=N` is authoritative. Without one, render `chapter_title` as `<h1 class="adt-h1">`, `section_heading` as `<h2 class="adt-h2">`, and `subheading` as `<h3 class="adt-h3">`.
+- Render a generic `heading` with level N as `<hN class="adt-hN">`, supporting levels 1 through 6. Put its supplied `data-id` on the heading or a descendant. Do not hardcode every activity title or visual heading as H2.
+- The semantic rank (`hN`) comes from the outline, and the matching `adt-hN` class supplies its book-wide size. Book fonts and the styleguide may add font family, weight, color, decoration, alignment, and spacing, but they must never choose a different rank or size.
+- Never apply `text-*` or inline `font`/`font-size` overrides to a heading or its descendants. Local sizing remains available for non-heading activity controls and decorative UI text where the surrounding prompt allows it.

--- a/prompts/activity_fill_in_a_table.liquid
+++ b/prompts/activity_fill_in_a_table.liquid
@@ -54,9 +54,7 @@ Example fill in table activity:
 ```html
 <section data-section-type="activity_fill_in_a_table" data-section-id="SECTION_ID_FROM_INPUT" class="max-w-6xl mx-auto">
   <div class="flex items-center justify-center mb-4">
-    <h2 class="adt-h2 font-bold mb-4 bg-green-200 -mr-4 p-4 pr-8 rounded-lg" data-id="text-10-0">
-      Form title here
-    </h2>
+    <!-- If the input has a heading-role title, render it here with its authoritative hN/adt-hN pair and add font-bold mb-4 bg-green-200 -mr-4 p-4 pr-8 rounded-lg. -->
     <img class="rounded-full" src="images/image.png" alt="" data-id="img-10-0">
   </div>
 

--- a/prompts/activity_fill_in_a_table.liquid
+++ b/prompts/activity_fill_in_a_table.liquid
@@ -9,7 +9,7 @@ You are an expert frontend engineer creating beautiful, kid-friendly HTML pages 
 - Nest the content container inside: `container mx-auto max-w-5xl bg-white rounded-lg px-24 max-lg:px-12 max-sm:px-6 pt-12 pb-12` with `id="content"`
 
 ### Common Styling
-- Primary heading (H1): `text-5xl font-bold mb-4 text-amber-700`
+- Headings: use the semantic `<hN class="adt-hN">` mapping from the shared hierarchy rules, then add `font-bold mb-4 text-amber-700` as appropriate
 - Instruction line: `text-xl mb-8` with icon `<i class="fas fa-pen-to-square text-blue-700 mr-2"></i>`
 - Images: When pixel dimensions are provided, compute each image's width as a percentage of the widest image and set `style="width:X%"`, plus `class="h-auto rounded-lg"`. Do NOT use `w-full` or fixed pixel widths.
 
@@ -47,16 +47,16 @@ IMPORTANT: Your reasoning MUST be written in English, regardless of the activity
 - Multiple inputs per row: Use flex layouts with proper spacing
 
 **Title and instruction pattern:**
-- Title with background: `text-2xl font-bold mb-4 bg-green-200 -mr-4 p-4 pr-8 rounded-lg`
+- A title that is a heading must use its matching `adt-hN` class; add `font-bold mb-4 bg-green-200 -mr-4 p-4 pr-8 rounded-lg` for the background treatment
 - Instruction with icon: `<i class="fas fa-pen-to-square text-blue-700 mr-2"></i>` + instruction text
 
 Example fill in table activity:
 ```html
 <section data-section-type="activity_fill_in_a_table" data-section-id="SECTION_ID_FROM_INPUT" class="max-w-6xl mx-auto">
   <div class="flex items-center justify-center mb-4">
-    <h1 class="text-2xl font-bold mb-4 bg-green-200 -mr-4 p-4 pr-8 rounded-lg" data-id="text-10-0">
+    <h2 class="adt-h2 font-bold mb-4 bg-green-200 -mr-4 p-4 pr-8 rounded-lg" data-id="text-10-0">
       Form title here
-    </h1>
+    </h2>
     <img class="rounded-full" src="images/image.png" alt="" data-id="img-10-0">
   </div>
 

--- a/prompts/activity_matching.liquid
+++ b/prompts/activity_matching.liquid
@@ -9,7 +9,7 @@ You are an expert frontend engineer creating beautiful, kid-friendly HTML pages 
 - Nest the content container inside: `container mx-auto max-w-5xl bg-white rounded-lg px-24 max-lg:px-12 max-sm:px-6 pt-12 pb-12` with `id="content"`
 
 ### Common Styling
-- Primary heading (H1): `text-5xl font-bold mb-4 text-amber-700`
+- Headings: use the semantic `<hN class="adt-hN">` mapping from the shared hierarchy rules, then add `font-bold mb-4 text-amber-700` as appropriate
 - Instruction line: `text-xl mb-8` with icon `<i class="fas fa-pen-to-square text-blue-700 mr-2"></i>`
 - Images: When pixel dimensions are provided, compute each image's width as a percentage of the widest image and set `style="width:X%"`, plus `class="h-auto rounded-lg"`. Do NOT use `w-full` or fixed pixel widths.
 

--- a/prompts/activity_matching.liquid
+++ b/prompts/activity_matching.liquid
@@ -64,7 +64,7 @@ IMPORTANT: Your reasoning MUST be written in English, regardless of the activity
 
 Example matching activity:
 ```html
-<section data-section-type="activity_matching" data-section-id="SECTION_ID_FROM_INPUT" class="max-w-6xl mx-auto" aria-labelledby="main-heading">
+<section data-section-type="activity_matching" data-section-id="SECTION_ID_FROM_INPUT" class="max-w-6xl mx-auto">
   <div class="flex flex-row max-sm:flex-col items-start gap-4 mb-6">
     <!-- Draggable items -->
     <div class="grow grid grid-cols-1 max-sm:grid-cols-2 gap-4 text-center">

--- a/prompts/activity_open_ended_answer.liquid
+++ b/prompts/activity_open_ended_answer.liquid
@@ -88,7 +88,7 @@ IMPORTANT: Your reasoning MUST be written in English, regardless of the activity
 <div class="flex justify-center items-start min-h-[calc(100dvh-100px)]">
   <div class="container mx-auto max-w-5xl bg-white rounded-lg px-24 max-lg:px-12 max-sm:px-6 pt-12 pb-12" id="content">
     <section data-section-type="activity_open_ended_answer" data-section-id="SECTION_ID_FROM_INPUT" class="max-w-6xl mx-auto">
-      <h2 class="adt-h2 font-bold mb-4 text-amber-700" data-id="text-1">Activity Title</h2>
+      <!-- If the input has a heading-role title, render it here with its authoritative hN/adt-hN pair and add font-bold mb-4 text-amber-700. -->
 
       <p class="text-xl mb-8">
         <i class="fas fa-pen-to-square text-blue-700 mr-2"></i>

--- a/prompts/activity_open_ended_answer.liquid
+++ b/prompts/activity_open_ended_answer.liquid
@@ -16,7 +16,7 @@ You are an expert frontend engineer creating beautiful, kid-friendly HTML pages 
 ### Activity Components
 
 **1. Title**
-- Use: `text-5xl font-bold mb-4 text-amber-700`
+- When the title is a heading, use its semantic `<hN class="adt-hN">` mapping; add `font-bold mb-4 text-amber-700`
 - Must have data-id from provided text IDs
 
 **2. Instructions**
@@ -88,7 +88,7 @@ IMPORTANT: Your reasoning MUST be written in English, regardless of the activity
 <div class="flex justify-center items-start min-h-[calc(100dvh-100px)]">
   <div class="container mx-auto max-w-5xl bg-white rounded-lg px-24 max-lg:px-12 max-sm:px-6 pt-12 pb-12" id="content">
     <section data-section-type="activity_open_ended_answer" data-section-id="SECTION_ID_FROM_INPUT" class="max-w-6xl mx-auto">
-      <h1 class="text-5xl font-bold mb-4 text-amber-700" data-id="text-1">Activity Title</h1>
+      <h2 class="adt-h2 font-bold mb-4 text-amber-700" data-id="text-1">Activity Title</h2>
 
       <p class="text-xl mb-8">
         <i class="fas fa-pen-to-square text-blue-700 mr-2"></i>

--- a/prompts/activity_sorting.liquid
+++ b/prompts/activity_sorting.liquid
@@ -55,7 +55,7 @@ IMPORTANT: Your reasoning MUST be written in English, regardless of the activity
 **Categories (drop zones):**
 - Class: `category` - REQUIRED
 - Attribute: `data-activity-category="category-name"` - REQUIRED
-- Visible heading: a `<label>` (or heading) holding the category name. Category names are usually NOT in the source text, so you GENERATE them — see "Generated category labels" below.
+- Visible category label: a `<p>` or `<span>` holding the category name. This is activity UI, not a document-outline heading, so do not use `<h1>`–`<h6>` or an `adt-hN` class. Category names are usually NOT in the source text, so you GENERATE them — see "Generated category labels" below.
 - Must contain: `<ul class="word-list"></ul>` - REQUIRED (empty initially)
 - Color-coded backgrounds: `bg-yellow-200`, `bg-blue-200`, `bg-green-200`, `bg-red-200`, `bg-purple-200`
 
@@ -92,13 +92,13 @@ Example sorting activity:
     <div class="grid gap-3 activity-text" role="listbox">
       <div class="category bg-yellow-200 border border-yellow-300 rounded p-2 min-h-[3rem]"
            data-activity-category="category1" tabindex="0" role="listbox">
-        <label class="font-semibold text-center" data-id="activity_gen_cat1">Category 1</label>
+        <p class="font-semibold text-center" data-id="activity_gen_cat1">Category 1</p>
         <ul class="word-list flex flex-wrap"></ul>
       </div>
 
       <div class="category bg-blue-200 border border-blue-300 rounded p-2 min-h-[3rem]"
            data-activity-category="category2" tabindex="0" role="listbox">
-        <label class="font-semibold text-center" data-id="activity_gen_cat2">Category 2</label>
+        <p class="font-semibold text-center" data-id="activity_gen_cat2">Category 2</p>
         <ul class="word-list flex flex-wrap"></ul>
       </div>
     </div>

--- a/prompts/activity_sorting.liquid
+++ b/prompts/activity_sorting.liquid
@@ -9,7 +9,7 @@ You are an expert frontend engineer creating beautiful, kid-friendly HTML pages 
 - Nest the content container inside: `container mx-auto max-w-5xl bg-white rounded-lg px-24 max-lg:px-12 max-sm:px-6 pt-12 pb-12` with `id="content"`
 
 ### Common Styling
-- Primary heading (H1): `text-5xl font-bold mb-4 text-amber-700`
+- Headings: use the semantic `<hN class="adt-hN">` mapping from the shared hierarchy rules, then add `font-bold mb-4 text-amber-700` as appropriate
 - Instruction line: `text-xl mb-8` with icon `<i class="fas fa-pen-to-square text-blue-700 mr-2"></i>`
 - Images: When pixel dimensions are provided, compute each image's width as a percentage of the widest image and set `style="width:X%"`, plus `class="h-auto rounded-lg"`. Do NOT use `w-full` or fixed pixel widths.
 

--- a/prompts/activity_true_false.liquid
+++ b/prompts/activity_true_false.liquid
@@ -60,7 +60,7 @@ Example true/false activity:
 ```html
 <section class="space-y-4 w-3/4 max-lg:w-full mx-auto" data-section-type="activity_true_false" data-section-id="SECTION_ID_FROM_INPUT">
   <!-- Title and image -->
-  <h2 class="adt-h2 font-bold text-center mb-4" data-id="text-19-0">Activity Title</h2>
+  <!-- If the input has a heading-role title, render it here with its authoritative hN/adt-hN pair and add font-bold text-center mb-4. -->
   <img class="h-auto max-w-64 mx-auto block mb-4 rounded-lg" style="width:75%" data-id="img-19-0" src="images/image.jpg" alt="Description">
 
   <!-- Instructions -->

--- a/prompts/activity_true_false.liquid
+++ b/prompts/activity_true_false.liquid
@@ -9,7 +9,7 @@ You are an expert frontend engineer creating beautiful, kid-friendly HTML pages 
 - Nest the content container inside: `container mx-auto max-w-5xl bg-white rounded-lg px-24 max-lg:px-12 max-sm:px-6 pt-12 pb-12` with `id="content"`
 
 ### Common Styling
-- Primary heading (H1): `text-5xl font-bold mb-4 text-amber-700`
+- Headings: use the semantic `<hN class="adt-hN">` mapping from the shared hierarchy rules, then add `font-bold mb-4 text-amber-700` as appropriate
 - Instruction line: `text-xl mb-8` with icon `<i class="fas fa-pen-to-square text-blue-700 mr-2"></i>`
 - Images: When pixel dimensions are provided, compute each image's width as a percentage of the widest image and set `style="width:X%"`, plus `class="h-auto rounded-lg"`. Do NOT use `w-full` or fixed pixel widths.
 
@@ -60,7 +60,7 @@ Example true/false activity:
 ```html
 <section class="space-y-4 w-3/4 max-lg:w-full mx-auto" data-section-type="activity_true_false" data-section-id="SECTION_ID_FROM_INPUT">
   <!-- Title and image -->
-  <h1 class="font-bold text-4xl text-center mb-4" data-id="text-19-0">Activity Title</h1>
+  <h2 class="adt-h2 font-bold text-center mb-4" data-id="text-19-0">Activity Title</h2>
   <img class="h-auto max-w-64 mx-auto block mb-4 rounded-lg" style="width:75%" data-id="img-19-0" src="images/image.jpg" alt="Description">
 
   <!-- Instructions -->

--- a/prompts/activity_underline_text.liquid
+++ b/prompts/activity_underline_text.liquid
@@ -117,7 +117,8 @@ Use this exact outer shell:
 ```html
 <section class="section mb-8" data-section-type="SECTION_TYPE_FROM_INPUT" data-section-id="SECTION_ID_FROM_INPUT">
   <div class="space-y-6">
-    <h2 class="adt-h2 font-bold text-blue-700" data-id="TEXT_ID_1">Underline the pronoun.</h2>
+    <!-- This example assumes TEXT_ID_1 is an activity_instruction, not a document heading. -->
+    <p class="font-bold text-blue-700" data-id="TEXT_ID_1">Underline the pronoun.</p>
     <p class="text-2xl leading-relaxed">
       <span data-id="TEXT_ID_2">
         <span class="activity-underline-option inline rounded px-1 cursor-pointer transition-colors underline-offset-4 decoration-2" data-activity-item="item-1" data-question-group="question-group-1">Mimi</span>

--- a/prompts/activity_underline_text.liquid
+++ b/prompts/activity_underline_text.liquid
@@ -1,6 +1,8 @@
 {% chat role: "system" %}
 You are an expert frontend engineer creating HTML for educational textbook activities.
 
+{% include "_render_fidelity" %}
+
 ## Required Output Contract
 You MUST return valid JSON with exactly two fields:
 ```json
@@ -115,7 +117,7 @@ Use this exact outer shell:
 ```html
 <section class="section mb-8" data-section-type="SECTION_TYPE_FROM_INPUT" data-section-id="SECTION_ID_FROM_INPUT">
   <div class="space-y-6">
-    <h1 class="text-4xl font-bold text-blue-700" data-id="TEXT_ID_1">Underline the pronoun.</h1>
+    <h2 class="adt-h2 font-bold text-blue-700" data-id="TEXT_ID_1">Underline the pronoun.</h2>
     <p class="text-2xl leading-relaxed">
       <span data-id="TEXT_ID_2">
         <span class="activity-underline-option inline rounded px-1 cursor-pointer transition-colors underline-offset-4 decoration-2" data-activity-item="item-1" data-question-group="question-group-1">Mimi</span>

--- a/prompts/book_outline.liquid
+++ b/prompts/book_outline.liquid
@@ -10,15 +10,19 @@ The input contains:
 Rules:
 1. Return genuine outline headings only. Do not turn every bold label, caption, running header, exercise option, or page number into an outline entry.
    Exclude cover/title-page display text and book metadata unless it genuinely participates in the navigable outline.
+   On table-of-contents pages, keep only the page's own heading (for example “Contents” or “Sumário”). TOC navigation rows are links/list items that point elsewhere, NOT document headings; never include their chapter/section titles as outline entries.
 2. Support heading levels 1 through 6. Preserve the book's real depth; do not force everything into three levels.
 3. Font size is evidence, not hierarchy by itself. Use numbering, wording, position, repeated publisher styles, the original table of contents, and surrounding structure together.
+   Treat the compact TOC hierarchy guide as the initial book-wide level map. When an in-book heading matches a TOC title, preserve its suggested level unless the visible page provides unequivocal contrary structure. TOC rows remain evidence only and MUST NOT become outline entries.
 4. Assign visually equivalent recurring publisher styles to one `styleClusterId` and one consistent level throughout the book.
+   Every entry using a cluster MUST use that cluster's level; use separate cluster IDs when the same visual treatment serves different hierarchy depths.
 5. `kind` is independent from `level`. A callout or activity title may be level 2, 3, or 4 depending on its parent.
-6. Every entry must reference one or more supplied candidate IDs from the same page. Never invent page IDs, page numbers, or candidate IDs.
-7. Entries must be in reading/page order. Each `parentId` must reference an earlier, shallower entry. Use null only for true top-level entries.
-8. Use stable sequential IDs (`outline-001`, `outline-002`, ...).
-9. Use the exact visible heading wording for `title`, joining adjacent candidates only when they visibly form one heading (for example a chapter number plus chapter name).
-10. Confidence reflects the evidence: use lower confidence when hierarchy or candidate matching is genuinely ambiguous.
+6. Every entry must reference one or more supplied candidate IDs from the same page. Never invent candidate IDs. Adjacent candidates may be joined only when they visibly form one heading (for example a chapter number plus chapter name).
+7. Entries must be in reading/page order. Assign the correct semantic `level`; the application deterministically derives each parent as the nearest earlier entry with a shallower level.
+8. Return only the compact semantic decisions in the schema. Do not repeat titles, page IDs, page numbers, outline IDs, or parent information; the application derives them exactly from candidate IDs, levels, and array order.
+9. Confidence reflects the evidence: use lower confidence when hierarchy or candidate matching is genuinely ambiguous.
+10. Keep `reasoning` concise (600 characters maximum).
+11. Before returning, mechanically verify every entry level equals its referenced style cluster level.
 
 Think globally before assigning levels. A classification is not reliable merely because it looks plausible on one isolated page.
 {% endchat %}
@@ -30,9 +34,18 @@ Body: {{ type_scale.bodyPx }}px; detected H1: {{ type_scale.h1Px }}px; H2: {{ ty
 Observed sizes (px → character count):{% for size in type_scale.observed %} {{ size.px }}→{{ size.chars }}{% unless forloop.last %},{% endunless %}{% endfor %}
 {% else %}No reliable PDF font-size histogram was available.{% endif %}
 
+## Compact table-of-contents hierarchy guide (evidence only)
+These rows were recovered from TOC indentation. Match them to visible in-book headings, but never return the TOC rows themselves.
+{% if toc_hierarchy.size > 0 %}
+{% for entry in toc_hierarchy %}
+- suggested level {{ entry.suggestedLevel }} | title={{ entry.title | json }} | TOC page {{ entry.tocPageNumber }} | confidence={{ entry.confidence }}
+{% endfor %}
+{% else %}No reliable TOC hierarchy was detected.{% endif %}
+
 ## Positioned-text candidates in reading order
+Compact columns: candidate_id | page_id | page_number | exact_text | px | size/body ratio | weight | centered(1/0) | top ratio | family | color | heading score.
 {% for candidate in candidates %}
-- {{ candidate.candidateId }} | {{ candidate.pageId }} / page {{ candidate.pageNumber }} | text={{ candidate.text | json }} | size={{ candidate.fontSizePx }} | bodyRatio={{ candidate.sizeToBodyRatio }} | weight={{ candidate.fontWeight }} | centered={{ candidate.centered }} | top={{ candidate.topRatio }} | left={{ candidate.leftRatio }} | width={{ candidate.widthRatio }} | family={{ candidate.fontFamily }} | color={{ candidate.color }} | localHint={{ candidate.headingLikelihood }}
+- {{ candidate.candidateId }}|{{ candidate.pageId }}|{{ candidate.pageNumber }}|{{ candidate.text | json }}|{{ candidate.fontSizePx }}|{{ candidate.sizeToBodyRatio }}|{{ candidate.fontWeight }}|{% if candidate.centered %}1{% else %}0{% endif %}|{{ candidate.topRatio }}|{{ candidate.fontFamily }}|{{ candidate.color }}|{{ candidate.headingLikelihood }}
 {% endfor %}
 
 ## Bounded page text

--- a/prompts/book_outline_chunk.liquid
+++ b/prompts/book_outline_chunk.liquid
@@ -2,13 +2,15 @@
 You are analyzing one deterministic page chunk from a larger book. Identify genuine outline headings and recurring publisher styles in this chunk. A later global pass will normalize levels and parents across all chunks.
 
 Rules:
-1. Return genuine navigational headings only. Exclude running headers, captions, page numbers, exercise options, and decorative cover metadata.
+1. Return genuine navigational headings only. Exclude running headers, captions, page numbers, exercise options, and decorative cover metadata. On table-of-contents pages, keep only the page's own heading (for example “Contents” or “Sumário”); exclude every TOC navigation row because it is a link/list item, not a document heading.
 2. Use levels 1 through 6 as your best provisional judgment. Font size is evidence, not hierarchy by itself.
-3. Group visually equivalent styles under stable descriptive `styleClusterId` values.
-4. Every entry must reference supplied candidate IDs from the same page and use their exact visible wording.
-5. Keep entries in page/reading order. Parent IDs may only reference earlier, shallower entries in this chunk; use null when the parent is outside the chunk or uncertain.
-6. Use stable sequential IDs within the chunk (`outline-001`, `outline-002`, ...).
-7. Confidence must reflect ambiguity. Do not invent headings to fill hierarchy gaps.
+   Treat the compact TOC hierarchy guide as the initial book-wide level map. Matching in-book headings should keep its suggested level unless the visible page provides unequivocal contrary structure. TOC rows remain evidence only and MUST NOT become outline entries.
+3. Group visually equivalent styles under stable descriptive `styleClusterId` values. Each style cluster has exactly one level, and every entry using it MUST use that same level. If the same visual treatment is used at different hierarchy depths, create distinct cluster IDs for those depths.
+4. Every entry must reference supplied candidate IDs from the same page. Adjacent candidates may be joined only when they visibly form one heading.
+5. Keep entries in page/reading order and assign the correct semantic `level`; the application derives each parent as the nearest earlier entry with a shallower level.
+6. Return only the compact semantic decisions in the schema. Do not repeat titles, page IDs, page numbers, outline IDs, or parent information; the application derives them exactly.
+7. Confidence must reflect ambiguity. Do not invent headings to fill hierarchy gaps. Keep `reasoning` within 600 characters.
+8. Before returning, mechanically verify every entry level equals its referenced style cluster level.
 {% endchat %}
 
 {% chat role: "user" %}
@@ -18,9 +20,17 @@ Body: {{ type_scale.bodyPx }}px; detected H1: {{ type_scale.h1Px }}px; H2: {{ ty
 Observed sizes (px → character count):{% for size in type_scale.observed %} {{ size.px }}→{{ size.chars }}{% unless forloop.last %},{% endunless %}{% endfor %}
 {% else %}No reliable PDF font-size histogram was available.{% endif %}
 
+## Compact table-of-contents hierarchy guide (evidence only)
+{% if toc_hierarchy.size > 0 %}
+{% for entry in toc_hierarchy %}
+- suggested level {{ entry.suggestedLevel }} | title={{ entry.title | json }} | TOC page {{ entry.tocPageNumber }} | confidence={{ entry.confidence }}
+{% endfor %}
+{% else %}No reliable TOC hierarchy was detected.{% endif %}
+
 ## Positioned-text candidates in reading order
+Compact columns: candidate_id | page_id | page_number | exact_text | px | size/body ratio | weight | centered(1/0) | top ratio | family | color | heading score.
 {% for candidate in candidates %}
-- {{ candidate.candidateId }} | {{ candidate.pageId }} / page {{ candidate.pageNumber }} | text={{ candidate.text | json }} | size={{ candidate.fontSizePx }} | bodyRatio={{ candidate.sizeToBodyRatio }} | weight={{ candidate.fontWeight }} | centered={{ candidate.centered }} | top={{ candidate.topRatio }} | left={{ candidate.leftRatio }} | width={{ candidate.widthRatio }} | family={{ candidate.fontFamily }} | color={{ candidate.color }} | localHint={{ candidate.headingLikelihood }}
+- {{ candidate.candidateId }}|{{ candidate.pageId }}|{{ candidate.pageNumber }}|{{ candidate.text | json }}|{{ candidate.fontSizePx }}|{{ candidate.sizeToBodyRatio }}|{{ candidate.fontWeight }}|{% if candidate.centered %}1{% else %}0{% endif %}|{{ candidate.topRatio }}|{{ candidate.fontFamily }}|{{ candidate.color }}|{{ candidate.headingLikelihood }}
 {% endfor %}
 
 ## Bounded page text

--- a/prompts/book_outline_synthesis.liquid
+++ b/prompts/book_outline_synthesis.liquid
@@ -2,13 +2,15 @@
 You are the final book-structure analyst. Normalize provisional chunk outlines into one authoritative hierarchy for the entire book.
 
 Rules:
-1. Preserve only genuine navigational headings proposed by the chunks. Do not invent page IDs, candidate IDs, or titles.
-2. Reconcile equivalent publisher styles across chunks into one `styleClusterId` and one consistent level.
-3. Use levels 1 through 6 and assign parents across chunk boundaries. Every parent must be an earlier, shallower entry.
-4. Preserve page and reading order. Renumber final entries sequentially (`outline-001`, `outline-002`, ...).
-5. Keep every entry's exact title, page ID, page number, and source candidate IDs. You may correct provisional level, kind, parent, style cluster, and confidence.
+1. Preserve only genuine navigational headings proposed by the chunks. Do not invent page IDs, candidate IDs, or titles. Never restore table-of-contents navigation rows; only the TOC page's own heading may remain.
+2. Reconcile equivalent publisher styles across chunks into one `styleClusterId` and one consistent level. Every entry using a cluster MUST use that cluster's level; use separate cluster IDs when the same visual treatment serves different hierarchy depths.
+3. Use levels 1 through 6. The application derives each parent across chunk boundaries as the nearest earlier final entry with a shallower level.
+4. Preserve page and reading order.
+5. Keep every entry's source candidate IDs. Return only compact semantic decisions; the application derives exact titles, pages, sequential outline IDs, and parents from candidate IDs, levels, and array order.
 6. Font size is evidence, not hierarchy by itself. Use numbering, wording, recurring styles, and surrounding structure together.
+   The compact TOC hierarchy guide is the initial book-wide level map. Preserve its suggested level for matching in-book headings unless the chunk evidence provides unequivocal contrary structure. The TOC rows remain evidence only, never entries.
 7. Confidence must reflect unresolved ambiguity.
+8. Keep `reasoning` within 600 characters. Before returning, mechanically verify every entry level equals its referenced style cluster level.
 {% endchat %}
 
 {% chat role: "user" %}
@@ -16,6 +18,13 @@ Rules:
 {% if type_scale %}
 Body: {{ type_scale.bodyPx }}px; detected H1: {{ type_scale.h1Px }}px; H2: {{ type_scale.h2Px }}px; H3: {{ type_scale.h3Px }}px.
 {% else %}No reliable PDF font-size histogram was available.{% endif %}
+
+## Compact table-of-contents hierarchy guide (evidence only)
+{% if toc_hierarchy.size > 0 %}
+{% for entry in toc_hierarchy %}
+- suggested level {{ entry.suggestedLevel }} | title={{ entry.title | json }} | TOC page {{ entry.tocPageNumber }} | confidence={{ entry.confidence }}
+{% endfor %}
+{% else %}No reliable TOC hierarchy was detected.{% endif %}
 
 ## Provisional chunk outlines
 {% for chunk in chunks %}

--- a/prompts/html_edit.liquid
+++ b/prompts/html_edit.liquid
@@ -15,10 +15,11 @@ Your PRIMARY job is to apply the user's edit instruction fully and accurately. T
 
 ## Preserve the book-wide heading hierarchy
 
-- An existing semantic heading that remains in the output must keep the same native `<h1>` through `<h6>` tag and its matching `adt-h1` through `adt-h6` class. This applies when its `data-id` is on the heading or on a descendant inside it.
+- An existing semantic heading that remains in the output must keep the same native `<h1>` through `<h6>` tag. If it already uses the matching `adt-h1` through `adt-h6` class, preserve that class too. This applies when its `data-id` is on the heading or on a descendant inside it.
 - Unrelated presentation and layout edits must never turn a heading into a `<div>`, `<span>`, `<p>`, or other generic element.
 - Restyling a heading means changing layout, spacing, weight, color, or decoration around its fixed tag and type-scale class. Do not replace or remove its `adt-hN` class.
 - Never add `text-xs` through `text-9xl`, arbitrary `text-[...]` font sizes, or inline `font`/`font-size` styles to a heading or its descendants.
+- Older HTML may contain headings without an `adt-hN` class. Do not migrate or otherwise rewrite that legacy typography during an unrelated edit; preserve its native heading tag and existing presentation classes.
 - Heading rank changes are not supported by AI editing. Preserve the current rank and explain that the user must make the hierarchy change in Sectioning. Intentional removal of the entire heading remains allowed when the instruction explicitly asks for it.
 
 ## Overlaying text on images (absolute positioning)

--- a/prompts/html_edit.liquid
+++ b/prompts/html_edit.liquid
@@ -6,12 +6,20 @@ Your PRIMARY job is to apply the user's edit instruction fully and accurately. T
 ## How to edit
 
 1. **Do exactly what the user asked — no more, no less.**
-2. The instruction MAY require removing, replacing, rewriting, or adding elements, text, or images. You are allowed to do all of these when the instruction asks for them.
+2. The instruction MAY require removing, replacing, rewriting, or adding elements, text, or images. You are allowed to do all of these when the instruction asks for them, except that heading rank changes must be made in Sectioning.
 3. **You MAY restructure the HTML tree** — wrap siblings in a new container, change flex/grid layout, switch from flow layout to absolute overlay positioning — whenever the instruction requires it.
 4. If the instruction is about styling only (size, spacing, colors, alignment, etc.), change only styling. Prefer Tailwind utility classes; inline `style` attributes are fine for values Tailwind cannot express.
 5. Leave unrelated content alone. If the instruction doesn't mention a given element or piece of text, do not change it.
 6. For elements you keep, preserve their `data-id` attribute value exactly. If you remove an element because the instruction asked you to, its `data-id` is removed with it — that's fine.
 7. Keep the outer `<section>` wrapper (and the `<div id="content">` wrapper if present).
+
+## Preserve the book-wide heading hierarchy
+
+- An existing semantic heading that remains in the output must keep the same native `<h1>` through `<h6>` tag and its matching `adt-h1` through `adt-h6` class. This applies when its `data-id` is on the heading or on a descendant inside it.
+- Unrelated presentation and layout edits must never turn a heading into a `<div>`, `<span>`, `<p>`, or other generic element.
+- Restyling a heading means changing layout, spacing, weight, color, or decoration around its fixed tag and type-scale class. Do not replace or remove its `adt-hN` class.
+- Never add `text-xs` through `text-9xl`, arbitrary `text-[...]` font sizes, or inline `font`/`font-size` styles to a heading or its descendants.
+- Heading rank changes are not supported by AI editing. Preserve the current rank and explain that the user must make the hierarchy change in Sectioning. Intentional removal of the entire heading remains allowed when the instruction explicitly asks for it.
 
 ## Overlaying text on images (absolute positioning)
 

--- a/prompts/page_sectioning.liquid
+++ b/prompts/page_sectioning.liquid
@@ -42,6 +42,7 @@ Book ancestors that establish the current nesting context:
 
 - Represent every listed page entry as heading leaf content. Set `outline_entry_id`, `heading_level`, and `heading_style_cluster_id` exactly from the outline entry.
 - Levels 1, 2, and 3 use roles `chapter_title`, `section_heading`, and `subheading` respectively. Levels 4, 5, and 6 use the generic `heading` role plus their authoritative `heading_level`.
+- This role mapping is mechanical and overrides every later wording or visual-classification heuristic. For example, a table-of-contents entry whose text begins with “CAPÍTULO” still uses `section_heading` when its supplied outline level is 2; do not independently reclassify any listed entry.
 - If one outline title is split into adjacent visible leaves (for example chapter number + name), each heading leaf may reference the same outline entry, but preserve each leaf's exact visible text.
 - Do not attach outline metadata to captions, labels, body text, running headers, or decorative text.
 {% endif %}
@@ -62,6 +63,7 @@ Book ancestors that establish the current nesting context:
 - A table of contents may span multiple consecutive pages. Only its first page may show a heading such as "Table of Contents" or "Contents"; continuation pages often begin directly with the next chapter or unit.
 - Classify a page as `table_of_contents` when it predominantly contains repeated navigation-entry rows: a chapter/section/subsection title on the left, dot leaders or a wide alignment gap in the middle, and an Arabic or Roman page number at the right edge. This repeated row pattern is sufficient even when the TOC heading is absent.
 - Preserve every entry in reading order and preserve hierarchy containers/indentation visible in the page image. A continued TOC page remains one `table_of_contents` section; never downgrade it to `text_only`, `list`, or `other` merely because the heading is not repeated.
+- TOC navigation rows are list/link content, not semantic headings in the current document. Represent their titles and page numbers with ordinary `text` leaves inside the TOC list structure—never `chapter_title`, `section_heading`, `subheading`, or `heading`. Only the TOC page's own visible title (for example “Contents” or “Sumário”) may use a heading role.
 - Dot leaders between TOC titles and terminal page numbers are navigation formatting, NOT writable response lines. TOC continuation detection takes precedence over WRITABLE-PAGE PRECEDENCE below.
 
 ## Activity classification rules

--- a/prompts/styleguide_generation.liquid
+++ b/prompts/styleguide_generation.liquid
@@ -37,7 +37,7 @@ Keep this container IDENTICAL on every page — same alignment, padding, and max
 5. **Text Styles** — A table mapping each text_type to an HTML element and Tailwind classes. Required text_types:
    - book_title, book_subtitle, chapter_title, section_heading, activity_title
    - section_text, instruction_text, standalone_text, image_associated_text
-   For FONT SIZE, when a typography scale is provided in the input, set the size via the shared classes (`adt-h1`/`adt-h2`/`adt-h3` for headings, `adt-body` for body/instruction/standalone text, `adt-caption` for captions and image-associated text) instead of choosing per-type `text-*` sizes — the size is fixed book-wide by these classes and keeps every page identical. Choose font weights and colors that match the original style. If no typography scale is provided, choose sizes that match the original.
+   For FONT SIZE, when a typography scale is provided in the input, use `adt-h1` through `adt-h6` for headings, `adt-body` for body/instruction/standalone text, and `adt-caption` for captions and image-associated text instead of choosing per-type `text-*` sizes. A heading's exact `hN`/`adt-hN` pair is selected later from the authoritative outline, not by the styleguide. Choose font families, weights, colors, decoration, and spacing that match the original. If no typography scale is provided, choose sizes that match the original.
 
 6. **Image Styles** — A table defining classes for single images, multiple images, and image grid containers.
 
@@ -110,7 +110,7 @@ Reference them via inline `style="font-family: '...'"` (or Tailwind arbitrary va
 This book uses a FIXED, accessible type scale. In the Text Styles table, set FONT SIZE via these classes only (do not add competing `text-*` size utilities on those elements):
 {% for s in typography %}- `{{ s.className }}` — {{ s.label }} ({{ s.mobilePx }}px mobile → {{ s.desktopPx }}px desktop)
 {% endfor %}
-Suggested mapping: book_title / chapter_title → `adt-h1`; book_subtitle / section_heading / activity_title → `adt-h2` (use `adt-h3` for minor or callout headings); section_text / instruction_text / standalone_text → `adt-body`; image_associated_text → `adt-caption`. Show these classes on the elements in your Text Styles examples and Page Templates.
+Canonical mappings are `chapter_title` → `adt-h1` and `section_heading` → `adt-h2`. Other document headings, including activity titles, MUST use the authoritative level supplied later by the content tree (`hN` with matching `adt-hN`); do not assign every activity title to H2 in this styleguide. In the Text Styles table, write `hN` / `adt-hN` for `activity_title` instead of choosing a fixed numeric level. Use `adt-body` for section/instruction/standalone text and `adt-caption` for image-associated text. Heading examples may demonstrate family, weight, color, decoration, and spacing, but must state that their semantic tag and `adt-hN` class are substituted from the supplied outline level at render time.
 {% endif %}
 
 {% for image in page_images %}

--- a/prompts/visual_review.liquid
+++ b/prompts/visual_review.liquid
@@ -84,7 +84,7 @@ The base (no-prefix) classes are the DESKTOP design — overlay and side-by-side
 - Preserve ALL text content exactly — do not change, add, or remove any words
 - Preserve ALL image tags and their data-id attributes
 - Only change layout and styling: Tailwind CSS classes, inline styles, spacing, positioning
-- Do NOT change font SIZE. Preserve EVERY `adt-*` class (`adt-h1`, `adt-h2`, `adt-h3`, `adt-body`, `adt-caption`) exactly as it appears in the input — never remove or rename them, and never add a `text-xs`…`text-9xl`, `text-[..]`, or inline `font-size` to a text element. The book's type scale is fixed and deterministic; changing it here breaks page-to-page consistency. If a heading/body looks "too big" vs the original, that is INTENTIONAL — leave it. Adjust only layout, positioning, spacing, and color.
+- Do NOT change font SIZE. Preserve EVERY `adt-*` class (`adt-h1` through `adt-h6`, `adt-body`, and `adt-caption`) exactly as it appears in the input — never remove or rename them, and never add a `text-xs`…`text-9xl`, `text-[..]`, or inline `font-size` to a text element. The book's type scale is fixed and deterministic; changing it here breaks page-to-page consistency. If a heading/body looks "too big" vs the original, that is INTENTIONAL — leave it. Adjust only layout, positioning, spacing, and color.
 - Keep the <section> wrapper and its role/data-section-type/data-section-id attributes
 - Do NOT add <script>, <iframe>, <object>, or <embed> tags
 - Do NOT add event handler attributes (onclick, onload, etc.)

--- a/prompts/visual_review_edit.liquid
+++ b/prompts/visual_review_edit.liquid
@@ -31,7 +31,7 @@ This section combines content merged from MORE THAN ONE original page (for examp
 - Overlapping text or elements
 - Text hidden behind images — text overlays MUST have `z-10` or higher so they always render above images. Different browsers may stack elements differently, so explicit z-index is required
 - Content that is cut off or hidden
-- Text that is unreadably small or excessively large
+- Text that is unreadably small and is not controlled by an existing `adt-*` class. Do not reject or resize the intentionally large, accessible book-wide type scale.
 - Images that are missing, broken, wildly misplaced, or stretched beyond their natural size (use `max-w-full` not `w-full` to prevent upscaling)
 - Text alignment that differs from the original — body text and headings that are left-aligned in the original should NOT be centered (and vice versa)
 - Content that doesn't reflow at smaller viewports (overflowing, horizontal scroll)
@@ -39,7 +39,7 @@ This section combines content merged from MORE THAN ONE original page (for examp
 ## WHAT IS ACCEPTABLE (do NOT reject for these)
 - Light transparent backgrounds behind text to improve readability
 - Minor differences in spacing, padding, or margins vs the original
-- Slightly different font sizes if readability is maintained
+- The existing book-wide `adt-*` font sizes; these are fixed even when they differ from the original page
 - Responsive adaptations (e.g., a two-column layout stacking to single column on mobile, or overlay text flowing below the image on mobile instead of on top of it)
 - Color or background differences that maintain the overall feel
 - Subtle styling improvements that enhance the appearance
@@ -58,6 +58,7 @@ The base (no-prefix) classes are the DESKTOP design — overlay and side-by-side
 - Preserve ALL text content exactly — do not change, add, or remove any words (unless the edit instruction specifically asks for text changes)
 - Preserve ALL image tags and their data-id attributes
 - Only change layout and styling: Tailwind CSS classes, inline styles, spacing, positioning
+- Preserve every native heading tag and every existing `adt-h1` through `adt-h6`, `adt-body`, and `adt-caption` class. Never add a `text-*` size utility or inline `font`/`font-size` to a heading or its descendants.
 - Keep the <section> wrapper and its role/data-section-type/data-section-id attributes
 - Do NOT add <script>, <iframe>, <object>, or <embed> tags
 - Do NOT add event handler attributes (onclick, onload, etc.)

--- a/prompts/visual_review_flexible.liquid
+++ b/prompts/visual_review_flexible.liquid
@@ -31,7 +31,7 @@ This is a web textbook. The print original is a *reference for content*, not a *
 **Do NOT reject for stylistic differences from the original** — these are all ACCEPTABLE:
 - **Layout style** — card-based layouts, panels, or flat lists where the original uses worksheet-style flat lines (or vice versa)
 - **Input affordances** — rounded input boxes, modern form fields, or button-style toggles where the original uses underlines, blanks, or boxes (or vice versa)
-- **Typography** — clean sans-serif rendering where the original uses textbook serif; different font weights or sizing as long as readable
+- **Typography** — clean sans-serif rendering where the original uses textbook serif and different font weights are acceptable, but the existing semantic `adt-*` type-scale classes and heading ranks remain fixed
 - **Colors and backgrounds** — different but coherent color palette (e.g., blue panels, white background, green accents) where the original uses cream/beige worksheet paper, or vice versa
 - **Decorative styling** — added subtle gradients, borders, shadows, badges, or icons that improve appearance
 - **Section composition** — different arrangement of elements within the section (stacked vs. side-by-side, centered vs. left-aligned, single-column vs. multi-column) as long as the result is coherent and readable
@@ -47,7 +47,7 @@ Reject ONLY when one of these is clearly true:
 - **Text hidden behind images** — text overlays MUST have `z-10` or higher so they always render above images. Different browsers stack elements differently, so explicit z-index is required
 - **Content cut off or clipped** — text or images cropped at viewport edges or container boundaries (especially on mobile)
 - **Horizontal overflow** — content extending past the viewport width on any size, forcing horizontal scroll
-- **Unreadably small or excessively large text** — text below ~12px or so large it breaks the layout
+- **Unreadably small text** — text below ~12px that is not controlled by an existing `adt-*` class. Do not reject or resize the intentionally large, accessible book-wide type scale.
 - **Broken images** — `<img>` tags showing alt text, broken icons, or grossly stretched/distorted images (use `max-w-full` not `w-full` to prevent upscaling)
 - **Layout that fails at one viewport** — e.g., works on desktop but mobile has stacked overlap, or tablet has form fields running off the side
 
@@ -65,6 +65,7 @@ On mobile only (no prefix), favor a single-column stacked layout. At tablet (`md
 - Preserve ALL text content exactly — do not change, add, or remove any words
 - Preserve ALL image tags and their data-id attributes
 - Only change layout and styling: Tailwind CSS classes, inline styles, spacing, positioning
+- Preserve every native heading tag and every existing `adt-h1` through `adt-h6`, `adt-body`, and `adt-caption` class. Never add a `text-*` size utility or inline `font`/`font-size` to a heading or its descendants.
 - Keep the <section> wrapper and its role/data-section-type/data-section-id attributes
 - Do NOT add <script>, <iframe>, <object>, or <embed> tags
 - Do NOT add event handler attributes (onclick, onload, etc.)

--- a/prompts/web_generation_html.liquid
+++ b/prompts/web_generation_html.liquid
@@ -85,8 +85,8 @@ This book uses a fixed, accessible type scale. Font SIZE is applied automaticall
 {% for s in typography %}- `{{ s.className }}` — {{ s.label }} ({{ s.mobilePx }}px mobile → {{ s.desktopPx }}px desktop)
 {% endfor %}
 Rules:
-- Heading roles are authoritative, as are provided `heading_level` values: `chapter_title` → semantic `<h1 class="adt-h1">`; `section_heading` → `<h2 class="adt-h2">`; `subheading` → `<h3 class="adt-h3">`. A generic `heading` with `heading_level=4`, for example, must use `<h4 class="adt-h4">`. Support levels 1 through 6. Put the provided `data-id` on that heading or a descendant inside it. Never mix a heading tag with a different-level `adt-h*` class.
-- For a legacy generic `heading` with no provided level, infer H1–H6 from the original page and surrounding hierarchy, then keep its semantic heading tag and matching `adt-h*` class aligned.
+- Follow the shared book-wide heading hierarchy above; it is the sole authority for heading tags and matching `adt-h*` classes.
+- For a legacy generic `heading` with no provided level, infer H1–H6 from the original page and surrounding hierarchy, then keep its semantic tag and matching `adt-h*` class aligned.
 - Paragraphs, running text, and list items use `adt-body`; captions and image labels use `adt-caption`.
 - Do NOT set any font-size utility (`text-sm` … `text-6xl`, `text-[..]`) or inline `font-size` — sizing comes only from the `adt-*` class, scales fluidly between mobile and desktop, and cannot be overridden. Handle responsiveness with LAYOUT (stack columns with `max-lg:flex-col`, adjust spacing), not font size.
 - Keep using Tailwind for everything else (font weight, color, spacing, alignment).

--- a/prompts/web_generation_html_overlay.liquid
+++ b/prompts/web_generation_html_overlay.liquid
@@ -56,7 +56,7 @@ Use a normal-flow layout. Do NOT create any `<img>` tags. Text groups flow verti
     <section data-section-type="..." data-section-id="..." class="space-y-6">
         <!-- Each text group as a normal-flow block -->
         <div class="space-y-2">
-            <h2 class="adt-h2 font-bold text-gray-900" data-id="[HEADING_ID]">Heading</h2>
+            <!-- If the input has a heading-role leaf, render it here with the shared heading_level → hN/adt-hN rule. -->
         </div>
         <div class="space-y-3">
             <p class="text-lg leading-relaxed text-gray-800" data-id="[TEXT_ID_1]">First line</p>
@@ -129,7 +129,7 @@ Example — three groups forming one column:
 <!-- All three share left-[8%] and max-w-[55%] — only top varies -->
 <!-- All include bg-white/85 rounded-lg p-3 for readability -->
 <div class="absolute top-[10%] left-[8%] max-w-[55%] bg-white/85 rounded-lg p-3 z-10">
-    <h2 class="adt-h2 font-bold text-gray-900" data-id="[HEADING_ID]">Title</h2>
+    <!-- Render the input heading-role leaf here with its authoritative hN/adt-hN pair. -->
 </div>
 <div class="absolute top-[18%] left-[8%] max-w-[55%] bg-white/85 rounded-lg p-3 z-10 space-y-2">
     <p class="text-base leading-relaxed text-gray-800" data-id="[ID_1]">First paragraph</p>
@@ -159,7 +159,7 @@ Preserve the original text alignment from the page image. Most body text and hea
 **Heading group:**
 ```html
 <div class="absolute top-[Y%] left-[X%] max-w-[W%] bg-white/85 rounded-lg p-3 z-10">
-    <h2 class="adt-h2 font-bold text-gray-900" data-id="[ID]">Title</h2>
+    <!-- Render the input heading-role leaf here with its authoritative hN/adt-hN pair; add font-bold and text-gray-900 if appropriate. -->
 </div>
 ```
 

--- a/prompts/web_generation_html_overlay.liquid
+++ b/prompts/web_generation_html_overlay.liquid
@@ -56,7 +56,7 @@ Use a normal-flow layout. Do NOT create any `<img>` tags. Text groups flow verti
     <section data-section-type="..." data-section-id="..." class="space-y-6">
         <!-- Each text group as a normal-flow block -->
         <div class="space-y-2">
-            <h1 class="text-2xl font-bold text-gray-900" data-id="[HEADING_ID]">Heading</h1>
+            <h2 class="adt-h2 font-bold text-gray-900" data-id="[HEADING_ID]">Heading</h2>
         </div>
         <div class="space-y-3">
             <p class="text-lg leading-relaxed text-gray-800" data-id="[TEXT_ID_1]">First line</p>
@@ -129,7 +129,7 @@ Example — three groups forming one column:
 <!-- All three share left-[8%] and max-w-[55%] — only top varies -->
 <!-- All include bg-white/85 rounded-lg p-3 for readability -->
 <div class="absolute top-[10%] left-[8%] max-w-[55%] bg-white/85 rounded-lg p-3 z-10">
-    <h1 class="text-2xl font-bold text-gray-900" data-id="[HEADING_ID]">Title</h1>
+    <h2 class="adt-h2 font-bold text-gray-900" data-id="[HEADING_ID]">Title</h2>
 </div>
 <div class="absolute top-[18%] left-[8%] max-w-[55%] bg-white/85 rounded-lg p-3 z-10 space-y-2">
     <p class="text-base leading-relaxed text-gray-800" data-id="[ID_1]">First paragraph</p>
@@ -159,7 +159,7 @@ Preserve the original text alignment from the page image. Most body text and hea
 **Heading group:**
 ```html
 <div class="absolute top-[Y%] left-[X%] max-w-[W%] bg-white/85 rounded-lg p-3 z-10">
-    <h1 class="text-2xl font-bold text-gray-900" data-id="[ID]">Title</h1>
+    <h2 class="adt-h2 font-bold text-gray-900" data-id="[ID]">Title</h2>
 </div>
 ```
 


### PR DESCRIPTION
Fixes #746.

## Summary

- preserve every retained heading's native level and matching book-wide typography class during AI HTML edits
- reject semantic demotion, tag/class mismatches, and heading-local font-size overrides through the existing LLM validation/retry path
- keep intentional heading removal and independent activity-control sizing unchanged
- route semantic rank changes to Sectioning with actionable validator and prompt guidance
- remove contradictory heading-size examples from activity and overlay prompts, and give underline rendering the shared hierarchy rules

## Regression protection

The edit guard derives only the heading data IDs that survive the edit. A removed ID remains allowed under the existing deletion policy, while IDs on either the heading itself or descendants must remain within the original h1-h6 level and matching adt-h1 through adt-h6 class.

Parameterized prompt tests cover both web renderers and all ten HTML-producing activity renderers. Service and pipeline tests cover generic-element demotion, level/class drift, local size overrides, descendant IDs, intentional removal, and non-heading activity sizing.

## Validation

- `pnpm build`
- focused pipeline/API suites: 47 tests passed
- `env -u OPENAI_API_KEY pnpm exec vitest run --maxWorkers=4`: 207 files, 2,617 tests passed
- `pnpm lint`: 0 errors (9 pre-existing unused-suppression warnings)
- `git diff --check`
