### PR TITLE
fix(storyboard): allow deleting containers without persisted data-ids

### DIFF
--- a/apps/studio/src/components/pipeline/stages/storyboard/components/BookPreviewFrame.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/BookPreviewFrame.tsx
@@ -13,6 +13,7 @@ import {
   demoteFirstHeadingIfPromoted,
   promoteFirstHeadingToH1,
   reconstructHtmlWithEdit,
+  removeElementFromSourceHtml,
   serializeContentWrapper,
 } from "./iframe-html"
 import {
@@ -87,13 +88,12 @@ export interface BookPreviewFrameHandle {
    *  element by data-id. Returns updated full HTML, or null. Used for styling
    *  that must win over class/cascade rules (e.g. per-element font-family). */
   setElementStyleProp: (dataId: string, property: string, value: string) => string | null
-  /** Remove an element by data-id from the live iframe DOM and serialize the
-   *  result. Returns the updated full HTML plus the real (non-transient)
-   *  data-ids found in the removed subtree, or null when the element isn't in
-   *  the iframe. Needed for containers whose data-id is a transient `_el#`
-   *  assigned at selection time — those ids never exist in the stored HTML,
-   *  so removal has to go through the iframe DOM. The reported ids let the
-   *  caller drop the matching sectioning leaves along with the HTML. */
+  /** Resolve an iframe element by data-id, remove its counterpart from the
+   *  unsanitized source HTML, and mirror the removal in the live DOM. Returns
+   *  the updated source HTML plus the real (non-transient) data-ids found in
+   *  the removed subtree, or null when the element cannot be resolved safely.
+   *  Needed for containers whose transient `_el#` id exists only in the live
+   *  iframe. The reported ids let the caller drop matching sectioning leaves. */
   removeElement: (dataId: string) => { html: string; removedDataIds: string[] } | null
   /** Re-inject the current `html` prop into the iframe, discarding any in-iframe
    *  DOM mutations (e.g. live `setElementClasses` edits). Used when the parent
@@ -290,17 +290,12 @@ export const BookPreviewFrame = forwardRef<BookPreviewFrameHandle, BookPreviewFr
       if (!doc) return null
       const el = doc.querySelector(`[data-id="${CSS.escape(dataId)}"]`) as HTMLElement | null
       if (!el) return null
-      const removedDataIds = [el, ...Array.from(el.querySelectorAll("[data-id]"))]
-        .map((n) => n.getAttribute("data-id"))
-        .filter((id): id is string => !!id && !/^_el\d+$/.test(id))
+      const liveRoot = doc.getElementById("content") ?? doc.body
+      const removed = removeElementFromSourceHtml(sourceHtmlRef.current, liveRoot, el)
+      if (!removed) return null
       el.remove()
       stripTransientAttributes(doc)
-      const wrapper = doc.getElementById("content")
-      const html = wrapper ? serializeContentWrapper(wrapper) : doc.body.innerHTML
-      return {
-        html: demoteFirstHeadingIfPromoted(html, sanitizedHtmlRef.current),
-        removedDataIds,
-      }
+      return removed
     },
     resetContent: () => {
       if (readyRef.current) injectContent(latestHtmlRef.current)
@@ -376,6 +371,7 @@ export const BookPreviewFrame = forwardRef<BookPreviewFrameHandle, BookPreviewFr
   const [availableWidth, setAvailableWidth] = useState(DEFAULT_RENDER_WIDTH)
   const readyRef = useRef(false)
   const latestHtmlRef = useRef("")
+  const sourceHtmlRef = useRef("")
   const sanitizedHtmlRef = useRef("")
   const originalTextsRef = useRef<Record<string, string>>({})
   const measureTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -406,6 +402,7 @@ export const BookPreviewFrame = forwardRef<BookPreviewFrameHandle, BookPreviewFr
     return () => { cancelled = true }
   }, [sanitizedHtml, assetsPrefix, thumbnail])
   latestHtmlRef.current = displayHtml
+  sourceHtmlRef.current = html
   sanitizedHtmlRef.current = sanitizedHtml
 
   // Build a map of data-id → original LaTeX innerHTML so the iframe can swap

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/BookPreviewFrame.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/BookPreviewFrame.tsx
@@ -87,6 +87,14 @@ export interface BookPreviewFrameHandle {
    *  element by data-id. Returns updated full HTML, or null. Used for styling
    *  that must win over class/cascade rules (e.g. per-element font-family). */
   setElementStyleProp: (dataId: string, property: string, value: string) => string | null
+  /** Remove an element by data-id from the live iframe DOM and serialize the
+   *  result. Returns the updated full HTML plus the real (non-transient)
+   *  data-ids found in the removed subtree, or null when the element isn't in
+   *  the iframe. Needed for containers whose data-id is a transient `_el#`
+   *  assigned at selection time — those ids never exist in the stored HTML,
+   *  so removal has to go through the iframe DOM. The reported ids let the
+   *  caller drop the matching sectioning leaves along with the HTML. */
+  removeElement: (dataId: string) => { html: string; removedDataIds: string[] } | null
   /** Re-inject the current `html` prop into the iframe, discarding any in-iframe
    *  DOM mutations (e.g. live `setElementClasses` edits). Used when the parent
    *  wants to revert to the saved state without changing the html prop. */
@@ -276,6 +284,23 @@ export const BookPreviewFrame = forwardRef<BookPreviewFrameHandle, BookPreviewFr
       const html = wrapper ? serializeContentWrapper(wrapper) : doc.body.innerHTML
       el.setAttribute("data-adt-selected", "true")
       return demoteFirstHeadingIfPromoted(html, sanitizedHtmlRef.current)
+    },
+    removeElement: (dataId: string): { html: string; removedDataIds: string[] } | null => {
+      const doc = iframeRef.current?.contentDocument
+      if (!doc) return null
+      const el = doc.querySelector(`[data-id="${CSS.escape(dataId)}"]`) as HTMLElement | null
+      if (!el) return null
+      const removedDataIds = [el, ...Array.from(el.querySelectorAll("[data-id]"))]
+        .map((n) => n.getAttribute("data-id"))
+        .filter((id): id is string => !!id && !/^_el\d+$/.test(id))
+      el.remove()
+      stripTransientAttributes(doc)
+      const wrapper = doc.getElementById("content")
+      const html = wrapper ? serializeContentWrapper(wrapper) : doc.body.innerHTML
+      return {
+        html: demoteFirstHeadingIfPromoted(html, sanitizedHtmlRef.current),
+        removedDataIds,
+      }
     },
     resetContent: () => {
       if (readyRef.current) injectContent(latestHtmlRef.current)

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
@@ -2287,6 +2287,7 @@ export function StoryboardSectionDetail({
       tagName: tag,
       textType: leaf && !isImage ? leaf.role : undefined,
       isPruned: leaf?.isPruned ?? false,
+      hasTreeNode: leaf != null,
       imageSrc: isImage ? `${BASE_URL}/books/${bookLabel}/images/${dataId}` : undefined,
     }
   }
@@ -3203,9 +3204,15 @@ export function StoryboardSectionDetail({
                   storyboardRunning || selectedInfo.isContainer
                     ? undefined
                     : handleToolbarChangeTextType,
-                onTogglePrune:
-                  storyboardRunning || selectedInfo.isContainer
-                    ? undefined
+                // Containers with a sectioning-tree node prune like any leaf
+                // (inherited prune greys and strips their contents at save).
+                // Decoration containers the renderer invented have no tree
+                // node to hold prune state, so the prune action removes them
+                // outright, same as Delete.
+                onTogglePrune: storyboardRunning
+                  ? undefined
+                  : selectedInfo.isContainer && !selectedInfo.hasTreeNode
+                    ? handleDeleteBlock
                     : handleToolbarPrune,
                 onCrop:
                   selectedInfo.isImage && !storyboardRunning

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
@@ -1467,17 +1467,35 @@ export function StoryboardSectionDetail({
   // Delete selected block from rendered HTML and remove the matching leaf from sectioning.
   const handleDeleteBlock = useCallback(
     (dataId: string) => {
-      removeElementsFromRendering([dataId])
+      const treeIds = new Set([dataId])
+      if (!removeElementsFromRendering([dataId])) {
+        // Containers the renderer emitted without a data-id carry a transient
+        // `_el#` id that exists only in the live iframe DOM, so the stored-HTML
+        // removal above can't find them. Remove from the iframe and queue the
+        // serialized result the same way class/style edits do — the deselect
+        // below flushes it into pendingRendering. The subtree's real data-ids
+        // are deleted from the sectioning tree as well; leaving them behind
+        // would resurrect the content on the next LLM re-render and keep it in
+        // the text catalog and TTS.
+        const removed = previewFrameRef.current?.removeElement(dataId)
+        if (removed) {
+          pendingHtmlRef.current = { html: removed.html, sectionIndex }
+          setHasUnflushedEdits(true)
+          markPending("elements")
+          for (const id of removed.removedDataIds) treeIds.add(id)
+        }
+      }
       const sBase = pendingSectioning ?? (page.sectioningTree as SectioningData | null)
       if (sBase && section) {
-        const nextNodes = deleteNode(section.nodes, dataId)
+        let nextNodes = section.nodes
+        for (const id of treeIds) nextNodes = deleteNode(nextNodes, id)
         if (nextNodes !== section.nodes) {
           setPendingSectioning(withSectionNodes(sBase, sectionIndex, nextNodes))
         }
       }
       setSelectedElement(null)
     },
-    [removeElementsFromRendering, pendingSectioning, page.sectioningTree, sectionIndex, section]
+    [removeElementsFromRendering, pendingSectioning, page.sectioningTree, sectionIndex, section, markPending]
   )
 
   // Replace the current section with an updated copy (from SectionTreeEditor).

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
@@ -3207,12 +3207,11 @@ export function StoryboardSectionDetail({
                 // Containers with a sectioning-tree node prune like any leaf
                 // (inherited prune greys and strips their contents at save).
                 // Decoration containers the renderer invented have no tree
-                // node to hold prune state, so the prune action removes them
-                // outright, same as Delete.
-                onTogglePrune: storyboardRunning
-                  ? undefined
-                  : selectedInfo.isContainer && !selectedInfo.hasTreeNode
-                    ? handleDeleteBlock
+                // node to hold prune state, so they get no prune toggle —
+                // Delete is their removal path.
+                onTogglePrune:
+                  storyboardRunning || (selectedInfo.isContainer && !selectedInfo.hasTreeNode)
+                    ? undefined
                     : handleToolbarPrune,
                 onCrop:
                   selectedInfo.isImage && !storyboardRunning

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/iframe-html.test.ts
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/iframe-html.test.ts
@@ -1,6 +1,10 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from "vitest"
-import { reconstructHtmlWithEdit, serializeContentWrapper } from "./iframe-html"
+import {
+  reconstructHtmlWithEdit,
+  removeElementFromSourceHtml,
+  serializeContentWrapper,
+} from "./iframe-html"
 
 // jsdom does not implement CSS.escape, which reconstructHtmlWithEdit relies on
 // (present in real browsers / Electron). The fixtures use plain-identifier
@@ -111,5 +115,39 @@ describe("reconstructHtmlWithEdit", () => {
 
   it("returns null when the data-id is not found", () => {
     expect(reconstructHtmlWithEdit(FIXED_LAYOUT, "missing", "x")).toBeNull()
+  })
+})
+
+describe("removeElementFromSourceHtml", () => {
+  it("removes the matching source wrapper while preserving scripts and LaTeX", () => {
+    const source = `<div id="content" class="container"><section>
+  <div class="keep"><p data-id="keep">The area is $\\pi r^2$</p></div>
+  <script>window.adtRegisterCustomActivity(section, { validate: () => true })</script>
+  <div class="bg-orange-100"><span data-id="remove">Remove me</span></div>
+</section></div>`
+    const live = wrapperFrom(`<div id="content" class="container"><section>
+  <div class="keep"><p data-id="keep">The area is <math><mi>π</mi></math></p></div>
+  <div class="bg-orange-100" data-id="_el1"><span data-id="remove">Remove me</span></div>
+</section></div>`)
+    const target = live.querySelector('[data-id="_el1"]')
+    if (!target) throw new Error("no transient target in fixture")
+
+    const result = removeElementFromSourceHtml(source, live, target)
+
+    expect(result).not.toBeNull()
+    expect(result?.removedDataIds).toEqual(["remove"])
+    expect(result?.html).not.toContain("Remove me")
+    expect(result?.html).toContain("$\\pi r^2$")
+    expect(result?.html).not.toContain("<math")
+    expect(result?.html).toContain("window.adtRegisterCustomActivity")
+  })
+
+  it("refuses to remove when the live subtree cannot be matched to the source", () => {
+    const source = `<div id="content" class="container"><div><span data-id="source">Source</span></div></div>`
+    const live = wrapperFrom(`<div id="content" class="container"><div data-id="_el1"><span data-id="other">Other</span></div></div>`)
+    const target = live.querySelector('[data-id="_el1"]')
+    if (!target) throw new Error("no transient target in fixture")
+
+    expect(removeElementFromSourceHtml(source, live, target)).toBeNull()
   })
 })

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/iframe-html.ts
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/iframe-html.ts
@@ -60,6 +60,94 @@ export function serializeContentWrapper(wrapper: Element): string {
   return clone.outerHTML
 }
 
+interface ElementPathSegment {
+  tagName: string
+  indexAmongTag: number
+}
+
+/**
+ * Describe an element's location without relying on transient preview ids.
+ * Indexing among siblings with the same tag keeps the path stable when
+ * DOMPurify removes a sibling <script> before the preview is injected.
+ */
+function elementPath(root: Element, target: Element): ElementPathSegment[] | null {
+  if (root === target || !root.contains(target)) return null
+  const reversed: ElementPathSegment[] = []
+  let current = target
+
+  while (current !== root) {
+    const parent = current.parentElement
+    if (!parent) return null
+    const tagName = current.tagName.toLowerCase()
+    const sameTagSiblings = Array.from(parent.children).filter(
+      (child) => child.tagName.toLowerCase() === tagName
+    )
+    const indexAmongTag = sameTagSiblings.indexOf(current)
+    if (indexAmongTag < 0) return null
+    reversed.push({ tagName, indexAmongTag })
+    current = parent
+  }
+
+  return reversed.reverse()
+}
+
+function elementAtPath(root: Element, path: ElementPathSegment[]): Element | null {
+  let current = root
+  for (const segment of path) {
+    const matches = Array.from(current.children).filter(
+      (child) => child.tagName.toLowerCase() === segment.tagName
+    )
+    const next = matches[segment.indexAmongTag]
+    if (!next) return null
+    current = next
+  }
+  return current
+}
+
+/**
+ * Remove a transiently-addressed preview element from the persistence source.
+ * The live iframe contains sanitized HTML and display-only MathML, so
+ * serializing it would drop custom-activity scripts and replace source LaTeX.
+ */
+export function removeElementFromSourceHtml(
+  sourceHtml: string,
+  liveRoot: Element,
+  liveTarget: Element
+): { html: string; removedDataIds: string[] } | null {
+  const path = elementPath(liveRoot, liveTarget)
+  if (!path) return null
+
+  const parser = new DOMParser()
+  const doc = parser.parseFromString(`<div id="__root">${sourceHtml}</div>`, "text/html")
+  // eslint-disable-next-line lingui/no-unlocalized-strings -- Internal DOM id, not user-visible
+  const syntheticRoot = doc.getElementById("__root")
+  if (!syntheticRoot) return null
+  const sourceRoot = doc.getElementById("content") ?? syntheticRoot
+  const sourceTarget = elementAtPath(sourceRoot, path)
+  if (!sourceTarget) return null
+
+  const liveDataIds = Array.from(liveTarget.querySelectorAll("[data-id]"))
+    .map((node) => node.getAttribute("data-id"))
+    .filter((id): id is string => !!id && !/^_el\d+$/.test(id))
+  if (
+    liveDataIds.some(
+      (id) => sourceTarget.querySelector(`[data-id="${CSS.escape(id)}"]`) === null
+    )
+  ) {
+    return null
+  }
+
+  const removedDataIds = [sourceTarget, ...Array.from(sourceTarget.querySelectorAll("[data-id]"))]
+    .map((node) => node.getAttribute("data-id"))
+    .filter((id): id is string => !!id && !/^_el\d+$/.test(id))
+  sourceTarget.remove()
+
+  return {
+    html: serializeContentWrapper(sourceRoot),
+    removedDataIds,
+  }
+}
+
 // Apply a text edit to the original (LaTeX) HTML by splicing the iframe's
 // edited innerHTML into the element matching the given data-id. Using innerHTML
 // (rather than `textContent = newText`) preserves the inner span structure that
@@ -77,6 +165,7 @@ export function reconstructHtmlWithEdit(
     const el = doc.querySelector(`[data-id="${CSS.escape(dataId)}"]`)
     if (!el) return null
     el.innerHTML = editedInnerHtml
+    // eslint-disable-next-line lingui/no-unlocalized-strings -- Internal DOM id, not user-visible
     const wrapper = doc.getElementById("content") ?? doc.getElementById("__root")
     if (!wrapper) return null
     return serializeContentWrapper(wrapper)


### PR DESCRIPTION
Colored background divs and similar containers get a transient `_el#` data-id assigned in the live iframe DOM at selection time, so the stored-HTML delete path could never find them — the delete button silently did nothing while text and images deleted fine.

This adds a `removeElement` method to `BookPreviewFrame`'s imperative handle that removes the element from the live iframe DOM and serializes the result the same way class/style edits do, and `handleDeleteBlock` falls back to it when the stored-HTML removal finds nothing; the serialized HTML is staged through the existing `pendingHtmlRef` queue so the Save flow and `stripTransientIds` behave unchanged. `removeElement` also reports the real (non-transient) data-ids inside the removed subtree so their sectioning-tree leaves are deleted in the same action — otherwise the content would resurrect on the next LLM re-render and linger in the text catalog and TTS. Deleting one of these containers intentionally removes its contents too; keeping the inner text is done by clearing the container's background color instead.

The style panel's prune toggle, previously hidden for all containers, now shows for containers that have a sectioning-tree node (reversible prune, matching what the tree editor already allowed); decoration containers without a tree node get no prune toggle since Delete is their only meaningful removal. Text and image deletion keep using the existing stored-HTML path unchanged.