### PR TITLE
fix(book-outline): reconcile style clusters instead of failing the whole book

### DIFF
--- a/packages/pipeline/src/__tests__/book-outline.test.ts
+++ b/packages/pipeline/src/__tests__/book-outline.test.ts
@@ -700,6 +700,66 @@ describe("book outline generation", () => {
     })
   })
 
+  it("keeps an existing cluster distinct from a colliding derived id", async () => {
+    const parentEvidence = buildBookOutlineEvidence(
+      [{
+        pageId: "pg001",
+        pageNumber: 1,
+        text: "Chapter\nFirst section\nSecond section",
+        imageBase64: pngBase64(),
+      }],
+      null,
+    )
+    const compact: BookOutlineProposalOutput = {
+      reasoning: "Two level-two headings use distinct visual styles.",
+      styleClusters: [
+        { styleClusterId: "display", description: "Display heading", level: 1 },
+        {
+          styleClusterId: "display-level-2",
+          description: "Independent section style",
+          level: 2,
+        },
+      ],
+      entries: [
+        { level: 1, kind: "chapter" as const, styleClusterId: "display" },
+        { level: 2, kind: "section" as const, styleClusterId: "display" },
+        { level: 2, kind: "section" as const, styleClusterId: "display-level-2" },
+      ].map((entry, index) => ({
+        sourceCandidateIds: [`pg001_hc${String(index + 1).padStart(3, "0")}`],
+        level: entry.level,
+        kind: entry.kind,
+        styleClusterId: entry.styleClusterId,
+        confidence: 0.9,
+      })),
+    }
+    const llm: LLMModel = {
+      generateObject: async <T>(options: GenerateObjectOptions) => {
+        expect(options.validate?.(compact, options.context ?? {})).toEqual({
+          valid: true,
+          errors: [],
+        })
+        return { object: compact as T }
+      },
+    }
+
+    const result = await generateBookOutline(
+      parentEvidence,
+      buildBookOutlineConfig({ structure_types: {}, role_types: {} }),
+      llm,
+    )
+
+    expect(result.entries.map((entry) => entry.styleClusterId)).toEqual([
+      "display",
+      "display-level-2-2",
+      "display-level-2",
+    ])
+    expect(result.styleClusters).toContainEqual({
+      styleClusterId: "display-level-2",
+      description: "Independent section style",
+      level: 2,
+    })
+  })
+
   it("repairs undeclared, duplicate, and mismatched style clusters instead of failing the book", async () => {
     const parentEvidence = buildBookOutlineEvidence(
       [{

--- a/packages/pipeline/src/__tests__/book-outline.test.ts
+++ b/packages/pipeline/src/__tests__/book-outline.test.ts
@@ -700,6 +700,70 @@ describe("book outline generation", () => {
     })
   })
 
+  it("repairs undeclared, duplicate, and mismatched style clusters instead of failing the book", async () => {
+    const parentEvidence = buildBookOutlineEvidence(
+      [{
+        pageId: "pg001",
+        pageNumber: 1,
+        text: "Chapter\nSection\nSubsection\nActivity",
+        imageBase64: pngBase64(),
+      }],
+      null,
+    )
+    const compact: BookOutlineProposalOutput = {
+      reasoning: "A real book reuses ids and forgets to declare a cluster.",
+      styleClusters: [
+        { styleClusterId: "sc_blue", description: "Blue heading", level: 1 },
+        // Duplicate id — must not fail validation.
+        { styleClusterId: "sc_blue", description: "Blue heading again", level: 2 },
+      ],
+      entries: [
+        // Reuses sc_blue at level 2 (mismatch vs. its level-1 declaration).
+        { level: 1, kind: "chapter" as const, styleClusterId: "sc_blue" },
+        { level: 2, kind: "section" as const, styleClusterId: "sc_blue" },
+        // References a cluster that was never declared.
+        { level: 3, kind: "subsection" as const, styleClusterId: "sc_undeclared" },
+        { level: 3, kind: "activity" as const, styleClusterId: "sc_undeclared" },
+      ].map((entry, index) => ({
+        sourceCandidateIds: [`pg001_hc${String(index + 1).padStart(3, "0")}`],
+        level: entry.level,
+        kind: entry.kind,
+        styleClusterId: entry.styleClusterId,
+        confidence: 0.9,
+      })),
+    }
+    const llm: LLMModel = {
+      generateObject: async <T>(options: GenerateObjectOptions) => {
+        expect(options.validate?.(compact, options.context ?? {})).toEqual({
+          valid: true,
+          errors: [],
+        })
+        return { object: compact as T }
+      },
+    }
+
+    const result = await generateBookOutline(
+      parentEvidence,
+      buildBookOutlineConfig({ structure_types: {}, role_types: {} }),
+      llm,
+    )
+
+    // Every entry ends up pointing at a defined cluster whose level matches.
+    const byId = new Map(
+      result.styleClusters.map((cluster) => [cluster.styleClusterId, cluster]),
+    )
+    expect(new Set(result.styleClusters.map((c) => c.styleClusterId)).size).toBe(
+      result.styleClusters.length,
+    )
+    for (const entry of result.entries) {
+      const cluster = byId.get(entry.styleClusterId)
+      expect(cluster).toBeDefined()
+      expect(cluster?.level).toBe(entry.level)
+    }
+    expect(result.entries[1].styleClusterId).toBe("sc_blue-level-2")
+    expect(result.entries.map((entry) => entry.level)).toEqual([1, 2, 3, 3])
+  })
+
   it("corrects a cluster declaration when all entries agree on another level", async () => {
     const llm: LLMModel = {
       generateObject: async <T>(options: GenerateObjectOptions) => {

--- a/packages/pipeline/src/book-outline.ts
+++ b/packages/pipeline/src/book-outline.ts
@@ -267,16 +267,16 @@ function reconcileStyleClusters(output: BookOutlineOutput): boolean {
     )
   }
 
-  // Allocate every final id so it maps to exactly one level; a collision with
-  // a differently-levelled id is disambiguated with a numeric suffix.
-  const idLevels = new Map<string, number>()
-  const claim = (baseId: string, level: number): string => {
+  // Reserve every primary id before allocating variants so an existing style
+  // is never renamed or merged with a derived id that happens to match it.
+  const claimedIds = new Set(primaryLevel.keys())
+  const claimVariant = (baseId: string): string => {
     let candidate = baseId
     let suffix = 2
-    while (idLevels.has(candidate) && idLevels.get(candidate) !== level) {
+    while (claimedIds.has(candidate)) {
       candidate = `${baseId}-${suffix++}`
     }
-    idLevels.set(candidate, level)
+    claimedIds.add(candidate)
     return candidate
   }
 
@@ -286,7 +286,7 @@ function reconcileStyleClusters(output: BookOutlineOutput): boolean {
   for (const { id, level } of usageOrder) {
     const baseDescription = declared.get(id)?.description ?? `Headings styled as ${id}`
     const isPrimary = level === primaryLevel.get(id)
-    const finalId = claim(isPrimary ? id : `${id}-level-${level}`, level)
+    const finalId = isPrimary ? id : claimVariant(`${id}-level-${level}`)
     finalIdByUsage.set(`${id}::${level}`, finalId)
     if (!rebuiltIds.has(finalId)) {
       rebuiltIds.add(finalId)

--- a/packages/pipeline/src/book-outline.ts
+++ b/packages/pipeline/src/book-outline.ts
@@ -221,6 +221,108 @@ function finalizeBookOutlineProposal(
   return (validation.cleaned as BookOutlineOutput | undefined) ?? converted.outline
 }
 
+/**
+ * Deterministically reconcile the cosmetic style-cluster bookkeeping so an
+ * otherwise-valid whole-book hierarchy is never rejected over it. Each entry
+ * carries an opaque style label plus its authoritative semantic level, and
+ * downstream stages only need the label to be defined and to agree with the
+ * entry's level. Rather than fail the book on duplicate cluster ids, undeclared
+ * references, or level mismatches — mistakes the model cannot reliably avoid on
+ * a large book — rebuild the cluster set from how entries actually use it. A
+ * single visual style reused at multiple levels is split into one cluster per
+ * level, exactly the representation the schema requires. Returns whether any
+ * declaration or entry label was changed.
+ */
+function reconcileStyleClusters(output: BookOutlineOutput): boolean {
+  const declared = new Map<string, BookOutlineStyleCluster>()
+  for (const cluster of output.styleClusters) {
+    if (!declared.has(cluster.styleClusterId)) declared.set(cluster.styleClusterId, cluster)
+  }
+
+  // Distinct (id, level) usages in first-seen order keep the rebuild stable.
+  const levelsById = new Map<string, Set<number>>()
+  const usageOrder: Array<{ id: string; level: number }> = []
+  const usageSeen = new Set<string>()
+  for (const entry of output.entries) {
+    const key = `${entry.styleClusterId}::${entry.level}`
+    if (!usageSeen.has(key)) {
+      usageSeen.add(key)
+      usageOrder.push({ id: entry.styleClusterId, level: entry.level })
+    }
+    const levels = levelsById.get(entry.styleClusterId) ?? new Set<number>()
+    levels.add(entry.level)
+    levelsById.set(entry.styleClusterId, levels)
+  }
+
+  // The primary level keeps the original cluster id. Prefer the model's
+  // declared level when an entry actually uses it, else the lowest used level.
+  const primaryLevel = new Map<string, number>()
+  for (const [id, levels] of levelsById) {
+    const declaredLevel = declared.get(id)?.level
+    primaryLevel.set(
+      id,
+      declaredLevel !== undefined && levels.has(declaredLevel)
+        ? declaredLevel
+        : Math.min(...levels),
+    )
+  }
+
+  // Allocate every final id so it maps to exactly one level; a collision with
+  // a differently-levelled id is disambiguated with a numeric suffix.
+  const idLevels = new Map<string, number>()
+  const claim = (baseId: string, level: number): string => {
+    let candidate = baseId
+    let suffix = 2
+    while (idLevels.has(candidate) && idLevels.get(candidate) !== level) {
+      candidate = `${baseId}-${suffix++}`
+    }
+    idLevels.set(candidate, level)
+    return candidate
+  }
+
+  const rebuilt: BookOutlineStyleCluster[] = []
+  const rebuiltIds = new Set<string>()
+  const finalIdByUsage = new Map<string, string>()
+  for (const { id, level } of usageOrder) {
+    const baseDescription = declared.get(id)?.description ?? `Headings styled as ${id}`
+    const isPrimary = level === primaryLevel.get(id)
+    const finalId = claim(isPrimary ? id : `${id}-level-${level}`, level)
+    finalIdByUsage.set(`${id}::${level}`, finalId)
+    if (!rebuiltIds.has(finalId)) {
+      rebuiltIds.add(finalId)
+      rebuilt.push({
+        styleClusterId: finalId,
+        description: isPrimary
+          ? baseDescription
+          : `${baseDescription} (level ${level} variant)`,
+        level,
+      })
+    }
+  }
+
+  let changed = false
+  for (const entry of output.entries) {
+    const mapped = finalIdByUsage.get(`${entry.styleClusterId}::${entry.level}`)
+    if (mapped && mapped !== entry.styleClusterId) {
+      entry.styleClusterId = mapped
+      changed = true
+    }
+  }
+  const declarationsChanged =
+    output.styleClusters.length !== rebuilt.length ||
+    rebuilt.some((cluster, index) => {
+      const original = output.styleClusters[index]
+      return (
+        !original ||
+        original.styleClusterId !== cluster.styleClusterId ||
+        original.level !== cluster.level ||
+        original.description !== cluster.description
+      )
+    })
+  output.styleClusters = rebuilt
+  return changed || declarationsChanged
+}
+
 function validateBookOutline(
   raw: unknown,
   evidence: BookOutlineEvidence,
@@ -234,77 +336,26 @@ function validateBookOutline(
   }
 
   const errors: string[] = []
-  let cleaned = false
   const output: BookOutlineOutput = {
     ...parsed.data,
     entries: parsed.data.entries.map((entry) => ({ ...entry })),
     styleClusters: parsed.data.styleClusters.map((cluster) => ({ ...cluster })),
   }
+
+  // Style clusters are cosmetic bookkeeping, not a structural invariant. Repair
+  // them deterministically (dedupe ids, synthesize undeclared references, split
+  // a style reused across levels) so the whole book is never blocked on them.
+  // Every check below is a genuine invariant that cannot be auto-repaired.
+  let cleaned = reconcileStyleClusters(output)
+
   const pages = new Map(evidence.pages.map((page) => [page.pageId, page]))
   const candidates = new Map(evidence.candidates.map((candidate) => [candidate.candidateId, candidate]))
   const candidateOrder = new Map(
     evidence.candidates.map((candidate, index) => [candidate.candidateId, index]),
   )
-  const clusters = new Map<string, BookOutlineStyleCluster>()
   const entryIds = new Set<string>()
   const usedCandidates = new Set<string>()
   let previousPageNumber = 0
-
-  for (const cluster of output.styleClusters) {
-    if (clusters.has(cluster.styleClusterId)) {
-      errors.push(`Duplicate styleClusterId "${cluster.styleClusterId}".`)
-    }
-    clusters.set(cluster.styleClusterId, cluster)
-  }
-
-  // A cluster/entry level mismatch does not require another semantic pass.
-  // Preserve the model's hierarchy and split a reused visual style into one
-  // cluster per semantic level, which is exactly the representation the
-  // schema requires. If every use agrees on a level other than the cluster's
-  // declared level, simply correct the unused declaration.
-  if (clusters.size === output.styleClusters.length) {
-    const usedLevels = new Map<string, Set<number>>()
-    for (const entry of output.entries) {
-      if (!clusters.has(entry.styleClusterId)) continue
-      const levels = usedLevels.get(entry.styleClusterId) ?? new Set<number>()
-      levels.add(entry.level)
-      usedLevels.set(entry.styleClusterId, levels)
-    }
-
-    for (const [clusterId, levels] of usedLevels) {
-      const cluster = clusters.get(clusterId)!
-      if (!levels.has(cluster.level)) {
-        cluster.level = levels.values().next().value!
-        cleaned = true
-      }
-      if (levels.size === 1) {
-        const [usedLevel] = levels
-        cluster.level = usedLevel
-        continue
-      }
-
-      for (const level of levels) {
-        if (level === cluster.level) continue
-        const baseId = `${clusterId}-level-${level}`
-        let derivedId = baseId
-        let suffix = 2
-        while (clusters.has(derivedId)) derivedId = `${baseId}-${suffix++}`
-        const derived: BookOutlineStyleCluster = {
-          styleClusterId: derivedId,
-          description: `${cluster.description} (level ${level} variant)`,
-          level,
-        }
-        output.styleClusters.push(derived)
-        clusters.set(derivedId, derived)
-        for (const entry of output.entries) {
-          if (entry.styleClusterId === clusterId && entry.level === level) {
-            entry.styleClusterId = derivedId
-          }
-        }
-        cleaned = true
-      }
-    }
-  }
 
   for (const entry of output.entries) {
     if (entryIds.has(entry.outlineId)) {
@@ -375,18 +426,6 @@ function validateBookOutline(
           )
         }
       }
-    }
-
-    const cluster = clusters.get(entry.styleClusterId)
-    if (!cluster) {
-      errors.push(
-        `Outline entry "${entry.outlineId}" references unknown style cluster "${entry.styleClusterId}".`,
-      )
-    } else if (cluster.level !== entry.level) {
-      errors.push(
-        `Style cluster "${entry.styleClusterId}" is level ${cluster.level}, ` +
-          `but "${entry.outlineId}" is level ${entry.level}.`,
-      )
     }
 
     entryIds.add(entry.outlineId)


### PR DESCRIPTION
## Problem

The **`book-outline` stage errored after 6 attempts and blocked an entire book** (`SAYANSI-STD-5-SB`). Because every downstream stage depends on `book-outline`, a single failure here takes the whole book down.

Every failure was **cosmetic style-cluster bookkeeping**, not a real structural problem. The model has to emit a `styleClusters` array and tag each of ~180 headings with a `styleClusterId`; the validator hard-rejected the book on:

- `Duplicate styleClusterId "..."`
- `references unknown style cluster "..."` (entry cited a cluster it never declared)
- `cluster is level 2, but entry is level 3` mismatches

The existing self-heal only ran when there were *no* duplicate ids and never repaired an undeclared reference, so on a real book all three modes slipped through. Retries made it worse — the response payload grew from 95 KB → 336 KB across attempts as the model fought a constraint it structurally can't satisfy.

`styleClusterId` is only an **opaque pass-through label** downstream (page-sectioning checks a heading node's id matches the entry's; the `styleClusters` array is a UI tooltip). The authoritative data — `level` / `title` / `kind` / `pageId` / `parentId` — was all fine.

## Fix

New `reconcileStyleClusters()` **rebuilds the cluster set deterministically from how entries actually use it**, instead of rejecting — the same philosophy already applied to titles and TOC levels:

- **Dedupes** cluster ids
- **Synthesizes** any undeclared cluster an entry references
- **Splits** a style reused at multiple levels into one cluster per level (preserving the existing `-level-N` behavior)
- Guarantees every entry's `styleClusterId` resolves to a defined cluster whose level matches

All genuine structural invariants (unknown candidate refs, page order, parent hierarchy, candidate uniqueness, title derivation) still fail loudly.

## Verification

- **Real-data proof**: ran reconcile against the actual failed proposal stored in the book DB → cluster errors **25 → 0** (1 duplicate + 24 undeclared), ids unique.
- **Tests**: added a regression test covering all three failure modes coexisting; `page-sectioning` + `book-outline` suites → **75/75 pass** (incl. the two pre-existing split tests).
- `pnpm typecheck` clean.

## Note

This repairs the pipeline going forward. The already-failed book still has its `book-outline` step marked `error` in its DB and needs a **re-run of the outline stage** to pick up the fix.