### PR TITLE
fix(storyboard): make sectionIds stable across structural ops

### DIFF
--- a/apps/api/src/routes/adt-preview.test.ts
+++ b/apps/api/src/routes/adt-preview.test.ts
@@ -191,6 +191,48 @@ describe("ADT preview routes", () => {
     expect(res.status).toBe(404)
   })
 
+  it("resolves a stored legacy `_sN` section id", async () => {
+    // Books upgraded from a version whose agent tools minted `_sN` ids still
+    // store them, and the UI builds the preview URL from the stored id. The
+    // section is still matched exactly — only the owner-page parse is widened.
+    const storage = createBookStorage(label, tmpDir)
+    try {
+      storage.putNodeData("page-sectioning", `${label}_p1`, {
+        reasoning: "ok",
+        sections: [
+          {
+            sectionId: `${label}_p1_sec001`,
+            sectionType: "content",
+            backgroundColor: "#fff",
+            textColor: "#000",
+            pageNumber: 1,
+            isPruned: false,
+            nodes: [],
+          },
+          {
+            sectionId: `${label}_p1_s2`,
+            sectionType: "content",
+            backgroundColor: "#fff",
+            textColor: "#000",
+            pageNumber: 1,
+            isPruned: false,
+            nodes: [],
+          },
+        ],
+      })
+    } finally {
+      storage.close()
+    }
+
+    const app = createAdtPreviewRoutes(tmpDir, webAssetsDir, path.resolve(process.cwd(), "config.yaml"))
+    const res = await app.request(`/books/${label}/adt-preview/${label}_p1_s2.html`)
+
+    expect(res.status).toBe(200)
+    const html = await res.text()
+    expect(html).toContain("Second section body")
+    expect(html).not.toContain("First section body")
+  })
+
 
   it("applies shared section-role cleanup and image alt fallbacks in preview output", async () => {
     const app = createAdtPreviewRoutes(tmpDir, webAssetsDir, path.resolve(process.cwd(), "config.yaml"))

--- a/apps/api/src/routes/adt-preview.ts
+++ b/apps/api/src/routes/adt-preview.ts
@@ -4,7 +4,7 @@ import { createHash } from "node:crypto"
 import { pathToFileURL } from "node:url"
 import { Hono } from "hono"
 import { HTTPException } from "hono/http-exception"
-import { isHeadingRole, isTtsExcluded, parseBookLabel } from "@adt/types"
+import { isHeadingRole, isTtsExcluded, parseBookLabel, parseSectionId } from "@adt/types"
 import {
   WebRenderingOutput,
   type SpeechConfig,
@@ -304,10 +304,9 @@ function buildSectionIdToPageIndex(storage: Storage): Map<string, number> {
         const sections = [...parsed.data.sections].sort((a, b) => a.sectionIndex - b.sectionIndex)
         for (const rs of sections) {
           const sectionMeta = sectioning?.sections?.[rs.sectionIndex]
-          if (sectionMeta?.isPruned) continue
+          if (!sectionMeta || sectionMeta.isPruned) continue
           index++
-          const sectionId = sectionMeta?.sectionId ?? `${page.pageId}_sec${String(rs.sectionIndex + 1).padStart(3, "0")}`
-          map.set(sectionId, index)
+          map.set(sectionMeta.sectionId, index)
         }
       }
     }
@@ -348,9 +347,11 @@ function buildPagesManifest(storage: Storage): Array<{ section_id: string; href:
         const sections = [...parsed.data.sections].sort((a, b) => a.sectionIndex - b.sectionIndex)
         for (const rs of sections) {
           const sectionMeta = sectioning?.sections?.[rs.sectionIndex]
-          // Skip sections that are pruned in the sectioning data
-          if (sectionMeta?.isPruned) continue
-          const sectionId = sectionMeta?.sectionId ?? `${page.pageId}_sec${String(rs.sectionIndex + 1).padStart(3, "0")}`
+          // Skip sections that are pruned, and orphan rendering entries with no
+          // sectioning row — their real sectionId is unknowable and a positional
+          // guess could collide with another section's id.
+          if (!sectionMeta || sectionMeta.isPruned) continue
+          const sectionId = sectionMeta.sectionId
           const entry: { section_id: string; href: string; page_number?: number } = {
             section_id: sectionId,
             href: `${sectionId}.html`,
@@ -435,7 +436,7 @@ function buildHeadingBasedToc(storage: Storage): Array<{ section_id: string; hre
       const sectionMeta = sectioning?.sections?.[rs.sectionIndex]
       if (!sectionMeta || sectionMeta.isPruned) continue
 
-      const sectionId = sectionMeta.sectionId ?? `${page.pageId}_sec${String(rs.sectionIndex + 1).padStart(3, "0")}`
+      const sectionId = sectionMeta.sectionId
 
       const heading = findFirstHeadingLeaf(sectionMeta.nodes)
       if (heading) {
@@ -1090,12 +1091,11 @@ export function createAdtPreviewRoutes(
 
       // Content page — require sectionId format (e.g. pg001_sec001).
       // This prevents ambiguous fallback to unrelated sections.
-      const sectionIdMatch = pageId.match(/^(.+)_sec(\d{3})$/)
-      if (!sectionIdMatch) {
+      const parsedSectionId = parseSectionId(pageId)
+      if (!parsedSectionId) {
         throw new HTTPException(404, { message: `Section not found: ${pageId}` })
       }
-      const ownerPageId = sectionIdMatch[1]
-      const fallbackSectionIndex = parseInt(sectionIdMatch[2], 10) - 1
+      const ownerPageId = parsedSectionId.pageId
 
       const renderRow = storage.getLatestNodeData("web-rendering", ownerPageId)
       if (!renderRow) {
@@ -1107,12 +1107,14 @@ export function createAdtPreviewRoutes(
         throw new HTTPException(500, { message: "Invalid rendering data" })
       }
 
-      // Get sectioning to look up sectionId → sectionIndex mapping
+      // Get sectioning to look up sectionId → sectionIndex mapping. The id's
+      // sequence number is NOT its array position (ids are allocated once and
+      // never reused), so there is no positional fallback — an unresolvable id
+      // is a 404 rather than a guess that would serve a different section.
       const sectioning = getRenderSectioning(storage, ownerPageId)
-      const resolvedIndex = sectioning
+      const targetSectionIndex = sectioning
         ? sectioning.sections.findIndex((s) => s.sectionId === pageId)
         : -1
-      const targetSectionIndex = resolvedIndex >= 0 ? resolvedIndex : fallbackSectionIndex
       const renderedSection = parsed.data.sections.find((s) => s.sectionIndex === targetSectionIndex)
 
       if (!renderedSection || targetSectionIndex < 0) {

--- a/apps/api/src/routes/adt-preview.ts
+++ b/apps/api/src/routes/adt-preview.ts
@@ -4,7 +4,13 @@ import { createHash } from "node:crypto"
 import { pathToFileURL } from "node:url"
 import { Hono } from "hono"
 import { HTTPException } from "hono/http-exception"
-import { isHeadingRole, isTtsExcluded, parseBookLabel, parseSectionId, resolveEntryVoiceSlot } from "@adt/types"
+import {
+  isHeadingRole,
+  isTtsExcluded,
+  parseBookLabel,
+  parseAnySectionId,
+  resolveEntryVoiceSlot,
+} from "@adt/types"
 import {
   WebRenderingOutput,
   type SpeechConfig,
@@ -1158,9 +1164,12 @@ export function createAdtPreviewRoutes(
         return c.body(html)
       }
 
-      // Content page — require sectionId format (e.g. pg001_sec001).
-      // This prevents ambiguous fallback to unrelated sections.
-      const parsedSectionId = parseSectionId(pageId)
+      // Content page — the id must have a section shape (e.g. pg001_sec001) so
+      // this cannot fall back to an unrelated section. The legacy `_sN` shape is
+      // accepted too: books upgraded from a version whose agent tools minted
+      // those still store them, and the section is matched exactly below either
+      // way, so widening the parse resolves them without guessing anything.
+      const parsedSectionId = parseAnySectionId(pageId)
       if (!parsedSectionId) {
         throw new HTTPException(404, { message: `Section not found: ${pageId}` })
       }

--- a/apps/api/src/routes/adt-preview.ts
+++ b/apps/api/src/routes/adt-preview.ts
@@ -4,7 +4,7 @@ import { createHash } from "node:crypto"
 import { pathToFileURL } from "node:url"
 import { Hono } from "hono"
 import { HTTPException } from "hono/http-exception"
-import { isHeadingRole, isTtsExcluded, parseBookLabel, resolveEntryVoiceSlot } from "@adt/types"
+import { isHeadingRole, isTtsExcluded, parseBookLabel, parseSectionId, resolveEntryVoiceSlot } from "@adt/types"
 import {
   WebRenderingOutput,
   type SpeechConfig,
@@ -310,10 +310,9 @@ function buildSectionIdToPageIndex(storage: Storage): Map<string, number> {
         const sections = [...parsed.data.sections].sort((a, b) => a.sectionIndex - b.sectionIndex)
         for (const rs of sections) {
           const sectionMeta = sectioning?.sections?.[rs.sectionIndex]
-          if (sectionMeta?.isPruned) continue
+          if (!sectionMeta || sectionMeta.isPruned) continue
           index++
-          const sectionId = sectionMeta?.sectionId ?? `${page.pageId}_sec${String(rs.sectionIndex + 1).padStart(3, "0")}`
-          map.set(sectionId, index)
+          map.set(sectionMeta.sectionId, index)
         }
       }
     }
@@ -354,9 +353,11 @@ function buildPagesManifest(storage: Storage): Array<{ section_id: string; href:
         const sections = [...parsed.data.sections].sort((a, b) => a.sectionIndex - b.sectionIndex)
         for (const rs of sections) {
           const sectionMeta = sectioning?.sections?.[rs.sectionIndex]
-          // Skip sections that are pruned in the sectioning data
-          if (sectionMeta?.isPruned) continue
-          const sectionId = sectionMeta?.sectionId ?? `${page.pageId}_sec${String(rs.sectionIndex + 1).padStart(3, "0")}`
+          // Skip sections that are pruned, and orphan rendering entries with no
+          // sectioning row — their real sectionId is unknowable and a positional
+          // guess could collide with another section's id.
+          if (!sectionMeta || sectionMeta.isPruned) continue
+          const sectionId = sectionMeta.sectionId
           const entry: { section_id: string; href: string; page_number?: number } = {
             section_id: sectionId,
             href: `${sectionId}.html`,
@@ -441,7 +442,7 @@ function buildHeadingBasedToc(storage: Storage): Array<{ section_id: string; hre
       const sectionMeta = sectioning?.sections?.[rs.sectionIndex]
       if (!sectionMeta || sectionMeta.isPruned) continue
 
-      const sectionId = sectionMeta.sectionId ?? `${page.pageId}_sec${String(rs.sectionIndex + 1).padStart(3, "0")}`
+      const sectionId = sectionMeta.sectionId
 
       const heading = findFirstHeadingLeaf(sectionMeta.nodes)
       if (heading) {
@@ -1159,12 +1160,11 @@ export function createAdtPreviewRoutes(
 
       // Content page — require sectionId format (e.g. pg001_sec001).
       // This prevents ambiguous fallback to unrelated sections.
-      const sectionIdMatch = pageId.match(/^(.+)_sec(\d{3})$/)
-      if (!sectionIdMatch) {
+      const parsedSectionId = parseSectionId(pageId)
+      if (!parsedSectionId) {
         throw new HTTPException(404, { message: `Section not found: ${pageId}` })
       }
-      const ownerPageId = sectionIdMatch[1]
-      const fallbackSectionIndex = parseInt(sectionIdMatch[2], 10) - 1
+      const ownerPageId = parsedSectionId.pageId
 
       const renderRow = storage.getLatestNodeData("web-rendering", ownerPageId)
       if (!renderRow) {
@@ -1176,12 +1176,14 @@ export function createAdtPreviewRoutes(
         throw new HTTPException(500, { message: "Invalid rendering data" })
       }
 
-      // Get sectioning to look up sectionId → sectionIndex mapping
+      // Get sectioning to look up sectionId → sectionIndex mapping. The id's
+      // sequence number is NOT its array position (ids are allocated once and
+      // never reused), so there is no positional fallback — an unresolvable id
+      // is a 404 rather than a guess that would serve a different section.
       const sectioning = getRenderSectioning(storage, ownerPageId)
-      const resolvedIndex = sectioning
+      const targetSectionIndex = sectioning
         ? sectioning.sections.findIndex((s) => s.sectionId === pageId)
         : -1
-      const targetSectionIndex = resolvedIndex >= 0 ? resolvedIndex : fallbackSectionIndex
       const renderedSection = parsed.data.sections.find((s) => s.sectionIndex === targetSectionIndex)
 
       if (!renderedSection || targetSectionIndex < 0) {

--- a/apps/api/src/routes/books.ts
+++ b/apps/api/src/routes/books.ts
@@ -484,16 +484,18 @@ export function createBookRoutes(
         safeLabel,
         "prepare-export",
         `Preparing ${format} export`,
-        async () => {
-          await prepareExport(label, format, booksDir, webAssetsDir ?? "", configPath, features, defaultSettings)
-        },
+        // Returned so the task result carries any pages packaging had to omit
+        // — the export otherwise completes looking clean while the bundle is
+        // short.
+        async () =>
+          await prepareExport(label, format, booksDir, webAssetsDir ?? "", configPath, features, defaultSettings),
         { url: `/books/${safeLabel}/export-${format}` }
       )
       return c.json({ status: "submitted", taskId, label: safeLabel })
     }
 
-    await prepareExport(label, format, booksDir, webAssetsDir ?? "", configPath, features, defaultSettings)
-    return c.json({ status: "completed", label: safeLabel })
+    const { warnings } = await prepareExport(label, format, booksDir, webAssetsDir ?? "", configPath, features, defaultSettings)
+    return c.json({ status: "completed", label: safeLabel, warnings })
   })
 
   // Export download routes — each format delegates to its service function,

--- a/apps/api/src/routes/package.test.ts
+++ b/apps/api/src/routes/package.test.ts
@@ -147,6 +147,55 @@ describe("Package routes", () => {
       expect(body.error).toContain("web rendering")
     })
 
+    it("returns no warnings when rendering and sectioning agree", { timeout: 20_000 }, async () => {
+      createRenderedBook("book-clean")
+      createWebAssets()
+
+      const res = await app.request("/api/books/book-clean/package-adt", { method: "POST" })
+
+      expect(res.status).toBe(200)
+      const body = await res.json() as { warnings?: unknown[] }
+      expect(body.warnings).toEqual([])
+    })
+
+    it("reports sections omitted from the bundle, and still reports them on a cache hit", { timeout: 30_000 }, async () => {
+      createRenderedBook("book-orphan")
+      createWebAssets()
+
+      // Give the page a second rendering entry with no sectioning row behind
+      // it — the state restoring an older `page-sectioning` version leaves,
+      // since that does not resync `web-rendering`. Packaging cannot invent a
+      // sectionId for it (ids are never reused, so a positional guess could
+      // name a real section) so it drops the section.
+      const storage = createBookStorage("book-orphan", tmpDir)
+      storage.putNodeData("web-rendering", "pg001", {
+        sections: [
+          { sectionIndex: 0, sectionType: "content", reasoning: "ok", html: "<main><p>Kept</p></main>" },
+          { sectionIndex: 1, sectionType: "content", reasoning: "ok", html: "<main><p>Orphan</p></main>" },
+        ],
+      })
+      storage.close()
+
+      const res = await app.request("/api/books/book-orphan/package-adt", { method: "POST" })
+      expect(res.status).toBe(200)
+      const body = await res.json() as {
+        warnings?: Array<{ kind: string; pageId: string; sectionIndex: number }>
+      }
+      expect(body.warnings).toEqual([
+        { kind: "orphaned-rendering", pageId: "pg001", sectionIndex: 1 },
+      ])
+
+      // Packaging again hits the build cache and skips the work. The bundle on
+      // disk is still short, so the warning has to come back with it — reading
+      // it off the cached sidecar rather than vanishing.
+      const cached = await app.request("/api/books/book-orphan/package-adt", { method: "POST" })
+      expect(cached.status).toBe(200)
+      const cachedBody = await cached.json() as {
+        warnings?: Array<{ kind: string; pageId: string; sectionIndex: number }>
+      }
+      expect(cachedBody.warnings).toEqual(body.warnings)
+    })
+
     it("stores accessibility assessment output after packaging", { timeout: 20_000 }, async () => {
       createRenderedBook("book-a11y")
       createWebAssets()

--- a/apps/api/src/routes/package.test.ts
+++ b/apps/api/src/routes/package.test.ts
@@ -194,6 +194,18 @@ describe("Package routes", () => {
         warnings?: Array<{ kind: string; pageId: string; sectionIndex: number }>
       }
       expect(cachedBody.warnings).toEqual(body.warnings)
+
+      // A build cached before the sidecar existed — the state every book is in
+      // on upgrade. The hash still matches, so without treating a missing
+      // sidecar as a stale cache this returns a clean result over the same
+      // short bundle.
+      fs.rmSync(path.join(tmpDir, "book-orphan", "adt", ".build-warnings"))
+      const upgraded = await app.request("/api/books/book-orphan/package-adt", { method: "POST" })
+      expect(upgraded.status).toBe(200)
+      const upgradedBody = await upgraded.json() as {
+        warnings?: Array<{ kind: string; pageId: string; sectionIndex: number }>
+      }
+      expect(upgradedBody.warnings).toEqual(body.warnings)
     })
 
     it("stores accessibility assessment output after packaging", { timeout: 20_000 }, async () => {

--- a/apps/api/src/routes/package.ts
+++ b/apps/api/src/routes/package.ts
@@ -2,7 +2,7 @@ import fs from "node:fs"
 import path from "node:path"
 import { Hono } from "hono"
 import { HTTPException } from "hono/http-exception"
-import { parseBookLabel } from "@adt/types"
+import { parseBookLabel, PackagingWarning } from "@adt/types"
 import { createBookStorage } from "@adt/storage"
 import {
   packageAdtWeb,
@@ -32,6 +32,7 @@ interface PackagingStatus {
 
 interface PackagingResult {
   version: string
+  warnings: PackagingWarning[]
 }
 
 function packageVersionFromHash(hash: string): string {
@@ -44,6 +45,34 @@ function getBuildHashPath(bookDir: string): string {
 
 function getBuildVersionPath(bookDir: string): string {
   return path.join(bookDir, "adt", ".build-version")
+}
+
+function getBuildWarningsPath(bookDir: string): string {
+  return path.join(bookDir, "adt", ".build-warnings")
+}
+
+/**
+ * Cached alongside the build hash so a cache hit reports the same omissions as
+ * the build that produced the bundle. Without this, packaging a second time
+ * short-circuits and the bundle looks clean while still missing pages.
+ */
+function writeBuildWarnings(bookDir: string, warnings: PackagingWarning[]): void {
+  fs.writeFileSync(getBuildWarningsPath(bookDir), JSON.stringify(warnings), "utf-8")
+}
+
+function readBuildWarnings(bookDir: string): PackagingWarning[] {
+  const warningsPath = getBuildWarningsPath(bookDir)
+  if (!fs.existsSync(warningsPath)) return []
+  try {
+    const parsed = PackagingWarning.array().safeParse(
+      JSON.parse(fs.readFileSync(warningsPath, "utf-8")) as unknown,
+    )
+    return parsed.success ? parsed.data : []
+  } catch {
+    // A truncated or hand-edited sidecar is not worth failing a package over —
+    // the warning is diagnostic, and the next real build rewrites it.
+    return []
+  }
 }
 
 function readBuildVersion(bookDir: string, fallbackHash: string): string {
@@ -157,10 +186,17 @@ export function createPackageRoutes(
         })
       }
 
-      // Fast path: skip task submission entirely when build cache is valid
+      // Fast path: skip task submission entirely when build cache is valid.
+      // The bundle on disk is whatever the cached build produced, omissions
+      // included, so replay that build's warnings rather than reporting none.
       cacheState = getPackagingCacheState(storage, safeLabel, booksDir, bookDir, webAssetsDir, configPath)
       if (cacheState.cached) {
-        return c.json({ status: "completed", label: safeLabel, version: cacheState.version })
+        return c.json({
+          status: "completed",
+          label: safeLabel,
+          version: cacheState.version,
+          warnings: readBuildWarnings(bookDir),
+        })
       }
     } finally {
       storage.close()
@@ -193,7 +229,14 @@ export function createPackageRoutes(
 
     try {
       const result = await runPackaging(safeLabel, booksDir, bookDir, webAssetsDir, configPath)
-      return c.json({ status: "completed", label: safeLabel, version: result.version })
+      return c.json({
+        status: "completed",
+        label: safeLabel,
+        version: result.version,
+        // Anything packaging had to omit. The run still succeeds, so a caller
+        // that ignores this cannot tell a short bundle from a complete one.
+        warnings: result.warnings,
+      })
     } catch (err) {
       if (err instanceof HTTPException) throw err
       const message = err instanceof Error ? err.message : String(err)
@@ -254,10 +297,13 @@ async function runPackaging(
     const preHash = computePackagingInputHash(hashOptions)
     const bundleVersion = packageVersionFromHash(preHash)
     if (fs.existsSync(hashPath) && fs.readFileSync(hashPath, "utf-8").trim() === preHash) {
-      return { version: readBuildVersion(bookDir, preHash) }
+      return {
+        version: readBuildVersion(bookDir, preHash),
+        warnings: readBuildWarnings(bookDir),
+      }
     }
 
-    await packageAdtWeb(storage, {
+    const { warnings } = await packageAdtWeb(storage, {
       bookDir,
       label: safeLabel,
       language,
@@ -272,6 +318,7 @@ async function runPackaging(
       quizMatchBookStyle: config.quiz_generation?.match_book_style ?? true,
     })
     fs.writeFileSync(versionPath, bundleVersion, "utf-8")
+    writeBuildWarnings(bookDir, warnings)
 
     const baseAccessibility = await runAccessibilityAssessment({
       bookDir,
@@ -297,7 +344,7 @@ async function runPackaging(
     const postHash = computePackagingInputHash(hashOptions)
     fs.writeFileSync(hashPath, postHash, "utf-8")
     fs.writeFileSync(versionPath, bundleVersion, "utf-8")
-    return { version: bundleVersion }
+    return { version: bundleVersion, warnings }
   } finally {
     storage.close()
   }

--- a/apps/api/src/routes/package.ts
+++ b/apps/api/src/routes/package.ts
@@ -75,6 +75,21 @@ function readBuildWarnings(bookDir: string): PackagingWarning[] {
   }
 }
 
+/**
+ * Whether the bundle on disk can be served without rebuilding.
+ *
+ * The inputs must be unchanged *and* the warnings sidecar must exist. A cache
+ * entry that cannot say what its build left out is not usable: builds cached
+ * before the sidecar existed would otherwise pass the hash check and report a
+ * clean run while the bundle on disk is still missing pages. Treating those as
+ * stale costs one rebuild per book on upgrade, once.
+ */
+function isBuildCacheValid(bookDir: string, hash: string): boolean {
+  const hashPath = getBuildHashPath(bookDir)
+  if (!fs.existsSync(hashPath) || fs.readFileSync(hashPath, "utf-8").trim() !== hash) return false
+  return fs.existsSync(getBuildWarningsPath(bookDir))
+}
+
 function readBuildVersion(bookDir: string, fallbackHash: string): string {
   const versionPath = getBuildVersionPath(bookDir)
   if (fs.existsSync(versionPath)) {
@@ -99,7 +114,6 @@ function getPackagingCacheState(
   webAssetsDir: string,
   configPath?: string,
 ): PackagingCacheState {
-  const hashPath = getBuildHashPath(bookDir)
   const { language, outputLanguages, title, config } = resolvePackagingParams(
     storage, safeLabel, booksDir, configPath,
   )
@@ -108,7 +122,7 @@ function getPackagingCacheState(
     webAssetsDir, applyBodyBackground: config.apply_body_background,
     config: config as unknown as Record<string, unknown>,
   })
-  const cached = fs.existsSync(hashPath) && fs.readFileSync(hashPath, "utf-8").trim() === hash
+  const cached = isBuildCacheValid(bookDir, hash)
   return {
     cached,
     version: cached ? readBuildVersion(bookDir, hash) : packageVersionFromHash(hash),
@@ -296,7 +310,7 @@ async function runPackaging(
     const versionPath = getBuildVersionPath(bookDir)
     const preHash = computePackagingInputHash(hashOptions)
     const bundleVersion = packageVersionFromHash(preHash)
-    if (fs.existsSync(hashPath) && fs.readFileSync(hashPath, "utf-8").trim() === preHash) {
+    if (isBuildCacheValid(bookDir, preHash)) {
       return {
         version: readBuildVersion(bookDir, preHash),
         warnings: readBuildWarnings(bookDir),

--- a/apps/api/src/routes/pages.test.ts
+++ b/apps/api/src/routes/pages.test.ts
@@ -1568,6 +1568,33 @@ describe("Page routes", () => {
       expect(readSectionIds()).toContain(`${label}_p1_sec005`)
     })
 
+    it("counts ids from history versions that no longer satisfy the schema", async () => {
+      const storage = createBookStorage(label, tmpDir)
+      try {
+        // A stored version that fails `PageSectioningOutput` today — a legacy
+        // row, or a shape from before a migration. It still spent `_sec005`.
+        // Reading the high-water mark off parsed rows only would skip it and
+        // reissue that id onto unrelated content.
+        storage.putNodeData("page-sectioning", `${label}_p1`, {
+          sections: [{ sectionId: `${label}_p1_sec005`, legacyShape: true }],
+        })
+      } finally {
+        storage.close()
+      }
+      seedSections(1)
+
+      const clone = await app.request(
+        `/api/books/${label}/pages/${label}_p1/sections/0/clone`,
+        { method: "POST" }
+      )
+      expect(clone.status).toBe(200)
+
+      expect(readSectionIds()).toEqual([
+        `${label}_p1_sec001`,
+        `${label}_p1_sec006`,
+      ])
+    })
+
     it("keeps a sign-language video attached to its section across a merge, and unassigns the retired one", async () => {
       seedSections(3)
 

--- a/apps/api/src/routes/pages.test.ts
+++ b/apps/api/src/routes/pages.test.ts
@@ -966,7 +966,7 @@ describe("Page routes", () => {
       }
     })
 
-    it("splits a section before a top-level node and renumbers sectionIds", async () => {
+    it("splits a section, keeping the first half's id and leaving the untouched section alone", async () => {
       seedThreeNodeSection({ rendering: true })
 
       const res = await app.request(
@@ -993,10 +993,14 @@ describe("Page routes", () => {
           }>
         }
         expect(sectioning.sections).toHaveLength(3)
+        // The first half keeps `_sec001`; the new second half mints `_sec003`;
+        // the pre-existing `_sec002` keeps its id even though it moved to index
+        // 2. Renumbering it would silently hand its TOC entry, sign-language
+        // video and answer-text catalog keys to the newly created half.
         expect(sectioning.sections.map((s) => s.sectionId)).toEqual([
           `${label}_p1_sec001`,
-          `${label}_p1_sec002`,
           `${label}_p1_sec003`,
+          `${label}_p1_sec002`,
         ])
         expect(sectioning.sections[0].nodes.map((n) => n.nodeId)).toEqual([
           `${label}_p1_n0001`,
@@ -1013,8 +1017,9 @@ describe("Page routes", () => {
           `${label}_p1_n0005`,
         ])
 
-        // Rendering: split section's entry dropped, other section shifted +1
-        // with its data-section-id rewritten.
+        // Rendering: the split section's entry is dropped and the untouched
+        // section's index shifts +1, but its HTML keeps its own section id —
+        // the split must not rewrite another section's markup.
         const renderingRow = verify.getLatestNodeData("web-rendering", `${label}_p1`)
         const rendering = renderingRow?.data as {
           sections: Array<{ sectionIndex: number; html: string }>
@@ -1022,7 +1027,7 @@ describe("Page routes", () => {
         expect(rendering.sections).toHaveLength(1)
         expect(rendering.sections[0].sectionIndex).toBe(2)
         expect(rendering.sections[0].html).toContain(
-          `data-section-id="${label}_p1_sec003"`
+          `data-section-id="${label}_p1_sec002"`
         )
       } finally {
         verify.close()
@@ -1352,6 +1357,188 @@ describe("Page routes", () => {
           `${label}_p1_n0002`,
         ])
         expect(sectioning.sections[0].viewport).toEqual({ width: 595, height: 842 })
+      } finally {
+        verify.close()
+      }
+    })
+  })
+
+  describe("sectionId stability across structural ops", () => {
+    /** Seed page 1 with `count` sections, ids `_sec001.._secNNN`. */
+    function seedSections(count: number, pageId = `${label}_p1`) {
+      const storage = createBookStorage(label, tmpDir)
+      try {
+        storage.putNodeData("page-sectioning", pageId, {
+          reasoning: "sectioned",
+          sections: Array.from({ length: count }, (_, i) => ({
+            sectionId: `${pageId}_sec${String(i + 1).padStart(3, "0")}`,
+            sectionType: "content",
+            backgroundColor: "#ffffff",
+            textColor: "#000000",
+            pageNumber: 1,
+            isPruned: false,
+            nodes: [
+              {
+                nodeId: `${pageId}_n000${i + 1}`,
+                isPruned: false,
+                role: "text",
+                text: `Section ${i + 1}`,
+              },
+            ],
+          })),
+        })
+      } finally {
+        storage.close()
+      }
+    }
+
+    function readSectionIds(pageId = `${label}_p1`): string[] {
+      const verify = createBookStorage(label, tmpDir)
+      try {
+        const row = verify.getLatestNodeData("page-sectioning", pageId)
+        const data = row?.data as { sections: Array<{ sectionId: string }> }
+        return data.sections.map((s) => s.sectionId)
+      } finally {
+        verify.close()
+      }
+    }
+
+    it("keeps every surviving id when a middle section is deleted", async () => {
+      seedSections(4)
+
+      const res = await app.request(
+        `/api/books/${label}/pages/${label}_p1/sections/1`,
+        { method: "DELETE" }
+      )
+      expect(res.status).toBe(200)
+
+      // `_sec002` is retired and leaves a gap; nothing is renumbered into it.
+      expect(readSectionIds()).toEqual([
+        `${label}_p1_sec001`,
+        `${label}_p1_sec003`,
+        `${label}_p1_sec004`,
+      ])
+    })
+
+    it("keeps every surviving id when a middle section is cloned", async () => {
+      seedSections(3)
+
+      const res = await app.request(
+        `/api/books/${label}/pages/${label}_p1/sections/0/clone`,
+        { method: "POST" }
+      )
+      expect(res.status).toBe(200)
+
+      // The clone lands after its original with a fresh id; the sections it
+      // pushed down keep theirs.
+      expect(readSectionIds()).toEqual([
+        `${label}_p1_sec001`,
+        `${label}_p1_sec004`,
+        `${label}_p1_sec002`,
+        `${label}_p1_sec003`,
+      ])
+    })
+
+    it("never reissues a retired id, even after the deletion is no longer visible", async () => {
+      seedSections(3)
+
+      const del = await app.request(
+        `/api/books/${label}/pages/${label}_p1/sections/2`,
+        { method: "DELETE" }
+      )
+      expect(del.status).toBe(200)
+      expect(readSectionIds()).toEqual([`${label}_p1_sec001`, `${label}_p1_sec002`])
+
+      // A max-of-current counter would hand out `_sec003` again here, silently
+      // adopting the deleted section's TOC entry, sign-language video and
+      // answer-text catalog keys. The id space is tracked across all versions.
+      const clone = await app.request(
+        `/api/books/${label}/pages/${label}_p1/sections/0/clone`,
+        { method: "POST" }
+      )
+      expect(clone.status).toBe(200)
+
+      const ids = readSectionIds()
+      expect(ids).not.toContain(`${label}_p1_sec003`)
+      expect(ids).toEqual([
+        `${label}_p1_sec001`,
+        `${label}_p1_sec004`,
+        `${label}_p1_sec002`,
+      ])
+    })
+
+    it("keeps a sign-language video attached to its section across a merge, and unassigns the retired one", async () => {
+      seedSections(3)
+
+      const storage = createBookStorage(label, tmpDir)
+      try {
+        storage.putSignLanguageVideo("vid-keep", Buffer.from("a"), "keep.mp4", "video/mp4")
+        storage.putSignLanguageVideo("vid-gone", Buffer.from("b"), "gone.mp4", "video/mp4")
+        storage.assignSignLanguageVideo("vid-keep", `${label}_p1_sec003`)
+        storage.assignSignLanguageVideo("vid-gone", `${label}_p1_sec002`)
+      } finally {
+        storage.close()
+      }
+
+      // Merge sections 0 and 1: `_sec001` survives, `_sec002` is retired.
+      const res = await app.request(
+        `/api/books/${label}/pages/${label}_p1/sections/0/merge?direction=next`,
+        { method: "POST" }
+      )
+      expect(res.status).toBe(200)
+
+      const verify = createBookStorage(label, tmpDir)
+      try {
+        const byId = new Map(
+          verify.getSignLanguageVideos().map((v) => [v.videoId, v.sectionId])
+        )
+        // The untouched section kept its id, so its video is still attached —
+        // renumbering used to slide this video onto a different section.
+        expect(byId.get("vid-keep")).toBe(`${label}_p1_sec003`)
+        // The merged-away section's video is unassigned, not deleted, so the
+        // user can reattach the upload they made.
+        expect(byId.get("vid-gone")).toBeNull()
+        expect(verify.getSignLanguageVideoPath("vid-gone")).not.toBeNull()
+      } finally {
+        verify.close()
+      }
+    })
+
+    it("drops toc entries for retired sections and keeps the rest", async () => {
+      seedSections(3)
+
+      const storage = createBookStorage(label, tmpDir)
+      try {
+        storage.putNodeData("toc-generation", "book", {
+          pageCount: 3,
+          generatedAt: "2026-01-01T00:00:00.000Z",
+          entries: [1, 2, 3].map((n) => ({
+            id: `toc_00${n}`,
+            title: `Section ${n}`,
+            sectionId: `${label}_p1_sec00${n}`,
+            href: `${label}_p1_sec00${n}.html`,
+            chapterId: "ch1",
+            level: 1,
+          })),
+        })
+      } finally {
+        storage.close()
+      }
+
+      const res = await app.request(
+        `/api/books/${label}/pages/${label}_p1/sections/1`,
+        { method: "DELETE" }
+      )
+      expect(res.status).toBe(200)
+
+      const verify = createBookStorage(label, tmpDir)
+      try {
+        const row = verify.getLatestNodeData("toc-generation", "book")
+        const toc = row?.data as { entries: Array<{ sectionId: string }> }
+        expect(toc.entries.map((e) => e.sectionId)).toEqual([
+          `${label}_p1_sec001`,
+          `${label}_p1_sec003`,
+        ])
       } finally {
         verify.close()
       }

--- a/apps/api/src/routes/pages.test.ts
+++ b/apps/api/src/routes/pages.test.ts
@@ -1369,14 +1369,20 @@ describe("Page routes", () => {
   })
 
   describe("sectionId stability across structural ops", () => {
-    /** Seed page 1 with `count` sections, ids `_sec001.._secNNN`. */
-    function seedSections(count: number, pageId = `${label}_p1`) {
+    /**
+     * Seed a page with sections carrying exactly these id sequence numbers.
+     * A gap in `seqs` models a page that has already been edited, which is the
+     * only state where a renumbering bug is visible: renumbering a *dense*
+     * sequence is the identity, so a test seeded densely can pass against the
+     * very bug it is meant to catch. Returns the version written.
+     */
+    function seedSectionSeqs(seqs: number[], pageId = `${label}_p1`): number {
       const storage = createBookStorage(label, tmpDir)
       try {
-        storage.putNodeData("page-sectioning", pageId, {
+        return storage.putNodeData("page-sectioning", pageId, {
           reasoning: "sectioned",
-          sections: Array.from({ length: count }, (_, i) => ({
-            sectionId: `${pageId}_sec${String(i + 1).padStart(3, "0")}`,
+          sections: seqs.map((seq) => ({
+            sectionId: `${pageId}_sec${String(seq).padStart(3, "0")}`,
             sectionType: "content",
             backgroundColor: "#ffffff",
             textColor: "#000000",
@@ -1384,10 +1390,10 @@ describe("Page routes", () => {
             isPruned: false,
             nodes: [
               {
-                nodeId: `${pageId}_n000${i + 1}`,
+                nodeId: `${pageId}_n000${seq}`,
                 isPruned: false,
                 role: "text",
-                text: `Section ${i + 1}`,
+                text: `Section ${seq}`,
               },
             ],
           })),
@@ -1395,6 +1401,15 @@ describe("Page routes", () => {
       } finally {
         storage.close()
       }
+    }
+
+    /** Seed page 1 with `count` sections, ids `_sec001.._secNNN`. Returns the
+     *  version written, so a test can restore back to it. */
+    function seedSections(count: number, pageId = `${label}_p1`): number {
+      return seedSectionSeqs(
+        Array.from({ length: count }, (_, i) => i + 1),
+        pageId
+      )
     }
 
     function readSectionIds(pageId = `${label}_p1`): string[] {
@@ -1470,6 +1485,87 @@ describe("Page routes", () => {
         `${label}_p1_sec004`,
         `${label}_p1_sec002`,
       ])
+    })
+
+    it("keeps the surviving ids on BOTH pages across a cross-page merge", async () => {
+      // Both pages start with gaps, so wholesale renumbering would be visible
+      // on each of them. Seeding densely hides the bug: removing the last
+      // section of a dense page and renumbering the rest is a no-op.
+      seedSectionSeqs([1, 4, 5], `${label}_p1`)
+      seedSectionSeqs([1, 3], `${label}_p2`)
+
+      // Move p2's first section back into p1's last. This is the op that used
+      // to renumber both pages wholesale — reassigning every later section's
+      // TOC entry, sign-language video and answer-text catalog keys on two
+      // pages at once. The existing tests for this endpoint use single-section
+      // pages, so nothing there could have caught it.
+      const res = await app.request(
+        `/api/books/${label}/pages/${label}_p2/sections/0/merge-cross-page?direction=prev`,
+        { method: "POST" }
+      )
+      expect(res.status).toBe(200)
+
+      // Target: every id untouched. The receiving section absorbed nodes, not a
+      // new identity, and its neighbours kept their own.
+      expect(readSectionIds(`${label}_p1`)).toEqual([
+        `${label}_p1_sec001`,
+        `${label}_p1_sec004`,
+        `${label}_p1_sec005`,
+      ])
+      // Source: only the moved section's id retires; the survivor keeps `_sec003`
+      // rather than sliding down into the vacated `_sec001`.
+      expect(readSectionIds(`${label}_p2`)).toEqual([`${label}_p2_sec003`])
+
+      // The content really did move — otherwise the ids above would be stable
+      // for the trivial reason that nothing happened.
+      const verify = createBookStorage(label, tmpDir)
+      try {
+        const tgt = verify.getLatestNodeData("page-sectioning", `${label}_p1`)
+          ?.data as { sections: Array<{ nodes: Array<{ nodeId: string }> }> }
+        expect(tgt.sections[2].nodes.map((n) => n.nodeId)).toContain(
+          `${label}_p2_n0001`
+        )
+      } finally {
+        verify.close()
+      }
+    })
+
+    it("does not reissue a spent id after an earlier sectioning version is restored", async () => {
+      const seededVersion = seedSections(3)
+
+      const clone = await app.request(
+        `/api/books/${label}/pages/${label}_p1/sections/0/clone`,
+        { method: "POST" }
+      )
+      expect(clone.status).toBe(200)
+      expect(readSectionIds()).toContain(`${label}_p1_sec004`)
+
+      // Roll the node back to before `_sec004` existed. Restoring only moves
+      // the current-version pointer, so `_sec004` remains in history and must
+      // stay spent. A counter stored on the entity would have been rewound
+      // along with it and reissued `_sec004` to different content.
+      const restore = await app.request(
+        `/api/books/${label}/versions/page-sectioning/${label}_p1/restore`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ version: seededVersion }),
+        }
+      )
+      expect(restore.status).toBe(200)
+
+      const second = await app.request(
+        `/api/books/${label}/pages/${label}_p1/sections/0/clone`,
+        { method: "POST" }
+      )
+      expect(second.status).toBe(200)
+
+      // Structural ops currently read the latest version rather than the
+      // restored pointer, so today this holds for that reason too. The
+      // assertion is on the id space regardless: whoever makes a restore
+      // authoritative for these ops must keep the factory's history-wide
+      // high-water mark, or this fails.
+      expect(readSectionIds()).toContain(`${label}_p1_sec005`)
     })
 
     it("keeps a sign-language video attached to its section across a merge, and unassigns the retired one", async () => {

--- a/apps/api/src/routes/pages.test.ts
+++ b/apps/api/src/routes/pages.test.ts
@@ -1632,6 +1632,90 @@ describe("Page routes", () => {
       }
     })
 
+    it("parks a removed page's recording, since re-applying remints its ids", async () => {
+      // `spreads/apply` is the structural path that clears no manifests, so the
+      // prune is load-bearing here — and because `deletePage` drops the page's
+      // sectioning history, un-applying the spread re-creates it under the same
+      // id starting at `_sec001` and regenerates straight over any recording
+      // left at `audio/<lang>/${sectionId}_ans_*`. Once the entry is pruned
+      // nothing knows the file is orphaned, so parking has to happen here.
+      //
+      // Pinned to `end_page: 1` so the only desired page already exists: that
+      // makes `toAdd` empty and skips real PDF extraction, leaving the fixture
+      // pages as the ones to remove.
+      fs.writeFileSync(
+        path.join(tmpDir, label, "config.yaml"),
+        "start_page: 1\nend_page: 1\n"
+      )
+      fs.copyFileSync(
+        path.resolve(import.meta.dirname, "../../../../tests/fixtures/raven.pdf"),
+        path.join(tmpDir, label, `${label}.pdf`)
+      )
+
+      const audioDir = path.join(tmpDir, label, "audio", "en")
+      fs.mkdirSync(audioDir, { recursive: true })
+      const fileName = `${label}_p1_sec001_ans_a.mp3`
+      fs.writeFileSync(path.join(audioDir, fileName), "uploaded-audio")
+
+      const storage = createBookStorage(label, tmpDir)
+      try {
+        storage.putExtractedPage({
+          pageId: "pg001",
+          pageNumber: 1,
+          text: "Kept page",
+          pageImage: {
+            imageId: "pg001_page",
+            buffer: Buffer.from("fake-png-data"),
+            format: "png" as const,
+            hash: "keep123",
+            width: 800,
+            height: 600,
+          },
+          images: [],
+        })
+        storage.putNodeData("tts", "en", {
+          entries: [
+            {
+              textId: `${label}_p1_sec001_ans_a`,
+              language: "en",
+              fileName,
+              voice: "uploaded",
+              model: "uploaded",
+              cached: false,
+              provider: "manual",
+              voiceSlot: "primary" as const,
+            },
+          ],
+          generatedAt: "2026-01-01T00:00:00.000Z",
+        })
+      } finally {
+        storage.close()
+      }
+
+      const res = await app.request(`/api/books/${label}/spreads/apply`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ spreadPairs: [] }),
+      })
+      expect(res.status).toBe(200)
+
+      const verify = createBookStorage(label, tmpDir)
+      try {
+        const tts = verify.getLatestNodeData("tts", "en")?.data as {
+          entries: Array<{ textId: string }>
+        }
+        expect(tts.entries).toEqual([])
+      } finally {
+        verify.close()
+      }
+      // Moved out of the path a re-mint regenerates into, and not deleted.
+      expect(fs.existsSync(path.join(audioDir, fileName))).toBe(false)
+      const parked = path.join(tmpDir, label, "audio", ".detached")
+      expect(
+        fs.readdirSync(parked).flatMap((stamp) => fs.readdirSync(path.join(parked, stamp, "en")))
+      ).toEqual([fileName])
+    })
+
     it("clears the speech manifests wholesale, so no entry outlives a retired id", async () => {
       // This is why `retireSectionIds`' speech prune is moot on the section-level
       // ops but load-bearing on `spreads/apply` and the stage rerun: those two

--- a/apps/api/src/routes/pages.test.ts
+++ b/apps/api/src/routes/pages.test.ts
@@ -1632,6 +1632,59 @@ describe("Page routes", () => {
       }
     })
 
+    it("clears the speech manifests wholesale, so no entry outlives a retired id", async () => {
+      // This is why `retireSectionIds`' speech prune is moot on the section-level
+      // ops but load-bearing on `spreads/apply` and the stage rerun: those two
+      // drop a page's sectioning history without clearing the manifests, while
+      // every op that goes through `saveStoryboardNode` wipes them entirely
+      // (`clearCaptionData`). If that ever stops being true, the prune is the
+      // only thing standing between a re-minted id and the old recording — so
+      // pin the behaviour rather than leaving it implied.
+      seedSections(3)
+
+      const audioDir = path.join(tmpDir, label, "audio", "en")
+      fs.mkdirSync(audioDir, { recursive: true })
+      const storage = createBookStorage(label, tmpDir)
+      try {
+        storage.putNodeData("tts", "en", {
+          entries: [`${label}_p1_sec002_ans_a`, `${label}_p1_sec003_ans_a`].map((textId) => {
+            fs.writeFileSync(path.join(audioDir, `${textId}.mp3`), "fake-audio")
+            return {
+              textId,
+              language: "en",
+              fileName: `${textId}.mp3`,
+              voice: "uploaded",
+              model: "uploaded",
+              cached: false,
+              provider: "manual",
+              voiceSlot: "primary" as const,
+            }
+          }),
+          generatedAt: "2026-01-01T00:00:00.000Z",
+        })
+      } finally {
+        storage.close()
+      }
+
+      const res = await app.request(
+        `/api/books/${label}/pages/${label}_p1/sections/1`,
+        { method: "DELETE" }
+      )
+      expect(res.status).toBe(200)
+
+      const verify = createBookStorage(label, tmpDir)
+      try {
+        expect(verify.getNodeItemIds("tts")).toEqual([])
+        expect(verify.getNodeItemIds("tts-timestamps")).toEqual([])
+      } finally {
+        verify.close()
+      }
+      // The manifests go; the uploads never do.
+      for (const textId of [`${label}_p1_sec002_ans_a`, `${label}_p1_sec003_ans_a`]) {
+        expect(fs.existsSync(path.join(audioDir, `${textId}.mp3`))).toBe(true)
+      }
+    })
+
     it("drops toc entries for retired sections and keeps the rest", async () => {
       seedSections(3)
 

--- a/apps/api/src/routes/pages.test.ts
+++ b/apps/api/src/routes/pages.test.ts
@@ -971,7 +971,7 @@ describe("Page routes", () => {
       }
     })
 
-    it("splits a section before a top-level node and renumbers sectionIds", async () => {
+    it("splits a section, keeping the first half's id and leaving the untouched section alone", async () => {
       seedThreeNodeSection({ rendering: true })
 
       const res = await app.request(
@@ -998,10 +998,14 @@ describe("Page routes", () => {
           }>
         }
         expect(sectioning.sections).toHaveLength(3)
+        // The first half keeps `_sec001`; the new second half mints `_sec003`;
+        // the pre-existing `_sec002` keeps its id even though it moved to index
+        // 2. Renumbering it would silently hand its TOC entry, sign-language
+        // video and answer-text catalog keys to the newly created half.
         expect(sectioning.sections.map((s) => s.sectionId)).toEqual([
           `${label}_p1_sec001`,
-          `${label}_p1_sec002`,
           `${label}_p1_sec003`,
+          `${label}_p1_sec002`,
         ])
         expect(sectioning.sections[0].nodes.map((n) => n.nodeId)).toEqual([
           `${label}_p1_n0001`,
@@ -1018,8 +1022,9 @@ describe("Page routes", () => {
           `${label}_p1_n0005`,
         ])
 
-        // Rendering: split section's entry dropped, other section shifted +1
-        // with its data-section-id rewritten.
+        // Rendering: the split section's entry is dropped and the untouched
+        // section's index shifts +1, but its HTML keeps its own section id —
+        // the split must not rewrite another section's markup.
         const renderingRow = verify.getLatestNodeData("web-rendering", `${label}_p1`)
         const rendering = renderingRow?.data as {
           sections: Array<{ sectionIndex: number; html: string }>
@@ -1027,7 +1032,7 @@ describe("Page routes", () => {
         expect(rendering.sections).toHaveLength(1)
         expect(rendering.sections[0].sectionIndex).toBe(2)
         expect(rendering.sections[0].html).toContain(
-          `data-section-id="${label}_p1_sec003"`
+          `data-section-id="${label}_p1_sec002"`
         )
       } finally {
         verify.close()
@@ -1357,6 +1362,188 @@ describe("Page routes", () => {
           `${label}_p1_n0002`,
         ])
         expect(sectioning.sections[0].viewport).toEqual({ width: 595, height: 842 })
+      } finally {
+        verify.close()
+      }
+    })
+  })
+
+  describe("sectionId stability across structural ops", () => {
+    /** Seed page 1 with `count` sections, ids `_sec001.._secNNN`. */
+    function seedSections(count: number, pageId = `${label}_p1`) {
+      const storage = createBookStorage(label, tmpDir)
+      try {
+        storage.putNodeData("page-sectioning", pageId, {
+          reasoning: "sectioned",
+          sections: Array.from({ length: count }, (_, i) => ({
+            sectionId: `${pageId}_sec${String(i + 1).padStart(3, "0")}`,
+            sectionType: "content",
+            backgroundColor: "#ffffff",
+            textColor: "#000000",
+            pageNumber: 1,
+            isPruned: false,
+            nodes: [
+              {
+                nodeId: `${pageId}_n000${i + 1}`,
+                isPruned: false,
+                role: "text",
+                text: `Section ${i + 1}`,
+              },
+            ],
+          })),
+        })
+      } finally {
+        storage.close()
+      }
+    }
+
+    function readSectionIds(pageId = `${label}_p1`): string[] {
+      const verify = createBookStorage(label, tmpDir)
+      try {
+        const row = verify.getLatestNodeData("page-sectioning", pageId)
+        const data = row?.data as { sections: Array<{ sectionId: string }> }
+        return data.sections.map((s) => s.sectionId)
+      } finally {
+        verify.close()
+      }
+    }
+
+    it("keeps every surviving id when a middle section is deleted", async () => {
+      seedSections(4)
+
+      const res = await app.request(
+        `/api/books/${label}/pages/${label}_p1/sections/1`,
+        { method: "DELETE" }
+      )
+      expect(res.status).toBe(200)
+
+      // `_sec002` is retired and leaves a gap; nothing is renumbered into it.
+      expect(readSectionIds()).toEqual([
+        `${label}_p1_sec001`,
+        `${label}_p1_sec003`,
+        `${label}_p1_sec004`,
+      ])
+    })
+
+    it("keeps every surviving id when a middle section is cloned", async () => {
+      seedSections(3)
+
+      const res = await app.request(
+        `/api/books/${label}/pages/${label}_p1/sections/0/clone`,
+        { method: "POST" }
+      )
+      expect(res.status).toBe(200)
+
+      // The clone lands after its original with a fresh id; the sections it
+      // pushed down keep theirs.
+      expect(readSectionIds()).toEqual([
+        `${label}_p1_sec001`,
+        `${label}_p1_sec004`,
+        `${label}_p1_sec002`,
+        `${label}_p1_sec003`,
+      ])
+    })
+
+    it("never reissues a retired id, even after the deletion is no longer visible", async () => {
+      seedSections(3)
+
+      const del = await app.request(
+        `/api/books/${label}/pages/${label}_p1/sections/2`,
+        { method: "DELETE" }
+      )
+      expect(del.status).toBe(200)
+      expect(readSectionIds()).toEqual([`${label}_p1_sec001`, `${label}_p1_sec002`])
+
+      // A max-of-current counter would hand out `_sec003` again here, silently
+      // adopting the deleted section's TOC entry, sign-language video and
+      // answer-text catalog keys. The id space is tracked across all versions.
+      const clone = await app.request(
+        `/api/books/${label}/pages/${label}_p1/sections/0/clone`,
+        { method: "POST" }
+      )
+      expect(clone.status).toBe(200)
+
+      const ids = readSectionIds()
+      expect(ids).not.toContain(`${label}_p1_sec003`)
+      expect(ids).toEqual([
+        `${label}_p1_sec001`,
+        `${label}_p1_sec004`,
+        `${label}_p1_sec002`,
+      ])
+    })
+
+    it("keeps a sign-language video attached to its section across a merge, and unassigns the retired one", async () => {
+      seedSections(3)
+
+      const storage = createBookStorage(label, tmpDir)
+      try {
+        storage.putSignLanguageVideo("vid-keep", Buffer.from("a"), "keep.mp4", "video/mp4")
+        storage.putSignLanguageVideo("vid-gone", Buffer.from("b"), "gone.mp4", "video/mp4")
+        storage.assignSignLanguageVideo("vid-keep", `${label}_p1_sec003`)
+        storage.assignSignLanguageVideo("vid-gone", `${label}_p1_sec002`)
+      } finally {
+        storage.close()
+      }
+
+      // Merge sections 0 and 1: `_sec001` survives, `_sec002` is retired.
+      const res = await app.request(
+        `/api/books/${label}/pages/${label}_p1/sections/0/merge?direction=next`,
+        { method: "POST" }
+      )
+      expect(res.status).toBe(200)
+
+      const verify = createBookStorage(label, tmpDir)
+      try {
+        const byId = new Map(
+          verify.getSignLanguageVideos().map((v) => [v.videoId, v.sectionId])
+        )
+        // The untouched section kept its id, so its video is still attached —
+        // renumbering used to slide this video onto a different section.
+        expect(byId.get("vid-keep")).toBe(`${label}_p1_sec003`)
+        // The merged-away section's video is unassigned, not deleted, so the
+        // user can reattach the upload they made.
+        expect(byId.get("vid-gone")).toBeNull()
+        expect(verify.getSignLanguageVideoPath("vid-gone")).not.toBeNull()
+      } finally {
+        verify.close()
+      }
+    })
+
+    it("drops toc entries for retired sections and keeps the rest", async () => {
+      seedSections(3)
+
+      const storage = createBookStorage(label, tmpDir)
+      try {
+        storage.putNodeData("toc-generation", "book", {
+          pageCount: 3,
+          generatedAt: "2026-01-01T00:00:00.000Z",
+          entries: [1, 2, 3].map((n) => ({
+            id: `toc_00${n}`,
+            title: `Section ${n}`,
+            sectionId: `${label}_p1_sec00${n}`,
+            href: `${label}_p1_sec00${n}.html`,
+            chapterId: "ch1",
+            level: 1,
+          })),
+        })
+      } finally {
+        storage.close()
+      }
+
+      const res = await app.request(
+        `/api/books/${label}/pages/${label}_p1/sections/1`,
+        { method: "DELETE" }
+      )
+      expect(res.status).toBe(200)
+
+      const verify = createBookStorage(label, tmpDir)
+      try {
+        const row = verify.getLatestNodeData("toc-generation", "book")
+        const toc = row?.data as { entries: Array<{ sectionId: string }> }
+        expect(toc.entries.map((e) => e.sectionId)).toEqual([
+          `${label}_p1_sec001`,
+          `${label}_p1_sec003`,
+        ])
       } finally {
         verify.close()
       }

--- a/apps/api/src/routes/pages.test.ts
+++ b/apps/api/src/routes/pages.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
 import fs from "node:fs"
 import path from "node:path"
 import os from "node:os"
@@ -1632,7 +1632,7 @@ describe("Page routes", () => {
       }
     })
 
-    it("parks a removed page's recording, since re-applying remints its ids", async () => {
+    it.each([false, true])("backs up a removed page's recording (retry after failure: %s)", async (failFirst) => {
       // `spreads/apply` is the structural path that clears no manifests, so the
       // prune is load-bearing here — and because `deletePage` drops the page's
       // sectioning history, un-applying the spread re-creates it under the same
@@ -1692,11 +1692,32 @@ describe("Page routes", () => {
         storage.close()
       }
 
-      const res = await app.request(`/api/books/${label}/spreads/apply`, {
+      const request = () => app.request(`/api/books/${label}/spreads/apply`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ spreadPairs: [] }),
       })
+      if (failFirst) {
+        const copy = vi.spyOn(fs, "copyFileSync").mockImplementationOnce(() => {
+          throw Object.assign(new Error("disk full"), { code: "ENOSPC" })
+        })
+        try {
+          expect((await request()).status).toBe(500)
+        } finally {
+          copy.mockRestore()
+        }
+        const failed = createBookStorage(label, tmpDir)
+        try {
+          expect(failed.getPages().some((page) => page.pageId === `${label}_p1`)).toBe(true)
+          expect(failed.getLatestNodeData("tts", "en")?.data).toMatchObject({
+            entries: [{ textId: `${label}_p1_sec001_ans_a`, provider: "manual" }],
+          })
+        } finally {
+          failed.close()
+        }
+        expect(fs.readFileSync(path.join(audioDir, fileName), "utf8")).toBe("uploaded-audio")
+      }
+      const res = await request()
       expect(res.status).toBe(200)
 
       const verify = createBookStorage(label, tmpDir)
@@ -1708,8 +1729,9 @@ describe("Page routes", () => {
       } finally {
         verify.close()
       }
-      // Moved out of the path a re-mint regenerates into, and not deleted.
-      expect(fs.existsSync(path.join(audioDir, fileName))).toBe(false)
+      // Keep the original as well as the backup, so transaction rollback never
+      // leaves the old manifest pointing to a missing upload.
+      expect(fs.existsSync(path.join(audioDir, fileName))).toBe(true)
       const parked = path.join(tmpDir, label, "audio", ".detached")
       expect(
         fs.readdirSync(parked).flatMap((stamp) => fs.readdirSync(path.join(parked, stamp, "en")))

--- a/apps/api/src/routes/pages.ts
+++ b/apps/api/src/routes/pages.ts
@@ -736,6 +736,34 @@ function migrateEditableActivities(
 }
 
 /**
+ * Every `${pageId}_sec${NNN}` id that appears in *any* stored version of this
+ * page's sectioning — the ids that are spent and must never be handed out
+ * again.
+ *
+ * Scanned out of the raw JSON rather than off parsed rows on purpose. A version
+ * that no longer satisfies today's schema (a legacy row with no `sectionId`
+ * field, a shape from before a migration) still burned the ids it contains, and
+ * skipping it because `safeParse` failed would let them be reissued. Matching
+ * text is a non-risk in the other direction: an incidental `_secNNN` inside
+ * some node's text only makes the set larger, which can never cause reuse.
+ */
+function collectSpentSectionIds(storage: Storage, pageId: string): Set<string> {
+  const spent = new Set<string>()
+  const pattern = new RegExp(
+    `${pageId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}_sec\\d+`,
+    "g"
+  )
+  for (const node of [PAGE_SECTIONING_NODE, FIXED_LAYOUT_SECTIONING_NODE]) {
+    for (const row of storage.getAllNodeVersions(node, pageId)) {
+      for (const match of JSON.stringify(row.data).matchAll(pattern)) {
+        spent.add(match[0])
+      }
+    }
+  }
+  return spent
+}
+
+/**
  * Mint `${pageId}_sec${NNN}` ids that no version of this page's sectioning has
  * ever used, so a section's id is immutable for its whole life and a retired id
  * is never handed out again.
@@ -751,18 +779,12 @@ function migrateEditableActivities(
  * counter back and reissue every id allocated since.
  */
 function createSectionIdFactory(storage: Storage, pageId: string): () => string {
-  const used = new Set<number>()
-  for (const node of [PAGE_SECTIONING_NODE, FIXED_LAYOUT_SECTIONING_NODE]) {
-    for (const row of storage.getAllNodeVersions(node, pageId)) {
-      const parsed = PageSectioningOutput.safeParse(row.data)
-      if (!parsed.success) continue
-      for (const section of parsed.data.sections) {
-        const id = parseSectionId(section.sectionId)
-        if (id) used.add(id.seq)
-      }
-    }
+  let highWaterMark = 0
+  for (const id of collectSpentSectionIds(storage, pageId)) {
+    const parsed = parseSectionId(id)
+    if (parsed) highWaterMark = Math.max(highWaterMark, parsed.seq)
   }
-  let next = (used.size > 0 ? Math.max(...used) : 0) + 1
+  let next = highWaterMark + 1
   return () => {
     if (next > MAX_SECTION_SEQ) {
       // Unreachable in practice: each structural op allocates one id, so this
@@ -1424,6 +1446,18 @@ export function createPageRoutes(
         )
       }
     }
+    // Retire before deleting, and in one pass so the whole reconcile costs a
+    // single `toc-generation` version. `deletePage` drops the page's entire
+    // node_data history, including the sectioning the id factory reads its
+    // high-water mark from — so a page later re-created under the same id
+    // restarts at `_sec001`. Any `toc-generation` entry or sign-language video
+    // still pointing at an id that page spent would then silently reattach to
+    // unrelated content, which is exactly what id immutability prevents
+    // everywhere else.
+    const spentOnRemovedPages = toRemove.flatMap((id) => [
+      ...collectSpentSectionIds(storage, id),
+    ])
+    retireSectionIds(storage, spentOnRemovedPages)
     for (const id of toRemove) storage.deletePage(id)
 
     return c.json({

--- a/apps/api/src/routes/pages.ts
+++ b/apps/api/src/routes/pages.ts
@@ -26,6 +26,10 @@ import {
   getStageClearOrder,
   getStageDependents,
   EDITABLE_ACTIVITY_NODE,
+  TocGenerationOutput,
+  formatSectionId,
+  parseSectionId,
+  MAX_SECTION_SEQ,
   CoreTtsCatalogOutput,
   TextCatalogOutput,
   type TTSOutput,
@@ -48,6 +52,8 @@ import {
   remapEditableActivities,
   invalidateCoreTtsForDisplayEntries,
   resolveFigureExtractionMode,
+  PAGE_SECTIONING_NODE,
+  FIXED_LAYOUT_SECTIONING_NODE,
 } from "@adt/pipeline"
 import { samplePageEdges, extractPages, computeGroups, countPdfPages } from "@adt/pdf"
 import { reRenderPage, aiEditSection } from "../services/page-edit-service.js"
@@ -729,13 +735,75 @@ function migrateEditableActivities(
   return storage.putNodeData(EDITABLE_ACTIVITY_NODE, pageId, { activities })
 }
 
-/** Renumber sectionIds to the canonical `${pageId}_sec${NNN}` sequence. */
-function renumberSectionIds(
-  sections: Array<{ sectionId: string }>,
-  pageId: string
-): void {
-  for (let i = 0; i < sections.length; i++) {
-    sections[i].sectionId = `${pageId}_sec${String(i + 1).padStart(3, "0")}`
+/**
+ * Mint `${pageId}_sec${NNN}` ids that no version of this page's sectioning has
+ * ever used, so a section's id is immutable for its whole life and a retired id
+ * is never handed out again.
+ *
+ * The high-water mark comes from *history*, not just the current version. Delete
+ * `_sec003`, then split `_sec002`, and a max-of-current counter would reissue
+ * `_sec003` — silently adopting the deleted section's `toc-generation` entry,
+ * sign-language video and text-catalog `${sectionId}_ans_*` keys (and therefore
+ * their translations and generated audio) onto unrelated content.
+ *
+ * A counter stored on the entity would be worse: it would live inside the very
+ * thing it counts, so restoring an older sectioning version would roll the
+ * counter back and reissue every id allocated since.
+ */
+function createSectionIdFactory(storage: Storage, pageId: string): () => string {
+  const used = new Set<number>()
+  for (const node of [PAGE_SECTIONING_NODE, FIXED_LAYOUT_SECTIONING_NODE]) {
+    for (const row of storage.getAllNodeVersions(node, pageId)) {
+      const parsed = PageSectioningOutput.safeParse(row.data)
+      if (!parsed.success) continue
+      for (const section of parsed.data.sections) {
+        const id = parseSectionId(section.sectionId)
+        if (id) used.add(id.seq)
+      }
+    }
+  }
+  let next = (used.size > 0 ? Math.max(...used) : 0) + 1
+  return () => {
+    if (next > MAX_SECTION_SEQ) {
+      // Unreachable in practice: each structural op allocates one id, so this
+      // needs ~1000 edits to a single page. Capped so the `_sec(\d{3})` shape
+      // every consumer parses stays valid rather than silently widening.
+      throw new HTTPException(400, {
+        message: `Page ${pageId} has allocated all ${MAX_SECTION_SEQ} of its section ids. Split this page's content across pages, or re-extract it, before editing its sections further.`,
+      })
+    }
+    return formatSectionId(pageId, next++)
+  }
+}
+
+/**
+ * Drop book-level references to sections that no longer exist. Called by every
+ * op that removes a section; without it a merge or delete leaves a dangling
+ * `toc-generation` entry (a broken href in the EPUB nav) or a sign-language
+ * video pinned to an id nothing resolves.
+ *
+ * Videos are *unassigned*, not deleted: the upload is the user's, and they can
+ * reattach it to the surviving section.
+ */
+function retireSectionIds(storage: Storage, retired: string[]): void {
+  if (retired.length === 0) return
+  const retiredIds = new Set(retired)
+
+  const tocRow = storage.getLatestNodeData("toc-generation", "book")
+  if (tocRow) {
+    const parsed = TocGenerationOutput.safeParse(tocRow.data)
+    if (parsed.success) {
+      const entries = parsed.data.entries.filter((entry) => !retiredIds.has(entry.sectionId))
+      if (entries.length !== parsed.data.entries.length) {
+        storage.putNodeData("toc-generation", "book", { ...parsed.data, entries })
+      }
+    }
+  }
+
+  for (const video of storage.getSignLanguageVideos()) {
+    if (video.sectionId && retiredIds.has(video.sectionId)) {
+      storage.assignSignLanguageVideo(video.videoId, null)
+    }
   }
 }
 
@@ -971,7 +1039,9 @@ export function createPageRoutes(
           }
 
           const sectionEntries: PageSummarySection[] = (rawSections ?? []).map((s, i) => {
-            const sectionId = s.sectionId ?? `${row.item_id}_sec${String(i + 1).padStart(3, "0")}`
+            // `sectionId` is required by the schema; this only covers raw legacy
+            // rows that never had one. Display-only — nothing names a file from it.
+            const sectionId = s.sectionId ?? formatSectionId(row.item_id, i + 1)
             // Pruned sections keep their own text in the per-section preview so
             // they can be displayed in the storyboard sidebar even when grayed out.
             const sectionText = collectText(s.nodes, { skipPruned: false })
@@ -2169,10 +2239,12 @@ export function createPageRoutes(
         throw new HTTPException(400, { message: `Section index ${idx} out of range (page has ${sectioning.sections.length} sections)` })
       }
 
-      // Clone the section and insert after the original
+      // Clone the section and insert after the original. The original keeps its
+      // sectionId — only the clone gets a new one.
       const containerIdMap = new Map<string, string>()
       const clonedSection = {
         ...sectioning.sections[idx],
+        sectionId: createSectionIdFactory(storage, pageId)(),
         nodes: cloneNodesWithFreshContainerIds(
           sectioning.sections[idx].nodes,
           createNodeIdFactory(pageId, sectioning.sections),
@@ -2181,8 +2253,6 @@ export function createPageRoutes(
       }
       const newSections = [...sectioning.sections]
       newSections.splice(idx + 1, 0, clonedSection)
-
-      renumberSectionIds(newSections, pageId)
 
       const updatedSectioning = { ...sectioning, sections: newSections }
 
@@ -2372,8 +2442,11 @@ export function createPageRoutes(
         nodes: keptNodes,
         ...(keptPlacement ? { placement: keptPlacement } : {}),
       }
+      // The first half keeps the original sectionId (it inherits it from
+      // `section`); only the new second half gets a fresh one.
       const movedSection = {
         ...section,
+        sectionId: createSectionIdFactory(storage, pageId)(),
         nodes: movedNodes,
         ...(movedPlacement ? { placement: movedPlacement } : {}),
       }
@@ -2387,8 +2460,6 @@ export function createPageRoutes(
       const newSections = [...sectioning.sections]
       newSections[idx] = keptSection
       newSections.splice(idx + 1, 0, movedSection)
-
-      renumberSectionIds(newSections, pageId)
 
       const updatedSectioning = { ...sectioning, sections: newSections }
 
@@ -2523,7 +2594,9 @@ export function createPageRoutes(
       }
       newSections.splice(removeIdx, 1)
 
-      renumberSectionIds(newSections, pageId)
+      // The surviving section keeps its sectionId (inherited from `keepSection`);
+      // the removed section's id is retired, never reassigned to a survivor.
+      const retiredSectionIds = [removeSection.sectionId]
 
       const updatedSectioning = { ...sectioning, sections: newSections }
 
@@ -2588,6 +2661,7 @@ export function createPageRoutes(
         mapIndex: (i) =>
           i === keepIdx || i === removeIdx ? null : i > removeIdx ? i - 1 : i,
       })
+      retireSectionIds(storage, retiredSectionIds)
 
       return c.json({
         mergedSectionIndex: keepIdx,
@@ -2705,9 +2779,11 @@ export function createPageRoutes(
       const newSrcSections = [...srcSectioning.sections]
       newSrcSections.splice(idx, 1)
 
-      renumberSectionIds(newSrcSections, pageId)
-
-      renumberSectionIds(newTgtSections, targetPageId)
+      // The target section keeps its sectionId; the moved section's id is
+      // retired. Surviving sections on *either* page keep theirs — this op used
+      // to renumber both pages wholesale, which silently reassigned every later
+      // section's TOC entry, sign-language video and answer-text catalog keys.
+      const retiredSectionIds = [movedSection.sectionId]
 
       // Save updated sectionings
       const srcVersion = saveStoryboardNode(
@@ -2743,6 +2819,7 @@ export function createPageRoutes(
       migrateEditableActivities(storage, targetPageId, {
         mapIndex: (i) => (i === tgtIdx ? null : i),
       })
+      retireSectionIds(storage, retiredSectionIds)
 
       return c.json({
         sourcePageId: pageId,
@@ -2796,11 +2873,10 @@ export function createPageRoutes(
         throw new HTTPException(400, { message: `Section index ${idx} out of range (page has ${sectioning.sections.length} sections)` })
       }
 
-      // Remove section at idx
+      // Remove section at idx. Survivors keep their sectionIds; only the
+      // deleted section's id is retired.
       const newSections = [...sectioning.sections]
-      newSections.splice(idx, 1)
-
-      renumberSectionIds(newSections, pageId)
+      const [deletedSection] = newSections.splice(idx, 1)
 
       const updatedSectioning = { ...sectioning, sections: newSections }
 
@@ -2835,8 +2911,8 @@ export function createPageRoutes(
       }
 
       // Deleting rebuilds the rendering to match: the section's HTML entry is
-      // dropped, later indexes shift down, and section ids are rewritten. The
-      // surviving sections keep the HTML they already had, so nothing needs
+      // dropped and later indexes shift down. The surviving sections keep both
+      // their sectionIds and the HTML they already had, so nothing needs
       // re-rendering and the storyboard stays current.
       const sectioningVersion = saveStoryboardNode(
         storage,
@@ -2851,6 +2927,7 @@ export function createPageRoutes(
       migrateEditableActivities(storage, pageId, {
         mapIndex: (i) => (i === idx ? null : i > idx ? i - 1 : i),
       })
+      retireSectionIds(storage, [deletedSection.sectionId])
 
       return c.json({
         sectioningVersion,

--- a/apps/api/src/routes/pages.ts
+++ b/apps/api/src/routes/pages.ts
@@ -25,6 +25,10 @@ import {
   getStageClearOrder,
   getStageDependents,
   EDITABLE_ACTIVITY_NODE,
+  TocGenerationOutput,
+  formatSectionId,
+  parseSectionId,
+  MAX_SECTION_SEQ,
   CoreTtsCatalogOutput,
   TextCatalogOutput,
   type TTSOutput,
@@ -47,6 +51,8 @@ import {
   remapEditableActivities,
   invalidateCoreTtsForDisplayEntries,
   resolveFigureExtractionMode,
+  PAGE_SECTIONING_NODE,
+  FIXED_LAYOUT_SECTIONING_NODE,
 } from "@adt/pipeline"
 import { samplePageEdges, extractPages, computeGroups, countPdfPages } from "@adt/pdf"
 import { reRenderPage, aiEditSection } from "../services/page-edit-service.js"
@@ -726,13 +732,75 @@ function migrateEditableActivities(
   return storage.putNodeData(EDITABLE_ACTIVITY_NODE, pageId, { activities })
 }
 
-/** Renumber sectionIds to the canonical `${pageId}_sec${NNN}` sequence. */
-function renumberSectionIds(
-  sections: Array<{ sectionId: string }>,
-  pageId: string
-): void {
-  for (let i = 0; i < sections.length; i++) {
-    sections[i].sectionId = `${pageId}_sec${String(i + 1).padStart(3, "0")}`
+/**
+ * Mint `${pageId}_sec${NNN}` ids that no version of this page's sectioning has
+ * ever used, so a section's id is immutable for its whole life and a retired id
+ * is never handed out again.
+ *
+ * The high-water mark comes from *history*, not just the current version. Delete
+ * `_sec003`, then split `_sec002`, and a max-of-current counter would reissue
+ * `_sec003` — silently adopting the deleted section's `toc-generation` entry,
+ * sign-language video and text-catalog `${sectionId}_ans_*` keys (and therefore
+ * their translations and generated audio) onto unrelated content.
+ *
+ * A counter stored on the entity would be worse: it would live inside the very
+ * thing it counts, so restoring an older sectioning version would roll the
+ * counter back and reissue every id allocated since.
+ */
+function createSectionIdFactory(storage: Storage, pageId: string): () => string {
+  const used = new Set<number>()
+  for (const node of [PAGE_SECTIONING_NODE, FIXED_LAYOUT_SECTIONING_NODE]) {
+    for (const row of storage.getAllNodeVersions(node, pageId)) {
+      const parsed = PageSectioningOutput.safeParse(row.data)
+      if (!parsed.success) continue
+      for (const section of parsed.data.sections) {
+        const id = parseSectionId(section.sectionId)
+        if (id) used.add(id.seq)
+      }
+    }
+  }
+  let next = (used.size > 0 ? Math.max(...used) : 0) + 1
+  return () => {
+    if (next > MAX_SECTION_SEQ) {
+      // Unreachable in practice: each structural op allocates one id, so this
+      // needs ~1000 edits to a single page. Capped so the `_sec(\d{3})` shape
+      // every consumer parses stays valid rather than silently widening.
+      throw new HTTPException(400, {
+        message: `Page ${pageId} has allocated all ${MAX_SECTION_SEQ} of its section ids. Split this page's content across pages, or re-extract it, before editing its sections further.`,
+      })
+    }
+    return formatSectionId(pageId, next++)
+  }
+}
+
+/**
+ * Drop book-level references to sections that no longer exist. Called by every
+ * op that removes a section; without it a merge or delete leaves a dangling
+ * `toc-generation` entry (a broken href in the EPUB nav) or a sign-language
+ * video pinned to an id nothing resolves.
+ *
+ * Videos are *unassigned*, not deleted: the upload is the user's, and they can
+ * reattach it to the surviving section.
+ */
+function retireSectionIds(storage: Storage, retired: string[]): void {
+  if (retired.length === 0) return
+  const retiredIds = new Set(retired)
+
+  const tocRow = storage.getLatestNodeData("toc-generation", "book")
+  if (tocRow) {
+    const parsed = TocGenerationOutput.safeParse(tocRow.data)
+    if (parsed.success) {
+      const entries = parsed.data.entries.filter((entry) => !retiredIds.has(entry.sectionId))
+      if (entries.length !== parsed.data.entries.length) {
+        storage.putNodeData("toc-generation", "book", { ...parsed.data, entries })
+      }
+    }
+  }
+
+  for (const video of storage.getSignLanguageVideos()) {
+    if (video.sectionId && retiredIds.has(video.sectionId)) {
+      storage.assignSignLanguageVideo(video.videoId, null)
+    }
   }
 }
 
@@ -968,7 +1036,9 @@ export function createPageRoutes(
           }
 
           const sectionEntries: PageSummarySection[] = (rawSections ?? []).map((s, i) => {
-            const sectionId = s.sectionId ?? `${row.item_id}_sec${String(i + 1).padStart(3, "0")}`
+            // `sectionId` is required by the schema; this only covers raw legacy
+            // rows that never had one. Display-only — nothing names a file from it.
+            const sectionId = s.sectionId ?? formatSectionId(row.item_id, i + 1)
             // Pruned sections keep their own text in the per-section preview so
             // they can be displayed in the storyboard sidebar even when grayed out.
             const sectionText = collectText(s.nodes, { skipPruned: false })
@@ -2171,10 +2241,12 @@ export function createPageRoutes(
         throw new HTTPException(400, { message: `Section index ${idx} out of range (page has ${sectioning.sections.length} sections)` })
       }
 
-      // Clone the section and insert after the original
+      // Clone the section and insert after the original. The original keeps its
+      // sectionId — only the clone gets a new one.
       const containerIdMap = new Map<string, string>()
       const clonedSection = {
         ...sectioning.sections[idx],
+        sectionId: createSectionIdFactory(storage, pageId)(),
         nodes: cloneNodesWithFreshContainerIds(
           sectioning.sections[idx].nodes,
           createNodeIdFactory(pageId, sectioning.sections),
@@ -2183,8 +2255,6 @@ export function createPageRoutes(
       }
       const newSections = [...sectioning.sections]
       newSections.splice(idx + 1, 0, clonedSection)
-
-      renumberSectionIds(newSections, pageId)
 
       const updatedSectioning = { ...sectioning, sections: newSections }
 
@@ -2374,8 +2444,11 @@ export function createPageRoutes(
         nodes: keptNodes,
         ...(keptPlacement ? { placement: keptPlacement } : {}),
       }
+      // The first half keeps the original sectionId (it inherits it from
+      // `section`); only the new second half gets a fresh one.
       const movedSection = {
         ...section,
+        sectionId: createSectionIdFactory(storage, pageId)(),
         nodes: movedNodes,
         ...(movedPlacement ? { placement: movedPlacement } : {}),
       }
@@ -2389,8 +2462,6 @@ export function createPageRoutes(
       const newSections = [...sectioning.sections]
       newSections[idx] = keptSection
       newSections.splice(idx + 1, 0, movedSection)
-
-      renumberSectionIds(newSections, pageId)
 
       const updatedSectioning = { ...sectioning, sections: newSections }
 
@@ -2525,7 +2596,9 @@ export function createPageRoutes(
       }
       newSections.splice(removeIdx, 1)
 
-      renumberSectionIds(newSections, pageId)
+      // The surviving section keeps its sectionId (inherited from `keepSection`);
+      // the removed section's id is retired, never reassigned to a survivor.
+      const retiredSectionIds = [removeSection.sectionId]
 
       const updatedSectioning = { ...sectioning, sections: newSections }
 
@@ -2590,6 +2663,7 @@ export function createPageRoutes(
         mapIndex: (i) =>
           i === keepIdx || i === removeIdx ? null : i > removeIdx ? i - 1 : i,
       })
+      retireSectionIds(storage, retiredSectionIds)
 
       return c.json({
         mergedSectionIndex: keepIdx,
@@ -2707,9 +2781,11 @@ export function createPageRoutes(
       const newSrcSections = [...srcSectioning.sections]
       newSrcSections.splice(idx, 1)
 
-      renumberSectionIds(newSrcSections, pageId)
-
-      renumberSectionIds(newTgtSections, targetPageId)
+      // The target section keeps its sectionId; the moved section's id is
+      // retired. Surviving sections on *either* page keep theirs — this op used
+      // to renumber both pages wholesale, which silently reassigned every later
+      // section's TOC entry, sign-language video and answer-text catalog keys.
+      const retiredSectionIds = [movedSection.sectionId]
 
       // Save updated sectionings
       const srcVersion = saveStoryboardNode(
@@ -2745,6 +2821,7 @@ export function createPageRoutes(
       migrateEditableActivities(storage, targetPageId, {
         mapIndex: (i) => (i === tgtIdx ? null : i),
       })
+      retireSectionIds(storage, retiredSectionIds)
 
       return c.json({
         sourcePageId: pageId,
@@ -2798,11 +2875,10 @@ export function createPageRoutes(
         throw new HTTPException(400, { message: `Section index ${idx} out of range (page has ${sectioning.sections.length} sections)` })
       }
 
-      // Remove section at idx
+      // Remove section at idx. Survivors keep their sectionIds; only the
+      // deleted section's id is retired.
       const newSections = [...sectioning.sections]
-      newSections.splice(idx, 1)
-
-      renumberSectionIds(newSections, pageId)
+      const [deletedSection] = newSections.splice(idx, 1)
 
       const updatedSectioning = { ...sectioning, sections: newSections }
 
@@ -2837,8 +2913,8 @@ export function createPageRoutes(
       }
 
       // Deleting rebuilds the rendering to match: the section's HTML entry is
-      // dropped, later indexes shift down, and section ids are rewritten. The
-      // surviving sections keep the HTML they already had, so nothing needs
+      // dropped and later indexes shift down. The surviving sections keep both
+      // their sectionIds and the HTML they already had, so nothing needs
       // re-rendering and the storyboard stays current.
       const sectioningVersion = saveStoryboardNode(
         storage,
@@ -2853,6 +2929,7 @@ export function createPageRoutes(
       migrateEditableActivities(storage, pageId, {
         mapIndex: (i) => (i === idx ? null : i > idx ? i - 1 : i),
       })
+      retireSectionIds(storage, [deletedSection.sectionId])
 
       return c.json({
         sectioningVersion,

--- a/apps/api/src/routes/pages.ts
+++ b/apps/api/src/routes/pages.ts
@@ -28,8 +28,6 @@ import {
   EDITABLE_ACTIVITY_NODE,
   TocGenerationOutput,
   formatSectionId,
-  parseSectionId,
-  MAX_SECTION_SEQ,
   CoreTtsCatalogOutput,
   TextCatalogOutput,
   type TTSOutput,
@@ -52,8 +50,9 @@ import {
   remapEditableActivities,
   invalidateCoreTtsForDisplayEntries,
   resolveFigureExtractionMode,
-  PAGE_SECTIONING_NODE,
-  FIXED_LAYOUT_SECTIONING_NODE,
+  createSectionIdFactory,
+  collectSpentSectionIds,
+  SectionIdExhaustedError,
 } from "@adt/pipeline"
 import { samplePageEdges, extractPages, computeGroups, countPdfPages } from "@adt/pdf"
 import { reRenderPage, aiEditSection } from "../services/page-edit-service.js"
@@ -736,65 +735,20 @@ function migrateEditableActivities(
 }
 
 /**
- * Every `${pageId}_sec${NNN}` id that appears in *any* stored version of this
- * page's sectioning — the ids that are spent and must never be handed out
- * again.
+ * Allocate one section id, mapping the pipeline's exhaustion error onto a 400.
  *
- * Scanned out of the raw JSON rather than off parsed rows on purpose. A version
- * that no longer satisfies today's schema (a legacy row with no `sectionId`
- * field, a shape from before a migration) still burned the ids it contains, and
- * skipping it because `safeParse` failed would let them be reissued. Matching
- * text is a non-risk in the other direction: an incidental `_secNNN` inside
- * some node's text only makes the set larger, which can never cause reuse.
+ * The factory itself lives in `@adt/pipeline` so the agent activity tools mint
+ * ids the same way these routes do — an id derived from `sections.length`
+ * collides as soon as a delete leaves a gap.
  */
-function collectSpentSectionIds(storage: Storage, pageId: string): Set<string> {
-  const spent = new Set<string>()
-  const pattern = new RegExp(
-    `${pageId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}_sec\\d+`,
-    "g"
-  )
-  for (const node of [PAGE_SECTIONING_NODE, FIXED_LAYOUT_SECTIONING_NODE]) {
-    for (const row of storage.getAllNodeVersions(node, pageId)) {
-      for (const match of JSON.stringify(row.data).matchAll(pattern)) {
-        spent.add(match[0])
-      }
+function mintSectionId(storage: Storage, pageId: string): string {
+  try {
+    return createSectionIdFactory(storage, pageId)()
+  } catch (err) {
+    if (err instanceof SectionIdExhaustedError) {
+      throw new HTTPException(400, { message: err.message })
     }
-  }
-  return spent
-}
-
-/**
- * Mint `${pageId}_sec${NNN}` ids that no version of this page's sectioning has
- * ever used, so a section's id is immutable for its whole life and a retired id
- * is never handed out again.
- *
- * The high-water mark comes from *history*, not just the current version. Delete
- * `_sec003`, then split `_sec002`, and a max-of-current counter would reissue
- * `_sec003` — silently adopting the deleted section's `toc-generation` entry,
- * sign-language video and text-catalog `${sectionId}_ans_*` keys (and therefore
- * their translations and generated audio) onto unrelated content.
- *
- * A counter stored on the entity would be worse: it would live inside the very
- * thing it counts, so restoring an older sectioning version would roll the
- * counter back and reissue every id allocated since.
- */
-function createSectionIdFactory(storage: Storage, pageId: string): () => string {
-  let highWaterMark = 0
-  for (const id of collectSpentSectionIds(storage, pageId)) {
-    const parsed = parseSectionId(id)
-    if (parsed) highWaterMark = Math.max(highWaterMark, parsed.seq)
-  }
-  let next = highWaterMark + 1
-  return () => {
-    if (next > MAX_SECTION_SEQ) {
-      // Unreachable in practice: each structural op allocates one id, so this
-      // needs ~1000 edits to a single page. Capped so the `_sec(\d{3})` shape
-      // every consumer parses stays valid rather than silently widening.
-      throw new HTTPException(400, {
-        message: `Page ${pageId} has allocated all ${MAX_SECTION_SEQ} of its section ids. Split this page's content across pages, or re-extract it, before editing its sections further.`,
-      })
-    }
-    return formatSectionId(pageId, next++)
+    throw err
   }
 }
 
@@ -2278,7 +2232,7 @@ export function createPageRoutes(
       const containerIdMap = new Map<string, string>()
       const clonedSection = {
         ...sectioning.sections[idx],
-        sectionId: createSectionIdFactory(storage, pageId)(),
+        sectionId: mintSectionId(storage, pageId),
         nodes: cloneNodesWithFreshContainerIds(
           sectioning.sections[idx].nodes,
           createNodeIdFactory(pageId, sectioning.sections),
@@ -2480,7 +2434,7 @@ export function createPageRoutes(
       // `section`); only the new second half gets a fresh one.
       const movedSection = {
         ...section,
-        sectionId: createSectionIdFactory(storage, pageId)(),
+        sectionId: mintSectionId(storage, pageId),
         nodes: movedNodes,
         ...(movedPlacement ? { placement: movedPlacement } : {}),
       }

--- a/apps/api/src/routes/pages.ts
+++ b/apps/api/src/routes/pages.ts
@@ -83,6 +83,7 @@ import {
 import { AiProviderError, assertModelCredentials, createLLMModel, createPromptEngine, renderLiquidTemplate, generateImageWithCache } from "@adt/llm"
 import type { ResolvedCredentials } from "@adt/llm"
 import { readProviderCredentials } from "../middleware/provider-credentials.js"
+import { parkDetachedRecordings, DETACHED_AUDIO_DIR } from "../services/detached-audio.js"
 
 /**
  * Lazily-initialized shared Playwright renderer for section screenshots.
@@ -1382,7 +1383,21 @@ export function createPageRoutes(
     const spentOnRemovedPages = toRemove.flatMap((id) => [
       ...collectSpentSectionIds(storage, id),
     ])
-    retireSectionIds(storage, spentOnRemovedPages)
+    const retired = retireSectionIds(storage, spentOnRemovedPages)
+    // Park before `deletePage`, for the same reason retirement runs before it.
+    // Un-applying the spread re-creates these pages under their old ids with no
+    // history to allocate past, so they re-mint `_sec001` and Speech regenerates
+    // straight over any recording left at `audio/<lang>/${sectionId}_ans_*`. The
+    // manifest entry is gone by then, so nothing downstream could rescue it.
+    if (retired.detachedRecordings.length > 0) {
+      const parked = parkDetachedRecordings(
+        path.join(path.resolve(booksDir), safeLabel),
+        retired.detachedRecordings
+      )
+      console.warn(
+        `[pages] ${safeLabel}: detached ${retired.detachedRecordings.length} uploaded audio recording(s) from removed page(s); ${parked.length} file(s) moved to ${DETACHED_AUDIO_DIR}/ so a later re-section cannot overwrite them.`
+      )
+    }
     for (const id of toRemove) storage.deletePage(id)
 
     return c.json({

--- a/apps/api/src/routes/pages.ts
+++ b/apps/api/src/routes/pages.ts
@@ -1373,10 +1373,12 @@ export function createPageRoutes(
     // single `toc-generation` version. `deletePage` drops the page's entire
     // node_data history, including the sectioning the id factory reads its
     // high-water mark from — so a page later re-created under the same id
-    // restarts at `_sec001`. Any `toc-generation` entry or sign-language video
-    // still pointing at an id that page spent would then silently reattach to
-    // unrelated content, which is exactly what id immutability prevents
-    // everywhere else.
+    // restarts at `_sec001`. Any `toc-generation` entry, sign-language video or
+    // speech manifest entry still pointing at an id that page spent would then
+    // silently reattach to unrelated content, which is exactly what id
+    // immutability prevents everywhere else. The speech manifests are the ones
+    // `deletePage` cannot reach on its own: they are keyed by language, not by
+    // page.
     const spentOnRemovedPages = toRemove.flatMap((id) => [
       ...collectSpentSectionIds(storage, id),
     ])

--- a/apps/api/src/routes/pages.ts
+++ b/apps/api/src/routes/pages.ts
@@ -26,7 +26,6 @@ import {
   getStageClearOrder,
   getStageDependents,
   EDITABLE_ACTIVITY_NODE,
-  TocGenerationOutput,
   formatSectionId,
   CoreTtsCatalogOutput,
   TextCatalogOutput,
@@ -52,6 +51,7 @@ import {
   resolveFigureExtractionMode,
   createSectionIdFactory,
   collectSpentSectionIds,
+  retireSectionIds,
   SectionIdExhaustedError,
 } from "@adt/pipeline"
 import { samplePageEdges, extractPages, computeGroups, countPdfPages } from "@adt/pdf"
@@ -749,37 +749,6 @@ function mintSectionId(storage: Storage, pageId: string): string {
       throw new HTTPException(400, { message: err.message })
     }
     throw err
-  }
-}
-
-/**
- * Drop book-level references to sections that no longer exist. Called by every
- * op that removes a section; without it a merge or delete leaves a dangling
- * `toc-generation` entry (a broken href in the EPUB nav) or a sign-language
- * video pinned to an id nothing resolves.
- *
- * Videos are *unassigned*, not deleted: the upload is the user's, and they can
- * reattach it to the surviving section.
- */
-function retireSectionIds(storage: Storage, retired: string[]): void {
-  if (retired.length === 0) return
-  const retiredIds = new Set(retired)
-
-  const tocRow = storage.getLatestNodeData("toc-generation", "book")
-  if (tocRow) {
-    const parsed = TocGenerationOutput.safeParse(tocRow.data)
-    if (parsed.success) {
-      const entries = parsed.data.entries.filter((entry) => !retiredIds.has(entry.sectionId))
-      if (entries.length !== parsed.data.entries.length) {
-        storage.putNodeData("toc-generation", "book", { ...parsed.data, entries })
-      }
-    }
-  }
-
-  for (const video of storage.getSignLanguageVideos()) {
-    if (video.sectionId && retiredIds.has(video.sectionId)) {
-      storage.assignSignLanguageVideo(video.videoId, null)
-    }
   }
 }
 

--- a/apps/api/src/routes/pages.ts
+++ b/apps/api/src/routes/pages.ts
@@ -83,7 +83,7 @@ import {
 import { AiProviderError, assertModelCredentials, createLLMModel, createPromptEngine, renderLiquidTemplate, generateImageWithCache } from "@adt/llm"
 import type { ResolvedCredentials } from "@adt/llm"
 import { readProviderCredentials } from "../middleware/provider-credentials.js"
-import { parkDetachedRecordings, DETACHED_AUDIO_DIR } from "../services/detached-audio.js"
+import { retireWithPreservedRecordings, DETACHED_AUDIO_DIR } from "../services/detached-audio.js"
 
 /**
  * Lazily-initialized shared Playwright renderer for section screenshots.
@@ -1383,19 +1383,19 @@ export function createPageRoutes(
     const spentOnRemovedPages = toRemove.flatMap((id) => [
       ...collectSpentSectionIds(storage, id),
     ])
-    const retired = retireSectionIds(storage, spentOnRemovedPages)
-    // Park before `deletePage`, for the same reason retirement runs before it.
+    const { retired, preserved } = retireWithPreservedRecordings(
+      storage,
+      path.join(path.resolve(booksDir), safeLabel),
+      () => retireSectionIds(storage, spentOnRemovedPages)
+    )
+    // Preserve before `deletePage`, for the same reason retirement runs before it.
     // Un-applying the spread re-creates these pages under their old ids with no
     // history to allocate past, so they re-mint `_sec001` and Speech regenerates
     // straight over any recording left at `audio/<lang>/${sectionId}_ans_*`. The
     // manifest entry is gone by then, so nothing downstream could rescue it.
     if (retired.detachedRecordings.length > 0) {
-      const parked = parkDetachedRecordings(
-        path.join(path.resolve(booksDir), safeLabel),
-        retired.detachedRecordings
-      )
       console.warn(
-        `[pages] ${safeLabel}: detached ${retired.detachedRecordings.length} uploaded audio recording(s) from removed page(s); ${parked.length} file(s) moved to ${DETACHED_AUDIO_DIR}/ so a later re-section cannot overwrite them.`
+        `[pages] ${safeLabel}: detached ${retired.detachedRecordings.length} uploaded audio recording(s) from removed page(s); ${preserved.length} file(s) backed up to ${DETACHED_AUDIO_DIR}/ so a later re-section cannot overwrite the backups.`
       )
     }
     for (const id of toRemove) storage.deletePage(id)

--- a/apps/api/src/routes/stages.test.ts
+++ b/apps/api/src/routes/stages.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
 import fs from "node:fs"
 import path from "node:path"
 import os from "node:os"
@@ -358,9 +358,9 @@ describe("retireSectionIdsForClearedSectioning", () => {
     )
   })
 
-  it("parks a detached recording so the run cannot overwrite it, then clears", () => {
+  it("backs up a detached recording before the run can overwrite it, then clears", () => {
     // The ordering `makeBeforeRun` depends on, end to end: retire, move the
-    // upload out of the path the re-mint will regenerate into, then clear — and
+    // upload to a separate path the re-mint cannot regenerate into, then clear — and
     // the pruned `tts` row has to survive that clear, which is the only reason
     // pruning it was worth doing.
     const retiredSection = formatSectionId(pageId, 3)
@@ -369,8 +369,9 @@ describe("retireSectionIdsForClearedSectioning", () => {
 
     makeBeforeRun(label, "sectioning", "speech", tmpDir)()
 
-    // Moved aside, not deleted, and out of the language dir the run writes into.
-    expect(audioExists("en", fileName)).toBe(false)
+    // The original remains usable if a later step fails; its backup is safe
+    // outside the language dir that regeneration writes into.
+    expect(audioExists("en", fileName)).toBe(true)
     const parked = path.join(tmpDir, label, "audio", ".detached")
     const found = fs
       .readdirSync(parked)
@@ -380,6 +381,52 @@ describe("retireSectionIdsForClearedSectioning", () => {
     expect(withStorage((storage) => storage.getLatestNodeData("page-sectioning", pageId))).toBeNull()
     expect(ttsTextIds("en")).toEqual(["pg001_t001"])
   })
+
+  it.each(["sectioning", "extract"] as const)(
+    "rolls back retirement when backup fails on a %s rerun, and can retry",
+    (fromStage) => {
+      const section = formatSectionId(pageId, 3)
+      const textId = `${section}_ans_a`
+      const fileName = `${textId}.mp3`
+      seedTts("en", [{ textId, manual: true }])
+      seedTimestamps("en", [textId])
+      withStorage((storage) => {
+        storage.putSignLanguageVideo("retry-video", Buffer.from("video"), "retry.mp4", "video/mp4")
+        storage.assignSignLanguageVideo("retry-video", section)
+      })
+      const before = withStorage((storage) => storage.getNodeVersionFingerprint())
+      const run = makeBeforeRun(label, fromStage, "speech", tmpDir)
+      const copy = vi.spyOn(fs, "copyFileSync").mockImplementationOnce(() => {
+        throw Object.assign(new Error("permission denied"), { code: "EACCES" })
+      })
+      try {
+        expect(run).toThrow("Could not preserve uploaded recording")
+      } finally {
+        copy.mockRestore()
+      }
+      expect(withStorage((storage) => storage.getNodeVersionFingerprint())).toEqual(before)
+      expect(sectionIdsByVideo().get("retry-video")).toBe(section)
+      expect(ttsTextIds("en")).toEqual([textId])
+      expect(timestampKeys("en")).toEqual([textId])
+      expect(fs.readFileSync(path.join(tmpDir, label, "audio", "en", fileName), "utf8")).toBe("fake-audio")
+
+      // Reuse the same callback: failed preservation must not trip its once guard.
+      expect(run).not.toThrow()
+      expect(ttsTextIds("en")).toEqual([])
+      expect(sectionIdsByVideo().get("retry-video")).toBeNull()
+      expect(withStorage((storage) => storage.getLatestNodeData("page-sectioning", pageId))).toBeNull()
+      const backupRoot = path.join(tmpDir, label, "audio", ".detached")
+      const backups = fs.readdirSync(backupRoot)
+        .map((batch) => path.join(backupRoot, batch, "en", fileName))
+        .filter((file) => fs.existsSync(file))
+      expect(backups).toHaveLength(1)
+      fs.writeFileSync(path.join(tmpDir, label, "audio", "en", fileName), "new generated audio")
+      expect(fs.readFileSync(backups[0], "utf8")).toBe("fake-audio")
+      const completed = withStorage((storage) => storage.getNodeVersionFingerprint())
+      run()
+      expect(withStorage((storage) => storage.getNodeVersionFingerprint())).toEqual(completed)
+    }
+  )
 
   it("reconciles both the canonical and legacy language row spellings", () => {
     const retiredSection = formatSectionId(pageId, 3)

--- a/apps/api/src/routes/stages.test.ts
+++ b/apps/api/src/routes/stages.test.ts
@@ -342,6 +342,7 @@ describe("retireSectionIdsForClearedSectioning", () => {
     // identical but written separately.
     const retiredSection = formatSectionId(pageId, 3)
     seedTts("en", [{ textId: "pg001_t001" }], [`${retiredSection}_ans_a`])
+    withStorage((storage) => storage.markStepCompleted("tts"))
 
     withStorage((storage) =>
       retireSectionIdsForClearedSectioning(storage, "sectioning", "speech")
@@ -350,6 +351,11 @@ describe("retireSectionIdsForClearedSectioning", () => {
     expect(
       withStorage((storage) => storage.getLatestNodeData("tts", "en")?.data)
     ).not.toHaveProperty("failed")
+    // The row was rewritten, so Speech must not stay marked complete over it —
+    // a counter-driven guard would miss this, since no delivered entry dropped.
+    expect(withStorage((storage) => storage.getStepRuns().map((run) => run.step))).not.toContain(
+      "tts"
+    )
   })
 
   it("parks a detached recording so the run cannot overwrite it, then clears", () => {

--- a/apps/api/src/routes/stages.test.ts
+++ b/apps/api/src/routes/stages.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import fs from "node:fs"
+import path from "node:path"
+import os from "node:os"
+import { createBookStorage } from "@adt/storage"
+import type { Storage } from "@adt/storage"
+import { formatSectionId } from "@adt/types"
+import { retireVideosForClearedSectioning } from "./stages.js"
+
+/**
+ * A rerun that clears `page-sectioning` deletes the history section ids are
+ * allocated from, so the re-section re-mints densely from `_sec001`. These cover
+ * the one reference that clear does not reach — `sign_language_videos` lives
+ * outside `node_data` — which is what would otherwise let a pinned video
+ * reappear on unrelated regenerated content.
+ */
+describe("retireVideosForClearedSectioning", () => {
+  let tmpDir: string
+  const label = "rerun-book"
+  const pageId = `${label}_p1`
+
+  /** Sparse on purpose: a dense seed would pass even against reuse. */
+  function seedSectioning(seqs: number[]): void {
+    withStorage((storage) => {
+      storage.putNodeData("page-sectioning", pageId, {
+        reasoning: "seed",
+        sections: seqs.map((seq) => ({
+          sectionId: formatSectionId(pageId, seq),
+          nodes: [],
+        })),
+      })
+    })
+  }
+
+  function withStorage<T>(fn: (storage: Storage) => T): T {
+    const storage = createBookStorage(label, tmpDir)
+    try {
+      return fn(storage)
+    } finally {
+      storage.close()
+    }
+  }
+
+  function sectionIdsByVideo(): Map<string, string | null> {
+    return withStorage(
+      (storage) => new Map(storage.getSignLanguageVideos().map((v) => [v.videoId, v.sectionId]))
+    )
+  }
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "stages-routes-"))
+    withStorage((storage) => {
+      storage.putExtractedPage({
+        pageId,
+        pageNumber: 1,
+        text: "Page one text content",
+        pageImage: {
+          imageId: `${pageId}_page`,
+          buffer: Buffer.from("fake-png-data"),
+          format: "png" as const,
+          hash: "abc123",
+          width: 800,
+          height: 600,
+        },
+        images: [],
+      })
+    })
+    seedSectioning([1, 3])
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it("unassigns a video pinned to a section the re-section will re-mint", () => {
+    withStorage((storage) => {
+      storage.putSignLanguageVideo("vid-1", Buffer.from("a"), "one.mp4", "video/mp4")
+      storage.assignSignLanguageVideo("vid-1", formatSectionId(pageId, 3))
+    })
+
+    const unassigned = withStorage((storage) =>
+      retireVideosForClearedSectioning(storage, "sectioning", "speech")
+    )
+
+    expect(unassigned).toBe(1)
+    expect(sectionIdsByVideo().get("vid-1")).toBeNull()
+    // Unassigned, never deleted — the upload is the user's to reattach.
+    expect(withStorage((storage) => storage.getSignLanguageVideoPath("vid-1"))).not.toBeNull()
+  })
+
+  it("counts ids from history versions, not just the current sectioning", () => {
+    // `_sec003` is retired by a later edit, but a video is still pinned to it.
+    withStorage((storage) => {
+      storage.putSignLanguageVideo("vid-old", Buffer.from("a"), "old.mp4", "video/mp4")
+      storage.assignSignLanguageVideo("vid-old", formatSectionId(pageId, 3))
+    })
+    seedSectioning([1])
+
+    const unassigned = withStorage((storage) =>
+      retireVideosForClearedSectioning(storage, "sectioning", "speech")
+    )
+
+    expect(unassigned).toBe(1)
+    expect(sectionIdsByVideo().get("vid-old")).toBeNull()
+  })
+
+  it("leaves glossary assignments alone — they are a separate id namespace", () => {
+    withStorage((storage) => {
+      storage.putSignLanguageVideo("vid-gl", Buffer.from("a"), "gl.mp4", "video/mp4")
+      storage.assignSignLanguageVideo("vid-gl", "gl001")
+    })
+
+    const unassigned = withStorage((storage) =>
+      retireVideosForClearedSectioning(storage, "sectioning", "speech")
+    )
+
+    expect(unassigned).toBe(0)
+    expect(sectionIdsByVideo().get("vid-gl")).toBe("gl001")
+  })
+
+  it("leaves assignments alone when the rerun does not clear sectioning", () => {
+    withStorage((storage) => {
+      storage.putSignLanguageVideo("vid-1", Buffer.from("a"), "one.mp4", "video/mp4")
+      storage.assignSignLanguageVideo("vid-1", formatSectionId(pageId, 3))
+    })
+
+    // Rerunning from storyboard re-renders but keeps `page-sectioning`, so the
+    // ids — and everything pinned to them — stay valid.
+    const unassigned = withStorage((storage) =>
+      retireVideosForClearedSectioning(storage, "storyboard", "speech")
+    )
+
+    expect(unassigned).toBe(0)
+    expect(sectionIdsByVideo().get("vid-1")).toBe(formatSectionId(pageId, 3))
+  })
+
+  it("keeps assignments across a storyboard rerun that clears fixed-layout sectioning", () => {
+    // A storyboard rerun does clear `fixed-layout-sectioning`, but that node's
+    // id is derived from the pageId rather than allocated, so it regenerates
+    // identically and nothing pinned to it is at risk. Retiring it would detach
+    // every video on a fixed-layout book, and here it would also retire a
+    // `_sec001` that the untouched `page-sectioning` still owns.
+    withStorage((storage) => {
+      storage.putNodeData("fixed-layout-sectioning", pageId, {
+        sections: [{ sectionId: formatSectionId(pageId, 1), nodes: [] }],
+      })
+      storage.putSignLanguageVideo("vid-1", Buffer.from("a"), "one.mp4", "video/mp4")
+      storage.assignSignLanguageVideo("vid-1", formatSectionId(pageId, 1))
+    })
+
+    const unassigned = withStorage((storage) =>
+      retireVideosForClearedSectioning(storage, "storyboard", "speech")
+    )
+
+    expect(unassigned).toBe(0)
+    expect(sectionIdsByVideo().get("vid-1")).toBe(formatSectionId(pageId, 1))
+  })
+
+  it("does not scan sectioning history when nothing is pinned", () => {
+    withStorage((storage) => {
+      storage.putSignLanguageVideo("vid-loose", Buffer.from("a"), "loose.mp4", "video/mp4")
+    })
+
+    const unassigned = withStorage((storage) =>
+      retireVideosForClearedSectioning(storage, "sectioning", "speech")
+    )
+
+    expect(unassigned).toBe(0)
+    expect(sectionIdsByVideo().get("vid-loose")).toBeNull()
+  })
+
+  it("unassigns on a full extract rerun, which clears every node", () => {
+    withStorage((storage) => {
+      storage.putSignLanguageVideo("vid-1", Buffer.from("a"), "one.mp4", "video/mp4")
+      storage.assignSignLanguageVideo("vid-1", formatSectionId(pageId, 1))
+    })
+
+    const unassigned = withStorage((storage) =>
+      retireVideosForClearedSectioning(storage, "extract", "speech")
+    )
+
+    expect(unassigned).toBe(1)
+    expect(sectionIdsByVideo().get("vid-1")).toBeNull()
+  })
+})

--- a/apps/api/src/routes/stages.test.ts
+++ b/apps/api/src/routes/stages.test.ts
@@ -4,17 +4,21 @@ import path from "node:path"
 import os from "node:os"
 import { createBookStorage } from "@adt/storage"
 import type { Storage } from "@adt/storage"
-import { formatSectionId } from "@adt/types"
-import { retireVideosForClearedSectioning } from "./stages.js"
+import { formatSectionId, parseVoiceSlotEntryId } from "@adt/types"
+import { retireSectionIdsForClearedSectioning, makeBeforeRun } from "./stages.js"
 
 /**
  * A rerun that clears `page-sectioning` deletes the history section ids are
  * allocated from, so the re-section re-mints densely from `_sec001`. These cover
- * the one reference that clear does not reach — `sign_language_videos` lives
- * outside `node_data` — which is what would otherwise let a pinned video
- * reappear on unrelated regenerated content.
+ * the references that clear does not reach, which is what would otherwise let
+ * them reappear on unrelated regenerated content:
+ *
+ * - `sign_language_videos` lives in a table, not `node_data`.
+ * - `tts` is deliberately preserved whenever Speech is in the rerun range, and
+ *   `tts-timestamps` is in no clear list at all — both are keyed by language,
+ *   not by page.
  */
-describe("retireVideosForClearedSectioning", () => {
+describe("retireSectionIdsForClearedSectioning", () => {
   let tmpDir: string
   const label = "rerun-book"
   const pageId = `${label}_p1`
@@ -39,6 +43,87 @@ describe("retireVideosForClearedSectioning", () => {
     } finally {
       storage.close()
     }
+  }
+
+  /** A `tts` manifest row plus the audio files its entries name. */
+  function seedTts(
+    language: string,
+    entries: Array<{ textId: string; manual?: boolean }>,
+    failed: string[] = []
+  ): void {
+    const audioDir = path.join(tmpDir, label, "audio", language)
+    fs.mkdirSync(audioDir, { recursive: true })
+    withStorage((storage) => {
+      storage.putNodeData("tts", language, {
+        entries: entries.map(({ textId, manual }) => {
+          fs.writeFileSync(path.join(audioDir, `${textId}.mp3`), "fake-audio")
+          return {
+            textId,
+            language,
+            fileName: `${textId}.mp3`,
+            voice: manual ? "uploaded" : "alloy",
+            model: manual ? "uploaded" : "tts-1",
+            cached: false,
+            provider: manual ? "manual" : "openai",
+            voiceSlot: "primary" as const,
+          }
+        }),
+        ...(failed.length > 0
+          ? { failed: failed.map((textId) => ({ textId, error: "boom" })) }
+          : {}),
+        generatedAt: "2026-01-01T00:00:00.000Z",
+      })
+    })
+  }
+
+  function seedTimestamps(language: string, keys: string[], failed: string[] = []): void {
+    withStorage((storage) => {
+      storage.putNodeData("tts-timestamps", language, {
+        entries: Object.fromEntries(
+          keys.map((key) => [
+            key,
+            {
+              ...parseVoiceSlotEntryId(key),
+              language,
+              words: [{ word: "hi", start: 0, end: 1 }],
+              duration: 1,
+            },
+          ])
+        ),
+        ...(failed.length > 0
+          ? { failed: failed.map((textId) => ({ textId, error: "boom" })) }
+          : {}),
+        generatedAt: "2026-01-01T00:00:00.000Z",
+      })
+    })
+  }
+
+  function ttsTextIds(language: string): string[] {
+    return withStorage((storage) => {
+      const row = storage.getLatestNodeData("tts", language)
+      const data = row?.data as { entries?: Array<{ textId: string }> } | undefined
+      return (data?.entries ?? []).map((entry) => entry.textId)
+    })
+  }
+
+  function ttsFailedIds(language: string): string[] {
+    return withStorage((storage) => {
+      const row = storage.getLatestNodeData("tts", language)
+      const data = row?.data as { failed?: Array<{ textId: string }> } | undefined
+      return (data?.failed ?? []).map((entry) => entry.textId)
+    })
+  }
+
+  function timestampKeys(language: string): string[] {
+    return withStorage((storage) => {
+      const row = storage.getLatestNodeData("tts-timestamps", language)
+      const data = row?.data as { entries?: Record<string, unknown> } | undefined
+      return Object.keys(data?.entries ?? {})
+    })
+  }
+
+  function audioExists(language: string, fileName: string): boolean {
+    return fs.existsSync(path.join(tmpDir, label, "audio", language, fileName))
   }
 
   function sectionIdsByVideo(): Map<string, string | null> {
@@ -78,11 +163,11 @@ describe("retireVideosForClearedSectioning", () => {
       storage.assignSignLanguageVideo("vid-1", formatSectionId(pageId, 3))
     })
 
-    const unassigned = withStorage((storage) =>
-      retireVideosForClearedSectioning(storage, "sectioning", "speech")
+    const retired = withStorage((storage) =>
+      retireSectionIdsForClearedSectioning(storage, "sectioning", "speech")
     )
 
-    expect(unassigned).toBe(1)
+    expect(retired.videos).toBe(1)
     expect(sectionIdsByVideo().get("vid-1")).toBeNull()
     // Unassigned, never deleted — the upload is the user's to reattach.
     expect(withStorage((storage) => storage.getSignLanguageVideoPath("vid-1"))).not.toBeNull()
@@ -96,11 +181,11 @@ describe("retireVideosForClearedSectioning", () => {
     })
     seedSectioning([1])
 
-    const unassigned = withStorage((storage) =>
-      retireVideosForClearedSectioning(storage, "sectioning", "speech")
+    const retired = withStorage((storage) =>
+      retireSectionIdsForClearedSectioning(storage, "sectioning", "speech")
     )
 
-    expect(unassigned).toBe(1)
+    expect(retired.videos).toBe(1)
     expect(sectionIdsByVideo().get("vid-old")).toBeNull()
   })
 
@@ -110,11 +195,11 @@ describe("retireVideosForClearedSectioning", () => {
       storage.assignSignLanguageVideo("vid-gl", "gl001")
     })
 
-    const unassigned = withStorage((storage) =>
-      retireVideosForClearedSectioning(storage, "sectioning", "speech")
+    const retired = withStorage((storage) =>
+      retireSectionIdsForClearedSectioning(storage, "sectioning", "speech")
     )
 
-    expect(unassigned).toBe(0)
+    expect(retired.videos).toBe(0)
     expect(sectionIdsByVideo().get("vid-gl")).toBe("gl001")
   })
 
@@ -126,11 +211,11 @@ describe("retireVideosForClearedSectioning", () => {
 
     // Rerunning from storyboard re-renders but keeps `page-sectioning`, so the
     // ids — and everything pinned to them — stay valid.
-    const unassigned = withStorage((storage) =>
-      retireVideosForClearedSectioning(storage, "storyboard", "speech")
+    const retired = withStorage((storage) =>
+      retireSectionIdsForClearedSectioning(storage, "storyboard", "speech")
     )
 
-    expect(unassigned).toBe(0)
+    expect(retired.videos).toBe(0)
     expect(sectionIdsByVideo().get("vid-1")).toBe(formatSectionId(pageId, 3))
   })
 
@@ -148,24 +233,243 @@ describe("retireVideosForClearedSectioning", () => {
       storage.assignSignLanguageVideo("vid-1", formatSectionId(pageId, 1))
     })
 
-    const unassigned = withStorage((storage) =>
-      retireVideosForClearedSectioning(storage, "storyboard", "speech")
+    const retired = withStorage((storage) =>
+      retireSectionIdsForClearedSectioning(storage, "storyboard", "speech")
     )
 
-    expect(unassigned).toBe(0)
+    expect(retired.videos).toBe(0)
     expect(sectionIdsByVideo().get("vid-1")).toBe(formatSectionId(pageId, 1))
   })
 
-  it("does not scan sectioning history when nothing is pinned", () => {
+  it("drops the manual recording for a re-minted id, keeping the file on disk", () => {
+    const retiredSection = formatSectionId(pageId, 3)
+    seedTts("en", [
+      { textId: `${retiredSection}_ans_a`, manual: true },
+      { textId: `${retiredSection}_ans_b` },
+      { textId: "pg001_t001" },
+    ])
+
+    const retired = withStorage((storage) =>
+      retireSectionIdsForClearedSectioning(storage, "sectioning", "speech")
+    )
+
+    expect(retired.speechEntries).toBe(2)
+    expect(retired.detachedRecordings).toHaveLength(1)
+    expect(ttsTextIds("en")).toEqual(["pg001_t001"])
+    // The upload is the user's: only the association goes, never the bytes.
+    expect(audioExists("en", `${retiredSection}_ans_a.mp3`)).toBe(true)
+  })
+
+  it("drops timestamps for every slot and suffix of a retired answer", () => {
+    const retiredSection = formatSectionId(pageId, 3)
+    seedTimestamps(
+      "en",
+      [
+        `${retiredSection}_ans_a`,
+        // Slot-qualified: a bare key comparison would leave this behind.
+        `${retiredSection}_ans_a--secondary`,
+        `${retiredSection}_ans_a_easy_read`,
+        "pg001_t001",
+      ],
+      [`${retiredSection}_ans_a`]
+    )
+
+    const retired = withStorage((storage) =>
+      retireSectionIdsForClearedSectioning(storage, "sectioning", "speech")
+    )
+
+    expect(retired.wordTimestamps).toBe(3)
+    expect(timestampKeys("en")).toEqual(["pg001_t001"])
+    expect(
+      withStorage((storage) => storage.getLatestNodeData("tts-timestamps", "en")?.data),
+    ).not.toHaveProperty("failed")
+  })
+
+  it("treats the `_ans_` separator as the boundary, not a bare id prefix", () => {
+    const retiredSection = formatSectionId(pageId, 3)
+    seedTts("en", [
+      // Shares the section id as a prefix but is not an answer of it.
+      { textId: `${retiredSection}_answer`, manual: true },
+      { textId: "gl001_def" },
+      { textId: "qz001_que" },
+    ])
+
+    const retired = withStorage((storage) =>
+      retireSectionIdsForClearedSectioning(storage, "sectioning", "speech")
+    )
+
+    expect(retired.speechEntries).toBe(0)
+    expect(ttsTextIds("en")).toEqual([`${retiredSection}_answer`, "gl001_def", "qz001_que"])
+  })
+
+  it("does not let a legacy `_s1` id swallow `_s11`'s answers", () => {
+    // The agent tools once minted variable-length `_sN` ids, so the separator is
+    // the only thing keeping `_s1` from matching `_s11`'s answers.
+    withStorage((storage) => {
+      storage.putNodeData("page-sectioning", pageId, {
+        reasoning: "legacy",
+        sections: [{ sectionId: `${pageId}_s1`, nodes: [] }],
+      })
+    })
+    seedTts("en", [
+      { textId: `${pageId}_s1_ans_a`, manual: true },
+      { textId: `${pageId}_s11_ans_a`, manual: true },
+    ])
+
+    const retired = withStorage((storage) =>
+      retireSectionIdsForClearedSectioning(storage, "sectioning", "speech")
+    )
+
+    expect(retired.speechEntries).toBe(1)
+    expect(ttsTextIds("en")).toEqual([`${pageId}_s11_ans_a`])
+  })
+
+  it("drops the failed entry for a retired answer too", () => {
+    const retiredSection = formatSectionId(pageId, 3)
+    seedTts("en", [{ textId: "pg001_t001" }], [`${retiredSection}_ans_a`, "pg001_t002"])
+
+    withStorage((storage) =>
+      retireSectionIdsForClearedSectioning(storage, "sectioning", "speech")
+    )
+
+    expect(ttsFailedIds("en")).toEqual(["pg001_t002"])
+  })
+
+  it("drops the `failed` key entirely once its last entry is retired", () => {
+    // Rebuilding with `{...parsed.data, entries, ...(failed.length ? {failed} : {})}`
+    // silently keeps the *original* array when the filter empties it. Asserted on
+    // the `tts` loop as well as the timestamps one — they are structurally
+    // identical but written separately.
+    const retiredSection = formatSectionId(pageId, 3)
+    seedTts("en", [{ textId: "pg001_t001" }], [`${retiredSection}_ans_a`])
+
+    withStorage((storage) =>
+      retireSectionIdsForClearedSectioning(storage, "sectioning", "speech")
+    )
+
+    expect(
+      withStorage((storage) => storage.getLatestNodeData("tts", "en")?.data)
+    ).not.toHaveProperty("failed")
+  })
+
+  it("parks a detached recording so the run cannot overwrite it, then clears", () => {
+    // The ordering `makeBeforeRun` depends on, end to end: retire, move the
+    // upload out of the path the re-mint will regenerate into, then clear — and
+    // the pruned `tts` row has to survive that clear, which is the only reason
+    // pruning it was worth doing.
+    const retiredSection = formatSectionId(pageId, 3)
+    const fileName = `${retiredSection}_ans_a.mp3`
+    seedTts("en", [{ textId: `${retiredSection}_ans_a`, manual: true }, { textId: "pg001_t001" }])
+
+    makeBeforeRun(label, "sectioning", "speech", tmpDir)()
+
+    // Moved aside, not deleted, and out of the language dir the run writes into.
+    expect(audioExists("en", fileName)).toBe(false)
+    const parked = path.join(tmpDir, label, "audio", ".detached")
+    const found = fs
+      .readdirSync(parked)
+      .flatMap((stamp) => fs.readdirSync(path.join(parked, stamp, "en")))
+    expect(found).toEqual([fileName])
+    // `page-sectioning` is gone; the pruned manifest is not.
+    expect(withStorage((storage) => storage.getLatestNodeData("page-sectioning", pageId))).toBeNull()
+    expect(ttsTextIds("en")).toEqual(["pg001_t001"])
+  })
+
+  it("reconciles both the canonical and legacy language row spellings", () => {
+    const retiredSection = formatSectionId(pageId, 3)
+    seedTts("pt-BR", [{ textId: `${retiredSection}_ans_a`, manual: true }])
+    seedTts("pt_BR", [{ textId: `${retiredSection}_ans_a`, manual: true }])
+
+    const retired = withStorage((storage) =>
+      retireSectionIdsForClearedSectioning(storage, "sectioning", "speech")
+    )
+
+    expect(retired.speechEntries).toBe(2)
+    expect(ttsTextIds("pt-BR")).toEqual([])
+    expect(ttsTextIds("pt_BR")).toEqual([])
+  })
+
+  it("keeps a valid manual recording when the rerun does not clear sectioning", () => {
+    const section = formatSectionId(pageId, 3)
+    seedTts("en", [{ textId: `${section}_ans_a`, manual: true }])
+
+    // Rerunning from storyboard keeps `page-sectioning`, so the ids stay valid
+    // and the recording still describes the text it was made for.
+    const retired = withStorage((storage) =>
+      retireSectionIdsForClearedSectioning(storage, "storyboard", "speech")
+    )
+
+    expect(retired.speechEntries).toBe(0)
+    expect(retired.detachedRecordings).toHaveLength(0)
+    expect(ttsTextIds("en")).toEqual([`${section}_ans_a`])
+    expect(audioExists("en", `${section}_ans_a.mp3`)).toBe(true)
+  })
+
+  it("keeps recordings across a storyboard rerun that clears fixed-layout sectioning", () => {
+    // Same scoping as the video case above, but here over-retiring would destroy
+    // a real recording rather than merely detach a pin.
+    withStorage((storage) => {
+      storage.putNodeData("fixed-layout-sectioning", pageId, {
+        sections: [{ sectionId: formatSectionId(pageId, 1), nodes: [] }],
+      })
+    })
+    seedTts("en", [{ textId: `${formatSectionId(pageId, 1)}_ans_a`, manual: true }])
+
+    const retired = withStorage((storage) =>
+      retireSectionIdsForClearedSectioning(storage, "storyboard", "speech")
+    )
+
+    expect(retired.speechEntries).toBe(0)
+    expect(ttsTextIds("en")).toEqual([`${formatSectionId(pageId, 1)}_ans_a`])
+  })
+
+  it("prunes speech entries even when no video is pinned", () => {
+    // The fast path used to bail on "nothing pinned", which skipped the speech
+    // manifests entirely.
+    seedTts("en", [{ textId: `${formatSectionId(pageId, 3)}_ans_a`, manual: true }])
+
+    const retired = withStorage((storage) =>
+      retireSectionIdsForClearedSectioning(storage, "sectioning", "speech")
+    )
+
+    expect(retired.detachedRecordings).toHaveLength(1)
+    expect(ttsTextIds("en")).toEqual([])
+  })
+
+  it("skips the history scan for a book whose audio names no section", () => {
+    // A `tts` row alone must not be enough to pay for the scan — otherwise the
+    // fast path is dead for every book that has ever run speech.
+    seedTts("en", [{ textId: "pg001_t001", manual: true }, { textId: "gl001_def" }])
+    seedTimestamps("en", ["pg001_t001"])
+
+    const retired = withStorage((storage) =>
+      retireSectionIdsForClearedSectioning(storage, "sectioning", "speech")
+    )
+
+    expect(retired).toEqual({
+      videos: 0,
+      speechEntries: 0,
+      detachedRecordings: [],
+      wordTimestamps: 0,
+    })
+    expect(ttsTextIds("en")).toEqual(["pg001_t001", "gl001_def"])
+  })
+
+  it("does not scan sectioning history when nothing points at a section id", () => {
     withStorage((storage) => {
       storage.putSignLanguageVideo("vid-loose", Buffer.from("a"), "loose.mp4", "video/mp4")
     })
 
-    const unassigned = withStorage((storage) =>
-      retireVideosForClearedSectioning(storage, "sectioning", "speech")
+    const retired = withStorage((storage) =>
+      retireSectionIdsForClearedSectioning(storage, "sectioning", "speech")
     )
 
-    expect(unassigned).toBe(0)
+    expect(retired).toEqual({
+      videos: 0,
+      speechEntries: 0,
+      detachedRecordings: [],
+      wordTimestamps: 0,
+    })
     expect(sectionIdsByVideo().get("vid-loose")).toBeNull()
   })
 
@@ -175,11 +479,11 @@ describe("retireVideosForClearedSectioning", () => {
       storage.assignSignLanguageVideo("vid-1", formatSectionId(pageId, 1))
     })
 
-    const unassigned = withStorage((storage) =>
-      retireVideosForClearedSectioning(storage, "extract", "speech")
+    const retired = withStorage((storage) =>
+      retireSectionIdsForClearedSectioning(storage, "extract", "speech")
     )
 
-    expect(unassigned).toBe(1)
+    expect(retired.videos).toBe(1)
     expect(sectionIdsByVideo().get("vid-1")).toBeNull()
   })
 })

--- a/apps/api/src/routes/stages.ts
+++ b/apps/api/src/routes/stages.ts
@@ -23,7 +23,22 @@ const StageRunBody = z
   .strict()
 
 /** Build a beforeRun callback that clears downstream data for a stage.
- *  The returned function is idempotent — only runs once even if called multiple times. */
+ *  The returned function is idempotent — only runs once even if called multiple times.
+ *
+ *  KNOWN GAP (tracked separately): both branches below delete *every* version of
+ *  the nodes they clear, `page-sectioning` included. That resets the history the
+ *  section-id high-water mark is read from, so `finalizePageSectioning` re-mints
+ *  densely from `_sec001` and a re-section can hand a retired id to unrelated
+ *  content — the reuse that `createSectionIdFactory` exists to prevent.
+ *
+ *  `toc-generation` and `text-catalog` reference sectionIds but live in
+ *  `node_data` and are wiped by the same clear, so they self-heal. The one
+ *  reference that survives is `sign_language_videos.section_id`, a separate
+ *  table nothing here reconciles — so a video stays pinned to an id the new
+ *  sectioning has reissued. The fix is to unassign videos for the pages being
+ *  re-sectioned, the way `retireSectionIds` does in `pages.ts` (see the page
+ *  reconcile route, which already handles this identical hazard around
+ *  `deletePage`). */
 function makeBeforeRun(label: string, fromStage: StageName, toStage: StageName, booksDir: string): () => void {
   let ran = false
   return () => {

--- a/apps/api/src/routes/stages.ts
+++ b/apps/api/src/routes/stages.ts
@@ -15,11 +15,12 @@ import {
   NOTHING_RETIRED,
   PAGE_SECTIONING_NODE,
 } from "@adt/pipeline"
-import type { SectionIdRetirementResult, DetachedRecording } from "@adt/pipeline"
+import type { SectionIdRetirementResult } from "@adt/pipeline"
 import type { StageService } from "../services/stage-service.js"
 import type { BookEventBus, BookSSEEvent } from "../services/book-event-bus.js"
 import type { PageErrorDecisions } from "../services/page-error-decisions.js"
 import { readProviderCredentials } from "../middleware/provider-credentials.js"
+import { parkDetachedRecordings, DETACHED_AUDIO_DIR } from "../services/detached-audio.js"
 
 const StageRunBody = z
   .object({
@@ -155,52 +156,6 @@ export function retireSectionIdsForClearedSectioning(
   }
   // Page-scoped by construction, so glossary assignments (`gl001`…) are untouched.
   return retireSectionIds(storage, retired)
-}
-
-/** Where a detached upload is parked, relative to the book directory. */
-export const DETACHED_AUDIO_DIR = path.join("audio", ".detached")
-
-/**
- * Move uploaded recordings out of the way of the run that is about to reissue
- * their filenames, and return where each landed.
- *
- * Necessary because audio filenames are derived from the textId: the re-section
- * re-mints the id, the catalog rebuilds `${sectionId}_ans_*` under it, and Speech
- * writes generated audio to `audio/<lang>/<textId>.<ext>` — the upload's own
- * path. Dropping the manifest entry stops the recording being *served* for
- * content it was never made for, but on its own it would leave the file to be
- * overwritten minutes later, so "the upload is the user's" would be a promise
- * this code breaks. Parking it under a dot-directory keeps it out of the
- * language dirs that `resolveSpeechAudioPath` probes, and packaging copies
- * individual files named by manifest entries rather than walking `audio/`, so
- * nothing here can reach a bundle.
- *
- * Best-effort: a book whose audio has already been cleared from disk has nothing
- * to move, and failing to park a file must not abort the run the user asked for.
- */
-function parkDetachedRecordings(
-  bookDir: string,
-  detached: readonly DetachedRecording[]
-): string[] {
-  const parked: string[] = []
-  // One stamp for the whole batch, so a single run's detachments stay together
-  // and a later run cannot overwrite an earlier one's.
-  const stamp = new Date().toISOString().replace(/[:.]/g, "-")
-  for (const { language, fileName } of detached) {
-    const source = path.join(bookDir, "audio", language, fileName)
-    if (!fs.existsSync(source)) continue
-    const targetDir = path.join(bookDir, DETACHED_AUDIO_DIR, stamp, language)
-    try {
-      fs.mkdirSync(targetDir, { recursive: true })
-      fs.renameSync(source, path.join(targetDir, fileName))
-      parked.push(path.join(DETACHED_AUDIO_DIR, stamp, language, fileName))
-    } catch (err) {
-      console.warn(
-        `[stages] could not preserve detached recording ${fileName} (${language}): ${String(err)}`
-      )
-    }
-  }
-  return parked
 }
 
 /** Build a beforeRun callback that clears downstream data for a stage.

--- a/apps/api/src/routes/stages.ts
+++ b/apps/api/src/routes/stages.ts
@@ -20,7 +20,7 @@ import type { StageService } from "../services/stage-service.js"
 import type { BookEventBus, BookSSEEvent } from "../services/book-event-bus.js"
 import type { PageErrorDecisions } from "../services/page-error-decisions.js"
 import { readProviderCredentials } from "../middleware/provider-credentials.js"
-import { parkDetachedRecordings, DETACHED_AUDIO_DIR } from "../services/detached-audio.js"
+import { retireWithPreservedRecordings, DETACHED_AUDIO_DIR } from "../services/detached-audio.js"
 
 const StageRunBody = z
   .object({
@@ -114,8 +114,8 @@ function hasAnswerSpeechEntries(storage: Storage): boolean {
  * by the same clear.
  *
  * Nothing the user uploaded is deleted, as in the structural edit routes: a
- * video is unassigned in place, and a recording is parked by the caller (see
- * `parkDetachedRecordings`, which is needed because audio filenames — unlike
+ * video is unassigned in place, and a recording is backed up by the caller (see
+ * `retireWithPreservedRecordings`, which is needed because audio filenames — unlike
  * video paths — are derived from the very id being reissued). Same shape as the
  * `spreads/apply` reconcile, which retires ids before `deletePage` drops the
  * history for the identical reason — and it goes through the same
@@ -160,29 +160,28 @@ export function retireSectionIdsForClearedSectioning(
 
 /** Build a beforeRun callback that clears downstream data for a stage.
  *  The returned function is idempotent — only runs once even if called multiple times.
- *  Exported so tests can pin the retire-park-clear ordering it depends on. */
+ *  Exported so tests can pin the preserve-retirement-clear boundary. */
 export function makeBeforeRun(label: string, fromStage: StageName, toStage: StageName, booksDir: string): () => void {
   let ran = false
   return () => {
     if (ran) return
-    ran = true
     const storage = createBookStorage(label, booksDir)
     try {
-      const retired = retireSectionIdsForClearedSectioning(storage, fromStage, toStage)
+      const { retired, preserved } = retireWithPreservedRecordings(
+        storage,
+        path.join(path.resolve(booksDir), label),
+        () => retireSectionIdsForClearedSectioning(storage, fromStage, toStage)
+      )
+      // A failed preservation rolls retirement back and must remain retryable.
+      ran = true
       if (retired.videos > 0) {
         console.warn(
           `[stages] ${label}: unassigned ${retired.videos} sign-language video(s) — the sections they were pinned to are being regenerated. The uploads are kept and can be reattached.`
         )
       }
       if (retired.detachedRecordings.length > 0) {
-        // Park them before the clear, for the same reason the retirement runs
-        // before it: this reads the manifest the clear may delete.
-        const parked = parkDetachedRecordings(
-          path.join(path.resolve(booksDir), label),
-          retired.detachedRecordings
-        )
         console.warn(
-          `[stages] ${label}: detached ${retired.detachedRecordings.length} uploaded audio recording(s) — the sections their text belonged to are being regenerated, so the recordings no longer match. ${parked.length} file(s) moved to ${DETACHED_AUDIO_DIR}/ so this run cannot overwrite them; re-upload the ones you still want.`
+          `[stages] ${label}: detached ${retired.detachedRecordings.length} uploaded audio recording(s) — the sections their text belonged to are being regenerated, so the recordings no longer match. ${preserved.length} file(s) backed up to ${DETACHED_AUDIO_DIR}/ so this run cannot overwrite the backups; re-upload the ones you still want.`
         )
       }
 

--- a/apps/api/src/routes/stages.ts
+++ b/apps/api/src/routes/stages.ts
@@ -6,14 +6,16 @@ import { HTTPException } from "hono/http-exception"
 import { z } from "zod"
 import { createBookStorage, openBookDb } from "@adt/storage"
 import type { Storage } from "@adt/storage"
-import { StageName, STAGE_ORDER, PIPELINE, parseBookLabel, getStageRerunClearNodes, getStageClearOrder, PageErrorPolicy, DecisionBody } from "@adt/types"
+import { StageName, STAGE_ORDER, PIPELINE, parseBookLabel, getStageRerunClearNodes, getStageClearOrder, PageErrorPolicy, DecisionBody, TTSOutput, WordTimestampOutput, parseVoiceSlotEntryId, sectionIdOfAnswerTextId } from "@adt/types"
 import { assertStageRunModelCredentials } from "@adt/llm"
 import {
   loadBookConfig,
   collectSpentSectionIds,
-  unassignSignLanguageVideos,
+  retireSectionIds,
+  NOTHING_RETIRED,
   PAGE_SECTIONING_NODE,
 } from "@adt/pipeline"
+import type { SectionIdRetirementResult, DetachedRecording } from "@adt/pipeline"
 import type { StageService } from "../services/stage-service.js"
 import type { BookEventBus, BookSSEEvent } from "../services/book-event-bus.js"
 import type { PageErrorDecisions } from "../services/page-error-decisions.js"
@@ -48,40 +50,102 @@ function clearsSectionIdHistory(fromStage: StageName, toStage: StageName): boole
 }
 
 /**
- * Retire the sectionIds a rerun is about to invalidate, and report how many
- * sign-language videos that unassigned.
+ * Does any speech manifest hold audio keyed to a section at all?
+ *
+ * Only `${sectionId}_ans_*` entries can ever be retired, so a book whose audio
+ * is all page text, glossary and quiz content has nothing at stake no matter how
+ * its sections are renumbered. Reads the rows rather than merely checking that
+ * they exist, which is what makes the fast path below still worth having.
+ */
+function hasAnswerSpeechEntries(storage: Storage): boolean {
+  const isAnswer = (textId: string): boolean => sectionIdOfAnswerTextId(textId) !== null
+  for (const itemId of storage.getNodeItemIds("tts")) {
+    const parsed = TTSOutput.safeParse(storage.getLatestNodeData("tts", itemId)?.data)
+    // An unreadable row cannot be ruled out, so treat it as a reason to look.
+    if (!parsed.success) return true
+    // `failed` counts as much as `entries`: the prune reconciles both, so a row
+    // whose only answer reference is a failed item still has work to do.
+    if (parsed.data.entries.some((entry) => isAnswer(entry.textId))) return true
+    if (parsed.data.failed?.some((entry) => isAnswer(entry.textId))) return true
+  }
+  for (const itemId of storage.getNodeItemIds("tts-timestamps")) {
+    const parsed = WordTimestampOutput.safeParse(
+      storage.getLatestNodeData("tts-timestamps", itemId)?.data
+    )
+    if (!parsed.success) return true
+    if (
+      Object.keys(parsed.data.entries).some((key) =>
+        isAnswer(parseVoiceSlotEntryId(key).textId)
+      )
+    ) {
+      return true
+    }
+    if (parsed.data.failed?.some((entry) => isAnswer(entry.textId))) return true
+  }
+  return false
+}
+
+/**
+ * Retire every sectionId a rerun is about to invalidate, and report what that
+ * reconciled.
  *
  * Clearing a stage deletes *every* version of the nodes it clears. When
  * `page-sectioning` is among them the section-id high-water mark goes with it,
  * so the re-section re-mints densely from `_sec001` and hands out ids that named
  * different content a moment ago.
  *
- * That is only harmful while something still points at the old ids, and one
- * thing does: `sign_language_videos.section_id` is the sole sectionId reference
- * outside `node_data`, so the clear does not reach it and a pinned video would
- * silently reappear on whatever unrelated section inherits its id. Unassigning
- * it here is what makes the dense re-mint safe — every other reference
- * (`toc-generation`, `text-catalog` and the audio derived from it,
- * `editable-activity`) is deleted by the same clear, and audio filenames that
- * repeat are rewritten from the new text because TTS is cached on a content
- * hash, never served stale.
+ * That is only harmful while something still points at the old ids, and the
+ * clear does not reach everything:
  *
- * Videos are unassigned rather than deleted, as in the structural edit routes:
- * the upload is the user's. Same shape as the `spreads/apply` reconcile, which
- * retires ids before `deletePage` drops the history for the identical reason.
+ * - `sign_language_videos.section_id` lives in a table, not `node_data`, so a
+ *   pinned video would reappear on whatever unrelated section inherits its id.
+ * - The speech manifests are keyed by *language*, not by page. `tts` is
+ *   deliberately preserved by `getStageRerunClearNodes` whenever Speech is in
+ *   the rerun range, and `tts-timestamps` is in no clear list at all — the node
+ *   name differs from the `word-timestamps` step name that
+ *   `STAGE_OUTPUT_NODES` is derived from. Generated audio still heals itself on
+ *   `computeSpeechCacheKey`, but `canReuseSpeechEntry` accepts a
+ *   `provider: "manual"` entry on file existence alone, so a re-minted id would
+ *   inherit a recording of the old content.
+ *
+ * Retiring here is what makes the dense re-mint safe. Everything else keyed by
+ * sectionId (`toc-generation`, `text-catalog`, `editable-activity`) is deleted
+ * by the same clear.
+ *
+ * Nothing the user uploaded is deleted, as in the structural edit routes: a
+ * video is unassigned in place, and a recording is parked by the caller (see
+ * `parkDetachedRecordings`, which is needed because audio filenames — unlike
+ * video paths — are derived from the very id being reissued). Same shape as the
+ * `spreads/apply` reconcile, which retires ids before `deletePage` drops the
+ * history for the identical reason — and it goes through the same
+ * `retireSectionIds`, because the two paths previously reconciled different
+ * reference sets and that divergence is how the speech manifests were missed.
  *
  * Must run *before* the clear: it reads the sectioning history the ids come
  * from, and the `pages` table itself, both of which the extract branch deletes.
+ * The pruned `tts` version it writes has to survive that clear, which it does
+ * precisely because neither speech node is in `getStageRerunClearNodes`. On the
+ * extract branch `clearExtractedData` does delete them, making the write moot —
+ * but not special-cased, because "the clear will get it anyway" is the reasoning
+ * that produced the stale claim this doc comment replaces.
  */
-export function retireVideosForClearedSectioning(
+export function retireSectionIdsForClearedSectioning(
   storage: Storage,
   fromStage: StageName,
   toStage: StageName
-): number {
-  if (!clearsSectionIdHistory(fromStage, toStage)) return 0
-  // Scanning every stored sectioning version of every page is not free, and
-  // most books have nothing pinned at all.
-  if (!storage.getSignLanguageVideos().some((video) => video.sectionId !== null)) return 0
+): SectionIdRetirementResult {
+  if (!clearsSectionIdHistory(fromStage, toStage)) return NOTHING_RETIRED
+  // Scanning every stored sectioning version of every page is not free —
+  // `JSON.stringify` plus a global regex per version — so establish that
+  // *something* could be retired before paying for it. "Any book that has run
+  // speech" would be too coarse a guard to be worth having: the manifests are
+  // small and in memory, so ask them whether they hold any answer audio at all.
+  if (
+    !storage.getSignLanguageVideos().some((video) => video.sectionId !== null) &&
+    !hasAnswerSpeechEntries(storage)
+  ) {
+    return NOTHING_RETIRED
+  }
 
   const retired = new Set<string>()
   for (const page of storage.getPages()) {
@@ -90,22 +154,80 @@ export function retireVideosForClearedSectioning(
     }
   }
   // Page-scoped by construction, so glossary assignments (`gl001`…) are untouched.
-  return unassignSignLanguageVideos(storage, retired)
+  return retireSectionIds(storage, retired)
+}
+
+/** Where a detached upload is parked, relative to the book directory. */
+export const DETACHED_AUDIO_DIR = path.join("audio", ".detached")
+
+/**
+ * Move uploaded recordings out of the way of the run that is about to reissue
+ * their filenames, and return where each landed.
+ *
+ * Necessary because audio filenames are derived from the textId: the re-section
+ * re-mints the id, the catalog rebuilds `${sectionId}_ans_*` under it, and Speech
+ * writes generated audio to `audio/<lang>/<textId>.<ext>` — the upload's own
+ * path. Dropping the manifest entry stops the recording being *served* for
+ * content it was never made for, but on its own it would leave the file to be
+ * overwritten minutes later, so "the upload is the user's" would be a promise
+ * this code breaks. Parking it under a dot-directory keeps it out of the
+ * language dirs that `resolveSpeechAudioPath` probes, and packaging copies
+ * individual files named by manifest entries rather than walking `audio/`, so
+ * nothing here can reach a bundle.
+ *
+ * Best-effort: a book whose audio has already been cleared from disk has nothing
+ * to move, and failing to park a file must not abort the run the user asked for.
+ */
+function parkDetachedRecordings(
+  bookDir: string,
+  detached: readonly DetachedRecording[]
+): string[] {
+  const parked: string[] = []
+  // One stamp for the whole batch, so a single run's detachments stay together
+  // and a later run cannot overwrite an earlier one's.
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-")
+  for (const { language, fileName } of detached) {
+    const source = path.join(bookDir, "audio", language, fileName)
+    if (!fs.existsSync(source)) continue
+    const targetDir = path.join(bookDir, DETACHED_AUDIO_DIR, stamp, language)
+    try {
+      fs.mkdirSync(targetDir, { recursive: true })
+      fs.renameSync(source, path.join(targetDir, fileName))
+      parked.push(path.join(DETACHED_AUDIO_DIR, stamp, language, fileName))
+    } catch (err) {
+      console.warn(
+        `[stages] could not preserve detached recording ${fileName} (${language}): ${String(err)}`
+      )
+    }
+  }
+  return parked
 }
 
 /** Build a beforeRun callback that clears downstream data for a stage.
- *  The returned function is idempotent — only runs once even if called multiple times. */
-function makeBeforeRun(label: string, fromStage: StageName, toStage: StageName, booksDir: string): () => void {
+ *  The returned function is idempotent — only runs once even if called multiple times.
+ *  Exported so tests can pin the retire-park-clear ordering it depends on. */
+export function makeBeforeRun(label: string, fromStage: StageName, toStage: StageName, booksDir: string): () => void {
   let ran = false
   return () => {
     if (ran) return
     ran = true
     const storage = createBookStorage(label, booksDir)
     try {
-      const unassigned = retireVideosForClearedSectioning(storage, fromStage, toStage)
-      if (unassigned > 0) {
+      const retired = retireSectionIdsForClearedSectioning(storage, fromStage, toStage)
+      if (retired.videos > 0) {
         console.warn(
-          `[stages] ${label}: unassigned ${unassigned} sign-language video(s) — the sections they were pinned to are being regenerated. The uploads are kept and can be reattached.`
+          `[stages] ${label}: unassigned ${retired.videos} sign-language video(s) — the sections they were pinned to are being regenerated. The uploads are kept and can be reattached.`
+        )
+      }
+      if (retired.detachedRecordings.length > 0) {
+        // Park them before the clear, for the same reason the retirement runs
+        // before it: this reads the manifest the clear may delete.
+        const parked = parkDetachedRecordings(
+          path.join(path.resolve(booksDir), label),
+          retired.detachedRecordings
+        )
+        console.warn(
+          `[stages] ${label}: detached ${retired.detachedRecordings.length} uploaded audio recording(s) — the sections their text belonged to are being regenerated, so the recordings no longer match. ${parked.length} file(s) moved to ${DETACHED_AUDIO_DIR}/ so this run cannot overwrite them; re-upload the ones you still want.`
         )
       }
 

--- a/apps/api/src/routes/stages.ts
+++ b/apps/api/src/routes/stages.ts
@@ -5,9 +5,15 @@ import { streamSSE } from "hono/streaming"
 import { HTTPException } from "hono/http-exception"
 import { z } from "zod"
 import { createBookStorage, openBookDb } from "@adt/storage"
+import type { Storage } from "@adt/storage"
 import { StageName, STAGE_ORDER, PIPELINE, parseBookLabel, getStageRerunClearNodes, getStageClearOrder, PageErrorPolicy, DecisionBody } from "@adt/types"
 import { assertStageRunModelCredentials } from "@adt/llm"
-import { loadBookConfig } from "@adt/pipeline"
+import {
+  loadBookConfig,
+  collectSpentSectionIds,
+  unassignSignLanguageVideos,
+  PAGE_SECTIONING_NODE,
+} from "@adt/pipeline"
 import type { StageService } from "../services/stage-service.js"
 import type { BookEventBus, BookSSEEvent } from "../services/book-event-bus.js"
 import type { PageErrorDecisions } from "../services/page-error-decisions.js"
@@ -22,23 +28,73 @@ const StageRunBody = z
   })
   .strict()
 
+/**
+ * Does this rerun delete the `page-sectioning` history that section ids are
+ * allocated from?
+ *
+ * Only that node. `fixed-layout-sectioning` is cleared by a storyboard rerun
+ * too, but its id is not allocated — `sectionFixedLayoutPage` derives the page's
+ * single section id from the pageId alone, so regenerating it produces the same
+ * id and nothing pinned to it was ever at risk. Retiring those ids would detach
+ * every pinned video on each storyboard rerun of a fixed-layout book, and on a
+ * reflowable book carrying a stale fixed-layout row it would retire a `_sec001`
+ * the live `page-sectioning` still owns.
+ */
+function clearsSectionIdHistory(fromStage: StageName, toStage: StageName): boolean {
+  // `clearExtractedData` drops every node except the font ones, sectioning included.
+  if (fromStage === "extract") return true
+  const cleared: string[] = getStageRerunClearNodes(fromStage, toStage)
+  return cleared.includes(PAGE_SECTIONING_NODE)
+}
+
+/**
+ * Retire the sectionIds a rerun is about to invalidate, and report how many
+ * sign-language videos that unassigned.
+ *
+ * Clearing a stage deletes *every* version of the nodes it clears. When
+ * `page-sectioning` is among them the section-id high-water mark goes with it,
+ * so the re-section re-mints densely from `_sec001` and hands out ids that named
+ * different content a moment ago.
+ *
+ * That is only harmful while something still points at the old ids, and one
+ * thing does: `sign_language_videos.section_id` is the sole sectionId reference
+ * outside `node_data`, so the clear does not reach it and a pinned video would
+ * silently reappear on whatever unrelated section inherits its id. Unassigning
+ * it here is what makes the dense re-mint safe — every other reference
+ * (`toc-generation`, `text-catalog` and the audio derived from it,
+ * `editable-activity`) is deleted by the same clear, and audio filenames that
+ * repeat are rewritten from the new text because TTS is cached on a content
+ * hash, never served stale.
+ *
+ * Videos are unassigned rather than deleted, as in the structural edit routes:
+ * the upload is the user's. Same shape as the `spreads/apply` reconcile, which
+ * retires ids before `deletePage` drops the history for the identical reason.
+ *
+ * Must run *before* the clear: it reads the sectioning history the ids come
+ * from, and the `pages` table itself, both of which the extract branch deletes.
+ */
+export function retireVideosForClearedSectioning(
+  storage: Storage,
+  fromStage: StageName,
+  toStage: StageName
+): number {
+  if (!clearsSectionIdHistory(fromStage, toStage)) return 0
+  // Scanning every stored sectioning version of every page is not free, and
+  // most books have nothing pinned at all.
+  if (!storage.getSignLanguageVideos().some((video) => video.sectionId !== null)) return 0
+
+  const retired = new Set<string>()
+  for (const page of storage.getPages()) {
+    for (const id of collectSpentSectionIds(storage, page.pageId, [PAGE_SECTIONING_NODE])) {
+      retired.add(id)
+    }
+  }
+  // Page-scoped by construction, so glossary assignments (`gl001`…) are untouched.
+  return unassignSignLanguageVideos(storage, retired)
+}
+
 /** Build a beforeRun callback that clears downstream data for a stage.
- *  The returned function is idempotent — only runs once even if called multiple times.
- *
- *  KNOWN GAP (tracked separately): both branches below delete *every* version of
- *  the nodes they clear, `page-sectioning` included. That resets the history the
- *  section-id high-water mark is read from, so `finalizePageSectioning` re-mints
- *  densely from `_sec001` and a re-section can hand a retired id to unrelated
- *  content — the reuse that `createSectionIdFactory` exists to prevent.
- *
- *  `toc-generation` and `text-catalog` reference sectionIds but live in
- *  `node_data` and are wiped by the same clear, so they self-heal. The one
- *  reference that survives is `sign_language_videos.section_id`, a separate
- *  table nothing here reconciles — so a video stays pinned to an id the new
- *  sectioning has reissued. The fix is to unassign videos for the pages being
- *  re-sectioned, the way `retireSectionIds` does in `pages.ts` (see the page
- *  reconcile route, which already handles this identical hazard around
- *  `deletePage`). */
+ *  The returned function is idempotent — only runs once even if called multiple times. */
 function makeBeforeRun(label: string, fromStage: StageName, toStage: StageName, booksDir: string): () => void {
   let ran = false
   return () => {
@@ -46,6 +102,13 @@ function makeBeforeRun(label: string, fromStage: StageName, toStage: StageName, 
     ran = true
     const storage = createBookStorage(label, booksDir)
     try {
+      const unassigned = retireVideosForClearedSectioning(storage, fromStage, toStage)
+      if (unassigned > 0) {
+        console.warn(
+          `[stages] ${label}: unassigned ${unassigned} sign-language video(s) — the sections they were pinned to are being regenerated. The uploads are kept and can be reattached.`
+        )
+      }
+
       if (fromStage === "extract") {
         // clearExtractedData also clears step_runs
         storage.clearExtractedData()

--- a/apps/api/src/routes/toc.ts
+++ b/apps/api/src/routes/toc.ts
@@ -125,10 +125,12 @@ export function createTocRoutes(booksDir: string): Hono {
 
         for (const rs of renderParsed.data.sections) {
           const meta = sectioning?.sections?.[rs.sectionIndex]
-          if (meta?.isPruned) continue
+          // Orphan rendering entries have no resolvable sectionId — a positional
+          // guess could name a different section, so skip them.
+          if (!meta || meta.isPruned) continue
 
-          const sectionId = meta?.sectionId ?? `${page.pageId}_sec${String(rs.sectionIndex + 1).padStart(3, "0")}`
-          const title = meta ? (findFirstHeadingText(meta.nodes) ?? sectionId) : sectionId
+          const sectionId = meta.sectionId
+          const title = findFirstHeadingText(meta.nodes) ?? sectionId
 
           sections.push({
             sectionId,

--- a/apps/api/src/services/detached-audio.test.ts
+++ b/apps/api/src/services/detached-audio.test.ts
@@ -1,0 +1,67 @@
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { preserveDetachedRecordings } from "./detached-audio.js"
+
+describe("preserveDetachedRecordings", () => {
+  let bookDir: string
+
+  beforeEach(() => {
+    bookDir = fs.mkdtempSync(path.join(os.tmpdir(), "detached-audio-"))
+    fs.mkdirSync(path.join(bookDir, "audio", "en"), { recursive: true })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    fs.rmSync(bookDir, { recursive: true, force: true })
+  })
+
+  it("keeps every original on partial failure and safely retries in a fresh directory", () => {
+    const recordings = ["first.mp3", "second.mp3"].map((fileName) => ({ language: "en", fileName }))
+    for (const { fileName } of recordings) {
+      fs.writeFileSync(path.join(bookDir, "audio", "en", fileName), fileName)
+    }
+    // Even retries in the same millisecond cannot overwrite an earlier backup.
+    vi.spyOn(Date.prototype, "toISOString").mockReturnValue("2026-09-09T00:00:00.000Z")
+    const originalCopy = fs.copyFileSync
+    const copy = vi.spyOn(fs, "copyFileSync")
+      .mockImplementationOnce(originalCopy)
+      .mockImplementationOnce(() => {
+        throw Object.assign(new Error("disk full"), { code: "ENOSPC" })
+      })
+    expect(() => preserveDetachedRecordings(bookDir, recordings)).toThrow("Could not preserve uploaded recording second.mp3")
+    copy.mockRestore()
+    for (const { fileName } of recordings) {
+      expect(fs.readFileSync(path.join(bookDir, "audio", "en", fileName), "utf8")).toBe(fileName)
+    }
+    const preserved = preserveDetachedRecordings(bookDir, recordings)
+    expect(preserved).toHaveLength(2)
+    expect(fs.readdirSync(path.join(bookDir, "audio", ".detached"))).toHaveLength(2)
+    for (let i = 0; i < recordings.length; i++) {
+      fs.writeFileSync(path.join(bookDir, "audio", "en", recordings[i].fileName), "regenerated")
+      expect(fs.readFileSync(path.join(bookDir, preserved[i]), "utf8")).toBe(recordings[i].fileName)
+    }
+  })
+
+  it("skips an already-missing source without creating a backup directory", () => {
+    expect(preserveDetachedRecordings(bookDir, [{ language: "en", fileName: "missing.mp3" }])).toEqual([])
+    expect(fs.existsSync(path.join(bookDir, "audio", ".detached"))).toBe(false)
+  })
+
+  it("does not mistake an unreadable source for an already-missing upload", () => {
+    vi.spyOn(fs, "statSync").mockImplementationOnce(() => {
+      throw Object.assign(new Error("permission denied"), { code: "EACCES" })
+    })
+    expect(() => preserveDetachedRecordings(bookDir, [{ language: "en", fileName: "unreadable.mp3" }]))
+      .toThrow("Could not preserve uploaded recording")
+  })
+
+  it("backs up a file only once when multiple entries name it", () => {
+    const recording = { language: "en", fileName: "shared.mp3" }
+    fs.writeFileSync(path.join(bookDir, "audio", "en", recording.fileName), "original")
+    const preserved = preserveDetachedRecordings(bookDir, [recording, recording])
+    expect(preserved).toHaveLength(1)
+    expect(fs.readFileSync(path.join(bookDir, preserved[0]), "utf8")).toBe("original")
+  })
+})

--- a/apps/api/src/services/detached-audio.ts
+++ b/apps/api/src/services/detached-audio.ts
@@ -1,0 +1,59 @@
+import fs from "node:fs"
+import path from "node:path"
+import type { DetachedRecording } from "@adt/pipeline"
+
+/** Where a detached upload is parked, relative to the book directory. */
+export const DETACHED_AUDIO_DIR = path.join("audio", ".detached")
+
+/**
+ * Move uploaded recordings out of the way of the id that is about to be
+ * reissued, and return where each landed.
+ *
+ * Necessary because audio filenames are derived from the textId. `retireSectionIds`
+ * drops the manifest entry, which stops the recording being *served* for content
+ * it was never made for — but the file itself sits at
+ * `audio/<lang>/${sectionId}_ans_*.<ext>`, exactly where a re-minted id
+ * regenerates into (`generateSpeechFile` builds the same
+ * `voiceSlotEntryId(textId, slot)` name). Leaving it there means the next run
+ * overwrites it, so "the upload is the user's" would be a promise this code
+ * breaks. Unlike a sign-language video, which is stored under its own `videoId`
+ * and survives unassignment untouched, audio has to be moved.
+ *
+ * Every caller of `retireSectionIds` that does not itself delete the audio needs
+ * this — the stage rerun, where the re-mint happens minutes later, and
+ * `spreads/apply`, where it happens whenever the spread is un-applied and the
+ * page is re-created under its old id with no history to allocate past.
+ *
+ * Parking under a dot-directory keeps the files out of the language dirs
+ * `resolveSpeechAudioPath` probes, and packaging copies individual files named by
+ * manifest entries rather than walking `audio/`, so nothing here reaches a
+ * bundle.
+ *
+ * Best-effort: a book whose audio was already cleared from disk has nothing to
+ * move, and failing to park a file must not abort the operation the user asked
+ * for.
+ */
+export function parkDetachedRecordings(
+  bookDir: string,
+  detached: readonly DetachedRecording[]
+): string[] {
+  const parked: string[] = []
+  // One stamp for the whole batch, so a single operation's detachments stay
+  // together and a later one cannot overwrite an earlier one's.
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-")
+  for (const { language, fileName } of detached) {
+    const source = path.join(bookDir, "audio", language, fileName)
+    if (!fs.existsSync(source)) continue
+    const targetDir = path.join(bookDir, DETACHED_AUDIO_DIR, stamp, language)
+    try {
+      fs.mkdirSync(targetDir, { recursive: true })
+      fs.renameSync(source, path.join(targetDir, fileName))
+      parked.push(path.join(DETACHED_AUDIO_DIR, stamp, language, fileName))
+    } catch (err) {
+      console.warn(
+        `[detached-audio] could not preserve detached recording ${fileName} (${language}): ${String(err)}`
+      )
+    }
+  }
+  return parked
+}

--- a/apps/api/src/services/detached-audio.ts
+++ b/apps/api/src/services/detached-audio.ts
@@ -1,13 +1,14 @@
 import fs from "node:fs"
 import path from "node:path"
-import type { DetachedRecording } from "@adt/pipeline"
+import type { DetachedRecording, SectionIdRetirementResult } from "@adt/pipeline"
+import type { Storage } from "@adt/storage"
 
-/** Where a detached upload is parked, relative to the book directory. */
+/** Where detached uploads are backed up, relative to the book directory. */
 export const DETACHED_AUDIO_DIR = path.join("audio", ".detached")
 
 /**
- * Move uploaded recordings out of the way of the id that is about to be
- * reissued, and return where each landed.
+ * Copy uploaded recordings to a safe location before their ids can be reissued,
+ * and return the book-relative backup paths.
  *
  * Necessary because audio filenames are derived from the textId. `retireSectionIds`
  * drops the manifest entry, which stops the recording being *served* for content
@@ -17,43 +18,73 @@ export const DETACHED_AUDIO_DIR = path.join("audio", ".detached")
  * `voiceSlotEntryId(textId, slot)` name). Leaving it there means the next run
  * overwrites it, so "the upload is the user's" would be a promise this code
  * breaks. Unlike a sign-language video, which is stored under its own `videoId`
- * and survives unassignment untouched, audio has to be moved.
+ * and survives unassignment untouched, audio needs a separate backup.
  *
  * Every caller of `retireSectionIds` that does not itself delete the audio needs
  * this — the stage rerun, where the re-mint happens minutes later, and
  * `spreads/apply`, where it happens whenever the spread is un-applied and the
  * page is re-created under its old id with no history to allocate past.
  *
- * Parking under a dot-directory keeps the files out of the language dirs
+ * Backing up under a dot-directory keeps the copies out of the language dirs
  * `resolveSpeechAudioPath` probes, and packaging copies individual files named by
  * manifest entries rather than walking `audio/`, so nothing here reaches a
  * bundle.
  *
- * Best-effort: a book whose audio was already cleared from disk has nothing to
- * move, and failing to park a file must not abort the operation the user asked
- * for.
+ * Copy rather than move: if any copy or the surrounding storage transaction
+ * fails, every original still exists at the path in its rolled-back manifest.
+ * Successful copies are kept even on failure; retries use a fresh directory and
+ * cannot overwrite them. Only an already-missing source can be skipped.
  */
-export function parkDetachedRecordings(
+export function preserveDetachedRecordings(
   bookDir: string,
   detached: readonly DetachedRecording[]
 ): string[] {
-  const parked: string[] = []
-  // One stamp for the whole batch, so a single operation's detachments stay
-  // together and a later one cannot overwrite an earlier one's.
-  const stamp = new Date().toISOString().replace(/[:.]/g, "-")
+  const preserved: string[] = []
+  let batchDir: string | undefined
+  const copied = new Set<string>()
   for (const { language, fileName } of detached) {
     const source = path.join(bookDir, "audio", language, fileName)
-    if (!fs.existsSync(source)) continue
-    const targetDir = path.join(bookDir, DETACHED_AUDIO_DIR, stamp, language)
+    if (copied.has(source)) continue
     try {
+      // existsSync also returns false for permission errors. Those must abort,
+      // not be mistaken for an upload that no longer exists.
+      try {
+        fs.statSync(source)
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === "ENOENT") continue
+        throw err
+      }
+      if (!batchDir) {
+        const root = path.join(bookDir, DETACHED_AUDIO_DIR)
+        fs.mkdirSync(root, { recursive: true })
+        const stamp = new Date().toISOString().replace(/[:.]/g, "-")
+        batchDir = fs.mkdtempSync(path.join(root, `${stamp}-`))
+      }
+      const targetDir = path.join(batchDir, language)
       fs.mkdirSync(targetDir, { recursive: true })
-      fs.renameSync(source, path.join(targetDir, fileName))
-      parked.push(path.join(DETACHED_AUDIO_DIR, stamp, language, fileName))
+      const target = path.join(targetDir, fileName)
+      fs.copyFileSync(source, target, fs.constants.COPYFILE_EXCL)
+      copied.add(source)
+      preserved.push(path.relative(bookDir, target))
     } catch (err) {
-      console.warn(
-        `[detached-audio] could not preserve detached recording ${fileName} (${language}): ${String(err)}`
+      throw new Error(
+        `Could not preserve uploaded recording ${fileName} (${language}); retirement was stopped. Check audio directory permissions and free space, then retry.`,
+        { cause: err }
       )
     }
   }
-  return parked
+  return preserved
+}
+
+/** Keep all retirement writes retryable until every existing upload is safe. */
+export function retireWithPreservedRecordings(
+  storage: Storage,
+  bookDir: string,
+  retire: () => SectionIdRetirementResult
+) {
+  return storage.transaction(() => {
+    const retired = retire()
+    const preserved = preserveDetachedRecordings(bookDir, retired.detachedRecordings)
+    return { retired, preserved }
+  })
 }

--- a/apps/api/src/services/export-service.ts
+++ b/apps/api/src/services/export-service.ts
@@ -2,6 +2,7 @@ import fs from "node:fs"
 import path from "node:path"
 import { HTTPException } from "hono/http-exception"
 import { parseBookLabel } from "@adt/types"
+import type { PackagingWarning } from "@adt/types"
 import { createBookStorage } from "@adt/storage"
 import { packageAdtWeb, packageWebpub, packageEpub, packagePnld, loadBookConfig, normalizeLocale, isFixedLayoutBook } from "@adt/pipeline"
 import { createZipStream } from "./zip-util.js"
@@ -59,6 +60,11 @@ export interface ExportDefaultSettings {
   reduceMotion?: boolean
 }
 
+/** What the rebuild had to leave out of the exported bundle. */
+export interface PrepareExportResult {
+  warnings: PackagingWarning[]
+}
+
 /**
  * Prepare export by rebuilding the adt/ (and optionally webpub/) directories.
  * Called as a separate step before the actual download so the client can show
@@ -72,7 +78,7 @@ export async function prepareExport(
   configPath?: string,
   features?: ExportFeatures,
   defaultSettingsOverride?: ExportDefaultSettings,
-): Promise<void> {
+): Promise<PrepareExportResult> {
   const safeLabel = parseBookLabel(label)
   const resolvedDir = path.resolve(booksDir)
   const bookDir = path.join(resolvedDir, safeLabel)
@@ -157,7 +163,7 @@ export async function prepareExport(
       epubGlossary: config.epub_glossary,
     }
 
-    await packageAdtWeb(storage, opts)
+    const { warnings } = await packageAdtWeb(storage, opts)
 
     if (format === "webpub") {
       packageWebpub(storage, opts)
@@ -166,6 +172,8 @@ export async function prepareExport(
     } else if (format === "pnld") {
       packagePnld(storage, opts)
     }
+
+    return { warnings }
   } finally {
     storage.close()
   }

--- a/apps/api/src/services/stage-runner.test.ts
+++ b/apps/api/src/services/stage-runner.test.ts
@@ -3,7 +3,7 @@ import os from "node:os"
 import path from "node:path"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { PIPELINE, type AppConfig, type ProgressEvent } from "@adt/types"
-import { computeSpeechCacheKey, stripEmojis } from "@adt/pipeline"
+import { computeSpeechCacheKey, stripEmojis, retireSectionIds } from "@adt/pipeline"
 import { createBookStorage, openBookDb } from "@adt/storage"
 import {
   buildStageRunnerImageClassifyConfig,
@@ -2513,6 +2513,216 @@ structure_types:
       )
       expect(entry?.provider).toBe("manual")
       expect(entry?.voiceLabel).toBe("Renamed Narrator")
+    } finally {
+      storage.close()
+    }
+  })
+
+  /**
+   * A rerun that re-sections a page re-mints its ids densely, so
+   * `pg001_sec001_ans_a` can come back naming a different activity answer. The
+   * `tts` manifest survives that rerun (`getStageRerunClearNodes` preserves it
+   * whenever Speech is in range) and `canReuseSpeechEntry` accepts a manual
+   * entry on file existence alone — never comparing the text — so without
+   * retirement the old recording is served for the new answer.
+   */
+  function seedRetiredAnswerRecording(booksDir: string, label: string): string {
+    seedTextAndSpeechBook(booksDir, label)
+    const audioDir = path.join(booksDir, label, "audio", "en")
+    fs.mkdirSync(audioDir, { recursive: true })
+    fs.writeFileSync(path.join(audioDir, "pg001_sec001_ans_a.mp3"), Buffer.from("old-recording"))
+
+    const storage = createBookStorage(label, booksDir)
+    try {
+      // The re-minted `_sec001` now names a *different* activity answer. Seeded
+      // through rendering + sectioning rather than straight onto the catalog,
+      // because the catalog steps rebuild themselves from these on every run.
+      storage.putNodeData("page-sectioning", "pg001", {
+        reasoning: "re-sectioned",
+        sections: [
+          {
+            sectionId: "pg001_sec001",
+            sectionType: "activity",
+            backgroundColor: "#ffffff",
+            textColor: "#000000",
+            pageNumber: 1,
+            isPruned: false,
+            nodes: [
+              { nodeId: "pg001_n0001", isPruned: false, role: "text", text: "Question" },
+            ],
+          },
+        ],
+      })
+      storage.putNodeData("web-rendering", "pg001", {
+        sections: [
+          {
+            sectionIndex: 0,
+            sectionType: "activity",
+            reasoning: "",
+            html: '<p data-id="pg001_t001">Hello world</p>',
+            activityAnswers: { a: "New answer" },
+          },
+        ],
+      })
+      storage.putNodeData("text-catalog", "book", {
+        entries: [
+          { id: "pg001_t001", text: "Hello world" },
+          { id: "pg001_sec001_ans_a", text: "New answer" },
+        ],
+        generatedAt: "2026-01-01T00:00:00.000Z",
+      })
+      storage.putNodeData("core-tts-catalog", "en", {
+        language: "en",
+        generatedAt: "2026-01-01T00:00:00.000Z",
+        entries: [
+          readyCoreTtsEntry("pg001_t001", "Hello world"),
+          readyCoreTtsEntry("pg001_sec001_ans_a", "New answer"),
+        ],
+      })
+      storage.putNodeData("tts", "en", {
+        entries: [
+          {
+            textId: "pg001_sec001_ans_a",
+            language: "en",
+            fileName: "pg001_sec001_ans_a.mp3",
+            voice: "uploaded",
+            model: "uploaded",
+            cached: false,
+            provider: "manual",
+            voiceSlot: "primary",
+          },
+        ],
+        generatedAt: "2026-01-01T00:00:00.000Z",
+      })
+    } finally {
+      storage.close()
+    }
+    return audioDir
+  }
+
+  function writeSpeechConfig(tmpDir: string, configPath: string): void {
+    fs.mkdirSync(path.join(tmpDir, "prompts"), { recursive: true })
+    fs.writeFileSync(
+      configPath,
+      `role_types:
+  section_text: Main body text
+structure_types:
+  paragraph: Paragraph
+`,
+    )
+  }
+
+  it("regenerates a manual recording whose section id was retired", async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "stage-runner-tts-"))
+    const booksDir = path.join(tmpDir, "books")
+    const promptsDir = path.join(tmpDir, "prompts")
+    const configPath = path.join(tmpDir, "config.yaml")
+    writeSpeechConfig(tmpDir, configPath)
+    const label = "speech-retired-answer"
+    seedRetiredAnswerRecording(booksDir, label)
+
+    // What the rerun's beforeRun does before clearing the sectioning history.
+    const retireStorage = createBookStorage(label, booksDir)
+    try {
+      const retired = retireSectionIds(retireStorage, ["pg001_sec001"])
+      expect(retired.detachedRecordings).toHaveLength(1)
+    } finally {
+      retireStorage.close()
+    }
+
+    generateSpeechFileMock.mockClear()
+    // The suite default resolves `undefined` ("no audio produced"), which would
+    // leave no entry at all and make the assertions below vacuous. Return a real
+    // generated entry so "replaced by a generated one" is actually observable.
+    generateSpeechFileMock.mockImplementation(
+      async ({ textId, language, voice, model }: {
+        textId: string
+        language: string
+        voice: string
+        model: string
+      }) => ({
+        textId,
+        language,
+        fileName: `${textId}.mp3`,
+        voice,
+        model,
+        cached: false,
+        provider: "openai",
+        voiceSlot: "primary",
+      })
+    )
+    const runner = createStageRunner()
+    await runner.run(
+      label,
+      {
+        booksDir,
+        credentials: { openai: { apiKey: "sk-test" } },
+        promptsDir,
+        configPath,
+        fromStage: "translate",
+        toStage: "speech",
+      },
+      { emit: () => {} }
+    )
+
+    // Generated from the answer the id now names, not reused from the old one.
+    expect(generateSpeechFileMock).toHaveBeenCalledWith(
+      expect.objectContaining({ textId: "pg001_sec001_ans_a", text: "New answer" })
+    )
+    const storage = createBookStorage(label, booksDir)
+    try {
+      const output = storage.getLatestNodeData("tts", "en")?.data as {
+        entries: Array<{ textId: string; provider?: string }>
+      }
+      const entry = output.entries.find((e) => e.textId === "pg001_sec001_ans_a")
+      expect(entry).toBeDefined()
+      expect(entry?.provider).toBe("openai")
+    } finally {
+      storage.close()
+    }
+    // Note: retirement itself does no file I/O. Preserving the upload from the
+    // regeneration that reuses its filename is `parkDetachedRecordings`' job on
+    // the rerun path, covered in `stages.test.ts` — asserting the file here
+    // would only be testing that this mock does not write to disk.
+  })
+
+  it("reuses a manual recording when no section id was retired", async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "stage-runner-tts-"))
+    const booksDir = path.join(tmpDir, "books")
+    const promptsDir = path.join(tmpDir, "prompts")
+    const configPath = path.join(tmpDir, "config.yaml")
+    writeSpeechConfig(tmpDir, configPath)
+    const label = "speech-kept-answer"
+    seedRetiredAnswerRecording(booksDir, label)
+
+    // The control: identical state, no retirement. An ordinary rerun must not
+    // throw away a recording that still describes its own section.
+    generateSpeechFileMock.mockClear()
+    const runner = createStageRunner()
+    await runner.run(
+      label,
+      {
+        booksDir,
+        credentials: { openai: { apiKey: "sk-test" } },
+        promptsDir,
+        configPath,
+        fromStage: "translate",
+        toStage: "speech",
+      },
+      { emit: () => {} }
+    )
+
+    expect(generateSpeechFileMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({ textId: "pg001_sec001_ans_a" })
+    )
+    const storage = createBookStorage(label, booksDir)
+    try {
+      const output = storage.getLatestNodeData("tts", "en")?.data as {
+        entries: Array<{ textId: string; fileName: string; provider?: string }>
+      }
+      const entry = output.entries.find((e) => e.textId === "pg001_sec001_ans_a")
+      expect(entry?.provider).toBe("manual")
+      expect(entry?.fileName).toBe("pg001_sec001_ans_a.mp3")
     } finally {
       storage.close()
     }

--- a/apps/api/src/services/stage-runner.test.ts
+++ b/apps/api/src/services/stage-runner.test.ts
@@ -2681,7 +2681,7 @@ structure_types:
       storage.close()
     }
     // Note: retirement itself does no file I/O. Preserving the upload from the
-    // regeneration that reuses its filename is `parkDetachedRecordings`' job on
+    // regeneration that reuses its filename is `preserveDetachedRecordings`' job on
     // the rerun path, covered in `stages.test.ts` — asserting the file here
     // would only be testing that this mock does not write to disk.
   })

--- a/apps/studio/src/api/client.ts
+++ b/apps/studio/src/api/client.ts
@@ -12,6 +12,7 @@ import type {
   EditableActivity,
   FontAssignmentOutput,
   ExtractionWarning,
+  PackagingWarning,
   ReviewerPageValidationRecord,
   ReviewerValidationIdentificationField,
   ReviewerValidationInstruction,
@@ -1970,11 +1971,18 @@ export const api = {
       body: JSON.stringify({ language }),
     }),
 
+  // `warnings` is present whenever packaging completed inline (a cache hit, or a
+  // server with no task service). When it returns a taskId the warnings ride the
+  // task result instead. Either way the caller must surface them — a short
+  // bundle otherwise looks like a clean one.
   packageAdt: (label: string) =>
-    request<{ status: string; label: string; taskId?: string; version?: string }>(
-      `/books/${label}/package-adt`,
-      { method: "POST" }
-    ),
+    request<{
+      status: string
+      label: string
+      taskId?: string
+      version?: string
+      warnings?: PackagingWarning[]
+    }>(`/books/${label}/package-adt`, { method: "POST" }),
 
   getTasks: (label: string) =>
     request<{ tasks: TaskInfoResponse[] }>(`/books/${label}/tasks`),
@@ -2138,7 +2146,12 @@ export const api = {
     const body: Record<string, unknown> = {}
     if (features) body.features = features
     if (defaultSettings) body.defaultSettings = defaultSettings
-    return request<{ taskId?: string; status: string; label: string }>(
+    return request<{
+      taskId?: string
+      status: string
+      label: string
+      warnings?: PackagingWarning[]
+    }>(
       `/books/${label}/prepare-export?format=${format}`,
       {
         method: "POST",

--- a/apps/studio/src/components/pipeline/stages/PreviewView.tsx
+++ b/apps/studio/src/components/pipeline/stages/PreviewView.tsx
@@ -1,6 +1,12 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from "react"
 import type { AccessibilityFinding } from "@adt/types"
 import { Trans } from "@lingui/react/macro"
+import { useLingui } from "@lingui/react"
+import { toast } from "sonner"
+import {
+  readPackagingWarnings,
+  describePackagingWarnings,
+} from "@/lib/packaging-warnings"
 import { StageBlockedState } from "@/components/pipeline/components/StageBlockedState"
 import { LoadingState } from "@/components/pipeline/components/LoadingState"
 import { useAllPagesPruned } from "@/hooks/use-all-pages-pruned"
@@ -34,6 +40,7 @@ const HIGHLIGHT_SEVERITY_ATTR = "data-adt-a11y-hover-severity"
 const HIGHLIGHT_PAGE_ATTR = "data-adt-a11y-hover-page"
 
 export function PreviewView({ bookLabel }: { bookLabel: string }) {
+  const { i18n } = useLingui()
   const queryClient = useQueryClient()
   const navigate = useNavigate()
   const search = useSearch({ strict: false }) as { previewHref?: string }
@@ -157,6 +164,14 @@ export function PreviewView({ bookLabel }: { bookLabel: string }) {
       ]).then(() => {
         setVersion(readPackageVersion(task.result) ?? createPreviewVersion())
         setReady(true)
+        // Packaging skips rendered sections it cannot resolve a sectionId for.
+        // The bundle is short but the task still succeeds, so without this the
+        // omission is invisible.
+        const omitted = describePackagingWarnings(
+          readPackagingWarnings(task.result),
+          i18n,
+        )
+        if (omitted) toast.warning(omitted)
       })
     } else if (task.status === "failed") {
       setPendingTaskId(null)
@@ -166,7 +181,7 @@ export function PreviewView({ bookLabel }: { bookLabel: string }) {
         setError(task.error ?? "Packaging failed")
       }
     }
-  }, [pendingTaskId, getTask, bookLabel, queryClient, ready])
+  }, [pendingTaskId, getTask, bookLabel, queryClient, ready, i18n])
 
   useEffect(() => {
     if (!pendingVersion || ready) return

--- a/apps/studio/src/components/pipeline/stages/PreviewView.tsx
+++ b/apps/studio/src/components/pipeline/stages/PreviewView.tsx
@@ -2,11 +2,7 @@ import { useState, useEffect, useRef, useCallback, useMemo } from "react"
 import type { AccessibilityFinding } from "@adt/types"
 import { Trans } from "@lingui/react/macro"
 import { useLingui } from "@lingui/react"
-import { toast } from "sonner"
-import {
-  readPackagingWarnings,
-  describePackagingWarnings,
-} from "@/lib/packaging-warnings"
+import { toastPackagingWarnings } from "@/lib/packaging-warnings"
 import { StageBlockedState } from "@/components/pipeline/components/StageBlockedState"
 import { LoadingState } from "@/components/pipeline/components/LoadingState"
 import { useAllPagesPruned } from "@/hooks/use-all-pages-pruned"
@@ -167,11 +163,7 @@ export function PreviewView({ bookLabel }: { bookLabel: string }) {
         // Packaging skips rendered sections it cannot resolve a sectionId for.
         // The bundle is short but the task still succeeds, so without this the
         // omission is invisible.
-        const omitted = describePackagingWarnings(
-          readPackagingWarnings(task.result),
-          i18n,
-        )
-        if (omitted) toast.warning(omitted)
+        toastPackagingWarnings(task.result, i18n)
       })
     } else if (task.status === "failed") {
       setPendingTaskId(null)
@@ -216,12 +208,15 @@ export function PreviewView({ bookLabel }: { bookLabel: string }) {
         ])
         setVersion(result.version ?? createPreviewVersion())
         setReady(true)
+        // A cache hit replays the warnings of the build that produced the
+        // bundle on disk, so this branch omits exactly as much as the task one.
+        toastPackagingWarnings(result, i18n)
       }
     } catch (e) {
       setError(e instanceof Error ? e.message : "Packaging failed")
       setIsSubmittingPackage(false)
     }
-  }, [bookLabel, queryClient])
+  }, [bookLabel, queryClient, i18n])
 
   // Only trigger packaging when storyboard is done
   useEffect(() => {

--- a/apps/studio/src/components/pipeline/stages/ValidationView.test.tsx
+++ b/apps/studio/src/components/pipeline/stages/ValidationView.test.tsx
@@ -9,6 +9,7 @@ const useSearchMock = vi.fn(() => ({ tab: "accessibility-summary" }))
 const reviewerCatalogMock = vi.fn(() => ({ data: { enabled: false }, isLoading: false, error: null }))
 const isTaskRunningMock = vi.fn(() => false)
 const getTaskMock = vi.fn(() => undefined)
+const warningToastMock = vi.fn()
 
 vi.mock("@tanstack/react-router", () => ({
   useNavigate: () => navigateMock,
@@ -26,8 +27,22 @@ vi.mock("@lingui/react/macro", () => ({
       }
       return text
     },
+    i18n: { _: (descriptor: { id?: string }) => descriptor.id ?? "" },
   }),
 }))
+
+vi.mock("@lingui/core/macro", () => ({
+  msg(strings: TemplateStringsArray, ...values: unknown[]) {
+    let text = ""
+    for (let index = 0; index < strings.length; index += 1) {
+      text += strings[index]
+      if (index < values.length) text += String(values[index])
+    }
+    return { id: text }
+  },
+}))
+
+vi.mock("sonner", () => ({ toast: { warning: (message: string) => warningToastMock(message) } }))
 
 vi.mock("@/api/client", () => ({
   api: {
@@ -109,5 +124,30 @@ describe("ValidationView", () => {
     await waitFor(() => expect(screen.getByText("Accessibility Summary")).toBeTruthy())
 
     expect(screen.getByText(/accessibility-summary:demo-book/)).toBeTruthy()
+  })
+
+  it("warns when the bundle it validates is missing content", async () => {
+    // Validation reports on the packaged bundle, so it has to repeat what
+    // packaging left out — a clean validation over a short bundle reads as
+    // "the book is fine".
+    packageAdtMock.mockResolvedValue({
+      status: "completed",
+      label: "demo-book",
+      warnings: [{ kind: "orphaned-rendering", pageId: "pg002", sectionIndex: 1 }],
+    } as never)
+
+    const { ValidationView } = await import("./ValidationView")
+    render(<ValidationView bookLabel="demo-book" />)
+
+    await waitFor(() => expect(warningToastMock).toHaveBeenCalledTimes(1))
+    expect(String(warningToastMock.mock.calls[0][0])).toContain("pg002")
+  })
+
+  it("stays quiet when packaging left nothing out", async () => {
+    const { ValidationView } = await import("./ValidationView")
+    render(<ValidationView bookLabel="demo-book" />)
+
+    await waitFor(() => expect(packageAdtMock).toHaveBeenCalledWith("demo-book"))
+    expect(warningToastMock).not.toHaveBeenCalled()
   })
 })

--- a/apps/studio/src/components/pipeline/stages/ValidationView.tsx
+++ b/apps/studio/src/components/pipeline/stages/ValidationView.tsx
@@ -8,6 +8,7 @@ import { Trans, useLingui } from "@lingui/react/macro"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Button } from "@/components/ui/button"
 import { api } from "@/api/client"
+import { toastPackagingWarnings } from "@/lib/packaging-warnings"
 import { useBookRun } from "@/hooks/use-book-run"
 import { useBookTasks } from "@/hooks/use-book-tasks"
 import { AccessibilityOverviewTab } from "@/components/validation/AccessibilityValidationTabs"
@@ -27,7 +28,7 @@ function normalizeValidationTab(value: string | undefined) {
 }
 
 export function ValidationView({ bookLabel }: { bookLabel: string }) {
-  const { t } = useLingui()
+  const { t, i18n } = useLingui()
   const navigate = useNavigate()
   const search = useSearch({ strict: false }) as { tab?: string }
   const { stageState, isStatusLoading } = useBookRun()
@@ -56,6 +57,10 @@ export function ValidationView({ bookLabel }: { bookLabel: string }) {
         setPendingPackagingTaskId(taskId)
         return
       }
+      // Packaged inline (cache hit). Validation reports on the bundle, so
+      // anything left out of it has to be said out loud here too — otherwise a
+      // clean validation reads as "the book is fine" over a short bundle.
+      toastPackagingWarnings(result, i18n)
     } catch (e) {
       setError(e instanceof Error ? e.message : t`Packaging failed`)
     } finally {
@@ -63,7 +68,7 @@ export function ValidationView({ bookLabel }: { bookLabel: string }) {
         setIsSubmittingPackage(false)
       }
     }
-  }, [bookLabel, t])
+  }, [bookLabel, t, i18n])
 
   useEffect(() => {
     if (!storyboardDone || ranRef.current) return
@@ -80,12 +85,13 @@ export function ValidationView({ bookLabel }: { bookLabel: string }) {
     if (task.status === "completed") {
       setPendingPackagingTaskId(null)
       setIsSubmittingPackage(false)
+      toastPackagingWarnings(task.result, i18n)
     } else if (task.status === "failed") {
       setError(task.error ?? t`Packaging failed`)
       setPendingPackagingTaskId(null)
       setIsSubmittingPackage(false)
     }
-  }, [getTask, pendingPackagingTaskId, t])
+  }, [getTask, pendingPackagingTaskId, t, i18n])
 
   if (isStatusLoading || prunedLoading) {
     return <LoadingState stageSlug="validation" label={<Trans>Loading validation...</Trans>} />

--- a/apps/studio/src/components/pipeline/stages/languages/lib/catalog-entries.ts
+++ b/apps/studio/src/components/pipeline/stages/languages/lib/catalog-entries.ts
@@ -10,12 +10,12 @@
 import {
   getTextCatalogCategory,
   isTtsExcluded,
+  sectionIdOfAnswerTextId,
   type TextCatalogCategory,
   type TtsExclusionConfig,
 } from "@adt/types"
 
 const IMAGE_ID_RE = /_im\d{3}/
-const ANSWER_ID_RE = /_ans_/
 const GLOSSARY_ID_RE = /^gl(?:\d{3}|_manual_)/
 const EASY_READ_ID_RE = /_easy_read$/
 
@@ -26,7 +26,10 @@ export function isImageEntry(id: string): boolean {
 }
 
 export function isAnswerEntry(id: string): boolean {
-  return ANSWER_ID_RE.test(id)
+  // Shares @adt/types' definition rather than a local regex: answer ids are the
+  // one catalog id derived from a sectionId, and retirement resolves the owner
+  // with the same function.
+  return sectionIdOfAnswerTextId(id) !== null
 }
 
 export function isGlossaryEntry(id: string): boolean {

--- a/apps/studio/src/components/pipeline/stages/sectioning/SectioningPageDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/sectioning/SectioningPageDetail.tsx
@@ -228,9 +228,9 @@ export function SectioningPageDetail({
 
   /**
    * Gate for the server-side structural ops (split / duplicate / merge /
-   * cross-page merge / delete). They apply immediately and rewrite sectionIds,
-   * so they are confirmed first — and, like the save, they invalidate the
-   * storyboard chain, which the dialog spells out.
+   * cross-page merge / delete). They apply immediately and restructure the
+   * section list, so they are confirmed first — and, like the save, they
+   * invalidate the storyboard chain, which the dialog spells out.
    */
   const requestStructuralOp = useCallback(
     (op: PendingOp) => {
@@ -285,8 +285,8 @@ export function SectioningPageDetail({
       : undefined,
   })
 
-  // Server-side structural ops (merge/split/clone/delete) rewrite sectionIds,
-  // so they are blocked while there are unsaved local edits.
+  // Server-side structural ops (merge/split/clone/delete) rewrite the stored
+  // section list, so they are blocked while there are unsaved local edits.
   const structuralDisabled = saving || structuralBusy || dirty
 
   const runStructural = useCallback(
@@ -546,8 +546,8 @@ export function SectioningPageDetail({
                   textRoles={textTypes}
                   containerStructures={groupTypes}
                   disabled={saving || structuralBusy}
-                  // A split is a server-side op that rewrites sectionIds, so it
-                  // can't run over unsaved local edits. Disable it visibly
+                  // A split is a server-side op that rewrites the stored section
+                  // list, so it can't run over unsaved local edits. Disable it visibly
                   // rather than failing with an easily-missed inline error.
                   splitDisabledReason={
                     dirty

--- a/apps/studio/src/components/pipeline/stages/sign-language/SignLanguageLandingPage.tsx
+++ b/apps/studio/src/components/pipeline/stages/sign-language/SignLanguageLandingPage.tsx
@@ -369,8 +369,16 @@ export function SignLanguageLandingPage({ bookLabel }: { bookLabel: string }) {
                         <span className="text-[10px] font-semibold uppercase tracking-wider text-cyan-700">
                           <Trans>Next missing section</Trans>
                         </span>
-                        <span className="truncate text-[13px] font-semibold text-[#0a0a0a]">
-                          {nextMissing.sectionLabel}
+                        <span className="flex items-baseline gap-1.5">
+                          <span className="truncate text-[13px] font-semibold text-[#0a0a0a]">
+                            {nextMissing.sectionLabel}
+                          </span>
+                          {/* Keeps the two spans from running together in the
+                              accessible name; not rendered as layout. */}
+                          {" "}
+                          <span className="shrink-0 font-mono text-[10px] font-normal text-[#737373]">
+                            {nextMissing.sectionId}
+                          </span>
                         </span>
                       </span>
                       <Plus

--- a/apps/studio/src/components/pipeline/stages/sign-language/components/ManageSectionsDialog.tsx
+++ b/apps/studio/src/components/pipeline/stages/sign-language/components/ManageSectionsDialog.tsx
@@ -152,6 +152,7 @@ export function ManageSectionsDialog({
                       <SectionRow
                         bookLabel={bookLabel}
                         label={section.sectionLabel}
+                        sectionId={section.sectionId}
                         video={videoBySection.get(section.sectionId) ?? null}
                         onUpload={() => onUploadForSection(section.sectionId)}
                         onUnassign={(videoId) => onAssign(videoId, null)}

--- a/apps/studio/src/components/pipeline/stages/sign-language/components/SectionAssignmentCombobox.test.tsx
+++ b/apps/studio/src/components/pipeline/stages/sign-language/components/SectionAssignmentCombobox.test.tsx
@@ -23,8 +23,9 @@ describe("SectionAssignmentCombobox", () => {
     const onAssign = vi.fn()
     const sections = Array.from({ length: 100 }, (_, index) => {
       const pageNumber = index + 1
+      const pageId = `pg${String(pageNumber).padStart(3, "0")}`
       return {
-        sectionId: `page-${pageNumber}`,
+        sectionId: `${pageId}_sec001`,
         sectionIndex: 0,
         pageNumber,
         pageLabel: `Page ${pageNumber}`,
@@ -38,9 +39,48 @@ describe("SectionAssignmentCombobox", () => {
     fireEvent.change(screen.getByPlaceholderText("Search sections"), {
       target: { value: "100" },
     })
-    fireEvent.click(screen.getByRole("option", { name: "Page 100" }))
+    // Each option names its section id alongside the positional label.
+    fireEvent.click(screen.getByRole("option", { name: "Page 100 pg100_sec001" }))
 
-    expect(onAssign).toHaveBeenCalledWith("page-100")
+    expect(onAssign).toHaveBeenCalledWith("pg100_sec001")
     expect(screen.queryByPlaceholderText("Search sections")).toBeNull()
+  })
+
+  it("tells same-page sections apart by id, which the position label cannot", () => {
+    // Ids are allocated once and never reused, so a page's sections are not
+    // numbered contiguously — "Section 2" here is `_sec005`. Without the id on
+    // the option there is nothing on screen distinguishing these two rows
+    // except an ordinal that does not match the id it assigns.
+    const onAssign = vi.fn()
+    const sections = [
+      {
+        sectionId: "pg003_sec001",
+        sectionIndex: 0,
+        pageNumber: 3,
+        pageLabel: "Page 3",
+        sectionLabel: "Page 3 — Section 1",
+      },
+      {
+        sectionId: "pg003_sec005",
+        sectionIndex: 1,
+        pageNumber: 3,
+        pageLabel: "Page 3",
+        sectionLabel: "Page 3 — Section 2",
+      },
+    ]
+
+    render(<SectionAssignmentCombobox sections={sections} onAssign={onAssign} />)
+
+    fireEvent.click(screen.getByRole("button", { name: "Assign..." }))
+    expect(screen.getByRole("option", { name: "Page 3 — Section 1 pg003_sec001" })).toBeTruthy()
+    expect(screen.getByRole("option", { name: "Page 3 — Section 2 pg003_sec005" })).toBeTruthy()
+
+    // Searching by the id reaches the section whose ordinal does not match it.
+    fireEvent.change(screen.getByPlaceholderText("Search sections"), {
+      target: { value: "sec005" },
+    })
+    fireEvent.click(screen.getByRole("option", { name: "Page 3 — Section 2 pg003_sec005" }))
+
+    expect(onAssign).toHaveBeenCalledWith("pg003_sec005")
   })
 })

--- a/apps/studio/src/components/pipeline/stages/sign-language/components/SectionAssignmentCombobox.tsx
+++ b/apps/studio/src/components/pipeline/stages/sign-language/components/SectionAssignmentCombobox.tsx
@@ -112,6 +112,19 @@ export function SectionAssignmentCombobox({
               className="flex w-full items-center gap-2 rounded px-2 py-1.5 pl-8 text-left text-[12px] transition-colors hover:bg-accent focus-visible:bg-accent focus-visible:outline-none"
             >
               <span className="truncate">{section.sectionLabel}</span>
+              {/* A whitespace-only text node between flex items is not
+                  rendered, so this changes no layout — but without it the
+                  accessible name runs the two spans together as
+                  "Page 3 — Section 2pg003_sec005". */}
+              {" "}
+              {/* The label counts positions ("Section 2"); the id does not —
+                  ids are allocated once and never reused, so after a split or
+                  delete `Section 2` may well be `_sec005`. Showing it is what
+                  lets someone tell two sections apart, match a video back to
+                  the section it was pinned to, and search by id. */}
+              <span className="ml-auto shrink-0 font-mono text-[10px] text-muted-foreground">
+                {section.sectionId}
+              </span>
             </button>
           ))}
           {matchingSections.length === 0 ? (

--- a/apps/studio/src/components/pipeline/stages/sign-language/components/SectionRow.tsx
+++ b/apps/studio/src/components/pipeline/stages/sign-language/components/SectionRow.tsx
@@ -7,6 +7,7 @@ import type { SignLanguageVideo } from "@/api/client"
 export function SectionRow({
   bookLabel,
   label,
+  sectionId,
   video,
   onUpload,
   onUnassign,
@@ -17,6 +18,9 @@ export function SectionRow({
 }: {
   bookLabel: string
   label: ReactNode
+  /** Shown beside the label so a row names the section a video is pinned to,
+   *  not just its position on the page. */
+  sectionId: string
   video: SignLanguageVideo | null
   onUpload: () => void
   onUnassign: (videoId: string) => void
@@ -29,8 +33,16 @@ export function SectionRow({
 
   return (
     <div className="flex items-center gap-2 bg-white px-2.5 py-2 transition-colors hover:bg-[#fafafa]">
-      <span className="min-w-0 flex-1 truncate text-[12.5px] font-medium text-[#0a0a0a]">
-        {label}
+      <span className="flex min-w-0 flex-1 items-baseline gap-1.5">
+        <span className="truncate text-[12.5px] font-medium text-[#0a0a0a]">
+          {label}
+        </span>
+        {/* Whitespace between flex items is not rendered, so this costs no
+            layout but keeps the accessible name from running together. */}
+        {" "}
+        <span className="shrink-0 font-mono text-[10px] text-[#a3a3a3]">
+          {sectionId}
+        </span>
       </span>
 
       {video ? (

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/SectioningOverview.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/SectioningOverview.tsx
@@ -889,8 +889,10 @@ function SectionDetail({
     onInvalidatePages(pageId)
   }, [bookLabel, pageId, sectionIndex, queryClient, onInvalidatePages])
 
-  const sectionFilename = `${pageId}_sec${String(sectionIndex + 1).padStart(3, "0")}.html`
-  const previewSrc = `${BASE_URL}/books/${bookLabel}/adt-preview/${sectionFilename}?embed=1&v=${renderingVersion ?? 0}`
+  // The sectionId names the section's HTML file. Ids are allocated once and
+  // never reused, so one cannot be derived from the array index — after a
+  // split/clone/delete a positional guess resolves to a *different* section.
+  const previewSrc = `${BASE_URL}/books/${bookLabel}/adt-preview/${section.sectionId}.html?embed=1&v=${renderingVersion ?? 0}`
 
   return (
     <div className="space-y-3">

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardSectionDetail.tsx
@@ -2665,6 +2665,13 @@ export function StoryboardSectionDetail({
           ? "classic-activity"
           : "book-frame"
 
+  // The sectionId names the section's HTML file in adt-preview and in every
+  // bundle. Ids are allocated once and never reused, so one cannot be derived
+  // from the array index — after a split/clone/delete a positional guess
+  // resolves to a *different* section. Always set where it is read: every
+  // preview mode that uses it requires `section`.
+  const previewSectionId = section?.sectionId
+
   return (
     <>
     {headerSlotEl && createPortal(headerControls, headerSlotEl)}
@@ -2847,7 +2854,7 @@ export function StoryboardSectionDetail({
                   )}
                 <StepperActivityPreview
                   key={`stepper-${sectionIndex}-${editableVersion}`}
-                  src={`${BASE_URL}/books/${bookLabel}/adt-preview/${pageId}_sec${String(sectionIndex + 1).padStart(3, "0")}.html?embed=1&v=ea${editableVersion}`}
+                  src={`${BASE_URL}/books/${bookLabel}/adt-preview/${previewSectionId}.html?embed=1&v=ea${editableVersion}`}
                   deviceView={deviceView}
                 />
               </>
@@ -2862,7 +2869,7 @@ export function StoryboardSectionDetail({
                 )}
                 <StepperActivityPreview
                   key={`classic-${sectionIndex}-${page.versions.rendering ?? 0}`}
-                  src={`${BASE_URL}/books/${bookLabel}/adt-preview/${pageId}_sec${String(sectionIndex + 1).padStart(3, "0")}.html?embed=1&v=${page.versions.rendering ?? 0}`}
+                  src={`${BASE_URL}/books/${bookLabel}/adt-preview/${previewSectionId}.html?embed=1&v=${page.versions.rendering ?? 0}`}
                   deviceView={deviceView}
                 />
               </>

--- a/apps/studio/src/hooks/use-export-watcher.ts
+++ b/apps/studio/src/hooks/use-export-watcher.ts
@@ -3,7 +3,12 @@ import type { I18n } from "@lingui/core"
 import { msg } from "@lingui/core/macro"
 import { useLingui } from "@lingui/react"
 import { useMutation } from "@tanstack/react-query"
+import { toast } from "sonner"
 import { api } from "@/api/client"
+import {
+  readPackagingWarnings,
+  describePackagingWarnings,
+} from "@/lib/packaging-warnings"
 import { isElectron } from "@/lib/utils"
 import { useBookTasks } from "./use-book-tasks"
 import type { ExportFeatureToggles } from "./use-export-features"
@@ -65,6 +70,14 @@ export function useExportWatcherSetup(label: string): ExportWatcherValue {
     if (task.status === "completed") {
       const format = pendingExport.format
       setPendingExport(null)
+      // The rebuild skips rendered sections whose sectionId cannot be
+      // resolved. The export still succeeds, so warn before the download
+      // starts rather than handing over a quietly short bundle.
+      const omitted = describePackagingWarnings(
+        readPackagingWarnings(task.result),
+        i18n,
+      )
+      if (omitted) toast.warning(omitted)
       runDownload(format)
     } else if (task.status === "failed") {
       setError({

--- a/apps/studio/src/hooks/use-export-watcher.ts
+++ b/apps/studio/src/hooks/use-export-watcher.ts
@@ -3,12 +3,8 @@ import type { I18n } from "@lingui/core"
 import { msg } from "@lingui/core/macro"
 import { useLingui } from "@lingui/react"
 import { useMutation } from "@tanstack/react-query"
-import { toast } from "sonner"
 import { api } from "@/api/client"
-import {
-  readPackagingWarnings,
-  describePackagingWarnings,
-} from "@/lib/packaging-warnings"
+import { toastPackagingWarnings } from "@/lib/packaging-warnings"
 import { isElectron } from "@/lib/utils"
 import { useBookTasks } from "./use-book-tasks"
 import type { ExportFeatureToggles } from "./use-export-features"
@@ -73,11 +69,7 @@ export function useExportWatcherSetup(label: string): ExportWatcherValue {
       // The rebuild skips rendered sections whose sectionId cannot be
       // resolved. The export still succeeds, so warn before the download
       // starts rather than handing over a quietly short bundle.
-      const omitted = describePackagingWarnings(
-        readPackagingWarnings(task.result),
-        i18n,
-      )
-      if (omitted) toast.warning(omitted)
+      toastPackagingWarnings(task.result, i18n)
       runDownload(format)
     } else if (task.status === "failed") {
       setError({
@@ -103,6 +95,9 @@ export function useExportWatcherSetup(label: string): ExportWatcherValue {
       if (result.taskId) {
         setPendingExport({ taskId: result.taskId, format, features })
       } else {
+        // Prepared inline, so the warnings are on the response rather than a
+        // task result — same omissions, and the download is about to start.
+        toastPackagingWarnings(result, i18n)
         runDownload(format)
       }
     },

--- a/apps/studio/src/lib/packaging-warnings.test.ts
+++ b/apps/studio/src/lib/packaging-warnings.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+// The Lingui macros are compile-time; the root vitest config does not load the
+// plugin, so stand them in the way the other studio unit tests do.
+vi.mock("@lingui/core/macro", () => ({
+  msg(strings: TemplateStringsArray, ...values: unknown[]) {
+    let text = ""
+    for (let i = 0; i < strings.length; i += 1) {
+      text += strings[i]
+      if (i < values.length) text += String(values[i])
+    }
+    return { id: text }
+  },
+}))
+
+const { warningToast } = vi.hoisted(() => ({ warningToast: vi.fn() }))
+vi.mock("sonner", () => ({ toast: { warning: warningToast } }))
+
+const { readPackagingWarnings, toastPackagingWarnings } = await import("./packaging-warnings")
+
+const i18n = { _: (d: { id?: string }) => d.id ?? "" } as never
+const orphan = { kind: "orphaned-rendering", pageId: "pg002", sectionIndex: 1 }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("readPackagingWarnings", () => {
+  it("reads warnings off a task result or a synchronous response alike", () => {
+    // Both channels carry the same field; the caller should not have to know
+    // which one answered.
+    expect(readPackagingWarnings({ warnings: [orphan] })).toEqual([orphan])
+    expect(readPackagingWarnings({ status: "completed", warnings: [orphan] })).toEqual([orphan])
+  })
+
+  it("returns nothing rather than throwing on results that carry no warnings", () => {
+    // Older task records and task kinds that never had the field.
+    expect(readPackagingWarnings(undefined)).toEqual([])
+    expect(readPackagingWarnings(null)).toEqual([])
+    expect(readPackagingWarnings({})).toEqual([])
+    expect(readPackagingWarnings({ warnings: "not-an-array" })).toEqual([])
+  })
+})
+
+describe("toastPackagingWarnings", () => {
+  it("names the affected pages when something was left out", () => {
+    toastPackagingWarnings({ warnings: [orphan] }, i18n)
+
+    expect(warningToast).toHaveBeenCalledTimes(1)
+    expect(String(warningToast.mock.calls[0][0])).toContain("pg002")
+  })
+
+  it("stays silent on a clean run", () => {
+    toastPackagingWarnings({ warnings: [] }, i18n)
+    toastPackagingWarnings({ status: "completed" }, i18n)
+
+    expect(warningToast).not.toHaveBeenCalled()
+  })
+})

--- a/apps/studio/src/lib/packaging-warnings.ts
+++ b/apps/studio/src/lib/packaging-warnings.ts
@@ -1,0 +1,39 @@
+import type { I18n } from "@lingui/core"
+import { msg } from "@lingui/core/macro"
+import { PackagingWarning } from "@adt/types"
+
+/**
+ * Pull the packaging warnings out of a task result.
+ *
+ * Packaging and export both report what they had to leave out of the bundle
+ * through the task result. Reading it defensively (rather than asserting the
+ * shape) keeps an older task record — or a task kind that carries no warnings —
+ * from throwing here.
+ */
+export function readPackagingWarnings(result: unknown): PackagingWarning[] {
+  if (typeof result !== "object" || result === null) return []
+  const parsed = PackagingWarning.array().safeParse(
+    (result as { warnings?: unknown }).warnings,
+  )
+  return parsed.success ? parsed.data : []
+}
+
+/**
+ * A single sentence naming what was omitted and how to fix it, or null when
+ * nothing was.
+ *
+ * The warnings arrive as data because they are produced in `@adt/pipeline`,
+ * which has no access to these catalogs — the wording belongs here.
+ */
+export function describePackagingWarnings(
+  warnings: PackagingWarning[],
+  i18n: I18n,
+): string | null {
+  if (warnings.length === 0) return null
+
+  const pages = [...new Set(warnings.map((w) => w.pageId))].sort()
+  const pageList = pages.join(", ")
+  return i18n._(
+    msg`Some content was left out of the bundle: ${warnings.length} rendered section(s) on ${pageList} have no sectioning row, so they could not be included. Re-run the storyboard render for those pages, then package again.`,
+  )
+}

--- a/apps/studio/src/lib/packaging-warnings.ts
+++ b/apps/studio/src/lib/packaging-warnings.ts
@@ -1,14 +1,17 @@
 import type { I18n } from "@lingui/core"
 import { msg } from "@lingui/core/macro"
+import { toast } from "sonner"
 import { PackagingWarning } from "@adt/types"
 
 /**
- * Pull the packaging warnings out of a task result.
+ * Pull the packaging warnings out of a task result or a synchronous response.
  *
- * Packaging and export both report what they had to leave out of the bundle
- * through the task result. Reading it defensively (rather than asserting the
- * shape) keeps an older task record — or a task kind that carries no warnings —
- * from throwing here.
+ * Packaging and export report what they had to leave out of the bundle through
+ * whichever channel the caller used — `task.result` when the work was queued,
+ * the response body when a cache hit answered inline — and both carry the same
+ * `warnings` field. Reading it defensively (rather than asserting the shape)
+ * keeps an older task record, or a task kind that carries no warnings, from
+ * throwing here.
  */
 export function readPackagingWarnings(result: unknown): PackagingWarning[] {
   if (typeof result !== "object" || result === null) return []
@@ -36,4 +39,16 @@ export function describePackagingWarnings(
   return i18n._(
     msg`Some content was left out of the bundle: ${warnings.length} rendered section(s) on ${pageList} have no sectioning row, so they could not be included. Re-run the storyboard render for those pages, then package again.`,
   )
+}
+
+/**
+ * Warn the user about anything packaging omitted, from any completion channel.
+ *
+ * Every path that packages has to call this. A short bundle is not an error —
+ * the run succeeds and the download starts — so an unread `warnings` field is
+ * indistinguishable to the user from a clean build.
+ */
+export function toastPackagingWarnings(source: unknown, i18n: I18n): void {
+  const omitted = describePackagingWarnings(readPackagingWarnings(source), i18n)
+  if (omitted) toast.warning(omitted)
 }

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -8966,6 +8966,10 @@ msgstr "Software update status"
 msgid "Some books are mostly single pages but have a few illustrations that run across two facing pages. Choose Single here — then, after extraction, the Extract view detects those spreads and lets you merge just those pairs while every other page stays on its own."
 msgstr "Some books are mostly single pages but have a few illustrations that run across two facing pages. Choose Single here — then, after extraction, the Extract view detects those spreads and lets you merge just those pairs while every other page stays on its own."
 
+#. placeholder {0}: warnings.length
+msgid "Some content was left out of the bundle: {0} rendered section(s) on {pageList} have no sectioning row, so they could not be included. Re-run the storyboard render for those pages, then package again."
+msgstr "Some content was left out of the bundle: {0} rendered section(s) on {pageList} have no sectioning row, so they could not be included. Re-run the storyboard render for those pages, then package again."
+
 msgid "Some pages have no embedded text layer — text was recovered from the page image. Prefer a text-based PDF."
 msgstr "Some pages have no embedded text layer — text was recovered from the page image. Prefer a text-based PDF."
 

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -8966,6 +8966,10 @@ msgstr "Estado de la actualización de software"
 msgid "Some books are mostly single pages but have a few illustrations that run across two facing pages. Choose Single here — then, after extraction, the Extract view detects those spreads and lets you merge just those pairs while every other page stays on its own."
 msgstr "Algunos libros son principalmente de páginas individuales pero tienen algunas ilustraciones que abarcan dos páginas enfrentadas. Elige Individual aquí — luego, después de la extracción, la vista de Extracción detecta esas dobles páginas y te permite fusionar solo esos pares mientras que cada otra página permanece por su cuenta."
 
+#. placeholder {0}: warnings.length
+msgid "Some content was left out of the bundle: {0} rendered section(s) on {pageList} have no sectioning row, so they could not be included. Re-run the storyboard render for those pages, then package again."
+msgstr "Parte del contenido quedó fuera del paquete: {0} sección(es) renderizada(s) en {pageList} no tienen fila de seccionamiento, por lo que no se pudieron incluir. Vuelve a ejecutar la renderización del storyboard para esas páginas y empaqueta de nuevo."
+
 msgid "Some pages have no embedded text layer — text was recovered from the page image. Prefer a text-based PDF."
 msgstr "Algunas páginas no tienen capa de texto incrustado — el texto se recuperó a partir de la imagen de la página. Usa preferentemente un PDF basado en texto."
 

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -8968,6 +8968,10 @@ msgstr "Statut de la mise à jour logicielle"
 msgid "Some books are mostly single pages but have a few illustrations that run across two facing pages. Choose Single here — then, after extraction, the Extract view detects those spreads and lets you merge just those pairs while every other page stays on its own."
 msgstr "Certains livres sont principalement composés de pages simples mais ont quelques illustrations qui s'étendent sur deux pages en vis-à-vis. Choisissez Simple ici — puis, après l'extraction, la vue d'extraction détecte ces fusions et vous permet de fusionner uniquement ces paires tandis que chaque autre page reste seule."
 
+#. placeholder {0}: warnings.length
+msgid "Some content was left out of the bundle: {0} rendered section(s) on {pageList} have no sectioning row, so they could not be included. Re-run the storyboard render for those pages, then package again."
+msgstr "Une partie du contenu a été exclue du paquet : {0} section(s) rendue(s) sur {pageList} n'ont pas de ligne de sectionnement et n'ont donc pas pu être incluses. Relancez le rendu du storyboard pour ces pages, puis empaquetez à nouveau."
+
 msgid "Some pages have no embedded text layer — text was recovered from the page image. Prefer a text-based PDF."
 msgstr "Certaines pages n'ont pas de couche de texte intégrée — le texte a été récupéré à partir de l'image de la page. Préférez un PDF basé sur du texte."
 

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -8966,6 +8966,10 @@ msgstr "Status da atualização de software"
 msgid "Some books are mostly single pages but have a few illustrations that run across two facing pages. Choose Single here — then, after extraction, the Extract view detects those spreads and lets you merge just those pairs while every other page stays on its own."
 msgstr "Alguns livros são principalmente de páginas únicas, mas têm algumas ilustrações que se estendem por duas páginas opostas. Escolha Único aqui — então, após a extração, a visualização de Extração detecta esses spreads e permite que você mescle apenas esses pares enquanto todas as outras páginas permanecem sozinhas."
 
+#. placeholder {0}: warnings.length
+msgid "Some content was left out of the bundle: {0} rendered section(s) on {pageList} have no sectioning row, so they could not be included. Re-run the storyboard render for those pages, then package again."
+msgstr "Parte do conteúdo ficou fora do pacote: {0} seção(ões) renderizada(s) em {pageList} não têm linha de seccionamento, portanto não puderam ser incluídas. Execute novamente a renderização do storyboard para essas páginas e empacote de novo."
+
 msgid "Some pages have no embedded text layer — text was recovered from the page image. Prefer a text-based PDF."
 msgstr "Algumas páginas não têm camada de texto incorporada — o texto foi recuperado a partir da imagem da página. Prefira um PDF baseado em texto."
 

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -8968,6 +8968,10 @@ msgstr "Gjendja e përditësimit të softuerit"
 msgid "Some books are mostly single pages but have a few illustrations that run across two facing pages. Choose Single here — then, after extraction, the Extract view detects those spreads and lets you merge just those pairs while every other page stays on its own."
 msgstr "Disa libra janë kryesisht faqe të vetme, por kanë disa ilustrime që shtrihen në dy faqe përballë. Zgjidhni e Vetme këtu — pastaj, pas ekstraktimit, pamja e Ekstraktit zbulon ato faqe të përbashkëta dhe ju lejon të bashkoni vetëm ato çifte ndërsa çdo faqe tjetër mbetet më vete."
 
+#. placeholder {0}: warnings.length
+msgid "Some content was left out of the bundle: {0} rendered section(s) on {pageList} have no sectioning row, so they could not be included. Re-run the storyboard render for those pages, then package again."
+msgstr "Një pjesë e përmbajtjes u lë jashtë paketës: {0} seksion(e) të vizatuar(a) në {pageList} nuk kanë rresht seksionimi, kështu që nuk mund të përfshihen. Ekzekutoni përsëri vizatimin e storyboard-it për ato faqe, pastaj paketoni sërish."
+
 msgid "Some pages have no embedded text layer — text was recovered from the page image. Prefer a text-based PDF."
 msgstr "Disa faqe nuk kanë shtresë teksti të integruar — teksti u rikuperua nga imazhi i faqes. Preferoni një PDF të bazuar në tekst."
 

--- a/packages/agents/src/__tests__/book-tools.test.ts
+++ b/packages/agents/src/__tests__/book-tools.test.ts
@@ -96,13 +96,15 @@ describe("createCustomSection — sectionIndex assignment", () => {
 
     expect(res.ok).toBe(true)
     expect(res.sectionIndex).toBe(3)
-    expect(res.sectionId).toBe("pg001_s3")
+    // The index is positional; the id is allocated above the page's high-water
+    // mark (`_sec002`), so the two deliberately do not match.
+    expect(res.sectionId).toBe("pg001_sec003")
 
     // The new section is appended to sectioning at index 3 (no overwrite).
     const sectioning = storage.getLatestNodeData("page-sectioning", pageId)!
       .data as { sections: Array<{ sectionId: string }> }
     expect(sectioning.sections).toHaveLength(4)
-    expect(sectioning.sections[3]?.sectionId).toBe("pg001_s3")
+    expect(sectioning.sections[3]?.sectionId).toBe("pg001_sec003")
 
     // And the rendering keeps a single section at index 2 — the append did not
     // collide with the pre-existing section.
@@ -158,5 +160,113 @@ describe("createCustomSection — sectionIndex assignment", () => {
     expect(res.error).toMatch(/<script>/)
     // Nothing was written.
     expect(touchedPageIds.has(pageId)).toBe(false)
+  })
+})
+
+describe("createCustomSection — sectionId allocation", () => {
+  /** Append one custom activity section to `pageId`, returning its new id. */
+  async function createSection(
+    storage: ReturnType<typeof tempStorage>,
+    pageId: string,
+  ): Promise<string> {
+    const { tools } = createBookTools({
+      storage,
+      bookLabel: "test-book",
+      booksDir: "",
+      promptsDir: "",
+      credentials: {},
+      restrictWritesToPageId: pageId,
+      activityMode: "custom",
+    })
+    const execute = tools.createCustomSection!.execute as (
+      args: unknown,
+      options: unknown,
+    ) => Promise<{ ok: boolean; sectionId: string; error?: string }>
+    const res = await execute(
+      {
+        pageId,
+        sectionType: "activity_custom_test",
+        html: `<section data-section-type="activity_custom_test"><p>Q</p><script>window.adtRegisterCustomActivity(document.currentScript.closest('section'),{validate:()=>true});</script></section>`,
+        reasoning: "test",
+        activityAnswers: null,
+      },
+      {},
+    )
+    expect(res.error).toBeUndefined()
+    expect(res.ok).toBe(true)
+    return res.sectionId
+  }
+
+  it("does not reissue an id after a deletion leaves a gap in the array", async () => {
+    const storage = tempStorage()
+    const pageId = "pg001"
+    storage.putNodeData("page-sectioning", pageId, {
+      reasoning: "seed",
+      sections: [sectioningSection("pg001_sec001", "text_only")],
+    })
+    storage.putNodeData("web-rendering", pageId, {
+      sections: [renderingSection(0, "text_only")],
+    })
+
+    const first = await createSection(storage, pageId)
+    expect(first).toBe("pg001_sec002")
+
+    // Delete the original section the way the structural routes do: splice the
+    // array, leave every survivor's id alone. The array is now length 1 again,
+    // but `_sec002` is spent.
+    const afterCreate = storage.getLatestNodeData("page-sectioning", pageId)!
+      .data as { reasoning: string; sections: Array<{ sectionId: string }> }
+    storage.putNodeData("page-sectioning", pageId, {
+      ...afterCreate,
+      sections: afterCreate.sections.slice(1),
+    })
+
+    // Pre-fix this minted `${pageId}_s1` a second time, because the id came
+    // from `sections.length`. Two sections sharing an id are ambiguous in the
+    // pages manifest and overwrite each other's `${sectionId}.html` on package.
+    const second = await createSection(storage, pageId)
+    expect(second).toBe("pg001_sec003")
+    expect(second).not.toBe(first)
+
+    const sectioning = storage.getLatestNodeData("page-sectioning", pageId)!
+      .data as { sections: Array<{ sectionId: string }> }
+    const ids = sectioning.sections.map((s) => s.sectionId)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it("allocates canonical `_secNNN` ids, so previews and bundles can resolve them", async () => {
+    const storage = tempStorage()
+    const pageId = "pg001"
+    storage.putNodeData("page-sectioning", pageId, {
+      reasoning: "seed",
+      sections: [sectioningSection("pg001_sec001", "text_only")],
+    })
+    storage.putNodeData("web-rendering", pageId, {
+      sections: [renderingSection(0, "text_only")],
+    })
+
+    // The legacy `${pageId}_s${index}` shape does not satisfy the `_sec\d+`
+    // form that adt-preview and the packaging manifest parse, so activities
+    // minted that way were unreachable in preview.
+    expect(await createSection(storage, pageId)).toMatch(/^pg001_sec\d{3}$/)
+  })
+
+  it("counts a legacy `_sN` id already in history, so it is never shadowed", async () => {
+    const storage = tempStorage()
+    const pageId = "pg001"
+    // A page edited before the tools used the factory: `_s2` is spent, and the
+    // canonical high-water mark alone would not see it.
+    storage.putNodeData("page-sectioning", pageId, {
+      reasoning: "seed",
+      sections: [
+        sectioningSection("pg001_sec001", "text_only"),
+        sectioningSection("pg001_s2", "text_only"),
+      ],
+    })
+    storage.putNodeData("web-rendering", pageId, {
+      sections: [renderingSection(0, "text_only"), renderingSection(1, "text_only")],
+    })
+
+    expect(await createSection(storage, pageId)).toBe("pg001_sec003")
   })
 })

--- a/packages/agents/src/layout-mirror.ts
+++ b/packages/agents/src/layout-mirror.ts
@@ -222,10 +222,19 @@ export async function mirrorLayout(
       )
       const sectioning = loadSectioning(storage, target.pageId)
       const oldSection = sectioning.sections[target.sectionIndex]
-      const sectionId =
-        oldSection?.sectionId ?? `${target.pageId}_s${target.sectionIndex}`
+      // sectionIds are allocated once and never reused, so one cannot be
+      // derived from an array position — a guessed id would likely name a
+      // *different* section, and it names this section's HTML file in every
+      // bundle. No sectioning row means rendering and sectioning are out of
+      // sync; say so rather than guess.
+      if (!oldSection) {
+        throw new Error(
+          `Cannot mirror onto section ${target.sectionIndex} of ${target.pageId}: it has a rendering entry but no sectioning row, so its sectionId is unknown. Re-run the storyboard render for this page to bring the two back in sync.`,
+        )
+      }
+      const sectionId = oldSection.sectionId
       const sectionType =
-        targetSection?.sectionType ?? oldSection?.sectionType ?? "content"
+        targetSection?.sectionType ?? oldSection.sectionType ?? "content"
       const newSectioningSection = buildSectioningSectionFromHtml({
         html: cleaned,
         sectionId,

--- a/packages/agents/src/tools/book-tools.ts
+++ b/packages/agents/src/tools/book-tools.ts
@@ -8,6 +8,7 @@ import {
   type PageSectioningSection,
   type SectionRendering,
 } from "@adt/types"
+import { createSectionIdFactory } from "@adt/pipeline"
 import { buildSectioningSectionFromHtml } from "./build-sectioning.js"
 import {
   TEMPLATED_ACTIVITY_TYPES,
@@ -355,8 +356,17 @@ export function createBookTools(ctx: BookToolsContext): BookToolsResult {
           // Refresh the sectioning tree so the edit panel and downstream
           // steps stay in sync with the rewritten HTML.
           const oldSection = sectioning.sections[sectionIndex]
-          const sectionId =
-            oldSection?.sectionId ?? `${pageId}_s${sectionIndex}`
+          // sectionIds are allocated once and never reused, so one cannot be
+          // derived from an array position — a guessed id would likely name a
+          // *different* section, and it names this section's HTML file in every
+          // bundle. With no sectioning row to read the real id from, rendering
+          // and sectioning are out of sync; say so rather than guess.
+          if (!oldSection) {
+            throw new Error(
+              `Cannot update section ${sectionIndex} of ${pageId}: it has a rendering entry but no sectioning row, so its sectionId is unknown. Re-run the storyboard render for this page to bring the two back in sync.`,
+            )
+          }
+          const sectionId = oldSection.sectionId
           const sectionType = found.sectionType
           const newSectioningSection = buildSectioningSectionFromHtml({
             html,
@@ -461,7 +471,11 @@ export function createBookTools(ctx: BookToolsContext): BookToolsResult {
           // section's index. The new section is appended at the end of the
           // sectioning array, so its index is the sectioning array's length.
           const nextIndex = existingSectioning.sections.length
-          const sectionId = `${pageId}_s${nextIndex}`
+          // The *id* is allocated, not derived from the index. `nextIndex` is a
+          // position and gets reused as soon as a delete leaves a gap, so using
+          // it as an id mints a duplicate — and two sections sharing an id
+          // overwrite each other's HTML file when the book is packaged.
+          const sectionId = createSectionIdFactory(ctx.storage, pageId)()
 
           // Promote agent-emitted nodes (no isPruned) to ContentNodeData.
           const promote = (n: ActivityNodeShape): ContentNodeData => ({
@@ -592,7 +606,8 @@ export function createBookTools(ctx: BookToolsContext): BookToolsResult {
           // pruned/empty sections, so basing the index on it collides with an
           // existing section. Append at the sectioning array's length instead.
           const nextIndex = sectioning.sections.length
-          const sectionId = `${pageId}_s${nextIndex}`
+          // Allocated, not derived from the index — see createTemplatedActivity.
+          const sectionId = createSectionIdFactory(ctx.storage, pageId)()
 
           // For custom activities, the script encodes correctness — but we
           // also surface a JSON answer key derived from the markup so the EDIT

--- a/packages/agents/src/tools/render-section.ts
+++ b/packages/agents/src/tools/render-section.ts
@@ -25,7 +25,11 @@ export interface RenderSyntheticActivityInput {
   anchorPageId: string
   /** The section index this activity will occupy after createSection's storage write. */
   sectionIndex: number
-  /** Stable section id, e.g. `${pageId}_s${nextIndex}`. */
+  /**
+   * The section's immutable id, e.g. `pg001_sec004`. Allocate it with
+   * `createSectionIdFactory` from `@adt/pipeline` — never derive it from an
+   * array index, which is reused as soon as a delete leaves a gap.
+   */
   sectionId: string
   sectionType: string
   /** The agent-emitted sectioning nodes. */

--- a/packages/pipeline/src/__tests__/package-web.test.ts
+++ b/packages/pipeline/src/__tests__/package-web.test.ts
@@ -1761,7 +1761,7 @@ describe("packageAdtWeb", () => {
     })
 
     const messages: string[] = []
-    await packageAdtWeb(
+    const result = await packageAdtWeb(
       storage,
       {
         bookDir,
@@ -1785,9 +1785,130 @@ describe("packageAdtWeb", () => {
     ) as Array<{ section_id: string }>
     expect(pageList.map((p) => p.section_id)).toEqual(["pg001_sec001"])
 
+    // The returned warnings are the load-bearing channel: the API packaging and
+    // export flows pass no progress sink at all, and the CLI's sink drops
+    // messages that carry no page counters. A `progress`-only warning reaches
+    // nobody.
+    expect(result.warnings).toEqual([
+      { kind: "orphaned-rendering", pageId: "pg001", sectionIndex: 1 },
+    ])
+
     const warning = messages.find((m) => m.startsWith("Warning:"))
     expect(warning).toContain("skipped 1 rendered section(s) with no sectioning row")
     expect(warning).toContain("pg001[1]")
+  })
+
+  it("reports every section of a page whose sectioning row is missing entirely", async () => {
+    const bookDir = path.join(tmpDir, "book")
+    const webAssetsDir = path.join(tmpDir, "assets-web")
+    fs.mkdirSync(bookDir, { recursive: true })
+    createWebAssets(webAssetsDir)
+
+    const pages: PageData[] = [
+      { pageId: "pg001", pageNumber: 1, text: "Page one" },
+      { pageId: "pg002", pageNumber: 2, text: "Page two" },
+    ]
+
+    // pg002 has a rendering but no sectioning row at all — the shape
+    // `getRenderSectioning` also returns for a row that fails to parse. Every
+    // one of its sections is unpackageable, so the whole page vanishes from the
+    // bundle; that must not be silent.
+    const storage = createMockStorage(pages, {
+      "web-rendering": {
+        pg001: {
+          sections: [
+            { sectionIndex: 0, sectionType: "content", reasoning: "ok", html: "<section><p>Kept</p></section>" },
+          ],
+        },
+        pg002: {
+          sections: [
+            { sectionIndex: 0, sectionType: "content", reasoning: "ok", html: "<section><p>Lost</p></section>" },
+            { sectionIndex: 1, sectionType: "content", reasoning: "ok", html: "<section><p>Also lost</p></section>" },
+          ],
+        },
+      },
+      "page-sectioning": {
+        pg001: {
+          reasoning: "ok",
+          sections: [
+            {
+              sectionId: "pg001_sec001",
+              sectionType: "content",
+              nodes: [],
+              backgroundColor: "#fff",
+              textColor: "#000",
+              pageNumber: 1,
+              isPruned: false,
+            },
+          ],
+        },
+      },
+    })
+
+    const result = await packageAdtWeb(storage, {
+      bookDir,
+      label: "book",
+      language: "en",
+      outputLanguages: ["en"],
+      title: "Book Title",
+      webAssetsDir,
+    })
+
+    const pageList = JSON.parse(
+      fs.readFileSync(path.join(bookDir, "adt", "content", "pages.json"), "utf-8"),
+    ) as Array<{ section_id: string }>
+    expect(pageList.map((p) => p.section_id)).toEqual(["pg001_sec001"])
+
+    expect(result.warnings).toEqual([
+      { kind: "orphaned-rendering", pageId: "pg002", sectionIndex: 0 },
+      { kind: "orphaned-rendering", pageId: "pg002", sectionIndex: 1 },
+    ])
+  })
+
+  it("reports no warnings when rendering and sectioning agree", async () => {
+    const bookDir = path.join(tmpDir, "book")
+    const webAssetsDir = path.join(tmpDir, "assets-web")
+    fs.mkdirSync(bookDir, { recursive: true })
+    createWebAssets(webAssetsDir)
+
+    const storage = createMockStorage([
+      { pageId: "pg001", pageNumber: 1, text: "Page one" },
+    ], {
+      "web-rendering": {
+        pg001: {
+          sections: [
+            { sectionIndex: 0, sectionType: "content", reasoning: "ok", html: "<section><p>Kept</p></section>" },
+          ],
+        },
+      },
+      "page-sectioning": {
+        pg001: {
+          reasoning: "ok",
+          sections: [
+            {
+              sectionId: "pg001_sec001",
+              sectionType: "content",
+              nodes: [],
+              backgroundColor: "#fff",
+              textColor: "#000",
+              pageNumber: 1,
+              isPruned: false,
+            },
+          ],
+        },
+      },
+    })
+
+    const result = await packageAdtWeb(storage, {
+      bookDir,
+      label: "book",
+      language: "en",
+      outputLanguages: ["en"],
+      title: "Book Title",
+      webAssetsDir,
+    })
+
+    expect(result.warnings).toEqual([])
   })
 
   it("converts LaTeX math to MathML in output HTML and does not include MathJax script", async () => {

--- a/packages/pipeline/src/__tests__/package-web.test.ts
+++ b/packages/pipeline/src/__tests__/package-web.test.ts
@@ -775,6 +775,20 @@ describe("packageAdtWeb", () => {
             },
           ],
         },
+        pg002: {
+          reasoning: "ok",
+          sections: [
+            {
+              sectionId: "pg002_sec001",
+              sectionType: "content",
+              nodes: [],
+              backgroundColor: "#fff",
+              textColor: "#000",
+              pageNumber: null,
+              isPruned: false,
+            },
+          ],
+        },
       },
       "quiz-generation": {
         book: {
@@ -1601,7 +1615,7 @@ describe("packageAdtWeb", () => {
     expect(pageHtml).toContain('alt="A lifecycle diagram with six stages"')
   })
 
-  it("sets activities true from rendered section type even without section metadata", async () => {
+  it("sets activities true from the rendered section type, not the sectioning's", async () => {
     const bookDir = path.join(tmpDir, "book")
     const webAssetsDir = path.join(tmpDir, "assets-web")
     fs.mkdirSync(bookDir, { recursive: true })
@@ -1621,6 +1635,24 @@ describe("packageAdtWeb", () => {
               reasoning: "ok",
               html: '<section role="activity"><div>Pick one</div></section>',
               activityAnswers: { "item-1": true },
+            },
+          ],
+        },
+      },
+      // Sectioning says "content" while the rendering says activity — the
+      // rendered type must win.
+      "page-sectioning": {
+        pg001: {
+          reasoning: "ok",
+          sections: [
+            {
+              sectionId: "pg001_sec001",
+              sectionType: "content",
+              nodes: [],
+              backgroundColor: "#fff",
+              textColor: "#000",
+              pageNumber: 1,
+              isPruned: false,
             },
           ],
         },

--- a/packages/pipeline/src/__tests__/package-web.test.ts
+++ b/packages/pipeline/src/__tests__/package-web.test.ts
@@ -1720,6 +1720,76 @@ describe("packageAdtWeb", () => {
     expect(configJson.features.activities).toBe(true)
   })
 
+  it("warns instead of silently dropping a rendered section with no sectioning row", async () => {
+    const bookDir = path.join(tmpDir, "book")
+    const webAssetsDir = path.join(tmpDir, "assets-web")
+    fs.mkdirSync(bookDir, { recursive: true })
+    createWebAssets(webAssetsDir)
+
+    const pages: PageData[] = [
+      { pageId: "pg001", pageNumber: 1, text: "Page one" },
+    ]
+
+    // Rendering has two entries, sectioning only one — the state a
+    // `page-sectioning` version restore leaves behind, since restoring does not
+    // resync `web-rendering`. Index 1 has no id to package under.
+    const storage = createMockStorage(pages, {
+      "web-rendering": {
+        pg001: {
+          sections: [
+            { sectionIndex: 0, sectionType: "content", reasoning: "ok", html: "<section><p>Kept</p></section>" },
+            { sectionIndex: 1, sectionType: "content", reasoning: "ok", html: "<section><p>Orphan</p></section>" },
+          ],
+        },
+      },
+      "page-sectioning": {
+        pg001: {
+          reasoning: "ok",
+          sections: [
+            {
+              sectionId: "pg001_sec001",
+              sectionType: "content",
+              nodes: [],
+              backgroundColor: "#fff",
+              textColor: "#000",
+              pageNumber: 1,
+              isPruned: false,
+            },
+          ],
+        },
+      },
+    })
+
+    const messages: string[] = []
+    await packageAdtWeb(
+      storage,
+      {
+        bookDir,
+        label: "book",
+        language: "en",
+        outputLanguages: ["en"],
+        title: "Book Title",
+        webAssetsDir,
+      },
+      {
+        emit: (event) => {
+          if (event.type === "step-progress") messages.push(event.message)
+        },
+      },
+    )
+
+    // The orphan is still skipped — a positional `_sec002` guess could collide
+    // with a real id — but the drop is now reported rather than invisible.
+    const pageList = JSON.parse(
+      fs.readFileSync(path.join(bookDir, "adt", "content", "pages.json"), "utf-8"),
+    ) as Array<{ section_id: string }>
+    expect(pageList.map((p) => p.section_id)).toEqual(["pg001_sec001"])
+
+    const warning = messages.find((m) => m.startsWith("Warning:"))
+    expect(warning).toContain("skipped 1 rendered section(s) with no sectioning row")
+    expect(warning).toContain("pg001[1]")
+  })
+
   it("converts LaTeX math to MathML in output HTML and does not include MathJax script", async () => {
     const bookDir = path.join(tmpDir, "book")
     const webAssetsDir = path.join(tmpDir, "assets-web")

--- a/packages/pipeline/src/__tests__/package-web.test.ts
+++ b/packages/pipeline/src/__tests__/package-web.test.ts
@@ -775,6 +775,20 @@ describe("packageAdtWeb", () => {
             },
           ],
         },
+        pg002: {
+          reasoning: "ok",
+          sections: [
+            {
+              sectionId: "pg002_sec001",
+              sectionType: "content",
+              nodes: [],
+              backgroundColor: "#fff",
+              textColor: "#000",
+              pageNumber: null,
+              isPruned: false,
+            },
+          ],
+        },
       },
       "quiz-generation": {
         book: {
@@ -1647,7 +1661,7 @@ describe("packageAdtWeb", () => {
     expect(pageHtml).toContain('alt="A lifecycle diagram with six stages"')
   })
 
-  it("sets activities true from rendered section type even without section metadata", async () => {
+  it("sets activities true from the rendered section type, not the sectioning's", async () => {
     const bookDir = path.join(tmpDir, "book")
     const webAssetsDir = path.join(tmpDir, "assets-web")
     fs.mkdirSync(bookDir, { recursive: true })
@@ -1667,6 +1681,24 @@ describe("packageAdtWeb", () => {
               reasoning: "ok",
               html: '<section role="activity"><div>Pick one</div></section>',
               activityAnswers: { "item-1": true },
+            },
+          ],
+        },
+      },
+      // Sectioning says "content" while the rendering says activity — the
+      // rendered type must win.
+      "page-sectioning": {
+        pg001: {
+          reasoning: "ok",
+          sections: [
+            {
+              sectionId: "pg001_sec001",
+              sectionType: "content",
+              nodes: [],
+              backgroundColor: "#fff",
+              textColor: "#000",
+              pageNumber: 1,
+              isPruned: false,
             },
           ],
         },

--- a/packages/pipeline/src/__tests__/text-catalog.test.ts
+++ b/packages/pipeline/src/__tests__/text-catalog.test.ts
@@ -391,12 +391,53 @@ describe("buildTextCatalog", () => {
           ],
         },
       },
+      "page-sectioning": {
+        pg001: {
+          reasoning: "",
+          sections: [
+            {
+              sectionId: "pg001_sec001",
+              sectionType: "activity_fill_in_the_blank",
+              nodes: [],
+              backgroundColor: "#ffffff",
+              textColor: "#000000",
+              pageNumber: 1,
+              isPruned: false,
+            },
+          ],
+        },
+      },
     })
 
     const result = await buildTextCatalog(storage, [pages[0]])
 
     expect(result.entries).toContainEqual({ id: "pg001_sec001_ans_item-1", text: "true" })
     expect(result.entries).toContainEqual({ id: "pg001_sec001_ans_item-2", text: "42" })
+  })
+
+  it("skips activity answers when no sectioning row resolves the section id", async () => {
+    // sectionIds are allocated once and never reused, so they cannot be derived
+    // from `sectionIndex`. Emitting a guessed id would attach these answers'
+    // translations and generated audio to whichever section owns that id.
+    const storage = createMockStorage({
+      "web-rendering": {
+        pg001: {
+          sections: [
+            {
+              sectionIndex: 0,
+              sectionType: "activity_fill_in_the_blank",
+              reasoning: "",
+              html: '<section><p data-id="pg001_gp001_tx001">Text</p></section>',
+              activityAnswers: { "item-1": "sun" },
+            },
+          ],
+        },
+      },
+    })
+
+    const result = await buildTextCatalog(storage, [pages[0]])
+
+    expect(result.entries.filter((e) => e.id.includes("_ans_"))).toEqual([])
   })
 
   it("skips sections without activity answers", async () => {

--- a/packages/pipeline/src/accessibility-assessment-shared.ts
+++ b/packages/pipeline/src/accessibility-assessment-shared.ts
@@ -8,6 +8,7 @@ import type {
   AccessibilityPageResult,
   BrowserAccessibilityAssessmentOutput,
 } from "@adt/types"
+import { parseSectionId } from "@adt/types"
 
 export const DEFAULT_AXE_RUN_ONLY_TAGS = [
   "wcag2a",
@@ -41,8 +42,7 @@ export const PackagedPageManifestEntry = z.object({
 export type PackagedPageManifestEntry = z.infer<typeof PackagedPageManifestEntry>
 
 export function derivePageId(sectionId: string): string | null {
-  const match = /^(.*)_sec\d+$/.exec(sectionId)
-  return match?.[1] ?? null
+  return parseSectionId(sectionId)?.pageId ?? null
 }
 
 export function getPackagedPageEntries(bookDir: string): PackagedPageManifestEntry[] {

--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -352,6 +352,7 @@ export {
   packageAdtWeb,
   computePackagingInputHash,
   type PackageAdtWebOptions,
+  type PackageAdtWebResult,
   type ComputePackagingInputHashOptions,
   renderPageHtml,
   resolveReflowableFontChain,
@@ -413,6 +414,11 @@ export {
   FIXED_LAYOUT_SECTIONING_NODE,
   PAGE_SECTIONING_NODE,
 } from "./render-sectioning.js"
+export {
+  createSectionIdFactory,
+  collectSpentSectionIds,
+  SectionIdExhaustedError,
+} from "./section-ids.js"
 export {
   extractEditableActivity,
   supportsEditableActivity,

--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -420,6 +420,9 @@ export {
   retireSectionIds,
   unassignSignLanguageVideos,
   SectionIdExhaustedError,
+  NOTHING_RETIRED,
+  type SectionIdRetirementResult,
+  type DetachedRecording,
 } from "./section-ids.js"
 export {
   extractEditableActivity,

--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -417,6 +417,8 @@ export {
 export {
   createSectionIdFactory,
   collectSpentSectionIds,
+  retireSectionIds,
+  unassignSignLanguageVideos,
   SectionIdExhaustedError,
 } from "./section-ids.js"
 export {

--- a/packages/pipeline/src/packaging/web.ts
+++ b/packages/pipeline/src/packaging/web.ts
@@ -386,8 +386,12 @@ export async function packageAdtWeb(
         const sections = [...rendering.sections].sort((a, b) => a.sectionIndex - b.sectionIndex)
         for (const rs of sections) {
           const sectionMeta = sectioning?.sections[rs.sectionIndex]
-          if (sectionMeta?.isPruned) continue
-          const sectionId = sectionMeta?.sectionId ?? `${page.pageId}_sec${String(rs.sectionIndex + 1).padStart(3, "0")}`
+          // No sectioning row for this rendering entry means the two are out of
+          // sync. sectionIds are allocated once and never reused, so a guessed
+          // `_secNNN` could collide with a real section and have two pages write
+          // the same file. Skip the orphan entry instead.
+          if (!sectionMeta || sectionMeta.isPruned) continue
+          const sectionId = sectionMeta.sectionId
 
           if (rs.sectionType.startsWith("activity_") || sectionMeta?.sectionType.startsWith("activity_")) {
             hasActivitySections = true

--- a/packages/pipeline/src/packaging/web.ts
+++ b/packages/pipeline/src/packaging/web.ts
@@ -391,8 +391,12 @@ export async function packageAdtWeb(
         const sections = [...rendering.sections].sort((a, b) => a.sectionIndex - b.sectionIndex)
         for (const rs of sections) {
           const sectionMeta = sectioning?.sections[rs.sectionIndex]
-          if (sectionMeta?.isPruned) continue
-          const sectionId = sectionMeta?.sectionId ?? `${page.pageId}_sec${String(rs.sectionIndex + 1).padStart(3, "0")}`
+          // No sectioning row for this rendering entry means the two are out of
+          // sync. sectionIds are allocated once and never reused, so a guessed
+          // `_secNNN` could collide with a real section and have two pages write
+          // the same file. Skip the orphan entry instead.
+          if (!sectionMeta || sectionMeta.isPruned) continue
+          const sectionId = sectionMeta.sectionId
 
           if (rs.sectionType.startsWith("activity_") || sectionMeta?.sectionType.startsWith("activity_")) {
             hasActivitySections = true

--- a/packages/pipeline/src/packaging/web.ts
+++ b/packages/pipeline/src/packaging/web.ts
@@ -22,6 +22,7 @@ import type {
   TocGenerationOutput,
   Quiz,
   ImageCaptioningOutput,
+  PackagingWarning,
 } from "@adt/types"
 import { WebRenderingOutput as WebRenderingOutputSchema, isHeadingRole, isTtsExcluded, resolveEntryVoiceSlot, FIXED_LAYOUT_MAX_SCALE } from "@adt/types"
 import { resolveNarratorLabel } from "../speech.js"
@@ -258,16 +259,27 @@ function hashValue(value: unknown): string {
 // Public API
 // ---------------------------------------------------------------------------
 
+/** What packaging had to leave out. Empty on a clean run. */
+export interface PackageAdtWebResult {
+  warnings: PackagingWarning[]
+}
+
 /**
  * Package all pipeline outputs into a standalone web application at
  * `{bookDir}/adt/`. The output is a self-contained directory that can be
  * opened directly in a browser (file://) or served by any static HTTP server.
+ *
+ * Anything omitted from the bundle comes back in `warnings`. Callers on a
+ * user-facing path must surface them: a silently short bundle is
+ * indistinguishable from a correct one. `progress` is a diagnostic trail only —
+ * the CLI sink drops messages without page counters, and it defaults to
+ * `nullProgress`.
  */
 export async function packageAdtWeb(
   storage: Storage,
   options: PackageAdtWebOptions,
   progress: Progress = nullProgress,
-): Promise<void> {
+): Promise<PackageAdtWebResult> {
   const {
     bookDir,
     label,
@@ -362,8 +374,9 @@ export async function packageAdtWeb(
   const sectionIdToPageIndex = new Map<string, number>()
   // Rendering entries with no sectioning row behind them. They are dropped from
   // the bundle (see the skip below), which is silent otherwise — the page just
-  // isn't there. Reported at the end so a stale rendering is diagnosable.
-  const orphanedRenderings: string[] = []
+  // isn't there. Returned to the caller so the packaging and export flows can
+  // surface it; a `progress` message alone reaches no live sink.
+  const orphanedRenderings: PackagingWarning[] = []
 
   // Build a map from afterPageId -> quizzes for interleaving
   const quizzesByAfterPageId = new Map<string, Quiz[]>()
@@ -400,7 +413,11 @@ export async function packageAdtWeb(
           // `_secNNN` could collide with a real section and have two pages write
           // the same file. Skip the orphan entry instead.
           if (!sectionMeta) {
-            orphanedRenderings.push(`${page.pageId}[${rs.sectionIndex}]`)
+            orphanedRenderings.push({
+              kind: "orphaned-rendering",
+              pageId: page.pageId,
+              sectionIndex: rs.sectionIndex,
+            })
             continue
           }
           if (sectionMeta.isPruned) continue
@@ -549,12 +566,16 @@ export async function packageAdtWeb(
   }
 
   if (orphanedRenderings.length > 0) {
+    // Also emitted as progress so a CLI/log trace records it. The returned
+    // `warnings` are the load-bearing channel — the CLI progress sink drops
+    // messages with no page counters, and the API flows pass no sink at all.
     progress.emit({
       type: "step-progress",
       step,
       message:
         `Warning: skipped ${orphanedRenderings.length} rendered section(s) with no sectioning row ` +
-        `(${orphanedRenderings.join(", ")}). They are absent from the bundle. ` +
+        `(${orphanedRenderings.map((w) => `${w.pageId}[${w.sectionIndex}]`).join(", ")}). ` +
+        `They are absent from the bundle. ` +
         `Re-run the storyboard render for these pages to bring rendering back in sync with sectioning.`,
     })
   }
@@ -1006,6 +1027,8 @@ export async function packageAdtWeb(
   }
 
   progress.emit({ type: "step-complete", step })
+
+  return { warnings: orphanedRenderings }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/pipeline/src/packaging/web.ts
+++ b/packages/pipeline/src/packaging/web.ts
@@ -360,6 +360,10 @@ export async function packageAdtWeb(
   let hasActivitySections = false
   const copiedImages = new Set<string>()
   const sectionIdToPageIndex = new Map<string, number>()
+  // Rendering entries with no sectioning row behind them. They are dropped from
+  // the bundle (see the skip below), which is silent otherwise — the page just
+  // isn't there. Reported at the end so a stale rendering is diagnosable.
+  const orphanedRenderings: string[] = []
 
   // Build a map from afterPageId -> quizzes for interleaving
   const quizzesByAfterPageId = new Map<string, Quiz[]>()
@@ -395,10 +399,14 @@ export async function packageAdtWeb(
           // sync. sectionIds are allocated once and never reused, so a guessed
           // `_secNNN` could collide with a real section and have two pages write
           // the same file. Skip the orphan entry instead.
-          if (!sectionMeta || sectionMeta.isPruned) continue
+          if (!sectionMeta) {
+            orphanedRenderings.push(`${page.pageId}[${rs.sectionIndex}]`)
+            continue
+          }
+          if (sectionMeta.isPruned) continue
           const sectionId = sectionMeta.sectionId
 
-          if (rs.sectionType.startsWith("activity_") || sectionMeta?.sectionType.startsWith("activity_")) {
+          if (rs.sectionType.startsWith("activity_") || sectionMeta.sectionType.startsWith("activity_")) {
             hasActivitySections = true
           }
 
@@ -538,6 +546,17 @@ export async function packageAdtWeb(
 
       pageList.push({ section_id: quizId, href: quizFilename })
     }
+  }
+
+  if (orphanedRenderings.length > 0) {
+    progress.emit({
+      type: "step-progress",
+      step,
+      message:
+        `Warning: skipped ${orphanedRenderings.length} rendered section(s) with no sectioning row ` +
+        `(${orphanedRenderings.join(", ")}). They are absent from the bundle. ` +
+        `Re-run the storyboard render for these pages to bring rendering back in sync with sectioning.`,
+    })
   }
 
   // ------------------------------------------------------------------

--- a/packages/pipeline/src/page-sectioning.ts
+++ b/packages/pipeline/src/page-sectioning.ts
@@ -8,6 +8,7 @@ import {
   DEFAULT_LLM_MODEL_ID,
   buildPageSectioningLLMSchema,
   buildPageSectioningRefinementLLMSchema,
+  formatSectionId,
 } from "@adt/types"
 import type { LLMModel, ValidationResult } from "@adt/llm"
 import type { PageOutlineContext } from "./book-outline.js"
@@ -649,7 +650,7 @@ export function finalizePageSectioning(
   const counter = { n: 0 }
 
   const sections: PageSectioningSection[] = raw.sections.map((section, sIdx) => {
-    const sectionId = `${input.pageId}_sec${String(sIdx + 1).padStart(3, "0")}`
+    const sectionId = formatSectionId(input.pageId, sIdx + 1)
     const nodes = section.nodes.map((node) =>
       toContentNode(node, input.pageId, counter, prunedRoles)
     )

--- a/packages/pipeline/src/section-ids.ts
+++ b/packages/pipeline/src/section-ids.ts
@@ -1,0 +1,100 @@
+import type { Storage } from "@adt/storage"
+import { formatSectionId, parseSectionId, MAX_SECTION_SEQ } from "@adt/types"
+import { PAGE_SECTIONING_NODE, FIXED_LAYOUT_SECTIONING_NODE } from "./render-sectioning.js"
+
+/**
+ * Thrown when a page has burned all `MAX_SECTION_SEQ` of its sequence numbers.
+ *
+ * A named error rather than an HTTP exception so this module stays usable from
+ * the pipeline and the agent tools; the route layer maps it to a 400.
+ */
+export class SectionIdExhaustedError extends Error {
+  constructor(readonly pageId: string) {
+    super(
+      `Page ${pageId} has allocated all ${MAX_SECTION_SEQ} of its section ids. Split this page's content across pages, or re-extract it, before editing its sections further.`
+    )
+    this.name = "SectionIdExhaustedError"
+  }
+}
+
+/**
+ * Every section id that appears in *any* stored version of this page's
+ * sectioning — the ids that are spent and must never be handed out again.
+ *
+ * Scanned out of the raw JSON rather than off parsed rows on purpose. A version
+ * that no longer satisfies today's schema (a legacy row with no `sectionId`
+ * field, a shape from before a migration) still burned the ids it contains, and
+ * skipping it because `safeParse` failed would let them be reissued. Matching
+ * text is a non-risk in the other direction: an incidental `_secNNN` inside
+ * some node's text only makes the set larger, which can never cause reuse.
+ *
+ * The pattern admits the legacy `_sN` shape (`packages/agents` minted those
+ * before it used this factory) as well as the canonical `_secNNN`, so a legacy
+ * id also burns its sequence number instead of being invisible to the
+ * high-water mark.
+ */
+export function collectSpentSectionIds(storage: Storage, pageId: string): Set<string> {
+  const spent = new Set<string>()
+  const pattern = new RegExp(
+    `${pageId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}_s(?:ec)?\\d+`,
+    "g"
+  )
+  for (const node of [PAGE_SECTIONING_NODE, FIXED_LAYOUT_SECTIONING_NODE]) {
+    for (const row of storage.getAllNodeVersions(node, pageId)) {
+      for (const match of JSON.stringify(row.data).matchAll(pattern)) {
+        spent.add(match[0])
+      }
+    }
+  }
+  return spent
+}
+
+/** The sequence number an id of either shape spent, or null if it spent none. */
+function spentSeq(pageId: string, id: string): number | null {
+  const canonical = parseSectionId(id)
+  if (canonical) return canonical.seq
+  // Legacy `${pageId}_s${N}`, minted by the agent tools before they used this
+  // factory. Its N came from an array length, so it is not a high-water mark —
+  // but it is still a number this page has used, and counting it keeps a fresh
+  // canonical id from landing on the same sequence.
+  const legacy = new RegExp(`^${pageId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}_s(\\d+)$`).exec(id)
+  return legacy ? Number(legacy[1]) : null
+}
+
+/**
+ * Mint section ids that no version of this page's sectioning has ever used, so
+ * a section's id is immutable for its whole life and a retired id is never
+ * handed out again.
+ *
+ * The high-water mark comes from *history*, not just the current version. Delete
+ * `_sec003`, then split `_sec002`, and a max-of-current counter would reissue
+ * `_sec003` — silently adopting the deleted section's `toc-generation` entry,
+ * sign-language video and text-catalog `${sectionId}_ans_*` keys (and therefore
+ * their translations and generated audio) onto unrelated content.
+ *
+ * A counter stored on the entity would be worse: it would live inside the very
+ * thing it counts, so restoring an older sectioning version would roll the
+ * counter back and reissue every id allocated since.
+ *
+ * Every caller that adds a section must allocate through this — the structural
+ * edit routes and the agent activity tools alike. An id derived from
+ * `sections.length` is not just non-canonical, it collides: after a delete
+ * leaves a gap, the next append reuses a length that is already taken.
+ */
+export function createSectionIdFactory(storage: Storage, pageId: string): () => string {
+  let highWaterMark = 0
+  for (const id of collectSpentSectionIds(storage, pageId)) {
+    const seq = spentSeq(pageId, id)
+    if (seq !== null) highWaterMark = Math.max(highWaterMark, seq)
+  }
+  let next = highWaterMark + 1
+  return () => {
+    if (next > MAX_SECTION_SEQ) {
+      // Unreachable in practice: each structural op allocates one id, so this
+      // needs ~1000 edits to a single page. Capped so the `_sec(\d{3})` shape
+      // every consumer parses stays valid rather than silently widening.
+      throw new SectionIdExhaustedError(pageId)
+    }
+    return formatSectionId(pageId, next++)
+  }
+}

--- a/packages/pipeline/src/section-ids.ts
+++ b/packages/pipeline/src/section-ids.ts
@@ -1,5 +1,5 @@
 import type { Storage } from "@adt/storage"
-import { formatSectionId, parseSectionId, MAX_SECTION_SEQ } from "@adt/types"
+import { formatSectionId, parseAnySectionId, MAX_SECTION_SEQ, TocGenerationOutput } from "@adt/types"
 import { PAGE_SECTIONING_NODE, FIXED_LAYOUT_SECTIONING_NODE } from "./render-sectioning.js"
 
 /**
@@ -32,14 +32,23 @@ export class SectionIdExhaustedError extends Error {
  * before it used this factory) as well as the canonical `_secNNN`, so a legacy
  * id also burns its sequence number instead of being invisible to the
  * high-water mark.
+ *
+ * `nodes` narrows the scan to particular sectioning nodes. Allocation always
+ * wants both (an id spent under either shape must not be reissued); a caller
+ * retiring the ids of one node that is about to be deleted passes just that one,
+ * so it does not retire ids the surviving node still owns.
  */
-export function collectSpentSectionIds(storage: Storage, pageId: string): Set<string> {
+export function collectSpentSectionIds(
+  storage: Storage,
+  pageId: string,
+  nodes: readonly string[] = [PAGE_SECTIONING_NODE, FIXED_LAYOUT_SECTIONING_NODE]
+): Set<string> {
   const spent = new Set<string>()
   const pattern = new RegExp(
     `${pageId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}_s(?:ec)?\\d+`,
     "g"
   )
-  for (const node of [PAGE_SECTIONING_NODE, FIXED_LAYOUT_SECTIONING_NODE]) {
+  for (const node of nodes) {
     for (const row of storage.getAllNodeVersions(node, pageId)) {
       for (const match of JSON.stringify(row.data).matchAll(pattern)) {
         spent.add(match[0])
@@ -49,16 +58,16 @@ export function collectSpentSectionIds(storage: Storage, pageId: string): Set<st
   return spent
 }
 
-/** The sequence number an id of either shape spent, or null if it spent none. */
+/**
+ * The sequence number an id spent, or null if it belongs to another page.
+ *
+ * Legacy `${pageId}_s${N}` ids count too. Their N came from an array length, so
+ * it is not a high-water mark — but it is still a number this page has used, and
+ * counting it keeps a fresh canonical id from landing on the same sequence.
+ */
 function spentSeq(pageId: string, id: string): number | null {
-  const canonical = parseSectionId(id)
-  if (canonical) return canonical.seq
-  // Legacy `${pageId}_s${N}`, minted by the agent tools before they used this
-  // factory. Its N came from an array length, so it is not a high-water mark —
-  // but it is still a number this page has used, and counting it keeps a fresh
-  // canonical id from landing on the same sequence.
-  const legacy = new RegExp(`^${pageId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}_s(\\d+)$`).exec(id)
-  return legacy ? Number(legacy[1]) : null
+  const parsed = parseAnySectionId(id)
+  return parsed?.pageId === pageId ? parsed.seq : null
 }
 
 /**
@@ -97,4 +106,63 @@ export function createSectionIdFactory(storage: Storage, pageId: string): () => 
     }
     return formatSectionId(pageId, next++)
   }
+}
+
+/**
+ * Clear the section assignment of every sign-language video pinned to one of
+ * `retiredIds`, and report how many were cleared.
+ *
+ * Videos are *unassigned*, never deleted: the upload is the user's, and they can
+ * reattach it to whatever section now carries that content.
+ *
+ * This is the one sectionId reference that lives outside `node_data` — no other
+ * table holds one — so it is the only one that survives an operation which drops
+ * a page's node history. Everything else keyed by sectionId (`toc-generation`,
+ * `text-catalog` and the audio derived from it, `editable-activity`) goes with
+ * that history.
+ */
+export function unassignSignLanguageVideos(
+  storage: Storage,
+  retiredIds: Iterable<string>
+): number {
+  const retired = retiredIds instanceof Set ? retiredIds : new Set(retiredIds)
+  if (retired.size === 0) return 0
+
+  let unassigned = 0
+  for (const video of storage.getSignLanguageVideos()) {
+    if (video.sectionId && retired.has(video.sectionId)) {
+      storage.assignSignLanguageVideo(video.videoId, null)
+      unassigned += 1
+    }
+  }
+  return unassigned
+}
+
+/**
+ * Drop book-level references to sections that no longer exist. Called by every
+ * op that removes a section; without it a merge or delete leaves a dangling
+ * `toc-generation` entry (a broken href in the EPUB nav) or a sign-language
+ * video pinned to an id nothing resolves.
+ *
+ * Lives here rather than in the route that first needed it because retirement is
+ * the other half of allocation: the same reasoning that says an id is never
+ * reissued says its references must go when it retires, and both the structural
+ * edit routes and the stage-rerun path have to agree on it.
+ */
+export function retireSectionIds(storage: Storage, retired: string[]): void {
+  if (retired.length === 0) return
+  const retiredIds = new Set(retired)
+
+  const tocRow = storage.getLatestNodeData("toc-generation", "book")
+  if (tocRow) {
+    const parsed = TocGenerationOutput.safeParse(tocRow.data)
+    if (parsed.success) {
+      const entries = parsed.data.entries.filter((entry) => !retiredIds.has(entry.sectionId))
+      if (entries.length !== parsed.data.entries.length) {
+        storage.putNodeData("toc-generation", "book", { ...parsed.data, entries })
+      }
+    }
+  }
+
+  unassignSignLanguageVideos(storage, retiredIds)
 }

--- a/packages/pipeline/src/section-ids.ts
+++ b/packages/pipeline/src/section-ids.ts
@@ -1,5 +1,14 @@
 import type { Storage } from "@adt/storage"
-import { formatSectionId, parseAnySectionId, MAX_SECTION_SEQ, TocGenerationOutput } from "@adt/types"
+import {
+  formatSectionId,
+  parseAnySectionId,
+  MAX_SECTION_SEQ,
+  TocGenerationOutput,
+  TTSOutput,
+  WordTimestampOutput,
+  parseVoiceSlotEntryId,
+  sectionIdOfAnswerTextId,
+} from "@adt/types"
 import { PAGE_SECTIONING_NODE, FIXED_LAYOUT_SECTIONING_NODE } from "./render-sectioning.js"
 
 /**
@@ -115,11 +124,11 @@ export function createSectionIdFactory(storage: Storage, pageId: string): () => 
  * Videos are *unassigned*, never deleted: the upload is the user's, and they can
  * reattach it to whatever section now carries that content.
  *
- * This is the one sectionId reference that lives outside `node_data` — no other
- * table holds one — so it is the only one that survives an operation which drops
- * a page's node history. Everything else keyed by sectionId (`toc-generation`,
- * `text-catalog` and the audio derived from it, `editable-activity`) goes with
- * that history.
+ * This is the only sectionId reference held in a *table* rather than in
+ * `node_data` — no other table holds one. It is not, however, the only one that
+ * survives an operation which drops a page's node history: the speech manifests
+ * are keyed by *language*, so a per-page clear never reaches them either. See
+ * `retireSectionIds`.
  */
 export function unassignSignLanguageVideos(
   storage: Storage,
@@ -138,20 +147,208 @@ export function unassignSignLanguageVideos(
   return unassigned
 }
 
+/** An uploaded recording whose entry was dropped, and where its file still is. */
+export type DetachedRecording = {
+  /** The `tts` row's item id — the language dir the file lives under, verbatim. */
+  language: string
+  fileName: string
+}
+
+/** What one retirement pass reconciled. */
+export type SectionIdRetirementResult = {
+  /** Sign-language video pins cleared. */
+  videos: number
+  /** `tts` manifest entries dropped, across every language. */
+  speechEntries: number
+  /**
+   * The `provider: "manual"` entries among them — recordings the user uploaded.
+   *
+   * Reported rather than merely counted because the caller has to act on them.
+   * Audio filenames are derived from the textId, so the same run that re-mints
+   * a retired id also regenerates audio straight over the upload's path — unlike
+   * a sign-language video, which is stored under its own `videoId` and survives
+   * unassignment untouched. Dropping the entry alone would destroy the file.
+   * Retirement itself does no file I/O; moving the upload out of the way is the
+   * caller's job, because only the rerun path regenerates into the same names.
+   */
+  detachedRecordings: DetachedRecording[]
+  /** `tts-timestamps` map entries dropped, across every language. */
+  wordTimestamps: number
+}
+
+/** The result of retiring nothing. Frozen so callers can return it directly. */
+export const NOTHING_RETIRED: SectionIdRetirementResult = Object.freeze({
+  videos: 0,
+  speechEntries: 0,
+  detachedRecordings: Object.freeze([]) as unknown as DetachedRecording[],
+  wordTimestamps: 0,
+})
+
 /**
- * Drop book-level references to sections that no longer exist. Called by every
- * op that removes a section; without it a merge or delete leaves a dangling
- * `toc-generation` entry (a broken href in the EPUB nav) or a sign-language
- * video pinned to an id nothing resolves.
+ * Drop every speech reference to a retired section, across all languages.
+ *
+ * The `tts` manifest and `tts-timestamps` are keyed by language, not by page,
+ * so neither a page-scoped history drop nor a stage rerun's clear reaches them:
+ * `getStageRerunClearNodes` deliberately *preserves* `tts` whenever Speech is
+ * in the rerun range, and `tts-timestamps` appears in no clear list at all
+ * (`STAGE_OUTPUT_NODES` is built from step names, and the step is called
+ * `word-timestamps` while the node is `tts-timestamps`). Both therefore outlive
+ * the sectioning history their `${sectionId}_ans_*` ids came from.
+ *
+ * A *generated* entry heals itself — `canReuseSpeechEntry` gates it on
+ * `computeSpeechCacheKey`, a hash of the text — but a `provider: "manual"` entry
+ * is accepted on file existence alone, so a re-minted id would inherit a
+ * recording of whatever content used to hold it. Timestamps are worse: with
+ * `word_highlighting` off the speech run never rewrites them, so stale word
+ * boundaries survive a full run and ship in the EPUB.
+ *
+ * Every entry for a retired id goes, not just the manual ones. Generated
+ * entries are harmless but dangling, and dropping one costs a `copyFileSync`
+ * rather than an API call because generation checks the on-disk cache before
+ * the provider. One rule beats deciding per store which references are the
+ * dangerous kind — that is the reasoning that let this survive in the first
+ * place.
+ *
+ * Uploaded recordings are reported back rather than deleted; see
+ * `detachedRecordings` for why they cannot simply be left where they are.
+ *
+ * Reading and writing back the same `itemId` `getNodeItemIds` returned is what
+ * makes this correct for both the canonical (`pt-BR`) and legacy (`pt_BR`)
+ * language row spellings without any alias juggling.
+ */
+function pruneSpeechForRetiredSections(
+  storage: Storage,
+  retiredIds: ReadonlySet<string>
+): Omit<SectionIdRetirementResult, "videos"> {
+  const ownedByRetiredSection = (textId: string): boolean => {
+    const sectionId = sectionIdOfAnswerTextId(textId)
+    return sectionId !== null && retiredIds.has(sectionId)
+  }
+
+  let speechEntries = 0
+  let wordTimestamps = 0
+  const detachedRecordings: DetachedRecording[] = []
+  const generatedAt = new Date().toISOString()
+
+  for (const itemId of storage.getNodeItemIds("tts")) {
+    const row = storage.getLatestNodeData("tts", itemId)
+    if (!row) continue
+    // A row today's schema cannot read cannot be reconciled entry by entry, so
+    // leave it rather than rewrite it into a shape nothing expects — but say so,
+    // because this is a safety reconcile and skipping one fails *open*: any
+    // stale manual entry inside stays reusable under a re-minted id.
+    const parsed = TTSOutput.safeParse(row.data)
+    if (!parsed.success) {
+      console.warn(
+        `[section-ids] tts/${itemId} does not satisfy the current schema; its entries were left as-is and may still reference retired sections.`
+      )
+      continue
+    }
+
+    // `failed` is pulled out of the rest rather than spread over, so emptying
+    // it drops the key instead of leaving the original array behind.
+    const { entries: priorEntries, failed: priorFailed, ...rest } = parsed.data
+    const entries = priorEntries.filter((entry) => !ownedByRetiredSection(entry.textId))
+    const failed = priorFailed?.filter((entry) => !ownedByRetiredSection(entry.textId))
+    const droppedEntries = priorEntries.length - entries.length
+    const droppedFailed = (priorFailed?.length ?? 0) - (failed?.length ?? 0)
+    if (droppedEntries + droppedFailed === 0) continue
+
+    speechEntries += droppedEntries
+    for (const entry of priorEntries) {
+      if (entry.provider === "manual" && ownedByRetiredSection(entry.textId)) {
+        detachedRecordings.push({ language: itemId, fileName: entry.fileName })
+      }
+    }
+    storage.putNodeData("tts", itemId, {
+      ...rest,
+      entries,
+      ...(failed && failed.length > 0 ? { failed } : {}),
+      generatedAt,
+    })
+  }
+
+  for (const itemId of storage.getNodeItemIds("tts-timestamps")) {
+    const row = storage.getLatestNodeData("tts-timestamps", itemId)
+    if (!row) continue
+    const parsed = WordTimestampOutput.safeParse(row.data)
+    if (!parsed.success) {
+      console.warn(
+        `[section-ids] tts-timestamps/${itemId} does not satisfy the current schema; its entries were left as-is and may still reference retired sections.`
+      )
+      continue
+    }
+
+    const { entries: priorEntries, failed: priorFailed, ...rest } = parsed.data
+    // Map keys are slot-qualified (`textId` / `textId--secondary`), so recover
+    // the base textId before asking who owns it — otherwise the secondary
+    // voice's timings outlive the section they describe.
+    const entries = Object.fromEntries(
+      Object.entries(priorEntries).filter(
+        ([key]) => !ownedByRetiredSection(parseVoiceSlotEntryId(key).textId)
+      )
+    )
+    const failed = priorFailed?.filter((entry) => !ownedByRetiredSection(entry.textId))
+    const droppedEntries = Object.keys(priorEntries).length - Object.keys(entries).length
+    const droppedFailed = (priorFailed?.length ?? 0) - (failed?.length ?? 0)
+    if (droppedEntries + droppedFailed === 0) continue
+
+    wordTimestamps += droppedEntries
+    storage.putNodeData("tts-timestamps", itemId, {
+      ...rest,
+      entries,
+      ...(failed && failed.length > 0 ? { failed } : {}),
+      generatedAt,
+    })
+  }
+
+  // Every other path that removes `tts` entries also invalidates the steps that
+  // produced them (`easy-read.ts`, the version-restore reconcile in `pages.ts`,
+  // `text-catalog.ts`). Without this, `spreads/apply` leaves Speech marked
+  // complete over a manifest with holes — the rerun path clears step runs a
+  // moment later anyway, so this only ever adds information.
+  if (speechEntries > 0 || wordTimestamps > 0) {
+    storage.clearStepRuns(["tts", "word-timestamps"])
+  }
+
+  return { speechEntries, detachedRecordings, wordTimestamps }
+}
+
+/**
+ * Drop book-level references to sections that no longer exist, and report what
+ * went. Called by every op that removes a section — and by the stage rerun that
+ * drops a page's whole sectioning history; without it a merge or delete leaves a
+ * dangling `toc-generation` entry (a broken href in the EPUB nav), a
+ * sign-language video pinned to an id nothing resolves, or an uploaded recording
+ * that a re-minted id would silently adopt.
+ *
+ * Which references each caller actually depends on differs, and it is worth
+ * being exact about it:
+ *
+ * - The section-level ops (merge, cross-page merge, delete) reach this through
+ *   `saveStoryboardNode`, whose `clearCaptionData` already deletes the `tts` and
+ *   `tts-timestamps` nodes outright, so the speech prune finds nothing. It runs
+ *   anyway rather than being conditioned on "something else will get it" — the
+ *   reasoning that let the rerun path ship without it.
+ * - `spreads/apply` retires before `deletePage`, and clears no manifests, so the
+ *   prune is what stops a page re-created under the same id from adopting the
+ *   old page's answer audio.
+ * - The stage rerun likewise: `getStageRerunClearNodes` deliberately preserves
+ *   `tts`, so the prune is the whole point there.
  *
  * Lives here rather than in the route that first needed it because retirement is
  * the other half of allocation: the same reasoning that says an id is never
  * reissued says its references must go when it retires, and both the structural
- * edit routes and the stage-rerun path have to agree on it.
+ * edit routes and the stage-rerun path have to agree on it. They previously
+ * reconciled different sets of references, which is exactly how the speech
+ * manifests came to be missed — so both now go through here.
  */
-export function retireSectionIds(storage: Storage, retired: string[]): void {
-  if (retired.length === 0) return
-  const retiredIds = new Set(retired)
+export function retireSectionIds(
+  storage: Storage,
+  retired: Iterable<string>
+): SectionIdRetirementResult {
+  const retiredIds = retired instanceof Set ? retired : new Set(retired)
+  if (retiredIds.size === 0) return NOTHING_RETIRED
 
   const tocRow = storage.getLatestNodeData("toc-generation", "book")
   if (tocRow) {
@@ -164,5 +361,12 @@ export function retireSectionIds(storage: Storage, retired: string[]): void {
     }
   }
 
-  unassignSignLanguageVideos(storage, retiredIds)
+  // Videos before the speech prune: nothing here is transactional, and the
+  // prune is by far the larger failure surface (a write per language row, for
+  // two nodes). Doing the one-UPDATE reconcile first keeps a failure in the big
+  // one from also leaving videos pinned to ids that are about to be reissued.
+  const videos = unassignSignLanguageVideos(storage, retiredIds)
+  const speech = pruneSpeechForRetiredSections(storage, retiredIds)
+
+  return { videos, ...speech }
 }

--- a/packages/pipeline/src/section-ids.ts
+++ b/packages/pipeline/src/section-ids.ts
@@ -168,8 +168,12 @@ export type SectionIdRetirementResult = {
    * a retired id also regenerates audio straight over the upload's path — unlike
    * a sign-language video, which is stored under its own `videoId` and survives
    * unassignment untouched. Dropping the entry alone would destroy the file.
-   * Retirement itself does no file I/O; moving the upload out of the way is the
-   * caller's job, because only the rerun path regenerates into the same names.
+   *
+   * Retirement itself does no file I/O, so every caller that does not delete the
+   * audio outright has to park these (`parkDetachedRecordings`): the stage rerun,
+   * and `spreads/apply`, where un-applying the spread re-creates the page under
+   * its old id and re-mints the same names. Once the entry is gone nothing
+   * downstream knows the orphaned file exists, so it cannot be rescued later.
    */
   detachedRecordings: DetachedRecording[]
   /** `tts-timestamps` map entries dropped, across every language. */
@@ -227,6 +231,11 @@ function pruneSpeechForRetiredSections(
 
   let speechEntries = 0
   let wordTimestamps = 0
+  // Tracked separately from the counters: a row rewritten *only* because a
+  // `failed` item named a retired section still has to invalidate the steps that
+  // produced it, but it dropped no delivered audio, so counting it as a dropped
+  // entry would misreport what the user lost.
+  let rewroteAnyRow = false
   const detachedRecordings: DetachedRecording[] = []
   const generatedAt = new Date().toISOString()
 
@@ -254,6 +263,7 @@ function pruneSpeechForRetiredSections(
     const droppedFailed = (priorFailed?.length ?? 0) - (failed?.length ?? 0)
     if (droppedEntries + droppedFailed === 0) continue
 
+    rewroteAnyRow = true
     speechEntries += droppedEntries
     for (const entry of priorEntries) {
       if (entry.provider === "manual" && ownedByRetiredSection(entry.textId)) {
@@ -293,6 +303,7 @@ function pruneSpeechForRetiredSections(
     const droppedFailed = (priorFailed?.length ?? 0) - (failed?.length ?? 0)
     if (droppedEntries + droppedFailed === 0) continue
 
+    rewroteAnyRow = true
     wordTimestamps += droppedEntries
     storage.putNodeData("tts-timestamps", itemId, {
       ...rest,
@@ -307,7 +318,7 @@ function pruneSpeechForRetiredSections(
   // `text-catalog.ts`). Without this, `spreads/apply` leaves Speech marked
   // complete over a manifest with holes — the rerun path clears step runs a
   // moment later anyway, so this only ever adds information.
-  if (speechEntries > 0 || wordTimestamps > 0) {
+  if (rewroteAnyRow) {
     storage.clearStepRuns(["tts", "word-timestamps"])
   }
 

--- a/packages/pipeline/src/section-ids.ts
+++ b/packages/pipeline/src/section-ids.ts
@@ -170,10 +170,12 @@ export type SectionIdRetirementResult = {
    * unassignment untouched. Dropping the entry alone would destroy the file.
    *
    * Retirement itself does no file I/O, so every caller that does not delete the
-   * audio outright has to park these (`parkDetachedRecordings`): the stage rerun,
-   * and `spreads/apply`, where un-applying the spread re-creates the page under
+   * audio outright has to back these up (`retireWithPreservedRecordings`): the
+   * stage rerun and `spreads/apply`, where un-applying the spread re-creates the page under
    * its old id and re-mints the same names. Once the entry is gone nothing
    * downstream knows the orphaned file exists, so it cannot be rescued later.
+   * Those callers wrap retirement and backup in one storage transaction so a
+   * failed copy rolls the associations back, leaving the originals retryable.
    */
   detachedRecordings: DetachedRecording[]
   /** `tts-timestamps` map entries dropped, across every language. */

--- a/packages/pipeline/src/text-catalog.ts
+++ b/packages/pipeline/src/text-catalog.ts
@@ -132,9 +132,12 @@ function extractAnswerEntries(
   const answers = section.activityAnswers
   if (!answers || Object.keys(answers).length === 0) return []
 
-  const sectionId =
-    sectioning?.sections[section.sectionIndex]?.sectionId ??
-    `${pageId}_sec${pad3(section.sectionIndex + 1)}`
+  // sectionIds are allocated once and never reused, so they cannot be derived
+  // from an array position. With no sectioning row to read the real id from,
+  // a guessed `_secNNN` would likely belong to a *different* section — and
+  // these ids key the answers' translations and generated audio. Skip instead.
+  const sectionId = sectioning?.sections[section.sectionIndex]?.sectionId
+  if (!sectionId) return []
 
   const entries: TextCatalogEntry[] = []
   for (const [key, value] of Object.entries(answers)) {

--- a/packages/pipeline/src/text-catalog.ts
+++ b/packages/pipeline/src/text-catalog.ts
@@ -11,6 +11,7 @@ import type {
 } from "@adt/types"
 import {
   WebRenderingOutput as WebRenderingOutputSchema,
+  answerTextId,
 } from "@adt/types"
 import type { Storage, PageData } from "@adt/storage"
 import { getGlossaryItemTextId } from "./glossary.js"
@@ -143,7 +144,7 @@ function extractAnswerEntries(
   for (const [key, value] of Object.entries(answers)) {
     const text = String(value)
     if (text.length > 0) {
-      entries.push({ id: `${sectionId}_ans_${key}`, text })
+      entries.push({ id: answerTextId(sectionId, key), text })
     }
   }
   return entries

--- a/packages/storage/src/__tests__/book-storage.test.ts
+++ b/packages/storage/src/__tests__/book-storage.test.ts
@@ -536,6 +536,27 @@ describe("putNodeData / getLatestNodeData", () => {
     storage.close()
   })
 
+  it("getAllNodeVersions returns every version oldest-first, past the current pointer", () => {
+    const { storage } = createTempStorage()
+
+    storage.putNodeData("page-sectioning", "pg001", { reasoning: "v1" })
+    storage.putNodeData("page-sectioning", "pg001", { reasoning: "v2" })
+    storage.putNodeData("page-sectioning", "pg001", { reasoning: "v3" })
+    // Rolling the pointer back must not hide the versions after it — id
+    // allocation reads history so a restore can't make a fresh id collide
+    // with one a later version already used.
+    expect(storage.setCurrentNodeVersion("page-sectioning", "pg001", 1)).toBe(true)
+
+    expect(storage.getAllNodeVersions("page-sectioning", "pg001")).toEqual([
+      { version: 1, data: { reasoning: "v1" } },
+      { version: 2, data: { reasoning: "v2" } },
+      { version: 3, data: { reasoning: "v3" } },
+    ])
+    expect(storage.getAllNodeVersions("page-sectioning", "pg999")).toEqual([])
+
+    storage.close()
+  })
+
   it("handles different nodes independently", () => {
     const { storage } = createTempStorage()
 

--- a/packages/storage/src/__tests__/book-storage.test.ts
+++ b/packages/storage/src/__tests__/book-storage.test.ts
@@ -557,6 +557,24 @@ describe("putNodeData / getLatestNodeData", () => {
     storage.close()
   })
 
+  it("getNodeItemIds lists each item once, regardless of version count", () => {
+    const { storage } = createTempStorage()
+
+    // `tts` is keyed by language, and both the canonical and legacy spellings
+    // can coexist — a caller reconciling the whole book has to reach both.
+    storage.putNodeData("tts", "pt-BR", { entries: [] })
+    storage.putNodeData("tts", "pt-BR", { entries: [], generatedAt: "later" })
+    storage.putNodeData("tts", "pt_BR", { entries: [] })
+    storage.putNodeData("tts", "en", { entries: [] })
+    storage.putNodeData("tts-timestamps", "en", { entries: {} })
+
+    expect(storage.getNodeItemIds("tts")).toEqual(["en", "pt-BR", "pt_BR"])
+    expect(storage.getNodeItemIds("tts-timestamps")).toEqual(["en"])
+    expect(storage.getNodeItemIds("page-sectioning")).toEqual([])
+
+    storage.close()
+  })
+
   it("handles different nodes independently", () => {
     const { storage } = createTempStorage()
 

--- a/packages/storage/src/book-storage.ts
+++ b/packages/storage/src/book-storage.ts
@@ -468,6 +468,14 @@ export function createBookStorage(label: string, booksRoot: string): Storage {
       }
     },
 
+    getAllNodeVersions(node: string, itemId: string): NodeDataRow[] {
+      const rows = db.all(
+        "SELECT version, data FROM node_data WHERE node = ? AND item_id = ? ORDER BY version",
+        [node, itemId]
+      ) as Array<{ version: number; data: string }>
+      return rows.map((row) => ({ version: row.version, data: JSON.parse(row.data) }))
+    },
+
     getNodeVersionFingerprint(excludeNodes: string[] = []): Array<{ node: string; itemId: string; version: number }> {
       // Fingerprint off the *current* version so switching back to an older
       // version invalidates downstream caches / packaged output.

--- a/packages/storage/src/book-storage.ts
+++ b/packages/storage/src/book-storage.ts
@@ -476,6 +476,16 @@ export function createBookStorage(label: string, booksRoot: string): Storage {
       return rows.map((row) => ({ version: row.version, data: JSON.parse(row.data) }))
     },
 
+    getNodeItemIds(node: string): string[] {
+      // node_data's primary key is (node, item_id, version), so this is a range
+      // scan over one node's slice rather than a scan of the whole table.
+      const rows = db.all(
+        "SELECT DISTINCT item_id FROM node_data WHERE node = ? ORDER BY item_id",
+        [node]
+      ) as Array<{ item_id: string }>
+      return rows.map((row) => row.item_id)
+    },
+
     getNodeVersionFingerprint(excludeNodes: string[] = []): Array<{ node: string; itemId: string; version: number }> {
       // Fingerprint off the *current* version so switching back to an older
       // version invalidates downstream caches / packaged output.

--- a/packages/storage/src/storage.ts
+++ b/packages/storage/src/storage.ts
@@ -97,6 +97,13 @@ export interface Storage {
 
   putNodeData(node: string, itemId: string, data: unknown): number
   getLatestNodeData(node: string, itemId: string): NodeDataRow | null
+  /**
+   * Every stored version for (node, itemId), oldest first — including versions
+   * the current pointer has moved past. Used to allocate ids that were never
+   * used by *any* version, so a rollback can't make a fresh id collide with a
+   * retired one.
+   */
+  getAllNodeVersions(node: string, itemId: string): NodeDataRow[]
   /** Point (node, itemId) at an existing version without creating a new one
    *  (rollback). Returns false if that version doesn't exist. */
   setCurrentNodeVersion(node: string, itemId: string, version: number): boolean

--- a/packages/storage/src/storage.ts
+++ b/packages/storage/src/storage.ts
@@ -104,6 +104,16 @@ export interface Storage {
    * retired one.
    */
   getAllNodeVersions(node: string, itemId: string): NodeDataRow[]
+  /**
+   * Every item id this node holds data for, in id order.
+   *
+   * For the book-scoped nodes whose item id is a language code (`tts`,
+   * `tts-timestamps`), where a caller reconciling the whole book has to reach
+   * every language row — including the legacy `pt_BR` spelling alongside the
+   * canonical `pt-BR`. Reading and writing back the id this returns keeps that
+   * alias handling out of the caller entirely.
+   */
+  getNodeItemIds(node: string): string[]
   /** Point (node, itemId) at an existing version without creating a new one
    *  (rollback). Returns false if that version doesn't exist. */
   setCurrentNodeVersion(node: string, itemId: string, version: number): boolean

--- a/packages/types/src/__tests__/page-sectioning.test.ts
+++ b/packages/types/src/__tests__/page-sectioning.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest"
+import { formatSectionId, parseSectionId, MAX_SECTION_SEQ } from "../page-sectioning.js"
+
+describe("formatSectionId", () => {
+  it("zero-pads the sequence to three digits", () => {
+    expect(formatSectionId("pg003", 1)).toBe("pg003_sec001")
+    expect(formatSectionId("pg003", 42)).toBe("pg003_sec042")
+    expect(formatSectionId("pg003", MAX_SECTION_SEQ)).toBe("pg003_sec999")
+  })
+
+  it("preserves spread page ids", () => {
+    expect(formatSectionId("pg003004", 2)).toBe("pg003004_sec002")
+  })
+})
+
+describe("parseSectionId", () => {
+  it("round-trips formatSectionId", () => {
+    expect(parseSectionId(formatSectionId("pg003", 7))).toEqual({ pageId: "pg003", seq: 7 })
+    expect(parseSectionId(formatSectionId("pg003004", 12))).toEqual({
+      pageId: "pg003004",
+      seq: 12,
+    })
+  })
+
+  it("accepts ids whose page id contains underscores", () => {
+    expect(parseSectionId("test-book_p1_sec002")).toEqual({ pageId: "test-book_p1", seq: 2 })
+  })
+
+  it("returns null for ids of other kinds", () => {
+    // Quiz, glossary page and TOC ids must not be mistaken for section ids.
+    expect(parseSectionId("qz001")).toBeNull()
+    expect(parseSectionId("glp001")).toBeNull()
+    expect(parseSectionId("toc_001")).toBeNull()
+    expect(parseSectionId("pg003")).toBeNull()
+    expect(parseSectionId("pg003_sec")).toBeNull()
+  })
+})

--- a/packages/types/src/__tests__/page-sectioning.test.ts
+++ b/packages/types/src/__tests__/page-sectioning.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest"
-import { formatSectionId, parseSectionId, MAX_SECTION_SEQ } from "../page-sectioning.js"
+import {
+  formatSectionId,
+  parseSectionId,
+  parseAnySectionId,
+  MAX_SECTION_SEQ,
+} from "../page-sectioning.js"
 
 describe("formatSectionId", () => {
   it("zero-pads the sequence to three digits", () => {
@@ -33,5 +38,38 @@ describe("parseSectionId", () => {
     expect(parseSectionId("toc_001")).toBeNull()
     expect(parseSectionId("pg003")).toBeNull()
     expect(parseSectionId("pg003_sec")).toBeNull()
+  })
+})
+
+describe("parseAnySectionId", () => {
+  it("parses canonical ids and reports them as such", () => {
+    expect(parseAnySectionId("pg003_sec007")).toEqual({ pageId: "pg003", seq: 7, legacy: false })
+  })
+
+  it("parses the legacy `_sN` shape the agent tools used to mint", () => {
+    expect(parseAnySectionId("pg003_s2")).toEqual({ pageId: "pg003", seq: 2, legacy: true })
+  })
+
+  it("splits at the last separator, so page ids containing `_s` survive", () => {
+    expect(parseAnySectionId("bk_stuff_p1_sec002")).toEqual({
+      pageId: "bk_stuff_p1",
+      seq: 2,
+      legacy: false,
+    })
+    expect(parseAnySectionId("bk_stuff_p1_s2")).toEqual({
+      pageId: "bk_stuff_p1",
+      seq: 2,
+      legacy: true,
+    })
+  })
+
+  it("still rejects ids of other kinds", () => {
+    // Widening the shape must not start accepting quiz or glossary ids.
+    expect(parseAnySectionId("qz001")).toBeNull()
+    expect(parseAnySectionId("glp001")).toBeNull()
+    expect(parseAnySectionId("gl001")).toBeNull()
+    expect(parseAnySectionId("pg003")).toBeNull()
+    expect(parseAnySectionId("pg003_sec")).toBeNull()
+    expect(parseAnySectionId("pg003_slide3")).toBeNull()
   })
 })

--- a/packages/types/src/__tests__/speech.test.ts
+++ b/packages/types/src/__tests__/speech.test.ts
@@ -15,7 +15,11 @@ import {
   parseVoiceSlotEntryId,
   sortSpeechEntries,
 } from "../speech.js"
-import { getTextCatalogCategory } from "../text-catalog.js"
+import {
+  getTextCatalogCategory,
+  answerTextId,
+  sectionIdOfAnswerTextId,
+} from "../text-catalog.js"
 
 describe("getTextCatalogCategory", () => {
   it("classifies catalog entry ids by their conventions", () => {
@@ -32,6 +36,47 @@ describe("getTextCatalogCategory", () => {
   it("prefers easy-read over the source entry's category", () => {
     expect(getTextCatalogCategory("pg001_im001_easy_read")).toBe("easy-read")
     expect(getTextCatalogCategory("gl001_easy_read")).toBe("easy-read")
+  })
+})
+
+/**
+ * Answer ids are the one catalog id derived from a sectionId, so when a section
+ * retires this is what says which entries — and which audio — retire with it.
+ */
+describe("sectionIdOfAnswerTextId", () => {
+  it("recovers the owning section from a canonical answer id", () => {
+    expect(sectionIdOfAnswerTextId("pg001_sec003_ans_a")).toBe("pg001_sec003")
+  })
+
+  it("recovers it from the legacy `_sN` shape the agent tools used to mint", () => {
+    expect(sectionIdOfAnswerTextId("pg001_s1_ans_a")).toBe("pg001_s1")
+    // Variable-length legacy seqs: the separator is the only thing stopping
+    // `_s1` from claiming `_s11`'s answers.
+    expect(sectionIdOfAnswerTextId("pg001_s11_ans_a")).toBe("pg001_s11")
+  })
+
+  it("resolves suffixed variants to the same owner", () => {
+    expect(sectionIdOfAnswerTextId("pg001_sec003_ans_a--secondary")).toBe("pg001_sec003")
+    expect(sectionIdOfAnswerTextId("pg001_sec003_ans_a_easy_read")).toBe("pg001_sec003")
+  })
+
+  it("tolerates page ids that contain the separator's characters", () => {
+    // Spread pages carry concatenated ids; nothing about the shape is validated.
+    expect(sectionIdOfAnswerTextId("pg001002_sec001_ans_a")).toBe("pg001002_sec001")
+  })
+
+  it("returns null for ids that are not answers", () => {
+    expect(sectionIdOfAnswerTextId("pg001_t001")).toBeNull()
+    expect(sectionIdOfAnswerTextId("gl001_def")).toBeNull()
+    expect(sectionIdOfAnswerTextId("qz001_o1_exp")).toBeNull()
+    // Shares the prefix but is not an answer of that section.
+    expect(sectionIdOfAnswerTextId("pg001_sec003_answer")).toBeNull()
+    // No owner to the left of the separator.
+    expect(sectionIdOfAnswerTextId("_ans_a")).toBeNull()
+  })
+
+  it("round-trips ids built by answerTextId", () => {
+    expect(sectionIdOfAnswerTextId(answerTextId("pg001_sec003", "item-1"))).toBe("pg001_sec003")
   })
 })
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -242,6 +242,7 @@ export {
 } from "./book-outline.js"
 
 export { ExtractionWarning } from "./extraction-warning.js"
+export { PackagingWarning } from "./packaging-warning.js"
 
 export {
   FIXED_LAYOUT_MAX_SCALE,

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -163,6 +163,9 @@ export {
   ImagePartBounds,
   SectionViewport,
   NodePlacement,
+  formatSectionId,
+  parseSectionId,
+  MAX_SECTION_SEQ,
 } from "./page-sectioning.js"
 
 export {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -167,6 +167,9 @@ export {
   ImagePartBounds,
   SectionViewport,
   NodePlacement,
+  formatSectionId,
+  parseSectionId,
+  MAX_SECTION_SEQ,
 } from "./page-sectioning.js"
 
 export {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -306,6 +306,9 @@ export {
   TextCatalogOutput,
   TextCatalogCategory,
   getTextCatalogCategory,
+  ANSWER_ID_SEPARATOR,
+  answerTextId,
+  sectionIdOfAnswerTextId,
 } from "./text-catalog.js"
 
 export {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -169,6 +169,7 @@ export {
   NodePlacement,
   formatSectionId,
   parseSectionId,
+  parseAnySectionId,
   MAX_SECTION_SEQ,
 } from "./page-sectioning.js"
 

--- a/packages/types/src/packaging-warning.ts
+++ b/packages/types/src/packaging-warning.ts
@@ -1,0 +1,25 @@
+import { z } from "zod"
+
+/**
+ * Something packaging had to leave out of the bundle.
+ *
+ * Carried as *data*, not a formatted sentence, for two reasons: the message is
+ * composed in `packages/pipeline`, which has no access to the Studio's Lingui
+ * catalogs, and a structured warning can be grouped and counted in the UI. The
+ * translated wording lives with the component that renders it.
+ *
+ * - `orphaned-rendering` — a rendered section with no sectioning row behind it.
+ *   sectionIds are allocated once and never reused, so packaging cannot invent
+ *   one from the array position without risking a collision with a real
+ *   section, and two sections resolving to one id overwrite each other's HTML
+ *   file. The section is skipped instead, which is silent without this warning.
+ *   Usually means `web-rendering` is stale relative to `page-sectioning` — most
+ *   often after restoring an older sectioning version, which does not resync
+ *   the rendering. Re-running the storyboard render for the page fixes it.
+ */
+export const PackagingWarning = z.object({
+  kind: z.literal("orphaned-rendering"),
+  pageId: z.string(),
+  sectionIndex: z.number().int(),
+})
+export type PackagingWarning = z.infer<typeof PackagingWarning>

--- a/packages/types/src/page-sectioning.ts
+++ b/packages/types/src/page-sectioning.ts
@@ -196,6 +196,35 @@ export const PageSectioningOutput = z.object({
 })
 export type PageSectioningOutput = z.infer<typeof PageSectioningOutput>
 
+// ── Section identity ────────────────────────────────────────────
+// A sectionId is `${pageId}_sec${NNN}`. It identifies one output page and is
+// immutable for that section's whole life: it names the section's HTML file in
+// every bundle, and `sign_language_videos`, `toc-generation` entries and
+// text-catalog `${sectionId}_ans_*` keys all reference it. The sequence number
+// is allocated once and never reused, so it is NOT the section's array
+// position — `pg003_sec004` may well be `sections[1]`, and `pg003_sec001` may
+// not exist at all. Use the array index for array lookups and the id for
+// identity; never derive one from the other.
+
+/** Sequence numbers are zero-padded to 3 digits, so this is the ceiling. */
+export const MAX_SECTION_SEQ = 999
+
+/** Build the canonical sectionId for a page + sequence number. */
+export function formatSectionId(pageId: string, seq: number): string {
+  return `${pageId}_sec${String(seq).padStart(3, "0")}`
+}
+
+/**
+ * Split a sectionId back into its page and sequence number. Returns null for
+ * ids of other kinds (quiz `qz001`, glossary page `glp001`, …) so callers can
+ * use this as a type guard rather than a partial regex.
+ */
+export function parseSectionId(id: string): { pageId: string; seq: number } | null {
+  const match = /^(.+)_sec(\d+)$/.exec(id)
+  if (!match) return null
+  return { pageId: match[1], seq: Number(match[2]) }
+}
+
 // ── LLM-facing schemas ──────────────────────────────────────────
 // Recursive via z.lazy() so the JSON schema produced for OpenAI
 // structured outputs has proper `items` on `children` (OpenAI strict

--- a/packages/types/src/page-sectioning.ts
+++ b/packages/types/src/page-sectioning.ts
@@ -225,6 +225,30 @@ export function parseSectionId(id: string): { pageId: string; seq: number } | nu
   return { pageId: match[1], seq: Number(match[2]) }
 }
 
+/**
+ * As `parseSectionId`, but also accepts the legacy `${pageId}_s${N}` shape that
+ * `packages/agents` minted before it allocated through `createSectionIdFactory`.
+ *
+ * Use this on *read* paths that need to find the page an already-stored id
+ * belongs to — a book upgraded from a version that shipped those ids still has
+ * them, and rejecting one strands its section with no resolvable URL. Writers
+ * keep using `formatSectionId`, and `parseSectionId` stays the canonical-only
+ * guard for anything that must not accept a legacy id.
+ *
+ * Widening the parse is not the same as guessing: the caller still matches the
+ * id exactly against stored ids. `legacy` is reported so a caller that cares
+ * (the high-water mark) can treat the sequence number as spent-but-positional.
+ */
+export function parseAnySectionId(
+  id: string
+): { pageId: string; seq: number; legacy: boolean } | null {
+  // Greedy `(.+)` so a pageId that itself contains `_s` splits at the *last*
+  // separator: `bk_stuff_p1_sec002` is page `bk_stuff_p1`, not `bk`.
+  const match = /^(.+)_s(ec)?(\d+)$/.exec(id)
+  if (!match) return null
+  return { pageId: match[1], seq: Number(match[3]), legacy: match[2] === undefined }
+}
+
 // ── LLM-facing schemas ──────────────────────────────────────────
 // Recursive via z.lazy() so the JSON schema produced for OpenAI
 // structured outputs has proper `items` on `children` (OpenAI strict

--- a/packages/types/src/pipeline-effects.ts
+++ b/packages/types/src/pipeline-effects.ts
@@ -241,8 +241,20 @@ export function getStageRerunClearNodes(
   const speechIndex = STAGE_ORDER.indexOf("speech")
   if (speechIndex >= fromIndex && speechIndex <= toIndex) {
     // The speech runner merges valid cached entries and manual recordings into
-    // the replacement version. Keep only the prior audio manifest available
-    // for that merge; timestamps are regenerated from the replacement output.
+    // the replacement version, so keep the prior audio manifest available for
+    // that merge.
+    //
+    // A preserved manifest outlives the sectioning history its
+    // `${sectionId}_ans_*` ids came from, so anything that clears
+    // `page-sectioning` must retire those entries first — see
+    // `retireSectionIds` in @adt/pipeline.
+    //
+    // Timestamps are not listed here and are not cleared either: the node is
+    // `tts-timestamps` while STAGE_OUTPUT_NODES is derived from the step name
+    // `word-timestamps`, so no clear list names it. That is load-bearing rather
+    // than accidental — with `word_highlighting` off the runner deliberately
+    // leaves those rows alone to preserve hand-calculated timings — which is
+    // why they, too, are retired explicitly.
     preservedNodes.add("tts")
   }
 

--- a/packages/types/src/text-catalog.ts
+++ b/packages/types/src/text-catalog.ts
@@ -32,16 +32,50 @@ export const TextCatalogCategory = z.enum([
 export type TextCatalogCategory = z.infer<typeof TextCatalogCategory>
 
 const IMAGE_ID_RE = /_im\d{3}/
-const ANSWER_ID_RE = /_ans_/
 const GLOSSARY_ID_RE = /^gl(?:\d{3}|_manual_)/
 const EASY_READ_ID_RE = /_easy_read$/
+
+/** Separates an activity answer's owning sectionId from its answer key. */
+export const ANSWER_ID_SEPARATOR = "_ans_"
+
+/** The catalog id for one activity answer. The only place answer ids are built. */
+export function answerTextId(sectionId: string, answerKey: string): string {
+  return `${sectionId}${ANSWER_ID_SEPARATOR}${answerKey}`
+}
+
+/**
+ * The sectionId that owns an activity answer text id, or null if the id is not
+ * an answer id. The inverse of `answerTextId`.
+ *
+ * Section ids are immutable and are retired rather than reissued, so every
+ * store keyed by an answer id (`text-catalog`, its translations, the `tts`
+ * manifest and the audio derived from it) has to be able to ask which section
+ * an id belongs to when that section retires. Deriving the owner is O(1) per
+ * id; testing every retired id as a prefix would be O(retired x entries).
+ *
+ * The separator is what makes this collision-free. Canonical sequence numbers
+ * are always three digits, but the legacy `${pageId}_s${N}` shape the agent
+ * tools once minted is variable-length -- and `pg001_s11_ans_a` still resolves
+ * to `pg001_s11`, not `pg001_s1`, because the character after `pg001_s1` is
+ * `1` rather than the separator. Suffixed variants only ever append
+ * (`--secondary` from `voiceSlotEntryId`, `_easy_read` from easy-read
+ * flattening), so they resolve to the same owner, which is what callers want.
+ *
+ * Deliberately does not validate that the prefix *looks* like a section id:
+ * legacy `_sN` ids and spread page ids (`pg001002`) both have to work, and a
+ * caller's own set of retired ids is the real validation.
+ */
+export function sectionIdOfAnswerTextId(textId: string): string | null {
+  const index = textId.indexOf(ANSWER_ID_SEPARATOR)
+  return index > 0 ? textId.slice(0, index) : null
+}
 
 export function getTextCatalogCategory(id: string): TextCatalogCategory {
   // Easy Read ids are `{sourceId}_easy_read`; check first so they are not
   // mistaken for their source entry's category.
   if (EASY_READ_ID_RE.test(id)) return "easy-read"
   if (IMAGE_ID_RE.test(id)) return "captions"
-  if (ANSWER_ID_RE.test(id)) return "answers"
+  if (sectionIdOfAnswerTextId(id) !== null) return "answers"
   if (GLOSSARY_ID_RE.test(id)) return "glossary"
   return "text"
 }


### PR DESCRIPTION
First of five PRs splitting #777 (#660, reorder storyboard pages) into reviewable pieces. **This one stands alone and fixes live data corruption on `develop` today** — it is worth reading on its own merits, not as groundwork.

## The bug

Every structural operation on a page renumbered that page's `sectionId`s. So editing one section silently renamed its neighbours — and only `editable-activity` was migrated to match. Everything else keyed by `sectionId` was left pointing at the wrong section:

- `sign_language_videos.section_id` — a sign-language video reattached to unrelated content
- `toc-generation` entries
- text-catalog keys `${sectionId}_ans_*`, and so the translations and generated TTS audio derived from them

Cross-page merge renumbered both pages wholesale.

## The fix

`sectionId` becomes immutable. Clone, split, merge, cross-page merge and delete now retire ids rather than renumber survivors, via a new `createSectionIdFactory` / `retireSectionIds` pair in `apps/api/src/routes/pages.ts`.

**Ids are never reused.** The factory reads its high-water mark from *all* stored versions of a page's sectioning, not just the current one — hence the new `Storage.getAllNodeVersions`. Without that, `delete _sec003` → `split _sec002` reissues `_sec003` and adopts the deleted section's TOC entry, video and catalog keys.

This also rules out storing the counter on the entity itself: it would live inside the thing it counts, so a version restore would roll it back and reissue everything allocated since.

## Public surface added

- `formatSectionId` / `parseSectionId` / `MAX_SECTION_SEQ` in `packages/types/src/page-sectioning.ts`
- `Storage.getAllNodeVersions(node, itemId)` in `packages/storage`

No schema change, no migration.

## Not addressed here

Books already edited on `develop` carry dangling `sign_language_videos.section_id` and `toc-generation` sectionIds from historical renumbering. This stops the bleeding but repairs nothing. Surfacing those as a validation warning is follow-up work — they must never be auto-remapped, since a wrong guess silently attaches a sign-language video to unrelated content.

## Verification

`pnpm typecheck` clean · `pnpm test` 2745 passing · `pnpm lint` 0 errors.

Load-bearing tests: `sectionId stability across structural ops` in `apps/api/src/routes/pages.test.ts` (drives the real HTTP routes, one case per operation), no-reuse-after-delete, and sign-language survival across a merge.

---

**Review stack** (merge bottom-up): **#1 this** → stable quizIds → one reading-order resolver → id-based output filenames → #777 the feature.
