### PR TITLE
feat(desktop): show onboarding once per installed version

### DIFF
--- a/apps/desktop/src/main/services/onboarding-state.ts
+++ b/apps/desktop/src/main/services/onboarding-state.ts
@@ -3,6 +3,9 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 interface OnboardingState {
+  /** App version for which the user last finished onboarding. */
+  completedVersion?: string;
+  /** Legacy flag from builds that tracked completion as a boolean. Ignored. */
   completed?: boolean;
 }
 
@@ -26,10 +29,24 @@ function writeState(state: OnboardingState): void {
   }
 }
 
+/**
+ * Onboarding runs once per installed version. Completion is stamped with the
+ * app version, and any version that differs from the last completed one shows
+ * the flow again — so a fresh install (no state) and every install/update run
+ * onboarding, regardless of whether the user installed the app before.
+ *
+ * This is keyed on the version because macOS keeps `userData` across
+ * uninstall/reinstall: a plain boolean flag would suppress onboarding forever
+ * after the first run, even on a brand-new install of a new build.
+ *
+ * Note: reinstalling the *exact same version* won't re-show onboarding, since
+ * the persisted version still matches. Normal releases always bump the version,
+ * so each distributed install shows it once.
+ */
 export function hasCompletedOnboarding(): boolean {
-  return readState().completed === true;
+  return readState().completedVersion === app.getVersion();
 }
 
 export function markOnboardingCompleted(): void {
-  writeState({ ...readState(), completed: true });
+  writeState({ completedVersion: app.getVersion() });
 }


### PR DESCRIPTION
## What

Keys first-run onboarding completion on the **app version** instead of a boolean flag, so onboarding runs once per installed version.

`apps/desktop/src/main/services/onboarding-state.ts`:
- `hasCompletedOnboarding()` → `readState().completedVersion === app.getVersion()`
- `markOnboardingCompleted()` → writes `{ completedVersion: <app version> }`

## Why

Completion is persisted in `onboarding-state.json` under the app's `userData`, and **macOS keeps `userData` across uninstall/reinstall**. A plain boolean flag therefore suppresses onboarding forever after the first run — even on a brand-new install of a newer build. Keying on the version fixes that: a fresh install (no state) and every install/update run the flow once.

## Behavior

| State | Shows onboarding? |
|---|---|
| No state file (fresh install) | ✅ yes |
| Legacy `{"completed":true}` (older builds) | ✅ yes, once (migration) |
| `completedVersion` == current version | ❌ no (already onboarded) |
| `completedVersion` != current version (update / new install) | ✅ yes |

Since every release bumps the version, each distributed install/update shows onboarding once.

**Caveat:** reinstalling the *exact same version* won't re-show it (the persisted version still matches, and there's no reliable macOS "fresh install" signal). Normal releases always bump the version.

## Testing

Verified in a local unpacked build (`build:unpack`) by driving `onboarding-state.json` at the real userData path (`~/Library/Application Support/@adt/desktop/`):
- no file → onboarding ✅
- legacy `{"completed":true}` → onboarding ✅
- matching version → main window, no onboarding ✅
- mismatched version → onboarding ✅

Only the main-process gate changes; the renderer's `/` localStorage guard is unaffected (the onboarding window loads `/onboarding` directly).