### PR TITLE
feat(site): localize release content

### DIFF
--- a/apps/site/src/components/pages/DownloadPage.tsx
+++ b/apps/site/src/components/pages/DownloadPage.tsx
@@ -24,7 +24,7 @@ import {
 } from "./download/shared";
 
 export function DownloadPage() {
-  const { t } = useLingui();
+  const { i18n, t } = useLingui();
   const { releases, loading, error } = useStableReleases();
   const latest: GithubRelease | undefined = releases?.[0];
   const [userPlatform, setUserPlatform] = useState<DetectedPlatform | null>(
@@ -264,7 +264,9 @@ export function DownloadPage() {
           </div>
           {latest && (
             <div className="font-mono text-[10px] text-[color:var(--color-muted-foreground)]/70">
-              <Trans>Released {formatRelativeDate(latest.published_at)}</Trans>
+              <Trans>
+                Released {formatRelativeDate(latest.published_at, i18n.locale)}
+              </Trans>
             </div>
           )}
         </div>

--- a/apps/site/src/components/pages/ReleasesPage.tsx
+++ b/apps/site/src/components/pages/ReleasesPage.tsx
@@ -6,7 +6,10 @@ import { Button } from "@/components/Button";
 import { ReleaseMarkdown } from "@/components/ReleaseMarkdown";
 import { cn } from "@/lib/cn";
 import { withBase } from "@/lib/href";
-import { localizeGithubRelease } from "@/lib/release-i18n";
+import {
+  localizeGithubRelease,
+  type LocalizedGithubRelease,
+} from "@/lib/release-i18n";
 import {
   sectionTone,
   summarizeSections,
@@ -16,7 +19,6 @@ import {
   formatAbsoluteDate,
   formatRelativeDate,
   useStableReleases,
-  type GithubRelease,
 } from "@/lib/useGithubReleases";
 
 function anchorIdForTag(tag: string): string {
@@ -24,7 +26,7 @@ function anchorIdForTag(tag: string): string {
 }
 
 export function ReleasesPage({ focusTag }: { focusTag?: string }) {
-  const { i18n } = useLingui();
+  const { i18n, t } = useLingui();
   const { releases, loading, error } = useStableReleases();
   const [mounted, setMounted] = useState(false);
 
@@ -33,12 +35,14 @@ export function ReleasesPage({ focusTag }: { focusTag?: string }) {
     return () => cancelAnimationFrame(id);
   }, []);
 
-  const items = useMemo(
-    () =>
-      releases?.map((release) => localizeGithubRelease(release, i18n.locale)) ??
-      [],
-    [i18n.locale, releases],
-  );
+  const items = useMemo(() => {
+    const fullDiffLabel = t`Full diff`;
+    return (
+      releases?.map((release) =>
+        localizeGithubRelease(release, i18n.locale, { fullDiffLabel }),
+      ) ?? []
+    );
+  }, [i18n.locale, releases, t]);
 
   /** After items render, scroll the focused tag into view. */
   useEffect(() => {
@@ -161,13 +165,17 @@ function ReleaseEntry({
   mounted,
   delayMs,
 }: {
-  release: GithubRelease;
+  release: LocalizedGithubRelease;
   isLatest: boolean;
   mounted: boolean;
   delayMs: number;
 }) {
+  const { i18n } = useLingui();
   const title = release.name?.trim() || release.tag_name;
-  const sections = summarizeSections(release.body).slice(0, 5);
+  const sections = summarizeSections(
+    release.body,
+    release.localization?.sections,
+  ).slice(0, 5);
   return (
     <li
       id={anchorIdForTag(release.tag_name)}
@@ -190,7 +198,7 @@ function ReleaseEntry({
           )}
         />
         <div className="font-mono text-[11px] font-semibold uppercase tracking-[0.16em] text-[color:var(--color-muted-foreground)]">
-          {formatAbsoluteDate(release.published_at)}
+          {formatAbsoluteDate(release.published_at, i18n.locale)}
         </div>
         <div className="mt-2 inline-flex items-center gap-1 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-card)] px-2 py-0.5 font-mono text-[12px] font-bold text-[color:var(--color-foreground)] shadow-sm">
           {release.tag_name}
@@ -209,7 +217,7 @@ function ReleaseEntry({
             </span>
           )}
           <span className="font-mono text-[10px] text-[color:var(--color-muted-foreground)]/80">
-            {formatRelativeDate(release.published_at)}
+            {formatRelativeDate(release.published_at, i18n.locale)}
           </span>
         </div>
 
@@ -220,7 +228,7 @@ function ReleaseEntry({
                 key={s.title}
                 label={s.title}
                 count={s.count}
-                tone={sectionTone(s.title)}
+                tone={sectionTone(s.kind)}
               />
             ))}
           </div>

--- a/apps/site/src/components/pages/ReleasesPage.tsx
+++ b/apps/site/src/components/pages/ReleasesPage.tsx
@@ -1,4 +1,4 @@
-import { Trans } from "@lingui/react/macro";
+import { Trans, useLingui } from "@lingui/react/macro";
 import { ArrowLeft, ArrowUpRight } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { GithubIcon } from "@/components/icons/GithubIcon";
@@ -6,6 +6,7 @@ import { Button } from "@/components/Button";
 import { ReleaseMarkdown } from "@/components/ReleaseMarkdown";
 import { cn } from "@/lib/cn";
 import { withBase } from "@/lib/href";
+import { localizeGithubRelease } from "@/lib/release-i18n";
 import {
   sectionTone,
   summarizeSections,
@@ -23,6 +24,7 @@ function anchorIdForTag(tag: string): string {
 }
 
 export function ReleasesPage({ focusTag }: { focusTag?: string }) {
+  const { i18n } = useLingui();
   const { releases, loading, error } = useStableReleases();
   const [mounted, setMounted] = useState(false);
 
@@ -31,7 +33,12 @@ export function ReleasesPage({ focusTag }: { focusTag?: string }) {
     return () => cancelAnimationFrame(id);
   }, []);
 
-  const items = useMemo(() => releases ?? [], [releases]);
+  const items = useMemo(
+    () =>
+      releases?.map((release) => localizeGithubRelease(release, i18n.locale)) ??
+      [],
+    [i18n.locale, releases],
+  );
 
   /** After items render, scroll the focused tag into view. */
   useEffect(() => {

--- a/apps/site/src/components/sections/ReleasesScene.tsx
+++ b/apps/site/src/components/sections/ReleasesScene.tsx
@@ -3,6 +3,7 @@ import { ArrowRight, ArrowUpRight, Sparkles, Tag } from "lucide-react";
 import { SectionEyebrow } from "@/components/SectionEyebrow";
 import { cn } from "@/lib/cn";
 import { withBase } from "@/lib/href";
+import { localizeGithubRelease } from "@/lib/release-i18n";
 import {
   firstImageFromBody,
   firstParagraphFromBody,
@@ -19,10 +20,12 @@ import {
 import { useInView } from "@/lib/useScrollProgress";
 
 export function ReleasesScene() {
-  const { t } = useLingui();
+  const { i18n, t } = useLingui();
   const { releases, loading } = useStableReleases();
   const { ref, inView: mounted } = useInView<HTMLDivElement>({ threshold: 0.2 });
-  const latest = releases?.[0];
+  const latest = releases?.[0]
+    ? localizeGithubRelease(releases[0], i18n.locale)
+    : undefined;
 
   return (
     <section

--- a/apps/site/src/components/sections/ReleasesScene.tsx
+++ b/apps/site/src/components/sections/ReleasesScene.tsx
@@ -3,7 +3,10 @@ import { ArrowRight, ArrowUpRight, Sparkles, Tag } from "lucide-react";
 import { SectionEyebrow } from "@/components/SectionEyebrow";
 import { cn } from "@/lib/cn";
 import { withBase } from "@/lib/href";
-import { localizeGithubRelease } from "@/lib/release-i18n";
+import {
+  localizeGithubRelease,
+  type LocalizedGithubRelease,
+} from "@/lib/release-i18n";
 import {
   firstImageFromBody,
   firstParagraphFromBody,
@@ -15,7 +18,6 @@ import {
   formatAbsoluteDate,
   formatRelativeDate,
   useStableReleases,
-  type GithubRelease,
 } from "@/lib/useGithubReleases";
 import { useInView } from "@/lib/useScrollProgress";
 
@@ -101,12 +103,15 @@ export function ReleasesScene() {
   );
 }
 
-function HeroSpotlight({ release }: { release: GithubRelease }) {
-  const { t } = useLingui();
+function HeroSpotlight({ release }: { release: LocalizedGithubRelease }) {
+  const { i18n, t } = useLingui();
   const title = release.name?.trim() || release.tag_name;
   const cover = firstImageFromBody(release.body);
   const excerpt = firstParagraphFromBody(release.body, 240);
-  const sections = summarizeSections(release.body).slice(0, 4);
+  const sections = summarizeSections(
+    release.body,
+    release.localization?.sections,
+  ).slice(0, 4);
   const detailHref = withBase(`/releases/${encodeURIComponent(release.tag_name)}`);
 
   return (
@@ -134,10 +139,10 @@ function HeroSpotlight({ release }: { release: GithubRelease }) {
             <Trans>Latest</Trans>
           </span>
           <span aria-hidden className="opacity-50">·</span>
-          <span>{formatAbsoluteDate(release.published_at)}</span>
+          <span>{formatAbsoluteDate(release.published_at, i18n.locale)}</span>
           <span className="opacity-60">
             {" · "}
-            {formatRelativeDate(release.published_at)}
+            {formatRelativeDate(release.published_at, i18n.locale)}
           </span>
         </div>
 
@@ -158,7 +163,7 @@ function HeroSpotlight({ release }: { release: GithubRelease }) {
                 key={s.title}
                 label={s.title}
                 count={s.count}
-                tone={sectionTone(s.title)}
+                tone={sectionTone(s.kind)}
               />
             ))}
           </div>

--- a/apps/site/src/components/sections/ReleasesScene.tsx
+++ b/apps/site/src/components/sections/ReleasesScene.tsx
@@ -9,7 +9,7 @@ import {
 } from "@/lib/release-i18n";
 import {
   firstImageFromBody,
-  firstParagraphFromBody,
+  releaseExcerpt,
   sectionTone,
   summarizeSections,
   type SectionTone,
@@ -107,7 +107,7 @@ function HeroSpotlight({ release }: { release: LocalizedGithubRelease }) {
   const { i18n, t } = useLingui();
   const title = release.name?.trim() || release.tag_name;
   const cover = firstImageFromBody(release.body);
-  const excerpt = firstParagraphFromBody(release.body, 240);
+  const excerpt = releaseExcerpt(release.body, release.localization?.summary);
   const sections = summarizeSections(
     release.body,
     release.localization?.sections,
@@ -199,13 +199,13 @@ function HeroCover({
 }) {
   if (image) {
     return (
-      <div className="pointer-events-none relative z-[1] aspect-[16/9] w-full overflow-hidden rounded-2xl border border-[color:var(--color-border)] bg-[color:var(--color-muted)]/40">
+      <div className="pointer-events-none relative z-[1] aspect-[3/2] w-full overflow-hidden rounded-2xl border border-[color:var(--color-border)] bg-[color:var(--color-muted)]/40">
         <img
           src={image}
           alt=""
           loading="lazy"
           decoding="async"
-          className="h-full w-full object-cover transition-transform duration-[900ms] ease-[cubic-bezier(0.22,1,0.36,1)] group-hover/hero:scale-[1.02]"
+          className="h-full w-full object-contain transition-transform duration-[900ms] ease-[cubic-bezier(0.22,1,0.36,1)] group-hover/hero:scale-[1.02]"
         />
       </div>
     );
@@ -213,7 +213,7 @@ function HeroCover({
   return (
     <div
       aria-hidden
-      className="pointer-events-none relative z-[1] aspect-[16/9] w-full overflow-hidden rounded-2xl border border-[color:var(--color-border)]"
+      className="pointer-events-none relative z-[1] aspect-[3/2] w-full overflow-hidden rounded-2xl border border-[color:var(--color-border)]"
     >
       <div className="absolute inset-0 [background:radial-gradient(120%_120%_at_25%_15%,color-mix(in_oklch,var(--color-primary)_30%,transparent),transparent_60%),radial-gradient(120%_120%_at_80%_80%,color-mix(in_oklch,#a855f7_22%,transparent),transparent_65%),linear-gradient(180deg,color-mix(in_oklch,var(--color-muted)_70%,transparent),color-mix(in_oklch,var(--color-card)_100%,transparent))]" />
       <div

--- a/apps/site/src/components/sections/WelcomeScene.tsx
+++ b/apps/site/src/components/sections/WelcomeScene.tsx
@@ -13,7 +13,7 @@ import {
 import { trackEvent } from "@/lib/matomo";
 
 export function WelcomeScene() {
-  const { t } = useLingui();
+  const { i18n, t } = useLingui();
   const [mounted, setMounted] = useState(false);
   const { releases } = useStableReleases();
   const latest = releases?.[0];
@@ -62,7 +62,7 @@ export function WelcomeScene() {
                 <span className="font-mono">{latest.tag_name}</span>
                 <span className="text-[color:var(--color-muted-foreground)]/80">
                   {" · "}
-                  {formatRelativeDate(latest.published_at)}
+                  {formatRelativeDate(latest.published_at, i18n.locale)}
                 </span>
                 <span className="hidden sm:inline">
                   {" · "}

--- a/apps/site/src/lib/release-i18n.test.ts
+++ b/apps/site/src/lib/release-i18n.test.ts
@@ -3,7 +3,11 @@ import {
   localizeGithubRelease,
   stripReleaseLocalizations,
 } from "./release-i18n";
-import { sectionTone, summarizeSections } from "./releaseSummary";
+import {
+  releaseExcerpt,
+  sectionTone,
+  summarizeSections,
+} from "./releaseSummary";
 import type { GithubRelease } from "./useGithubReleases";
 
 const metadata = {
@@ -74,6 +78,25 @@ describe("release localization", () => {
       count: 1,
     });
     expect(sectionTone(sections[0].kind)).toBe("added");
+  });
+
+  it("preserves unmarked human content outside generated note markers", () => {
+    const warning = "⚠️ **Windows users: reinstall manually.**";
+    const markedBody = `${warning}\n\n<picture><img alt="English cover" src="https://example.com/light.png"></picture>\n\nManual reviewer note.\n\n<!-- adt-ai-notes:start -->\n## English title\n\nEnglish generated notes.\n<!-- adt-ai-notes:end -->\n\n<!-- adt-release-i18n\n${JSON.stringify(metadata)}\n-->`;
+
+    const localized = localizeGithubRelease(
+      githubRelease(markedBody),
+      "pt-BR",
+    );
+
+    expect(localized.body).toContain(warning);
+    expect(localized.body).toContain("Manual reviewer note.");
+    expect(localized.body).toContain("Controle criativo summary");
+    expect(localized.body).not.toContain("English generated notes.");
+    expect(localized.body).toContain('alt="Controle criativo"');
+    expect(
+      releaseExcerpt(localized.body, localized.localization?.summary),
+    ).toBe("Controle criativo summary");
   });
 
   it("matches a regional locale by language", () => {

--- a/apps/site/src/lib/release-i18n.test.ts
+++ b/apps/site/src/lib/release-i18n.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import {
+  localizeGithubRelease,
+  stripReleaseLocalizations,
+} from "./release-i18n";
+import type { GithubRelease } from "./useGithubReleases";
+
+const metadata = {
+  schemaVersion: 1,
+  defaultLocale: "en",
+  locales: {
+    en: release("Creative Control", "Added", "Split books."),
+    "pt-BR": release("Controle criativo", "Adicionado", "Divida livros."),
+    fr: release("Contrôle créatif", "Ajouté", "Scindez des livres."),
+  },
+};
+
+function release(title: string, heading: string, item: string) {
+  return {
+    title,
+    summary: `${title} summary`,
+    coverAlt: title,
+    sections: {
+      added: { heading, items: [item] },
+      improved: { heading: "Improved", items: [] },
+      fixed: { heading: "Fixed", items: [] },
+    },
+  };
+}
+
+function githubRelease(body: string): GithubRelease {
+  return {
+    tag_name: "v0.7.4",
+    name: "ADT Studio v0.7.4",
+    body,
+    html_url: "https://github.com/unicef/adt-studio/releases/tag/v0.7.4",
+    published_at: "2026-07-08T04:57:43Z",
+    prerelease: false,
+    draft: false,
+    assets: [],
+  };
+}
+
+describe("release localization", () => {
+  const body = `<picture><img alt="English cover" src="https://example.com/light.png"></picture>\n\n## Creative Control\n\nEnglish notes.\n\n---\n\nFull diff: example\n\n<!-- adt-release-i18n\n${JSON.stringify(metadata)}\n-->`;
+
+  it("selects an exact locale while preserving the cover and footer", () => {
+    const localized = localizeGithubRelease(githubRelease(body), "pt-BR");
+    expect(localized.body).toContain("<picture>");
+    expect(localized.body).toContain('alt="Controle criativo"');
+    expect(localized.body).toContain("## Controle criativo");
+    expect(localized.body).toContain("### Adicionado");
+    expect(localized.body).toContain("- Divida livros.");
+    expect(localized.body).toContain("Full diff: example");
+    expect(localized.body).not.toContain("adt-release-i18n");
+  });
+
+  it("matches a regional locale by language", () => {
+    const localized = localizeGithubRelease(githubRelease(body), "fr-CA");
+    expect(localized.body).toContain("## Contrôle créatif");
+  });
+
+  it("falls back to English and strips malformed metadata", () => {
+    expect(localizeGithubRelease(githubRelease(body), "de").body).toContain(
+      "## Creative Control",
+    );
+    expect(stripReleaseLocalizations(`${body}\n`)).not.toContain(
+      "adt-release-i18n",
+    );
+    const malformed = githubRelease(
+      "Notes\n<!-- adt-release-i18n\nnot-json\n-->",
+    );
+    expect(localizeGithubRelease(malformed, "fr").body).toBe("Notes");
+  });
+});

--- a/apps/site/src/lib/release-i18n.test.ts
+++ b/apps/site/src/lib/release-i18n.test.ts
@@ -3,6 +3,7 @@ import {
   localizeGithubRelease,
   stripReleaseLocalizations,
 } from "./release-i18n";
+import { sectionTone, summarizeSections } from "./releaseSummary";
 import type { GithubRelease } from "./useGithubReleases";
 
 const metadata = {
@@ -45,25 +46,41 @@ describe("release localization", () => {
   const body = `<picture><img alt="English cover" src="https://example.com/light.png"></picture>\n\n## Creative Control\n\nEnglish notes.\n\n---\n\nFull diff: example\n\n<!-- adt-release-i18n\n${JSON.stringify(metadata)}\n-->`;
 
   it("selects an exact locale while preserving the cover and footer", () => {
-    const localized = localizeGithubRelease(githubRelease(body), "pt-BR");
+    const localized = localizeGithubRelease(githubRelease(body), "pt-BR", {
+      fullDiffLabel: "Comparação completa",
+    });
+    expect(localized.name).toBe("Controle criativo");
     expect(localized.body).toContain("<picture>");
     expect(localized.body).toContain('alt="Controle criativo"');
-    expect(localized.body).toContain("## Controle criativo");
+    expect(localized.body).not.toContain("## Controle criativo");
+    expect(localized.body).toContain("Controle criativo summary");
     expect(localized.body).toContain("### Adicionado");
     expect(localized.body).toContain("- Divida livros.");
-    expect(localized.body).toContain("Full diff: example");
+    expect(localized.body).toContain("Comparação completa: example");
     expect(localized.body).not.toContain("adt-release-i18n");
+
+    const sections = summarizeSections(
+      localized.body,
+      localized.localization?.sections,
+    );
+    expect(sections[0]).toEqual({
+      kind: "added",
+      title: "Adicionado",
+      count: 1,
+    });
+    expect(sectionTone(sections[0].kind)).toBe("added");
   });
 
   it("matches a regional locale by language", () => {
     const localized = localizeGithubRelease(githubRelease(body), "fr-CA");
-    expect(localized.body).toContain("## Contrôle créatif");
+    expect(localized.name).toBe("Contrôle créatif");
+    expect(localized.body).toContain("Contrôle créatif summary");
   });
 
   it("falls back to English and strips malformed metadata", () => {
-    expect(localizeGithubRelease(githubRelease(body), "de").body).toContain(
-      "## Creative Control",
-    );
+    const fallback = localizeGithubRelease(githubRelease(body), "de");
+    expect(fallback.name).toBe("Creative Control");
+    expect(fallback.body).toContain("Creative Control summary");
     expect(stripReleaseLocalizations(`${body}\n`)).not.toContain(
       "adt-release-i18n",
     );

--- a/apps/site/src/lib/release-i18n.test.ts
+++ b/apps/site/src/lib/release-i18n.test.ts
@@ -43,13 +43,18 @@ function githubRelease(body: string): GithubRelease {
 }
 
 describe("release localization", () => {
-  const body = `<picture><img alt="English cover" src="https://example.com/light.png"></picture>\n\n## Creative Control\n\nEnglish notes.\n\n---\n\nFull diff: example\n\n<!-- adt-release-i18n\n${JSON.stringify(metadata)}\n-->`;
+  const notice = `<!-- adt-release-notice:start -->\n**Windows users: reinstall this release manually.**\n<!-- adt-release-notice:end -->`;
+  const body = `${notice}\n\n<picture><img alt="English cover" src="https://example.com/light.png"></picture>\n\n## Creative Control\n\nEnglish notes.\n\n---\n\nFull diff: example\n\n<!-- adt-release-i18n\n${JSON.stringify(metadata)}\n-->`;
 
   it("selects an exact locale while preserving the cover and footer", () => {
     const localized = localizeGithubRelease(githubRelease(body), "pt-BR", {
       fullDiffLabel: "Comparação completa",
     });
     expect(localized.name).toBe("Controle criativo");
+    expect(localized.body).toMatch(/^<!-- adt-release-notice:start -->/);
+    expect(localized.body).toContain(
+      "Windows users: reinstall this release manually.",
+    );
     expect(localized.body).toContain("<picture>");
     expect(localized.body).toContain('alt="Controle criativo"');
     expect(localized.body).not.toContain("## Controle criativo");

--- a/apps/site/src/lib/release-i18n.ts
+++ b/apps/site/src/lib/release-i18n.ts
@@ -3,6 +3,8 @@ import type { GithubRelease } from "./useGithubReleases";
 const LOCALIZATION_PATTERN = /<!--\s*adt-release-i18n\s*\n([\s\S]*?)-->/i;
 const RELEASE_NOTICE_PATTERN =
   /<!--\s*adt-release-notice:start\s*-->[\s\S]*?<!--\s*adt-release-notice:end\s*-->/i;
+const RELEASE_NOTES_PATTERN =
+  /(<!--\s*adt-ai-notes:start\s*-->)([\s\S]*?)(<!--\s*adt-ai-notes:end\s*-->)/i;
 
 export type LocalizedSection = {
   kind: string;
@@ -102,26 +104,53 @@ function renderLocalizedBody(
   localized: LocalizedRelease,
   options: LocalizationOptions,
 ): string {
-  const releaseNotice = originalBody.match(RELEASE_NOTICE_PATTERN)?.[0];
-  const originalPicture = originalBody.match(
-    /<picture\b[\s\S]*?<\/picture>/i,
-  )?.[0];
-  const picture = originalPicture
-    ? replaceImageAlt(originalPicture, localized.coverAlt)
-    : undefined;
-  const originalFooter = originalBody.match(/\n---\s*\n([\s\S]*?)\s*$/)?.[1];
-  const footer = originalFooter
-    ? localizeFooter(originalFooter, options.fullDiffLabel)
-    : undefined;
   const sections = localized.sections
     .filter((section) => section.items.length > 0)
     .map(
       (section) =>
         `### ${section.heading}\n\n${section.items.map((item) => `- ${item}`).join("\n")}`,
     );
+
+  const generated = originalBody.match(RELEASE_NOTES_PATTERN);
+  if (generated) {
+    const originalFooter = generated[2].match(
+      /\n---\s*\n([\s\S]*?)\s*$/,
+    )?.[1];
+    const footer = originalFooter
+      ? localizeFooter(originalFooter, options.fullDiffLabel)
+      : undefined;
+    const content = [
+      localized.summary,
+      ...sections,
+      footer ? `---\n\n${footer.trim()}` : undefined,
+    ]
+      .filter(Boolean)
+      .join("\n\n");
+    return replaceImageAlt(
+      originalBody.replace(
+        generated[0],
+        `${generated[1]}\n${content}\n${generated[3]}`,
+      ),
+      localized.coverAlt,
+    );
+  }
+
+  const releaseNotice = originalBody.match(RELEASE_NOTICE_PATTERN)?.[0];
+  const pictureMatch = originalBody.match(/<picture\b[\s\S]*?<\/picture>/i);
+  const originalPicture = pictureMatch?.[0];
+  const preamble =
+    pictureMatch?.index != null
+      ? originalBody.slice(0, pictureMatch.index).trim()
+      : releaseNotice;
+  const originalFooter = originalBody.match(/\n---\s*\n([\s\S]*?)\s*$/)?.[1];
+  const footer = originalFooter
+    ? localizeFooter(originalFooter, options.fullDiffLabel)
+    : undefined;
   return [
-    releaseNotice,
-    picture,
+    preamble,
+    originalPicture
+      ? replaceImageAlt(originalPicture, localized.coverAlt)
+      : undefined,
     localized.summary,
     ...sections,
     footer ? `---\n\n${footer.trim()}` : undefined,

--- a/apps/site/src/lib/release-i18n.ts
+++ b/apps/site/src/lib/release-i18n.ts
@@ -2,7 +2,8 @@ import type { GithubRelease } from "./useGithubReleases";
 
 const LOCALIZATION_PATTERN = /<!--\s*adt-release-i18n\s*\n([\s\S]*?)-->/i;
 
-type LocalizedSection = {
+export type LocalizedSection = {
+  kind: string;
   heading: string;
   items: string[];
 };
@@ -11,11 +12,15 @@ export type LocalizedRelease = {
   title: string;
   summary: string;
   coverAlt: string;
-  sections: {
-    added: LocalizedSection;
-    improved: LocalizedSection;
-    fixed: LocalizedSection;
-  };
+  sections: LocalizedSection[];
+};
+
+export type LocalizedGithubRelease = GithubRelease & {
+  localization?: LocalizedRelease;
+};
+
+type LocalizationOptions = {
+  fullDiffLabel?: string;
 };
 
 type ReleaseLocalizations = {
@@ -27,7 +32,8 @@ type ReleaseLocalizations = {
 export function localizeGithubRelease(
   release: GithubRelease,
   locale: string,
-): GithubRelease {
+  options: LocalizationOptions = {},
+): LocalizedGithubRelease {
   if (!release.body) return release;
   const localizations = parseReleaseLocalizations(release.body);
   const cleanBody = stripReleaseLocalizations(release.body);
@@ -36,7 +42,9 @@ export function localizeGithubRelease(
   if (!localized) return { ...release, body: cleanBody };
   return {
     ...release,
-    body: renderLocalizedBody(cleanBody, localized),
+    name: localized.title,
+    body: renderLocalizedBody(cleanBody, localized, options),
+    localization: localized,
   };
 }
 
@@ -90,6 +98,7 @@ function resolveLocalization(
 function renderLocalizedBody(
   originalBody: string,
   localized: LocalizedRelease,
+  options: LocalizationOptions,
 ): string {
   const originalPicture = originalBody.match(
     /<picture\b[\s\S]*?<\/picture>/i,
@@ -97,8 +106,11 @@ function renderLocalizedBody(
   const picture = originalPicture
     ? replaceImageAlt(originalPicture, localized.coverAlt)
     : undefined;
-  const footer = originalBody.match(/\n---\s*\n([\s\S]*?)\s*$/)?.[1];
-  const sections = Object.values(localized.sections)
+  const originalFooter = originalBody.match(/\n---\s*\n([\s\S]*?)\s*$/)?.[1];
+  const footer = originalFooter
+    ? localizeFooter(originalFooter, options.fullDiffLabel)
+    : undefined;
+  const sections = localized.sections
     .filter((section) => section.items.length > 0)
     .map(
       (section) =>
@@ -106,13 +118,21 @@ function renderLocalizedBody(
     );
   return [
     picture,
-    `## ${localized.title}`,
     localized.summary,
     ...sections,
     footer ? `---\n\n${footer.trim()}` : undefined,
   ]
     .filter(Boolean)
     .join("\n\n");
+}
+
+function localizeFooter(footer: string, fullDiffLabel?: string): string {
+  if (!fullDiffLabel) return footer;
+  return footer.replace(
+    /(\*{0,2})Full diff(\*{0,2})(\s*:)/i,
+    (_match, opening: string, closing: string, suffix: string) =>
+      `${opening}${fullDiffLabel}${closing}${suffix}`,
+  );
 }
 
 function replaceImageAlt(picture: string, alt: string): string {
@@ -130,16 +150,17 @@ function replaceImageAlt(picture: string, alt: string): string {
 
 function parseLocalizedRelease(value: unknown): LocalizedRelease | undefined {
   if (!isRecord(value) || !isRecord(value.sections)) return undefined;
-  const added = parseSection(value.sections.added);
-  const improved = parseSection(value.sections.improved);
-  const fixed = parseSection(value.sections.fixed);
+  const sectionEntries = Object.entries(value.sections);
+  const sections = sectionEntries.flatMap(([kind, candidate]) => {
+    const parsed = parseSection(kind, candidate);
+    return parsed ? [parsed] : [];
+  });
   if (
     typeof value.title !== "string" ||
     typeof value.summary !== "string" ||
     typeof value.coverAlt !== "string" ||
-    !added ||
-    !improved ||
-    !fixed
+    sections.length === 0 ||
+    sections.length !== sectionEntries.length
   ) {
     return undefined;
   }
@@ -147,12 +168,16 @@ function parseLocalizedRelease(value: unknown): LocalizedRelease | undefined {
     title: value.title,
     summary: value.summary,
     coverAlt: value.coverAlt,
-    sections: { added, improved, fixed },
+    sections,
   };
 }
 
-function parseSection(value: unknown): LocalizedSection | undefined {
+function parseSection(
+  kind: string,
+  value: unknown,
+): LocalizedSection | undefined {
   if (
+    !kind.trim() ||
     !isRecord(value) ||
     typeof value.heading !== "string" ||
     !Array.isArray(value.items) ||
@@ -160,7 +185,7 @@ function parseSection(value: unknown): LocalizedSection | undefined {
   ) {
     return undefined;
   }
-  return { heading: value.heading, items: value.items };
+  return { kind, heading: value.heading, items: value.items };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/site/src/lib/release-i18n.ts
+++ b/apps/site/src/lib/release-i18n.ts
@@ -1,0 +1,168 @@
+import type { GithubRelease } from "./useGithubReleases";
+
+const LOCALIZATION_PATTERN = /<!--\s*adt-release-i18n\s*\n([\s\S]*?)-->/i;
+
+type LocalizedSection = {
+  heading: string;
+  items: string[];
+};
+
+export type LocalizedRelease = {
+  title: string;
+  summary: string;
+  coverAlt: string;
+  sections: {
+    added: LocalizedSection;
+    improved: LocalizedSection;
+    fixed: LocalizedSection;
+  };
+};
+
+type ReleaseLocalizations = {
+  schemaVersion: 1;
+  defaultLocale: string;
+  locales: Record<string, LocalizedRelease>;
+};
+
+export function localizeGithubRelease(
+  release: GithubRelease,
+  locale: string,
+): GithubRelease {
+  if (!release.body) return release;
+  const localizations = parseReleaseLocalizations(release.body);
+  const cleanBody = stripReleaseLocalizations(release.body);
+  if (!localizations) return { ...release, body: cleanBody };
+  const localized = resolveLocalization(localizations, locale);
+  if (!localized) return { ...release, body: cleanBody };
+  return {
+    ...release,
+    body: renderLocalizedBody(cleanBody, localized),
+  };
+}
+
+export function stripReleaseLocalizations(body: string): string {
+  return body.replace(LOCALIZATION_PATTERN, "").trimEnd();
+}
+
+export function parseReleaseLocalizations(
+  body: string,
+): ReleaseLocalizations | undefined {
+  const match = body.match(LOCALIZATION_PATTERN);
+  if (!match) return undefined;
+  try {
+    const value: unknown = JSON.parse(match[1]);
+    if (!isRecord(value) || value.schemaVersion !== 1) return undefined;
+    if (typeof value.defaultLocale !== "string" || !isRecord(value.locales)) {
+      return undefined;
+    }
+    const locales: Record<string, LocalizedRelease> = {};
+    for (const [locale, candidate] of Object.entries(value.locales)) {
+      const parsed = parseLocalizedRelease(candidate);
+      if (parsed) locales[locale] = parsed;
+    }
+    if (!locales[value.defaultLocale]) return undefined;
+    return {
+      schemaVersion: 1,
+      defaultLocale: value.defaultLocale,
+      locales,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveLocalization(
+  localizations: ReleaseLocalizations,
+  requestedLocale: string,
+): LocalizedRelease | undefined {
+  const normalized = requestedLocale.toLowerCase();
+  const exact = Object.entries(localizations.locales).find(
+    ([locale]) => locale.toLowerCase() === normalized,
+  )?.[1];
+  if (exact) return exact;
+  const language = normalized.split("-")[0];
+  const languageMatch = Object.entries(localizations.locales).find(
+    ([locale]) => locale.toLowerCase().split("-")[0] === language,
+  )?.[1];
+  return languageMatch ?? localizations.locales[localizations.defaultLocale];
+}
+
+function renderLocalizedBody(
+  originalBody: string,
+  localized: LocalizedRelease,
+): string {
+  const originalPicture = originalBody.match(
+    /<picture\b[\s\S]*?<\/picture>/i,
+  )?.[0];
+  const picture = originalPicture
+    ? replaceImageAlt(originalPicture, localized.coverAlt)
+    : undefined;
+  const footer = originalBody.match(/\n---\s*\n([\s\S]*?)\s*$/)?.[1];
+  const sections = Object.values(localized.sections)
+    .filter((section) => section.items.length > 0)
+    .map(
+      (section) =>
+        `### ${section.heading}\n\n${section.items.map((item) => `- ${item}`).join("\n")}`,
+    );
+  return [
+    picture,
+    `## ${localized.title}`,
+    localized.summary,
+    ...sections,
+    footer ? `---\n\n${footer.trim()}` : undefined,
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+}
+
+function replaceImageAlt(picture: string, alt: string): string {
+  const escaped = alt
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+  return picture.replace(/<img\b[^>]*>/i, (image) =>
+    /\salt=["'][^"']*["']/i.test(image)
+      ? image.replace(/\salt=["'][^"']*["']/i, ` alt="${escaped}"`)
+      : image.replace(/>$/, ` alt="${escaped}">`),
+  );
+}
+
+function parseLocalizedRelease(value: unknown): LocalizedRelease | undefined {
+  if (!isRecord(value) || !isRecord(value.sections)) return undefined;
+  const added = parseSection(value.sections.added);
+  const improved = parseSection(value.sections.improved);
+  const fixed = parseSection(value.sections.fixed);
+  if (
+    typeof value.title !== "string" ||
+    typeof value.summary !== "string" ||
+    typeof value.coverAlt !== "string" ||
+    !added ||
+    !improved ||
+    !fixed
+  ) {
+    return undefined;
+  }
+  return {
+    title: value.title,
+    summary: value.summary,
+    coverAlt: value.coverAlt,
+    sections: { added, improved, fixed },
+  };
+}
+
+function parseSection(value: unknown): LocalizedSection | undefined {
+  if (
+    !isRecord(value) ||
+    typeof value.heading !== "string" ||
+    !Array.isArray(value.items) ||
+    !value.items.every((item) => typeof item === "string")
+  ) {
+    return undefined;
+  }
+  return { heading: value.heading, items: value.items };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/apps/site/src/lib/release-i18n.ts
+++ b/apps/site/src/lib/release-i18n.ts
@@ -1,6 +1,8 @@
 import type { GithubRelease } from "./useGithubReleases";
 
 const LOCALIZATION_PATTERN = /<!--\s*adt-release-i18n\s*\n([\s\S]*?)-->/i;
+const RELEASE_NOTICE_PATTERN =
+  /<!--\s*adt-release-notice:start\s*-->[\s\S]*?<!--\s*adt-release-notice:end\s*-->/i;
 
 export type LocalizedSection = {
   kind: string;
@@ -100,6 +102,7 @@ function renderLocalizedBody(
   localized: LocalizedRelease,
   options: LocalizationOptions,
 ): string {
+  const releaseNotice = originalBody.match(RELEASE_NOTICE_PATTERN)?.[0];
   const originalPicture = originalBody.match(
     /<picture\b[\s\S]*?<\/picture>/i,
   )?.[0];
@@ -117,6 +120,7 @@ function renderLocalizedBody(
         `### ${section.heading}\n\n${section.items.map((item) => `- ${item}`).join("\n")}`,
     );
   return [
+    releaseNotice,
     picture,
     localized.summary,
     ...sections,

--- a/apps/site/src/lib/releaseSummary.ts
+++ b/apps/site/src/lib/releaseSummary.ts
@@ -195,6 +195,14 @@ export function firstParagraphFromBody(
   return `${text.slice(0, maxChars - 1).replace(/\s+\S*$/, "")}…`;
 }
 
+export function releaseExcerpt(
+  body: string | null | undefined,
+  localizedSummary?: string,
+  maxChars = 240,
+): string {
+  return localizedSummary?.trim() || firstParagraphFromBody(body, maxChars);
+}
+
 /**
  * Map a section heading like "Added" / "Fixed" / "Performance" to a chip
  * palette key. Anything we don't recognize falls back to "neutral".

--- a/apps/site/src/lib/releaseSummary.ts
+++ b/apps/site/src/lib/releaseSummary.ts
@@ -67,6 +67,8 @@ export function firstImageFromBody(
 }
 
 export type ReleaseSection = {
+  /** Stable semantic identifier, e.g. "added", even when the title is translated. */
+  kind: string;
   /** Trimmed heading text, e.g. "Added", "Fixed", "Performance". */
   title: string;
   /** Bullet count under this heading (counts top-level `- ` / `* ` lines). */
@@ -84,7 +86,22 @@ export type ReleaseSection = {
  */
 export function summarizeSections(
   body: string | null | undefined,
+  localizedSections?: ReadonlyArray<{
+    kind: string;
+    heading: string;
+    items: readonly string[];
+  }>,
 ): ReleaseSection[] {
+  if (localizedSections) {
+    return localizedSections
+      .filter((section) => section.items.length > 0)
+      .map((section) => ({
+        kind: section.kind,
+        title: section.heading,
+        count: section.items.length,
+      }))
+      .slice(0, 5);
+  }
   if (!body) return [];
   const lines = body.replace(/\r\n/g, "\n").split("\n");
 
@@ -102,13 +119,15 @@ export function summarizeSections(
 
     const h3Match = /^###\s+(.+?)\s*$/.exec(raw);
     if (h3Match) {
-      current = { title: cleanHeading(h3Match[1]), count: 0 };
+      const title = cleanHeading(h3Match[1]);
+      current = { kind: title, title, count: 0 };
       h3.push(current);
       continue;
     }
     const h2Match = /^##\s+(.+?)\s*$/.exec(raw);
     if (h2Match) {
-      current = { title: cleanHeading(h2Match[1]), count: 0 };
+      const title = cleanHeading(h2Match[1]);
+      current = { kind: title, title, count: 0 };
       h2.push(current);
       continue;
     }

--- a/apps/site/src/lib/useGithubReleases.test.ts
+++ b/apps/site/src/lib/useGithubReleases.test.ts
@@ -1,0 +1,21 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { formatAbsoluteDate, formatRelativeDate } from "./useGithubReleases";
+
+describe("release date formatting", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("uses the selected locale for absolute dates", () => {
+    expect(formatAbsoluteDate("2026-07-08T12:00:00Z", "fr")).toBe(
+      "8 juillet 2026",
+    );
+  });
+
+  it("uses the selected locale for relative dates", () => {
+    vi.spyOn(Date, "now").mockReturnValue(
+      new Date("2026-07-10T12:00:00Z").getTime(),
+    );
+    expect(formatRelativeDate("2026-07-08T12:00:00Z", "fr")).toBe(
+      "avant-hier",
+    );
+  });
+});

--- a/apps/site/src/lib/useGithubReleases.ts
+++ b/apps/site/src/lib/useGithubReleases.ts
@@ -162,7 +162,7 @@ export function useGithubRelease(tag: string | null): {
   return { release, loading, error };
 }
 
-export function formatRelativeDate(iso: string): string {
+export function formatRelativeDate(iso: string, locale?: string): string {
   const then = new Date(iso).getTime();
   const diff = Date.now() - then;
   const sec = Math.floor(diff / 1000);
@@ -171,12 +171,16 @@ export function formatRelativeDate(iso: string): string {
   const day = Math.floor(hr / 24);
   const month = Math.floor(day / 30);
   const year = Math.floor(day / 365);
-  if (year >= 1) return `${year}y ago`;
-  if (month >= 1) return `${month}mo ago`;
-  if (day >= 1) return `${day === 1 ? "1 day" : `${day} days`} ago`;
-  if (hr >= 1) return `${hr}h ago`;
-  if (min >= 1) return `${min}m ago`;
-  return "just now";
+  const formatter = new Intl.RelativeTimeFormat(locale, {
+    numeric: "auto",
+    style: "short",
+  });
+  if (year >= 1) return formatter.format(-year, "year");
+  if (month >= 1) return formatter.format(-month, "month");
+  if (day >= 1) return formatter.format(-day, "day");
+  if (hr >= 1) return formatter.format(-hr, "hour");
+  if (min >= 1) return formatter.format(-min, "minute");
+  return formatter.format(0, "second");
 }
 
 export function formatDownloads(n: number): string {
@@ -202,9 +206,9 @@ export function sumAllDownloads(releases: GithubRelease[] | null): number {
   return releases.reduce((acc, r) => acc + sumReleaseDownloads(r), 0);
 }
 
-export function formatAbsoluteDate(iso: string): string {
+export function formatAbsoluteDate(iso: string, locale?: string): string {
   const d = new Date(iso);
-  return d.toLocaleDateString(undefined, {
+  return d.toLocaleDateString(locale, {
     year: "numeric",
     month: "long",
     day: "numeric",

--- a/apps/site/src/locales/en.po
+++ b/apps/site/src/locales/en.po
@@ -389,6 +389,9 @@ msgstr "From PDF to"
 msgid "Full control over render strategies, pruning, and filters."
 msgstr "Full control over render strategies, pruning, and filters."
 
+msgid "Full diff"
+msgstr "Full diff"
+
 msgid "Full transparency"
 msgstr "Full transparency"
 
@@ -728,7 +731,7 @@ msgstr "Reference"
 msgid "Release to upload"
 msgstr "Release to upload"
 
-#. placeholder {0}: formatRelativeDate(latest.published_at)
+#. placeholder {0}: formatRelativeDate(latest.published_at, i18n.locale)
 msgid "Released {0}"
 msgstr "Released {0}"
 

--- a/apps/site/src/locales/es.po
+++ b/apps/site/src/locales/es.po
@@ -390,6 +390,9 @@ msgstr "De PDF a"
 msgid "Full control over render strategies, pruning, and filters."
 msgstr "Control total sobre estrategias de renderizado, poda y filtros."
 
+msgid "Full diff"
+msgstr "Comparación completa"
+
 msgid "Full transparency"
 msgstr "Total transparencia"
 
@@ -726,7 +729,7 @@ msgstr "Referencia"
 msgid "Release to upload"
 msgstr "Suelta para subir"
 
-#. placeholder {0}: formatRelativeDate(latest.published_at)
+#. placeholder {0}: formatRelativeDate(latest.published_at, i18n.locale)
 msgid "Released {0}"
 msgstr "Publicado {0}"
 

--- a/apps/site/src/locales/fr.po
+++ b/apps/site/src/locales/fr.po
@@ -390,6 +390,9 @@ msgstr "De PDF à"
 msgid "Full control over render strategies, pruning, and filters."
 msgstr "Contrôle total sur les stratégies de rendu, l'élagage et les filtres."
 
+msgid "Full diff"
+msgstr "Comparaison complète"
+
 msgid "Full transparency"
 msgstr "Transparence totale"
 
@@ -726,7 +729,7 @@ msgstr "Référence"
 msgid "Release to upload"
 msgstr "Relâchez pour téléverser"
 
-#. placeholder {0}: formatRelativeDate(latest.published_at)
+#. placeholder {0}: formatRelativeDate(latest.published_at, i18n.locale)
 msgid "Released {0}"
 msgstr "Publié {0}"
 

--- a/apps/site/src/locales/pt-BR.po
+++ b/apps/site/src/locales/pt-BR.po
@@ -390,6 +390,9 @@ msgstr "De PDF para"
 msgid "Full control over render strategies, pruning, and filters."
 msgstr "Controle total sobre estratégias de renderização, poda e filtros."
 
+msgid "Full diff"
+msgstr "Comparação completa"
+
 msgid "Full transparency"
 msgstr "Transparência total"
 
@@ -726,7 +729,7 @@ msgstr "Referência"
 msgid "Release to upload"
 msgstr "Solte para enviar"
 
-#. placeholder {0}: formatRelativeDate(latest.published_at)
+#. placeholder {0}: formatRelativeDate(latest.published_at, i18n.locale)
 msgid "Released {0}"
 msgstr "Lançado {0}"
 


### PR DESCRIPTION
## Summary

- read the versioned `adt-release-i18n` metadata embedded in GitHub release bodies
- render the selected site locale across the homepage spotlight, downloads, welcome scene, and changelog
- normalize GitHub release data once and preserve theme-aware covers, localized alt text, and full-diff links
- safely ignore malformed metadata and fall back by language, then to English

The live v0.7.4 release now contains the five-locale test fixture and a matching `release-i18n.json` asset.

## Review stack

This is the website consumer of the contract introduced by #757. Review #757 first, then this PR alongside #756.

```text
#757 Release producer (develop)
├── #756 Electron app consumer (develop)
└── #755 Website consumer (landing-page) ← this PR
```

1. [#757 — Release workflow and generated assets](https://github.com/unicef/adt-studio/pull/757)
2. [#756 — App: localized release content](https://github.com/unicef/adt-studio/pull/756)
3. **#755 — Site: localized release content** (this PR)

The consumers share the same versioned `adt-release-i18n` contract. They remain parallel because `apps/site` is deployed from `landing-page` and is not present on `develop`; retargeting this PR would mix deployment branches.

## Test plan

- `pnpm exec vitest run apps/site/src/lib/release-i18n.test.ts apps/site/src/lib/useGithubReleases.test.ts`
- `pnpm --filter @adt/site types:check`
- `pnpm --filter @adt/site build`
- switch `?lang=en`, `pt-BR`, `es`, and `fr` and inspect v0.7.4
