### PR TITLE
refactor(pipeline): resolve reading order in one place

### DIFF
--- a/apps/adt-runtime/src/features/language/hooks/useTranslation.test.tsx
+++ b/apps/adt-runtime/src/features/language/hooks/useTranslation.test.tsx
@@ -1,12 +1,13 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it } from "vitest"
-import { renderHook } from "@testing-library/react"
+import { cleanup, renderHook } from "@testing-library/react"
 import { getDefaultStore } from "jotai"
 import { translationsAtom } from "@/features/language/state/language.atoms"
 import { useTranslation } from "./useTranslation"
 
 describe("useTranslation", () => {
   afterEach(() => {
+    cleanup()
     getDefaultStore().set(translationsAtom, {})
   })
 

--- a/apps/api/src/routes/adt-preview.ts
+++ b/apps/api/src/routes/adt-preview.ts
@@ -27,6 +27,10 @@ import {
 } from "@adt/types"
 import { createBookStorage, type Storage } from "@adt/storage"
 import {
+  resolveReadingOrder,
+  toPageEntry,
+  readingOrderHref,
+  type PageEntry,
   renderPageHtml,
   NAV_HTML,
   buildPreviewTailwindCss,
@@ -286,100 +290,9 @@ function buildRuntimeTimecodeMap(
   return map
 }
 
-/** Build a map from sectionId → 1-based pageIndex matching the manifest order */
-function buildSectionIdToPageIndex(storage: Storage): Map<string, number> {
-  const pages = storage.getPages()
-  const quizData = getQuizData(storage)
-  const quizzesByAfterPageId = new Map<string, Quiz[]>()
-  if (quizData?.quizzes) {
-    for (const quiz of quizData.quizzes) {
-      const existing = quizzesByAfterPageId.get(quiz.afterPageId) ?? []
-      existing.push(quiz)
-      quizzesByAfterPageId.set(quiz.afterPageId, existing)
-    }
-  }
-
-  const map = new Map<string, number>()
-  let index = 0
-  for (const page of pages) {
-    const renderRow = storage.getLatestNodeData("web-rendering", page.pageId)
-    if (renderRow) {
-      const parsed = WebRenderingOutput.safeParse(renderRow.data)
-      if (parsed.success && parsed.data.sections.length > 0) {
-        const sectioning = getRenderSectioning(storage, page.pageId)
-        const sections = [...parsed.data.sections].sort((a, b) => a.sectionIndex - b.sectionIndex)
-        for (const rs of sections) {
-          const sectionMeta = sectioning?.sections?.[rs.sectionIndex]
-          if (!sectionMeta || sectionMeta.isPruned) continue
-          index++
-          map.set(sectionMeta.sectionId, index)
-        }
-      }
-    }
-    // Quiz pages also increment the index but aren't tied to a sectionId for video purposes
-    const quizzes = quizzesByAfterPageId.get(page.pageId)
-    if (quizzes) {
-      index += quizzes.length
-    }
-  }
-  return map
-}
-
-/** Build the pages.json manifest — one entry per rendered section, interleaving quiz pages */
-function buildPagesManifest(storage: Storage): Array<{ section_id: string; href: string; page_number?: number }> {
-  const pages = storage.getPages()
-  const quizData = getQuizData(storage)
-
-  // Build a map from afterPageId -> quizzes for interleaving
-  const quizzesByAfterPageId = new Map<string, Quiz[]>()
-  if (quizData?.quizzes) {
-    for (const quiz of quizData.quizzes) {
-      const existing = quizzesByAfterPageId.get(quiz.afterPageId) ?? []
-      existing.push(quiz)
-      quizzesByAfterPageId.set(quiz.afterPageId, existing)
-    }
-  }
-
-  const list: Array<{ section_id: string; href: string; page_number?: number }> = []
-  for (const page of pages) {
-    const renderRow = storage.getLatestNodeData("web-rendering", page.pageId)
-    if (renderRow) {
-      const parsed = WebRenderingOutput.safeParse(renderRow.data)
-      if (parsed.success && parsed.data.sections.length > 0) {
-        // Get sectioning data for sectionIds and page numbers
-        const sectioning = getRenderSectioning(storage, page.pageId)
-
-        // One entry per rendered section (stable by sectionIndex), skip pruned
-        const sections = [...parsed.data.sections].sort((a, b) => a.sectionIndex - b.sectionIndex)
-        for (const rs of sections) {
-          const sectionMeta = sectioning?.sections?.[rs.sectionIndex]
-          // Skip sections that are pruned, and orphan rendering entries with no
-          // sectioning row — their real sectionId is unknowable and a positional
-          // guess could collide with another section's id.
-          if (!sectionMeta || sectionMeta.isPruned) continue
-          const sectionId = sectionMeta.sectionId
-          const entry: { section_id: string; href: string; page_number?: number } = {
-            section_id: sectionId,
-            href: `${sectionId}.html`,
-          }
-          if (sectionMeta?.pageNumber !== null && sectionMeta?.pageNumber !== undefined) {
-            entry.page_number = sectionMeta.pageNumber
-          }
-          list.push(entry)
-        }
-      }
-    }
-
-    // Insert quiz pages after this page
-    const quizzes = quizzesByAfterPageId.get(page.pageId)
-    if (quizzes) {
-      for (const quiz of quizzes) {
-        const quizId = resolveQuizId(quiz, quizData!.quizzes.indexOf(quiz))
-        list.push({ section_id: quizId, href: `${quizId}.html` })
-      }
-    }
-  }
-  return list
+/** Build the pages.json manifest — one entry per output page, in reading order. */
+function buildPagesManifest(storage: Storage): PageEntry[] {
+  return resolveReadingOrder(storage).items.map(toPageEntry)
 }
 
 /** DFS-find the first non-pruned heading leaf in a content-node tree. */
@@ -407,15 +320,25 @@ function buildTocManifest(storage: Storage): Array<{ section_id: string; href: s
     const tocData = tocRow.data as TocGenerationOutput
     if (tocData.entries.length > 0) {
       // Build href map from pages manifest for accurate hrefs
-      const pagesManifest = buildPagesManifest(storage)
-      const hrefMap = new Map(pagesManifest.map((p) => [p.section_id, p.href]))
-      return tocData.entries.map((e) => ({
-        section_id: e.sectionId,
-        href: hrefMap.get(e.sectionId) ?? e.href,
-        title: e.title,
-        chapter_id: e.chapterId,
-        level: e.level,
-      }))
+      const readingOrder = resolveReadingOrder(storage)
+      const hrefMap = new Map(readingOrder.items.map((i) => [i.id, readingOrderHref(i)]))
+      // Sort into document order — the LLM's entry order is its own, and the
+      // nav panel nests a flat list by `level` as it walks it. Entries whose
+      // section is not in the reading order keep their relative order at the end.
+      return tocData.entries
+        .map((entry, index) => ({ entry, index }))
+        .sort((a, b) => {
+          const posA = readingOrder.positionById.get(a.entry.sectionId) ?? Infinity
+          const posB = readingOrder.positionById.get(b.entry.sectionId) ?? Infinity
+          return posA === posB ? a.index - b.index : posA - posB
+        })
+        .map(({ entry: e }) => ({
+          section_id: e.sectionId,
+          href: hrefMap.get(e.sectionId) ?? e.href,
+          title: e.title,
+          chapter_id: e.chapterId,
+          level: e.level,
+        }))
     }
   }
 
@@ -425,33 +348,18 @@ function buildTocManifest(storage: Storage): Array<{ section_id: string; href: s
 
 /** Fallback TOC: one entry per section that contains a heading */
 function buildHeadingBasedToc(storage: Storage): Array<{ section_id: string; href: string; title: string; chapter_id: string }> {
-  const pages = storage.getPages()
   const toc: Array<{ section_id: string; href: string; title: string; chapter_id: string }> = []
 
-  for (const page of pages) {
-    const renderRow = storage.getLatestNodeData("web-rendering", page.pageId)
-    if (!renderRow) continue
-    const parsed = WebRenderingOutput.safeParse(renderRow.data)
-    if (!parsed.success || parsed.data.sections.length === 0) continue
-
-    const sectioning = getRenderSectioning(storage, page.pageId)
-
-    const sections = [...parsed.data.sections].sort((a, b) => a.sectionIndex - b.sectionIndex)
-    for (const rs of sections) {
-      const sectionMeta = sectioning?.sections?.[rs.sectionIndex]
-      if (!sectionMeta || sectionMeta.isPruned) continue
-
-      const sectionId = sectionMeta.sectionId
-
-      const heading = findFirstHeadingLeaf(sectionMeta.nodes)
-      if (heading) {
-        toc.push({
-          section_id: sectionId,
-          href: `${sectionId}.html`,
-          title: heading.text,
-          chapter_id: heading.nodeId,
-        })
-      }
+  for (const item of resolveReadingOrder(storage).items) {
+    if (item.kind !== "section") continue
+    const heading = findFirstHeadingLeaf(item.section.nodes)
+    if (heading) {
+      toc.push({
+        section_id: item.id,
+        href: readingOrderHref(item),
+        title: heading.text,
+        chapter_id: heading.nodeId,
+      })
     }
   }
 
@@ -935,7 +843,7 @@ export function createAdtPreviewRoutes(
   app.get("/books/:label/adt-preview/content/i18n/:lang/videos.json", (c) => {
     const videosMap = withStorage(c.req.param("label"), (storage) => {
       const map: Record<string, string> = {}
-      const sectionToIndex = buildSectionIdToPageIndex(storage)
+      const sectionToIndex = resolveReadingOrder(storage).positionById
       for (const video of storage.getSignLanguageVideos()) {
         if (video.sectionId) {
           const ext = video.mimeType === "video/webm" ? ".webm" : ".mp4"

--- a/apps/api/src/routes/adt-preview.ts
+++ b/apps/api/src/routes/adt-preview.ts
@@ -31,6 +31,10 @@ import {
 } from "@adt/types"
 import { createBookStorage, type Storage } from "@adt/storage"
 import {
+  resolveReadingOrder,
+  toPageEntry,
+  readingOrderHref,
+  type PageEntry,
   renderPageHtml,
   NAV_HTML,
   buildPreviewTailwindCss,
@@ -294,100 +298,9 @@ function buildRuntimeTimecodeMap(
   return map
 }
 
-/** Build a map from sectionId → 1-based pageIndex matching the manifest order */
-function buildSectionIdToPageIndex(storage: Storage): Map<string, number> {
-  const pages = storage.getPages()
-  const quizData = getQuizData(storage)
-  const quizzesByAfterPageId = new Map<string, Quiz[]>()
-  if (quizData?.quizzes) {
-    for (const quiz of quizData.quizzes) {
-      const existing = quizzesByAfterPageId.get(quiz.afterPageId) ?? []
-      existing.push(quiz)
-      quizzesByAfterPageId.set(quiz.afterPageId, existing)
-    }
-  }
-
-  const map = new Map<string, number>()
-  let index = 0
-  for (const page of pages) {
-    const renderRow = storage.getLatestNodeData("web-rendering", page.pageId)
-    if (renderRow) {
-      const parsed = WebRenderingOutput.safeParse(renderRow.data)
-      if (parsed.success && parsed.data.sections.length > 0) {
-        const sectioning = getRenderSectioning(storage, page.pageId)
-        const sections = [...parsed.data.sections].sort((a, b) => a.sectionIndex - b.sectionIndex)
-        for (const rs of sections) {
-          const sectionMeta = sectioning?.sections?.[rs.sectionIndex]
-          if (!sectionMeta || sectionMeta.isPruned) continue
-          index++
-          map.set(sectionMeta.sectionId, index)
-        }
-      }
-    }
-    // Quiz pages also increment the index but aren't tied to a sectionId for video purposes
-    const quizzes = quizzesByAfterPageId.get(page.pageId)
-    if (quizzes) {
-      index += quizzes.length
-    }
-  }
-  return map
-}
-
-/** Build the pages.json manifest — one entry per rendered section, interleaving quiz pages */
-function buildPagesManifest(storage: Storage): Array<{ section_id: string; href: string; page_number?: number }> {
-  const pages = storage.getPages()
-  const quizData = getQuizData(storage)
-
-  // Build a map from afterPageId -> quizzes for interleaving
-  const quizzesByAfterPageId = new Map<string, Quiz[]>()
-  if (quizData?.quizzes) {
-    for (const quiz of quizData.quizzes) {
-      const existing = quizzesByAfterPageId.get(quiz.afterPageId) ?? []
-      existing.push(quiz)
-      quizzesByAfterPageId.set(quiz.afterPageId, existing)
-    }
-  }
-
-  const list: Array<{ section_id: string; href: string; page_number?: number }> = []
-  for (const page of pages) {
-    const renderRow = storage.getLatestNodeData("web-rendering", page.pageId)
-    if (renderRow) {
-      const parsed = WebRenderingOutput.safeParse(renderRow.data)
-      if (parsed.success && parsed.data.sections.length > 0) {
-        // Get sectioning data for sectionIds and page numbers
-        const sectioning = getRenderSectioning(storage, page.pageId)
-
-        // One entry per rendered section (stable by sectionIndex), skip pruned
-        const sections = [...parsed.data.sections].sort((a, b) => a.sectionIndex - b.sectionIndex)
-        for (const rs of sections) {
-          const sectionMeta = sectioning?.sections?.[rs.sectionIndex]
-          // Skip sections that are pruned, and orphan rendering entries with no
-          // sectioning row — their real sectionId is unknowable and a positional
-          // guess could collide with another section's id.
-          if (!sectionMeta || sectionMeta.isPruned) continue
-          const sectionId = sectionMeta.sectionId
-          const entry: { section_id: string; href: string; page_number?: number } = {
-            section_id: sectionId,
-            href: `${sectionId}.html`,
-          }
-          if (sectionMeta?.pageNumber !== null && sectionMeta?.pageNumber !== undefined) {
-            entry.page_number = sectionMeta.pageNumber
-          }
-          list.push(entry)
-        }
-      }
-    }
-
-    // Insert quiz pages after this page
-    const quizzes = quizzesByAfterPageId.get(page.pageId)
-    if (quizzes) {
-      for (const quiz of quizzes) {
-        const quizId = resolveQuizId(quiz, quizData!.quizzes.indexOf(quiz))
-        list.push({ section_id: quizId, href: `${quizId}.html` })
-      }
-    }
-  }
-  return list
+/** Build the pages.json manifest — one entry per output page, in reading order. */
+function buildPagesManifest(storage: Storage): PageEntry[] {
+  return resolveReadingOrder(storage).items.map(toPageEntry)
 }
 
 /** DFS-find the first non-pruned heading leaf in a content-node tree. */
@@ -415,15 +328,25 @@ function buildTocManifest(storage: Storage): Array<{ section_id: string; href: s
     const tocData = tocRow.data as TocGenerationOutput
     if (tocData.entries.length > 0) {
       // Build href map from pages manifest for accurate hrefs
-      const pagesManifest = buildPagesManifest(storage)
-      const hrefMap = new Map(pagesManifest.map((p) => [p.section_id, p.href]))
-      return tocData.entries.map((e) => ({
-        section_id: e.sectionId,
-        href: hrefMap.get(e.sectionId) ?? e.href,
-        title: e.title,
-        chapter_id: e.chapterId,
-        level: e.level,
-      }))
+      const readingOrder = resolveReadingOrder(storage)
+      const hrefMap = new Map(readingOrder.items.map((i) => [i.id, readingOrderHref(i)]))
+      // Sort into document order — the LLM's entry order is its own, and the
+      // nav panel nests a flat list by `level` as it walks it. Entries whose
+      // section is not in the reading order keep their relative order at the end.
+      return tocData.entries
+        .map((entry, index) => ({ entry, index }))
+        .sort((a, b) => {
+          const posA = readingOrder.positionById.get(a.entry.sectionId) ?? Infinity
+          const posB = readingOrder.positionById.get(b.entry.sectionId) ?? Infinity
+          return posA === posB ? a.index - b.index : posA - posB
+        })
+        .map(({ entry: e }) => ({
+          section_id: e.sectionId,
+          href: hrefMap.get(e.sectionId) ?? e.href,
+          title: e.title,
+          chapter_id: e.chapterId,
+          level: e.level,
+        }))
     }
   }
 
@@ -433,33 +356,18 @@ function buildTocManifest(storage: Storage): Array<{ section_id: string; href: s
 
 /** Fallback TOC: one entry per section that contains a heading */
 function buildHeadingBasedToc(storage: Storage): Array<{ section_id: string; href: string; title: string; chapter_id: string }> {
-  const pages = storage.getPages()
   const toc: Array<{ section_id: string; href: string; title: string; chapter_id: string }> = []
 
-  for (const page of pages) {
-    const renderRow = storage.getLatestNodeData("web-rendering", page.pageId)
-    if (!renderRow) continue
-    const parsed = WebRenderingOutput.safeParse(renderRow.data)
-    if (!parsed.success || parsed.data.sections.length === 0) continue
-
-    const sectioning = getRenderSectioning(storage, page.pageId)
-
-    const sections = [...parsed.data.sections].sort((a, b) => a.sectionIndex - b.sectionIndex)
-    for (const rs of sections) {
-      const sectionMeta = sectioning?.sections?.[rs.sectionIndex]
-      if (!sectionMeta || sectionMeta.isPruned) continue
-
-      const sectionId = sectionMeta.sectionId
-
-      const heading = findFirstHeadingLeaf(sectionMeta.nodes)
-      if (heading) {
-        toc.push({
-          section_id: sectionId,
-          href: `${sectionId}.html`,
-          title: heading.text,
-          chapter_id: heading.nodeId,
-        })
-      }
+  for (const item of resolveReadingOrder(storage).items) {
+    if (item.kind !== "section") continue
+    const heading = findFirstHeadingLeaf(item.section.nodes)
+    if (heading) {
+      toc.push({
+        section_id: item.id,
+        href: readingOrderHref(item),
+        title: heading.text,
+        chapter_id: heading.nodeId,
+      })
     }
   }
 
@@ -1006,7 +914,7 @@ export function createAdtPreviewRoutes(
   app.get("/books/:label/adt-preview/content/i18n/:lang/videos.json", (c) => {
     const videosMap = withStorage(c.req.param("label"), (storage) => {
       const map: Record<string, string> = {}
-      const sectionToIndex = buildSectionIdToPageIndex(storage)
+      const sectionToIndex = resolveReadingOrder(storage).positionById
       for (const video of storage.getSignLanguageVideos()) {
         if (video.sectionId) {
           const ext = video.mimeType === "video/webm" ? ".webm" : ".mp4"

--- a/apps/api/src/routes/adt-preview.ts
+++ b/apps/api/src/routes/adt-preview.ts
@@ -32,6 +32,7 @@ import {
 import { createBookStorage, type Storage } from "@adt/storage"
 import {
   resolveReadingOrder,
+  orderTocEntries,
   toPageEntry,
   readingOrderHref,
   type PageEntry,
@@ -330,17 +331,8 @@ function buildTocManifest(storage: Storage): Array<{ section_id: string; href: s
       // Build href map from pages manifest for accurate hrefs
       const readingOrder = resolveReadingOrder(storage)
       const hrefMap = new Map(readingOrder.items.map((i) => [i.id, readingOrderHref(i)]))
-      // Sort into document order — the LLM's entry order is its own, and the
-      // nav panel nests a flat list by `level` as it walks it. Entries whose
-      // section is not in the reading order keep their relative order at the end.
-      return tocData.entries
-        .map((entry, index) => ({ entry, index }))
-        .sort((a, b) => {
-          const posA = readingOrder.positionById.get(a.entry.sectionId) ?? Infinity
-          const posB = readingOrder.positionById.get(b.entry.sectionId) ?? Infinity
-          return posA === posB ? a.index - b.index : posA - posB
-        })
-        .map(({ entry: e }) => ({
+      return orderTocEntries(tocData.entries, readingOrder.positionById)
+        .map((e) => ({
           section_id: e.sectionId,
           href: hrefMap.get(e.sectionId) ?? e.href,
           title: e.title,

--- a/apps/api/src/routes/toc-reading-order.test.ts
+++ b/apps/api/src/routes/toc-reading-order.test.ts
@@ -1,0 +1,94 @@
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { afterEach, describe, expect, it } from "vitest"
+import { createBookStorage } from "@adt/storage"
+import { packageAdtWeb, packageWebpub } from "@adt/pipeline"
+import { createAdtPreviewRoutes } from "./adt-preview.js"
+import { createTocRoutes } from "./toc.js"
+
+describe("TOC hierarchy across saved data, preview and export", () => {
+  const roots: string[] = []
+  afterEach(() => {
+    for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true })
+  })
+
+  it.each(["unlinked", "pruned"])("keeps children under a %s parent", async (parentKind) => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "adt-toc-order-"))
+    roots.push(root)
+    const label = "toc-book"
+    const assets = path.join(root, "assets")
+    fs.mkdirSync(assets)
+    for (const filename of ["base.bundle.min.js", "base.bundle.local.js"]) {
+      fs.writeFileSync(path.join(assets, filename), "window.__ADT_TEST__ = true;")
+    }
+    fs.writeFileSync(path.join(assets, "fonts.css"), "body { font-family: serif; }")
+    fs.writeFileSync(path.join(assets, "tailwind_css.css"), "@tailwind base;\n@tailwind components;\n@tailwind utilities;")
+    const storage = createBookStorage(label, root)
+    try {
+      for (const n of [3, 2, 1]) {
+        const pageId = `pg00${n}`
+        storage.putExtractedPage({
+          pageId, pageNumber: n, text: "",
+          pageImage: { imageId: `${pageId}_page`, buffer: Buffer.from("x"), format: "png", hash: `h${n}`, width: 10, height: 10 },
+          images: [],
+        })
+        storage.putNodeData("page-sectioning", pageId, {
+          reasoning: "", sections: [{
+            sectionId: `${pageId}_sec001`, sectionType: "content", backgroundColor: "#fff", textColor: "#000",
+            pageNumber: n, isPruned: n === 2,
+            nodes: [{ nodeId: `${pageId}_h1`, role: "heading", text: `Chapter ${n}`, isPruned: false }],
+          }],
+        })
+        storage.putNodeData("web-rendering", pageId, {
+          sections: [{ sectionIndex: 0, sectionType: "content", reasoning: "", html: `<h1 data-id="${pageId}_h1">Chapter ${n}</h1>` }],
+        })
+      }
+      const parentId = parentKind === "pruned" ? "pg002_sec001" : ""
+      const entry = (id: string, sectionId: string, level: number) => ({
+        id, title: id, sectionId, href: sectionId ? `${sectionId}.html` : "", chapterId: "", level,
+      })
+      // The second unit is intentionally stored first: sibling groups should
+      // move into reading order without separating either parent and child.
+      const entries = [
+        entry("Unit two", "pg003_sec001", 1),
+        entry("Chapter two", "pg003_sec001", 2),
+        entry("Unit one", parentId, 1),
+        entry("Chapter one", "pg001_sec001", 2),
+      ]
+      const toc = createTocRoutes(root)
+      const save = await toc.request(`/books/${label}/toc`, {
+        method: "PUT", headers: { "content-type": "application/json" },
+        body: JSON.stringify({ entries, pageCount: 3, generatedAt: "2026-01-01T00:00:00Z" }),
+      })
+      expect(save.status).toBe(200)
+      const readSaved = async () => (await (await toc.request(`/books/${label}/toc`)).json()).entries
+      expect(await readSaved()).toEqual(entries)
+
+      const preview = createAdtPreviewRoutes(root, assets, path.resolve("config.yaml"))
+      const response = await preview.request(`/books/${label}/adt-preview/content/toc.json`)
+      expect(response.status).toBe(200)
+      const previewToc = await response.json()
+      expect(previewToc.map((e: { title: string }) => e.title)).toEqual([
+        "Unit one", "Chapter one", "Unit two", "Chapter two",
+      ])
+
+      const bookDir = path.join(root, label)
+      const options = { bookDir, label, language: "en", outputLanguages: ["en"], title: "TOC book", webAssetsDir: assets }
+      await packageAdtWeb(storage, options)
+      packageWebpub(storage, options)
+      const packagedToc = JSON.parse(fs.readFileSync(path.join(bookDir, "adt/content/toc.json"), "utf8"))
+      // The first packaged page uses index.html; preview uses the section URL.
+      expect(packagedToc.map((e: { title: string; level: number }) => [e.title, e.level]))
+        .toEqual(previewToc.map((e: { title: string; level: number }) => [e.title, e.level]))
+      const manifest = JSON.parse(fs.readFileSync(path.join(bookDir, "webpub/manifest.json"), "utf8"))
+      expect(manifest.toc).toEqual([
+        { title: "Unit one", href: parentId ? `${parentId}.html` : "", children: [{ title: "Chapter one", href: "index.html" }] },
+        { title: "Unit two", href: "pg003_sec001.html", children: [{ title: "Chapter two", href: "pg003_sec001.html" }] },
+      ])
+      expect(await readSaved()).toEqual(entries)
+    } finally {
+      storage.close()
+    }
+  })
+})

--- a/apps/api/src/routes/toc.ts
+++ b/apps/api/src/routes/toc.ts
@@ -2,10 +2,10 @@ import fs from "node:fs"
 import path from "node:path"
 import { Hono } from "hono"
 import { HTTPException } from "hono/http-exception"
-import { TocGenerationOutput, WebRenderingOutput, isHeadingRole, parseBookLabel } from "@adt/types"
+import { TocGenerationOutput, isHeadingRole, parseBookLabel } from "@adt/types"
 import type { ContentNodeData } from "@adt/types"
 import { openBookDb, createBookStorage, readCurrentNodeRow } from "@adt/storage"
-import { getRenderSectioning } from "@adt/pipeline"
+import { resolveReadingOrder, readingOrderHref } from "@adt/pipeline"
 
 function safeParseLabel(label: string): string {
   try {
@@ -101,45 +101,35 @@ export function createTocRoutes(booksDir: string): Hono {
 
     const storage = createBookStorage(safeLabel, booksDir)
     try {
-      const pages = storage.getPages()
-      const sections: Array<{ sectionId: string; href: string; title: string; pageNumber: number }> = []
-
-      for (const page of pages) {
-        const renderRow = storage.getLatestNodeData("web-rendering", page.pageId)
-        if (!renderRow) continue
-        const renderParsed = WebRenderingOutput.safeParse(renderRow.data)
-        if (!renderParsed.success) continue
-
-        const sectioning = getRenderSectioning(storage, page.pageId)
-
-        const findFirstHeadingText = (nodes: ContentNodeData[]): string | null => {
-          const stack: ContentNodeData[] = [...nodes]
-          while (stack.length > 0) {
-            const node = stack.shift()!
-            if (node.isPruned) continue
-            if (isHeadingRole(node.role) && node.text) return node.text
-            if (node.children) stack.unshift(...node.children)
-          }
-          return null
+      const findFirstHeadingText = (nodes: ContentNodeData[]): string | null => {
+        const stack: ContentNodeData[] = [...nodes]
+        while (stack.length > 0) {
+          const node = stack.shift()!
+          if (node.isPruned) continue
+          if (isHeadingRole(node.role) && node.text) return node.text
+          if (node.children) stack.unshift(...node.children)
         }
-
-        for (const rs of renderParsed.data.sections) {
-          const meta = sectioning?.sections?.[rs.sectionIndex]
-          // Orphan rendering entries have no resolvable sectionId — a positional
-          // guess could name a different section, so skip them.
-          if (!meta || meta.isPruned) continue
-
-          const sectionId = meta.sectionId
-          const title = findFirstHeadingText(meta.nodes) ?? sectionId
-
-          sections.push({
-            sectionId,
-            href: `${sectionId}.html`,
-            title,
-            pageNumber: page.pageNumber,
-          })
-        }
+        return null
       }
+
+      // Reading order, so the section picker lists sections in the order the
+      // reader meets them. This walk used to iterate rendering entries in stored
+      // array order without sorting by `sectionIndex`, unlike every other
+      // consumer — the resolver makes that divergence impossible.
+      const pageNumberById = new Map(storage.getPages().map((p) => [p.pageId, p.pageNumber]))
+      const sections = resolveReadingOrder(storage, { includeQuizzes: false })
+        .items.flatMap((item) =>
+          item.kind !== "section"
+            ? []
+            : [
+                {
+                  sectionId: item.id,
+                  href: readingOrderHref(item),
+                  title: findFirstHeadingText(item.section.nodes) ?? item.id,
+                  pageNumber: pageNumberById.get(item.pageId) ?? 0,
+                },
+              ]
+        )
 
       return c.json(sections)
     } finally {

--- a/packages/pipeline/src/__tests__/package-web.test.ts
+++ b/packages/pipeline/src/__tests__/package-web.test.ts
@@ -18,6 +18,7 @@ import {
   containsMathContent,
 } from "../packaging/web.js"
 import { packageWebpub, nestTocEntries, injectActivitiesBundle } from "../packaging/webpub.js"
+import { resolveReadingOrder } from "../reading-order.js"
 import { deriveQuizPalette } from "../quiz-palette.js"
 
 function createMockStorage(
@@ -1805,6 +1806,132 @@ describe("packageAdtWeb", () => {
       { section_id: "pg001_sec001", href: "index.html", page_number: 1 },
       { section_id: "pg001_sec002", href: "pg001_sec002.html", page_number: 1 },
     ])
+  })
+
+  it("writes pages.json in exactly the resolver's reading order", async () => {
+    // The whole point of the shared resolver: packaging and the live preview
+    // read the same sequence, so they cannot drift. Anything that changes the
+    // resolver and not the packaged manifest (or vice versa) fails here.
+    const bookDir = path.join(tmpDir, "book")
+    const webAssetsDir = path.join(tmpDir, "assets-web")
+    fs.mkdirSync(bookDir, { recursive: true })
+    createWebAssets(webAssetsDir)
+
+    const pages: PageData[] = [
+      { pageId: "pg001", pageNumber: 1, text: "Page one" },
+      { pageId: "pg002", pageNumber: 2, text: "Page two" },
+    ]
+
+    const storage = createMockStorage(pages, {
+      "web-rendering": {
+        pg001: {
+          sections: [
+            { sectionIndex: 0, sectionType: "content", reasoning: "", html: "<p>1a</p>" },
+            { sectionIndex: 1, sectionType: "content", reasoning: "", html: "<p>1b</p>" },
+          ],
+        },
+        pg002: {
+          sections: [
+            { sectionIndex: 0, sectionType: "content", reasoning: "", html: "<p>2a</p>" },
+          ],
+        },
+      },
+      "page-sectioning": {
+        pg001: {
+          reasoning: "ok",
+          sections: [
+            {
+              sectionId: "pg001_sec001",
+              sectionType: "content",
+              nodes: [],
+              backgroundColor: "#fff",
+              textColor: "#000",
+              pageNumber: 1,
+              isPruned: false,
+            },
+            // Pruned: present in the book, absent from the output.
+            {
+              sectionId: "pg001_sec002",
+              sectionType: "content",
+              nodes: [],
+              backgroundColor: "#fff",
+              textColor: "#000",
+              pageNumber: 1,
+              isPruned: true,
+            },
+          ],
+        },
+        pg002: {
+          reasoning: "ok",
+          sections: [
+            {
+              sectionId: "pg002_sec001",
+              sectionType: "content",
+              nodes: [],
+              backgroundColor: "#fff",
+              textColor: "#000",
+              pageNumber: 2,
+              isPruned: false,
+            },
+          ],
+        },
+      },
+      "quiz-generation": {
+        book: {
+          generatedAt: "2026-01-01T00:00:00.000Z",
+          language: "en",
+          pagesPerQuiz: 3,
+          quizzes: [
+            {
+              quizId: "qz001",
+              quizIndex: 0,
+              afterPageId: "pg001",
+              pageIds: ["pg001"],
+              question: "What is 2+2?",
+              options: [
+                { text: "3", explanation: "" },
+                { text: "4", explanation: "" },
+                { text: "5", explanation: "" },
+              ],
+              answerIndex: 1,
+              reasoning: "...",
+            },
+          ],
+        },
+      },
+    })
+
+    await packageAdtWeb(storage, {
+      bookDir,
+      label: "book",
+      language: "en",
+      outputLanguages: ["en"],
+      title: "Book Title",
+      webAssetsDir,
+    })
+
+    const pagesJson = JSON.parse(
+      fs.readFileSync(path.join(bookDir, "adt", "content", "pages.json"), "utf-8"),
+    ) as Array<{ section_id: string; href: string }>
+
+    const resolved = resolveReadingOrder(storage)
+    expect(pagesJson.map((p) => p.section_id)).toEqual(resolved.items.map((i) => i.id))
+    // ...and that sequence is the expected one, so a resolver bug can't make
+    // both sides agree on something wrong.
+    expect(pagesJson.map((p) => p.section_id)).toEqual([
+      "pg001_sec001",
+      "qz001",
+      "pg002_sec001",
+    ])
+    // Every emitted page is a real file, named by id except the first.
+    expect(pagesJson.map((p) => p.href)).toEqual([
+      "index.html",
+      "qz001.html",
+      "pg002_sec001.html",
+    ])
+    for (const entry of pagesJson) {
+      expect(fs.existsSync(path.join(bookDir, "adt", entry.href))).toBe(true)
+    }
   })
 
   it("invokes apps/adt-runtime/build.config.mjs when only pre-built ESM exists", async () => {

--- a/packages/pipeline/src/__tests__/package-web.test.ts
+++ b/packages/pipeline/src/__tests__/package-web.test.ts
@@ -18,6 +18,7 @@ import {
   containsMathContent,
 } from "../packaging/web.js"
 import { packageWebpub, nestTocEntries, injectActivitiesBundle } from "../packaging/webpub.js"
+import { resolveReadingOrder } from "../reading-order.js"
 import { deriveQuizPalette } from "../quiz-palette.js"
 
 function createMockStorage(
@@ -2158,6 +2159,132 @@ describe("packageAdtWeb", () => {
       { section_id: "pg001_sec001", href: "index.html", page_number: 1 },
       { section_id: "pg001_sec002", href: "pg001_sec002.html", page_number: 1 },
     ])
+  })
+
+  it("writes pages.json in exactly the resolver's reading order", async () => {
+    // The whole point of the shared resolver: packaging and the live preview
+    // read the same sequence, so they cannot drift. Anything that changes the
+    // resolver and not the packaged manifest (or vice versa) fails here.
+    const bookDir = path.join(tmpDir, "book")
+    const webAssetsDir = path.join(tmpDir, "assets-web")
+    fs.mkdirSync(bookDir, { recursive: true })
+    createWebAssets(webAssetsDir)
+
+    const pages: PageData[] = [
+      { pageId: "pg001", pageNumber: 1, text: "Page one" },
+      { pageId: "pg002", pageNumber: 2, text: "Page two" },
+    ]
+
+    const storage = createMockStorage(pages, {
+      "web-rendering": {
+        pg001: {
+          sections: [
+            { sectionIndex: 0, sectionType: "content", reasoning: "", html: "<p>1a</p>" },
+            { sectionIndex: 1, sectionType: "content", reasoning: "", html: "<p>1b</p>" },
+          ],
+        },
+        pg002: {
+          sections: [
+            { sectionIndex: 0, sectionType: "content", reasoning: "", html: "<p>2a</p>" },
+          ],
+        },
+      },
+      "page-sectioning": {
+        pg001: {
+          reasoning: "ok",
+          sections: [
+            {
+              sectionId: "pg001_sec001",
+              sectionType: "content",
+              nodes: [],
+              backgroundColor: "#fff",
+              textColor: "#000",
+              pageNumber: 1,
+              isPruned: false,
+            },
+            // Pruned: present in the book, absent from the output.
+            {
+              sectionId: "pg001_sec002",
+              sectionType: "content",
+              nodes: [],
+              backgroundColor: "#fff",
+              textColor: "#000",
+              pageNumber: 1,
+              isPruned: true,
+            },
+          ],
+        },
+        pg002: {
+          reasoning: "ok",
+          sections: [
+            {
+              sectionId: "pg002_sec001",
+              sectionType: "content",
+              nodes: [],
+              backgroundColor: "#fff",
+              textColor: "#000",
+              pageNumber: 2,
+              isPruned: false,
+            },
+          ],
+        },
+      },
+      "quiz-generation": {
+        book: {
+          generatedAt: "2026-01-01T00:00:00.000Z",
+          language: "en",
+          pagesPerQuiz: 3,
+          quizzes: [
+            {
+              quizId: "qz001",
+              quizIndex: 0,
+              afterPageId: "pg001",
+              pageIds: ["pg001"],
+              question: "What is 2+2?",
+              options: [
+                { text: "3", explanation: "" },
+                { text: "4", explanation: "" },
+                { text: "5", explanation: "" },
+              ],
+              answerIndex: 1,
+              reasoning: "...",
+            },
+          ],
+        },
+      },
+    })
+
+    await packageAdtWeb(storage, {
+      bookDir,
+      label: "book",
+      language: "en",
+      outputLanguages: ["en"],
+      title: "Book Title",
+      webAssetsDir,
+    })
+
+    const pagesJson = JSON.parse(
+      fs.readFileSync(path.join(bookDir, "adt", "content", "pages.json"), "utf-8"),
+    ) as Array<{ section_id: string; href: string }>
+
+    const resolved = resolveReadingOrder(storage)
+    expect(pagesJson.map((p) => p.section_id)).toEqual(resolved.items.map((i) => i.id))
+    // ...and that sequence is the expected one, so a resolver bug can't make
+    // both sides agree on something wrong.
+    expect(pagesJson.map((p) => p.section_id)).toEqual([
+      "pg001_sec001",
+      "qz001",
+      "pg002_sec001",
+    ])
+    // Every emitted page is a real file, named by id except the first.
+    expect(pagesJson.map((p) => p.href)).toEqual([
+      "index.html",
+      "qz001.html",
+      "pg002_sec001.html",
+    ])
+    for (const entry of pagesJson) {
+      expect(fs.existsSync(path.join(bookDir, "adt", entry.href))).toBe(true)
+    }
   })
 
   it("invokes apps/adt-runtime/build.config.mjs when only pre-built ESM exists", async () => {

--- a/packages/pipeline/src/__tests__/reading-order.test.ts
+++ b/packages/pipeline/src/__tests__/reading-order.test.ts
@@ -1,0 +1,285 @@
+import { afterEach, describe, expect, it } from "vitest"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { createBookStorage, type Storage } from "@adt/storage"
+import { resolveReadingOrder, toPageEntry } from "../reading-order.js"
+
+describe("reading-order resolver", () => {
+  const tmpDirs: string[] = []
+  afterEach(() => {
+    for (const dir of tmpDirs) fs.rmSync(dir, { recursive: true, force: true })
+    tmpDirs.length = 0
+  })
+
+  function makeStorage() {
+    const booksRoot = fs.mkdtempSync(path.join(os.tmpdir(), "adt-reading-order-"))
+    tmpDirs.push(booksRoot)
+    return createBookStorage("test-book", booksRoot)
+  }
+
+  function section(
+    pageId: string,
+    seq: number,
+    overrides: { isPruned?: boolean; pageNumber?: number | null } = {}
+  ) {
+    return {
+      sectionId: `${pageId}_sec${String(seq).padStart(3, "0")}`,
+      sectionType: "content",
+      backgroundColor: "#fff",
+      textColor: "#000",
+      pageNumber: overrides.pageNumber ?? null,
+      isPruned: overrides.isPruned ?? false,
+      nodes: [],
+    }
+  }
+
+  function rendering(count: number) {
+    return {
+      sections: Array.from({ length: count }, (_, i) => ({
+        sectionIndex: i,
+        sectionType: "content",
+        reasoning: "",
+        html: `<section>${i}</section>`,
+      })),
+    }
+  }
+
+  /** Two pages, two sections each. Page numbers are deliberately non-sequential. */
+  function seedTwoPages(storage: Storage) {
+    storage.putExtractedPage({
+      pageId: "pg001",
+      pageNumber: 1,
+      text: "one",
+      pageImage: {
+        imageId: "pg001_page",
+        buffer: Buffer.from("x"),
+        format: "png" as const,
+        hash: "h1",
+        width: 10,
+        height: 10,
+      },
+      images: [],
+    })
+    storage.putExtractedPage({
+      pageId: "pg002",
+      pageNumber: 2,
+      text: "two",
+      pageImage: {
+        imageId: "pg002_page",
+        buffer: Buffer.from("y"),
+        format: "png" as const,
+        hash: "h2",
+        width: 10,
+        height: 10,
+      },
+      images: [],
+    })
+    storage.putNodeData("page-sectioning", "pg001", {
+      reasoning: "",
+      sections: [section("pg001", 1, { pageNumber: 10 }), section("pg001", 2)],
+    })
+    storage.putNodeData("page-sectioning", "pg002", {
+      reasoning: "",
+      sections: [section("pg002", 1), section("pg002", 2)],
+    })
+    storage.putNodeData("web-rendering", "pg001", rendering(2))
+    storage.putNodeData("web-rendering", "pg002", rendering(2))
+  }
+
+  function quizGeneration(quizzes: Array<{ quizId?: string; afterPageId: string }>) {
+    return {
+      generatedAt: "2026-01-01T00:00:00.000Z",
+      language: "en",
+      pagesPerQuiz: 3,
+      quizzes: quizzes.map((q, i) => ({
+        ...(q.quizId ? { quizId: q.quizId } : {}),
+        quizIndex: i,
+        afterPageId: q.afterPageId,
+        pageIds: [q.afterPageId],
+        question: `Q${i}`,
+        options: [
+          { text: "a", explanation: "" },
+          { text: "b", explanation: "" },
+          { text: "c", explanation: "" },
+        ],
+        answerIndex: 0,
+        reasoning: "",
+      })),
+    }
+  }
+
+  it("orders pages by page_number, then sections by sectionIndex", () => {
+    const storage = makeStorage()
+    try {
+      seedTwoPages(storage)
+      const { items } = resolveReadingOrder(storage)
+      expect(items.map((i) => i.id)).toEqual([
+        "pg001_sec001",
+        "pg001_sec002",
+        "pg002_sec001",
+        "pg002_sec002",
+      ])
+    } finally {
+      storage.close()
+    }
+  })
+
+  it("interleaves quizzes after the page they are anchored to", () => {
+    const storage = makeStorage()
+    try {
+      seedTwoPages(storage)
+      storage.putNodeData(
+        "quiz-generation",
+        "book",
+        quizGeneration([{ afterPageId: "pg001" }, { afterPageId: "pg002" }])
+      )
+
+      const { items } = resolveReadingOrder(storage)
+      expect(items.map((i) => i.id)).toEqual([
+        "pg001_sec001",
+        "pg001_sec002",
+        "qz001",
+        "pg002_sec001",
+        "pg002_sec002",
+        "qz002",
+      ])
+    } finally {
+      storage.close()
+    }
+  })
+
+  it("uses each quiz's stored id rather than its array position", () => {
+    const storage = makeStorage()
+    try {
+      seedTwoPages(storage)
+      // Stored out of id order: the quiz holding qz002 comes first in the array.
+      storage.putNodeData(
+        "quiz-generation",
+        "book",
+        quizGeneration([
+          { quizId: "qz002", afterPageId: "pg001" },
+          { quizId: "qz001", afterPageId: "pg002" },
+        ])
+      )
+
+      const { items } = resolveReadingOrder(storage)
+      expect(items.filter((i) => i.kind === "quiz").map((i) => i.id)).toEqual([
+        "qz002",
+        "qz001",
+      ])
+    } finally {
+      storage.close()
+    }
+  })
+
+  it("drops quiz items when quizzes are disabled", () => {
+    const storage = makeStorage()
+    try {
+      seedTwoPages(storage)
+      storage.putNodeData("quiz-generation", "book", quizGeneration([{ afterPageId: "pg001" }]))
+
+      const { items } = resolveReadingOrder(storage, { includeQuizzes: false })
+      expect(items.some((i) => i.kind === "quiz")).toBe(false)
+    } finally {
+      storage.close()
+    }
+  })
+
+  it("omits pruned sections without disturbing the positions around them", () => {
+    const storage = makeStorage()
+    try {
+      seedTwoPages(storage)
+      storage.putNodeData("page-sectioning", "pg001", {
+        reasoning: "",
+        sections: [section("pg001", 1, { isPruned: true }), section("pg001", 2)],
+      })
+
+      const { items, positionById } = resolveReadingOrder(storage)
+      expect(items.map((i) => i.id)).toEqual([
+        "pg001_sec002",
+        "pg002_sec001",
+        "pg002_sec002",
+      ])
+      expect(positionById.get("pg001_sec002")).toBe(1)
+      expect(positionById.has("pg001_sec001")).toBe(false)
+    } finally {
+      storage.close()
+    }
+  })
+
+  it("skips rendering entries with no matching sectioning row", () => {
+    const storage = makeStorage()
+    try {
+      seedTwoPages(storage)
+      // Three rendered entries but only two sections: the third is an orphan
+      // whose real sectionId is unknowable.
+      storage.putNodeData("web-rendering", "pg001", rendering(3))
+
+      const { items } = resolveReadingOrder(storage)
+      expect(items.map((i) => i.id)).toEqual([
+        "pg001_sec001",
+        "pg001_sec002",
+        "pg002_sec001",
+        "pg002_sec002",
+      ])
+    } finally {
+      storage.close()
+    }
+  })
+
+  it("resolves fixed-layout books through the positioned tree", () => {
+    const storage = makeStorage()
+    try {
+      seedTwoPages(storage)
+      storage.putNodeData("fixed-layout-sectioning", "pg001", {
+        reasoning: "",
+        sections: [{ ...section("pg001", 7), sectionType: "fixed-layout-page" }],
+      })
+      storage.putNodeData("web-rendering", "pg001", rendering(1))
+
+      const { items } = resolveReadingOrder(storage)
+      expect(items.map((i) => i.id)).toEqual([
+        "pg001_sec007",
+        "pg002_sec001",
+        "pg002_sec002",
+      ])
+    } finally {
+      storage.close()
+    }
+  })
+
+  it("carries the printed page number onto pages.json entries, and never onto quizzes", () => {
+    const storage = makeStorage()
+    try {
+      seedTwoPages(storage)
+      storage.putNodeData("quiz-generation", "book", quizGeneration([{ afterPageId: "pg001" }]))
+
+      const entries = resolveReadingOrder(storage).items.map(toPageEntry)
+      expect(entries[0]).toEqual({
+        section_id: "pg001_sec001",
+        href: "pg001_sec001.html",
+        page_number: 10,
+      })
+      // pageNumber null → key omitted entirely, as pages.json has always done.
+      expect(entries[1]).toEqual({
+        section_id: "pg001_sec002",
+        href: "pg001_sec002.html",
+      })
+      expect(entries[2]).toEqual({ section_id: "qz001", href: "qz001.html" })
+    } finally {
+      storage.close()
+    }
+  })
+
+  it("numbers positions 1-based over the emitted items only", () => {
+    const storage = makeStorage()
+    try {
+      seedTwoPages(storage)
+      const { items, positionById } = resolveReadingOrder(storage)
+      expect(items.map((i) => positionById.get(i.id))).toEqual([1, 2, 3, 4])
+    } finally {
+      storage.close()
+    }
+  })
+})

--- a/packages/pipeline/src/__tests__/reading-order.test.ts
+++ b/packages/pipeline/src/__tests__/reading-order.test.ts
@@ -173,6 +173,46 @@ describe("reading-order resolver", () => {
     }
   })
 
+  it.each([
+    ["qz002", undefined],
+    ["qz001", "qz001"],
+    ["../outside", "qz002"],
+  ])("rejects inconsistent stored quiz identities (%s, %s)", (first, second) => {
+    const storage = makeStorage()
+    try {
+      seedTwoPages(storage)
+      storage.putNodeData("quiz-generation", "book", quizGeneration([
+        { quizId: first, afterPageId: "pg001" },
+        { quizId: second, afterPageId: "pg002" },
+      ]))
+      expect(() => resolveReadingOrder(storage)).toThrow(/quiz id/i)
+      expect(resolveReadingOrder(storage, { includeQuizzes: false }).items).toHaveLength(4)
+    } finally {
+      storage.close()
+    }
+  })
+
+  it("resolves legacy IDs after rollback without writing a new version", () => {
+    const storage = makeStorage()
+    try {
+      seedTwoPages(storage)
+      const legacyVersion = storage.putNodeData("quiz-generation", "book", quizGeneration([
+        { afterPageId: "pg001" }, { afterPageId: "pg002" },
+      ]))
+      storage.putNodeData("quiz-generation", "book", quizGeneration([
+        { quizId: "qz009", afterPageId: "pg001" },
+      ]))
+      storage.setCurrentNodeVersion("quiz-generation", "book", legacyVersion)
+      const before = storage.getNodeVersionFingerprint()
+      expect(resolveReadingOrder(storage).items.filter((i) => i.kind === "quiz").map((i) => i.id))
+        .toEqual(["qz001", "qz002"])
+      expect(storage.getNodeVersionFingerprint()).toEqual(before)
+      expect(storage.getAllNodeVersions("quiz-generation", "book")).toHaveLength(2)
+    } finally {
+      storage.close()
+    }
+  })
+
   it("drops quiz items when quizzes are disabled", () => {
     const storage = makeStorage()
     try {

--- a/packages/pipeline/src/__tests__/toc-generation.test.ts
+++ b/packages/pipeline/src/__tests__/toc-generation.test.ts
@@ -53,6 +53,7 @@ function makeStorageWithSection(opts: {
   tocSection?: boolean
 }): Storage {
   return {
+    getPages: () => [{ pageId: "pg001", pageNumber: 1, text: "" }],
     getLatestNodeData: (node: string) => {
       if (node === "page-sectioning") {
         return {
@@ -178,6 +179,7 @@ describe("generateToc", () => {
     // Fixed-layout: the render (positioned) tree has only text/image roles;
     // the heading lives in the semantic page-sectioning tree.
     const storage = {
+      getPages: () => [{ pageId: "pg001", pageNumber: 1, text: "" }],
       getLatestNodeData: (node: string) => {
         if (node === "fixed-layout-sectioning") {
           return {

--- a/packages/pipeline/src/__tests__/toc-reading-order.test.ts
+++ b/packages/pipeline/src/__tests__/toc-reading-order.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest"
+import type { TocEntry } from "@adt/types"
+import { orderTocEntries } from "../toc-reading-order.js"
+import { nestTocEntries } from "../packaging/webpub.js"
+
+const entry = (id: string, level = 1, sectionId = id): TocEntry => ({
+  id, title: id, sectionId, href: id, chapterId: "", level,
+})
+const positions = new Map([["a", 1], ["b", 2], ["c", 3], ["d", 4]])
+const titles = (entries: TocEntry[]) => entries.map((e) => e.title)
+
+describe("orderTocEntries", () => {
+  it("sorts flat entries stably, including duplicate destinations and unmatched entries", () => {
+    const entries = [entry("unknown1"), entry("c"), entry("first-a", 1, "a"), entry("second-a", 1, "a"), entry("unknown2")]
+    const snapshot = structuredClone(entries)
+    expect(titles(orderTocEntries(entries, positions))).toEqual(["first-a", "second-a", "c", "unknown1", "unknown2"])
+    expect(entries).toEqual(snapshot)
+    expect(orderTocEntries([], positions)).toEqual([])
+    expect(orderTocEntries(entries, new Map())).toEqual(entries)
+  })
+
+  it("moves unlinked parents with their children and orders siblings within each group", () => {
+    const ordered = orderTocEntries([
+      entry("Unit two", 1, ""), entry("d", 2), entry("c", 2),
+      entry("Unit one", 1, ""), entry("b", 2), entry("a", 2),
+    ], positions)
+    expect(titles(ordered)).toEqual(["Unit one", "a", "b", "Unit two", "c", "d"])
+    expect(nestTocEntries(ordered)).toEqual([
+      { title: "Unit one", href: "Unit one", children: [{ title: "a", href: "a" }, { title: "b", href: "b" }] },
+      { title: "Unit two", href: "Unit two", children: [{ title: "c", href: "c" }, { title: "d", href: "d" }] },
+    ])
+  })
+
+  it("keeps pruned parents, deeply nested descendants, and wholly unmatched groups intact", () => {
+    const ordered = orderTocEntries([
+      entry("unmatched"), entry("missing-child", 2),
+      entry("c"), entry("pruned"), entry("subheading", 3, ""), entry("a", 6),
+    ], positions)
+    expect(titles(ordered)).toEqual(["pruned", "subheading", "a", "c", "unmatched", "missing-child"])
+    expect(ordered.map((e) => e.level)).toEqual([1, 3, 6, 1, 1, 2])
+  })
+
+  it("does not accidentally reparent siblings with different heading levels", () => {
+    const entries = [entry("c", 3), entry("a", 1), entry("d", 4), entry("b", 2)]
+    const ordered = orderTocEntries(entries, positions)
+    expect(ordered).toEqual(entries)
+    expect(nestTocEntries(ordered)).toEqual([
+      { title: "c", href: "c" },
+      { title: "a", href: "a", children: [{ title: "d", href: "d" }, { title: "b", href: "b" }] },
+    ])
+  })
+
+  it("prioritizes a saved parent-child relationship when their links point backwards", () => {
+    const ordered = orderTocEntries([entry("c"), entry("d"), entry("a", 2)], positions)
+    expect(titles(ordered)).toEqual(["d", "a", "c"])
+    expect(nestTocEntries(ordered)[0]).toEqual({ title: "d", href: "d", children: [{ title: "a", href: "a" }] })
+    expect(orderTocEntries(ordered, positions)).toEqual(ordered)
+  })
+  it("preserves the downstream hierarchy for arbitrary valid heading-level gaps", () => {
+    const levels = [1, 2, 4, 6]
+    const parents = (toc: TocEntry[]) => {
+      const edges: string[] = []
+      const walk = (links: ReturnType<typeof nestTocEntries>, parent = "root") => {
+        for (const link of links) {
+          edges.push(`${link.href}:${parent}`)
+          walk(link.children ?? [], link.href)
+        }
+      }
+      walk(nestTocEntries(toc))
+      return edges.sort()
+    }
+    for (const a of levels) for (const b of levels) for (const c of levels) for (const d of levels) {
+      const entries = [a, b, c, d].map((level, i) => entry(String(i), level))
+      const reversed = new Map(entries.map((e, i) => [e.sectionId, 4 - i]))
+      const ordered = orderTocEntries(entries, reversed)
+      expect(parents(ordered)).toEqual(parents(entries))
+      expect(orderTocEntries(ordered, reversed)).toEqual(ordered)
+      expect(ordered.map((e) => e.id).sort()).toEqual(["0", "1", "2", "3"])
+    }
+  })
+
+})

--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -405,6 +405,15 @@ export {
   PAGE_SECTIONING_NODE,
 } from "./render-sectioning.js"
 export {
+  resolveReadingOrder,
+  defaultReadingOrder,
+  toPageEntry,
+  readingOrderHref,
+  type ResolvedItem,
+  type ResolvedReadingOrder,
+  type PageEntry,
+} from "./reading-order.js"
+export {
   extractEditableActivity,
   supportsEditableActivity,
   type ExtractResult,

--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -426,6 +426,15 @@ export {
   type DetachedRecording,
 } from "./section-ids.js"
 export {
+  resolveReadingOrder,
+  defaultReadingOrder,
+  toPageEntry,
+  readingOrderHref,
+  type ResolvedItem,
+  type ResolvedReadingOrder,
+  type PageEntry,
+} from "./reading-order.js"
+export {
   extractEditableActivity,
   supportsEditableActivity,
   type ExtractResult,

--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -434,6 +434,7 @@ export {
   type ResolvedReadingOrder,
   type PageEntry,
 } from "./reading-order.js"
+export { orderTocEntries } from "./toc-reading-order.js"
 export {
   extractEditableActivity,
   supportsEditableActivity,

--- a/packages/pipeline/src/packaging/web.ts
+++ b/packages/pipeline/src/packaging/web.ts
@@ -53,6 +53,7 @@ import { buildTextCatalog } from "../text-catalog.js"
 import { flattenEasyReadEntries } from "../easy-read.js"
 import { getCoreTtsCatalog, getReadyCoreTtsEntries } from "../core-tts.js"
 import { getRenderSectioning } from "../render-sectioning.js"
+import { resolveReadingOrder, toPageEntry, type PageEntry } from "../reading-order.js"
 import { normalizeSectionRoles, promoteFirstHeadingToH1 } from "../html-semantics.js"
 import { escapeHtml, escapeAttr, escapeInlineScriptJson } from "../html-escape.js"
 import { buildTailwindCss } from "../tailwind.js"
@@ -102,11 +103,7 @@ export function pageNeedsActivitiesBundle(html: string): boolean {
   )
 }
 
-export interface PageEntry {
-  section_id: string
-  href: string
-  page_number?: number
-}
+export type { PageEntry } from "../reading-order.js"
 
 interface RuntimeTimecodeEntry {
   timecodes: [null, {
@@ -354,183 +351,164 @@ export async function packageAdtWeb(
   let hasMath = false
   let hasActivitySections = false
   const copiedImages = new Set<string>()
-  const sectionIdToPageIndex = new Map<string, number>()
 
-  // Build a map from afterPageId -> quizzes for interleaving
-  const quizzesByAfterPageId = new Map<string, Quiz[]>()
-  if ((features?.quizzes !== false) && quizData?.quizzes) {
-    for (const quiz of quizData.quizzes) {
-      const existing = quizzesByAfterPageId.get(quiz.afterPageId) ?? []
-      existing.push(quiz)
-      quizzesByAfterPageId.set(quiz.afterPageId, existing)
+  // The book's output sequence — the same resolver the live preview uses, so
+  // the two cannot drift.
+  const readingOrder = resolveReadingOrder(storage, {
+    includeQuizzes: features?.quizzes !== false,
+  })
+
+  // Reading order revisits a page once per section, so per-page reads are
+  // memoized instead of hoisted out of a page-grouped loop.
+  const decorativeImageIdsByPage = new Map<string, Set<string>>()
+  const editableActivitiesByPage = new Map<string, ReturnType<typeof readEditableActivities>>()
+  const decorativeImageIdsFor = (pageId: string) => {
+    let ids = decorativeImageIdsByPage.get(pageId)
+    if (!ids) {
+      ids = buildDecorativeImageIdSet(storage, pageId)
+      decorativeImageIdsByPage.set(pageId, ids)
     }
+    return ids
+  }
+  const editableActivitiesFor = (pageId: string) => {
+    if (!editableActivitiesByPage.has(pageId)) {
+      editableActivitiesByPage.set(pageId, readEditableActivities(storage, pageId))
+    }
+    return editableActivitiesByPage.get(pageId)!
   }
 
-  for (const page of pages) {
-    const quizzes = quizzesByAfterPageId.get(page.pageId) ?? []
+  for (const item of readingOrder.items) {
+    const isFirstPage = pageList.length === 0
+    const filename = isFirstPage ? "index.html" : `${item.id}.html`
+    const pageIndex = pageList.length + 1
 
-    // Resolver: fixed-layout books package from the positioned tree (its ids +
-    // 1-section/page shape match the rendered HTML the runtime hydrates).
-    const sectioning = getRenderSectioning(storage, page.pageId)
-    const imageCaptionMap = loadImageCaptionMap(storage, page.pageId)
-    const decorativeImageIds = buildDecorativeImageIdSet(storage, page.pageId)
-
-    const renderRow = storage.getLatestNodeData("web-rendering", page.pageId)
-    const editableActivities = readEditableActivities(storage, page.pageId)
-    if (renderRow) {
-      const parsed = WebRenderingOutputSchema.safeParse(renderRow.data)
-      if (parsed.success) {
-        const rendering = parsed.data
-
-        // One HTML file per rendered section (stable by sectionIndex), skip pruned
-        const sections = [...rendering.sections].sort((a, b) => a.sectionIndex - b.sectionIndex)
-        for (const rs of sections) {
-          const sectionMeta = sectioning?.sections[rs.sectionIndex]
-          // No sectioning row for this rendering entry means the two are out of
-          // sync. sectionIds are allocated once and never reused, so a guessed
-          // `_secNNN` could collide with a real section and have two pages write
-          // the same file. Skip the orphan entry instead.
-          if (!sectionMeta || sectionMeta.isPruned) continue
-          const sectionId = sectionMeta.sectionId
-
-          if (rs.sectionType.startsWith("activity_") || sectionMeta?.sectionType.startsWith("activity_")) {
-            hasActivitySections = true
-          }
-
-          // Step-by-step override: an enabled editable activity replaces the
-          // stored LLM HTML with the stepper shell (structured JSON + palette).
-          const stepperActivity = enabledEditableActivity(
-            editableActivities,
-            rs.sectionIndex,
-            rs.sectionType,
-          )
-
-          // Rewrite image URLs and copy referenced images
-          const preferredImageAltMap = buildPreferredImageAltMap(storage, page.pageId, sectionMeta)
-          let rewrittenHtml: string
-          let referencedImages: string[]
-          if (stepperActivity) {
-            const resolved = resolveEditableActivityImages(stepperActivity, imageMap, {
-              preferredAltMap: preferredImageAltMap,
-              decorativeImageIds,
-            })
-            rewrittenHtml = renderEditableActivityHtml(resolved.activity, {
-              palette: stepperBasePalette,
-            })
-            referencedImages = resolved.referencedImages
-          } else {
-            ;({ html: rewrittenHtml, referencedImages } = rewriteImageUrls(
-              rs.html,
-              label,
-              imageMap,
-              preferredImageAltMap,
-              decorativeImageIds,
-            ))
-          }
-
-          for (const imageId of referencedImages) {
-            if (!copiedImages.has(imageId)) {
-              const filename = imageMap.get(imageId)
-              if (filename) {
-                fs.copyFileSync(
-                  path.join(bookDir, "images", filename),
-                  path.join(imageDir, filename),
-                )
-                copiedImages.add(imageId)
-              }
-            }
-          }
-
-          // Convert LaTeX math to MathML (stepper shells are JSON — leave untouched)
-          const sectionHasMath = !stepperActivity && containsMathContent(rewrittenHtml)
-          if (sectionHasMath) {
-            hasMath = true
-            rewrittenHtml = convertLatexToMathml(rewrittenHtml)
-          }
-
-          const isFirstPage = pageList.length === 0
-          const filename = isFirstPage ? "index.html" : `${sectionId}.html`
-
-          const headingText = sectionMeta ? findHeadingText(sectionMeta) : null
-
-          // For fixed-layout pages, extract viewport from the rendered content div.
-          // Viewport matches content dimensions (2x render scale) exactly — no
-          // transform needed, Apple Books scales the viewport to fit the screen.
-          let fixedViewport: { width: number; height: number } | undefined
-          if (fixedLayout) {
-            const vp = rewrittenHtml.match(/width:(\d+)px;height:(\d+)px/)
-            if (vp) {
-              fixedViewport = { width: parseInt(vp[1], 10), height: parseInt(vp[2], 10) }
-            }
-          }
-
-          const pageHtml = renderPageHtml({
-            content: rewrittenHtml,
-            language,
-            sectionId,
-            pageTitle: title,
-            pageHeading: headingText?.text ?? title,
-            pageIndex: pageList.length + 1,
-            // Stepper answers travel inside the embedded JSON payload.
-            activityAnswers: stepperActivity ? undefined : rs.activityAnswers,
-            hasMath: sectionHasMath,
-            bundleVersion,
-            applyBodyBackground,
-            fixedViewport,
-            bodyFontFamily,
-          })
-          fs.writeFileSync(path.join(adtDir, filename), pageHtml)
-
-          const entry: PageEntry = {
-            section_id: sectionId,
-            href: filename,
-          }
-          if (sectionMeta?.pageNumber !== null && sectionMeta?.pageNumber !== undefined) {
-            entry.page_number = sectionMeta.pageNumber
-          }
-          pageList.push(entry)
-
-          // Track sectionId → pageIndex for sign language video mapping
-          sectionIdToPageIndex.set(sectionId, pageList.length) // pageIndex = pageList.length (1-based, already pushed)
-
-          // Build TOC entry from first heading text in this section
-          if (headingText) {
-            tocEntries.push({
-              section_id: sectionId,
-              href: filename,
-              title: headingText.text,
-              chapter_id: headingText.textId,
-            })
-          }
-        }
-      }
-    }
-
-    // Insert quiz pages after this page (even if page content was skipped)
-    for (const quiz of quizzes) {
-      const quizId = resolveQuizId(quiz, quizData!.quizzes.indexOf(quiz))
-
-      const isFirstPage = pageList.length === 0
-      const quizFilename = isFirstPage ? "index.html" : `${quizId}.html`
-
-      const quizHtmlContent = renderQuizHtml(quiz, quizId, catalog, quizStyle)
+    if (item.kind === "quiz") {
+      const quizHtmlContent = renderQuizHtml(item.quiz, item.id, catalog, quizStyle)
       const quizPageHtml = renderPageHtml({
         content: quizHtmlContent,
         language,
-        sectionId: quizId,
+        sectionId: item.id,
         pageTitle: title,
-        pageHeading: quiz.question,
-        pageIndex: pageList.length + 1,
-        activityAnswers: buildQuizAnswers(quiz, quizId),
+        pageHeading: item.quiz.question,
+        pageIndex,
+        activityAnswers: buildQuizAnswers(item.quiz, item.id),
         hasMath: false,
         bundleVersion,
         skipContentWrapper: true,
         applyBodyBackground,
         bodyFontFamily,
       })
-      fs.writeFileSync(path.join(adtDir, quizFilename), quizPageHtml)
+      fs.writeFileSync(path.join(adtDir, filename), quizPageHtml)
 
-      pageList.push({ section_id: quizId, href: quizFilename })
+      // Phase 4 drops the index.html special case; until then the first page
+    // keeps that name, so the entry's href is overridden here rather than in
+    // the resolver (which is already position-independent).
+    pageList.push({ ...toPageEntry(item), href: filename })
+      continue
+    }
+
+    const { pageId, section: sectionMeta, rendering: rs, id: sectionId } = item
+    const decorativeImageIds = decorativeImageIdsFor(pageId)
+    const editableActivities = editableActivitiesFor(pageId)
+
+    if (rs.sectionType.startsWith("activity_") || sectionMeta.sectionType.startsWith("activity_")) {
+      hasActivitySections = true
+    }
+
+    // Step-by-step override: an enabled editable activity replaces the
+    // stored LLM HTML with the stepper shell (structured JSON + palette).
+    const stepperActivity = enabledEditableActivity(
+      editableActivities,
+      rs.sectionIndex,
+      rs.sectionType,
+    )
+
+    // Rewrite image URLs and copy referenced images
+    const preferredImageAltMap = buildPreferredImageAltMap(storage, pageId, sectionMeta)
+    let rewrittenHtml: string
+    let referencedImages: string[]
+    if (stepperActivity) {
+      const resolved = resolveEditableActivityImages(stepperActivity, imageMap, {
+        preferredAltMap: preferredImageAltMap,
+        decorativeImageIds,
+      })
+      rewrittenHtml = renderEditableActivityHtml(resolved.activity, {
+        palette: stepperBasePalette,
+      })
+      referencedImages = resolved.referencedImages
+    } else {
+      ;({ html: rewrittenHtml, referencedImages } = rewriteImageUrls(
+        rs.html,
+        label,
+        imageMap,
+        preferredImageAltMap,
+        decorativeImageIds,
+      ))
+    }
+
+    for (const imageId of referencedImages) {
+      if (!copiedImages.has(imageId)) {
+        const imageFilename = imageMap.get(imageId)
+        if (imageFilename) {
+          fs.copyFileSync(
+            path.join(bookDir, "images", imageFilename),
+            path.join(imageDir, imageFilename),
+          )
+          copiedImages.add(imageId)
+        }
+      }
+    }
+
+    // Convert LaTeX math to MathML (stepper shells are JSON — leave untouched)
+    const sectionHasMath = !stepperActivity && containsMathContent(rewrittenHtml)
+    if (sectionHasMath) {
+      hasMath = true
+      rewrittenHtml = convertLatexToMathml(rewrittenHtml)
+    }
+
+    const headingText = findHeadingText(sectionMeta)
+
+    // For fixed-layout pages, extract viewport from the rendered content div.
+    // Viewport matches content dimensions (2x render scale) exactly — no
+    // transform needed, Apple Books scales the viewport to fit the screen.
+    let fixedViewport: { width: number; height: number } | undefined
+    if (fixedLayout) {
+      const vp = rewrittenHtml.match(/width:(\d+)px;height:(\d+)px/)
+      if (vp) {
+        fixedViewport = { width: parseInt(vp[1], 10), height: parseInt(vp[2], 10) }
+      }
+    }
+
+    const pageHtml = renderPageHtml({
+      content: rewrittenHtml,
+      language,
+      sectionId,
+      pageTitle: title,
+      pageHeading: headingText?.text ?? title,
+      pageIndex,
+      // Stepper answers travel inside the embedded JSON payload.
+      activityAnswers: stepperActivity ? undefined : rs.activityAnswers,
+      hasMath: sectionHasMath,
+      bundleVersion,
+      applyBodyBackground,
+      fixedViewport,
+      bodyFontFamily,
+    })
+    fs.writeFileSync(path.join(adtDir, filename), pageHtml)
+
+    // Phase 4 drops the index.html special case; until then the first page
+    // keeps that name, so the entry's href is overridden here rather than in
+    // the resolver (which is already position-independent).
+    pageList.push({ ...toPageEntry(item), href: filename })
+
+    // Build TOC entry from first heading text in this section
+    if (headingText) {
+      tocEntries.push({
+        section_id: sectionId,
+        href: filename,
+        title: headingText.text,
+        chapter_id: headingText.textId,
+      })
     }
   }
 
@@ -546,15 +524,29 @@ export async function packageAdtWeb(
     // Map LLM entries to the flat format expected by the runtime, resolving
     // hrefs from the page list (the first page is always index.html)
     const hrefMap = new Map(pageList.map((p) => [p.section_id, p.href]))
-    const tocJson = llmToc.entries.map((e) => ({
-      section_id: e.sectionId,
-      href: hrefMap.get(e.sectionId) ?? e.href,
-      title: e.title,
-      chapter_id: e.chapterId,
-      level: e.level,
-    }))
+    const tocJson = llmToc.entries
+      // The LLM returns entries in its own order, which is independent of the
+      // reading order. Downstream consumers require document order: WebPub's
+      // nav nests a flat list by `level` as it walks it, and EPUB/PNLD NCX
+      // `playOrder` must increase monotonically. Sort by resolved position, and
+      // keep entries whose section is not in the reading order at the end
+      // rather than silently dropping them.
+      .map((entry, index) => ({ entry, index }))
+      .sort((a, b) => {
+        const posA = readingOrder.positionById.get(a.entry.sectionId) ?? Infinity
+        const posB = readingOrder.positionById.get(b.entry.sectionId) ?? Infinity
+        return posA === posB ? a.index - b.index : posA - posB
+      })
+      .map(({ entry: e }) => ({
+        section_id: e.sectionId,
+        href: hrefMap.get(e.sectionId) ?? e.href,
+        title: e.title,
+        chapter_id: e.chapterId,
+        level: e.level,
+      }))
     writeJson(path.join(contentDir, "toc.json"), tocJson)
   } else {
+    // Already accumulated in reading order.
     writeJson(path.join(contentDir, "toc.json"), tocEntries)
   }
 
@@ -727,7 +719,7 @@ export async function packageAdtWeb(
       // glossary-item videos (sectionId = `gl001`…) feed the glossary
       // popover/panel instead and stay out of the page map.
       const pageVideos = allVideos.filter(
-        (v) => v.sectionId && sectionIdToPageIndex.has(v.sectionId),
+        (v) => v.sectionId && readingOrder.positionById.has(v.sectionId),
       )
       const glossaryVideos = allVideos.filter(
         (v) => v.sectionId && glossaryTextIds.has(v.sectionId),
@@ -742,7 +734,7 @@ export async function packageAdtWeb(
         const srcPath = storage.getSignLanguageVideoPath(video.videoId)
         if (srcPath && fs.existsSync(srcPath)) {
           fs.copyFileSync(srcPath, path.join(videoDir, filename))
-          videosMap[`video-${sectionIdToPageIndex.get(video.sectionId!)}`] = filename
+          videosMap[`video-${readingOrder.positionById.get(video.sectionId!)}`] = filename
         }
       }
       for (const video of glossaryVideos) {
@@ -800,7 +792,7 @@ export async function packageAdtWeb(
   // Only page-section videos light up the runtime PIP player; glossary-item
   // videos (sectionId = `gl001`…) are an EPUB glossary-page concern.
   const hasSignLanguageVideos = (features?.signLanguage !== false) &&
-    storage.getSignLanguageVideos().some((v) => v.sectionId !== null && sectionIdToPageIndex.has(v.sectionId))
+    storage.getSignLanguageVideos().some((v) => v.sectionId !== null && readingOrder.positionById.has(v.sectionId))
 
   const configJson: Record<string, unknown> = {
     title,

--- a/packages/pipeline/src/packaging/web.ts
+++ b/packages/pipeline/src/packaging/web.ts
@@ -56,6 +56,7 @@ import { buildTextCatalog } from "../text-catalog.js"
 import { flattenEasyReadEntries } from "../easy-read.js"
 import { getCoreTtsCatalog, getReadyCoreTtsEntries } from "../core-tts.js"
 import { getRenderSectioning } from "../render-sectioning.js"
+import { resolveReadingOrder, toPageEntry, type PageEntry } from "../reading-order.js"
 import { normalizeSectionRoles, promoteFirstHeadingToH1 } from "../html-semantics.js"
 import { escapeHtml, escapeAttr, escapeInlineScriptJson } from "../html-escape.js"
 import { buildTailwindCss } from "../tailwind.js"
@@ -105,11 +106,7 @@ export function pageNeedsActivitiesBundle(html: string): boolean {
   )
 }
 
-export interface PageEntry {
-  section_id: string
-  href: string
-  page_number?: number
-}
+export type { PageEntry } from "../reading-order.js"
 
 interface RuntimeTimecodeEntry {
   timecodes: [null, {
@@ -372,200 +369,186 @@ export async function packageAdtWeb(
   let hasMath = false
   let hasActivitySections = false
   const copiedImages = new Set<string>()
-  const sectionIdToPageIndex = new Map<string, number>()
-  // Rendering entries with no sectioning row behind them. They are dropped from
-  // the bundle (see the skip below), which is silent otherwise — the page just
-  // isn't there. Returned to the caller so the packaging and export flows can
-  // surface it; a `progress` message alone reaches no live sink.
+  // Keep reporting orphaned renderings even though the shared order resolver
+  // correctly omits entries without a real sectionId.
   const orphanedRenderings: PackagingWarning[] = []
-
-  // Build a map from afterPageId -> quizzes for interleaving
-  const quizzesByAfterPageId = new Map<string, Quiz[]>()
-  if ((features?.quizzes !== false) && quizData?.quizzes) {
-    for (const quiz of quizData.quizzes) {
-      const existing = quizzesByAfterPageId.get(quiz.afterPageId) ?? []
-      existing.push(quiz)
-      quizzesByAfterPageId.set(quiz.afterPageId, existing)
+  for (const page of pages) {
+    const sectioning = getRenderSectioning(storage, page.pageId)
+    const row = storage.getLatestNodeData("web-rendering", page.pageId)
+    const parsed = row ? WebRenderingOutputSchema.safeParse(row.data) : null
+    if (!parsed?.success) continue
+    for (const rendering of [...parsed.data.sections].sort((a, b) => a.sectionIndex - b.sectionIndex)) {
+      if (!sectioning?.sections[rendering.sectionIndex]) {
+        orphanedRenderings.push({
+          kind: "orphaned-rendering",
+          pageId: page.pageId,
+          sectionIndex: rendering.sectionIndex,
+        })
+      }
     }
   }
 
-  for (const page of pages) {
-    const quizzes = quizzesByAfterPageId.get(page.pageId) ?? []
+  // The book's output sequence — the same resolver the live preview uses, so
+  // the two cannot drift.
+  const readingOrder = resolveReadingOrder(storage, {
+    includeQuizzes: features?.quizzes !== false,
+  })
 
-    // Resolver: fixed-layout books package from the positioned tree (its ids +
-    // 1-section/page shape match the rendered HTML the runtime hydrates).
-    const sectioning = getRenderSectioning(storage, page.pageId)
-    const imageCaptionMap = loadImageCaptionMap(storage, page.pageId)
-    const decorativeImageIds = buildDecorativeImageIdSet(storage, page.pageId)
-
-    const renderRow = storage.getLatestNodeData("web-rendering", page.pageId)
-    const editableActivities = readEditableActivities(storage, page.pageId)
-    if (renderRow) {
-      const parsed = WebRenderingOutputSchema.safeParse(renderRow.data)
-      if (parsed.success) {
-        const rendering = parsed.data
-
-        // One HTML file per rendered section (stable by sectionIndex), skip pruned
-        const sections = [...rendering.sections].sort((a, b) => a.sectionIndex - b.sectionIndex)
-        for (const rs of sections) {
-          const sectionMeta = sectioning?.sections[rs.sectionIndex]
-          // No sectioning row for this rendering entry means the two are out of
-          // sync. sectionIds are allocated once and never reused, so a guessed
-          // `_secNNN` could collide with a real section and have two pages write
-          // the same file. Skip the orphan entry instead.
-          if (!sectionMeta) {
-            orphanedRenderings.push({
-              kind: "orphaned-rendering",
-              pageId: page.pageId,
-              sectionIndex: rs.sectionIndex,
-            })
-            continue
-          }
-          if (sectionMeta.isPruned) continue
-          const sectionId = sectionMeta.sectionId
-
-          if (rs.sectionType.startsWith("activity_") || sectionMeta.sectionType.startsWith("activity_")) {
-            hasActivitySections = true
-          }
-
-          // Step-by-step override: an enabled editable activity replaces the
-          // stored LLM HTML with the stepper shell (structured JSON + palette).
-          const stepperActivity = enabledEditableActivity(
-            editableActivities,
-            rs.sectionIndex,
-            rs.sectionType,
-          )
-
-          // Rewrite image URLs and copy referenced images
-          const preferredImageAltMap = buildPreferredImageAltMap(storage, page.pageId, sectionMeta)
-          let rewrittenHtml: string
-          let referencedImages: string[]
-          if (stepperActivity) {
-            const resolved = resolveEditableActivityImages(stepperActivity, imageMap, {
-              preferredAltMap: preferredImageAltMap,
-              decorativeImageIds,
-            })
-            rewrittenHtml = renderEditableActivityHtml(resolved.activity, {
-              palette: stepperBasePalette,
-            })
-            referencedImages = resolved.referencedImages
-          } else {
-            ;({ html: rewrittenHtml, referencedImages } = rewriteImageUrls(
-              rs.html,
-              label,
-              imageMap,
-              preferredImageAltMap,
-              decorativeImageIds,
-            ))
-          }
-
-          for (const imageId of referencedImages) {
-            if (!copiedImages.has(imageId)) {
-              const filename = imageMap.get(imageId)
-              if (filename) {
-                fs.copyFileSync(
-                  path.join(bookDir, "images", filename),
-                  path.join(imageDir, filename),
-                )
-                copiedImages.add(imageId)
-              }
-            }
-          }
-
-          // Convert LaTeX math to MathML (stepper shells are JSON — leave untouched)
-          const sectionHasMath = !stepperActivity && containsMathContent(rewrittenHtml)
-          if (sectionHasMath) {
-            hasMath = true
-            rewrittenHtml = convertLatexToMathml(rewrittenHtml)
-          }
-
-          const isFirstPage = pageList.length === 0
-          const filename = isFirstPage ? "index.html" : `${sectionId}.html`
-
-          const headingText = sectionMeta ? findHeadingText(sectionMeta) : null
-
-          // For fixed-layout pages, extract viewport from the rendered content div.
-          // Viewport matches content dimensions (2x render scale) exactly — no
-          // transform needed, Apple Books scales the viewport to fit the screen.
-          let fixedViewport: { width: number; height: number } | undefined
-          if (fixedLayout) {
-            const vp = rewrittenHtml.match(/width:(\d+)px;height:(\d+)px/)
-            if (vp) {
-              fixedViewport = { width: parseInt(vp[1], 10), height: parseInt(vp[2], 10) }
-            }
-          }
-
-          const pageHtml = renderPageHtml({
-            content: rewrittenHtml,
-            language,
-            sectionId,
-            pageTitle: title,
-            pageHeading: headingText?.text ?? title,
-            pageIndex: pageList.length + 1,
-            // Stepper answers travel inside the embedded JSON payload.
-            activityAnswers: stepperActivity ? undefined : rs.activityAnswers,
-            hasMath: sectionHasMath,
-            bundleVersion,
-            applyBodyBackground,
-            fixedViewport,
-            bodyFontFamily,
-          })
-          fs.writeFileSync(path.join(adtDir, filename), pageHtml)
-
-          const entry: PageEntry = {
-            section_id: sectionId,
-            href: filename,
-          }
-          if (sectionMeta?.pageNumber !== null && sectionMeta?.pageNumber !== undefined) {
-            entry.page_number = sectionMeta.pageNumber
-          }
-          pageList.push(entry)
-
-          // Track sectionId → pageIndex for sign language video mapping
-          sectionIdToPageIndex.set(sectionId, pageList.length) // pageIndex = pageList.length (1-based, already pushed)
-
-          // Build TOC entry from first heading text in this section
-          if (headingText) {
-            tocEntries.push({
-              section_id: sectionId,
-              href: filename,
-              title: headingText.text,
-              chapter_id: headingText.textId,
-            })
-          }
-        }
-      }
+  // Reading order revisits a page once per section, so per-page reads are
+  // memoized instead of hoisted out of a page-grouped loop.
+  const decorativeImageIdsByPage = new Map<string, Set<string>>()
+  const editableActivitiesByPage = new Map<string, ReturnType<typeof readEditableActivities>>()
+  const decorativeImageIdsFor = (pageId: string) => {
+    let ids = decorativeImageIdsByPage.get(pageId)
+    if (!ids) {
+      ids = buildDecorativeImageIdSet(storage, pageId)
+      decorativeImageIdsByPage.set(pageId, ids)
     }
+    return ids
+  }
+  const editableActivitiesFor = (pageId: string) => {
+    if (!editableActivitiesByPage.has(pageId)) {
+      editableActivitiesByPage.set(pageId, readEditableActivities(storage, pageId))
+    }
+    return editableActivitiesByPage.get(pageId)!
+  }
 
-    // Insert quiz pages after this page (even if page content was skipped)
-    for (const quiz of quizzes) {
-      const quizId = resolveQuizId(quiz, quizData!.quizzes.indexOf(quiz))
+  for (const item of readingOrder.items) {
+    const isFirstPage = pageList.length === 0
+    const filename = isFirstPage ? "index.html" : `${item.id}.html`
+    const pageIndex = pageList.length + 1
 
-      const isFirstPage = pageList.length === 0
-      const quizFilename = isFirstPage ? "index.html" : `${quizId}.html`
-
-      const quizHtmlContent = renderQuizHtml(quiz, quizId, catalog, quizStyle)
+    if (item.kind === "quiz") {
+      const quizHtmlContent = renderQuizHtml(item.quiz, item.id, catalog, quizStyle)
       const quizPageHtml = renderPageHtml({
         content: quizHtmlContent,
         language,
-        sectionId: quizId,
+        sectionId: item.id,
         pageTitle: title,
-        pageHeading: quiz.question,
-        pageIndex: pageList.length + 1,
-        activityAnswers: buildQuizAnswers(quiz, quizId),
+        pageHeading: item.quiz.question,
+        pageIndex,
+        activityAnswers: buildQuizAnswers(item.quiz, item.id),
         hasMath: false,
         bundleVersion,
         skipContentWrapper: true,
         applyBodyBackground,
         bodyFontFamily,
       })
-      const quizPath = path.resolve(adtDir, quizFilename)
+      const quizPath = path.resolve(adtDir, filename)
       if (path.dirname(quizPath) !== path.resolve(adtDir)) {
         throw new Error("Quiz output must remain inside the book's export directory")
       }
       fs.writeFileSync(quizPath, quizPageHtml)
 
-      pageList.push({ section_id: quizId, href: quizFilename })
+      // Phase 4 drops the index.html special case; until then the first page
+    // keeps that name, so the entry's href is overridden here rather than in
+    // the resolver (which is already position-independent).
+    pageList.push({ ...toPageEntry(item), href: filename })
+      continue
+    }
+
+    const { pageId, section: sectionMeta, rendering: rs, id: sectionId } = item
+    const decorativeImageIds = decorativeImageIdsFor(pageId)
+    const editableActivities = editableActivitiesFor(pageId)
+
+    if (rs.sectionType.startsWith("activity_") || sectionMeta.sectionType.startsWith("activity_")) {
+      hasActivitySections = true
+    }
+
+    // Step-by-step override: an enabled editable activity replaces the
+    // stored LLM HTML with the stepper shell (structured JSON + palette).
+    const stepperActivity = enabledEditableActivity(
+      editableActivities,
+      rs.sectionIndex,
+      rs.sectionType,
+    )
+
+    // Rewrite image URLs and copy referenced images
+    const preferredImageAltMap = buildPreferredImageAltMap(storage, pageId, sectionMeta)
+    let rewrittenHtml: string
+    let referencedImages: string[]
+    if (stepperActivity) {
+      const resolved = resolveEditableActivityImages(stepperActivity, imageMap, {
+        preferredAltMap: preferredImageAltMap,
+        decorativeImageIds,
+      })
+      rewrittenHtml = renderEditableActivityHtml(resolved.activity, {
+        palette: stepperBasePalette,
+      })
+      referencedImages = resolved.referencedImages
+    } else {
+      ;({ html: rewrittenHtml, referencedImages } = rewriteImageUrls(
+        rs.html,
+        label,
+        imageMap,
+        preferredImageAltMap,
+        decorativeImageIds,
+      ))
+    }
+
+    for (const imageId of referencedImages) {
+      if (!copiedImages.has(imageId)) {
+        const imageFilename = imageMap.get(imageId)
+        if (imageFilename) {
+          fs.copyFileSync(
+            path.join(bookDir, "images", imageFilename),
+            path.join(imageDir, imageFilename),
+          )
+          copiedImages.add(imageId)
+        }
+      }
+    }
+
+    // Convert LaTeX math to MathML (stepper shells are JSON — leave untouched)
+    const sectionHasMath = !stepperActivity && containsMathContent(rewrittenHtml)
+    if (sectionHasMath) {
+      hasMath = true
+      rewrittenHtml = convertLatexToMathml(rewrittenHtml)
+    }
+
+    const headingText = findHeadingText(sectionMeta)
+
+    // For fixed-layout pages, extract viewport from the rendered content div.
+    // Viewport matches content dimensions (2x render scale) exactly — no
+    // transform needed, Apple Books scales the viewport to fit the screen.
+    let fixedViewport: { width: number; height: number } | undefined
+    if (fixedLayout) {
+      const vp = rewrittenHtml.match(/width:(\d+)px;height:(\d+)px/)
+      if (vp) {
+        fixedViewport = { width: parseInt(vp[1], 10), height: parseInt(vp[2], 10) }
+      }
+    }
+
+    const pageHtml = renderPageHtml({
+      content: rewrittenHtml,
+      language,
+      sectionId,
+      pageTitle: title,
+      pageHeading: headingText?.text ?? title,
+      pageIndex,
+      // Stepper answers travel inside the embedded JSON payload.
+      activityAnswers: stepperActivity ? undefined : rs.activityAnswers,
+      hasMath: sectionHasMath,
+      bundleVersion,
+      applyBodyBackground,
+      fixedViewport,
+      bodyFontFamily,
+    })
+    fs.writeFileSync(path.join(adtDir, filename), pageHtml)
+
+    // Phase 4 drops the index.html special case; until then the first page
+    // keeps that name, so the entry's href is overridden here rather than in
+    // the resolver (which is already position-independent).
+    pageList.push({ ...toPageEntry(item), href: filename })
+
+    // Build TOC entry from first heading text in this section
+    if (headingText) {
+      tocEntries.push({
+        section_id: sectionId,
+        href: filename,
+        title: headingText.text,
+        chapter_id: headingText.textId,
+      })
     }
   }
 
@@ -596,15 +579,29 @@ export async function packageAdtWeb(
     // Map LLM entries to the flat format expected by the runtime, resolving
     // hrefs from the page list (the first page is always index.html)
     const hrefMap = new Map(pageList.map((p) => [p.section_id, p.href]))
-    const tocJson = llmToc.entries.map((e) => ({
-      section_id: e.sectionId,
-      href: hrefMap.get(e.sectionId) ?? e.href,
-      title: e.title,
-      chapter_id: e.chapterId,
-      level: e.level,
-    }))
+    const tocJson = llmToc.entries
+      // The LLM returns entries in its own order, which is independent of the
+      // reading order. Downstream consumers require document order: WebPub's
+      // nav nests a flat list by `level` as it walks it, and EPUB/PNLD NCX
+      // `playOrder` must increase monotonically. Sort by resolved position, and
+      // keep entries whose section is not in the reading order at the end
+      // rather than silently dropping them.
+      .map((entry, index) => ({ entry, index }))
+      .sort((a, b) => {
+        const posA = readingOrder.positionById.get(a.entry.sectionId) ?? Infinity
+        const posB = readingOrder.positionById.get(b.entry.sectionId) ?? Infinity
+        return posA === posB ? a.index - b.index : posA - posB
+      })
+      .map(({ entry: e }) => ({
+        section_id: e.sectionId,
+        href: hrefMap.get(e.sectionId) ?? e.href,
+        title: e.title,
+        chapter_id: e.chapterId,
+        level: e.level,
+      }))
     writeJson(path.join(contentDir, "toc.json"), tocJson)
   } else {
+    // Already accumulated in reading order.
     writeJson(path.join(contentDir, "toc.json"), tocEntries)
   }
 
@@ -810,7 +807,7 @@ export async function packageAdtWeb(
       // glossary-item videos (sectionId = `gl001`…) feed the glossary
       // popover/panel instead and stay out of the page map.
       const pageVideos = allVideos.filter(
-        (v) => v.sectionId && sectionIdToPageIndex.has(v.sectionId),
+        (v) => v.sectionId && readingOrder.positionById.has(v.sectionId),
       )
       const glossaryVideos = allVideos.filter(
         (v) => v.sectionId && glossaryTextIds.has(v.sectionId),
@@ -825,7 +822,7 @@ export async function packageAdtWeb(
         const srcPath = storage.getSignLanguageVideoPath(video.videoId)
         if (srcPath && fs.existsSync(srcPath)) {
           fs.copyFileSync(srcPath, path.join(videoDir, filename))
-          videosMap[`video-${sectionIdToPageIndex.get(video.sectionId!)}`] = filename
+          videosMap[`video-${readingOrder.positionById.get(video.sectionId!)}`] = filename
         }
       }
       for (const video of glossaryVideos) {
@@ -883,7 +880,7 @@ export async function packageAdtWeb(
   // Only page-section videos light up the runtime PIP player; glossary-item
   // videos (sectionId = `gl001`…) are an EPUB glossary-page concern.
   const hasSignLanguageVideos = (features?.signLanguage !== false) &&
-    storage.getSignLanguageVideos().some((v) => v.sectionId !== null && sectionIdToPageIndex.has(v.sectionId))
+    storage.getSignLanguageVideos().some((v) => v.sectionId !== null && readingOrder.positionById.has(v.sectionId))
 
   const configJson: Record<string, unknown> = {
     title,

--- a/packages/pipeline/src/packaging/web.ts
+++ b/packages/pipeline/src/packaging/web.ts
@@ -57,6 +57,7 @@ import { flattenEasyReadEntries } from "../easy-read.js"
 import { getCoreTtsCatalog, getReadyCoreTtsEntries } from "../core-tts.js"
 import { getRenderSectioning } from "../render-sectioning.js"
 import { resolveReadingOrder, toPageEntry, type PageEntry } from "../reading-order.js"
+import { orderTocEntries } from "../toc-reading-order.js"
 import { normalizeSectionRoles, promoteFirstHeadingToH1 } from "../html-semantics.js"
 import { escapeHtml, escapeAttr, escapeInlineScriptJson } from "../html-escape.js"
 import { buildTailwindCss } from "../tailwind.js"
@@ -441,9 +442,9 @@ export async function packageAdtWeb(
       fs.writeFileSync(quizPath, quizPageHtml)
 
       // Phase 4 drops the index.html special case; until then the first page
-    // keeps that name, so the entry's href is overridden here rather than in
-    // the resolver (which is already position-independent).
-    pageList.push({ ...toPageEntry(item), href: filename })
+      // keeps that name, so the entry's href is overridden here rather than in
+      // the resolver (which is already position-independent).
+      pageList.push({ ...toPageEntry(item), href: filename })
       continue
     }
 
@@ -574,25 +575,13 @@ export async function packageAdtWeb(
 
   writeJson(path.join(contentDir, "pages.json"), pageList)
 
-  // Table of contents — prefer LLM-generated TOC, fallback to heading-based
+  // Table of contents — prefer stored TOC (generated or edited), fallback to headings
   if (llmToc && llmToc.entries.length > 0) {
-    // Map LLM entries to the flat format expected by the runtime, resolving
+    // Preserve stored parent-child groups in the runtime TOC, resolving
     // hrefs from the page list (the first page is always index.html)
     const hrefMap = new Map(pageList.map((p) => [p.section_id, p.href]))
-    const tocJson = llmToc.entries
-      // The LLM returns entries in its own order, which is independent of the
-      // reading order. Downstream consumers require document order: WebPub's
-      // nav nests a flat list by `level` as it walks it, and EPUB/PNLD NCX
-      // `playOrder` must increase monotonically. Sort by resolved position, and
-      // keep entries whose section is not in the reading order at the end
-      // rather than silently dropping them.
-      .map((entry, index) => ({ entry, index }))
-      .sort((a, b) => {
-        const posA = readingOrder.positionById.get(a.entry.sectionId) ?? Infinity
-        const posB = readingOrder.positionById.get(b.entry.sectionId) ?? Infinity
-        return posA === posB ? a.index - b.index : posA - posB
-      })
-      .map(({ entry: e }) => ({
+    const tocJson = orderTocEntries(llmToc.entries, readingOrder.positionById)
+      .map((e) => ({
         section_id: e.sectionId,
         href: hrefMap.get(e.sectionId) ?? e.href,
         title: e.title,

--- a/packages/pipeline/src/reading-order.ts
+++ b/packages/pipeline/src/reading-order.ts
@@ -1,0 +1,210 @@
+/**
+ * Reading-order resolver — the single source of the book's output sequence.
+ *
+ * Before this existed, the same walk (pages by `page_number` → rendered sections
+ * by `sectionIndex` → quizzes by `afterPageId`) was reimplemented in packaging,
+ * in the live preview, and again for the preview's TOC and sign-language index.
+ * Those copies had already drifted: one sorted sections, another didn't; one
+ * renamed the first page to `index.html`, another didn't. Everything that needs
+ * to know "what order are the pages in" goes through here instead, so preview
+ * and export cannot disagree.
+ *
+ * The order is derived from source data today. Phase 5 slots a stored,
+ * user-editable order in at the marked point without moving any consumer.
+ */
+import type { Storage } from "@adt/storage"
+import type {
+  PageSectioningSection,
+  Quiz,
+  QuizGenerationOutput,
+  ReadingOrderItem,
+  SectionRendering,
+} from "@adt/types"
+import {
+  WebRenderingOutput as WebRenderingOutputSchema,
+  ensureQuizIds,
+  resolveQuizId,
+} from "@adt/types"
+import { getRenderSectioning } from "./render-sectioning.js"
+
+/** One output page, in reading order. */
+export type ResolvedItem =
+  | {
+      kind: "section"
+      /** Stable `sectionId` — also the bundle filename stem. */
+      id: string
+      /** Source page that owns this section. Provenance, not position. */
+      pageId: string
+      /** Array position within the page's sectioning / rendering — a lookup key. */
+      sectionIndex: number
+      section: PageSectioningSection
+      rendering: SectionRendering
+      /** Printed page number from the source PDF, when known. */
+      pageNumber: number | null
+    }
+  | {
+      kind: "quiz"
+      /** Stable `quizId` — also the bundle filename stem. */
+      id: string
+      quiz: Quiz
+      /** Array position in `quiz-generation.quizzes` — the catalog-id lookup key. */
+      quizIndex: number
+    }
+
+export interface ResolvedReadingOrder {
+  /** The output sequence. pages.json order, spine order, nav order. */
+  items: ResolvedItem[]
+  /**
+   * 1-based output position by item id. Replaces the ad-hoc `sectionIdToPageIndex`
+   * maps that consumers used to rebuild by walking the book a second time.
+   */
+  positionById: Map<string, number>
+}
+
+export interface ResolveReadingOrderOptions {
+  /** Drop quiz pages entirely (packaging with the quizzes feature disabled). */
+  includeQuizzes?: boolean
+}
+
+/** The `content/pages.json` entry shape, built in exactly one place. */
+export interface PageEntry {
+  section_id: string
+  href: string
+  page_number?: number
+}
+
+/** Bundle filename / preview route for an item. Always id-based, never positional. */
+export function readingOrderHref(item: ResolvedItem): string {
+  return `${item.id}.html`
+}
+
+export function toPageEntry(item: ResolvedItem): PageEntry {
+  const entry: PageEntry = { section_id: item.id, href: readingOrderHref(item) }
+  if (item.kind === "section" && item.pageNumber !== null) {
+    entry.page_number = item.pageNumber
+  }
+  return entry
+}
+
+/** Everything the resolver reads per page, gathered once. */
+interface PageContext {
+  pageId: string
+  sections: PageSectioningSection[]
+  /** Rendered entries, ascending by `sectionIndex`. */
+  rendering: SectionRendering[]
+}
+
+function readPageContexts(storage: Storage): PageContext[] {
+  return storage.getPages().map((page) => {
+    const sectioning = getRenderSectioning(storage, page.pageId)
+    const row = storage.getLatestNodeData("web-rendering", page.pageId)
+    const parsed = row ? WebRenderingOutputSchema.safeParse(row.data) : null
+    const rendering = parsed?.success ? [...parsed.data.sections] : []
+    rendering.sort((a, b) => a.sectionIndex - b.sectionIndex)
+    return { pageId: page.pageId, sections: sectioning?.sections ?? [], rendering }
+  })
+}
+
+/**
+ * The source-derived order: pages by `page_number`, each page's rendered
+ * sections by `sectionIndex`, then the quizzes anchored to that page.
+ *
+ * Emits pruned sections too — reading order tracks slots, and whether a slot is
+ * *shown* is a separate question answered by `isPruned`. Rendering entries with
+ * no matching sectioning row are dropped: their real `sectionId` is unknowable,
+ * and a positional guess could collide with a live section's id.
+ */
+export function defaultReadingOrder(
+  pageContexts: PageContext[],
+  quizzes: Quiz[]
+): ReadingOrderItem[] {
+  const quizzesByAfterPageId = new Map<string, Array<{ quiz: Quiz; index: number }>>()
+  quizzes.forEach((quiz, index) => {
+    const list = quizzesByAfterPageId.get(quiz.afterPageId) ?? []
+    list.push({ quiz, index })
+    quizzesByAfterPageId.set(quiz.afterPageId, list)
+  })
+
+  const items: ReadingOrderItem[] = []
+  for (const page of pageContexts) {
+    for (const entry of page.rendering) {
+      const section = page.sections[entry.sectionIndex]
+      if (!section) continue
+      items.push({ kind: "section", id: section.sectionId })
+    }
+    for (const { quiz, index } of quizzesByAfterPageId.get(page.pageId) ?? []) {
+      items.push({ kind: "quiz", id: resolveQuizId(quiz, index) })
+    }
+  }
+  return items
+}
+
+/**
+ * Resolve the book's output sequence.
+ *
+ * Pruned items are omitted from `items` — they exist in the book but not in the
+ * output — while keeping their slot in the underlying order, so un-pruning
+ * restores an item exactly where it was.
+ */
+export function resolveReadingOrder(
+  storage: Storage,
+  options: ResolveReadingOrderOptions = {}
+): ResolvedReadingOrder {
+  const pageContexts = readPageContexts(storage)
+
+  const quizRow = storage.getLatestNodeData("quiz-generation", "book")
+  const quizzes =
+    options.includeQuizzes === false || !quizRow
+      ? []
+      : ensureQuizIds(quizRow.data as QuizGenerationOutput).output.quizzes
+
+  // Phase 5 inserts the stored, user-editable order here, reconciled against
+  // this default. Until then the source-derived order is the only order.
+  const order = defaultReadingOrder(pageContexts, quizzes)
+
+  const sectionsById = new Map<
+    string,
+    { pageId: string; sectionIndex: number; section: PageSectioningSection; rendering: SectionRendering }
+  >()
+  for (const page of pageContexts) {
+    for (const entry of page.rendering) {
+      const section = page.sections[entry.sectionIndex]
+      if (!section) continue
+      sectionsById.set(section.sectionId, {
+        pageId: page.pageId,
+        sectionIndex: entry.sectionIndex,
+        section,
+        rendering: entry,
+      })
+    }
+  }
+  const quizzesById = new Map(
+    quizzes.map((quiz, index) => [resolveQuizId(quiz, index), { quiz, index }])
+  )
+
+  const items: ResolvedItem[] = []
+  for (const entry of order) {
+    if (entry.kind === "quiz") {
+      const hit = quizzesById.get(entry.id)
+      if (!hit) continue
+      items.push({ kind: "quiz", id: entry.id, quiz: hit.quiz, quizIndex: hit.index })
+      continue
+    }
+    const hit = sectionsById.get(entry.id)
+    if (!hit || hit.section.isPruned) continue
+    items.push({
+      kind: "section",
+      id: entry.id,
+      pageId: hit.pageId,
+      sectionIndex: hit.sectionIndex,
+      section: hit.section,
+      rendering: hit.rendering,
+      pageNumber: hit.section.pageNumber,
+    })
+  }
+
+  return {
+    items,
+    positionById: new Map(items.map((item, index) => [item.id, index + 1])),
+  }
+}

--- a/packages/pipeline/src/reading-order.ts
+++ b/packages/pipeline/src/reading-order.ts
@@ -22,7 +22,7 @@ import type {
 } from "@adt/types"
 import {
   WebRenderingOutput as WebRenderingOutputSchema,
-  ensureQuizIds,
+  withResolvedQuizIds,
   resolveQuizId,
 } from "@adt/types"
 import { getRenderSectioning } from "./render-sectioning.js"
@@ -156,7 +156,7 @@ export function resolveReadingOrder(
   const quizzes =
     options.includeQuizzes === false || !quizRow
       ? []
-      : ensureQuizIds(quizRow.data as QuizGenerationOutput).output.quizzes
+      : withResolvedQuizIds(quizRow.data as QuizGenerationOutput).quizzes
 
   // Phase 5 inserts the stored, user-editable order here, reconciled against
   // this default. Until then the source-derived order is the only order.

--- a/packages/pipeline/src/toc-generation.ts
+++ b/packages/pipeline/src/toc-generation.ts
@@ -17,6 +17,7 @@ import type { Storage, PageData } from "@adt/storage"
 import { buildLanguageContext } from "./language-context.js"
 import { stripHtml } from "./glossary.js"
 import { getRenderSectioning, getSemanticSectioning } from "./render-sectioning.js"
+import { resolveReadingOrder } from "./reading-order.js"
 
 export interface TocGenerationConfig {
   promptName: string
@@ -100,45 +101,45 @@ function collectHeadingsAndToc(
       }
     }
 
-    // Also check if the rendered section exists (so we have valid hrefs).
-    const renderRow = storage.getLatestNodeData("web-rendering", page.pageId)
-    const renderParsed = renderRow ? WebRenderingOutput.safeParse(renderRow.data) : null
-    const renderedIndices = new Set(
-      renderParsed?.success ? renderParsed.data.sections.map((s) => s.sectionIndex) : [],
-    )
+  }
 
-    // Collect first heading per non-pruned, rendered section.
-    let semanticSections: PageSectioningSection[] | null | undefined
-    for (let i = 0; i < sectioning.sections.length; i++) {
-      const section = sectioning.sections[i]
-      if (section.isPruned || !renderedIndices.has(i)) continue
+  // Collect the first heading of each section, in reading order — the LLM is
+  // asked to produce a table of contents, so it must see the book as a reader
+  // does. The resolver already drops pruned sections and any section with no
+  // rendered HTML (which would have no valid href).
+  const semanticSectionsByPage = new Map<string, PageSectioningSection[] | null>()
+  for (const item of resolveReadingOrder(storage, { includeQuizzes: false }).items) {
+    if (item.kind !== "section") continue
+    const section = item.section
 
-      let heading = findFirstHeading(section)
-      if (!heading && section.sectionType === "fixed-layout-page") {
-        // Fixed-layout pages render from a positioned tree that has no heading
-        // roles; read the semantic page-sectioning tree for the page instead.
-        if (semanticSections === undefined) {
-          semanticSections = getSemanticSectioning(storage, page.pageId)?.sections ?? null
-        }
-        for (const s of semanticSections ?? []) {
-          const h = findFirstHeading(s)
-          if (h) {
-            heading = h
-            break
-          }
+    let heading = findFirstHeading(section)
+    if (!heading && section.sectionType === "fixed-layout-page") {
+      // Fixed-layout pages render from a positioned tree that has no heading
+      // roles; read the semantic page-sectioning tree for the page instead.
+      if (!semanticSectionsByPage.has(item.pageId)) {
+        semanticSectionsByPage.set(
+          item.pageId,
+          getSemanticSectioning(storage, item.pageId)?.sections ?? null,
+        )
+      }
+      for (const s of semanticSectionsByPage.get(item.pageId) ?? []) {
+        const h = findFirstHeading(s)
+        if (h) {
+          heading = h
+          break
         }
       }
-      if (!heading) continue
-
-      headings.push({
-        sectionId: section.sectionId,
-        title: heading.text ?? "",
-        textId: heading.nodeId,
-        roleType: heading.role ?? "heading",
-        headingLevel: heading.headingLevel ?? headingLevelForRole(heading.role),
-        pageNumber: section.pageNumber,
-      })
     }
+    if (!heading) continue
+
+    headings.push({
+      sectionId: section.sectionId,
+      title: heading.text ?? "",
+      textId: heading.nodeId,
+      roleType: heading.role ?? "heading",
+      headingLevel: heading.headingLevel ?? headingLevelForRole(heading.role),
+      pageNumber: section.pageNumber,
+    })
   }
 
   return { headings, originalTocText }

--- a/packages/pipeline/src/toc-reading-order.ts
+++ b/packages/pipeline/src/toc-reading-order.ts
@@ -1,0 +1,57 @@
+import type { TocEntry } from "@adt/types"
+
+/**
+ * Order a TOC without changing the hierarchy encoded by its levels. A parent
+ * and its descendants move together, using their earliest resolved section as
+ * the group's position. Unlinked/pruned parents therefore stay with children;
+ * wholly unmatched groups sort last, stably, among comparable siblings.
+ *
+ * Siblings with different levels keep their relative runs. Moving a level-3
+ * sibling after a level-2 sibling would make it that sibling's child when the
+ * flat TOC is read again. Keeping those boundaries preserves skipped heading
+ * levels without rewriting user-authored levels or stored entries.
+ */
+export function orderTocEntries(
+  entries: readonly TocEntry[],
+  positionById: ReadonlyMap<string, number>,
+): TocEntry[] {
+  const roots: number[] = []
+  const children = entries.map(() => [] as number[])
+  const stack: number[] = []
+  const positions = entries.map((entry) => positionById.get(entry.sectionId) ?? Infinity)
+
+  for (let index = 0; index < entries.length; index++) {
+    while (stack.length && entries[stack[stack.length - 1]].level >= entries[index].level) {
+      stack.pop()
+    }
+    const parent = stack[stack.length - 1]
+    if (parent === undefined) roots.push(index)
+    else children[parent].push(index)
+    stack.push(index)
+  }
+
+  // Children have greater indices than their parent in the original preorder.
+  for (let index = entries.length - 1; index >= 0; index--) {
+    for (const child of children[index]) {
+      positions[index] = Math.min(positions[index], positions[child])
+    }
+  }
+
+  const result: TocEntry[] = []
+  const visit = (siblings: number[]) => {
+    for (let start = 0; start < siblings.length;) {
+      let end = start + 1
+      while (end < siblings.length && entries[siblings[end]].level === entries[siblings[start]].level) end++
+      const ordered = siblings.slice(start, end).sort((a, b) =>
+        positions[a] === positions[b] ? a - b : positions[a] - positions[b],
+      )
+      for (const index of ordered) {
+        result.push(entries[index])
+        visit(children[index])
+      }
+      start = end
+    }
+  }
+  visit(roots)
+  return result
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -350,6 +350,13 @@ export {
 } from "./toc.js"
 
 export {
+  READING_ORDER_NODE,
+  READING_ORDER_ITEM_ID,
+  ReadingOrderItem,
+  ReadingOrderOutput,
+} from "./reading-order.js"
+
+export {
   AccessibilityNodeResult,
   AccessibilityFinding,
   AccessibilityPageResult,

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -384,6 +384,13 @@ export {
 } from "./toc.js"
 
 export {
+  READING_ORDER_NODE,
+  READING_ORDER_ITEM_ID,
+  ReadingOrderItem,
+  ReadingOrderOutput,
+} from "./reading-order.js"
+
+export {
   AccessibilityNodeResult,
   AccessibilityFinding,
   AccessibilityPageResult,

--- a/packages/types/src/reading-order.ts
+++ b/packages/types/src/reading-order.ts
@@ -1,0 +1,36 @@
+import { z } from "zod"
+
+/**
+ * The book's output sequence: which pages the reader sees, in what order.
+ *
+ * Stored as a single book-level entity so a reorder is one versioned, roll-back-able
+ * change that never touches source data. Position in this list is the *output*
+ * position and is never written back to `pageNumber`, `sectionIndex`, or any
+ * asset name — source-PDF identity and provenance stay exactly as extracted.
+ *
+ * Items are referenced by their stable output ids (`pg003_sec002`, `qz001`),
+ * which is why those ids had to stop being positional first.
+ */
+export const READING_ORDER_NODE = "reading-order"
+export const READING_ORDER_ITEM_ID = "book"
+
+export const ReadingOrderItem = z.object({
+  kind: z.enum(["section", "quiz"]),
+  /** A stable `sectionId` or `quizId`. */
+  id: z.string().min(1),
+})
+export type ReadingOrderItem = z.infer<typeof ReadingOrderItem>
+
+export const ReadingOrderOutput = z.object({
+  /** Bumped only if the meaning of `items` ever changes. */
+  schemaVersion: z.literal(1).default(1),
+  /**
+   * The explicit output order. Holds pruned items too: a pruned item keeps its
+   * slot so re-including it restores its original position. Visibility is read
+   * from the entity itself (`section.isPruned`), never from this list — one
+   * writer per fact.
+   */
+  items: z.array(ReadingOrderItem),
+  updatedAt: z.string(),
+})
+export type ReadingOrderOutput = z.infer<typeof ReadingOrderOutput>


### PR DESCRIPTION
This PR consolidates the source-page → rendered-section → quiz ordering walk into `resolveReadingOrder`. Packaging, live preview, TOC generation, the TOC section picker, and sign-language page positions consume the same sequence. This fixes the section picker listing renderings in stored array order instead of `sectionIndex` order.

Targets `develop`. Prerequisites #784 and #785 are merged. This branch has been rebased onto develop commit `61ae503d`, preserving quiz identity validation and export path-containment protection.

This is the third slice of #660/#777. The reading-order schema prepares for the later stored-order feature; this PR does not yet expose user reordering or change the first packaged page's `index.html` filename.

The TOC change affects both generated and manually edited TOCs. A shared `orderTocEntries` helper sorts comparable sibling groups by their earliest resolved section while preserving their parent-child relationships. Unlinked or pruned parents stay with their children. Entirely unmatched groups retain stable ordering at the end of their comparable sibling run. Stored heading levels and entry data are preserved; different-level sibling boundaries stay in place so flattening cannot create accidental parent-child relationships.

For example, an unlinked “Unit one” followed by a linked level-2 “Chapter one” remains a parent and child in both preview and exported WebPub navigation. Sorting the flat entries independently previously separated them. Regression tests exercise the real TOC save/read routes, SQLite storage, preview, ADT packaging, and WebPub manifest hierarchy.

TOC generation also feeds headings to the LLM in resolved reading order, and packaging removes an unused image-caption read. EPUB/PNLD NCX numbering continues to derive from their page lists; TOC sorting is not required to establish that numbering.

Verification covers hierarchy preservation, unmatched entries, duplicate destinations, skipped heading levels, idempotence, legacy quiz rollback, invalid identities, preview/export parity, and quiz lifecycle/export protections. The original TOC regression was demonstrated failing before the correction.

Verification of the unchanged source tree before the rebase: Node 22 full Vitest run passed all 3,570 tests across 273 files; ten shuffled language-suite runs passed. Earlier Node 24 build, focused tests, full suite, lint (zero errors), and strict i18n compilation also passed. GitHub CI run 34605410052 passed test/typecheck, Docker, and i18n on its first attempt.

The test-cleanup commit explicitly unmounts translation test hooks before resetting their shared store. Vitest globals are disabled, so React Testing Library's automatic cleanup was not registered; the mounted hooks could schedule updates after jsdom teardown. This is a test-only correction for the observed asynchronous CI error.

Additional behavioral verification used isolated copies of a local 20-page book (16 visible output sections). All 331 files across ADT, WebPub, EPUB, and PNLD match the current parent after normalizing generated timestamps and publication UUIDs. Preview ordering matches, entity versions remain unchanged, and all EPUB/PNLD manifest resources and spine/NCX references resolve. Chromium and WebKit both passed complete forward/back navigation, first/last-page boundaries, both TOC destinations, and page-list jumps in live preview and the packaged reader, with no JavaScript exceptions. Existing optional-resource 404s were also observed on the parent. A separate 10,000-case deterministic TOC property check passed.

The history-only rebase produces head `322bb015` directly on current develop. Its complete source tree is identical to the previously reviewed `8a5ca7bd` tree. The single replay conflict was resolved by preserving the quiz export containment guard with the resolver's filename. Range-diff confirms the TOC correction and test-cleanup patches are unchanged. Fresh local build, 151 focused regression tests, and lint (zero errors, eight existing warnings) passed. CI verification for the rebased commit: [run 34608342197](https://github.com/unicef/adt-studio/actions/runs/34608342197).

External ebook reader applications and every possible customer book were not tested.
