### PR TITLE
Fix section tree editor three-dot menu losing focus

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -21,6 +21,7 @@
     "@monaco-editor/react": "^4.7.0",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-hover-card": "^1.1.15",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-popover": "^1.1.15",

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/SectionActionsDropdown.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/SectionActionsDropdown.tsx
@@ -58,6 +58,7 @@ export function SectionActionsDropdown({
     <ActionMenu
       trigger={<MoreHorizontal className="h-3.5 w-3.5 text-muted-foreground" />}
       triggerClassName="p-0.5 rounded hover:bg-accent transition-colors cursor-pointer"
+      triggerAriaLabel={t`Section actions`}
       menuClassName="min-w-[200px]"
       note={
         disabled ? (

--- a/apps/studio/src/components/section-tree-editor/TreeNode.tsx
+++ b/apps/studio/src/components/section-tree-editor/TreeNode.tsx
@@ -241,10 +241,13 @@ function RowMenu({
   items: ActionMenuItem[]
   disabled?: boolean
 }) {
+  const { t } = useLingui()
+
   return (
     <ActionMenu
       trigger={<MoreHorizontal className="h-3.5 w-3.5 text-muted-foreground" />}
       triggerClassName="p-0.5 rounded hover:bg-accent transition-colors cursor-pointer disabled:opacity-30"
+      triggerAriaLabel={t`Node actions`}
       triggerDisabled={disabled}
       items={items}
       itemsDisabled={disabled}

--- a/apps/studio/src/components/ui/action-menu.test.tsx
+++ b/apps/studio/src/components/ui/action-menu.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import React from "react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react"
+import { ActionMenu } from "./action-menu"
+
+afterEach(cleanup)
+
+describe("ActionMenu", () => {
+  it("portals accessible menu actions outside an overflow-clipped ancestor", () => {
+    const onSelect = vi.fn()
+    render(
+      <div data-testid="clipped-container" className="overflow-hidden">
+        <ActionMenu
+          trigger="Actions"
+          triggerClassName="button"
+          items={[{ label: "Delete", onClick: onSelect }]}
+        />
+      </div>
+    )
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Actions" }), {
+      button: 0,
+      ctrlKey: false,
+    })
+
+    const menu = screen.getByRole("menu")
+    expect(within(screen.getByTestId("clipped-container")).queryByRole("menu")).toBeNull()
+    expect(within(menu).getByRole("menuitem", { name: "Delete" })).toBeTruthy()
+
+    fireEvent.click(screen.getByRole("menuitem", { name: "Delete" }))
+    expect(onSelect).toHaveBeenCalledTimes(1)
+    expect(screen.queryByRole("menu")).toBeNull()
+  })
+
+  it("closes on Escape", () => {
+    render(
+      <ActionMenu
+        trigger="Actions"
+        triggerClassName="button"
+        items={[{ label: "Delete", onClick: vi.fn() }]}
+      />
+    )
+
+    const trigger = screen.getByRole("button", { name: "Actions" })
+    fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false })
+    fireEvent.keyDown(screen.getByRole("menu"), { key: "Escape" })
+
+    expect(screen.queryByRole("menu")).toBeNull()
+  })
+})

--- a/apps/studio/src/components/ui/action-menu.tsx
+++ b/apps/studio/src/components/ui/action-menu.tsx
@@ -1,10 +1,5 @@
-import {
-  useEffect,
-  useRef,
-  useState,
-  type ComponentType,
-  type ReactNode,
-} from "react"
+import { useState, type ComponentType, type ReactNode } from "react"
+import * as PopoverPrimitive from "@radix-ui/react-popover"
 import { cn } from "@/lib/utils"
 
 export interface ActionMenuItem {
@@ -26,9 +21,10 @@ function isSeparator(entry: ActionMenuEntry): entry is { separator: true } {
 }
 
 /**
- * Minimal dropdown menu: a toggle button plus an item list, closed on
- * outside mousedown. Shared by the tree editor row menus, the editor
- * footer buttons, and the section actions menu.
+ * Minimal dropdown menu. Its content is portalled so menus stay visible when
+ * their triggers live inside a scrolling or overflow-clipped container.
+ * Shared by the tree editor row menus, the editor footer buttons, and the
+ * section actions menu.
  */
 export function ActionMenu({
   trigger,
@@ -53,15 +49,6 @@ export function ActionMenu({
   menuClassName?: string
 }) {
   const [open, setOpen] = useState(false)
-  const ref = useRef<HTMLDivElement>(null)
-  useEffect(() => {
-    if (!open) return
-    const onDown = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false)
-    }
-    document.addEventListener("mousedown", onDown)
-    return () => document.removeEventListener("mousedown", onDown)
-  }, [open])
 
   // Drop hidden items, then collapse separators left dangling by the filter.
   const entries: ActionMenuEntry[] = []
@@ -79,50 +66,55 @@ export function ActionMenu({
   if (entries.length === 0) return null
 
   return (
-    <div className="relative" ref={ref} onClick={(e) => e.stopPropagation()}>
-      <button
-        type="button"
-        onClick={() => setOpen((v) => !v)}
-        disabled={triggerDisabled}
-        className={triggerClassName}
-      >
-        {trigger}
-      </button>
-      {open && (
-        <div
-          className={cn(
-            "absolute top-full z-50 mt-1 min-w-[160px] rounded-md border bg-popover py-1 text-xs shadow-md",
-            align === "right" ? "right-0" : "left-0",
-            menuClassName
-          )}
-        >
-          {note}
-          {entries.map((entry, i) =>
-            isSeparator(entry) ? (
-              <div key={i} className="my-1 border-t" />
-            ) : (
-              <button
-                key={i}
-                type="button"
-                onClick={() => {
-                  setOpen(false)
-                  entry.onClick()
-                }}
-                disabled={itemsDisabled || entry.disabled}
-                className={cn(
-                  "flex w-full items-center gap-2 px-3 py-1.5 text-left hover:bg-accent transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-default",
-                  entry.danger && "text-red-600 hover:bg-red-50 dark:hover:bg-red-950/30"
-                )}
-              >
-                {entry.icon ? (
-                  <entry.icon className={cn("h-3.5 w-3.5", entry.iconClassName)} />
-                ) : null}
-                {entry.label}
-              </button>
-            )
-          )}
-        </div>
-      )}
+    <div onClick={(e) => e.stopPropagation()}>
+      <PopoverPrimitive.Root open={open} onOpenChange={setOpen}>
+        <PopoverPrimitive.Trigger asChild>
+          <button
+            type="button"
+            disabled={triggerDisabled}
+            className={triggerClassName}
+          >
+            {trigger}
+          </button>
+        </PopoverPrimitive.Trigger>
+        <PopoverPrimitive.Portal>
+          <PopoverPrimitive.Content
+            align={align === "right" ? "end" : "start"}
+            sideOffset={4}
+            collisionPadding={8}
+            className={cn(
+              "z-50 min-w-[160px] rounded-md border bg-popover py-1 text-xs shadow-md",
+              menuClassName
+            )}
+          >
+            {note}
+            {entries.map((entry, i) =>
+              isSeparator(entry) ? (
+                <div key={i} className="my-1 border-t" />
+              ) : (
+                <button
+                  key={i}
+                  type="button"
+                  onClick={() => {
+                    setOpen(false)
+                    entry.onClick()
+                  }}
+                  disabled={itemsDisabled || entry.disabled}
+                  className={cn(
+                    "flex w-full items-center gap-2 px-3 py-1.5 text-left hover:bg-accent transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-default",
+                    entry.danger && "text-red-600 hover:bg-red-50 dark:hover:bg-red-950/30"
+                  )}
+                >
+                  {entry.icon ? (
+                    <entry.icon className={cn("h-3.5 w-3.5", entry.iconClassName)} />
+                  ) : null}
+                  {entry.label}
+                </button>
+              )
+            )}
+          </PopoverPrimitive.Content>
+        </PopoverPrimitive.Portal>
+      </PopoverPrimitive.Root>
     </div>
   )
 }

--- a/apps/studio/src/components/ui/action-menu.tsx
+++ b/apps/studio/src/components/ui/action-menu.tsx
@@ -1,5 +1,5 @@
 import { useState, type ComponentType, type ReactNode } from "react"
-import * as PopoverPrimitive from "@radix-ui/react-popover"
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
 import { cn } from "@/lib/utils"
 
 export interface ActionMenuItem {
@@ -29,6 +29,7 @@ function isSeparator(entry: ActionMenuEntry): entry is { separator: true } {
 export function ActionMenu({
   trigger,
   triggerClassName,
+  triggerAriaLabel,
   triggerDisabled,
   note,
   items,
@@ -39,6 +40,8 @@ export function ActionMenu({
   /** Content of the toggle button. */
   trigger: ReactNode
   triggerClassName: string
+  /** Accessible name for icon-only triggers. */
+  triggerAriaLabel?: string
   triggerDisabled?: boolean
   /** Optional block shown above the items (e.g. why actions are disabled). */
   note?: ReactNode
@@ -67,18 +70,19 @@ export function ActionMenu({
 
   return (
     <div onClick={(e) => e.stopPropagation()}>
-      <PopoverPrimitive.Root open={open} onOpenChange={setOpen}>
-        <PopoverPrimitive.Trigger asChild>
+      <DropdownMenuPrimitive.Root open={open} onOpenChange={setOpen}>
+        <DropdownMenuPrimitive.Trigger asChild>
           <button
             type="button"
             disabled={triggerDisabled}
             className={triggerClassName}
+            aria-label={triggerAriaLabel}
           >
             {trigger}
           </button>
-        </PopoverPrimitive.Trigger>
-        <PopoverPrimitive.Portal>
-          <PopoverPrimitive.Content
+        </DropdownMenuPrimitive.Trigger>
+        <DropdownMenuPrimitive.Portal>
+          <DropdownMenuPrimitive.Content
             align={align === "right" ? "end" : "start"}
             sideOffset={4}
             collisionPadding={8}
@@ -90,18 +94,17 @@ export function ActionMenu({
             {note}
             {entries.map((entry, i) =>
               isSeparator(entry) ? (
-                <div key={i} className="my-1 border-t" />
+                <DropdownMenuPrimitive.Separator key={i} className="my-1 border-t" />
               ) : (
-                <button
+                <DropdownMenuPrimitive.Item
                   key={i}
-                  type="button"
-                  onClick={() => {
+                  onSelect={() => {
                     setOpen(false)
                     entry.onClick()
                   }}
                   disabled={itemsDisabled || entry.disabled}
                   className={cn(
-                    "flex w-full items-center gap-2 px-3 py-1.5 text-left hover:bg-accent transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-default",
+                    "flex w-full items-center gap-2 px-3 py-1.5 text-left outline-none transition-colors cursor-pointer data-[highlighted]:bg-accent data-[disabled]:opacity-30 data-[disabled]:cursor-default",
                     entry.danger && "text-red-600 hover:bg-red-50 dark:hover:bg-red-950/30"
                   )}
                 >
@@ -109,12 +112,12 @@ export function ActionMenu({
                     <entry.icon className={cn("h-3.5 w-3.5", entry.iconClassName)} />
                   ) : null}
                   {entry.label}
-                </button>
+                </DropdownMenuPrimitive.Item>
               )
             )}
-          </PopoverPrimitive.Content>
-        </PopoverPrimitive.Portal>
-      </PopoverPrimitive.Root>
+          </DropdownMenuPrimitive.Content>
+        </DropdownMenuPrimitive.Portal>
+      </DropdownMenuPrimitive.Root>
     </div>
   )
 }

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -5877,6 +5877,9 @@ msgstr "No voice mappings configured."
 msgid "No voices found"
 msgstr "No voices found"
 
+msgid "Node actions"
+msgstr "Node actions"
+
 msgid "Nodes"
 msgstr "Nodes"
 
@@ -7906,6 +7909,9 @@ msgstr "Section 3 · Overview"
 
 msgid "Section 3.2"
 msgstr "Section 3.2"
+
+msgid "Section actions"
+msgstr "Section actions"
 
 msgid "Section heading"
 msgstr "Section heading"

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -5877,6 +5877,9 @@ msgstr "No hay asignaciones de voz configuradas."
 msgid "No voices found"
 msgstr "No se encontraron voces"
 
+msgid "Node actions"
+msgstr "Acciones del nodo"
+
 msgid "Nodes"
 msgstr "Nodes"
 
@@ -7906,6 +7909,9 @@ msgstr "Sección 3 · Resumen"
 
 msgid "Section 3.2"
 msgstr "Sección 3.2"
+
+msgid "Section actions"
+msgstr "Acciones de la sección"
 
 msgid "Section heading"
 msgstr "Encabezado de sección"

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -5879,6 +5879,9 @@ msgstr "Aucune correspondance de voix configurée."
 msgid "No voices found"
 msgstr "Aucune voix trouvée"
 
+msgid "Node actions"
+msgstr "Actions du nœud"
+
 msgid "Nodes"
 msgstr "Nodes"
 
@@ -7908,6 +7911,9 @@ msgstr "Section 3 · Aperçu"
 
 msgid "Section 3.2"
 msgstr "Section 3.2"
+
+msgid "Section actions"
+msgstr "Actions de la section"
 
 msgid "Section heading"
 msgstr "Titre de section"

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -5877,6 +5877,9 @@ msgstr "Nenhum mapeamento de voz configurado."
 msgid "No voices found"
 msgstr "Nenhuma voz encontrada"
 
+msgid "Node actions"
+msgstr "Ações do nó"
+
 msgid "Nodes"
 msgstr "Nodes"
 
@@ -7906,6 +7909,9 @@ msgstr "Seção 3 · Visão Geral"
 
 msgid "Section 3.2"
 msgstr "Seção 3.2"
+
+msgid "Section actions"
+msgstr "Ações da seção"
 
 msgid "Section heading"
 msgstr "Título de seção"

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -5878,6 +5878,9 @@ msgstr "Nuk ka vendosje zëri të konfiguruara."
 msgid "No voices found"
 msgstr "Nuk u gjet asnjë zë"
 
+msgid "Node actions"
+msgstr "Veprimet e nyjës"
+
 msgid "Nodes"
 msgstr "Nyje"
 
@@ -7907,6 +7910,9 @@ msgstr "Seksioni 3 · Përmbledhje"
 
 msgid "Section 3.2"
 msgstr "Seksioni 3.2"
+
+msgid "Section actions"
+msgstr "Veprimet e seksionit"
 
 msgid "Section heading"
 msgstr "Titull seksioni"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -340,6 +340,9 @@ importers:
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-dropdown-menu':
+        specifier: ^2.1.15
+        version: 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-hover-card':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)


### PR DESCRIPTION
## Summary

- render shared action-menu content through an accessible Radix dropdown-menu portal
- keep section-tree menu interactions above nested nodes (#612)
- prevent Storyboard Overview action menus from being clipped by overflow containers
- provide menu keyboard navigation, type-ahead, Escape dismissal, and accessible labels for icon-only action triggers

## Testing

- `pnpm typecheck`
- `pnpm --filter @adt/studio lint`
- focused ActionMenu and section-tree Vitest suites (4 tests)
- `git diff --check`

Closes #612