### PR TITLE
fix(quizzes): give quizzes stable ids instead of deriving them from position

### DIFF
--- a/apps/api/src/routes/adt-preview.ts
+++ b/apps/api/src/routes/adt-preview.ts
@@ -4,7 +4,14 @@ import { createHash } from "node:crypto"
 import { pathToFileURL } from "node:url"
 import { Hono } from "hono"
 import { HTTPException } from "hono/http-exception"
-import { isHeadingRole, isTtsExcluded, parseBookLabel, parseSectionId } from "@adt/types"
+import {
+  isHeadingRole,
+  isTtsExcluded,
+  parseBookLabel,
+  parseSectionId,
+  parseQuizId,
+  resolveQuizId,
+} from "@adt/types"
 import {
   WebRenderingOutput,
   type SpeechConfig,
@@ -34,7 +41,6 @@ import {
   buildQuizAnswers,
   buildTextCatalog,
   flattenEasyReadEntries,
-  pad3,
   loadBookConfig,
   buildPreferredImageAltMap,
   buildDecorativeImageIdSet,
@@ -368,8 +374,7 @@ function buildPagesManifest(storage: Storage): Array<{ section_id: string; href:
     const quizzes = quizzesByAfterPageId.get(page.pageId)
     if (quizzes) {
       for (const quiz of quizzes) {
-        const quizIndex = quizData!.quizzes.indexOf(quiz)
-        const quizId = `qz${pad3(quizIndex + 1)}`
+        const quizId = resolveQuizId(quiz, quizData!.quizzes.indexOf(quiz))
         list.push({ section_id: quizId, href: `${quizId}.html` })
       }
     }
@@ -751,7 +756,7 @@ export function createAdtPreviewRoutes(
         const catalog = await getTextCatalog(storage)
         if (quizData?.quizzes) {
           for (let i = 0; i < quizData.quizzes.length; i++) {
-            const quizId = `qz${pad3(i + 1)}`
+            const quizId = resolveQuizId(quizData.quizzes[i], i)
             allHtml += renderQuizHtml(quizData.quizzes[i], quizId, catalog) + "\n"
           }
         }
@@ -1048,15 +1053,17 @@ export function createAdtPreviewRoutes(
         reflowableFont: config.reflowable_font,
       })
 
-      // Check if this is a quiz page (qzNNN)
-      const quizMatch = pageId.match(/^qz(\d{3})$/)
-      if (quizMatch) {
-        const quizIndex = parseInt(quizMatch[1], 10) - 1
+      // Check if this is a quiz page (qzNNN). The id's number is NOT the quiz's
+      // array position — ids are allocated once and never reused — so resolve by
+      // id rather than indexing into the array.
+      if (parseQuizId(pageId) !== null) {
         const quizData = getQuizData(storage)
-        if (!quizData?.quizzes || quizIndex < 0 || quizIndex >= quizData.quizzes.length) {
+        const quiz = quizData?.quizzes?.find(
+          (q, i) => resolveQuizId(q, i) === pageId
+        )
+        if (!quiz) {
           throw new HTTPException(404, { message: `No quiz data for: ${pageId}` })
         }
-        const quiz = quizData.quizzes[quizIndex]
         const catalog = await getTextCatalog(storage)
 
         const quizPalette = (config.quiz_generation?.match_book_style ?? true)

--- a/apps/api/src/routes/adt-preview.ts
+++ b/apps/api/src/routes/adt-preview.ts
@@ -10,6 +10,8 @@ import {
   parseBookLabel,
   parseAnySectionId,
   resolveEntryVoiceSlot,
+  parseQuizId,
+  resolveQuizId,
 } from "@adt/types"
 import {
   WebRenderingOutput,
@@ -42,7 +44,6 @@ import {
   buildQuizAnswers,
   buildTextCatalog,
   flattenEasyReadEntries,
-  pad3,
   loadBookConfig,
   buildPreferredImageAltMap,
   buildDecorativeImageIdSet,
@@ -380,8 +381,7 @@ function buildPagesManifest(storage: Storage): Array<{ section_id: string; href:
     const quizzes = quizzesByAfterPageId.get(page.pageId)
     if (quizzes) {
       for (const quiz of quizzes) {
-        const quizIndex = quizData!.quizzes.indexOf(quiz)
-        const quizId = `qz${pad3(quizIndex + 1)}`
+        const quizId = resolveQuizId(quiz, quizData!.quizzes.indexOf(quiz))
         list.push({ section_id: quizId, href: `${quizId}.html` })
       }
     }
@@ -763,7 +763,7 @@ export function createAdtPreviewRoutes(
         const catalog = await getTextCatalog(storage)
         if (quizData?.quizzes) {
           for (let i = 0; i < quizData.quizzes.length; i++) {
-            const quizId = `qz${pad3(i + 1)}`
+            const quizId = resolveQuizId(quizData.quizzes[i], i)
             allHtml += renderQuizHtml(quizData.quizzes[i], quizId, catalog) + "\n"
           }
         }
@@ -1123,15 +1123,17 @@ export function createAdtPreviewRoutes(
         reflowableFont: config.reflowable_font,
       })
 
-      // Check if this is a quiz page (qzNNN)
-      const quizMatch = pageId.match(/^qz(\d{3})$/)
-      if (quizMatch) {
-        const quizIndex = parseInt(quizMatch[1], 10) - 1
+      // Check if this is a quiz page (qzNNN). The id's number is NOT the quiz's
+      // array position — ids are allocated once and never reused — so resolve by
+      // id rather than indexing into the array.
+      if (parseQuizId(pageId) !== null) {
         const quizData = getQuizData(storage)
-        if (!quizData?.quizzes || quizIndex < 0 || quizIndex >= quizData.quizzes.length) {
+        const quiz = quizData?.quizzes?.find(
+          (q, i) => resolveQuizId(q, i) === pageId
+        )
+        if (!quiz) {
           throw new HTTPException(404, { message: `No quiz data for: ${pageId}` })
         }
-        const quiz = quizData.quizzes[quizIndex]
         const catalog = await getTextCatalog(storage)
 
         const quizPalette = (config.quiz_generation?.match_book_style ?? true)

--- a/apps/api/src/routes/adt-preview.ts
+++ b/apps/api/src/routes/adt-preview.ts
@@ -12,6 +12,7 @@ import {
   resolveEntryVoiceSlot,
   parseQuizId,
   resolveQuizId,
+  withResolvedQuizIds,
 } from "@adt/types"
 import {
   WebRenderingOutput,
@@ -198,7 +199,7 @@ function getGlossary(storage: Storage): GlossaryOutput | undefined {
 
 function getQuizData(storage: Storage): QuizGenerationOutput | undefined {
   const row = storage.getLatestNodeData("quiz-generation", "book")
-  return row?.data as QuizGenerationOutput | undefined
+  return row ? withResolvedQuizIds(row.data as QuizGenerationOutput) : undefined
 }
 
 function buildTextsMap(

--- a/apps/api/src/routes/debug.ts
+++ b/apps/api/src/routes/debug.ts
@@ -3,7 +3,7 @@ import fs from "node:fs"
 import path from "node:path"
 import { Hono } from "hono"
 import { HTTPException } from "hono/http-exception"
-import { AccessibilityAssessmentOutput, parseBookLabel } from "@adt/types"
+import { AccessibilityAssessmentOutput, parseBookLabel, withResolvedQuizIds, type QuizGenerationOutput } from "@adt/types"
 import { openBookDb } from "@adt/storage"
 
 function getDbPath(label: string, booksDir: string): string {
@@ -284,10 +284,16 @@ export function createDebugRoutes(
           [node, itemId]
         ) as Array<{ version: number; data: string }>
 
-        const versions = rows.map((row) => ({
-          version: row.version,
-          data: JSON.parse(row.data),
-        }))
+        const versions = rows.map((row) => {
+          const data = JSON.parse(row.data)
+          // Opt-in read model for the version picker. Debug's default remains
+          // the exact stored JSON, and no read creates a backfill version.
+          const resolveIds = node === "quiz-generation" && c.req.query("resolveQuizIds") === "true"
+          return {
+            version: row.version,
+            data: resolveIds && data ? withResolvedQuizIds(data as QuizGenerationOutput) : data,
+          }
+        })
         return c.json({ versions })
       } else {
         const rows = db.all(

--- a/apps/api/src/routes/quiz-id-lifecycle.test.ts
+++ b/apps/api/src/routes/quiz-id-lifecycle.test.ts
@@ -204,6 +204,41 @@ describe("a legacy book's first edit", () => {
     expect(audioAfter).not.toContain("qz001_que.mp3")
   })
 
+  it("does not later hand a newcomer the audio of the quiz that first edit deleted", async () => {
+    // The delete above orphans qz001's .mp3 files, and the legacy version that
+    // spent qz001 never recorded it — the id lived only as an array position.
+    // A quiz added afterwards must still not be able to claim it, or it
+    // inherits a removed quiz's read-aloud in the packaged bundle.
+    seedLegacyBook([quiz("one"), quiz("two"), quiz("three")])
+    const audioBefore = await expectedAudioFilenames()
+
+    const fetched = await getQuizzes()
+    await putQuizzes({ ...fetched, quizzes: fetched.quizzes.slice(2) })
+
+    // A quiz on an earlier page sorts to the front, so it asks for the lowest
+    // free sequence number — qz001 unless qz001 is known to be spent.
+    const afterDelete = await getQuizzes()
+    await putQuizzes({
+      ...afterDelete,
+      quizzes: [quiz("newcomer"), ...afterDelete.quizzes],
+    })
+
+    const after = await quizCatalog()
+    expect(after).toEqual({
+      ...entriesFor("qz004", "newcomer"),
+      ...entriesFor("qz003", "three"),
+    })
+
+    // Said as the filenames, which is where the damage would be visible: the
+    // newcomer must not be voiced by any file the deleted quizzes left behind.
+    const newcomerAudio = Object.keys(entriesFor("qz004", "newcomer")).map(
+      (id) => `${id}.mp3`
+    )
+    for (const file of newcomerAudio) {
+      expect(audioBefore).not.toContain(file)
+    }
+  })
+
   it("keeps them when a quiz is inserted mid-book, and gives the newcomer fresh files", async () => {
     seedLegacyBook([quiz("one"), quiz("two"), quiz("three")])
     const before = await quizCatalog()

--- a/apps/api/src/routes/quiz-id-lifecycle.test.ts
+++ b/apps/api/src/routes/quiz-id-lifecycle.test.ts
@@ -1,0 +1,343 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { Hono } from "hono"
+import { createBookStorage } from "@adt/storage"
+import { buildTextCatalog } from "@adt/pipeline"
+import { errorHandler } from "../middleware/error-handler.js"
+import { createQuizRoutes } from "./quizzes.js"
+import type { Quiz, QuizGenerationOutput } from "@adt/types"
+
+/**
+ * The manual QA plan for stable quiz ids, run automatically.
+ *
+ * Quiz ids are not cosmetic: `${quizId}_que` / `${quizId}_o${n}` are the
+ * text-catalog keys, those keys are what the translation step writes against,
+ * and `speech.ts` names each generated audio file after the same key. So the
+ * question every step below asks is the same one a human would ask while
+ * clicking through the app: **does each quiz's text still answer to the id its
+ * translations and audio files are already stored under?**
+ *
+ * That is why these assert on the catalog rather than on `quizId` alone — an id
+ * that survives a delete but no longer keys the same question is exactly the
+ * corruption being tested for, and comparing ids to ids would miss it.
+ */
+
+const label = "quiz-lifecycle"
+let tmpDir: string
+let app: Hono
+
+function quiz(question: string, overrides: Partial<Quiz> = {}): Quiz {
+  return {
+    quizIndex: 0,
+    afterPageId: "pg001",
+    pageIds: ["pg001"],
+    question,
+    options: [
+      { text: `${question}-a`, explanation: `${question}-a-why` },
+      { text: `${question}-b`, explanation: `${question}-b-why` },
+      { text: `${question}-c`, explanation: `${question}-c-why` },
+    ],
+    answerIndex: 0,
+    reasoning: "",
+    ...overrides,
+  }
+}
+
+/** Every catalog entry `quiz(question)` contributes, filed under `id`. */
+function entriesFor(id: string, question: string): Record<string, string> {
+  const entries: Record<string, string> = { [`${id}_que`]: question }
+  ;["a", "b", "c"].forEach((suffix, i) => {
+    entries[`${id}_o${i}`] = `${question}-${suffix}`
+    entries[`${id}_o${i}_exp`] = `${question}-${suffix}-why`
+  })
+  return entries
+}
+
+function output(quizzes: Quiz[]): QuizGenerationOutput {
+  return {
+    generatedAt: "2026-01-01T00:00:00.000Z",
+    language: "en",
+    pagesPerQuiz: 3,
+    quizzes,
+  }
+}
+
+function withStorage<T>(fn: (storage: ReturnType<typeof createBookStorage>) => T): T {
+  const storage = createBookStorage(label, tmpDir)
+  try {
+    return fn(storage)
+  } finally {
+    storage.close()
+  }
+}
+
+/**
+ * Write quizzes straight to storage, bypassing the routes. The only way to set
+ * up a book whose stored quizzes carry no `quizId` — the state every book was
+ * in before the field existed, and the state the routes now stamp out of.
+ */
+function seedLegacyBook(quizzes: Quiz[]) {
+  withStorage((storage) => {
+    storage.putNodeData("quiz-generation", "book", output(quizzes))
+  })
+}
+
+function storedQuizzes(): Quiz[] {
+  return withStorage((storage) => {
+    const row = storage.getLatestNodeData("quiz-generation", "book")
+    return (row?.data as QuizGenerationOutput).quizzes
+  })
+}
+
+/**
+ * The `qz*` half of the text catalog, as `entryId -> text`.
+ *
+ * This is the map the translation step and the TTS step both key off, so it is
+ * the ground truth for "would this quiz keep its translations and audio". A
+ * legacy book with no stored ids produces exactly the same map it produced
+ * before `quizId` existed, because `resolveQuizId` falls back to the position.
+ */
+async function quizCatalog(): Promise<Record<string, string>> {
+  const catalog = await withStorage((storage) => buildTextCatalog(storage, []))
+  return Object.fromEntries(
+    catalog.entries
+      .filter((e) => e.id.startsWith("qz"))
+      .map((e) => [e.id, e.text])
+  )
+}
+
+/** The audio filenames TTS would write for the current catalog. */
+async function expectedAudioFilenames(): Promise<string[]> {
+  return Object.keys(await quizCatalog())
+    .map((id) => `${id}.mp3`)
+    .sort()
+}
+
+async function getQuizzes(): Promise<QuizGenerationOutput> {
+  const res = await app.request(`/api/books/${label}/quizzes`)
+  expect(res.status).toBe(200)
+  return (await res.json()).quizzes as QuizGenerationOutput
+}
+
+async function putQuizzes(body: QuizGenerationOutput) {
+  const res = await app.request(`/api/books/${label}/quizzes`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  })
+  expect(res.status).toBe(200)
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "adt-quiz-lifecycle-"))
+  withStorage(() => {})
+
+  app = new Hono()
+  app.onError(errorHandler)
+  app.route("/api", createQuizRoutes(tmpDir))
+})
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+})
+
+// ── Plan §0/§1 — a book nobody edits must not change ────────────
+
+describe("a legacy book nobody edits", () => {
+  it("produces byte-identical catalog keys and audio filenames", async () => {
+    seedLegacyBook([quiz("one"), quiz("two"), quiz("three")])
+
+    // Exactly what this book produced before `quizId` existed. If this map ever
+    // shifts, every stored translation and every generated .mp3 is now filed
+    // under a key that names different content.
+    expect(await quizCatalog()).toEqual({
+      ...entriesFor("qz001", "one"),
+      ...entriesFor("qz002", "two"),
+      ...entriesFor("qz003", "three"),
+    })
+  })
+
+  it("is not rewritten by being read", async () => {
+    seedLegacyBook([quiz("one")])
+    const before = storedQuizzes()
+
+    await getQuizzes()
+
+    // A GET that persisted a backfill would add a version to the history on
+    // mere page load, and could disagree with the read paths after a rollback.
+    expect(storedQuizzes()).toEqual(before)
+    expect(storedQuizzes()[0].quizId).toBeUndefined()
+  })
+})
+
+// ── Plan §2 — the first edit on a legacy book ───────────────────
+
+describe("a legacy book's first edit", () => {
+  it("keeps every survivor's translations and audio when the first quiz is deleted", async () => {
+    seedLegacyBook([quiz("one"), quiz("two"), quiz("three")])
+    const before = await quizCatalog()
+    const audioBefore = await expectedAudioFilenames()
+
+    // Exactly what the studio does: round-trip what GET handed it, minus one.
+    const fetched = await getQuizzes()
+    await putQuizzes({ ...fetched, quizzes: fetched.quizzes.slice(1) })
+
+    const after = await quizCatalog()
+
+    // "two" and "three" keep the keys their audio is already filed under.
+    expect(after).toEqual({
+      ...entriesFor("qz002", "two"),
+      ...entriesFor("qz003", "three"),
+    })
+
+    // Stated the other way round, because this is the actual regression: no
+    // surviving key may change the text it points at.
+    for (const [id, text] of Object.entries(after)) {
+      expect(before[id]).toBe(text)
+    }
+
+    // The deleted quiz's audio files are simply orphaned — never reassigned.
+    const audioAfter = await expectedAudioFilenames()
+    expect(audioAfter.every((f) => audioBefore.includes(f))).toBe(true)
+    expect(audioAfter).not.toContain("qz001_que.mp3")
+  })
+
+  it("keeps them when a quiz is inserted mid-book, and gives the newcomer fresh files", async () => {
+    seedLegacyBook([quiz("one"), quiz("two"), quiz("three")])
+    const before = await quizCatalog()
+
+    const fetched = await getQuizzes()
+    await putQuizzes({
+      ...fetched,
+      quizzes: [fetched.quizzes[0], quiz("new"), ...fetched.quizzes.slice(1)],
+    })
+
+    const after = await quizCatalog()
+
+    expect(storedQuizzes().map((q) => q.question)).toEqual([
+      "one",
+      "new",
+      "two",
+      "three",
+    ])
+    for (const [id, text] of Object.entries(before)) {
+      expect(after[id]).toBe(text)
+    }
+    // The newcomer sits second in the book but takes the next free id, not the
+    // id of whatever used to be second.
+    expect(after.qz004_que).toBe("new")
+  })
+
+  it("keeps them when the quizzes are reordered without adding or removing any", async () => {
+    seedLegacyBook([quiz("one"), quiz("two"), quiz("three")])
+    const before = await quizCatalog()
+
+    const fetched = await getQuizzes()
+    await putQuizzes({
+      ...fetched,
+      quizzes: [...fetched.quizzes].reverse(),
+    })
+
+    expect(await quizCatalog()).toEqual(before)
+    expect(storedQuizzes().map((q) => q.quizId)).toEqual([
+      "qz003",
+      "qz002",
+      "qz001",
+    ])
+  })
+})
+
+// ── Plan §3 — a book that already carries ids ───────────────────
+
+describe("a book that already carries ids", () => {
+  beforeEach(async () => {
+    seedLegacyBook([quiz("one"), quiz("two")])
+    await putQuizzes(await getQuizzes())
+  })
+
+  it("leaves existing ids alone when a quiz is added at the front", async () => {
+    const before = await quizCatalog()
+
+    const fetched = await getQuizzes()
+    await putQuizzes({
+      ...fetched,
+      quizzes: [quiz("new"), ...fetched.quizzes],
+    })
+
+    const after = await quizCatalog()
+    for (const [id, text] of Object.entries(before)) {
+      expect(after[id]).toBe(text)
+    }
+    expect(after.qz003_que).toBe("new")
+  })
+
+  it("never reissues the id of a deleted quiz, even versions later", async () => {
+    const fetched = await getQuizzes()
+
+    // Delete "two" (qz002) …
+    await putQuizzes({ ...fetched, quizzes: [fetched.quizzes[0]] })
+    // … then add two more quizzes across two separate versions.
+    const afterDelete = await getQuizzes()
+    await putQuizzes({
+      ...afterDelete,
+      quizzes: [...afterDelete.quizzes, quiz("three")],
+    })
+    const afterAdd = await getQuizzes()
+    await putQuizzes({ ...afterAdd, quizzes: [...afterAdd.quizzes, quiz("four")] })
+
+    const catalog = await quizCatalog()
+    // qz002's translations and audio still exist on disk; handing that id to
+    // new content would silently give it a removed quiz's read-aloud.
+    expect(catalog.qz002_que).toBeUndefined()
+    expect(storedQuizzes().map((q) => q.quizId)).toEqual([
+      "qz001",
+      "qz003",
+      "qz004",
+    ])
+  })
+
+  it("keeps ids stable across an unrelated content edit", async () => {
+    const fetched = await getQuizzes()
+    const edited = fetched.quizzes.map((q, i) =>
+      i === 0 ? { ...q, question: "one, reworded" } : q
+    )
+
+    await putQuizzes({ ...fetched, quizzes: edited })
+
+    const catalog = await quizCatalog()
+    // Editing the text re-points the same key, which is what invalidates that
+    // one entry's translation and audio — and only that one.
+    expect(catalog.qz001_que).toBe("one, reworded")
+    expect(catalog.qz002_que).toBe("two")
+  })
+})
+
+// ── Plan §2/§3 — rollback ───────────────────────────────────────
+
+describe("rollback", () => {
+  it("serves the ids the restored version's catalog was written for", async () => {
+    seedLegacyBook([quiz("one"), quiz("two"), quiz("three")])
+    const legacyCatalog = await quizCatalog()
+
+    // Move the book forward, then restore the original unstamped version by
+    // pointing the current version back at it.
+    const fetched = await getQuizzes()
+    await putQuizzes({ ...fetched, quizzes: fetched.quizzes.slice(1) })
+    withStorage((storage) =>
+      expect(storage.setCurrentNodeVersion("quiz-generation", "book", 1)).toBe(true)
+    )
+
+    // The restored version has no stored ids, so every consumer — the catalog
+    // here, and the UI through GET — must fall back to the same positional ids
+    // that version's translations and audio were filed under.
+    expect(await quizCatalog()).toEqual(legacyCatalog)
+    const served = await getQuizzes()
+    expect(served.quizzes.map((q) => q.quizId)).toEqual([
+      "qz001",
+      "qz002",
+      "qz003",
+    ])
+  })
+})

--- a/apps/api/src/routes/quiz-identity-regressions.test.ts
+++ b/apps/api/src/routes/quiz-identity-regressions.test.ts
@@ -1,0 +1,425 @@
+import { beforeEach, afterEach, describe, it, expect, vi } from "vitest"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { Hono } from "hono"
+import { createBookStorage } from "@adt/storage"
+import { buildTextCatalog, packageAdtWeb, saveQuizOutput } from "@adt/pipeline"
+import { formatQuizId, type Quiz, type QuizGenerationOutput } from "@adt/types"
+import { createQuizRoutes } from "./quizzes.js"
+import { createAdtPreviewRoutes } from "./adt-preview.js"
+import { errorHandler } from "../middleware/error-handler.js"
+import { createDebugRoutes } from "./debug.js"
+import { makeBeforeRun } from "./stages.js"
+import { createStageRunner } from "../services/stage-runner.js"
+
+// Only the remote model is stubbed. Generation, routes, SQLite, catalog,
+// HTML rendering and packaging remain production implementations.
+vi.mock("@adt/llm", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@adt/llm")>()
+  return {
+    ...original,
+    createLLMModel: () => ({
+      generateObject: generateObjectMock,
+    }),
+    createTTSSynthesizer: () => ({ synthesize: synthesizeMock }),
+  }
+})
+
+const { generateObjectMock, synthesizeMock } = vi.hoisted(() => ({
+  generateObjectMock: vi.fn(),
+  synthesizeMock: vi.fn(),
+}))
+const generatedResponse = {
+  object: {
+    question: "New replacement question",
+    reasoning: "review fixture",
+    options: [
+      { text: "a", explanation: "a-why" },
+      { text: "b", explanation: "b-why" },
+      { text: "c", explanation: "c-why" },
+    ],
+    answer_index: 0,
+  },
+}
+
+const label = "quiz-identity"
+let root: string
+let app: Hono
+let assets: string
+let configPath: string
+const quiz = (question: string, quizId?: string, afterPageId = "pg001"): Quiz => ({
+  ...(quizId === undefined ? {} : { quizId }), quizIndex: 0,
+  afterPageId, pageIds: [afterPageId], question,
+  options: ["a", "b", "c"].map((text) => ({ text, explanation: text + "-why" })),
+  answerIndex: 0, reasoning: "review fixture",
+})
+const output = (quizzes: Quiz[]): QuizGenerationOutput => ({
+  generatedAt: "2026-01-01T00:00:00.000Z", language: "en", pagesPerQuiz: 3, quizzes,
+})
+function useStorage<T>(fn: (s: ReturnType<typeof createBookStorage>) => T): T {
+  const s = createBookStorage(label, root)
+  try { return fn(s) } finally { s.close() }
+}
+function seed(quizzes: Quiz[]) {
+  useStorage((s) => s.putNodeData("quiz-generation", "book", output(quizzes)))
+}
+function stored(): QuizGenerationOutput {
+  return useStorage((s) => s.getLatestNodeData("quiz-generation", "book")!.data as QuizGenerationOutput)
+}
+async function put(quizzes: Quiz[]) {
+  return app.request(`/books/${label}/quizzes`, {
+    method: "PUT", headers: { "Content-Type": "application/json" }, body: JSON.stringify(output(quizzes)),
+  })
+}
+async function exportBook() {
+  const storage = createBookStorage(label, root)
+  try {
+    return await packageAdtWeb(storage, {
+      bookDir: path.join(root, label), label, language: "en", outputLanguages: ["en"],
+      title: "Review book", webAssetsDir: assets,
+    })
+  } finally { storage.close() }
+}
+beforeEach(() => {
+  generateObjectMock.mockReset().mockResolvedValue(generatedResponse)
+  synthesizeMock.mockReset().mockImplementation(async ({ input }: { input: string }) => Buffer.from(`AUDIO-FIXTURE: ${input}`))
+  root = fs.mkdtempSync(path.join(os.tmpdir(), "adt-quiz-identity-"))
+  configPath = path.join(root, "config.yaml")
+  fs.writeFileSync(configPath, "role_types: { section_text: Text }\nstructure_types: { paragraph: Paragraph }\nediting_language: en\nquiz_generation: { pages_per_quiz: 3 }\nspeech: { model: 'gpt-4o-mini-tts', voice: alloy }\n")
+  assets = path.join(root, "assets")
+  fs.mkdirSync(assets)
+  for (const f of ["base.bundle.min.js", "base.bundle.local.js", "activities.bundle.local.js"]) {
+    fs.writeFileSync(path.join(assets, f), "window.__review = true;")
+  }
+  fs.writeFileSync(path.join(assets, "fonts.css"), "body { font-family: serif; }")
+  fs.writeFileSync(path.join(assets, "tailwind_css.css"), "@tailwind base;\n@tailwind components;\n@tailwind utilities;\n")
+  useStorage((s) => {
+    for (let n = 1; n <= 2; n++) {
+      const pageId = `pg00${n}`
+      s.putExtractedPage({
+        pageId, pageNumber: n, text: `Page ${n}`,
+        pageImage: { imageId: `${pageId}_page`, buffer: Buffer.from("fixture"), format: "png", hash: `hash-${n}`, width: 100, height: 100 },
+        images: [],
+      })
+      s.putNodeData("web-rendering", pageId, { sections: [{ sectionIndex: 0, sectionType: "content", reasoning: "ok", html: `<div>Page ${n}</div>` }] })
+      s.putNodeData("page-sectioning", pageId, {
+        reasoning: "ok", sections: [{ sectionId: `${pageId}_sec001`, sectionType: "content", nodes: [], backgroundColor: "#fff", textColor: "#000", pageNumber: n, isPruned: false }],
+      })
+    }
+  })
+  app = new Hono()
+  app.onError(errorHandler)
+  app.route("/", createQuizRoutes(root, path.resolve("prompts"), configPath))
+  app.route("/", createAdtPreviewRoutes(root, assets, configPath))
+  app.route("/", createDebugRoutes(root, path.resolve("prompts"), configPath))
+})
+afterEach(() => fs.rmSync(root, { recursive: true, force: true }))
+
+describe("quiz identity across API edits and exports", () => {
+  it("does not give a legacy replacement the removed quiz's catalog and audio identity", async () => {
+    seed([quiz("Original question"), quiz("Survivor", undefined, "pg002")])
+    const audioDir = path.join(root, label, "audio/en")
+    fs.mkdirSync(audioDir, { recursive: true })
+    fs.writeFileSync(path.join(audioDir, "qz001_que.mp3"), "AUDIO-FIXTURE: Original question")
+    useStorage((s) => {
+      s.putNodeData("core-tts-catalog", "en", {
+        language: "en", generatedAt: "2026-01-01T00:00:00.000Z", entries: [{
+          id: "qz001_que", displayText: "Original question", speechText: "Original question",
+          changed: false, transformations: [], status: "ready",
+          generation: { mode: "unchanged", generatedAt: "2026-01-01T00:00:00.000Z", enabledTransformations: [], sourceTextHash: "old-source", contextHash: "old-context" },
+        }],
+      })
+      s.putNodeData("tts", "en", { entries: [{ textId: "qz001_que", language: "en", fileName: "qz001_que.mp3", voice: "alloy", model: "gpt-4o-mini-tts", cached: false }] })
+    })
+    const res = await app.request(`/books/${label}/quizzes/generate-one`, {
+      method: "POST", headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ pageIds: ["pg001"], afterPageId: "pg001", placement: "replace" }),
+    })
+    expect(res.status).toBe(200)
+    expect((await res.json()).quiz.quizId).toBe("qz003")
+    const s = createBookStorage(label, root)
+    let catalog
+    try { catalog = await buildTextCatalog(s, []) } finally { s.close() }
+    const questions = catalog.entries.filter((e) => e.id.endsWith("_que"))
+    await exportBook()
+    const locale = path.join(root, label, "adt/content/i18n/en")
+    const texts = JSON.parse(fs.readFileSync(path.join(locale, "texts.json"), "utf8"))
+    const audioMap = JSON.parse(fs.readFileSync(path.join(locale, "audios.json"), "utf8"))
+    expect(texts.qz003_que).toBe("New replacement question")
+    expect(audioMap.qz003_que).toBeUndefined()
+    expect(fs.readFileSync(path.join(audioDir, "qz001_que.mp3"), "utf8")).toBe("AUDIO-FIXTURE: Original question")
+    expect(questions).not.toContainEqual({ id: "qz001_que", text: "New replacement question" })
+    expect(stored().quizzes.map((q) => q.quizId)).toEqual(["qz003", "qz002"])
+  })
+
+  it("rejects duplicate quiz identities instead of silently overwriting one export page", async () => {
+    const res = await put([quiz("First question", "qz001"), quiz("Second question", "qz001", "pg002")])
+    expect(res.status).toBe(400)
+  })
+
+  it("does not let an API quizId overwrite a file outside the book during export", async () => {
+    const outside = path.join(root, "outside-book.html")
+    fs.writeFileSync(outside, "original outside-book content")
+    const res = await put([quiz("Traversal question", "../../outside-book")])
+    expect(res.status).toBe(400)
+    expect(useStorage((s) => s.getLatestNodeData("quiz-generation", "book"))).toBeNull()
+    expect(fs.readFileSync(outside, "utf8")).toBe("original outside-book content")
+  })
+
+  it("preserves identities when a legacy API client submits the same id-less payload twice", async () => {
+    seed([quiz("One"), quiz("Two", undefined, "pg002")])
+    const legacyBody = stored().quizzes
+    expect((await put(legacyBody)).status).toBe(200)
+    const firstIds = stored().quizzes.map((q) => q.quizId)
+    expect((await put(legacyBody)).status).toBe(200)
+    const secondIds = stored().quizzes.map((q) => q.quizId)
+    expect(secondIds).toEqual(firstIds)
+  })
+
+  it("previews sparse stable ids, serves the matching manifest, and 404s a retired id", async () => {
+    seed([quiz("First sparse question", "qz004"), quiz("Second sparse question", "qz003", "pg002")])
+    const pages = await app.request(`/books/${label}/adt-preview/content/pages.json`)
+    expect(pages.status).toBe(200)
+    expect(await pages.json()).toEqual(expect.arrayContaining([
+      { section_id: "qz004", href: "qz004.html" }, { section_id: "qz003", href: "qz003.html" },
+    ]))
+    const preview = await app.request(`/books/${label}/adt-preview/qz004.html`)
+    expect(preview.status).toBe(200)
+    expect(await preview.text()).toContain("First sparse question")
+    expect((await app.request(`/books/${label}/adt-preview/qz001.html`)).status).toBe(404)
+  })
+})
+
+async function runStage(stage: "quizzes" | "speech") {
+  await createStageRunner().run(label, {
+    booksDir: root, promptsDir: path.resolve("prompts"), configPath,
+    credentials: { openai: { apiKey: "test-fixture" } }, fromStage: stage, toStage: stage,
+  }, { emit: () => {} })
+}
+
+function history() {
+  return useStorage((s) => s.getAllNodeVersions("quiz-generation", "book"))
+}
+
+describe("quiz identity validation and legacy compatibility", () => {
+  it.each(["qz000", "qz1", "qz1000", "", "../qz001", "qz001\n", "qz001\r"])("rejects noncanonical id %j without a version write", async (id) => {
+    seed([quiz("Original", "qz001")])
+    expect((await put([quiz("Changed", id)])).status).toBe(400)
+    expect(history()).toHaveLength(1)
+    expect(stored().quizzes[0].question).toBe("Original")
+  })
+
+  it.each([
+    [quiz("Unsafe", "../../outside-book")],
+    [quiz("First", "qz001"), quiz("Collision", "qz001")],
+    [quiz("Explicit", "qz002"), quiz("Legacy collision")],
+  ])("rejects corrupt imported identities before touching an existing export (%#)", async (...quizzes) => {
+    seed(quizzes)
+    const adt = path.join(root, label, "adt")
+    fs.mkdirSync(adt)
+    fs.writeFileSync(path.join(adt, "index.html"), "previous successful export")
+    const outside = path.join(root, "outside-book.html")
+    fs.writeFileSync(outside, "outside original")
+    await expect(exportBook()).rejects.toThrow(/quiz id/i)
+    expect(fs.readFileSync(path.join(adt, "index.html"), "utf8")).toBe("previous successful export")
+    expect(fs.readFileSync(outside, "utf8")).toBe("outside original")
+    const storage = createBookStorage(label, root)
+    try { await expect(buildTextCatalog(storage, [])).rejects.toThrow(/quiz id/i) }
+    finally { storage.close() }
+    expect((await app.request(`/books/${label}/adt-preview/content/pages.json`)).status).toBe(500)
+  })
+
+  it("rejects ambiguous ID-less content edits but permits an explicit edit", async () => {
+    seed([quiz("Original")])
+    expect((await put([quiz("Changed")])).status).toBe(400)
+    expect(history()).toHaveLength(1)
+    expect((await put([quiz("Changed", "qz001")])).status).toBe(200)
+    expect(stored().quizzes[0]).toMatchObject({ question: "Changed", quizId: "qz001" })
+  })
+
+  it("preserves legacy identities through deletion, reordering, retry and append", async () => {
+    const quizzes = [quiz("One"), quiz("Two"), quiz("Three")]
+    seed(quizzes)
+    const reordered = [quizzes[2], quizzes[1]]
+    expect((await put(reordered)).status).toBe(200)
+    expect(stored().quizzes.map((q) => q.quizId)).toEqual(["qz003", "qz002"])
+    expect((await put([...reordered, quiz("Four")])).status).toBe(200)
+    expect((await put([...reordered, quiz("Four")])).status).toBe(200)
+    expect(stored().quizzes.map((q) => q.quizId)).toEqual(["qz003", "qz002", "qz004"])
+    expect(stored().quizzes.map((q) => q.quizIndex)).toEqual([0, 1, 2])
+    expect((await put([quiz("Cannot resurrect", "qz001")])).status).toBe(400)
+  })
+
+  it("accepts exact ID-less retries even when the unchanged set contains identical quizzes", async () => {
+    const original = [quiz("Same"), quiz("Same")]
+    seed(original)
+    expect((await put(original)).status).toBe(200)
+    expect((await put(original)).status).toBe(200)
+    expect(stored().quizzes.map((q) => q.quizId)).toEqual(["qz001", "qz002"])
+  })
+
+  it("rejects ID-less duplicate-content ambiguity instead of guessing identity", async () => {
+    seed([quiz("Same"), quiz("Same")])
+    expect((await put([quiz("Same")])).status).toBe(400)
+    expect(history()).toHaveLength(1)
+  })
+
+  it("does not let PUT race an active full-stage generation", async () => {
+    seed([quiz("Original", "qz001")])
+    useStorage((s) => s.markStepStarted("quiz-generation"))
+    expect((await put([quiz("Changed", "qz001")])).status).toBe(409)
+    expect(history()).toHaveLength(1)
+  })
+
+  it("rechecks stage activity after the generate-one model call completes", async () => {
+    seed([quiz("Original", "qz001")])
+    generateObjectMock.mockImplementationOnce(async () => {
+      useStorage((s) => s.markStepStarted("quiz-generation"))
+      return generatedResponse
+    })
+    const response = await app.request(`/books/${label}/quizzes/generate-one`, {
+      method: "POST", headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ pageIds: ["pg001"], afterPageId: "pg001", placement: "replace" }),
+    })
+    expect(response.status).toBe(409)
+    expect(history()).toHaveLength(1)
+  })
+
+  it("fails allocation atomically when all 999 identities are spent", async () => {
+    seed(Array.from({ length: 999 }, (_, i) => quiz(`Question ${i}`, formatQuizId(i + 1))))
+    expect((await put([])).status).toBe(200)
+    expect((await put([quiz("New")])).status).toBe(400)
+    expect(history()).toHaveLength(2)
+    expect(stored().quizzes).toEqual([])
+  })
+
+  it("normalizes history comparison without rewriting legacy debug data", async () => {
+    seed([quiz("One"), quiz("Two")])
+    expect((await put(stored().quizzes))).toHaveProperty("status", 200)
+    const url = `/books/${label}/debug/versions/quiz-generation/book?includeData=true`
+    const raw = await (await app.request(url)).json()
+    expect(raw.versions[1].data.quizzes[0].quizId).toBeUndefined()
+    const resolved = await (await app.request(`${url}&resolveQuizIds=true`)).json()
+    expect(resolved.versions[1].data.quizzes.map((q: Quiz) => q.quizId)).toEqual(["qz001", "qz002"])
+    expect(resolved.versions[0].data.quizzes).toEqual(resolved.versions[1].data.quizzes.map((q: Quiz, quizIndex: number) => ({ ...q, quizIndex })))
+    expect(history()).toHaveLength(2)
+    useStorage((s) => s.clearNodesByType(["quiz-generation"]))
+    const cleared = await (await app.request(`${url}&resolveQuizIds=true`)).json()
+    expect(cleared.versions[0].data).toBeNull()
+    expect((await (await app.request(`/books/${label}/quizzes`)).json()).quizzes).toBeNull()
+  })
+})
+
+describe("full-stage quiz regeneration", () => {
+  it("allocates fresh IDs on each full rerun and after rollback, even for identical model output", async () => {
+    seed([quiz("Legacy one"), quiz("Legacy two")])
+    makeBeforeRun(label, "quizzes", "quizzes", root)()
+    await runStage("quizzes")
+    expect(stored().quizzes.map((q) => q.quizId)).toEqual(["qz003"])
+    makeBeforeRun(label, "quizzes", "quizzes", root)()
+    await runStage("quizzes")
+    expect(stored().quizzes.map((q) => q.quizId)).toEqual(["qz004"])
+    useStorage((s) => expect(s.setCurrentNodeVersion("quiz-generation", "book", 1)).toBe(true))
+    expect(stored().quizzes[0].question).toBe("Legacy one")
+    makeBeforeRun(label, "quizzes", "quizzes", root)()
+    await runStage("quizzes")
+    expect(stored().quizzes.map((q) => q.quizId)).toEqual(["qz005"])
+    expect(history()).toHaveLength(4)
+  })
+
+  it("can regenerate corrupt imported identities while retaining their history", async () => {
+    seed([quiz("First", "qz001"), quiz("Duplicate", "qz001")])
+    makeBeforeRun(label, "quizzes", "quizzes", root)()
+    await runStage("quizzes")
+    expect(stored().quizzes[0].quizId).toBe("qz002")
+    expect(history()).toHaveLength(2)
+  })
+
+  it("publishes an empty result if no pages remain eligible, without erasing history", async () => {
+    seed([quiz("Original", "qz001")])
+    useStorage((s) => s.clearNodesByType(["web-rendering"]))
+    makeBeforeRun(label, "quizzes", "quizzes", root)()
+    await runStage("quizzes")
+    expect(stored().quizzes).toEqual([])
+    expect(history()).toHaveLength(2)
+    expect(generateObjectMock).not.toHaveBeenCalled()
+  })
+
+  it("does not replace prior output if a full rerun exhausts the ID space", async () => {
+    seed(Array.from({ length: 999 }, (_, i) => quiz(`Question ${i}`, formatQuizId(i + 1))))
+    makeBeforeRun(label, "quizzes", "quizzes", root)()
+    await expect(runStage("quizzes")).rejects.toThrow("allocated all 999")
+    expect(history()).toHaveLength(1)
+    expect(stored().quizzes).toHaveLength(999)
+  })
+
+  it("reserves a removed legacy singleton and IDs from versions newer than a rollback", async () => {
+    seed([quiz("Legacy")])
+    seed([quiz("Newer", "qz002")])
+    useStorage((s) => s.setCurrentNodeVersion("quiz-generation", "book", 1))
+    const response = await app.request(`/books/${label}/quizzes/generate-one`, {
+      method: "POST", headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ pageIds: ["pg001"], afterPageId: "pg001", placement: "replace" }),
+    })
+    expect(response.status).toBe(200)
+    expect((await response.json()).quiz.quizId).toBe("qz003")
+    expect(stored().quizzes).toEqual([expect.objectContaining({ quizId: "qz003" })])
+  })
+
+  it("keeps the previous quiz output and history if full generation fails", async () => {
+    seed([quiz("Original", "qz001")])
+    generateObjectMock.mockRejectedValue(new Error("model unavailable"))
+    makeBeforeRun(label, "quizzes", "quizzes", root)()
+    await expect(runStage("quizzes")).rejects.toThrow("model unavailable")
+    expect(stored().quizzes[0]).toMatchObject({ question: "Original", quizId: "qz001" })
+    expect(history()).toHaveLength(1)
+    expect(useStorage((s) => s.getStepRuns()).find((s) => s.step === "quiz-generation")?.status).toBe("error")
+  })
+
+  it("reserves IDs after upstream invalidation and a complete extraction reset", async () => {
+    seed([quiz("One"), quiz("Two")])
+    makeBeforeRun(label, "storyboard", "storyboard", root)()
+    expect(useStorage((s) => s.getLatestNodeData("quiz-generation", "book"))).toBeNull()
+    useStorage((s) => saveQuizOutput(s, output([quiz("Three")]), "replace"))
+    expect(stored().quizzes[0].quizId).toBe("qz003")
+    makeBeforeRun(label, "extract", "quizzes", root)()
+    expect(useStorage((s) => s.getLatestNodeData("quiz-generation", "book"))).toBeNull()
+    useStorage((s) => saveQuizOutput(s, output([quiz("Four")]), "replace"))
+    expect(stored().quizzes[0].quizId).toBe("qz004")
+    expect(history()).toHaveLength(5)
+  })
+
+  it("cannot reuse or overwrite old manual audio when the full run preserves the speech manifest", async () => {
+    seed([quiz("Original question", "qz001")])
+    const audioDir = path.join(root, label, "audio/en")
+    fs.mkdirSync(audioDir, { recursive: true })
+    fs.writeFileSync(path.join(audioDir, "qz001_que.mp3"), "ORIGINAL MANUAL RECORDING")
+    useStorage((s) => s.putNodeData("tts", "en", { entries: [{
+      textId: "qz001_que", language: "en", fileName: "qz001_que.mp3",
+      voice: "manual", model: "manual", provider: "manual", voiceSlot: "primary", cached: false,
+    }] }))
+    makeBeforeRun(label, "quizzes", "speech", root)()
+    expect(useStorage((s) => s.getLatestNodeData("tts", "en"))).not.toBeNull()
+    await runStage("quizzes")
+    expect(stored().quizzes[0].quizId).toBe("qz002")
+    // Seed the intermediate ready catalog; the actual Speech runner, cache and
+    // output writer execute below. Only the provider's audio bytes are stubbed.
+    useStorage((s) => s.putNodeData("core-tts-catalog", "en", {
+      language: "en", generatedAt: "2026-01-01T00:00:00.000Z", entries: [{
+        id: "qz002_que", displayText: "New replacement question", speechText: "New replacement question",
+        changed: false, transformations: [], status: "ready",
+        generation: { mode: "unchanged", generatedAt: "2026-01-01T00:00:00.000Z", enabledTransformations: [], sourceTextHash: "new", contextHash: "new" },
+      }],
+    }))
+    await runStage("speech")
+    expect(synthesizeMock).toHaveBeenCalledWith(expect.objectContaining({ input: "New replacement question" }))
+    expect(fs.readFileSync(path.join(audioDir, "qz002_que.mp3"), "utf8")).toBe("AUDIO-FIXTURE: New replacement question")
+    expect(fs.readFileSync(path.join(audioDir, "qz001_que.mp3"), "utf8")).toBe("ORIGINAL MANUAL RECORDING")
+    const tts = useStorage((s) => s.getLatestNodeData("tts", "en")!.data) as { entries: Array<{textId: string; provider: string}> }
+    expect(tts.entries).toEqual([expect.objectContaining({ textId: "qz002_que", provider: "openai" })])
+    useStorage((s) => s.setCurrentNodeVersion("quiz-generation", "book", 1))
+    expect(stored().quizzes[0].question).toBe("Original question")
+    expect(fs.readFileSync(path.join(audioDir, "qz001_que.mp3"), "utf8")).toBe("ORIGINAL MANUAL RECORDING")
+  })
+})

--- a/apps/api/src/routes/quiz-identity-regressions.test.ts
+++ b/apps/api/src/routes/quiz-identity-regressions.test.ts
@@ -4,17 +4,23 @@ import os from "node:os"
 import path from "node:path"
 import { Hono } from "hono"
 import { createBookStorage } from "@adt/storage"
-import { buildTextCatalog, packageAdtWeb, saveQuizOutput } from "@adt/pipeline"
-import { formatQuizId, type Quiz, type QuizGenerationOutput } from "@adt/types"
+import { buildTextCatalog, packageAdtWeb, packageWebpub, packageEpub, saveQuizOutput, assertQuizGenerationCapacity } from "@adt/pipeline"
+import { formatQuizId, QuizIdExhaustedError, type Quiz, type QuizGenerationOutput } from "@adt/types"
 import { createQuizRoutes } from "./quizzes.js"
+import { createPageRoutes } from "./pages.js"
 import { createAdtPreviewRoutes } from "./adt-preview.js"
 import { errorHandler } from "../middleware/error-handler.js"
 import { createDebugRoutes } from "./debug.js"
 import { makeBeforeRun } from "./stages.js"
 import { createStageRunner } from "../services/stage-runner.js"
 
-// Only the remote model is stubbed. Generation, routes, SQLite, catalog,
-// HTML rendering and packaging remain production implementations.
+// Providers are stubbed. Capacity-failure tests additionally inject a guard
+// failure rather than materializing an impossible number of stored quizzes.
+// Normal scenarios call the real guard; SQLite, generation and exports are real.
+vi.mock("@adt/pipeline", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@adt/pipeline")>()
+  return { ...original, assertQuizGenerationCapacity: vi.fn(original.assertQuizGenerationCapacity) }
+})
 vi.mock("@adt/llm", async (importOriginal) => {
   const original = await importOriginal<typeof import("@adt/llm")>()
   return {
@@ -82,6 +88,7 @@ async function exportBook() {
   } finally { storage.close() }
 }
 beforeEach(() => {
+  vi.mocked(assertQuizGenerationCapacity).mockReset()
   generateObjectMock.mockReset().mockResolvedValue(generatedResponse)
   synthesizeMock.mockReset().mockImplementation(async ({ input }: { input: string }) => Buffer.from(`AUDIO-FIXTURE: ${input}`))
   root = fs.mkdtempSync(path.join(os.tmpdir(), "adt-quiz-identity-"))
@@ -203,7 +210,7 @@ function history() {
 }
 
 describe("quiz identity validation and legacy compatibility", () => {
-  it.each(["qz000", "qz1", "qz1000", "", "../qz001", "qz001\n", "qz001\r"])("rejects noncanonical id %j without a version write", async (id) => {
+  it.each(["qz000", "qz1", "qz0001", "qz9007199254740992", "", "../qz001", "qz001\n", "qz1000\n", "qz001\r"])("rejects noncanonical id %j without a version write", async (id) => {
     seed([quiz("Original", "qz001")])
     expect((await put([quiz("Changed", id)])).status).toBe(400)
     expect(history()).toHaveLength(1)
@@ -286,12 +293,12 @@ describe("quiz identity validation and legacy compatibility", () => {
     expect(history()).toHaveLength(1)
   })
 
-  it("fails allocation atomically when all 999 identities are spent", async () => {
+  it("allocates qz1000 after the first 999 identities have been retired", async () => {
     seed(Array.from({ length: 999 }, (_, i) => quiz(`Question ${i}`, formatQuizId(i + 1))))
     expect((await put([])).status).toBe(200)
-    expect((await put([quiz("New")])).status).toBe(400)
-    expect(history()).toHaveLength(2)
-    expect(stored().quizzes).toEqual([])
+    expect((await put([quiz("New")])).status).toBe(200)
+    expect(history()).toHaveLength(3)
+    expect(stored().quizzes).toEqual([expect.objectContaining({ quizId: "qz1000" })])
   })
 
   it("normalizes history comparison without rewriting legacy debug data", async () => {
@@ -346,12 +353,16 @@ describe("full-stage quiz regeneration", () => {
     expect(generateObjectMock).not.toHaveBeenCalled()
   })
 
-  it("does not replace prior output if a full rerun exhausts the ID space", async () => {
+  it("regenerates past qz999 while retaining every prior version", async () => {
     seed(Array.from({ length: 999 }, (_, i) => quiz(`Question ${i}`, formatQuizId(i + 1))))
     makeBeforeRun(label, "quizzes", "quizzes", root)()
-    await expect(runStage("quizzes")).rejects.toThrow("allocated all 999")
-    expect(history()).toHaveLength(1)
-    expect(stored().quizzes).toHaveLength(999)
+    await runStage("quizzes")
+    expect(history()).toHaveLength(2)
+    expect(stored().quizzes[0].quizId).toBe("qz1000")
+    makeBeforeRun(label, "quizzes", "quizzes", root)()
+    await runStage("quizzes")
+    expect(stored().quizzes[0].quizId).toBe("qz1001")
+    expect(history()).toHaveLength(3)
   })
 
   it("reserves a removed legacy singleton and IDs from versions newer than a rollback", async () => {
@@ -421,5 +432,126 @@ describe("full-stage quiz regeneration", () => {
     useStorage((s) => s.setCurrentNodeVersion("quiz-generation", "book", 1))
     expect(stored().quizzes[0].question).toBe("Original question")
     expect(fs.readFileSync(path.join(audioDir, "qz001_que.mp3"), "utf8")).toBe("ORIGINAL MANUAL RECORDING")
+  })
+})
+
+
+describe("recoverable inactive quiz history", () => {
+  it("exposes history while keeping invalidated output absent, and restores without allocating IDs", async () => {
+    app.route("/", createPageRoutes(root, path.resolve("prompts"), assets, configPath))
+    seed([quiz("Original", "qz1000")])
+    makeBeforeRun(label, "storyboard", "storyboard", root)()
+    expect(await (await app.request(`/books/${label}/quizzes`)).json()).toEqual({
+      quizzes: null, version: null, historyVersion: 2,
+    })
+    const restore = await app.request(`/books/${label}/versions/quiz-generation/book/restore`, {
+      method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ version: 1 }),
+    })
+    expect(restore.status).toBe(200)
+    expect(await (await app.request(`/books/${label}/quizzes`)).json()).toMatchObject({
+      version: 1, historyVersion: 1, quizzes: { quizzes: [{ quizId: "qz1000" }] },
+    })
+    expect(history()).toHaveLength(2)
+    useStorage((s) => s.setCurrentNodeVersion("quiz-generation", "book", 2))
+    expect(await (await app.request(`/books/${label}/quizzes`)).json()).toEqual({
+      quizzes: null, version: null, historyVersion: 2,
+    })
+  })
+})
+
+
+describe("quiz allocation preflight", () => {
+  it("rejects full generation before model calls or writes when capacity is insufficient", async () => {
+    seed([quiz("Original", "qz001")])
+    vi.mocked(assertQuizGenerationCapacity).mockImplementationOnce(() => { throw new QuizIdExhaustedError(1, 0) })
+    makeBeforeRun(label, "quizzes", "quizzes", root)()
+    await expect(runStage("quizzes")).rejects.toThrow("Not enough quiz IDs available: 1 requested, 0 remaining.")
+    expect(assertQuizGenerationCapacity).toHaveBeenCalledWith(expect.anything(), 1)
+    expect(generateObjectMock).not.toHaveBeenCalled()
+    expect(history()).toHaveLength(1)
+    expect(stored().quizzes[0].question).toBe("Original")
+  })
+
+  it("rejects generate-one before its model call, with a client error", async () => {
+    seed([quiz("Original", "qz001")])
+    vi.mocked(assertQuizGenerationCapacity).mockImplementationOnce(() => { throw new QuizIdExhaustedError(1, 0) })
+    const response = await app.request(`/books/${label}/quizzes/generate-one`, {
+      method: "POST", headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ pageIds: ["pg001"], afterPageId: "pg001", placement: "replace" }),
+    })
+    expect(response.status).toBe(400)
+    expect(generateObjectMock).not.toHaveBeenCalled()
+    expect(history()).toHaveLength(1)
+  })
+
+  it("re-reads reservations at persistence if another write occurs during generation", async () => {
+    generateObjectMock.mockImplementationOnce(async () => {
+      useStorage((s) => saveQuizOutput(s, output([quiz("Concurrent")]), "replace"))
+      return generatedResponse
+    })
+    await runStage("quizzes")
+    expect(stored().quizzes[0].quizId).toBe("qz002")
+    expect(history()).toHaveLength(2)
+  })
+})
+
+describe("wide quiz IDs in output formats", () => {
+  it("keeps old IDs and carries qz1000/qz1001 through preview, web, WebPub and EPUB", async () => {
+    const ids = ["qz999", "qz1000", "qz1001"]
+    expect((await put(ids.map((id) => quiz(`Question ${id}`, id)))).status).toBe(200)
+    const audioDir = path.join(root, label, "audio/en")
+    fs.mkdirSync(audioDir, { recursive: true })
+    for (const id of ids) fs.writeFileSync(path.join(audioDir, `${id}_que.mp3`), `AUDIO: ${id}`)
+    useStorage((s) => {
+      s.putNodeData("core-tts-catalog", "en", {
+        language: "en", generatedAt: "2026-01-01T00:00:00.000Z", entries: ids.map((id) => ({
+          id: `${id}_que`, displayText: `Question ${id}`, speechText: `Question ${id}`,
+          changed: false, transformations: [], status: "ready",
+          generation: { mode: "unchanged", generatedAt: "2026-01-01T00:00:00.000Z", enabledTransformations: [], sourceTextHash: id, contextHash: id },
+        })),
+      })
+      s.putNodeData("tts", "en", { entries: ids.map((id) => ({
+        textId: `${id}_que`, language: "en", fileName: `${id}_que.mp3`, voice: "manual",
+        model: "manual", provider: "manual", voiceSlot: "primary", cached: false,
+      })) })
+    })
+    for (const id of ids) {
+      const preview = await app.request(`/books/${label}/adt-preview/${id}.html`)
+      expect(preview.status).toBe(200)
+      expect(await preview.text()).toContain(`Question ${id}`)
+    }
+    await exportBook()
+    const bookDir = path.join(root, label)
+    for (const id of ids) {
+      const html = fs.readFileSync(path.join(bookDir, "adt", `${id}.html`), "utf8")
+      expect(html).toContain(`${id}_que`)
+      expect(html).toContain(`${id}_o0`)
+      const locale = path.join(bookDir, "adt/content/i18n/en")
+      const audioMap = JSON.parse(fs.readFileSync(path.join(locale, "audios.json"), "utf8"))
+      expect(audioMap[`${id}_que`]).toBe(`${id}_que.mp3`)
+      expect(fs.readFileSync(path.join(locale, "audio", audioMap[`${id}_que`]), "utf8")).toBe(`AUDIO: ${id}`)
+      expect(fs.readFileSync(path.join(audioDir, `${id}_que.mp3`), "utf8")).toBe(`AUDIO: ${id}`)
+    }
+    const storage = createBookStorage(label, root)
+    const options = { bookDir, label, language: "en", title: "Identity boundaries", webAssetsDir: assets }
+    try {
+      packageWebpub(storage, options)
+      const manifest = JSON.parse(fs.readFileSync(path.join(bookDir, "webpub/manifest.json"), "utf8"))
+      for (const id of ids) expect(manifest.readingOrder).toContainEqual(expect.objectContaining({ href: `${id}.html` }))
+      packageEpub(storage, options)
+      const pages = JSON.parse(fs.readFileSync(path.join(bookDir, "epub/OEBPS/content/pages.json"), "utf8"))
+      for (const id of ids) {
+        expect(pages).toContainEqual(expect.objectContaining({ section_id: id, href: `${id}.xhtml` }))
+        expect(fs.readFileSync(path.join(bookDir, "epub/OEBPS", `${id}.xhtml`), "utf8")).toContain(`${id}_que`)
+      }
+      for (const formatRoot of ["webpub", "epub/OEBPS"]) {
+        const locale = path.join(bookDir, formatRoot, "content/i18n/en")
+        const audioMap = JSON.parse(fs.readFileSync(path.join(locale, "audios.json"), "utf8"))
+        for (const id of ids) {
+          expect(audioMap[`${id}_que`]).toBe(`${id}_que.mp3`)
+          expect(fs.readFileSync(path.join(locale, "audio", audioMap[`${id}_que`]), "utf8")).toBe(`AUDIO: ${id}`)
+        }
+      }
+    } finally { storage.close() }
   })
 })

--- a/apps/api/src/routes/quizzes.test.ts
+++ b/apps/api/src/routes/quizzes.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { Hono } from "hono"
+import { createBookStorage } from "@adt/storage"
+import { errorHandler } from "../middleware/error-handler.js"
+import { createQuizRoutes } from "./quizzes.js"
+import type { Quiz, QuizGenerationOutput } from "@adt/types"
+
+const label = "quiz-book"
+let tmpDir: string
+let app: Hono
+
+function quiz(question: string, overrides: Partial<Quiz> = {}): Quiz {
+  return {
+    quizIndex: 0,
+    afterPageId: "pg001",
+    pageIds: ["pg001"],
+    question,
+    options: [
+      { text: "a", explanation: "" },
+      { text: "b", explanation: "" },
+      { text: "c", explanation: "" },
+    ],
+    answerIndex: 0,
+    reasoning: "",
+    ...overrides,
+  }
+}
+
+function output(quizzes: Quiz[]): QuizGenerationOutput {
+  return {
+    generatedAt: "2026-01-01T00:00:00.000Z",
+    language: "en",
+    pagesPerQuiz: 3,
+    quizzes,
+  }
+}
+
+function putQuizzes(body: QuizGenerationOutput) {
+  return app.request(`/api/books/${label}/quizzes`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  })
+}
+
+function storedQuizzes(): Quiz[] {
+  const storage = createBookStorage(label, tmpDir)
+  try {
+    const row = storage.getLatestNodeData("quiz-generation", "book")
+    return (row?.data as QuizGenerationOutput).quizzes
+  } finally {
+    storage.close()
+  }
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "adt-quiz-route-"))
+  const storage = createBookStorage(label, tmpDir)
+  storage.close()
+
+  app = new Hono()
+  app.onError(errorHandler)
+  app.route("/api", createQuizRoutes(tmpDir))
+})
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+})
+
+describe("PUT /api/books/:label/quizzes", () => {
+  it("stamps missing quizIds with the ids their catalog entries already use", async () => {
+    // A book saved before quizId existed. Its `${quizId}_que` catalog entries,
+    // translations and audio were all keyed off array position, so backfilling
+    // must reproduce exactly those ids.
+    const res = await putQuizzes(output([quiz("one"), quiz("two")]))
+    expect(res.status).toBe(200)
+
+    expect(storedQuizzes().map((q) => q.quizId)).toEqual(["qz001", "qz002"])
+  })
+
+  it("keeps existing ids when a quiz is inserted at the front", async () => {
+    await putQuizzes(output([quiz("one"), quiz("two")]))
+    const existing = storedQuizzes()
+
+    const res = await putQuizzes(output([quiz("new"), ...existing]))
+    expect(res.status).toBe(200)
+
+    const saved = storedQuizzes()
+    expect(saved.map((q) => q.question)).toEqual(["new", "one", "two"])
+    // "one" and "two" keep qz001/qz002 — the newcomer does not take qz001 and
+    // inherit their translations and generated audio.
+    expect(saved.map((q) => q.quizId)).toEqual(["qz003", "qz001", "qz002"])
+  })
+
+  it("does not reissue the id of a quiz deleted in an earlier version", async () => {
+    await putQuizzes(output([quiz("one"), quiz("two")]))
+    const [first] = storedQuizzes()
+
+    // Delete "two" (qz002), then add a fresh quiz.
+    await putQuizzes(output([first]))
+    const res = await putQuizzes(output([first, quiz("three")]))
+    expect(res.status).toBe(200)
+
+    const ids = storedQuizzes().map((q) => q.quizId)
+    expect(ids).toEqual(["qz001", "qz003"])
+    expect(ids).not.toContain("qz002")
+  })
+})

--- a/apps/api/src/routes/quizzes.test.ts
+++ b/apps/api/src/routes/quizzes.test.ts
@@ -59,6 +59,11 @@ function storedQuizzes(): Quiz[] {
 /** Write straight to storage, bypassing the route — the only way to set up a
  *  book whose stored quizzes have no ids, as every book did before `quizId`. */
 function seedQuizzes(body: QuizGenerationOutput) {
+  seedRaw(body)
+}
+
+/** `seedQuizzes` without the schema, for versions today's schema rejects. */
+function seedRaw(body: unknown) {
   const storage = createBookStorage(label, tmpDir)
   try {
     storage.putNodeData("quiz-generation", "book", body)
@@ -110,6 +115,45 @@ describe("PUT /api/books/:label/quizzes", () => {
     // "one" and "two" keep qz001/qz002 — the newcomer does not take qz001 and
     // inherit their translations and generated audio.
     expect(saved.map((q) => q.quizId)).toEqual(["qz003", "qz001", "qz002"])
+  })
+
+  it("reserves ids held by a version today's schema no longer accepts", async () => {
+    // A superseded version whose quizzes don't satisfy the current schema (here
+    // two options where three are required) still burned the ids it holds. If
+    // the reservation validates each version and skips the ones that fail, that
+    // version's ids look free and get handed straight back out.
+    seedRaw({
+      generatedAt: "2026-01-01T00:00:00.000Z",
+      language: "en",
+      pagesPerQuiz: 3,
+      quizzes: [
+        {
+          quizId: "qz002",
+          quizIndex: 0,
+          afterPageId: "pg001",
+          pageIds: ["pg001"],
+          question: "retired",
+          options: [
+            { text: "a", explanation: "" },
+            { text: "b", explanation: "" },
+          ],
+          answerIndex: 0,
+          reasoning: "",
+        },
+      ],
+    })
+    seedQuizzes(output([quiz("one", { quizId: "qz001" })]))
+
+    const fetched = await getQuizzes()
+    const res = await putQuizzes({
+      ...fetched,
+      quizzes: [...fetched.quizzes, quiz("newcomer")],
+    })
+    expect(res.status).toBe(200)
+
+    const ids = storedQuizzes().map((q) => q.quizId)
+    expect(ids).toEqual(["qz001", "qz003"])
+    expect(ids).not.toContain("qz002")
   })
 
   it("does not reissue the id of a quiz deleted in an earlier version", async () => {
@@ -189,5 +233,46 @@ describe("legacy books whose first edit reorders the quizzes", () => {
       "qz002",
       "qz003",
     ])
+  })
+
+  it("does not reissue an id the legacy version spent but never stored", async () => {
+    // A legacy version records no quizIds at all, so the ids it spent exist
+    // only as array positions. Deleting those quizzes on the *first* edit
+    // retires qz001/qz002 without ever writing them into a stored version —
+    // and a reservation that reads only stored `quizId` fields cannot see them.
+    seedQuizzes(output([quiz("one"), quiz("two"), quiz("three")]))
+
+    const fetched = await getQuizzes()
+    await putQuizzes({ ...fetched, quizzes: fetched.quizzes.slice(2) })
+    expect(storedQuizzes().map((q) => q.quizId)).toEqual(["qz003"])
+
+    // Now add a quiz on an earlier page, so it sorts to the front and asks for
+    // the lowest free sequence number.
+    const afterDelete = await getQuizzes()
+    const res = await putQuizzes({
+      ...afterDelete,
+      quizzes: [quiz("newcomer"), ...afterDelete.quizzes],
+    })
+    expect(res.status).toBe(200)
+
+    const saved = storedQuizzes()
+    expect(saved.map((q) => q.question)).toEqual(["newcomer", "three"])
+    // qz001 and qz002 belong to the deleted quizzes for good — their
+    // translations and generated audio are still on disk under those keys.
+    expect(saved.map((q) => q.quizId)).toEqual(["qz004", "qz003"])
+  })
+
+  it("still stamps positional ids when an unstamped body re-saves the current version", async () => {
+    // The counterpart to the test above: retiring a superseded version's
+    // positional ids must not retire the *current* version's. A direct API
+    // caller that PUTs the quizzes it has without ids is claiming this book's
+    // existing qz001/qz002 — the keys its catalog is already written against —
+    // not asking for two fresh ones.
+    seedQuizzes(output([quiz("one"), quiz("two")]))
+
+    const res = await putQuizzes(output([quiz("one"), quiz("two")]))
+    expect(res.status).toBe(200)
+
+    expect(storedQuizzes().map((q) => q.quizId)).toEqual(["qz001", "qz002"])
   })
 })

--- a/apps/api/src/routes/quizzes.test.ts
+++ b/apps/api/src/routes/quizzes.test.ts
@@ -56,6 +56,23 @@ function storedQuizzes(): Quiz[] {
   }
 }
 
+/** Write straight to storage, bypassing the route — the only way to set up a
+ *  book whose stored quizzes have no ids, as every book did before `quizId`. */
+function seedQuizzes(body: QuizGenerationOutput) {
+  const storage = createBookStorage(label, tmpDir)
+  try {
+    storage.putNodeData("quiz-generation", "book", body)
+  } finally {
+    storage.close()
+  }
+}
+
+async function getQuizzes(): Promise<QuizGenerationOutput> {
+  const res = await app.request(`/api/books/${label}/quizzes`)
+  expect(res.status).toBe(200)
+  return (await res.json()).quizzes as QuizGenerationOutput
+}
+
 beforeEach(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "adt-quiz-route-"))
   const storage = createBookStorage(label, tmpDir)
@@ -107,5 +124,70 @@ describe("PUT /api/books/:label/quizzes", () => {
     const ids = storedQuizzes().map((q) => q.quizId)
     expect(ids).toEqual(["qz001", "qz003"])
     expect(ids).not.toContain("qz002")
+  })
+})
+
+describe("GET /api/books/:label/quizzes", () => {
+  it("resolves ids for a book stored before quizId existed", async () => {
+    seedQuizzes(output([quiz("one"), quiz("two")]))
+
+    const got = await getQuizzes()
+
+    // Exactly the ids `resolveQuizId` derives, so the catalog keys the UI shows
+    // match the ones packaging and the text catalog already use.
+    expect(got.quizzes.map((q) => q.quizId)).toEqual(["qz001", "qz002"])
+  })
+
+  it("does not persist a version just for being read", async () => {
+    seedQuizzes(output([quiz("one")]))
+    const before = storedQuizzes()
+
+    await getQuizzes()
+
+    expect(storedQuizzes()).toEqual(before)
+    expect(storedQuizzes()[0].quizId).toBeUndefined()
+  })
+})
+
+describe("legacy books whose first edit reorders the quizzes", () => {
+  it("keeps each survivor's id when the first of three quizzes is deleted", async () => {
+    // The regression this exists to prevent. A book with no stored ids: its
+    // catalog entries, translations and audio are keyed qz001/qz002/qz003 by
+    // array position. Deleting the first quiz shifts the survivors up, so
+    // stamping the post-delete array would give them qz001/qz002 — the ids of
+    // the quizzes that used to precede them.
+    seedQuizzes(output([quiz("one"), quiz("two"), quiz("three")]))
+
+    // The studio round-trips what GET handed it, minus the deleted quiz.
+    const fetched = await getQuizzes()
+    const res = await putQuizzes({
+      ...fetched,
+      quizzes: fetched.quizzes.slice(1),
+    })
+    expect(res.status).toBe(200)
+
+    const saved = storedQuizzes()
+    expect(saved.map((q) => q.question)).toEqual(["two", "three"])
+    expect(saved.map((q) => q.quizId)).toEqual(["qz002", "qz003"])
+  })
+
+  it("keeps them when a quiz is inserted mid-book, and gives the newcomer a fresh id", async () => {
+    seedQuizzes(output([quiz("one"), quiz("two"), quiz("three")]))
+
+    const fetched = await getQuizzes()
+    const res = await putQuizzes({
+      ...fetched,
+      quizzes: [fetched.quizzes[0], quiz("new"), ...fetched.quizzes.slice(1)],
+    })
+    expect(res.status).toBe(200)
+
+    const saved = storedQuizzes()
+    expect(saved.map((q) => q.question)).toEqual(["one", "new", "two", "three"])
+    expect(saved.map((q) => q.quizId)).toEqual([
+      "qz001",
+      "qz004",
+      "qz002",
+      "qz003",
+    ])
   })
 })

--- a/apps/api/src/routes/quizzes.ts
+++ b/apps/api/src/routes/quizzes.ts
@@ -6,10 +6,11 @@ import { z } from "zod"
 import {
   parseBookLabel,
   QuizGenerationOutput,
+  ensureQuizIds,
   type Quiz,
   type WebRenderingOutput,
 } from "@adt/types"
-import { openBookDb, createBookStorage, readCurrentNodeRow } from "@adt/storage"
+import { openBookDb, createBookStorage, readCurrentNodeRow, type Storage } from "@adt/storage"
 import {
   buildQuizGenerationConfig,
   generateQuiz,
@@ -28,6 +29,24 @@ function safeParseLabel(label: string): string {
       message: err instanceof Error ? err.message : String(err),
     })
   }
+}
+
+/**
+ * Every quiz id this book has ever used, across all stored versions. Reserving
+ * them means a delete-then-add cannot reissue a retired quiz's id and inherit
+ * its `${quizId}_que` / `${quizId}_o${n}` catalog entries — and with them the
+ * translations and generated audio of a quiz the user removed.
+ */
+function usedQuizIds(storage: Storage): string[] {
+  const ids: string[] = []
+  for (const row of storage.getAllNodeVersions("quiz-generation", "book")) {
+    const parsed = QuizGenerationOutput.safeParse(row.data)
+    if (!parsed.success) continue
+    for (const quiz of parsed.data.quizzes) {
+      if (quiz.quizId) ids.push(quiz.quizId)
+    }
+  }
+  return ids
 }
 
 export function createQuizRoutes(
@@ -102,7 +121,10 @@ export function createQuizRoutes(
 
     const storage = createBookStorage(safeLabel, booksDir)
     try {
-      const version = storage.putNodeData("quiz-generation", "book", parsed.data)
+      // Stamp ids on any quiz that still lacks one, so this book stops deriving
+      // them from array positions from here on.
+      const { output } = ensureQuizIds(parsed.data, usedQuizIds(storage))
+      const version = storage.putNodeData("quiz-generation", "book", output)
       return c.json({ version })
     } finally {
       storage.close()
@@ -251,12 +273,17 @@ export function createQuizRoutes(
         q.quizIndex = i
       })
 
-      const output: QuizGenerationOutput = {
-        generatedAt: existing?.generatedAt ?? new Date().toISOString(),
-        language: existing?.language ?? quizConfig.language,
-        pagesPerQuiz: existing?.pagesPerQuiz ?? quizConfig.pagesPerQuiz,
-        quizzes,
-      }
+      // Stamp ids before writing: the new quiz needs one, and any pre-existing
+      // quiz that predates `quizId` keeps the id its catalog entries already use.
+      const { output } = ensureQuizIds(
+        {
+          generatedAt: existing?.generatedAt ?? new Date().toISOString(),
+          language: existing?.language ?? quizConfig.language,
+          pagesPerQuiz: existing?.pagesPerQuiz ?? quizConfig.pagesPerQuiz,
+          quizzes,
+        },
+        usedQuizIds(storage)
+      )
 
       const version = storage.putNodeData("quiz-generation", "book", output)
       // Adding a quiz by hand produces the same output as running the stage, so

--- a/apps/api/src/routes/quizzes.ts
+++ b/apps/api/src/routes/quizzes.ts
@@ -6,10 +6,11 @@ import { z } from "zod"
 import {
   parseBookLabel,
   QuizGenerationOutput,
+  ensureQuizIds,
   type Quiz,
   type WebRenderingOutput,
 } from "@adt/types"
-import { openBookDb, createBookStorage, readCurrentNodeRow } from "@adt/storage"
+import { openBookDb, createBookStorage, readCurrentNodeRow, type Storage } from "@adt/storage"
 import {
   buildQuizGenerationConfig,
   generateQuiz,
@@ -29,6 +30,24 @@ function safeParseLabel(label: string): string {
       message: err instanceof Error ? err.message : String(err),
     })
   }
+}
+
+/**
+ * Every quiz id this book has ever used, across all stored versions. Reserving
+ * them means a delete-then-add cannot reissue a retired quiz's id and inherit
+ * its `${quizId}_que` / `${quizId}_o${n}` catalog entries — and with them the
+ * translations and generated audio of a quiz the user removed.
+ */
+function usedQuizIds(storage: Storage): string[] {
+  const ids: string[] = []
+  for (const row of storage.getAllNodeVersions("quiz-generation", "book")) {
+    const parsed = QuizGenerationOutput.safeParse(row.data)
+    if (!parsed.success) continue
+    for (const quiz of parsed.data.quizzes) {
+      if (quiz.quizId) ids.push(quiz.quizId)
+    }
+  }
+  return ids
 }
 
 export function createQuizRoutes(
@@ -103,7 +122,10 @@ export function createQuizRoutes(
 
     const storage = createBookStorage(safeLabel, booksDir)
     try {
-      const version = storage.putNodeData("quiz-generation", "book", parsed.data)
+      // Stamp ids on any quiz that still lacks one, so this book stops deriving
+      // them from array positions from here on.
+      const { output } = ensureQuizIds(parsed.data, usedQuizIds(storage))
+      const version = storage.putNodeData("quiz-generation", "book", output)
       return c.json({ version })
     } finally {
       storage.close()
@@ -242,12 +264,17 @@ export function createQuizRoutes(
         q.quizIndex = i
       })
 
-      const output: QuizGenerationOutput = {
-        generatedAt: existing?.generatedAt ?? new Date().toISOString(),
-        language: existing?.language ?? quizConfig.language,
-        pagesPerQuiz: existing?.pagesPerQuiz ?? quizConfig.pagesPerQuiz,
-        quizzes,
-      }
+      // Stamp ids before writing: the new quiz needs one, and any pre-existing
+      // quiz that predates `quizId` keeps the id its catalog entries already use.
+      const { output } = ensureQuizIds(
+        {
+          generatedAt: existing?.generatedAt ?? new Date().toISOString(),
+          language: existing?.language ?? quizConfig.language,
+          pagesPerQuiz: existing?.pagesPerQuiz ?? quizConfig.pagesPerQuiz,
+          quizzes,
+        },
+        usedQuizIds(storage)
+      )
 
       const version = storage.putNodeData("quiz-generation", "book", output)
       // Adding a quiz by hand produces the same output as running the stage, so

--- a/apps/api/src/routes/quizzes.ts
+++ b/apps/api/src/routes/quizzes.ts
@@ -17,6 +17,7 @@ import {
   buildQuizGenerationConfig,
   generateQuiz,
   saveQuizOutput,
+  assertQuizGenerationCapacity,
   loadBookConfig,
   normalizeLocale,
   getRenderSectioning,
@@ -36,9 +37,9 @@ function safeParseLabel(label: string): string {
 }
 
 /** Surface identity validation and allocation failures as client errors. */
-function saveQuizzes(storage: Storage, output: QuizGenerationOutput, mode: "edit" | "insert") {
+function withQuizIdentityErrors<T>(operation: () => T): T {
   try {
-    return saveQuizOutput(storage, output, mode)
+    return operation()
   } catch (err) {
     if (err instanceof QuizIdExhaustedError || err instanceof QuizIdentityError) {
       throw new HTTPException(400, { message: err.message })
@@ -79,10 +80,11 @@ export function createQuizRoutes(
     const db = openBookDb(dbPath)
     try {
       // Current-pointer version (falls back to MAX) so a rollback is reflected.
-      const row = readCurrentNodeRow(db, "quiz-generation", "book")
+      const row = readCurrentNodeRow(db, "quiz-generation", "book", { includeInvalidated: true })
 
-      if (!row) {
-        return c.json({ quizzes: null, version: null })
+      if (!row || row.data === "null") {
+        // History selection survives invalidation; active output stays absent.
+        return c.json({ quizzes: null, version: null, historyVersion: row?.version ?? null })
       }
 
       let parsed: unknown
@@ -109,6 +111,7 @@ export function createQuizRoutes(
       return c.json({
         quizzes: withResolvedQuizIds(validated.data),
         version: row.version,
+        historyVersion: row.version,
       })
     } finally {
       db.close()
@@ -131,7 +134,7 @@ export function createQuizRoutes(
     const storage = createBookStorage(safeLabel, booksDir)
     try {
       assertQuizzesIdle(storage)
-      const { version } = saveQuizzes(storage, parsed.data, "edit")
+      const { version } = withQuizIdentityErrors(() => saveQuizOutput(storage, parsed.data, "edit"))
       return c.json({ version })
     } finally {
       storage.close()
@@ -232,6 +235,7 @@ export function createQuizRoutes(
         providerCredentials: credentials,
       })
 
+      withQuizIdentityErrors(() => assertQuizGenerationCapacity(storage, 1))
       const generated = await generateQuiz(batch, 0, quizConfig, llmModel)
       // The user chooses where the quiz lands, independent of its source pages.
       const newQuiz: Quiz = { ...generated, afterPageId }
@@ -273,7 +277,7 @@ export function createQuizRoutes(
         // Only the newcomer still lacks an id; allocation reserves every
         // id this book has ever issued, so it cannot adopt a retired quiz's
         // catalog entries.
-        const { output, version } = saveQuizzes(
+        const { output, version } = withQuizIdentityErrors(() => saveQuizOutput(
           storage,
           {
             generatedAt: existing?.generatedAt ?? new Date().toISOString(),
@@ -282,7 +286,7 @@ export function createQuizRoutes(
             quizzes,
           },
           "insert"
-        )
+        ))
 
         // Adding a quiz by hand produces the same output as running the stage, so
         // mark the step done — otherwise the quizzes stage never lights up as

--- a/apps/api/src/routes/quizzes.ts
+++ b/apps/api/src/routes/quizzes.ts
@@ -6,10 +6,9 @@ import { z } from "zod"
 import {
   parseBookLabel,
   QuizGenerationOutput,
-  ensureQuizIds,
   withResolvedQuizIds,
-  formatQuizId,
   QuizIdExhaustedError,
+  QuizIdentityError,
   type Quiz,
   type WebRenderingOutput,
 } from "@adt/types"
@@ -17,6 +16,7 @@ import { openBookDb, createBookStorage, readCurrentNodeRow, type Storage } from 
 import {
   buildQuizGenerationConfig,
   generateQuiz,
+  saveQuizOutput,
   loadBookConfig,
   normalizeLocale,
   getRenderSectioning,
@@ -35,59 +35,21 @@ function safeParseLabel(label: string): string {
   }
 }
 
-/**
- * Every quiz id this book has ever spent, across all stored versions. Reserving
- * them means a delete-then-add cannot reissue a retired quiz's id and inherit
- * its `${quizId}_que` / `${quizId}_o${n}` catalog entries — and with them the
- * translations and generated audio of a quiz the user removed.
- *
- * A version stored before `quizId` existed carries no ids, but it still spent
- * the positional ones every consumer derived for its slots, so those are
- * reserved too — otherwise the *first* edit on a legacy book retires an id that
- * was never written down anywhere, and the next quiz added can be handed it.
- *
- * The one exception is the current version. It is the base an incoming body is
- * presumed to descend from, so a caller that sends quizzes with no ids is still
- * claiming its positional ids rather than asking for fresh ones — that is the
- * positional back-compat `ensureQuizIds` provides. Only *superseded* versions
- * have their positional ids retired for good.
- *
- * Read leniently rather than through `QuizGenerationOutput.safeParse`: a
- * version that no longer satisfies today's schema still burned the ids it
- * holds, and skipping it would let them be reissued. Reserving too much can
- * only push an allocation forward; reserving too little corrupts a book.
- */
-function usedQuizIds(storage: Storage): string[] {
-  const currentVersion =
-    storage.getLatestNodeData("quiz-generation", "book")?.version ?? null
-  const ids: string[] = []
-  for (const row of storage.getAllNodeVersions("quiz-generation", "book")) {
-    const quizzes = (row.data as { quizzes?: unknown } | null)?.quizzes
-    if (!Array.isArray(quizzes)) continue
-    quizzes.forEach((quiz, index) => {
-      const stored = (quiz as { quizId?: unknown } | null)?.quizId
-      if (typeof stored === "string" && stored.length > 0) {
-        ids.push(stored)
-      } else if (row.version !== currentVersion) {
-        ids.push(formatQuizId(index + 1))
-      }
-    })
-  }
-  return ids
-}
-
-/** `ensureQuizIds` with the exhaustion error surfaced as a 400. */
-function stampQuizIds(
-  output: QuizGenerationOutput,
-  storage: Storage
-): QuizGenerationOutput {
+/** Surface identity validation and allocation failures as client errors. */
+function saveQuizzes(storage: Storage, output: QuizGenerationOutput, mode: "edit" | "insert") {
   try {
-    return ensureQuizIds(output, usedQuizIds(storage)).output
+    return saveQuizOutput(storage, output, mode)
   } catch (err) {
-    if (err instanceof QuizIdExhaustedError) {
+    if (err instanceof QuizIdExhaustedError || err instanceof QuizIdentityError) {
       throw new HTTPException(400, { message: err.message })
     }
     throw err
+  }
+}
+
+function assertQuizzesIdle(storage: Storage): void {
+  if (storage.getStepRuns().some((run) => run.step === "quiz-generation" && run.status === "running")) {
+    throw new HTTPException(409, { message: "Quiz generation is currently running. Wait for it to finish before editing quizzes." })
   }
 }
 
@@ -168,12 +130,8 @@ export function createQuizRoutes(
 
     const storage = createBookStorage(safeLabel, booksDir)
     try {
-      // Safety net for bodies that arrive without ids. GET resolves them on the
-      // way out, so the studio's own edits already carry each quiz's id and
-      // nothing is allocated here; a direct API caller that omits them gets the
-      // positional back-compat instead.
-      const output = stampQuizIds(parsed.data, storage)
-      const version = storage.putNodeData("quiz-generation", "book", output)
+      assertQuizzesIdle(storage)
+      const { version } = saveQuizzes(storage, parsed.data, "edit")
       return c.json({ version })
     } finally {
       storage.close()
@@ -217,15 +175,7 @@ export function createQuizRoutes(
       // A running quiz-generation stage rewrites the entire quiz set when it
       // finishes, so a quiz added mid-run would be silently clobbered. Reject
       // until the run completes (the UI also hides the entry points).
-      const quizStep = storage
-        .getStepRuns()
-        .find((r) => r.step === "quiz-generation")
-      if (quizStep?.status === "running") {
-        throw new HTTPException(409, {
-          message:
-            "Quiz generation is currently running. Wait for it to finish before adding a quiz.",
-        })
-      }
+      assertQuizzesIdle(storage)
 
       const appConfig = loadBookConfig(safeLabel, booksDir, configPath)
       const metadataRow = storage.getLatestNodeData("metadata", "book")
@@ -299,44 +249,47 @@ export function createQuizRoutes(
       // stamping after the sort would hand the newcomer whichever id used to
       // belong to the quiz at its index — along with that quiz's translations
       // and generated audio.
-      const existingRow = storage.getLatestNodeData("quiz-generation", "book")
-      const existing = existingRow
-        ? withResolvedQuizIds(existingRow.data as QuizGenerationOutput)
-        : null
+      return storage.transaction(() => {
+        assertQuizzesIdle(storage)
+        const existingRow = storage.getLatestNodeData("quiz-generation", "book")
+        const existing = existingRow
+          ? withResolvedQuizIds(existingRow.data as QuizGenerationOutput)
+          : null
 
-      const priorQuizzes =
-        placement === "after"
-          ? (existing?.quizzes ?? [])
-          : (existing?.quizzes ?? []).filter((q) => q.afterPageId !== afterPageId)
-      const quizzes = [...priorQuizzes, newQuiz]
-      quizzes.sort(
-        (a, b) =>
-          (pageNumberById.get(a.afterPageId) ?? 0) -
-          (pageNumberById.get(b.afterPageId) ?? 0)
-      )
-      quizzes.forEach((q, i) => {
-        q.quizIndex = i
+        const priorQuizzes =
+          placement === "after"
+            ? (existing?.quizzes ?? [])
+            : (existing?.quizzes ?? []).filter((q) => q.afterPageId !== afterPageId)
+        const quizzes = [...priorQuizzes, newQuiz]
+        quizzes.sort(
+          (a, b) =>
+            (pageNumberById.get(a.afterPageId) ?? 0) -
+            (pageNumberById.get(b.afterPageId) ?? 0)
+        )
+        quizzes.forEach((q, i) => {
+          q.quizIndex = i
+        })
+
+        // Only the newcomer still lacks an id; allocation reserves every
+        // id this book has ever issued, so it cannot adopt a retired quiz's
+        // catalog entries.
+        const { output, version } = saveQuizzes(
+          storage,
+          {
+            generatedAt: existing?.generatedAt ?? new Date().toISOString(),
+            language: existing?.language ?? quizConfig.language,
+            pagesPerQuiz: existing?.pagesPerQuiz ?? quizConfig.pagesPerQuiz,
+            quizzes,
+          },
+          "insert"
+        )
+
+        // Adding a quiz by hand produces the same output as running the stage, so
+        // mark the step done — otherwise the quizzes stage never lights up as
+        // completed for books whose quizzes were all added one at a time.
+        storage.markStepCompleted("quiz-generation")
+        return c.json({ quiz: output.quizzes[quizzes.indexOf(newQuiz)], version })
       })
-
-      // Only the newcomer still lacks an id; `usedQuizIds` keeps it off every
-      // id this book has ever issued, so it cannot adopt a retired quiz's
-      // catalog entries.
-      const output = stampQuizIds(
-        {
-          generatedAt: existing?.generatedAt ?? new Date().toISOString(),
-          language: existing?.language ?? quizConfig.language,
-          pagesPerQuiz: existing?.pagesPerQuiz ?? quizConfig.pagesPerQuiz,
-          quizzes,
-        },
-        storage
-      )
-
-      const version = storage.putNodeData("quiz-generation", "book", output)
-      // Adding a quiz by hand produces the same output as running the stage, so
-      // mark the step done — otherwise the quizzes stage never lights up as
-      // completed for books whose quizzes were all added one at a time.
-      storage.markStepCompleted("quiz-generation")
-      return c.json({ quiz: newQuiz, version })
     } finally {
       storage.close()
     }

--- a/apps/api/src/routes/quizzes.ts
+++ b/apps/api/src/routes/quizzes.ts
@@ -7,6 +7,8 @@ import {
   parseBookLabel,
   QuizGenerationOutput,
   ensureQuizIds,
+  withResolvedQuizIds,
+  QuizIdExhaustedError,
   type Quiz,
   type WebRenderingOutput,
 } from "@adt/types"
@@ -48,6 +50,21 @@ function usedQuizIds(storage: Storage): string[] {
     }
   }
   return ids
+}
+
+/** `ensureQuizIds` with the exhaustion error surfaced as a 400. */
+function stampQuizIds(
+  output: QuizGenerationOutput,
+  storage: Storage
+): QuizGenerationOutput {
+  try {
+    return ensureQuizIds(output, usedQuizIds(storage)).output
+  } catch (err) {
+    if (err instanceof QuizIdExhaustedError) {
+      throw new HTTPException(400, { message: err.message })
+    }
+    throw err
+  }
 }
 
 export function createQuizRoutes(
@@ -98,8 +115,13 @@ export function createQuizRoutes(
         })
       }
 
+      // Resolve ids on the way out so the client always holds them and can send
+      // them back on a PUT. Deliberately a plain positional resolve — no
+      // reserved-id allocation and no write: this is exactly what every read
+      // path derives from the same stored array, so the ids the UI shows can
+      // never diverge from the ids the pipeline uses.
       return c.json({
-        quizzes: validated.data,
+        quizzes: withResolvedQuizIds(validated.data),
         version: row.version,
       })
     } finally {
@@ -122,9 +144,11 @@ export function createQuizRoutes(
 
     const storage = createBookStorage(safeLabel, booksDir)
     try {
-      // Stamp ids on any quiz that still lacks one, so this book stops deriving
-      // them from array positions from here on.
-      const { output } = ensureQuizIds(parsed.data, usedQuizIds(storage))
+      // Safety net for bodies that arrive without ids. GET resolves them on the
+      // way out, so the studio's own edits already carry each quiz's id and
+      // nothing is allocated here; a direct API caller that omits them gets the
+      // positional back-compat instead.
+      const output = stampQuizIds(parsed.data, storage)
       const version = storage.putNodeData("quiz-generation", "book", output)
       return c.json({ version })
     } finally {
@@ -245,9 +269,15 @@ export function createQuizRoutes(
       // Then re-order by book position and renumber so quizIndex stays sequential.
       // The sort is stable, so quizzes sharing an afterPageId keep their relative
       // order and the appended quiz stays last among them.
+      //
+      // The stored set's ids are pinned *before* the insert, not after: a book
+      // that predates `quizId` derives its catalog keys from array position, so
+      // stamping after the sort would hand the newcomer whichever id used to
+      // belong to the quiz at its index — along with that quiz's translations
+      // and generated audio.
       const existingRow = storage.getLatestNodeData("quiz-generation", "book")
       const existing = existingRow
-        ? (existingRow.data as QuizGenerationOutput)
+        ? withResolvedQuizIds(existingRow.data as QuizGenerationOutput)
         : null
 
       const priorQuizzes =
@@ -264,16 +294,17 @@ export function createQuizRoutes(
         q.quizIndex = i
       })
 
-      // Stamp ids before writing: the new quiz needs one, and any pre-existing
-      // quiz that predates `quizId` keeps the id its catalog entries already use.
-      const { output } = ensureQuizIds(
+      // Only the newcomer still lacks an id; `usedQuizIds` keeps it off every
+      // id this book has ever issued, so it cannot adopt a retired quiz's
+      // catalog entries.
+      const output = stampQuizIds(
         {
           generatedAt: existing?.generatedAt ?? new Date().toISOString(),
           language: existing?.language ?? quizConfig.language,
           pagesPerQuiz: existing?.pagesPerQuiz ?? quizConfig.pagesPerQuiz,
           quizzes,
         },
-        usedQuizIds(storage)
+        storage
       )
 
       const version = storage.putNodeData("quiz-generation", "book", output)

--- a/apps/api/src/routes/quizzes.ts
+++ b/apps/api/src/routes/quizzes.ts
@@ -8,6 +8,7 @@ import {
   QuizGenerationOutput,
   ensureQuizIds,
   withResolvedQuizIds,
+  formatQuizId,
   QuizIdExhaustedError,
   type Quiz,
   type WebRenderingOutput,
@@ -35,19 +36,42 @@ function safeParseLabel(label: string): string {
 }
 
 /**
- * Every quiz id this book has ever used, across all stored versions. Reserving
+ * Every quiz id this book has ever spent, across all stored versions. Reserving
  * them means a delete-then-add cannot reissue a retired quiz's id and inherit
  * its `${quizId}_que` / `${quizId}_o${n}` catalog entries — and with them the
  * translations and generated audio of a quiz the user removed.
+ *
+ * A version stored before `quizId` existed carries no ids, but it still spent
+ * the positional ones every consumer derived for its slots, so those are
+ * reserved too — otherwise the *first* edit on a legacy book retires an id that
+ * was never written down anywhere, and the next quiz added can be handed it.
+ *
+ * The one exception is the current version. It is the base an incoming body is
+ * presumed to descend from, so a caller that sends quizzes with no ids is still
+ * claiming its positional ids rather than asking for fresh ones — that is the
+ * positional back-compat `ensureQuizIds` provides. Only *superseded* versions
+ * have their positional ids retired for good.
+ *
+ * Read leniently rather than through `QuizGenerationOutput.safeParse`: a
+ * version that no longer satisfies today's schema still burned the ids it
+ * holds, and skipping it would let them be reissued. Reserving too much can
+ * only push an allocation forward; reserving too little corrupts a book.
  */
 function usedQuizIds(storage: Storage): string[] {
+  const currentVersion =
+    storage.getLatestNodeData("quiz-generation", "book")?.version ?? null
   const ids: string[] = []
   for (const row of storage.getAllNodeVersions("quiz-generation", "book")) {
-    const parsed = QuizGenerationOutput.safeParse(row.data)
-    if (!parsed.success) continue
-    for (const quiz of parsed.data.quizzes) {
-      if (quiz.quizId) ids.push(quiz.quizId)
-    }
+    const quizzes = (row.data as { quizzes?: unknown } | null)?.quizzes
+    if (!Array.isArray(quizzes)) continue
+    quizzes.forEach((quiz, index) => {
+      const stored = (quiz as { quizId?: unknown } | null)?.quizId
+      if (typeof stored === "string" && stored.length > 0) {
+        ids.push(stored)
+      } else if (row.version !== currentVersion) {
+        ids.push(formatQuizId(index + 1))
+      }
+    })
   }
   return ids
 }

--- a/apps/api/src/services/stage-runner.ts
+++ b/apps/api/src/services/stage-runner.ts
@@ -49,6 +49,8 @@ import {
   buildTocGenerationConfig,
   generateAllQuizzes,
   saveQuizOutput,
+  assertQuizGenerationCapacity,
+  batchPages,
   buildQuizGenerationConfig,
   // Master step imports
   getRenderSectioning,
@@ -1882,6 +1884,7 @@ async function runQuizzesStep(
     )
 
     if (quizPages.length > 0) {
+      assertQuizGenerationCapacity(storage, batchPages(quizPages, quizConfig.pagesPerQuiz, quizConfig.quizSectionTypes).length)
       const quizResult = await generateAllQuizzes(quizPages, quizConfig, quizModel, {
         concurrency: effectiveConcurrency,
         onQuizComplete: (completed, total) => {

--- a/apps/api/src/services/stage-runner.ts
+++ b/apps/api/src/services/stage-runner.ts
@@ -48,6 +48,7 @@ import {
   generateToc,
   buildTocGenerationConfig,
   generateAllQuizzes,
+  saveQuizOutput,
   buildQuizGenerationConfig,
   // Master step imports
   getRenderSectioning,
@@ -1893,7 +1894,8 @@ async function runQuizzesStep(
           })
         },
       })
-      storage.putNodeData("quiz-generation", "book", quizResult)
+      options.signal?.throwIfAborted()
+      saveQuizOutput(storage, quizResult, "replace")
       console.log(
         `[stage-run] ${label}: generated ${quizResult.quizzes.length} quiz(zes) from ${quizPages.length} page(s)`
       )
@@ -1903,6 +1905,13 @@ async function runQuizzesStep(
         message: `${quizResult.quizzes.length} quizzes from ${quizPages.length} pages`,
       })
     } else {
+      // A successful empty rerun must not leave the preserved previous quizzes
+      // active. Keep their history, but publish the now-empty result.
+      options.signal?.throwIfAborted()
+      saveQuizOutput(storage, {
+        generatedAt: new Date().toISOString(), language: quizConfig.language,
+        pagesPerQuiz: quizConfig.pagesPerQuiz, quizzes: [],
+      }, "replace")
       // Nothing to generate. This is the silent "finished instantly, no quizzes"
       // case — surface it loudly instead of completing green with no output.
       console.warn(

--- a/apps/studio/src/api/client.ts
+++ b/apps/studio/src/api/client.ts
@@ -579,6 +579,11 @@ export interface QuizOption {
 }
 
 export interface QuizItem {
+  /** Stable output-page id (`qz001`). Filled in by GET /quizzes; optional only
+   *  because a book written before it existed has none stored. Round-trip it on
+   *  every write — it keys the quiz's catalog entries, translations and audio. */
+  quizId?: string
+  /** @deprecated Positional, renumbered on every add/delete. Not an identity. */
   quizIndex: number
   afterPageId: string
   pageIds: string[]

--- a/apps/studio/src/api/client.ts
+++ b/apps/studio/src/api/client.ts
@@ -601,6 +601,8 @@ export interface QuizGenerationOutput {
 }
 
 export interface QuizzesResponse {
+  /** Selected history version, including an inactive quiz version. */
+  historyVersion: number | null
   quizzes: (Omit<QuizGenerationOutput, "quizzes"> & { quizzes: Array<QuizItem & { quizId: string }> }) | null
   version: number | null
 }

--- a/apps/studio/src/api/client.ts
+++ b/apps/studio/src/api/client.ts
@@ -601,7 +601,7 @@ export interface QuizGenerationOutput {
 }
 
 export interface QuizzesResponse {
-  quizzes: QuizGenerationOutput | null
+  quizzes: (Omit<QuizGenerationOutput, "quizzes"> & { quizzes: Array<QuizItem & { quizId: string }> }) | null
   version: number | null
 }
 
@@ -1669,10 +1669,11 @@ export const api = {
     label: string,
     node: string,
     itemId: string,
-    includeData?: boolean
+    includeData?: boolean,
+    resolveQuizIds?: boolean,
   ) =>
     request<VersionListResponse>(
-      `/books/${label}/debug/versions/${node}/${itemId}${includeData ? "?includeData=true" : ""}`
+      `/books/${label}/debug/versions/${node}/${itemId}${includeData ? `?includeData=true${resolveQuizIds ? "&resolveQuizIds=true" : ""}` : ""}`
     ),
 
   getBookOutline: (label: string) =>

--- a/apps/studio/src/components/pipeline/components/StoryboardIndex.tsx
+++ b/apps/studio/src/components/pipeline/components/StoryboardIndex.tsx
@@ -11,7 +11,7 @@ import { usePages, usePageImage } from "@/hooks/use-pages"
 import { useQuizzes } from "@/hooks/use-quizzes"
 import { getSectionScreenshotUrl, type PageSummaryItem, type PageSummarySection } from "@/api/client"
 import { STAGES } from "../stage-config"
-import type { Quiz } from "@adt/types"
+import { resolveQuizId, type Quiz } from "@adt/types"
 
 /**
  * Sidebar list shown only on the storyboard stage. Lists every section
@@ -40,12 +40,14 @@ export function StoryboardIndex({
 
   const items = useMemo<StoryboardListItem[]>(() => {
     if (!pages) return []
-    const quizzesByAfterPageId = new Map<string, Quiz[]>()
-    for (const q of quizzesData?.quizzes?.quizzes ?? []) {
+    // Resolve each quiz's stable id from its position in the stored array —
+    // the only place that position is meaningful — and carry it from here on.
+    const quizzesByAfterPageId = new Map<string, Array<{ quiz: Quiz; quizId: string }>>()
+    ;(quizzesData?.quizzes?.quizzes ?? []).forEach((q, i) => {
       const list = quizzesByAfterPageId.get(q.afterPageId) ?? []
-      list.push(q)
+      list.push({ quiz: q, quizId: resolveQuizId(q, i) })
       quizzesByAfterPageId.set(q.afterPageId, list)
-    }
+    })
 
     const out: StoryboardListItem[] = []
     for (const page of pages) {
@@ -58,8 +60,8 @@ export function StoryboardIndex({
       }
       const quizzes = quizzesByAfterPageId.get(page.pageId)
       if (quizzes) {
-        for (const quiz of quizzes) {
-          out.push({ kind: "quiz", page, quiz })
+        for (const { quiz, quizId } of quizzes) {
+          out.push({ kind: "quiz", page, quiz, quizId })
         }
       }
     }
@@ -89,20 +91,20 @@ export function StoryboardIndex({
     }
   }, [selectedItemIndex, virtualizer])
 
-  // Quizzes are routed via a synthetic pageId of `quiz-{index}` so we can
+  // Quizzes are routed via a synthetic pageId of `quiz-{quizId}` so we can
   // reuse the existing route shape (`/books/$label/$step/$pageId`). The
   // storyboard view detects that prefix and renders the quiz panel.
-  const selectedQuizIndex = selectedPageId?.startsWith("quiz-")
-    ? parseInt(selectedPageId.slice(5), 10)
+  const selectedQuizId = selectedPageId?.startsWith("quiz-")
+    ? selectedPageId.slice("quiz-".length)
     : null
   const handleQuizClick = useCallback(
-    (quizIndex: number) => {
+    (quizId: string) => {
       navigate({
         to: "/books/$label/$step/$pageId",
         params: {
           label: bookLabel,
           step: "storyboard",
-          pageId: `quiz-${quizIndex}`,
+          pageId: `quiz-${quizId}`,
         },
       })
     },
@@ -140,13 +142,13 @@ export function StoryboardIndex({
             item.kind === "section"
               ? item.page.pageId === selectedPageId &&
                 item.section.sectionIndex === (sectionIndex ?? 0)
-              : item.quiz.quizIndex === selectedQuizIndex
+              : item.quizId === selectedQuizId
           return (
             <div
               key={
                 item.kind === "section"
                   ? `s:${item.section.sectionId}`
-                  : `q:${item.quiz.quizIndex}:${item.page.pageId}`
+                  : `q:${item.quizId}`
               }
               data-index={virtualRow.index}
               ref={virtualizer.measureElement}
@@ -177,7 +179,7 @@ export function StoryboardIndex({
                   page={item.page}
                   quiz={item.quiz}
                   isActive={isActive}
-                  onSelect={() => handleQuizClick(item.quiz.quizIndex)}
+                  onSelect={() => handleQuizClick(item.quizId)}
                 />
               )}
             </div>
@@ -190,7 +192,7 @@ export function StoryboardIndex({
 
 type StoryboardListItem =
   | { kind: "section"; page: PageSummaryItem; section: PageSummarySection }
-  | { kind: "quiz"; page: PageSummaryItem; quiz: Quiz }
+  | { kind: "quiz"; page: PageSummaryItem; quiz: Quiz; quizId: string }
 
 /* ---------- SectionRow ---------- */
 

--- a/apps/studio/src/components/pipeline/components/StoryboardIndex.tsx
+++ b/apps/studio/src/components/pipeline/components/StoryboardIndex.tsx
@@ -11,7 +11,8 @@ import { usePages, usePageImage } from "@/hooks/use-pages"
 import { useQuizzes } from "@/hooks/use-quizzes"
 import { getSectionScreenshotUrl, type PageSummaryItem, type PageSummarySection } from "@/api/client"
 import { STAGES } from "../stage-config"
-import { parseQuizRouteId, resolveQuizId, type Quiz } from "@adt/types"
+import type { Quiz } from "@adt/types"
+import { parseQuizRouteId } from "@/lib/quiz-route"
 
 /**
  * Sidebar list shown only on the storyboard stage. Lists every section
@@ -40,12 +41,11 @@ export function StoryboardIndex({
 
   const items = useMemo<StoryboardListItem[]>(() => {
     if (!pages) return []
-    // Resolve each quiz's stable id from its position in the stored array —
-    // the only place that position is meaningful — and carry it from here on.
+    // The API resolves legacy IDs before returning quizzes.
     const quizzesByAfterPageId = new Map<string, Array<{ quiz: Quiz; quizId: string }>>()
-    ;(quizzesData?.quizzes?.quizzes ?? []).forEach((q, i) => {
+    ;(quizzesData?.quizzes?.quizzes ?? []).forEach((q) => {
       const list = quizzesByAfterPageId.get(q.afterPageId) ?? []
-      list.push({ quiz: q, quizId: resolveQuizId(q, i) })
+      list.push({ quiz: q, quizId: q.quizId })
       quizzesByAfterPageId.set(q.afterPageId, list)
     })
 

--- a/apps/studio/src/components/pipeline/components/StoryboardIndex.tsx
+++ b/apps/studio/src/components/pipeline/components/StoryboardIndex.tsx
@@ -11,7 +11,7 @@ import { usePages, usePageImage } from "@/hooks/use-pages"
 import { useQuizzes } from "@/hooks/use-quizzes"
 import { getSectionScreenshotUrl, type PageSummaryItem, type PageSummarySection } from "@/api/client"
 import { STAGES } from "../stage-config"
-import { resolveQuizId, type Quiz } from "@adt/types"
+import { parseQuizRouteId, resolveQuizId, type Quiz } from "@adt/types"
 
 /**
  * Sidebar list shown only on the storyboard stage. Lists every section
@@ -93,10 +93,10 @@ export function StoryboardIndex({
 
   // Quizzes are routed via a synthetic pageId of `quiz-{quizId}` so we can
   // reuse the existing route shape (`/books/$label/$step/$pageId`). The
-  // storyboard view detects that prefix and renders the quiz panel.
-  const selectedQuizId = selectedPageId?.startsWith("quiz-")
-    ? selectedPageId.slice("quiz-".length)
-    : null
+  // storyboard view detects that prefix and renders the quiz panel; it parses
+  // the id with the same helper, so a legacy `quiz-{arrayIndex}` link highlights
+  // the row it renders.
+  const selectedQuizId = selectedPageId ? parseQuizRouteId(selectedPageId) : null
   const handleQuizClick = useCallback(
     (quizId: string) => {
       navigate({

--- a/apps/studio/src/components/pipeline/components/VersionPicker.tsx
+++ b/apps/studio/src/components/pipeline/components/VersionPicker.tsx
@@ -263,7 +263,7 @@ export function VersionPicker({
       if (versions == null) setLoadingVersions(true)
       setLoadError(false)
       try {
-        const res = await api.getVersionHistory(bookLabel, step, itemId, true)
+        const res = await api.getVersionHistory(bookLabel, step, itemId, true, step === "quiz-generation")
         setVersions(res.versions)
       } catch {
         setLoadError(true)

--- a/apps/studio/src/components/pipeline/components/VersionPicker.tsx
+++ b/apps/studio/src/components/pipeline/components/VersionPicker.tsx
@@ -95,6 +95,8 @@ interface VersionPickerProps {
   step: VersionedStep
   itemId: string
   currentVersion: number | null
+  /** The selected quiz version invalidates active output but retains history. */
+  currentVersionInactive?: boolean
   saving: boolean
   dirty: boolean
   bookLabel: string
@@ -161,6 +163,7 @@ export function VersionPicker({
   step,
   itemId,
   currentVersion,
+  currentVersionInactive = false,
   saving,
   dirty,
   bookLabel,
@@ -410,6 +413,9 @@ export function VersionPicker({
             </span>
           )}
         </span>
+        {step === "quiz-generation" && v.data === null && (
+          <span className="text-[10px] text-muted-foreground">{t`Invalidated`}</span>
+        )}
         {b &&
           (b.total === 0 ? (
             <span className="shrink-0 text-[10px] text-muted-foreground">{t`no changes`}</span>
@@ -553,6 +559,7 @@ export function VersionPicker({
             className={`flex items-center gap-0.5 text-[10px] font-normal normal-case tracking-normal rounded px-1.5 py-0.5 transition-colors ${styling.triggerClass}`}
           >
             v{currentVersion}
+            {currentVersionInactive && <span className="ml-1">{t`Invalidated`}</span>}
             <ChevronDown className="h-2.5 w-2.5" />
           </button>
         </PopoverTrigger>

--- a/apps/studio/src/components/pipeline/stages/quizzes/QuizzesView.history.test.tsx
+++ b/apps/studio/src/components/pipeline/stages/quizzes/QuizzesView.history.test.tsx
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+import React, { createContext, useContext, useState, type ReactNode } from "react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { QuizzesResponse } from "@/api/client"
+
+const join = (strings: TemplateStringsArray, ...values: unknown[]) =>
+  strings.reduce((text, part, index) => text + part + (index < values.length ? String(values[index]) : ""), "")
+
+// Vitest does not compile Lingui macros. Production compilation and extraction
+// separately verify that these labels reach every locale.
+vi.mock("@lingui/core/macro", () => ({
+  msg: (strings: TemplateStringsArray, ...values: unknown[]) => ({ message: join(strings, ...values) }),
+}))
+vi.mock("@lingui/react/macro", () => ({
+  Trans: ({ children }: { children: ReactNode }) => <>{children}</>,
+  useLingui: () => ({ t: join, i18n: { _: (d: { message: string }) => d.message } }),
+}))
+
+const HeaderContext = createContext<{ setExtra: (extra: ReactNode) => void }>({ setExtra: () => {} })
+vi.mock("../../components/StepViewRouter", () => ({ useStepHeader: () => useContext(HeaderContext) }))
+vi.mock("@/hooks/use-pages", () => ({ usePages: () => ({ data: [] }), usePageImage: () => ({}) }))
+vi.mock("@/hooks/use-api-key", () => ({ useBookStructuredTextAvailability: () => false }))
+vi.mock("@/hooks/use-stage-status", () => ({ useStageStatus: () => ({ isRunning: false }) }))
+vi.mock("../../components/floating-save", () => ({
+  useFloatingSave: () => {},
+  PendingChip: ({ children }: { children: ReactNode }) => <>{children}</>,
+}))
+vi.mock("./components/QuizzesHintBanner", () => ({ QuizzesHintBanner: () => null }))
+vi.mock("./components/QuizJumper", () => ({ QuizJumper: () => null }))
+vi.mock("./AddQuizDialog", () => ({ AddQuizDialog: () => null }))
+vi.mock("../../components/PageLightbox", () => ({ PageLightbox: () => null }))
+vi.mock("@/api/client", () => ({ api: { getQuizzes: vi.fn(), getVersionHistory: vi.fn(), restoreVersion: vi.fn() } }))
+vi.mock("@/components/ui/sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+
+const { api } = await import("@/api/client")
+const { toast } = await import("@/components/ui/sonner")
+const { QuizzesView } = await import("./QuizzesView")
+
+const output = {
+  generatedAt: "2026-01-01T00:00:00.000Z", language: "en", pagesPerQuiz: 1,
+  quizzes: [{
+    quizId: "qz1000", quizIndex: 0, afterPageId: "pg001", pageIds: [], question: "Retained question",
+    options: ["A", "B", "C"].map((text) => ({ text, explanation: "Explanation" })), answerIndex: 0, reasoning: "Reason",
+  }],
+}
+let response: QuizzesResponse
+let client: QueryClient
+
+function Harness() {
+  const [extra, setExtra] = useState<ReactNode>(null)
+  return <HeaderContext.Provider value={{ setExtra }}>
+    <header>{extra}</header>
+    <QuizzesView bookLabel="book" />
+  </HeaderContext.Provider>
+}
+
+function renderView() {
+  client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(<QueryClientProvider client={client}><Harness /></QueryClientProvider>)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.stubGlobal("IntersectionObserver", class {
+    observe() {}
+    disconnect() {}
+  })
+  response = { quizzes: null, version: null, historyVersion: 2 }
+  vi.mocked(api.getQuizzes).mockImplementation(async () => response)
+  vi.mocked(api.getVersionHistory).mockResolvedValue({ versions: [
+    { version: 2, data: null },
+    { version: 1, data: output },
+  ] })
+  vi.mocked(api.restoreVersion).mockImplementation(async (_book, _step, _item, version) => {
+    response = version === 1
+      ? { quizzes: output, version: 1, historyVersion: 1 }
+      : { quizzes: null, version: null, historyVersion: 2 }
+    return { node: "quiz-generation", itemId: "book", version }
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  client?.clear()
+  vi.unstubAllGlobals()
+})
+
+describe("quiz history recovery", () => {
+  it("offers retained history while inactive, restores it, and labels a later invalidation", async () => {
+    renderView()
+    const trigger = await screen.findByRole("button", { name: /^v\s*2\s*Invalidated$/ })
+    expect(screen.queryByDisplayValue("Retained question")).toBeNull()
+    fireEvent.click(trigger)
+    fireEvent.click(await screen.findByRole("button", { name: /^v\s*1/ }))
+    await waitFor(() => expect(api.restoreVersion).toHaveBeenCalledWith("book", "quiz-generation", "book", 1))
+    expect(await screen.findByDisplayValue("Retained question")).toBeTruthy()
+    expect(api.getVersionHistory).toHaveBeenCalledWith("book", "quiz-generation", "book", true, true)
+
+    fireEvent.click(await screen.findByRole("button", { name: /^v\s*1$/ }))
+    fireEvent.click(await screen.findByRole("button", { name: /^v\s*2\s*Invalidated/ }))
+    expect(await screen.findByRole("button", { name: /^v\s*2\s*Invalidated$/ })).toBeTruthy()
+    expect(screen.queryByDisplayValue("Retained question")).toBeNull()
+    expect(api.restoreVersion).toHaveBeenLastCalledWith("book", "quiz-generation", "book", 2)
+  })
+
+  it("keeps recovery available after a failed restore", async () => {
+    vi.mocked(api.restoreVersion).mockRejectedValueOnce(new Error("Restore failed"))
+    renderView()
+    fireEvent.click(await screen.findByRole("button", { name: /^v\s*2\s*Invalidated$/ }))
+    fireEvent.click(await screen.findByRole("button", { name: /^v\s*1/ }))
+    await waitFor(() => expect(toast.error).toHaveBeenCalled())
+    expect(await screen.findByRole("button", { name: /^v\s*2\s*Invalidated$/ })).toBeTruthy()
+    expect(screen.queryByDisplayValue("Retained question")).toBeNull()
+  })
+
+  it("does not invent history for a book that has never generated quizzes", async () => {
+    response = { quizzes: null, version: null, historyVersion: null }
+    renderView()
+    await waitFor(() => expect(client.isFetching()).toBe(0))
+    expect(screen.queryByRole("button", { name: /^v\s*\d/ })).toBeNull()
+    expect(api.getVersionHistory).not.toHaveBeenCalled()
+  })
+})

--- a/apps/studio/src/components/pipeline/stages/quizzes/QuizzesView.tsx
+++ b/apps/studio/src/components/pipeline/stages/quizzes/QuizzesView.tsx
@@ -322,16 +322,9 @@ export function QuizzesView({
           diff={{
             unifiedList: true,
             items: (d) => (d as QuizData | null)?.quizzes ?? [],
-            // quizId is the stable cross-version identity — quizIndex is
-            // positional (renumbered 0..n on add/delete), so a single delete
-            // would shift every index and mis-report the whole set as changed.
-            // Versions written before quizId existed fall back to the question
-            // text, which reads add/delete correctly but shows an edited
-            // question as remove+add rather than a single edit.
-            keyOf: (q) => {
-              const quiz = q as QuizData["quizzes"][number]
-              return quiz.quizId ?? quiz.question
-            },
+            // VersionPicker requests IDs resolved within each historical array,
+            // so legacy and stamped versions use the same comparison keys.
+            keyOf: (q) => (q as QuizData["quizzes"][number]).quizId!,
             isEqual: (a, b) => {
               const x = a as QuizData["quizzes"][number]
               const y = b as QuizData["quizzes"][number]

--- a/apps/studio/src/components/pipeline/stages/quizzes/QuizzesView.tsx
+++ b/apps/studio/src/components/pipeline/stages/quizzes/QuizzesView.tsx
@@ -304,13 +304,14 @@ export function QuizzesView({
   );
 
   useEffect(() => {
-    if (!data?.quizzes) return;
+    if (!data || (data.historyVersion ?? data.version) == null) return;
     setExtra(
       <div className="flex items-center gap-1.5 ml-auto">
         <VersionPicker
           step="quiz-generation"
           itemId="book"
-          currentVersion={data.version}
+          currentVersion={data.historyVersion ?? data.version}
+          currentVersionInactive={data.quizzes === null}
           saving={saving}
           dirty={dirty}
           bookLabel={bookLabel}

--- a/apps/studio/src/components/pipeline/stages/quizzes/QuizzesView.tsx
+++ b/apps/studio/src/components/pipeline/stages/quizzes/QuizzesView.tsx
@@ -167,7 +167,9 @@ export function QuizzesView({
   } = usePendingChanges({
     prev: data?.quizzes?.quizzes ?? [],
     next: pending?.quizzes,
-    keyOf: (q) => String(q.quizIndex),
+    // quizId is stable across add/delete; quizIndex is renumbered, so it would
+    // report an unrelated quiz as edited after a single removal.
+    keyOf: (q) => q.quizId ?? String(q.quizIndex),
     isEqual: (a, b) =>
       a.question === b.question &&
       a.answerIndex === b.answerIndex &&
@@ -274,6 +276,11 @@ export function QuizzesView({
   // Remove a quiz from the book. Operates on the currently visible list (so any
   // unsaved edits are preserved), renumbers quizIndex, and persists immediately.
   // A removed quiz can still be recovered from version history.
+  //
+  // The spread must carry `quizId` through untouched: only quizIndex is
+  // positional. Rebuilding these objects field-by-field would drop the ids and
+  // let the server re-derive them from the post-delete positions, handing each
+  // survivor the previous quiz's translations and generated audio.
   const deleteQuiz = useCallback(
     async (idx: number) => {
       const base = pending ?? data?.quizzes;
@@ -315,12 +322,16 @@ export function QuizzesView({
           diff={{
             unifiedList: true,
             items: (d) => (d as QuizData | null)?.quizzes ?? [],
-            // quizIndex is positional (renumbered 0..n on add/delete), so it's
-            // not a stable cross-version identity — a single delete would shift
-            // every index and mis-report the whole set as changed. Key by the
-            // question text instead so add/delete read correctly (trade-off: an
-            // edited question reads as remove+add rather than a single edit).
-            keyOf: (q) => (q as QuizData["quizzes"][number]).question,
+            // quizId is the stable cross-version identity — quizIndex is
+            // positional (renumbered 0..n on add/delete), so a single delete
+            // would shift every index and mis-report the whole set as changed.
+            // Versions written before quizId existed fall back to the question
+            // text, which reads add/delete correctly but shows an edited
+            // question as remove+add rather than a single edit.
+            keyOf: (q) => {
+              const quiz = q as QuizData["quizzes"][number]
+              return quiz.quizId ?? quiz.question
+            },
             isEqual: (a, b) => {
               const x = a as QuizData["quizzes"][number]
               const y = b as QuizData["quizzes"][number]

--- a/apps/studio/src/components/pipeline/stages/storyboard/StoryboardView.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/StoryboardView.tsx
@@ -16,6 +16,7 @@ import { useSectionNav } from "@/routes/books.$label"
 import { Trans } from "@lingui/react/macro"
 import { useLingui } from "@lingui/react/macro"
 import { useHasUnsavedChanges } from "../../components/floating-save"
+import { formatQuizId } from "@adt/types"
 
 
 export function StoryboardView({ bookLabel, selectedPageId: selectedPageIdProp, onSelectPage }: { bookLabel: string; selectedPageId?: string; onSelectPage?: (pageId: string | null) => void }) {
@@ -62,12 +63,20 @@ export function StoryboardView({ bookLabel, selectedPageId: selectedPageIdProp, 
   const isGeneratingRef = useRef(false)
   const handleGeneratingChange = useCallback((g: boolean) => { isGeneratingRef.current = g }, [])
 
-  // Quizzes appear in the sidebar with a synthetic pageId of `quiz-{index}`.
+  // Quizzes appear in the sidebar with a synthetic pageId of `quiz-{quizId}`.
   // When that pageId is in the URL we render the quiz panel instead of loading
   // page detail — calling usePage with a fake id would 404.
-  const quizMatch = selectedPageIdProp?.match(/^quiz-(\d+)$/)
-  const selectedQuizIndex = quizMatch ? parseInt(quizMatch[1], 10) : null
-  const isQuizRoute = selectedQuizIndex != null
+  //
+  // Links made before quizzes had stable ids carry `quiz-{arrayIndex}`; those
+  // resolve to the id that index derived back then, so old tabs and bookmarks
+  // keep working.
+  const quizMatch = selectedPageIdProp?.match(/^quiz-(.+)$/)
+  const selectedQuizId = quizMatch
+    ? /^\d+$/.test(quizMatch[1])
+      ? formatQuizId(parseInt(quizMatch[1], 10) + 1)
+      : quizMatch[1]
+    : null
+  const isQuizRoute = selectedQuizId != null
 
   // Auto-select first page when no page is selected
   useEffect(() => {
@@ -440,12 +449,12 @@ export function StoryboardView({ bookLabel, selectedPageId: selectedPageIdProp, 
     )
   }
 
-  // Quiz route: pseudo-pageId is `quiz-{index}`. Render the quiz panel.
-  if (isQuizRoute && selectedQuizIndex != null) {
+  // Quiz route: pseudo-pageId is `quiz-{quizId}`. Render the quiz panel.
+  if (isQuizRoute && selectedQuizId != null) {
     return (
       <StoryboardQuizDetail
         bookLabel={bookLabel}
-        quizIndex={selectedQuizIndex}
+        quizId={selectedQuizId}
         navigationArrows={
           <div className="flex gap-1">{overviewToggle}{outlineToggle}</div>
         }

--- a/apps/studio/src/components/pipeline/stages/storyboard/StoryboardView.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/StoryboardView.tsx
@@ -16,6 +16,7 @@ import { useSectionNav } from "@/routes/books.$label"
 import { Trans } from "@lingui/react/macro"
 import { useLingui } from "@lingui/react/macro"
 import { useHasUnsavedChanges } from "../../components/floating-save"
+import { formatQuizId } from "@adt/types"
 
 
 export function StoryboardView({ bookLabel, selectedPageId: selectedPageIdProp, onSelectPage }: { bookLabel: string; selectedPageId?: string; onSelectPage?: (pageId: string | null) => void }) {
@@ -61,12 +62,20 @@ export function StoryboardView({ bookLabel, selectedPageId: selectedPageIdProp, 
   const isGeneratingRef = useRef(false)
   const handleGeneratingChange = useCallback((g: boolean) => { isGeneratingRef.current = g }, [])
 
-  // Quizzes appear in the sidebar with a synthetic pageId of `quiz-{index}`.
+  // Quizzes appear in the sidebar with a synthetic pageId of `quiz-{quizId}`.
   // When that pageId is in the URL we render the quiz panel instead of loading
   // page detail — calling usePage with a fake id would 404.
-  const quizMatch = selectedPageIdProp?.match(/^quiz-(\d+)$/)
-  const selectedQuizIndex = quizMatch ? parseInt(quizMatch[1], 10) : null
-  const isQuizRoute = selectedQuizIndex != null
+  //
+  // Links made before quizzes had stable ids carry `quiz-{arrayIndex}`; those
+  // resolve to the id that index derived back then, so old tabs and bookmarks
+  // keep working.
+  const quizMatch = selectedPageIdProp?.match(/^quiz-(.+)$/)
+  const selectedQuizId = quizMatch
+    ? /^\d+$/.test(quizMatch[1])
+      ? formatQuizId(parseInt(quizMatch[1], 10) + 1)
+      : quizMatch[1]
+    : null
+  const isQuizRoute = selectedQuizId != null
 
   // Auto-select first page when no page is selected
   useEffect(() => {
@@ -439,12 +448,12 @@ export function StoryboardView({ bookLabel, selectedPageId: selectedPageIdProp, 
     )
   }
 
-  // Quiz route: pseudo-pageId is `quiz-{index}`. Render the quiz panel.
-  if (isQuizRoute && selectedQuizIndex != null) {
+  // Quiz route: pseudo-pageId is `quiz-{quizId}`. Render the quiz panel.
+  if (isQuizRoute && selectedQuizId != null) {
     return (
       <StoryboardQuizDetail
         bookLabel={bookLabel}
-        quizIndex={selectedQuizIndex}
+        quizId={selectedQuizId}
         navigationArrows={
           <div className="flex gap-1">{overviewToggle}{outlineToggle}</div>
         }

--- a/apps/studio/src/components/pipeline/stages/storyboard/StoryboardView.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/StoryboardView.tsx
@@ -16,7 +16,7 @@ import { useSectionNav } from "@/routes/books.$label"
 import { Trans } from "@lingui/react/macro"
 import { useLingui } from "@lingui/react/macro"
 import { useHasUnsavedChanges } from "../../components/floating-save"
-import { formatQuizId } from "@adt/types"
+import { parseQuizRouteId } from "@adt/types"
 
 
 export function StoryboardView({ bookLabel, selectedPageId: selectedPageIdProp, onSelectPage }: { bookLabel: string; selectedPageId?: string; onSelectPage?: (pageId: string | null) => void }) {
@@ -65,16 +65,11 @@ export function StoryboardView({ bookLabel, selectedPageId: selectedPageIdProp, 
 
   // Quizzes appear in the sidebar with a synthetic pageId of `quiz-{quizId}`.
   // When that pageId is in the URL we render the quiz panel instead of loading
-  // page detail — calling usePage with a fake id would 404.
-  //
-  // Links made before quizzes had stable ids carry `quiz-{arrayIndex}`; those
-  // resolve to the id that index derived back then, so old tabs and bookmarks
-  // keep working.
-  const quizMatch = selectedPageIdProp?.match(/^quiz-(.+)$/)
-  const selectedQuizId = quizMatch
-    ? /^\d+$/.test(quizMatch[1])
-      ? formatQuizId(parseInt(quizMatch[1], 10) + 1)
-      : quizMatch[1]
+  // page detail — calling usePage with a fake id would 404. `parseQuizRouteId`
+  // also carries the legacy `quiz-{arrayIndex}` shape, and StoryboardIndex uses
+  // it too so the sidebar highlights the same row this renders.
+  const selectedQuizId = selectedPageIdProp
+    ? parseQuizRouteId(selectedPageIdProp)
     : null
   const isQuizRoute = selectedQuizId != null
 

--- a/apps/studio/src/components/pipeline/stages/storyboard/StoryboardView.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/StoryboardView.tsx
@@ -16,7 +16,7 @@ import { useSectionNav } from "@/routes/books.$label"
 import { Trans } from "@lingui/react/macro"
 import { useLingui } from "@lingui/react/macro"
 import { useHasUnsavedChanges } from "../../components/floating-save"
-import { parseQuizRouteId } from "@adt/types"
+import { parseQuizRouteId } from "@/lib/quiz-route"
 
 
 export function StoryboardView({ bookLabel, selectedPageId: selectedPageIdProp, onSelectPage }: { bookLabel: string; selectedPageId?: string; onSelectPage?: (pageId: string | null) => void }) {

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardQuizDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardQuizDetail.tsx
@@ -8,7 +8,7 @@ import { StorySectionBanner } from "./StorySectionBanner"
 import { useQuizzes } from "@/hooks/use-quizzes"
 import { usePageImage, usePages } from "@/hooks/use-pages"
 import { BASE_URL } from "@/api/client"
-import type { Quiz } from "@adt/types"
+import { resolveQuizId, type Quiz } from "@adt/types"
 
 /**
  * Quiz panel rendered inside the storyboard stage when a quiz row is selected.
@@ -21,12 +21,13 @@ import type { Quiz } from "@adt/types"
  */
 export function StoryboardQuizDetail({
   bookLabel,
-  quizIndex,
+  quizId,
   navigationExtra,
   navigationArrows,
 }: {
   bookLabel: string
-  quizIndex: number
+  /** Stable quiz id (`qz001`) — also the adt-preview filename stem. */
+  quizId: string
   navigationExtra?: ReactNode
   navigationArrows?: ReactNode
 }) {
@@ -37,7 +38,7 @@ export function StoryboardQuizDetail({
   const { data: pages } = usePages(bookLabel)
 
   const quiz: Quiz | undefined = quizzesData?.quizzes?.quizzes?.find(
-    (q) => q.quizIndex === quizIndex,
+    (q, i) => resolveQuizId(q, i) === quizId,
   )
 
   const afterPage = pages?.find((p) => p.pageId === quiz?.afterPageId)
@@ -90,11 +91,6 @@ export function StoryboardQuizDetail({
       </div>
     )
   }
-
-  // Matches the backend's quiz file id: quizzes carry a contiguous quizIndex
-  // (sorted on generation), so qz{index+1} zero-padded to 3 digits is the
-  // adt-preview filename rendered by renderQuizHtml.
-  const quizId = `qz${String(quiz.quizIndex + 1).padStart(3, "0")}`
 
   return (
     <div className="flex-1 flex flex-col overflow-hidden bg-muted/20">

--- a/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardQuizDetail.tsx
+++ b/apps/studio/src/components/pipeline/stages/storyboard/components/StoryboardQuizDetail.tsx
@@ -8,7 +8,7 @@ import { StorySectionBanner } from "./StorySectionBanner"
 import { useQuizzes } from "@/hooks/use-quizzes"
 import { usePageImage, usePages } from "@/hooks/use-pages"
 import { BASE_URL } from "@/api/client"
-import { resolveQuizId, type Quiz } from "@adt/types"
+import type { Quiz } from "@adt/types"
 
 /**
  * Quiz panel rendered inside the storyboard stage when a quiz row is selected.
@@ -38,7 +38,7 @@ export function StoryboardQuizDetail({
   const { data: pages } = usePages(bookLabel)
 
   const quiz: Quiz | undefined = quizzesData?.quizzes?.quizzes?.find(
-    (q, i) => resolveQuizId(q, i) === quizId,
+    (q) => q.quizId === quizId,
   )
 
   const afterPage = pages?.find((p) => p.pageId === quiz?.afterPageId)

--- a/apps/studio/src/lib/quiz-route.test.ts
+++ b/apps/studio/src/lib/quiz-route.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest"
+import { parseQuizRouteId } from "./quiz-route"
+
+describe("quiz storyboard routes", () => {
+  it.each([
+    ["quiz-qz003", "qz003"], ["quiz-0", "qz001"], ["quiz-4", "qz005"],
+    ["quiz-998", "qz999"], ["quiz-999", null], ["quiz-qz000", null],
+    ["quiz-", null], ["quiz-../other", null], ["pg001", null],
+  ])("resolves %s", (route, expected) => expect(parseQuizRouteId(route)).toBe(expected))
+})

--- a/apps/studio/src/lib/quiz-route.test.ts
+++ b/apps/studio/src/lib/quiz-route.test.ts
@@ -4,7 +4,11 @@ import { parseQuizRouteId } from "./quiz-route"
 describe("quiz storyboard routes", () => {
   it.each([
     ["quiz-qz003", "qz003"], ["quiz-0", "qz001"], ["quiz-4", "qz005"],
-    ["quiz-998", "qz999"], ["quiz-999", null], ["quiz-qz000", null],
+    ["quiz-998", "qz999"], ["quiz-qz1000", "qz1000"], ["quiz-qz1001", "qz1001"],
+    ["quiz-qz9007199254740991", "qz9007199254740991"],
+    ["quiz-9007199254740990", "qz9007199254740991"], ["quiz-9007199254740991", null],
+    ["quiz-qz0001", null], ["quiz-qz9007199254740992", null], ["quiz-qz1000\n", null],
+    ["quiz-1000\n", null], ["quiz-1e3", null], ["quiz-999", "qz1000"], ["quiz-qz000", null],
     ["quiz-", null], ["quiz-../other", null], ["pg001", null],
   ])("resolves %s", (route, expected) => expect(parseQuizRouteId(route)).toBe(expected))
 })

--- a/apps/studio/src/lib/quiz-route.ts
+++ b/apps/studio/src/lib/quiz-route.ts
@@ -1,0 +1,11 @@
+/** Storyboard URL parsing belongs to the UI. Numeric links predate stored
+ * quiz IDs and encode the original zero-based array position. */
+export function parseQuizRouteId(pageId: string): string | null {
+  const match = /^quiz-(qz(?!000)\d{3}|\d+)$/.exec(pageId)
+  if (!match) return null
+  if (match[1].startsWith("qz")) return match[1]
+  const index = Number(match[1])
+  return Number.isInteger(index) && index >= 0 && index < 999
+    ? `qz${String(index + 1).padStart(3, "0")}`
+    : null
+}

--- a/apps/studio/src/lib/quiz-route.ts
+++ b/apps/studio/src/lib/quiz-route.ts
@@ -1,11 +1,15 @@
 /** Storyboard URL parsing belongs to the UI. Numeric links predate stored
  * quiz IDs and encode the original zero-based array position. */
 export function parseQuizRouteId(pageId: string): string | null {
-  const match = /^quiz-(qz(?!000)\d{3}|\d+)$/.exec(pageId)
-  if (!match) return null
-  if (match[1].startsWith("qz")) return match[1]
-  const index = Number(match[1])
-  return Number.isInteger(index) && index >= 0 && index < 999
-    ? `qz${String(index + 1).padStart(3, "0")}`
-    : null
+  if (!pageId.startsWith("quiz-")) return null
+  const value = pageId.slice(5)
+  if (value.startsWith("qz")) {
+    const seq = Number(value.slice(2))
+    return Number.isSafeInteger(seq) && seq > 0 && value === `qz${String(seq).padStart(3, "0")}`
+      ? value : null
+  }
+  // Strict decimal legacy index; leading zeros remain backward-compatible.
+  if (!/^[0-9]+$/.test(value) || value.trim() !== value) return null
+  const seq = Number(value) + 1
+  return Number.isSafeInteger(seq) && seq > 0 ? `qz${String(seq).padStart(3, "0")}` : null
 }

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -4945,6 +4945,9 @@ msgstr "Invalid range"
 msgid "Invalid value."
 msgstr "Invalid value."
 
+msgid "Invalidated"
+msgstr "Invalidated"
+
 msgid "Isolated asset"
 msgstr "Isolated asset"
 

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -4945,6 +4945,9 @@ msgstr "Intervalo no válido"
 msgid "Invalid value."
 msgstr "Valor no válido."
 
+msgid "Invalidated"
+msgstr "Invalidado"
+
 msgid "Isolated asset"
 msgstr "Recurso aislado"
 

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -4947,6 +4947,9 @@ msgstr "Plage non valide"
 msgid "Invalid value."
 msgstr "Valeur non valide."
 
+msgid "Invalidated"
+msgstr "Invalidé"
+
 msgid "Isolated asset"
 msgstr "Ressource isolée"
 

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -4945,6 +4945,9 @@ msgstr "Intervalo inválido"
 msgid "Invalid value."
 msgstr "Valor inválido."
 
+msgid "Invalidated"
+msgstr "Invalidado"
+
 msgid "Isolated asset"
 msgstr "Recurso isolado"
 

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -4947,6 +4947,9 @@ msgstr "Interval i pavlefshëm"
 msgid "Invalid value."
 msgstr "Vlerë e pavlefshme."
 
+msgid "Invalidated"
+msgstr "I zhvlerësuar"
+
 msgid "Isolated asset"
 msgstr "Asete e izoluar"
 

--- a/docs/QUIZ_IDENTITY.md
+++ b/docs/QUIZ_IDENTITY.md
@@ -1,0 +1,79 @@
+# Quiz identity
+
+A quiz owns a book-local `quizId` from `qz001` through `qz999`. The ID names
+its HTML page and its question/answer catalog keys, which also identify
+translations and audio files. `quizIndex` is a compatibility position field;
+it is normalized on save and never determines identity after allocation.
+
+## Allocation and regeneration
+
+All application quiz writes go through `saveQuizOutput` in
+`packages/pipeline/src/quiz-ids.ts`. It reads every retained quiz version,
+reserves explicit IDs and legacy positional IDs, allocates additions, and saves
+a new version in one storage transaction. The reservation includes the current
+version and versions newer than a restored version.
+
+- Editing, deleting, or repositioning an existing quiz preserves its ID.
+- Generate-one replacement and full-stage regeneration create new quizzes with
+  fresh IDs. Identical or cached model output does not reuse an old identity.
+- Restoring a version selects its existing quizzes and IDs. It does not allocate
+  new entities or release IDs used by later versions.
+- Exhaustion fails without a partial save. Removing quizzes, restoring a version,
+  or rerunning extraction does not release IDs. The current three-digit output
+  contract supports 999 distinct quiz identities over a book's retained lifetime.
+
+Full quiz reruns keep prior quiz output until successful persistence. A failed
+run leaves that output available; a successful run with no eligible pages saves
+an empty quiz set. This also applies to the CLI DAG generation path.
+
+Upstream invalidation and extraction resets retain quiz history and append a
+`null` invalidation version. Both storage and API current-row readers interpret
+that selected version as absent output, without falling back to an older quiz
+set. Repeated invalidation is idempotent. Other nodes retain their existing reset
+behavior, including preservation of font configuration during extraction.
+
+New IDs prevent regenerated quizzes from adopting an old quiz's translation or
+manual recording, even when the run retains the Speech manifest. Regeneration
+does not overwrite the old ID-derived audio files. Quiz history is not a full
+pipeline snapshot: restoring a quiz version still invalidates downstream
+catalogs and Speech under the existing restore contract.
+
+The guarantee covers retained history and all subsequent application writes.
+History already erased by older releases, external database edits, or replacing
+a book with an older archive cannot be reconstructed by this change.
+
+## API and read models
+
+`GET /books/:label/quizzes` resolves legacy IDs in each quiz's original array
+position without writing a backfill version. Clients should retain those IDs
+when saving edits. PUT accepts only canonical, unique IDs and rejects an
+explicit retired ID unless its version has first been restored.
+
+For older clients that omit IDs, unchanged quizzes are matched against the
+current set by their complete content and provenance. Unambiguous retries,
+deletions, reorders, and appends preserve identity. Ambiguous edits or identical
+candidate quizzes return HTTP 400 and instruct the caller to reload and include
+IDs. Edits during active quiz generation return HTTP 409; generate-one checks
+again after its model call before saving.
+
+The version picker requests `resolveQuizIds=true` together with `includeData=true`
+from the history endpoint, so legacy and stamped versions compare using the
+same identity. The default debug response remains the exact stored JSON.
+Studio consumes resolved IDs from the API; Storyboard URL parsing stays in
+Studio rather than importing runtime quiz helpers from shared packages.
+
+Catalog generation, preview, and packaging validate complete quiz arrays,
+including duplicate IDs and collisions between explicit and legacy positional
+IDs. Packaging validates before removing an existing export and separately
+checks that each quiz's destination stays in the export directory. This protects
+books imported directly from storage as well as API-created content.
+
+## Regression coverage
+
+`apps/api/src/routes/quiz-identity-regressions.test.ts` exercises real routes,
+SQLite, stage reset, quiz generation, catalogs, preview, packaging, and Speech
+file writing. Only remote model responses and synthesized audio bytes are
+stubbed. It checks rollback, full regeneration, legacy replacement, retries,
+exhaustion, corrupt imports, export containment, comparison normalization, and
+preservation of manual recording bytes. Storage tests additionally cover
+invalidation transaction rollback and both current-row readers.

--- a/docs/QUIZ_IDENTITY.md
+++ b/docs/QUIZ_IDENTITY.md
@@ -1,6 +1,8 @@
 # Quiz identity
 
-A quiz owns a book-local `quizId` from `qz001` through `qz999`. The ID names
+A quiz owns a book-local `quizId`: `qz001`, `qz002`, …, `qz999`, `qz1000`, and
+onward up to `qz9007199254740991` (JavaScript's maximum safe integer). Padding
+has a minimum width of three digits; existing IDs never change. The ID names
 its HTML page and its question/answer catalog keys, which also identify
 translations and audio files. `quizIndex` is a compatibility position field;
 it is normalized on save and never determines identity after allocation.
@@ -18,9 +20,13 @@ version and versions newer than a restored version.
   fresh IDs. Identical or cached model output does not reuse an old identity.
 - Restoring a version selects its existing quizzes and IDs. It does not allocate
   new entities or release IDs used by later versions.
-- Exhaustion fails without a partial save. Removing quizzes, restoring a version,
-  or rerunning extraction does not release IDs. The current three-digit output
-  contract supports 999 distinct quiz identities over a book's retained lifetime.
+- Removing quizzes, restoring a version, or rerunning extraction does not
+  release IDs. Allocation continues past 999 without renumbering earlier IDs.
+- Full generation and generate-one check remaining capacity before calling the
+  model. Allocation rechecks inside the save transaction, including any IDs
+  consumed while generation was in flight. Insufficient capacity reports the
+  requested and remaining counts without a partial save. Counting uses
+  subtraction to avoid overflowing the safe-integer bound.
 
 Full quiz reruns keep prior quiz output until successful persistence. A failed
 run leaves that output available; a successful run with no eligible pages saves
@@ -48,6 +54,15 @@ a book with an older archive cannot be reconstructed by this change.
 position without writing a backfill version. Clients should retain those IDs
 when saving edits. PUT accepts only canonical, unique IDs and rejects an
 explicit retired ID unless its version has first been restored.
+Alternate spellings such as `qz0001`, exponent notation, whitespace, and unsafe
+integers are rejected. Existing three-digit IDs and filenames remain valid.
+
+The response includes `historyVersion`, the selected version even when it is an
+invalidation marker. In that case `quizzes` and the active `version` remain
+`null`. Studio uses `historyVersion` to keep the picker available, labels null
+versions as **Invalidated**, and lets the user restore retained output. A book
+without quiz history has all three fields set to `null` and no picker. Restoring
+an invalidation marker makes active output absent again.
 
 For older clients that omit IDs, unchanged quizzes are matched against the
 current set by their complete content and provenance. Unambiguous retries,
@@ -72,8 +87,13 @@ books imported directly from storage as well as API-created content.
 
 `apps/api/src/routes/quiz-identity-regressions.test.ts` exercises real routes,
 SQLite, stage reset, quiz generation, catalogs, preview, packaging, and Speech
-file writing. Only remote model responses and synthesized audio bytes are
-stubbed. It checks rollback, full regeneration, legacy replacement, retries,
-exhaustion, corrupt imports, export containment, comparison normalization, and
-preservation of manual recording bytes. Storage tests additionally cover
-invalidation transaction rollback and both current-row readers.
+file writing. Remote model responses and synthesized audio bytes are stubbed;
+capacity-failure tests inject the guard's error to exercise preflight handling
+without allocating trillions of records. Boundary arithmetic is tested directly
+in the types package. Coverage includes rollback, full regeneration beyond 999,
+concurrent allocation, legacy replacement, retries, corrupt imports, export
+containment, comparison normalization, and preservation of manual recording
+bytes across web, WebPub, and EPUB output. Storage tests additionally cover
+invalidation transaction rollback and both current-row readers. A Studio
+component test exercises the real quiz view and version picker through restore,
+restore failure, and selection of an invalidation version.

--- a/packages/pipeline/src/__tests__/package-web.test.ts
+++ b/packages/pipeline/src/__tests__/package-web.test.ts
@@ -841,6 +841,122 @@ describe("packageAdtWeb", () => {
     expect(scorm).toContain('"qz001"')
   })
 
+  it("names quiz pages by their stored id, not their position in the array", async () => {
+    // A book that has had quizzes added and deleted: ids are sparse and no
+    // longer ascend with the array. Everything the bundle exposes — filenames,
+    // pages.json, the answer keys and the SCORM activity list — has to follow
+    // the stored id, because that is what the book's already-generated
+    // translations and audio files are named after.
+    const bookDir = path.join(tmpDir, "book")
+    const webAssetsDir = path.join(tmpDir, "assets-web")
+    fs.mkdirSync(bookDir, { recursive: true })
+    createWebAssets(webAssetsDir)
+
+    const pages: PageData[] = [
+      { pageId: "pg001", pageNumber: 1, text: "Page one" },
+      { pageId: "pg002", pageNumber: 2, text: "Page two" },
+    ]
+
+    const section = (sectionId: string, pageNumber: number | null) => ({
+      reasoning: "ok",
+      sections: [
+        {
+          sectionId,
+          sectionType: "content",
+          nodes: [],
+          backgroundColor: "#fff",
+          textColor: "#000",
+          pageNumber,
+          isPruned: false,
+        },
+      ],
+    })
+
+    const quiz = (quizId: string, afterPageId: string, question: string) => ({
+      quizId,
+      quizIndex: 0,
+      afterPageId,
+      pageIds: [afterPageId],
+      question,
+      options: [
+        { text: "3", explanation: "Nope" },
+        { text: "4", explanation: "Yes" },
+      ],
+      answerIndex: 1,
+      reasoning: "...",
+    })
+
+    const storage = createMockStorage(pages, {
+      "web-rendering": {
+        pg001: {
+          sections: [
+            { sectionIndex: 0, sectionType: "content", reasoning: "ok", html: "<div>One</div>" },
+          ],
+        },
+        pg002: {
+          sections: [
+            { sectionIndex: 0, sectionType: "content", reasoning: "ok", html: "<div>Two</div>" },
+          ],
+        },
+      },
+      "page-sectioning": {
+        pg001: section("pg001_sec001", 1),
+        pg002: section("pg002_sec001", 2),
+      },
+      "quiz-generation": {
+        book: {
+          generatedAt: "2026-01-01T00:00:00.000Z",
+          language: "en",
+          pagesPerQuiz: 3,
+          quizzes: [
+            // qz001 and qz002 were deleted at some point; qz004 was added
+            // before qz003 and so sits earlier in the array.
+            quiz("qz004", "pg001", "Which came later?"),
+            quiz("qz003", "pg002", "Which came first?"),
+          ],
+        },
+      },
+    })
+
+    await packageAdtWeb(storage, {
+      bookDir,
+      label: "book",
+      language: "en",
+      outputLanguages: ["en"],
+      title: "Book Title",
+      webAssetsDir,
+    })
+
+    const pagesJson = JSON.parse(
+      fs.readFileSync(path.join(bookDir, "adt", "content", "pages.json"), "utf-8"),
+    ) as Array<{ section_id: string; href: string }>
+
+    // Reading order still follows the book; the *names* follow the stored ids.
+    expect(pagesJson).toEqual([
+      { section_id: "pg001_sec001", href: "index.html", page_number: 1 },
+      { section_id: "qz004", href: "qz004.html" },
+      { section_id: "pg002_sec001", href: "pg002_sec001.html", page_number: 2 },
+      { section_id: "qz003", href: "qz003.html" },
+    ])
+
+    // The positional names must not exist at all — a `qz001.html` here would be
+    // this book's first quiz served under a deleted quiz's identity.
+    expect(fs.existsSync(path.join(bookDir, "adt", "qz004.html"))).toBe(true)
+    expect(fs.existsSync(path.join(bookDir, "adt", "qz003.html"))).toBe(true)
+    expect(fs.existsSync(path.join(bookDir, "adt", "qz001.html"))).toBe(false)
+    expect(fs.existsSync(path.join(bookDir, "adt", "qz002.html"))).toBe(false)
+
+    // Answer keys are catalog ids too, so they carry the same id.
+    const quizHtml = fs.readFileSync(path.join(bookDir, "adt", "qz004.html"), "utf-8")
+    expect(quizHtml).toContain('data-activity-item="qz004_o0"')
+    expect(quizHtml).not.toContain("qz001_o0")
+
+    const scorm = fs.readFileSync(path.join(bookDir, "adt", "assets", "scorm.js"), "utf-8")
+    expect(scorm).toContain('"qz004"')
+    expect(scorm).toContain('"qz003"')
+    expect(scorm).not.toContain('"qz001"')
+  })
+
   it("packages reader timecodes and enables word highlighting when timestamps exist", async () => {
     const bookDir = path.join(tmpDir, "book")
     const webAssetsDir = path.join(tmpDir, "assets-web")

--- a/packages/pipeline/src/__tests__/text-catalog.test.ts
+++ b/packages/pipeline/src/__tests__/text-catalog.test.ts
@@ -211,6 +211,56 @@ describe("buildTextCatalog", () => {
     ])
   })
 
+  it("keys quiz entries by the stored quizId, so inserting a quiz cannot steal them", async () => {
+    // Two quizzes with stable ids, stored with the newcomer FIRST in the array.
+    // Before quizIds, the array position drove the key: the new quiz would have
+    // taken `qz001_*` and inherited the existing quiz's translations and audio.
+    const storage = createMockStorage({
+      "quiz-generation": {
+        book: {
+          generatedAt: "2024-01-01T00:00:00.000Z",
+          language: "en",
+          pagesPerQuiz: 3,
+          quizzes: [
+            {
+              quizId: "qz002",
+              quizIndex: 0,
+              afterPageId: "pg001",
+              pageIds: ["pg001"],
+              question: "Inserted first?",
+              options: [
+                { text: "a", explanation: "" },
+                { text: "b", explanation: "" },
+                { text: "c", explanation: "" },
+              ],
+              answerIndex: 0,
+              reasoning: "...",
+            },
+            {
+              quizId: "qz001",
+              quizIndex: 1,
+              afterPageId: "pg003",
+              pageIds: ["pg003"],
+              question: "Original?",
+              options: [
+                { text: "a", explanation: "" },
+                { text: "b", explanation: "" },
+                { text: "c", explanation: "" },
+              ],
+              answerIndex: 0,
+              reasoning: "...",
+            },
+          ],
+        },
+      },
+    })
+
+    const result = await buildTextCatalog(storage, [])
+
+    expect(result.entries.find((e) => e.id === "qz001_que")?.text).toBe("Original?")
+    expect(result.entries.find((e) => e.id === "qz002_que")?.text).toBe("Inserted first?")
+  })
+
   it("skips empty text nodes", async () => {
     const storage = createMockStorage({
       "web-rendering": {

--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -4,6 +4,7 @@ export {
   createConsoleProgress,
 } from "./progress.js"
 export { processWithConcurrency } from "./concurrency.js"
+export { collectSpentQuizIds, saveQuizOutput } from "./quiz-ids.js"
 export {
   extractPDF,
   resolveFigureExtractionMode,

--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -4,7 +4,7 @@ export {
   createConsoleProgress,
 } from "./progress.js"
 export { processWithConcurrency } from "./concurrency.js"
-export { collectSpentQuizIds, saveQuizOutput } from "./quiz-ids.js"
+export { collectSpentQuizIds, assertQuizGenerationCapacity, saveQuizOutput } from "./quiz-ids.js"
 export {
   extractPDF,
   resolveFigureExtractionMode,

--- a/packages/pipeline/src/packaging/web.ts
+++ b/packages/pipeline/src/packaging/web.ts
@@ -22,7 +22,7 @@ import type {
   Quiz,
   ImageCaptioningOutput,
 } from "@adt/types"
-import { WebRenderingOutput as WebRenderingOutputSchema, isHeadingRole, isTtsExcluded, FIXED_LAYOUT_MAX_SCALE } from "@adt/types"
+import { WebRenderingOutput as WebRenderingOutputSchema, isHeadingRole, isTtsExcluded, FIXED_LAYOUT_MAX_SCALE, resolveQuizId } from "@adt/types"
 import {
   GOOGLE_FONTS,
   googleFontsReferencedIn,
@@ -508,8 +508,7 @@ export async function packageAdtWeb(
 
     // Insert quiz pages after this page (even if page content was skipped)
     for (const quiz of quizzes) {
-      const quizIndex = quizData!.quizzes.indexOf(quiz)
-      const quizId = `qz${pad3(quizIndex + 1)}`
+      const quizId = resolveQuizId(quiz, quizData!.quizzes.indexOf(quiz))
 
       const isFirstPage = pageList.length === 0
       const quizFilename = isFirstPage ? "index.html" : `${quizId}.html`

--- a/packages/pipeline/src/packaging/web.ts
+++ b/packages/pipeline/src/packaging/web.ts
@@ -24,7 +24,7 @@ import type {
   ImageCaptioningOutput,
   PackagingWarning,
 } from "@adt/types"
-import { WebRenderingOutput as WebRenderingOutputSchema, isHeadingRole, isTtsExcluded, resolveEntryVoiceSlot, FIXED_LAYOUT_MAX_SCALE } from "@adt/types"
+import { WebRenderingOutput as WebRenderingOutputSchema, isHeadingRole, isTtsExcluded, resolveEntryVoiceSlot, FIXED_LAYOUT_MAX_SCALE, resolveQuizId } from "@adt/types"
 import { resolveNarratorLabel } from "../speech.js"
 import {
   GOOGLE_FONTS,
@@ -538,8 +538,7 @@ export async function packageAdtWeb(
 
     // Insert quiz pages after this page (even if page content was skipped)
     for (const quiz of quizzes) {
-      const quizIndex = quizData!.quizzes.indexOf(quiz)
-      const quizId = `qz${pad3(quizIndex + 1)}`
+      const quizId = resolveQuizId(quiz, quizData!.quizzes.indexOf(quiz))
 
       const isFirstPage = pageList.length === 0
       const quizFilename = isFirstPage ? "index.html" : `${quizId}.html`

--- a/packages/pipeline/src/packaging/web.ts
+++ b/packages/pipeline/src/packaging/web.ts
@@ -24,7 +24,7 @@ import type {
   ImageCaptioningOutput,
   PackagingWarning,
 } from "@adt/types"
-import { WebRenderingOutput as WebRenderingOutputSchema, isHeadingRole, isTtsExcluded, resolveEntryVoiceSlot, FIXED_LAYOUT_MAX_SCALE, resolveQuizId } from "@adt/types"
+import { WebRenderingOutput as WebRenderingOutputSchema, isHeadingRole, isTtsExcluded, resolveEntryVoiceSlot, FIXED_LAYOUT_MAX_SCALE, resolveQuizId, withResolvedQuizIds } from "@adt/types"
 import { resolveNarratorLabel } from "../speech.js"
 import {
   GOOGLE_FONTS,
@@ -314,6 +314,10 @@ export async function packageAdtWeb(
   const stepperBasePalette = quizPalette ?? DEFAULT_QUIZ_PALETTE
 
   const step = "package-web" as const
+  // Validate stored/imported quiz identities before deleting or writing any
+  // bundle files. API validation alone cannot protect imported book databases.
+  const quizRow = storage.getLatestNodeData("quiz-generation", "book")
+  const quizData = quizRow ? withResolvedQuizIds(quizRow.data as QuizGenerationOutput) : undefined
   progress.emit({ type: "step-start", step })
   progress.emit({ type: "step-progress", step, message: "Setting up directories..." })
 
@@ -344,9 +348,6 @@ export async function packageAdtWeb(
 
   const glossaryRow = storage.getLatestNodeData("glossary", "book")
   const glossary = glossaryRow?.data as GlossaryOutput | undefined
-
-  const quizRow = storage.getLatestNodeData("quiz-generation", "book")
-  const quizData = quizRow?.data as QuizGenerationOutput | undefined
 
   const metadataRow = storage.getLatestNodeData("metadata", "book")
   const metadata = metadataRow?.data as { title?: string | null; cover_page_number?: number | null } | undefined
@@ -558,7 +559,11 @@ export async function packageAdtWeb(
         applyBodyBackground,
         bodyFontFamily,
       })
-      fs.writeFileSync(path.join(adtDir, quizFilename), quizPageHtml)
+      const quizPath = path.resolve(adtDir, quizFilename)
+      if (path.dirname(quizPath) !== path.resolve(adtDir)) {
+        throw new Error("Quiz output must remain inside the book's export directory")
+      }
+      fs.writeFileSync(quizPath, quizPageHtml)
 
       pageList.push({ section_id: quizId, href: quizFilename })
     }

--- a/packages/pipeline/src/packaging/web.ts
+++ b/packages/pipeline/src/packaging/web.ts
@@ -2377,7 +2377,10 @@ async function renderAgentsMd(
   let sampleQuiz: Record<string, unknown> | undefined
   if (ctx.quizData?.quizzes?.length) {
     const quiz = ctx.quizData.quizzes[0]
-    const quizId = "qz001"
+    // Not "qz001": ids are allocated once and never reused, so the first quiz
+    // in the array may be `qz004`. Hardcoding it would document catalog keys
+    // and audio filenames that aren't in the bundle.
+    const quizId = resolveQuizId(quiz, 0)
     const correctAnswers: Record<string, boolean> = {}
     const explanations: Record<string, string> = {}
     const options = quiz.options.map((opt, i) => {

--- a/packages/pipeline/src/pipeline-dag.ts
+++ b/packages/pipeline/src/pipeline-dag.ts
@@ -67,8 +67,8 @@ import { createTemplateEngine } from "./render-template.js"
 import { captionPageImages, buildCaptionConfig, collectCaptionImageIds, groupGlossaryImageIdsByPage } from "./image-captioning.js"
 import { regenerateGlossaryPreservingEdits, buildGlossaryConfig } from "./glossary.js"
 import { generateToc, buildTocGenerationConfig } from "./toc-generation.js"
-import { generateAllQuizzes, buildQuizGenerationConfig, type QuizPageInput } from "./quiz-generation.js"
-import { saveQuizOutput } from "./quiz-ids.js"
+import { generateAllQuizzes, buildQuizGenerationConfig, batchPages, type QuizPageInput } from "./quiz-generation.js"
+import { saveQuizOutput, assertQuizGenerationCapacity } from "./quiz-ids.js"
 import { buildTextCatalog } from "./text-catalog.js"
 import { buildEasyReadConfig, buildEasyReadSourceBlocks, createEmptyEasyReadOutput, generateEasyRead, flattenEasyReadEntries, isDeterministicEmptyEasyReadOutput } from "./easy-read.js"
 import { translateCatalogBatch, buildCatalogTranslationConfig, getTargetLanguages } from "./catalog-translation.js"
@@ -718,6 +718,7 @@ export async function runFullPipeline(
         })
       }
       if (quizPages.length > 0) {
+        assertQuizGenerationCapacity(storage, batchPages(quizPages, quizConfig.pagesPerQuiz, quizConfig.quizSectionTypes).length)
         const result = await generateAllQuizzes(quizPages, quizConfig, model, {
           concurrency: effectiveConcurrency,
           onQuizComplete: (completed, total) => {

--- a/packages/pipeline/src/pipeline-dag.ts
+++ b/packages/pipeline/src/pipeline-dag.ts
@@ -68,6 +68,7 @@ import { captionPageImages, buildCaptionConfig, collectCaptionImageIds, groupGlo
 import { regenerateGlossaryPreservingEdits, buildGlossaryConfig } from "./glossary.js"
 import { generateToc, buildTocGenerationConfig } from "./toc-generation.js"
 import { generateAllQuizzes, buildQuizGenerationConfig, type QuizPageInput } from "./quiz-generation.js"
+import { saveQuizOutput } from "./quiz-ids.js"
 import { buildTextCatalog } from "./text-catalog.js"
 import { buildEasyReadConfig, buildEasyReadSourceBlocks, createEmptyEasyReadOutput, generateEasyRead, flattenEasyReadEntries, isDeterministicEmptyEasyReadOutput } from "./easy-read.js"
 import { translateCatalogBatch, buildCatalogTranslationConfig, getTargetLanguages } from "./catalog-translation.js"
@@ -729,7 +730,12 @@ export async function runFullPipeline(
             })
           },
         })
-        storage.putNodeData("quiz-generation", "book", result)
+        saveQuizOutput(storage, result, "replace")
+      } else {
+        saveQuizOutput(storage, {
+          generatedAt: new Date().toISOString(), language: quizConfig.language,
+          pagesPerQuiz: quizConfig.pagesPerQuiz, quizzes: [],
+        }, "replace")
       }
     })
 

--- a/packages/pipeline/src/quiz-generation.ts
+++ b/packages/pipeline/src/quiz-generation.ts
@@ -7,7 +7,7 @@ import type {
   QuizGenerationOutput,
   Quiz,
 } from "@adt/types"
-import { quizLLMSchema, DEFAULT_LLM_MAX_RETRIES } from "@adt/types"
+import { quizLLMSchema, DEFAULT_LLM_MAX_RETRIES, ensureQuizIds } from "@adt/types"
 import type { LLMModel, ValidationResult } from "@adt/llm"
 import { processWithConcurrency } from "./concurrency.js"
 import { buildLanguageContext, normalizeLocale } from "./language-context.js"
@@ -245,10 +245,12 @@ export async function generateAllQuizzes(
   // Sort by index since parallel execution may complete out of order
   quizzes.sort((a, b) => a.quizIndex - b.quizIndex)
 
-  return {
+  // A full stage run replaces the whole set, so ids start from `qz001` — the
+  // same values this output has always produced positionally.
+  return ensureQuizIds({
     generatedAt: new Date().toISOString(),
     language: config.language,
     pagesPerQuiz: config.pagesPerQuiz,
     quizzes,
-  }
+  }).output
 }

--- a/packages/pipeline/src/quiz-generation.ts
+++ b/packages/pipeline/src/quiz-generation.ts
@@ -7,7 +7,7 @@ import type {
   QuizGenerationOutput,
   Quiz,
 } from "@adt/types"
-import { quizLLMSchema, DEFAULT_LLM_MAX_RETRIES, ensureQuizIds } from "@adt/types"
+import { quizLLMSchema, DEFAULT_LLM_MAX_RETRIES } from "@adt/types"
 import type { LLMModel, ValidationResult } from "@adt/llm"
 import { processWithConcurrency } from "./concurrency.js"
 import { buildLanguageContext, normalizeLocale } from "./language-context.js"
@@ -245,12 +245,12 @@ export async function generateAllQuizzes(
   // Sort by index since parallel execution may complete out of order
   quizzes.sort((a, b) => a.quizIndex - b.quizIndex)
 
-  // A full stage run replaces the whole set, so ids start from `qz001` — the
-  // same values this output has always produced positionally.
-  return ensureQuizIds({
+  // Identity is allocated by saveQuizOutput at persistence, against the book's
+  // complete history. A cached LLM result is still a new quiz on regeneration.
+  return {
     generatedAt: new Date().toISOString(),
     language: config.language,
     pagesPerQuiz: config.pagesPerQuiz,
     quizzes,
-  }).output
+  }
 }

--- a/packages/pipeline/src/quiz-ids.ts
+++ b/packages/pipeline/src/quiz-ids.ts
@@ -1,0 +1,101 @@
+import type { Storage } from "@adt/storage"
+import {
+  ensureQuizIds,
+  formatQuizId,
+  parseQuizId,
+  withResolvedQuizIds,
+  QuizIdentityError,
+  type Quiz,
+  type QuizGenerationOutput,
+} from "@adt/types"
+
+/** History survives invalidation and extraction resets. Read leniently: old
+ * versions still spent IDs even if their other fields no longer validate. */
+export function collectSpentQuizIds(storage: Storage): Set<string> {
+  const ids = new Set<string>()
+  for (const row of storage.getAllNodeVersions("quiz-generation", "book")) {
+    const quizzes = (row.data as { quizzes?: unknown } | null)?.quizzes
+    if (!Array.isArray(quizzes)) continue
+    quizzes.forEach((quiz, index) => {
+      const id = (quiz as { quizId?: unknown } | null)?.quizId
+      if (typeof id === "string" && parseQuizId(id) !== null) ids.add(id)
+      else if (id == null) ids.add(formatQuizId(index + 1))
+    })
+  }
+  return ids
+}
+
+function contentKey(quiz: Quiz): string {
+  return JSON.stringify([
+    quiz.afterPageId, quiz.pageIds, quiz.question,
+    quiz.options.map((option) => [option.text, option.explanation]),
+    quiz.answerIndex, quiz.reasoning,
+  ])
+}
+
+/** Resolve unambiguous ID-less round trips by content, never by their edited
+ * positions. Older clients can retry, delete, reorder, or append unchanged
+ * entries; ambiguous content replacement must round-trip GET's explicit IDs. */
+function reconcileLegacyUpdate(output: QuizGenerationOutput, current: Quiz[]): QuizGenerationOutput {
+  // An exact unchanged round trip is unambiguous even when two quizzes have
+  // identical content: the complete ordered set still matches the source.
+  if (
+    output.quizzes.length === current.length &&
+    output.quizzes.every((quiz, index) => !quiz.quizId && contentKey(quiz) === contentKey(current[index]))
+  ) {
+    return { ...output, quizzes: output.quizzes.map((quiz, index) => ({ ...quiz, quizId: current[index].quizId })) }
+  }
+  const claimed = new Set(output.quizzes.flatMap((q) => q.quizId ? [q.quizId] : []))
+  const hasExplicitIds = claimed.size > 0
+  let unassigned = false
+  const quizzes = output.quizzes.map((quiz) => {
+    if (quiz.quizId) return quiz
+    const matches = current.filter((prior) => !claimed.has(prior.quizId!) && contentKey(prior) === contentKey(quiz))
+    if (matches.length > 1) {
+      throw new QuizIdentityError("Ambiguous quiz update. Reload quizzes and include their quizId when saving.")
+    }
+    if (matches.length === 1) {
+      claimed.add(matches[0].quizId!)
+      return { ...quiz, quizId: matches[0].quizId }
+    }
+    unassigned = true
+    return quiz
+  })
+  if (!hasExplicitIds && unassigned && current.some((q) => !claimed.has(q.quizId!))) {
+    throw new QuizIdentityError("Cannot identify edited quizzes. Reload quizzes and include their quizId when saving.")
+  }
+  return { ...output, quizzes }
+}
+
+/** All quiz writes share one atomic allocation/persistence boundary.
+ * - edit: reconcile compatible legacy requests before allocating additions.
+ * - insert: existing quizzes already carry IDs; every missing ID is new.
+ * - replace: full generation creates new entities, even when its LLM is cached.
+ * No generation or filesystem work is performed while the transaction is held. */
+export function saveQuizOutput(
+  storage: Storage,
+  output: QuizGenerationOutput,
+  mode: "edit" | "insert" | "replace",
+): { output: QuizGenerationOutput; version: number } {
+  return storage.transaction(() => {
+    const spent = collectSpentQuizIds(storage)
+    let incoming = output
+    if (mode === "replace") {
+      incoming = { ...output, quizzes: output.quizzes.map(({ quizId: _id, ...quiz }) => quiz) }
+    } else {
+      const row = storage.getLatestNodeData("quiz-generation", "book")
+      const current = row ? withResolvedQuizIds(row.data as QuizGenerationOutput).quizzes : []
+      const currentIds = new Set(current.map((quiz) => quiz.quizId))
+      for (const quiz of output.quizzes) {
+        if (quiz.quizId && spent.has(quiz.quizId) && !currentIds.has(quiz.quizId)) {
+          throw new QuizIdentityError("A quiz id is no longer current. Reload quizzes or restore its version before saving.")
+        }
+      }
+      if (mode === "edit") incoming = reconcileLegacyUpdate(output, current)
+    }
+    const stamped = ensureQuizIds(incoming, spent).output
+    const normalized = { ...stamped, quizzes: stamped.quizzes.map((quiz, quizIndex) => ({ ...quiz, quizIndex })) }
+    const version = storage.putNodeData("quiz-generation", "book", normalized)
+    return { output: normalized, version }
+  })
+}

--- a/packages/pipeline/src/quiz-ids.ts
+++ b/packages/pipeline/src/quiz-ids.ts
@@ -1,6 +1,7 @@
 import type { Storage } from "@adt/storage"
 import {
   ensureQuizIds,
+  assertQuizIdCapacity,
   formatQuizId,
   parseQuizId,
   withResolvedQuizIds,
@@ -23,6 +24,12 @@ export function collectSpentQuizIds(storage: Storage): Set<string> {
     })
   }
   return ids
+}
+
+/** Advisory preflight only: saveQuizOutput rechecks in its transaction because
+ * another write can consume IDs while a model request is in flight. */
+export function assertQuizGenerationCapacity(storage: Storage, requested: number): void {
+  assertQuizIdCapacity(collectSpentQuizIds(storage).size, requested)
 }
 
 function contentKey(quiz: Quiz): string {

--- a/packages/pipeline/src/text-catalog.ts
+++ b/packages/pipeline/src/text-catalog.ts
@@ -11,6 +11,7 @@ import type {
 } from "@adt/types"
 import {
   WebRenderingOutput as WebRenderingOutputSchema,
+  resolveQuizId,
 } from "@adt/types"
 import type { Storage, PageData } from "@adt/storage"
 import { getGlossaryItemTextId } from "./glossary.js"
@@ -203,7 +204,7 @@ function buildQuizEntries(storage: Storage): TextCatalogEntry[] {
   const entries: TextCatalogEntry[] = []
   for (let i = 0; i < data.quizzes.length; i++) {
     const quiz = data.quizzes[i]
-    const qid = `qz${pad3(i + 1)}`
+    const qid = resolveQuizId(quiz, i)
     entries.push({ id: `${qid}_que`, text: quiz.question })
 
     for (let j = 0; j < quiz.options.length; j++) {

--- a/packages/pipeline/src/text-catalog.ts
+++ b/packages/pipeline/src/text-catalog.ts
@@ -13,6 +13,7 @@ import {
   WebRenderingOutput as WebRenderingOutputSchema,
   answerTextId,
   resolveQuizId,
+  withResolvedQuizIds,
 } from "@adt/types"
 import type { Storage, PageData } from "@adt/storage"
 import { getGlossaryItemTextId } from "./glossary.js"
@@ -199,8 +200,9 @@ function buildQuizEntries(storage: Storage): TextCatalogEntry[] {
   const row = storage.getLatestNodeData("quiz-generation", "book")
   if (!row) return []
 
-  const data = row.data as QuizGenerationOutput
-  if (!data.quizzes) return []
+  const stored = row.data as QuizGenerationOutput
+  if (!stored.quizzes) return []
+  const data = withResolvedQuizIds(stored)
 
   const entries: TextCatalogEntry[] = []
   for (let i = 0; i < data.quizzes.length; i++) {

--- a/packages/pipeline/src/text-catalog.ts
+++ b/packages/pipeline/src/text-catalog.ts
@@ -12,6 +12,7 @@ import type {
 import {
   WebRenderingOutput as WebRenderingOutputSchema,
   answerTextId,
+  resolveQuizId,
 } from "@adt/types"
 import type { Storage, PageData } from "@adt/storage"
 import { getGlossaryItemTextId } from "./glossary.js"
@@ -204,7 +205,7 @@ function buildQuizEntries(storage: Storage): TextCatalogEntry[] {
   const entries: TextCatalogEntry[] = []
   for (let i = 0; i < data.quizzes.length; i++) {
     const quiz = data.quizzes[i]
-    const qid = `qz${pad3(i + 1)}`
+    const qid = resolveQuizId(quiz, i)
     entries.push({ id: `${qid}_que`, text: quiz.question })
 
     for (let j = 0; j < quiz.options.length; j++) {

--- a/packages/storage/src/__tests__/book-storage.test.ts
+++ b/packages/storage/src/__tests__/book-storage.test.ts
@@ -771,9 +771,11 @@ describe("quiz history retention on invalidation", () => {
       const db = openBookDb(paths.dbPath)
       try {
         expect(readCurrentNodeRow(db, "quiz-generation", "book")).toBeNull()
+        expect(readCurrentNodeRow(db, "quiz-generation", "book", { includeInvalidated: true })).toEqual({ version: 3, data: "null" })
         // A book without a pointer must not fall back past the tombstone.
         db.run("DELETE FROM node_current WHERE node = ?", ["quiz-generation"])
         expect(readCurrentNodeRow(db, "quiz-generation", "book")).toBeNull()
+        expect(readCurrentNodeRow(db, "quiz-generation", "book", { includeInvalidated: true })).toEqual({ version: 3, data: "null" })
       } finally { db.close() }
       expect(storage.getLatestNodeData("quiz-generation", "book")).toBeNull()
       expect(storage.setCurrentNodeVersion("quiz-generation", "book", 1)).toBe(true)

--- a/packages/storage/src/__tests__/book-storage.test.ts
+++ b/packages/storage/src/__tests__/book-storage.test.ts
@@ -781,6 +781,18 @@ describe("quiz history retention on invalidation", () => {
     } finally { storage.close() }
   })
 
+  it("preserves nullable payload semantics for nodes outside quiz invalidation", () => {
+    const { storage, paths } = createTempStorage()
+    try {
+      storage.putNodeData("metadata", "book", null)
+      expect(storage.getLatestNodeData("metadata", "book")).toEqual({ version: 1, data: null })
+      const db = openBookDb(paths.dbPath)
+      try {
+        expect(readCurrentNodeRow(db, "metadata", "book")).toEqual({ version: 1, data: "null" })
+      } finally { db.close() }
+    } finally { storage.close() }
+  })
+
   it("rolls quiz invalidation and dependent deletion back with a failed transaction", () => {
     const { storage } = createTempStorage()
     try {

--- a/packages/storage/src/__tests__/book-storage.test.ts
+++ b/packages/storage/src/__tests__/book-storage.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs"
 import os from "node:os"
 import path from "node:path"
 import { openBookDb } from "../db.js"
+import { readCurrentNodeRow } from "../node-current.js"
 import type { ExtractedPage } from "@adt/pdf"
 import { createBookStorage, resolveBookPaths } from "../book-storage.js"
 
@@ -746,5 +747,73 @@ describe("debug_images", () => {
       expect(fp?.version).toBe(1)
       storage.close()
     })
+  })
+})
+
+
+describe("quiz history retention on invalidation", () => {
+  it("hides invalidated output in both current readers, retains history, and is idempotent", () => {
+    const { storage, paths } = createTempStorage()
+    try {
+      const first = { quizzes: [{ quizId: "qz001" }] }
+      storage.putNodeData("quiz-generation", "book", first)
+      storage.putNodeData("quiz-generation", "book", { quizzes: [{ quizId: "qz002" }] })
+      storage.putNodeData("text-catalog", "book", { entries: [] })
+      storage.setCurrentNodeVersion("quiz-generation", "book", 1)
+      storage.clearNodesByType(["quiz-generation", "text-catalog"])
+      storage.clearNodesByType(["quiz-generation"])
+      expect(storage.getLatestNodeData("quiz-generation", "book")).toBeNull()
+      expect(storage.getAllNodeVersions("quiz-generation", "book")).toEqual([
+        { version: 1, data: first }, { version: 2, data: { quizzes: [{ quizId: "qz002" }] } },
+        { version: 3, data: null },
+      ])
+      expect(storage.getAllNodeVersions("text-catalog", "book")).toEqual([])
+      const db = openBookDb(paths.dbPath)
+      try {
+        expect(readCurrentNodeRow(db, "quiz-generation", "book")).toBeNull()
+        // A book without a pointer must not fall back past the tombstone.
+        db.run("DELETE FROM node_current WHERE node = ?", ["quiz-generation"])
+        expect(readCurrentNodeRow(db, "quiz-generation", "book")).toBeNull()
+      } finally { db.close() }
+      expect(storage.getLatestNodeData("quiz-generation", "book")).toBeNull()
+      expect(storage.setCurrentNodeVersion("quiz-generation", "book", 1)).toBe(true)
+      expect(storage.getLatestNodeData("quiz-generation", "book")?.data).toEqual(first)
+    } finally { storage.close() }
+  })
+
+  it("rolls quiz invalidation and dependent deletion back with a failed transaction", () => {
+    const { storage } = createTempStorage()
+    try {
+      storage.putNodeData("quiz-generation", "book", { quizzes: [] })
+      storage.putNodeData("text-catalog", "book", { entries: [] })
+      expect(() => storage.transaction(() => {
+        storage.clearNodesByType(["quiz-generation", "text-catalog"])
+        throw new Error("transaction failed")
+      })).toThrow("transaction failed")
+      expect(storage.getLatestNodeData("quiz-generation", "book")?.version).toBe(1)
+      expect(storage.getAllNodeVersions("quiz-generation", "book")).toHaveLength(1)
+      expect(storage.getLatestNodeData("text-catalog", "book")?.version).toBe(1)
+    } finally { storage.close() }
+  })
+
+  it("retains quiz versions and fonts while extraction clears source and derived output", () => {
+    const { storage } = createTempStorage()
+    try {
+      storage.putExtractedPage(makePage(1))
+      storage.putNodeData("quiz-generation", "book", { quizzes: [{ quizId: "qz001" }] })
+      storage.putNodeData("font-registry", "book", { fonts: [] })
+      storage.putNodeData("web-rendering", "pg001", { sections: [] })
+      storage.markStepCompleted("quiz-generation")
+      storage.clearExtractedData()
+      storage.clearExtractedData()
+      expect(storage.getPages()).toEqual([])
+      expect(storage.getStepRuns()).toEqual([])
+      expect(storage.getLatestNodeData("web-rendering", "pg001")).toBeNull()
+      expect(storage.getLatestNodeData("font-registry", "book")?.version).toBe(1)
+      expect(storage.getLatestNodeData("quiz-generation", "book")).toBeNull()
+      expect(storage.getAllNodeVersions("quiz-generation", "book")).toEqual([
+        { version: 1, data: { quizzes: [{ quizId: "qz001" }] } }, { version: 2, data: null },
+      ])
+    } finally { storage.close() }
   })
 })

--- a/packages/storage/src/book-storage.ts
+++ b/packages/storage/src/book-storage.ts
@@ -7,6 +7,7 @@ import type { LlmLogEntry } from "@adt/llm"
 import { parseBookLabel } from "@adt/types"
 import type { Storage, PageData, ImageData, NodeDataRow, CroppedImageInput, SegmentedImageInput, SignLanguageVideoData, TranslatedImageInput } from "./storage.js"
 import { openBookDb } from "./db.js"
+import { readCurrentNodeRow } from "./node-current.js"
 
 export interface BookPaths {
   bookDir: string
@@ -74,10 +75,15 @@ export function createBookStorage(label: string, booksRoot: string): Storage {
 
     clearNodesByType(nodes: string[]): void {
       if (nodes.length === 0) return
-      const placeholders = nodes.map(() => "?").join(", ")
       transaction(() => {
-        db.run(`DELETE FROM node_data WHERE node IN (${placeholders})`, nodes)
-        db.run(`DELETE FROM node_current WHERE node IN (${placeholders})`, nodes)
+        // Quiz history is also the permanent record of spent catalog/audio
+        // identities. Invalidate its current output, never erase that record.
+        if (nodes.includes("quiz-generation")) invalidateQuizOutput(db)
+        const deletable = nodes.filter((node) => node !== "quiz-generation")
+        if (deletable.length === 0) return
+        const placeholders = deletable.map(() => "?").join(", ")
+        db.run(`DELETE FROM node_data WHERE node IN (${placeholders})`, deletable)
+        db.run(`DELETE FROM node_current WHERE node IN (${placeholders})`, deletable)
       })
     },
 
@@ -452,19 +458,11 @@ export function createBookStorage(label: string, booksRoot: string): Storage {
     /** Returns the *current* version's row — the version pointed at by
      *  node_current, or MAX(version) when no pointer is set (or it dangles). */
     getLatestNodeData(node: string, itemId: string): NodeDataRow | null {
-      const rows = db.all(
-        `SELECT nd.version AS version, nd.data AS data
-         FROM node_data nd
-         LEFT JOIN node_current nc ON nc.node = nd.node AND nc.item_id = nd.item_id
-         WHERE nd.node = ? AND nd.item_id = ?
-         ORDER BY (nd.version = nc.version) DESC, nd.version DESC
-         LIMIT 1`,
-        [node, itemId]
-      ) as Array<{ version: number; data: string }>
-      if (rows.length === 0) return null
+      const row = readCurrentNodeRow(db, node, itemId)
+      if (!row) return null
       return {
-        version: rows[0].version,
-        data: JSON.parse(rows[0].data),
+        version: row.version,
+        data: JSON.parse(row.data),
       }
     },
 
@@ -605,8 +603,9 @@ function clearImageFiles(imagesDir: string): void {
 function clearExtractedRows(db: sqlite.Database): void {
   db.exec("BEGIN IMMEDIATE")
   try {
-    db.run("DELETE FROM node_data WHERE node NOT IN ('font-registry', 'font-assignment')")
-    db.run("DELETE FROM node_current WHERE node NOT IN ('font-registry', 'font-assignment')")
+    invalidateQuizOutput(db)
+    db.run("DELETE FROM node_data WHERE node NOT IN ('font-registry', 'font-assignment', 'quiz-generation')")
+    db.run("DELETE FROM node_current WHERE node NOT IN ('font-registry', 'font-assignment', 'quiz-generation')")
     db.run("DELETE FROM images")
     db.run("DELETE FROM pages")
     db.run("DELETE FROM step_runs")
@@ -614,6 +613,27 @@ function clearExtractedRows(db: sqlite.Database): void {
   } catch (err) {
     db.exec("ROLLBACK")
     throw err
+  }
+}
+
+/** Called inside the clearing transaction. The null version hides stale quiz
+ * output after an upstream reset while retaining every version for allocation
+ * and rollback. A repeated clear does not create another null version. */
+function invalidateQuizOutput(db: sqlite.Database): void {
+  const node = "quiz-generation"
+  const items = db.all("SELECT DISTINCT item_id FROM node_data WHERE node = ?", [node]) as Array<{ item_id: string }>
+  for (const { item_id: itemId } of items) {
+    if (!readCurrentNodeRow(db, node, itemId)) continue
+    const [{ version }] = db.all(
+      "SELECT MAX(version) + 1 AS version FROM node_data WHERE node = ? AND item_id = ?",
+      [node, itemId]
+    ) as Array<{ version: number }>
+    db.run("INSERT INTO node_data (node, item_id, version, data) VALUES (?, ?, ?, ?)", [node, itemId, version, "null"])
+    db.run(
+      `INSERT INTO node_current (node, item_id, version) VALUES (?, ?, ?)
+       ON CONFLICT (node, item_id) DO UPDATE SET version = excluded.version`,
+      [node, itemId, version]
+    )
   }
 }
 

--- a/packages/storage/src/node-current.ts
+++ b/packages/storage/src/node-current.ts
@@ -21,7 +21,9 @@ export function readCurrentNodeRow(
      LIMIT 1`,
     [node, itemId]
   ) as Array<{ version: number; data: string }>
-  return rows[0] ?? null
+  // A null version invalidates the active output without deleting its history.
+  // Do not filter null rows in SQL: that would resurrect an older version.
+  return rows[0]?.data === "null" ? null : rows[0] ?? null
 }
 
 /**

--- a/packages/storage/src/node-current.ts
+++ b/packages/storage/src/node-current.ts
@@ -21,9 +21,10 @@ export function readCurrentNodeRow(
      LIMIT 1`,
     [node, itemId]
   ) as Array<{ version: number; data: string }>
-  // A null version invalidates the active output without deleting its history.
+  // Quiz invalidation retains history behind a null current version. Keep this
+  // interpretation local to quizzes; other nodes retain their nullable payloads.
   // Do not filter null rows in SQL: that would resurrect an older version.
-  return rows[0]?.data === "null" ? null : rows[0] ?? null
+  return node === "quiz-generation" && rows[0]?.data === "null" ? null : rows[0] ?? null
 }
 
 /**

--- a/packages/storage/src/node-current.ts
+++ b/packages/storage/src/node-current.ts
@@ -5,12 +5,14 @@ import type sqlite from "node-sqlite3-wasm"
  * handle: the version pointed at by `node_current`, or MAX(version) when no
  * pointer is set (or it dangles). Mirrors `Storage.getLatestNodeData` for
  * routes that use `openBookDb` instead of the full storage wrapper, so both
- * agree on which version is current.
+ * agree on which version is current. History consumers can opt into receiving
+ * a selected invalidation row, while ordinary consumers still see absent output.
  */
 export function readCurrentNodeRow(
   db: sqlite.Database,
   node: string,
-  itemId: string
+  itemId: string,
+  options: { includeInvalidated?: boolean } = {},
 ): { version: number; data: string } | null {
   const rows = db.all(
     `SELECT nd.version AS version, nd.data AS data
@@ -24,7 +26,7 @@ export function readCurrentNodeRow(
   // Quiz invalidation retains history behind a null current version. Keep this
   // interpretation local to quizzes; other nodes retain their nullable payloads.
   // Do not filter null rows in SQL: that would resurrect an older version.
-  return node === "quiz-generation" && rows[0]?.data === "null" ? null : rows[0] ?? null
+  return !options.includeInvalidated && node === "quiz-generation" && rows[0]?.data === "null" ? null : rows[0] ?? null
 }
 
 /**

--- a/packages/storage/src/storage.ts
+++ b/packages/storage/src/storage.ts
@@ -96,10 +96,12 @@ export interface Storage {
   clearTranslatedImages(filter?: { sourceImageIds?: string[]; languageCodes?: string[] }): void
 
   putNodeData(node: string, itemId: string, data: unknown): number
+  /** Current output, or null when absent or explicitly invalidated. */
   getLatestNodeData(node: string, itemId: string): NodeDataRow | null
   /**
    * Every stored version for (node, itemId), oldest first — including versions
-   * the current pointer has moved past. Used to allocate ids that were never
+   * the current pointer has moved past and null invalidation versions.
+   * Used to allocate ids that were never
    * used by *any* version, so a rollback can't make a fresh id collide with a
    * retired one.
    */

--- a/packages/types/src/__tests__/quiz.test.ts
+++ b/packages/types/src/__tests__/quiz.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest"
+import {
+  formatQuizId,
+  parseQuizId,
+  resolveQuizId,
+  ensureQuizIds,
+  type Quiz,
+  type QuizGenerationOutput,
+} from "../quiz.js"
+
+function quiz(question: string, overrides: Partial<Quiz> = {}): Quiz {
+  return {
+    quizIndex: 0,
+    afterPageId: "pg001",
+    pageIds: ["pg001"],
+    question,
+    options: [
+      { text: "a", explanation: "" },
+      { text: "b", explanation: "" },
+      { text: "c", explanation: "" },
+    ],
+    answerIndex: 0,
+    reasoning: "",
+    ...overrides,
+  }
+}
+
+function output(quizzes: Quiz[]): QuizGenerationOutput {
+  return {
+    generatedAt: "2026-01-01T00:00:00.000Z",
+    language: "en",
+    pagesPerQuiz: 3,
+    quizzes,
+  }
+}
+
+describe("formatQuizId / parseQuizId", () => {
+  it("round-trips", () => {
+    expect(formatQuizId(1)).toBe("qz001")
+    expect(formatQuizId(42)).toBe("qz042")
+    expect(parseQuizId("qz042")).toBe(42)
+  })
+
+  it("returns null for ids of other kinds", () => {
+    expect(parseQuizId("pg001_sec001")).toBeNull()
+    expect(parseQuizId("glp001")).toBeNull()
+    expect(parseQuizId("qz")).toBeNull()
+  })
+})
+
+describe("resolveQuizId", () => {
+  it("prefers the stored id", () => {
+    expect(resolveQuizId(quiz("q", { quizId: "qz007" }), 0)).toBe("qz007")
+  })
+
+  it("falls back to the value derived before quizId existed", () => {
+    expect(resolveQuizId(quiz("q"), 0)).toBe("qz001")
+    expect(resolveQuizId(quiz("q"), 4)).toBe("qz005")
+  })
+})
+
+describe("ensureQuizIds", () => {
+  it("stamps legacy quizzes with the ids their catalog entries already use", () => {
+    // A book written before quizId existed: every consumer derived qz001..qz003
+    // from array position, and `${qid}_que` keys its translations and audio.
+    // Backfilling must reproduce exactly those ids, not fresh ones.
+    const { output: result, changed } = ensureQuizIds(
+      output([quiz("one"), quiz("two"), quiz("three")])
+    )
+
+    expect(changed).toBe(true)
+    expect(result.quizzes.map((q) => q.quizId)).toEqual(["qz001", "qz002", "qz003"])
+  })
+
+  it("is a no-op when every quiz already has an id", () => {
+    const input = output([quiz("one", { quizId: "qz005" })])
+    const { output: result, changed } = ensureQuizIds(input)
+
+    expect(changed).toBe(false)
+    expect(result).toBe(input)
+  })
+
+  it("leaves existing ids untouched when a quiz is inserted at the front", () => {
+    // The regression this exists to prevent: inserting a quiz used to shift
+    // every later quiz's id, re-pointing its question and options at another
+    // quiz's translations and generated audio.
+    const existing = ensureQuizIds(output([quiz("one"), quiz("two")])).output
+    const withInsert = output([quiz("new"), ...existing.quizzes])
+
+    const { output: result } = ensureQuizIds(withInsert)
+
+    expect(result.quizzes.map((q) => q.quizId)).toEqual(["qz003", "qz001", "qz002"])
+    expect(result.quizzes.map((q) => q.question)).toEqual(["new", "one", "two"])
+  })
+
+  it("does not reuse an id retired by an earlier version", () => {
+    // qz002's quiz was deleted. Reissuing qz002 would adopt the removed quiz's
+    // `qz002_que` / `qz002_o0` catalog entries onto unrelated content.
+    const { output: result } = ensureQuizIds(
+      output([quiz("kept", { quizId: "qz001" }), quiz("added")]),
+      ["qz001", "qz002", "qz003"]
+    )
+
+    expect(result.quizzes.map((q) => q.quizId)).toEqual(["qz001", "qz004"])
+  })
+})

--- a/packages/types/src/__tests__/quiz.test.ts
+++ b/packages/types/src/__tests__/quiz.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from "vitest"
 import {
   formatQuizId,
   parseQuizId,
-  parseQuizRouteId,
   resolveQuizId,
   withResolvedQuizIds,
   ensureQuizIds,
@@ -195,20 +194,27 @@ describe("withResolvedQuizIds", () => {
   })
 })
 
-describe("parseQuizRouteId", () => {
-  it("reads the canonical route shape", () => {
-    expect(parseQuizRouteId("quiz-qz003")).toBe("qz003")
+
+describe("quiz identity boundary validation", () => {
+  it.each(["qz000", "qz1", "qz1000", "", "../qz001", "qz001\n", "qz001\r"])("rejects invalid explicit id %j in allocation and reads", (quizId) => {
+    expect(parseQuizId(quizId)).toBeNull()
+    const input = output([quiz("Invalid", { quizId })])
+    expect(() => ensureQuizIds(input)).toThrow(/Invalid quiz id/)
+    expect(() => withResolvedQuizIds(input)).toThrow(/Invalid quiz id/)
   })
 
-  it("maps a legacy numeric route to the id that index used to derive", () => {
-    // Links minted before quizzes had stable ids carry `quiz-{arrayIndex}`.
-    expect(parseQuizRouteId("quiz-0")).toBe("qz001")
-    expect(parseQuizRouteId("quiz-4")).toBe("qz005")
+  it("rejects supplied duplicates and ambiguous partial legacy arrays", () => {
+    const duplicate = output([quiz("One", { quizId: "qz002" }), quiz("Two", { quizId: "qz002" })])
+    expect(() => ensureQuizIds(duplicate)).toThrow("Duplicate quiz id")
+    expect(() => withResolvedQuizIds(duplicate)).toThrow("Duplicate quiz id")
+    expect(() => withResolvedQuizIds(output([quiz("Explicit", { quizId: "qz002" }), quiz("Legacy")]))).toThrow("Duplicate quiz id")
   })
 
-  it("returns null for pageIds that aren't quiz routes", () => {
-    expect(parseQuizRouteId("pg001")).toBeNull()
-    expect(parseQuizRouteId("pg001_sec001")).toBeNull()
-    expect(parseQuizRouteId("quiz-")).toBeNull()
+  it("uses a lower unspent slot before reporting exhaustion on a sparse book", () => {
+    const reserved = Array.from({ length: 997 }, (_, i) => formatQuizId(i + 3))
+    const result = ensureQuizIds(output([
+      quiz("Existing", { quizId: "qz998" }), quiz("Existing 2", { quizId: "qz999" }), quiz("New"),
+    ]), reserved).output
+    expect(result.quizzes[2].quizId).toBe("qz001")
   })
 })

--- a/packages/types/src/__tests__/quiz.test.ts
+++ b/packages/types/src/__tests__/quiz.test.ts
@@ -2,8 +2,12 @@ import { describe, it, expect } from "vitest"
 import {
   formatQuizId,
   parseQuizId,
+  parseQuizRouteId,
   resolveQuizId,
+  withResolvedQuizIds,
   ensureQuizIds,
+  QuizIdExhaustedError,
+  MAX_QUIZ_SEQ,
   type Quiz,
   type QuizGenerationOutput,
 } from "../quiz.js"
@@ -102,5 +106,109 @@ describe("ensureQuizIds", () => {
     )
 
     expect(result.quizzes.map((q) => q.quizId)).toEqual(["qz001", "qz004"])
+  })
+
+  it("throws rather than minting a 4-digit id when every number is spent", () => {
+    const reserved = Array.from({ length: MAX_QUIZ_SEQ }, (_, i) =>
+      formatQuizId(i + 1)
+    )
+
+    expect(() => ensureQuizIds(output([quiz("one")]), reserved)).toThrow(
+      QuizIdExhaustedError
+    )
+  })
+})
+
+describe("withResolvedQuizIds", () => {
+  it("pins legacy ids to the positions their catalog entries were written for", () => {
+    const result = withResolvedQuizIds(
+      output([quiz("one"), quiz("two"), quiz("three")])
+    )
+
+    expect(result.quizzes.map((q) => q.quizId)).toEqual([
+      "qz001",
+      "qz002",
+      "qz003",
+    ])
+  })
+
+  it("is a no-op when every quiz already has an id", () => {
+    const input = output([quiz("one", { quizId: "qz009" })])
+
+    expect(withResolvedQuizIds(input)).toBe(input)
+  })
+
+  it("agrees with resolveQuizId, which is what the read paths use", () => {
+    const stored = output([quiz("one"), quiz("two")])
+    const resolved = withResolvedQuizIds(stored)
+
+    expect(resolved.quizzes.map((q) => q.quizId)).toEqual(
+      stored.quizzes.map((q, i) => resolveQuizId(q, i))
+    )
+  })
+
+  it("protects a legacy quiz's ids when the edit that follows reorders the array", () => {
+    // The gap `ensureQuizIds` alone leaves: a book with no stored ids, edited by
+    // deleting its first quiz. Stamping the post-delete array would give the
+    // survivors qz001/qz002 — the ids of the quizzes *before* them, and with
+    // them those quizzes' translations and generated audio. Resolving in stored
+    // order first pins each id before anything moves.
+    const stored = withResolvedQuizIds(
+      output([quiz("one"), quiz("two"), quiz("three")])
+    )
+
+    const afterDelete = ensureQuizIds({
+      ...stored,
+      quizzes: stored.quizzes.slice(1),
+    })
+
+    expect(afterDelete.changed).toBe(false)
+    expect(afterDelete.output.quizzes.map((q) => q.quizId)).toEqual([
+      "qz002",
+      "qz003",
+    ])
+  })
+
+  it("protects them on a mid-book insert too, and the newcomer takes a fresh id", () => {
+    const stored = withResolvedQuizIds(
+      output([quiz("one"), quiz("two"), quiz("three")])
+    )
+
+    // Insert at index 1, as `generate-one` does after sorting by page number.
+    const { output: result } = ensureQuizIds({
+      ...stored,
+      quizzes: [stored.quizzes[0], quiz("new"), ...stored.quizzes.slice(1)],
+    })
+
+    expect(result.quizzes.map((q) => q.question)).toEqual([
+      "one",
+      "new",
+      "two",
+      "three",
+    ])
+    expect(result.quizzes.map((q) => q.quizId)).toEqual([
+      "qz001",
+      "qz004",
+      "qz002",
+      "qz003",
+    ])
+  })
+})
+
+describe("parseQuizRouteId", () => {
+  it("reads the canonical route shape", () => {
+    expect(parseQuizRouteId("quiz-qz003")).toBe("qz003")
+  })
+
+  it("maps a legacy numeric route to the id that index used to derive", () => {
+    // Links minted before quizzes had stable ids carry `quiz-{arrayIndex}`.
+    expect(parseQuizRouteId("quiz-0")).toBe("qz001")
+    expect(parseQuizRouteId("quiz-4")).toBe("qz005")
+  })
+
+  it("returns null for pageIds that aren't quiz routes", () => {
+    expect(parseQuizRouteId("pg001")).toBeNull()
+    expect(parseQuizRouteId("pg001_sec001")).toBeNull()
+    expect(parseQuizRouteId("quiz-")).toBeNull()
   })
 })

--- a/packages/types/src/__tests__/quiz.test.ts
+++ b/packages/types/src/__tests__/quiz.test.ts
@@ -7,6 +7,7 @@ import {
   ensureQuizIds,
   QuizIdExhaustedError,
   MAX_QUIZ_SEQ,
+  assertQuizIdCapacity,
   type Quiz,
   type QuizGenerationOutput,
 } from "../quiz.js"
@@ -107,15 +108,12 @@ describe("ensureQuizIds", () => {
     expect(result.quizzes.map((q) => q.quizId)).toEqual(["qz001", "qz004"])
   })
 
-  it("throws rather than minting a 4-digit id when every number is spent", () => {
-    const reserved = Array.from({ length: MAX_QUIZ_SEQ }, (_, i) =>
-      formatQuizId(i + 1)
-    )
-
-    expect(() => ensureQuizIds(output([quiz("one")]), reserved)).toThrow(
-      QuizIdExhaustedError
-    )
+  it("allocates beyond qz999 without changing previous IDs", () => {
+    const reserved = Array.from({ length: 999 }, (_, i) => formatQuizId(i + 1))
+    const result = ensureQuizIds(output([quiz("New"), quiz("Next")]), reserved).output
+    expect(result.quizzes.map((q) => q.quizId)).toEqual(["qz1000", "qz1001"])
   })
+
 })
 
 describe("withResolvedQuizIds", () => {
@@ -196,7 +194,7 @@ describe("withResolvedQuizIds", () => {
 
 
 describe("quiz identity boundary validation", () => {
-  it.each(["qz000", "qz1", "qz1000", "", "../qz001", "qz001\n", "qz001\r"])("rejects invalid explicit id %j in allocation and reads", (quizId) => {
+  it.each(["qz000", "qz1", "qz0001", "qz01e3", "qz9007199254740992", "", "../qz001", "qz001\n", "qz1000\n", "qz001\r"])("rejects invalid explicit id %j in allocation and reads", (quizId) => {
     expect(parseQuizId(quizId)).toBeNull()
     const input = output([quiz("Invalid", { quizId })])
     expect(() => ensureQuizIds(input)).toThrow(/Invalid quiz id/)
@@ -210,11 +208,30 @@ describe("quiz identity boundary validation", () => {
     expect(() => withResolvedQuizIds(output([quiz("Explicit", { quizId: "qz002" }), quiz("Legacy")]))).toThrow("Duplicate quiz id")
   })
 
-  it("uses a lower unspent slot before reporting exhaustion on a sparse book", () => {
+  it("keeps sparse explicit IDs while allocating past the old width", () => {
     const reserved = Array.from({ length: 997 }, (_, i) => formatQuizId(i + 3))
     const result = ensureQuizIds(output([
       quiz("Existing", { quizId: "qz998" }), quiz("Existing 2", { quizId: "qz999" }), quiz("New"),
     ]), reserved).output
-    expect(result.quizzes[2].quizId).toBe("qz001")
+    expect(result.quizzes[2].quizId).toBe("qz1000")
+  })
+})
+
+describe("quiz capacity and safe integer boundaries", () => {
+  it.each([1, 999, 1000, 1001, MAX_QUIZ_SEQ])("round-trips sequence %s exactly", (sequence) => {
+    expect(parseQuizId(formatQuizId(sequence))).toBe(sequence)
+  })
+  it.each([0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY, MAX_QUIZ_SEQ + 1])("rejects unsafe sequence %s", (sequence) => {
+    expect(() => formatQuizId(sequence)).toThrow("Invalid quiz sequence number")
+  })
+  it("checks capacity without overflowing or claiming all IDs are already spent", () => {
+    expect(() => assertQuizIdCapacity(MAX_QUIZ_SEQ - 1, 1)).not.toThrow()
+    expect(() => assertQuizIdCapacity(MAX_QUIZ_SEQ - 1, 2)).toThrow("Not enough quiz IDs available: 2 requested, 1 remaining.")
+    expect(() => assertQuizIdCapacity(MAX_QUIZ_SEQ, 1)).toThrow(QuizIdExhaustedError)
+    expect(() => assertQuizIdCapacity(MAX_QUIZ_SEQ, 0)).not.toThrow()
+  })
+  it.each([-1, 1.5, Number.POSITIVE_INFINITY, MAX_QUIZ_SEQ + 1])("rejects invalid allocation count %s", (count) => {
+    expect(() => assertQuizIdCapacity(count, 1)).toThrow("Invalid quiz allocation count")
+    expect(() => assertQuizIdCapacity(1, count)).toThrow("Invalid quiz allocation count")
   })
 })

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -293,6 +293,11 @@ export {
   Quiz,
   QuizGenerationOutput,
   quizLLMSchema,
+  formatQuizId,
+  parseQuizId,
+  resolveQuizId,
+  ensureQuizIds,
+  MAX_QUIZ_SEQ,
 } from "./quiz.js"
 
 export {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -301,11 +301,12 @@ export {
   quizLLMSchema,
   formatQuizId,
   parseQuizId,
-  parseQuizRouteId,
   resolveQuizId,
   withResolvedQuizIds,
   ensureQuizIds,
   QuizIdExhaustedError,
+  QuizId,
+  QuizIdentityError,
   MAX_QUIZ_SEQ,
 } from "./quiz.js"
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -301,8 +301,11 @@ export {
   quizLLMSchema,
   formatQuizId,
   parseQuizId,
+  parseQuizRouteId,
   resolveQuizId,
+  withResolvedQuizIds,
   ensureQuizIds,
+  QuizIdExhaustedError,
   MAX_QUIZ_SEQ,
 } from "./quiz.js"
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -308,6 +308,7 @@ export {
   QuizId,
   QuizIdentityError,
   MAX_QUIZ_SEQ,
+  assertQuizIdCapacity,
 } from "./quiz.js"
 
 export {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -299,6 +299,11 @@ export {
   Quiz,
   QuizGenerationOutput,
   quizLLMSchema,
+  formatQuizId,
+  parseQuizId,
+  resolveQuizId,
+  ensureQuizIds,
+  MAX_QUIZ_SEQ,
 } from "./quiz.js"
 
 export {

--- a/packages/types/src/pipeline-effects.ts
+++ b/packages/types/src/pipeline-effects.ts
@@ -212,13 +212,12 @@ export function getStageClearNodes(stage: StageName): PipelineNodeName[] {
   return nodes
 }
 
-/** Stages whose handler merges its own prior output on re-run (e.g. glossary
- * preserves manual, edited, and pruned terms) rather than replacing it. */
-const STAGES_PRESERVING_OWN_OUTPUT: readonly StageName[] = ["glossary"]
+/** Keep prior output until these stages successfully write a new version.
+ * Quizzes also use their history to reserve IDs across full regeneration. */
+const STAGES_PRESERVING_OWN_OUTPUT: readonly StageName[] = ["glossary", "quizzes"]
 
-/** Like getStageClearNodes(fromStage), but keeps a merge-preserving stage's own
- * output when that stage is inside the [fromStage, toStage] run range so its
- * handler can re-merge the prior version. Outside the range it is still cleared. */
+/** Like getStageClearNodes(fromStage), but retains selected stages' prior output
+ * until their handlers save a new version. Outside the run range it is cleared. */
 export function getStageRerunClearNodes(
   fromStage: StageName,
   toStage: StageName

--- a/packages/types/src/quiz.ts
+++ b/packages/types/src/quiz.ts
@@ -7,7 +7,26 @@ export const QuizOption = z.object({
 export type QuizOption = z.infer<typeof QuizOption>
 
 export const Quiz = z.object({
+  /**
+   * Stable output-page id (`qz001`, …), allocated once and never reused. Names
+   * the quiz's HTML file and, through `${quizId}_que` / `${quizId}_o${n}`, its
+   * text-catalog entries — and therefore its translations and generated audio.
+   *
+   * Optional because books written before this field exists don't have one.
+   * Always read it through `resolveQuizId` / `ensureQuizIds`, never directly.
+   */
+  quizId: z.string().optional(),
+  /**
+   * @deprecated Positional. Kept so older readers keep working, and normalized
+   * to the array position on write, but never read for identity — inserting a
+   * quiz shifts it, which is exactly what `quizId` exists to avoid.
+   */
   quizIndex: z.number().int(),
+  /**
+   * The page this quiz is generated to follow. Provenance and the default
+   * placement for a newly generated quiz — not an authoritative position once
+   * an explicit reading order exists.
+   */
   afterPageId: z.string(),
   pageIds: z.array(z.string()),
   question: z.string(),
@@ -24,6 +43,72 @@ export const QuizGenerationOutput = z.object({
   quizzes: z.array(Quiz),
 })
 export type QuizGenerationOutput = z.infer<typeof QuizGenerationOutput>
+
+// ── Quiz identity ───────────────────────────────────────────────
+
+/** Sequence numbers are zero-padded to 3 digits, so this is the ceiling. */
+export const MAX_QUIZ_SEQ = 999
+
+/** Build the canonical quiz id for a sequence number. */
+export function formatQuizId(seq: number): string {
+  return `qz${String(seq).padStart(3, "0")}`
+}
+
+/** Sequence number of a quiz id, or null if `id` isn't one. */
+export function parseQuizId(id: string): number | null {
+  const match = /^qz(\d+)$/.exec(id)
+  return match ? Number(match[1]) : null
+}
+
+/**
+ * The quiz's stable id, falling back to the value every consumer derived before
+ * `quizId` existed: `qz${arrayIndex + 1}`. `index` must be the quiz's position
+ * in `QuizGenerationOutput.quizzes`.
+ */
+export function resolveQuizId(quiz: Quiz, index: number): string {
+  return quiz.quizId ?? formatQuizId(index + 1)
+}
+
+/**
+ * Fill in any missing `quizId`s so the rest of the code can treat them as
+ * given. Back-compat is the whole point of the allocation order here: a quiz
+ * with no id first tries the id today's consumers already derive for its array
+ * position, so an existing book's catalog keys — and the translations and audio
+ * keyed by them — stay byte-identical. Only when that number is taken does it
+ * take a fresh one.
+ *
+ * `reservedIds` should carry ids used by *previous* stored versions so a
+ * delete-then-add cannot resurrect a retired quiz's catalog entries.
+ *
+ * `changed` tells the caller whether persisting a new version is worthwhile;
+ * readers can ignore it and use the returned value in memory.
+ */
+export function ensureQuizIds(
+  output: QuizGenerationOutput,
+  reservedIds: Iterable<string> = []
+): { output: QuizGenerationOutput; changed: boolean } {
+  const used = new Set<number>()
+  for (const id of reservedIds) {
+    const seq = parseQuizId(id)
+    if (seq !== null) used.add(seq)
+  }
+  for (const quiz of output.quizzes) {
+    const seq = quiz.quizId ? parseQuizId(quiz.quizId) : null
+    if (seq !== null) used.add(seq)
+  }
+
+  let changed = false
+  const quizzes = output.quizzes.map((quiz, index) => {
+    if (quiz.quizId) return quiz
+    let seq = index + 1
+    while (used.has(seq)) seq += 1
+    used.add(seq)
+    changed = true
+    return { ...quiz, quizId: formatQuizId(seq) }
+  })
+
+  return { output: changed ? { ...output, quizzes } : output, changed }
+}
 
 /** Schema for what the LLM returns (simpler than the stored Quiz type) */
 export const quizLLMSchema = z.object({

--- a/packages/types/src/quiz.ts
+++ b/packages/types/src/quiz.ts
@@ -1,5 +1,15 @@
 import { z } from "zod"
 
+/** Canonical, filename-safe quiz identity. */
+export const QuizId = z.string().length(5).regex(/^qz(?!000)\d{3}$/, "Expected a quiz id from qz001 through qz999")
+
+export class QuizIdentityError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "QuizIdentityError"
+  }
+}
+
 export const QuizOption = z.object({
   text: z.string(),
   explanation: z.string(),
@@ -12,10 +22,10 @@ export const Quiz = z.object({
    * the quiz's HTML file and, through `${quizId}_que` / `${quizId}_o${n}`, its
    * text-catalog entries — and therefore its translations and generated audio.
    *
-   * Optional because books written before this field exists don't have one.
-   * Always read it through `resolveQuizId` / `ensureQuizIds`, never directly.
+   * Optional for legacy data and quizzes awaiting allocation. Stored data must
+   * pass `withResolvedQuizIds` before consumers use identity.
    */
-  quizId: z.string().optional(),
+  quizId: QuizId.optional(),
   /**
    * @deprecated Positional. Kept so older readers keep working, and normalized
    * to the array position on write, but never read for identity — inserting a
@@ -51,13 +61,14 @@ export const MAX_QUIZ_SEQ = 999
 
 /** Build the canonical quiz id for a sequence number. */
 export function formatQuizId(seq: number): string {
+  if (seq > MAX_QUIZ_SEQ) throw new QuizIdExhaustedError()
+  if (!Number.isInteger(seq) || seq < 1) throw new QuizIdentityError("Invalid quiz sequence number")
   return `qz${String(seq).padStart(3, "0")}`
 }
 
 /** Sequence number of a quiz id, or null if `id` isn't one. */
 export function parseQuizId(id: string): number | null {
-  const match = /^qz(\d+)$/.exec(id)
-  return match ? Number(match[1]) : null
+  return QuizId.safeParse(id).success ? Number(id.slice(2)) : null
 }
 
 /**
@@ -70,7 +81,7 @@ export function parseQuizId(id: string): number | null {
 export class QuizIdExhaustedError extends Error {
   constructor() {
     super(
-      `This book has allocated all ${MAX_QUIZ_SEQ} of its quiz ids. Remove some quiz history, or re-run quiz generation, before adding more quizzes.`
+      `This book has allocated all ${MAX_QUIZ_SEQ} of its quiz ids. New quizzes cannot be allocated without reusing an existing identity.`
     )
     this.name = "QuizIdExhaustedError"
   }
@@ -81,14 +92,14 @@ export class QuizIdExhaustedError extends Error {
  * `quizId` existed: `qz${arrayIndex + 1}`. `index` must be the quiz's position
  * in `QuizGenerationOutput.quizzes`.
  *
- * Only meaningful on an array that is *wholly* stamped or *wholly* unstamped —
- * the state `ensureQuizIds` and `withResolvedQuizIds` both guarantee, since they
- * stamp every quiz or none. On a half-stamped array the positional fallback can
- * collide with a stored id (`[X: "qz002", Y: undefined]` resolves Y to `qz002`
- * too), which would key two catalog entries and two output pages the same.
+ * Validate the whole array with `withResolvedQuizIds` before consuming it:
+ * a partially stamped array can otherwise give a legacy positional fallback
+ * the same ID as an explicit entry.
  */
 export function resolveQuizId(quiz: Quiz, index: number): string {
-  return quiz.quizId ?? formatQuizId(index + 1)
+  const id = quiz.quizId ?? formatQuizId(index + 1)
+  if (!QuizId.safeParse(id).success) throw new QuizIdentityError(`Invalid quiz id: ${id}`)
+  return id
 }
 
 /**
@@ -104,27 +115,16 @@ export function resolveQuizId(quiz: Quiz, index: number): string {
 export function withResolvedQuizIds(
   output: QuizGenerationOutput
 ): QuizGenerationOutput {
+  const ids = output.quizzes.map(resolveQuizId)
+  assertUniqueQuizIds(ids)
   if (output.quizzes.every((q) => q.quizId)) return output
   return {
     ...output,
     quizzes: output.quizzes.map((quiz, index) => ({
       ...quiz,
-      quizId: resolveQuizId(quiz, index),
+      quizId: ids[index],
     })),
   }
-}
-
-/**
- * The quiz id a storyboard route param refers to, or null if `pageId` isn't a
- * quiz route. Routes are `quiz-{quizId}`; links minted before quizzes had
- * stable ids carry `quiz-{arrayIndex}`, so a bare number resolves to the id
- * that index derived back then and old tabs and bookmarks keep working.
- */
-export function parseQuizRouteId(pageId: string): string | null {
-  const match = /^quiz-(.+)$/.exec(pageId)
-  if (!match) return null
-  const legacy = match[1]
-  return /^\d+$/.test(legacy) ? formatQuizId(Number(legacy) + 1) : legacy
 }
 
 /**
@@ -135,8 +135,8 @@ export function parseQuizRouteId(pageId: string): string | null {
  * keyed by them — stay byte-identical. Only when that number is taken does it
  * take a fresh one.
  *
- * `reservedIds` should carry ids used by *previous* stored versions so a
- * delete-then-add cannot resurrect a retired quiz's catalog entries.
+ * `reservedIds` must carry ids used by all stored versions, including the current
+ * version, so a delete-then-add cannot resurrect a retired quiz's catalog entries.
  *
  * Positional back-compat only holds if `output.quizzes` is still in its *stored*
  * order. Callers that reorder, insert or delete must run `withResolvedQuizIds`
@@ -153,6 +153,12 @@ export function ensureQuizIds(
   output: QuizGenerationOutput,
   reservedIds: Iterable<string> = []
 ): { output: QuizGenerationOutput; changed: boolean } {
+  const explicitIds = output.quizzes.flatMap((quiz) => {
+    if (quiz.quizId === undefined) return []
+    if (!QuizId.safeParse(quiz.quizId).success) throw new QuizIdentityError(`Invalid quiz id: ${quiz.quizId}`)
+    return [quiz.quizId]
+  })
+  assertUniqueQuizIds(explicitIds)
   const used = new Set<number>()
   for (const id of reservedIds) {
     const seq = parseQuizId(id)
@@ -169,10 +175,11 @@ export function ensureQuizIds(
     let seq = index + 1
     while (used.has(seq)) seq += 1
     if (seq > MAX_QUIZ_SEQ) {
-      // Unreachable in practice: this needs ~1000 quizzes to have existed in
-      // one book. Capped so the `qz\d{3}` shape every consumer parses stays
-      // valid rather than silently widening to `qz1000`.
-      throw new QuizIdExhaustedError()
+      // Sparse explicit IDs can leave a lower unused slot. Search it before
+      // reporting exhaustion; retired slots remain in `used` forever.
+      seq = 1
+      while (used.has(seq)) seq += 1
+      if (seq > MAX_QUIZ_SEQ) throw new QuizIdExhaustedError()
     }
     used.add(seq)
     changed = true
@@ -180,6 +187,14 @@ export function ensureQuizIds(
   })
 
   return { output: changed ? { ...output, quizzes } : output, changed }
+}
+
+function assertUniqueQuizIds(ids: string[]): void {
+  const seen = new Set<string>()
+  for (const id of ids) {
+    if (seen.has(id)) throw new QuizIdentityError(`Duplicate quiz id: ${id}`)
+    seen.add(id)
+  }
 }
 
 /** Schema for what the LLM returns (simpler than the stored Quiz type) */

--- a/packages/types/src/quiz.ts
+++ b/packages/types/src/quiz.ts
@@ -1,7 +1,14 @@
 import { z } from "zod"
 
-/** Canonical, filename-safe quiz identity. */
-export const QuizId = z.string().length(5).regex(/^qz(?!000)\d{3}$/, "Expected a quiz id from qz001 through qz999")
+/** IDs retain their three-digit minimum padding and grow without renumbering. */
+export const MAX_QUIZ_SEQ = Number.MAX_SAFE_INTEGER
+
+/** Canonical equality rejects alternate padding, whitespace, exponents, paths,
+ * and unsafe integers, while keeping every existing ID byte-for-byte stable. */
+export const QuizId = z.string().max(String(MAX_QUIZ_SEQ).length + 2).refine((id) => {
+  const seq = Number(id.slice(2))
+  return Number.isSafeInteger(seq) && seq > 0 && id === `qz${String(seq).padStart(3, "0")}`
+}, "Expected a canonical quiz id with a positive safe-integer sequence")
 
 export class QuizIdentityError extends Error {
   constructor(message: string) {
@@ -18,7 +25,7 @@ export type QuizOption = z.infer<typeof QuizOption>
 
 export const Quiz = z.object({
   /**
-   * Stable output-page id (`qz001`, …), allocated once and never reused. Names
+   * Stable output-page id (`qz001`, …), permanently reserved by retained history. Names
    * the quiz's HTML file and, through `${quizId}_que` / `${quizId}_o${n}`, its
    * text-catalog entries — and therefore its translations and generated audio.
    *
@@ -56,13 +63,9 @@ export type QuizGenerationOutput = z.infer<typeof QuizGenerationOutput>
 
 // ── Quiz identity ───────────────────────────────────────────────
 
-/** Sequence numbers are zero-padded to 3 digits, so this is the ceiling. */
-export const MAX_QUIZ_SEQ = 999
-
 /** Build the canonical quiz id for a sequence number. */
 export function formatQuizId(seq: number): string {
-  if (seq > MAX_QUIZ_SEQ) throw new QuizIdExhaustedError()
-  if (!Number.isInteger(seq) || seq < 1) throw new QuizIdentityError("Invalid quiz sequence number")
+  if (!Number.isSafeInteger(seq) || seq < 1) throw new QuizIdentityError("Invalid quiz sequence number")
   return `qz${String(seq).padStart(3, "0")}`
 }
 
@@ -72,19 +75,30 @@ export function parseQuizId(id: string): number | null {
 }
 
 /**
- * Thrown when a book has burned all `MAX_QUIZ_SEQ` sequence numbers.
+ * Thrown when the requested allocation exceeds the remaining capacity.
  *
  * A named error rather than an HTTP exception so this module stays usable from
  * the pipeline; the route layer maps it to a 400. Mirrors
  * `SectionIdExhaustedError`.
  */
 export class QuizIdExhaustedError extends Error {
-  constructor() {
-    super(
-      `This book has allocated all ${MAX_QUIZ_SEQ} of its quiz ids. New quizzes cannot be allocated without reusing an existing identity.`
+  constructor(requested?: number, remaining?: number) {
+    super(requested !== undefined && remaining !== undefined
+      ? `Not enough quiz IDs available: ${requested} requested, ${remaining} remaining.`
+      : "Quiz identity capacity exceeded. Existing identities cannot be reused."
     )
     this.name = "QuizIdExhaustedError"
   }
+}
+
+/** Check counts without adding them (the sum itself could be unsafe).
+ * Used before expensive generation and again at the allocation boundary. */
+export function assertQuizIdCapacity(allocated: number, requested: number): void {
+  if (!Number.isSafeInteger(allocated) || allocated < 0 || !Number.isSafeInteger(requested) || requested < 0) {
+    throw new QuizIdentityError("Invalid quiz allocation count")
+  }
+  const remaining = MAX_QUIZ_SEQ - allocated
+  if (requested > remaining) throw new QuizIdExhaustedError(requested, remaining)
 }
 
 /**
@@ -147,7 +161,7 @@ export function withResolvedQuizIds(
  * `changed` tells the caller whether persisting a new version is worthwhile;
  * readers can ignore it and use the returned value in memory.
  *
- * @throws {QuizIdExhaustedError} when every sequence number is spent.
+ * @throws {QuizIdExhaustedError} when there are too few unspent sequence numbers.
  */
 export function ensureQuizIds(
   output: QuizGenerationOutput,
@@ -169,6 +183,7 @@ export function ensureQuizIds(
     if (seq !== null) used.add(seq)
   }
 
+  assertQuizIdCapacity(used.size, output.quizzes.filter((quiz) => !quiz.quizId).length)
   let changed = false
   const quizzes = output.quizzes.map((quiz, index) => {
     if (quiz.quizId) return quiz

--- a/packages/types/src/quiz.ts
+++ b/packages/types/src/quiz.ts
@@ -61,12 +61,70 @@ export function parseQuizId(id: string): number | null {
 }
 
 /**
+ * Thrown when a book has burned all `MAX_QUIZ_SEQ` sequence numbers.
+ *
+ * A named error rather than an HTTP exception so this module stays usable from
+ * the pipeline; the route layer maps it to a 400. Mirrors
+ * `SectionIdExhaustedError`.
+ */
+export class QuizIdExhaustedError extends Error {
+  constructor() {
+    super(
+      `This book has allocated all ${MAX_QUIZ_SEQ} of its quiz ids. Remove some quiz history, or re-run quiz generation, before adding more quizzes.`
+    )
+    this.name = "QuizIdExhaustedError"
+  }
+}
+
+/**
  * The quiz's stable id, falling back to the value every consumer derived before
  * `quizId` existed: `qz${arrayIndex + 1}`. `index` must be the quiz's position
  * in `QuizGenerationOutput.quizzes`.
+ *
+ * Only meaningful on an array that is *wholly* stamped or *wholly* unstamped —
+ * the state `ensureQuizIds` and `withResolvedQuizIds` both guarantee, since they
+ * stamp every quiz or none. On a half-stamped array the positional fallback can
+ * collide with a stored id (`[X: "qz002", Y: undefined]` resolves Y to `qz002`
+ * too), which would key two catalog entries and two output pages the same.
  */
 export function resolveQuizId(quiz: Quiz, index: number): string {
   return quiz.quizId ?? formatQuizId(index + 1)
+}
+
+/**
+ * Every quiz's id filled in from `resolveQuizId`, so callers downstream can
+ * treat `quizId` as given. Unlike `ensureQuizIds` this allocates nothing: the
+ * result is exactly what the read paths (text catalog, packaging, adt-preview)
+ * derive from the same array, which is what makes it safe on a read path.
+ *
+ * Use it before *mutating* a stored quiz set, so legacy ids get pinned to the
+ * positions their catalog entries were written for rather than to the positions
+ * they happen to land on after the edit.
+ */
+export function withResolvedQuizIds(
+  output: QuizGenerationOutput
+): QuizGenerationOutput {
+  if (output.quizzes.every((q) => q.quizId)) return output
+  return {
+    ...output,
+    quizzes: output.quizzes.map((quiz, index) => ({
+      ...quiz,
+      quizId: resolveQuizId(quiz, index),
+    })),
+  }
+}
+
+/**
+ * The quiz id a storyboard route param refers to, or null if `pageId` isn't a
+ * quiz route. Routes are `quiz-{quizId}`; links minted before quizzes had
+ * stable ids carry `quiz-{arrayIndex}`, so a bare number resolves to the id
+ * that index derived back then and old tabs and bookmarks keep working.
+ */
+export function parseQuizRouteId(pageId: string): string | null {
+  const match = /^quiz-(.+)$/.exec(pageId)
+  if (!match) return null
+  const legacy = match[1]
+  return /^\d+$/.test(legacy) ? formatQuizId(Number(legacy) + 1) : legacy
 }
 
 /**
@@ -80,8 +138,16 @@ export function resolveQuizId(quiz: Quiz, index: number): string {
  * `reservedIds` should carry ids used by *previous* stored versions so a
  * delete-then-add cannot resurrect a retired quiz's catalog entries.
  *
+ * Positional back-compat only holds if `output.quizzes` is still in its *stored*
+ * order. Callers that reorder, insert or delete must run `withResolvedQuizIds`
+ * on the stored set first, so legacy ids are pinned before the edit moves
+ * anything — otherwise the newcomer inherits the catalog entries, translations
+ * and audio of whichever quiz used to sit at its index.
+ *
  * `changed` tells the caller whether persisting a new version is worthwhile;
  * readers can ignore it and use the returned value in memory.
+ *
+ * @throws {QuizIdExhaustedError} when every sequence number is spent.
  */
 export function ensureQuizIds(
   output: QuizGenerationOutput,
@@ -102,6 +168,12 @@ export function ensureQuizIds(
     if (quiz.quizId) return quiz
     let seq = index + 1
     while (used.has(seq)) seq += 1
+    if (seq > MAX_QUIZ_SEQ) {
+      // Unreachable in practice: this needs ~1000 quizzes to have existed in
+      // one book. Capped so the `qz\d{3}` shape every consumer parses stays
+      // valid rather than silently widening to `qz1000`.
+      throw new QuizIdExhaustedError()
+    }
     used.add(seq)
     changed = true
     return { ...quiz, quizId: formatQuizId(seq) }


### PR DESCRIPTION
Adding, deleting, or replacing a quiz previously changed the positional IDs used by later quizzes, which could attach another question's translations or audio. This PR gives quizzes persistent book-local identities across Studio, catalogs, preview, and exported output.

## Identity and recovery

- Existing quizzes retain their IDs through edits and repositioning. Legacy books resolve IDs from each original stored array without writing a backfill version.
- Every application write allocates and saves atomically against all retained quiz history, including versions newer than a rollback. Generate-one replacement and full API/CLI regeneration allocate fresh identities, even for cached model output.
- IDs use at least three digits: `qz001` through `qz999`, then `qz1000` onward, bounded by JavaScript's maximum safe integer. Existing IDs and filenames remain unchanged. Deletion, regeneration, and rollback never release retained identities.
- Generation preflights capacity before model calls and rechecks during transactional persistence. Errors report requested and remaining counts without a partial save.
- Full quiz reruns retain prior output until success. Upstream invalidation and extraction retain history behind an inactive version. The API exposes the selected `historyVersion` separately from active output, so Studio keeps restore available and labels inactive versions as **Invalidated** in every supported locale.

## Validation and compatibility

Canonical format and uniqueness checks reject unsafe paths, duplicate IDs, alternate padding, whitespace, and unsafe integers. Catalog generation, preview, and packaging validate stored/imported data too. Packaging validates before replacing an existing export and checks destination containment.

Legacy ID-less PUT retries, deletions, reorders, and appends preserve identity when unambiguous. Ambiguous content edits return HTTP 400 with instructions to reload and retain IDs. Writes during quiz generation return HTTP 409, with a second check after generate-one's model call.

Historical comparison resolves IDs within each original version, avoiding false additions/removals after a legacy quiz's first save. Raw debug history remains unchanged. Studio consumes API-resolved identities and parses Storyboard URLs locally; legacy numeric links remain compatible.

The guarantee covers retained history and subsequent application writes. Previously erased history or externally replaced archives cannot be reconstructed. Quiz restore keeps the existing downstream invalidation contract; it is not a full pipeline snapshot restore. See [the identity contract](docs/QUIZ_IDENTITY.md).

## Verification

- Final commit `57338f59`: [GitHub CI passed](https://github.com/unicef/adt-studio/actions/runs/34583208928), including **3,548 tests across 270 files**, the Docker API build, and i18n/lint. The local full regression suite also passed.
- Build/typecheck, Studio production build, runtime typecheck, locale extraction, and strict compilation for all five locales passed.
- Lint: zero errors and the same eight existing warnings.

Regression coverage exercises real routes, SQLite, generation/reset/rollback, catalogs, preview, web/WebPub/EPUB exports, and Speech file writing. Boundary cases include `qz999` to `qz1000` to `qz1001`, unchanged audio references and recording bytes, failed/empty generation, concurrent allocation, corrupt imports, and export containment. Studio component tests exercise the real quiz view and version picker through successful restore, failed restore, and selecting an invalidation version.

Remote model responses and synthesized audio bytes are stubbed. Capacity-failure tests inject the preflight error, with safe-integer capacity arithmetic tested directly. No live provider calls or signed desktop packaging were performed locally.

This is the stable-quiz-ID prerequisite for #660. Reading-order editing remains in the later stack. The stable-section-ID prerequisite #784 is already merged into `develop`.
