### PR TITLE
fix(tts): honor Azure audio options for single regeneration

### DIFF
--- a/apps/api/src/routes/tts.test.ts
+++ b/apps/api/src/routes/tts.test.ts
@@ -722,6 +722,52 @@ speech:
     expect(readLatestLogParams(label)).toMatchObject({ outputFormat: "mp3_22050_32" })
   })
 
+  // Regression: this route used to construct the Azure synthesizer without
+  // audio options, silently falling back to 24 kHz / 48 kbitrate while a full
+  // Speech run correctly honored the book configuration.
+  it("honors speech.sample_rate/bit_rate for a single Azure regeneration", async () => {
+    fs.writeFileSync(
+      configPath,
+      `role_types:
+  section_text: Main body text
+structure_types:
+  paragraph: Paragraph
+speech:
+  default_provider: azure
+  sample_rate: 48000
+  bit_rate: "192kbitrate"
+  providers:
+    azure:
+      languages:
+        - en
+`
+    )
+    const label = "azure-audio-options"
+    seedBook(label)
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(new Uint8Array([53, 54]), {
+        status: 200,
+        headers: { "Content-Type": "audio/mpeg" },
+      })
+    )
+
+    const app = createTTSRoutes(tmpDir, configPath)
+    const res = await app.request(`/books/${label}/tts/generate-one`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Azure-Speech-Key": "az-test",
+        "X-Azure-Speech-Region": "eastus",
+      },
+      body: JSON.stringify({ textId: "pg001_t001", language: "en" }),
+    })
+    expect(res.status).toBe(200)
+
+    const headers = fetchMock.mock.calls[0]?.[1]?.headers as Record<string, string>
+    expect(headers["X-Microsoft-OutputFormat"]).toBe("audio-48khz-192kbitrate-mono-mp3")
+  })
+
   // Regression: ElevenLabs throttles on concurrent requests, so a 429 here used
   // to fail the entry outright — the only retry path was gated on Gemini's "did
   // not include audio data" message.

--- a/apps/api/src/routes/tts.ts
+++ b/apps/api/src/routes/tts.ts
@@ -900,10 +900,16 @@ export function createTTSRoutes(booksDir: string, configPath?: string, taskServi
             options.targetProvider === "gemini"
               ? createGeminiTTSSynthesizer({ apiKey: geminiApiKey })
               : options.targetProvider === "azure"
-                ? createAzureTTSSynthesizer({
-                    subscriptionKey: azureSpeechKey!,
-                    region: azureSpeechRegion!,
-                  })
+                ? createAzureTTSSynthesizer(
+                    {
+                      subscriptionKey: azureSpeechKey!,
+                      region: azureSpeechRegion!,
+                    },
+                    {
+                      sampleRate: config.speech?.sample_rate,
+                      bitRate: config.speech?.bit_rate,
+                    },
+                  )
                 : options.targetProvider === "elevenlabs"
                   ? createElevenLabsTTSSynthesizer(
                       { apiKey: elevenLabsApiKey! },


### PR DESCRIPTION
## Summary

Fixes #720. Single-item Azure TTS regeneration now passes the book's configured `speech.sample_rate` and `speech.bit_rate` into `createAzureTTSSynthesizer`, matching the full Speech-run and CLI/DAG paths.

Previously, a one-item regeneration silently used Azure's 24 kHz / 48 kbitrate defaults even when the rest of the book used another configured format.

## Changes

- Pass the configured Azure audio options in `POST /books/:label/tts/generate-one`.
- Add a regression test asserting that `48000` + `192kbitrate` produces the Azure header `audio-48khz-192kbitrate-mono-mp3`.

## Verification

- `vitest run apps/api/src/routes/tts.test.ts` — 20 passing tests.

## Scope

This fixes the existing backend endpoint only. Studio does not yet expose Azure per-item regeneration; that follow-up is tracked in #781. Provider-aware validation of Azure output combinations is tracked in #783.