### PR TITLE
Limit concurrent screenshot captures with a process-wide semaphore

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,29 @@ The `PIPELINE` constant in `@adt/types` defines all stages, their steps, labels,
 
 **Never hardcode stage/step ordering, names, or groupings outside of `PIPELINE`.** If you need a new derived lookup, add it to `packages/types/src/pipeline.ts` alongside the existing ones (`STAGE_ORDER`, `STEP_TO_STAGE`, `STAGE_BY_NAME`, `ALL_STEP_NAMES`).
 
+### Screenshot capture concurrency
+
+The Storyboard visual-refinement pass renders pages through one shared Chromium
+instance (`createScreenshotRenderer()` in `packages/pipeline/src/screenshot.ts`).
+Page concurrency (`config.concurrency`, default 32) multiplied by the three
+viewports in `SCREENSHOT_VIEWPORTS` would otherwise open ~96 browser contexts at
+once — captures then contend for the same browser and each one gets slower, which
+is what drove them past their timeout budget.
+
+`createScreenshotRenderer()` therefore wraps every renderer in a process-wide
+semaphore so at most `ADT_SCREENSHOT_CONCURRENCY` captures run simultaneously.
+The cap is shared across renderer instances on purpose: a stage run and an
+interactive page edit compete for the same machine, not just the same browser
+object. Queued captures wait rather than compete.
+
+Playwright's per-operation timeouts only start once an operation actually runs,
+so queue time does not eat a capture's budget. If you ever add an outer timeout
+around a capture, apply it **inside** the semaphore for the same reason —
+wrapping the whole `screenshot()` call would charge queue time against it.
+
+Set `ADT_SCREENSHOT_DEBUG=1` to log queue wait, capture duration, and semaphore
+occupancy per capture when tuning the limit for a given machine.
+
 ## Docker
 
 Three build targets in `Dockerfile`:
@@ -94,6 +117,8 @@ docker run -p 8080:80 -v ./books:/app/books adt-studio
 | `FONTS_CACHE_DIR` | `<BOOKS_DIR>/.fonts-cache` | Global Google Fonts cache shared across books (persists in the books volume by default) |
 | `STYLEGUIDES_DIR` | `<BOOKS_DIR>/.styleguides` | User-uploaded global style guides. LLM-generated guides live under each book's `styleguides/` directory so project exports remain self-contained. Bundled presets remain read-only. |
 | `PORT` | `3001` | Internal only — nginx proxies to this |
