### PR TITLE
fix(wizard): hide recommended pill for figure extraction & image segmentation on textbook preset

### DIFF
--- a/apps/studio/src/components/wizard/step3ContentProcessing/index.tsx
+++ b/apps/studio/src/components/wizard/step3ContentProcessing/index.tsx
@@ -157,7 +157,7 @@ export function Step3() {
           previewFocus="figureExtraction"
           checked={figureExtraction}
           onCheckedChange={(checked) => form.setFieldValue("figureExtraction", checked)}
-          recommended={recommendations.figureExtraction === true}
+          recommended={recommendations.figureExtraction === true && selectedPresetId !== "textbook"}
           presetLabel={preset?.title}
           accent={accent}
         />
@@ -182,7 +182,7 @@ export function Step3() {
             previewFocus="segmentation"
             checked={imageSegmentation}
             onCheckedChange={(checked) => form.setFieldValue("imageSegmentation", checked)}
-            recommended={recommendations.imageSegmentation === true}
+            recommended={recommendations.imageSegmentation === true && selectedPresetId !== "textbook"}
             presetLabel={preset?.title}
             accent={accent}
           />


### PR DESCRIPTION
Removes the "Recommended for Textbooks & Activities" pill from the **Figure Extraction** and **Image Segmentation** toggles in the wizard's content-processing step (step 3) when the Textbooks & Activities (`textbook`) preset is selected. This is a UI-only gate on the `recommended` prop, so the shared `recommendations` object is left untouched — the PresetCard hover-card summary and the Reference preset's Figure Extraction pill are unaffected, and the actual toggle defaults (which come from `defaultWizardValues`) are unchanged. No user-visible strings were added or changed, so no i18n catalog update is needed.