+| `ADT_SCREENSHOT_CONCURRENCY` | `min(8, max(2, cores - 1))` | Max simultaneous Chromium captures process-wide (see [Screenshot capture concurrency](#screenshot-capture-concurrency)) |
+| `ADT_SCREENSHOT_DEBUG` | unset | Set to any value to log per-capture queue wait, capture duration, and semaphore occupancy |
 
 **`TEMPLATES_DIR` trap:** The Dockerfile and `docker-compose.yml` set `TEMPLATES_DIR=/app/templates` but the application **never reads this env var**. Templates dir is always derived from `path.join(path.dirname(PROMPTS_DIR), "templates")`. To use a custom templates directory, mount it as a sibling of `prompts/` — i.e. override `PROMPTS_DIR` and keep `templates/` next to it.
 

--- a/packages/pipeline/src/__tests__/screenshot-concurrency.test.ts
+++ b/packages/pipeline/src/__tests__/screenshot-concurrency.test.ts
@@ -205,7 +205,7 @@ describe("_withCaptureLimit", () => {
     expect(tracked.peak()).toBe(0)
   })
 
-  it("does not start a queued capture that was aborted while waiting", async () => {
+  it("immediately removes and rejects a queued capture aborted while waiting", async () => {
     const gate = deferred<void>()
     let started = 0
     const limited = _withCaptureLimit({
@@ -226,10 +226,11 @@ describe("_withCaptureLimit", () => {
     const assertion = expect(queued).rejects.toThrow("cancelled")
     controller.abort(new Error("cancelled"))
 
-    gate.resolve()
-    await Promise.all(holding)
     await assertion
     expect(started).toBe(2)
+
+    gate.resolve()
+    await Promise.all(holding)
   })
 
   it("releases the slot when the underlying capture fails", async () => {

--- a/packages/pipeline/src/__tests__/screenshot-concurrency.test.ts
+++ b/packages/pipeline/src/__tests__/screenshot-concurrency.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import { createSemaphore } from "../concurrency.js"
+import {
+  _withCaptureLimit,
+  _resetCaptureSemaphore,
+  resolveScreenshotConcurrency,
+  type ScreenshotRenderer,
+} from "../screenshot.js"
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+describe("createSemaphore", () => {
+  it("never runs more than `limit` tasks at once", async () => {
+    const semaphore = createSemaphore(3)
+    let active = 0
+    let peak = 0
+
+    await Promise.all(
+      Array.from({ length: 20 }, () =>
+        semaphore.run(async () => {
+          active++
+          peak = Math.max(peak, active)
+          await new Promise((r) => setTimeout(r, 1))
+          active--
+        })
+      )
+    )
+
+    expect(peak).toBe(3)
+    expect(semaphore.active).toBe(0)
+    expect(semaphore.queued).toBe(0)
+  })
+
+  it("releases the slot when a task throws", async () => {
+    const semaphore = createSemaphore(1)
+
+    await expect(semaphore.run(async () => {
+      throw new Error("boom")
+    })).rejects.toThrow("boom")
+
+    expect(semaphore.active).toBe(0)
+    await expect(semaphore.run(async () => "ok")).resolves.toBe("ok")
+  })
+
+  it("runs queued tasks in FIFO order", async () => {
+    const semaphore = createSemaphore(1)
+    const order: number[] = []
+
+    await Promise.all(
+      [1, 2, 3, 4].map((n) =>
+        semaphore.run(async () => {
+          order.push(n)
+          await new Promise((r) => setTimeout(r, 1))
+        })
+      )
+    )
+
+    expect(order).toEqual([1, 2, 3, 4])
+  })
+
+  it("coerces invalid limits to at least 1", async () => {
+    expect(createSemaphore(0).limit).toBe(1)
+    expect(createSemaphore(-5).limit).toBe(1)
+    expect(createSemaphore(2.9).limit).toBe(2)
+  })
+})
+
+describe("resolveScreenshotConcurrency", () => {
+  const original = process.env.ADT_SCREENSHOT_CONCURRENCY
+
+  afterEach(() => {
+    if (original === undefined) delete process.env.ADT_SCREENSHOT_CONCURRENCY
+    else process.env.ADT_SCREENSHOT_CONCURRENCY = original
+  })
+
+  it("honours the env override", () => {
+    process.env.ADT_SCREENSHOT_CONCURRENCY = "3"
+    expect(resolveScreenshotConcurrency()).toBe(3)
+  })
+
+  it("ignores a non-numeric or out-of-range override", () => {
+    process.env.ADT_SCREENSHOT_CONCURRENCY = "not-a-number"
+    const fallback = resolveScreenshotConcurrency()
+    expect(fallback).toBeGreaterThanOrEqual(2)
+    expect(fallback).toBeLessThanOrEqual(8)
+
+    process.env.ADT_SCREENSHOT_CONCURRENCY = "0"
+    expect(resolveScreenshotConcurrency()).toBe(fallback)
+  })
+
+  it("stays within the tuned 2-8 band by default", () => {
+    delete process.env.ADT_SCREENSHOT_CONCURRENCY
+    const n = resolveScreenshotConcurrency()
+    expect(n).toBeGreaterThanOrEqual(2)
+    expect(n).toBeLessThanOrEqual(8)
+  })
+})
+
+describe("_withCaptureLimit", () => {
+  const original = process.env.ADT_SCREENSHOT_CONCURRENCY
+
+  beforeEach(() => {
+    process.env.ADT_SCREENSHOT_CONCURRENCY = "2"
+    _resetCaptureSemaphore()
+  })
+
+  afterEach(() => {
+    if (original === undefined) delete process.env.ADT_SCREENSHOT_CONCURRENCY
+    else process.env.ADT_SCREENSHOT_CONCURRENCY = original
+    _resetCaptureSemaphore()
+  })
+
+  function trackingRenderer() {
+    let active = 0
+    let peak = 0
+    let closed = false
+    const renderer: ScreenshotRenderer = {
+      async screenshot() {
+        active++
+        peak = Math.max(peak, active)
+        await new Promise((r) => setTimeout(r, 2))
+        active--
+        return "base64"
+      },
+      async close() {
+        closed = true
+      },
+    }
+    return {
+      renderer,
+      peak: () => peak,
+      closed: () => closed,
+    }
+  }
+
+  it("caps concurrent captures regardless of caller concurrency", async () => {
+    const tracked = trackingRenderer()
+    const limited = _withCaptureLimit(tracked.renderer)
+
+    await Promise.all(Array.from({ length: 30 }, () => limited.screenshot("<p>hi</p>")))
+
+    expect(tracked.peak()).toBe(2)
+  })
+
+  it("shares the cap across separate renderer instances", async () => {
+    let active = 0
+    let peak = 0
+    const make = (): ScreenshotRenderer => ({
+      async screenshot() {
+        active++
+        peak = Math.max(peak, active)
+        await new Promise((r) => setTimeout(r, 2))
+        active--
+        return "base64"
+      },
+      async close() {},
+    })
+
+    const a = _withCaptureLimit(make())
+    const b = _withCaptureLimit(make())
+
+    await Promise.all([
+      ...Array.from({ length: 10 }, () => a.screenshot("<p>a</p>")),
+      ...Array.from({ length: 10 }, () => b.screenshot("<p>b</p>")),
+    ])
+
+    expect(peak).toBe(2)
+  })
+
+  it("forwards html, viewport and options to the underlying renderer", async () => {
+    const calls: Array<[string, unknown, unknown]> = []
+    const limited = _withCaptureLimit({
+      async screenshot(html, viewport, options) {
+        calls.push([html, viewport, options])
+        return "base64"
+      },
+      async close() {},
+    })
+
+    const controller = new AbortController()
+    await limited.screenshot("<p>hi</p>", { width: 390, height: 844 }, { signal: controller.signal })
+
+    expect(calls).toEqual([
+      ["<p>hi</p>", { width: 390, height: 844 }, { signal: controller.signal }],
+    ])
+  })
+
+  it("rejects without consuming a slot when already aborted", async () => {
+    const tracked = trackingRenderer()
+    const limited = _withCaptureLimit(tracked.renderer)
+    const controller = new AbortController()
+    controller.abort(new Error("cancelled"))
+
+    await expect(
+      limited.screenshot("<p>hi</p>", undefined, { signal: controller.signal })
+    ).rejects.toThrow("cancelled")
+    expect(tracked.peak()).toBe(0)
+  })
+
+  it("does not start a queued capture that was aborted while waiting", async () => {
+    const gate = deferred<void>()
+    let started = 0
+    const limited = _withCaptureLimit({
+      async screenshot() {
+        started++
+        await gate.promise
+        return "base64"
+      },
+      async close() {},
+    })
+
+    const holding = [limited.screenshot("<p>1</p>"), limited.screenshot("<p>2</p>")]
+    await new Promise((r) => setTimeout(r, 0))
+    expect(started).toBe(2)
+
+    const controller = new AbortController()
+    const queued = limited.screenshot("<p>3</p>", undefined, { signal: controller.signal })
+    const assertion = expect(queued).rejects.toThrow("cancelled")
+    controller.abort(new Error("cancelled"))
+
+    gate.resolve()
+    await Promise.all(holding)
+    await assertion
+    expect(started).toBe(2)
+  })
+
+  it("releases the slot when the underlying capture fails", async () => {
+    let calls = 0
+    const limited = _withCaptureLimit({
+      async screenshot() {
+        calls++
+        if (calls === 1) throw new Error("capture failed")
+        return "base64"
+      },
+      async close() {},
+    })
+
+    await expect(limited.screenshot("<p>hi</p>")).rejects.toThrow("capture failed")
+    await expect(limited.screenshot("<p>hi</p>")).resolves.toBe("base64")
+  })
+
+  it("delegates close to the underlying renderer", async () => {
+    const tracked = trackingRenderer()
+    await _withCaptureLimit(tracked.renderer).close()
+    expect(tracked.closed()).toBe(true)
+  })
+})

--- a/packages/pipeline/src/concurrency.ts
+++ b/packages/pipeline/src/concurrency.ts
@@ -18,3 +18,59 @@ export async function processWithConcurrency<T>(
   }
   await Promise.all(executing)
 }
+
+export interface Semaphore {
+  /** Run `fn` once a slot is free. Queued callers wait instead of competing. */
+  run<T>(fn: () => Promise<T>): Promise<T>
+  readonly limit: number
+  readonly active: number
+  readonly queued: number
+}
+
+/**
+ * Counting semaphore for capping concurrent access to a shared resource
+ * (e.g. a single Chromium instance) independently of caller-level concurrency.
+ */
+export function createSemaphore(limit: number): Semaphore {
+  const max = Math.max(1, Math.floor(limit))
+  const waiters: Array<() => void> = []
+  let active = 0
+
+  function acquire(): Promise<void> {
+    if (active < max) {
+      active++
+      return Promise.resolve()
+    }
+    return new Promise<void>((resolve) => {
+      waiters.push(() => {
+        active++
+        resolve()
+      })
+    })
+  }
+
+  function release(): void {
+    active--
+    waiters.shift()?.()
+  }
+
+  return {
+    get limit() {
+      return max
+    },
+    get active() {
+      return active
+    },
+    get queued() {
+      return waiters.length
+    },
+    async run<T>(fn: () => Promise<T>): Promise<T> {
+      await acquire()
+      try {
+        return await fn()
+      } finally {
+        release()
+      }
+    },
+  }
+}

--- a/packages/pipeline/src/concurrency.ts
+++ b/packages/pipeline/src/concurrency.ts
@@ -21,7 +21,7 @@ export async function processWithConcurrency<T>(
 
 export interface Semaphore {
   /** Run `fn` once a slot is free. Queued callers wait instead of competing. */
-  run<T>(fn: () => Promise<T>): Promise<T>
+  run<T>(fn: () => Promise<T>, signal?: AbortSignal): Promise<T>
   readonly limit: number
   readonly active: number
   readonly queued: number
@@ -33,25 +33,46 @@ export interface Semaphore {
  */
 export function createSemaphore(limit: number): Semaphore {
   const max = Math.max(1, Math.floor(limit))
-  const waiters: Array<() => void> = []
+  const waiters: Array<{
+    grant: () => void
+    reject: (reason: Error) => void
+  }> = []
   let active = 0
 
-  function acquire(): Promise<void> {
+  function abortError(signal: AbortSignal): Error {
+    return signal.reason instanceof Error ? signal.reason : new Error("Operation aborted")
+  }
+
+  function acquire(signal?: AbortSignal): Promise<void> {
+    if (signal?.aborted) return Promise.reject(abortError(signal))
     if (active < max) {
       active++
       return Promise.resolve()
     }
-    return new Promise<void>((resolve) => {
-      waiters.push(() => {
-        active++
-        resolve()
-      })
+
+    return new Promise<void>((resolve, reject) => {
+      const waiter = {
+        grant: () => {
+          signal?.removeEventListener("abort", onAbort)
+          active++
+          resolve()
+        },
+        reject,
+      }
+      const onAbort = () => {
+        const index = waiters.indexOf(waiter)
+        if (index === -1) return
+        waiters.splice(index, 1)
+        reject(abortError(signal!))
+      }
+      signal?.addEventListener("abort", onAbort, { once: true })
+      waiters.push(waiter)
     })
   }
 
   function release(): void {
     active--
-    waiters.shift()?.()
+    waiters.shift()?.grant()
   }
 
   return {
@@ -64,8 +85,8 @@ export function createSemaphore(limit: number): Semaphore {
     get queued() {
       return waiters.length
     },
-    async run<T>(fn: () => Promise<T>): Promise<T> {
-      await acquire()
+    async run<T>(fn: () => Promise<T>, signal?: AbortSignal): Promise<T> {
+      await acquire(signal)
       try {
         return await fn()
       } finally {

--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -3,7 +3,7 @@ export {
   nullProgress,
   createConsoleProgress,
 } from "./progress.js"
-export { processWithConcurrency } from "./concurrency.js"
+export { processWithConcurrency, createSemaphore, type Semaphore } from "./concurrency.js"
 export {
   extractPDF,
   resolveFigureExtractionMode,
@@ -130,6 +130,7 @@ export {
 } from "./visual-review.js"
 export {
   createScreenshotRenderer,
+  resolveScreenshotConcurrency,
   SCREENSHOT_VIEWPORTS,
   getViewportBreakpoints,
   type ScreenshotRenderer,

--- a/packages/pipeline/src/screenshot.ts
+++ b/packages/pipeline/src/screenshot.ts
@@ -7,11 +7,13 @@
  */
 
 import { randomUUID } from "node:crypto"
+import os from "node:os"
 import {
   screenshotIpcCloseSchema,
   screenshotIpcReplySchema,
   screenshotIpcRequestSchema,
 } from "@adt/types"
+import { createSemaphore, type Semaphore } from "./concurrency.js"
 
 export const SCREENSHOT_VIEWPORTS = [
   { label: "desktop", width: 1280, height: 800 },
@@ -100,11 +102,79 @@ export async function _createScreenshotRenderer(): Promise<ScreenshotRenderer> {
 }
 
 
+function detectCpuCount(): number {
+  const runtime = os as typeof os & { availableParallelism?: () => number }
+  const count = runtime.availableParallelism?.() ?? os.cpus().length
+  return Number.isFinite(count) && count > 0 ? count : 4
+}
+
+/**
+ * Captures per browser instance, capped independently of page concurrency.
+ * A whole book run can have dozens of pages in flight, each asking for three
+ * viewport captures — all served by one Chromium. Above a handful of
+ * simultaneous contexts they just contend and every capture gets slower, which
+ * is what pushed captures past their timeout budget. Tuned to cores, with
+ * `ADT_SCREENSHOT_CONCURRENCY` as an escape hatch.
+ */
+export function resolveScreenshotConcurrency(): number {
+  const override = Number(process.env?.ADT_SCREENSHOT_CONCURRENCY)
+  if (Number.isFinite(override) && override >= 1) return Math.floor(override)
+  return Math.min(8, Math.max(2, detectCpuCount() - 1))
+}
+
+let captureSemaphore: Semaphore | null = null
+
+function getCaptureSemaphore(): Semaphore {
+  if (!captureSemaphore) captureSemaphore = createSemaphore(resolveScreenshotConcurrency())
+  return captureSemaphore
+}
+
+/** Test seam — resets the process-wide capture limit. */
+export function _resetCaptureSemaphore(): void {
+  captureSemaphore = null
+}
+
+function logCapture(waitMs: number, captureMs: number, outcome: "ok" | "error"): void {
+  if (!process.env?.ADT_SCREENSHOT_DEBUG) return
+  const sem = getCaptureSemaphore()
+  console.log(
+    `[screenshot] ${outcome} wait=${Math.round(waitMs)}ms capture=${Math.round(captureMs)}ms ` +
+      `active=${sem.active}/${sem.limit} queued=${sem.queued}`
+  )
+}
+
+/**
+ * Bound concurrent captures process-wide. The limit is shared across every
+ * renderer instance because the contention is for machine resources, not for
+ * one browser object — a stage run and an interactive page edit compete too.
+ */
+export function _withCaptureLimit(renderer: ScreenshotRenderer): ScreenshotRenderer {
+  return {
+    async screenshot(html, viewport, options): Promise<string> {
+      throwIfAborted(options?.signal)
+      const queuedAt = performance.now()
+      return getCaptureSemaphore().run(async () => {
+        const startedAt = performance.now()
+        throwIfAborted(options?.signal)
+        try {
+          const result = await renderer.screenshot(html, viewport, options)
+          logCapture(startedAt - queuedAt, performance.now() - startedAt, "ok")
+          return result
+        } catch (err) {
+          logCapture(startedAt - queuedAt, performance.now() - startedAt, "error")
+          throw err
+        }
+      })
+    },
+    close: () => renderer.close(),
+  }
+}
+
 export async function createScreenshotRenderer(): Promise<ScreenshotRenderer> {
   if (process.env?.ADT_ENVIRONMENT === 'electron') {
-    return _createElectronScreenshotRenderer()
+    return _withCaptureLimit(await _createElectronScreenshotRenderer())
   }
-  return _createScreenshotRenderer()
+  return _withCaptureLimit(await _createScreenshotRenderer())
 }
 
 type ParentPortLike = {

--- a/packages/pipeline/src/screenshot.ts
+++ b/packages/pipeline/src/screenshot.ts
@@ -164,7 +164,7 @@ export function _withCaptureLimit(renderer: ScreenshotRenderer): ScreenshotRende
           logCapture(startedAt - queuedAt, performance.now() - startedAt, "error")
           throw err
         }
-      })
+      }, options?.signal)
     },
     close: () => renderer.close(),
   }


### PR DESCRIPTION
## Summary

- Adds a process-wide semaphore to limit concurrent screenshot captures.
- Prevents Chromium context contention during Storyboard visual refinement.
- Supports immediate cancellation of queued captures.
- Adds configurable concurrency through `ADT_SCREENSHOT_CONCURRENCY`.
- Adds optional capture timing diagnostics through `ADT_SCREENSHOT_DEBUG`.

## Validation

- Added semaphore and screenshot concurrency tests.
- Pipeline TypeScript build passes.
- All related tests pass.

Closes #661.
