### PR TITLE
feat(studio): redesigned in-app update UI — themed banner + ambient card

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -35,7 +35,10 @@ import {
   STUDIO_APP_SCHEME_PRIVILEGES,
 } from "./protocols/studio-app";
 
-import { checkForUpdates } from "./services/auto-updater";
+import {
+  checkForUpdates,
+  startPeriodicUpdateChecks,
+} from "./services/auto-updater";
 import { initPostUpdateDetection } from "./services/update-state";
 import { setStartupError } from "./services/debug-info";
 
@@ -119,6 +122,7 @@ app.whenReady().then(async () => {
       if (!splashWindow.isDestroyed()) splashWindow.destroy();
       if (closeAfter && !closeAfter.isDestroyed()) closeAfter.destroy();
       checkForUpdates().catch(() => {});
+      startPeriodicUpdateChecks();
     });
 
     return win;

--- a/apps/desktop/src/main/services/auto-updater.ts
+++ b/apps/desktop/src/main/services/auto-updater.ts
@@ -234,6 +234,43 @@ export async function checkForUpdates(): Promise<UpdateStatus> {
   }
 }
 
+const PERIODIC_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6 hours
+
+let periodicCheckTimer: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * Poll for updates on a fixed interval so a new release surfaces mid-session,
+ * not only at launch. Skips while a check/download/install is already in flight
+ * (a re-check would clobber that state). Idempotent; no-op when unpacked / dev.
+ */
+export function startPeriodicUpdateChecks(
+  intervalMs: number = PERIODIC_CHECK_INTERVAL_MS,
+): void {
+  if (periodicCheckTimer || !app.isPackaged) return;
+
+  periodicCheckTimer = setInterval(() => {
+    const phase = lastStatus.phase;
+    if (
+      phase === "checking" ||
+      phase === "downloading" ||
+      phase === "downloaded" ||
+      phase === "installing"
+    ) {
+      return;
+    }
+    checkForUpdates().catch(() => {});
+  }, intervalMs);
+
+  // The interval must not keep the app alive on its own.
+  periodicCheckTimer.unref?.();
+}
+
+export function stopPeriodicUpdateChecks(): void {
+  if (!periodicCheckTimer) return;
+  clearInterval(periodicCheckTimer);
+  periodicCheckTimer = null;
+}
+
 export async function listAvailableVersions(
   force = false,
 ): Promise<AvailableRelease[]> {

--- a/apps/studio/src/components/updates/PostUpdateDialog.tsx
+++ b/apps/studio/src/components/updates/PostUpdateDialog.tsx
@@ -8,9 +8,9 @@ import {
   DialogDescription,
   DialogTitle,
 } from "@/components/ui/dialog"
-import { ReleaseFallbackBanner } from "./ReleaseFallbackBanner"
+import { ReleaseCoverBanner } from "./ReleaseCoverBanner"
 import { ReleaseNotesMarkdown } from "./ReleaseNotesMarkdown"
-import { formatVersion, releaseNotesHaveImage } from "./release-banner-utils"
+import { formatVersion } from "./release-banner-utils"
 
 export interface PostUpdateDialogProps {
   open: boolean
@@ -58,11 +58,10 @@ export function PostUpdateContent({
   TitleTag = "h2",
 }: PostUpdateContentProps) {
   const label = formatVersion(version)
-  const showFallbackBanner = !releaseNotesHaveImage(releaseNotes)
   const notes = releaseNotes?.trim()
 
   return (
-    <div className="flex h-200 max-h-[calc(100vh-2rem)] flex-col">
+    <div className="flex max-h-[calc(100vh-4rem)] flex-col">
       <div className="flex shrink-0 items-center gap-3 px-6 pb-4 pt-6">
         <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
           <Sparkles className="size-5" />
@@ -77,15 +76,13 @@ export function PostUpdateContent({
         </div>
       </div>
 
-      {showFallbackBanner && (
-        <div className="shrink-0 px-6 pb-5">
-          <ReleaseFallbackBanner className="max-h-70" version={version} />
-        </div>
-      )}
+      <div className="shrink-0 px-6 pb-5">
+        <ReleaseCoverBanner version={version} notes={releaseNotes} />
+      </div>
 
       {notes ? (
         <div className="min-h-0 flex-1 overflow-auto border-y px-6 py-4">
-          <ReleaseNotesMarkdown>{notes}</ReleaseNotesMarkdown>
+          <ReleaseNotesMarkdown hideImages>{notes}</ReleaseNotesMarkdown>
         </div>
       ) : (
         <div className="flex min-h-0 flex-1 items-start px-6 pt-1">

--- a/apps/studio/src/components/updates/ReleaseCoverBanner.tsx
+++ b/apps/studio/src/components/updates/ReleaseCoverBanner.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useMemo, useState } from "react"
+import { useIsDarkTheme } from "@/hooks/use-is-dark-theme"
+import { cn } from "@/lib/utils"
+import { ReleaseFallbackBanner } from "./ReleaseFallbackBanner"
+import {
+  parseReleaseCover,
+  RELEASE_BANNER_ASPECT,
+  type ReleaseChannel,
+} from "./release-banner-utils"
+
+export interface ReleaseCoverBannerProps {
+  version: string
+  notes?: string
+  channel?: ReleaseChannel
+  className?: string
+}
+
+/**
+ * Renders the release's own themed cover (light/dark chosen from the active
+ * theme). Falls back to the generated {@link ReleaseFallbackBanner} when the
+ * release ships no usable cover or the image fails to load.
+ */
+export function ReleaseCoverBanner({
+  version,
+  notes,
+  channel,
+  className,
+}: ReleaseCoverBannerProps) {
+  const isDark = useIsDarkTheme()
+  const cover = useMemo(() => parseReleaseCover(notes), [notes])
+  const [failed, setFailed] = useState(false)
+
+  const src = isDark ? (cover.dark ?? cover.light) : (cover.light ?? cover.dark)
+
+  // A new/other cover (theme toggle or version change) deserves a fresh attempt.
+  useEffect(() => setFailed(false), [src])
+
+  if (!src || failed) {
+    return (
+      <ReleaseFallbackBanner
+        version={version}
+        channel={channel}
+        className={className}
+      />
+    )
+  }
+
+  return (
+    <img
+      src={src}
+      alt=""
+      loading="lazy"
+      onError={() => setFailed(true)}
+      className={cn(
+        "w-full rounded-lg border bg-muted/30 object-cover transition-opacity",
+        RELEASE_BANNER_ASPECT,
+        className,
+      )}
+    />
+  )
+}

--- a/apps/studio/src/components/updates/ReleaseNotesMarkdown.test.tsx
+++ b/apps/studio/src/components/updates/ReleaseNotesMarkdown.test.tsx
@@ -28,6 +28,41 @@ Full Changelog: https://github.com/unicef/adt-studio/compare/v0.7.4-beta.3...v0.
     expect(screen.queryByText(/https:\/\/github\.com/)).toBeNull()
   })
 
+  it("renders GitHub HTML release notes as structured content, not raw tags", () => {
+    render(
+      <ReleaseNotesMarkdown>{`<h2>What's Changed</h2>
+<ul>
+<li>feat(i18n): add Albanian (Kosovo) locale to Studio by <a class="user-mention" href="https://github.com/Eliezir">@Eliezir</a> in <a href="https://github.com/unicef/adt-studio/pull/593">#593</a></li>
+</ul>`}</ReleaseNotesMarkdown>,
+    )
+
+    expect(screen.getByRole("heading", { name: "What's Changed" })).toBeTruthy()
+    expect(screen.getByRole("listitem").textContent).toContain(
+      "feat(i18n): add Albanian (Kosovo) locale to Studio",
+    )
+    expect(
+      screen.getByRole("link", { name: "@Eliezir" }).getAttribute("href"),
+    ).toBe("https://github.com/Eliezir")
+    expect(
+      screen.getByRole("link", { name: "#593" }).getAttribute("href"),
+    ).toBe("https://github.com/unicef/adt-studio/pull/593")
+    expect(screen.queryByText(/<li>|<ul>|<h2>/)).toBeNull()
+  })
+
+  it("keeps parsing Markdown when the notes merely mention an HTML tag", () => {
+    render(
+      <ReleaseNotesMarkdown>{`## Fixes
+
+- Fixed \`<div>\` overflow in the reader
+      `}</ReleaseNotesMarkdown>,
+    )
+
+    expect(screen.getByRole("heading", { name: "Fixes" })).toBeTruthy()
+    expect(screen.getByRole("listitem").textContent).toContain(
+      "Fixed <div> overflow in the reader",
+    )
+  })
+
   it("renders images from trusted hosts and drops untrusted ones", () => {
     render(
       <ReleaseNotesMarkdown>{`

--- a/apps/studio/src/components/updates/ReleaseNotesMarkdown.tsx
+++ b/apps/studio/src/components/updates/ReleaseNotesMarkdown.tsx
@@ -5,6 +5,7 @@ import { RELEASE_BANNER_ASPECT, trustedAssetUrl } from "./release-banner-utils"
 export interface ReleaseNotesMarkdownProps {
   children: string
   className?: string
+  hideImages?: boolean
 }
 
 type Block =
@@ -17,8 +18,14 @@ type Block =
 export function ReleaseNotesMarkdown({
   children,
   className,
+  hideImages,
 }: ReleaseNotesMarkdownProps) {
-  const blocks = parseBlocks(children)
+  const parsed = looksLikeHtml(children)
+    ? parseHtmlBlocks(children)
+    : parseBlocks(children)
+  const blocks = hideImages
+    ? parsed.filter((block) => block.type !== "image")
+    : parsed
 
   return (
     <div className={cn("space-y-3 text-sm leading-relaxed", className)}>
@@ -163,6 +170,121 @@ function parseBlocks(markdown: string): Block[] {
   flushParagraph()
   flushList()
   return blocks
+}
+
+// Match a *closing* block tag rather than any opening tag name. GitHub's rendered
+// release notes always close their blocks (</h2>, </ul>, </li>, </p>…), while a
+// Markdown note that merely mentions a tag in prose or a code span (`<div>`)
+// almost never does — so this avoids routing real Markdown through the HTML path.
+const HTML_BLOCK_TAGS =
+  /<\/(?:h[1-6]|ul|ol|li|p|blockquote|pre|table|thead|tbody|tr|td)>/i
+
+function looksLikeHtml(value: string): boolean {
+  return HTML_BLOCK_TAGS.test(value)
+}
+
+function parseHtmlBlocks(html: string): Block[] {
+  if (typeof DOMParser === "undefined") {
+    return parseBlocks(html.replace(/<[^>]+>/g, " "))
+  }
+  const doc = new DOMParser().parseFromString(html, "text/html")
+  const blocks: Block[] = []
+  collectHtmlBlocks(doc.body, blocks)
+  return blocks
+}
+
+function collectHtmlBlocks(root: ParentNode, blocks: Block[]): void {
+  for (const node of Array.from(root.childNodes)) {
+    if (node.nodeType === Node.TEXT_NODE) {
+      const text = collapse(node.textContent ?? "")
+      if (text) blocks.push({ type: "paragraph", text })
+      continue
+    }
+
+    if (!(node instanceof Element)) continue
+    const tag = node.tagName.toLowerCase()
+
+    if (/^h[1-6]$/.test(tag)) {
+      const text = htmlInlineToText(node)
+      if (text) blocks.push({ type: "heading", text })
+      continue
+    }
+
+    if (tag === "ul" || tag === "ol") {
+      const items = Array.from(node.children)
+        .filter((child) => child.tagName.toLowerCase() === "li")
+        .map((li) => htmlInlineToText(li))
+        .filter(Boolean)
+      if (items.length) blocks.push({ type: "list", items })
+      continue
+    }
+
+    if (tag === "img" || tag === "picture") {
+      const src = htmlImageSrc(node)
+      if (src) blocks.push({ type: "image", src, alt: htmlImageAlt(node) })
+      continue
+    }
+
+    if (tag === "hr") {
+      blocks.push({ type: "rule" })
+      continue
+    }
+
+    if (tag === "p" || tag === "blockquote") {
+      const image = node.querySelector("img")
+      const src = image ? htmlImageSrc(image) : undefined
+      if (src) blocks.push({ type: "image", src, alt: htmlImageAlt(image!) })
+      const text = htmlInlineToText(node)
+      if (text) blocks.push({ type: "paragraph", text })
+      continue
+    }
+
+    collectHtmlBlocks(node, blocks)
+  }
+}
+
+function htmlInlineToText(root: Node): string {
+  let out = ""
+  for (const node of Array.from(root.childNodes)) {
+    if (node.nodeType === Node.TEXT_NODE) {
+      out += node.textContent ?? ""
+      continue
+    }
+    if (!(node instanceof Element)) continue
+    const tag = node.tagName.toLowerCase()
+    if (tag === "br") {
+      out += " "
+      continue
+    }
+    if (tag === "img") continue
+    if (tag === "a") {
+      const href = node.getAttribute("href") ?? ""
+      const label = htmlInlineToText(node)
+      out += /^https?:\/\//i.test(href) && label ? `[${label}](${href})` : label
+      continue
+    }
+    out += htmlInlineToText(node)
+  }
+  return collapse(out)
+}
+
+function htmlImageSrc(node: Element): string | undefined {
+  if (node.tagName.toLowerCase() === "img") {
+    return trustedAssetUrl(node.getAttribute("src") ?? undefined)
+  }
+  const source = node.querySelector("source[srcset]")
+  const fromSource = source?.getAttribute("srcset")?.trim().split(/\s+/)[0]
+  const img = node.querySelector("img")
+  return trustedAssetUrl(fromSource ?? img?.getAttribute("src") ?? undefined)
+}
+
+function htmlImageAlt(node: Element): string {
+  const img = node.tagName.toLowerCase() === "img" ? node : node.querySelector("img")
+  return img?.getAttribute("alt") ?? ""
+}
+
+function collapse(value: string): string {
+  return value.replace(/\s+/g, " ").trim()
 }
 
 function normalizeImages(markdown: string): {

--- a/apps/studio/src/components/updates/UpdateDialog.tsx
+++ b/apps/studio/src/components/updates/UpdateDialog.tsx
@@ -18,6 +18,7 @@ export interface UpdateDialogProps {
   statusOverride?: UpdateStatus
   modal?: boolean
   onShowWhatsNew?: () => void
+  onSeeDetails?: (payload: { version: string; releaseNotes?: string }) => void
 }
 
 export function UpdateDialog({
@@ -26,11 +27,16 @@ export function UpdateDialog({
   statusOverride,
   modal,
   onShowWhatsNew,
+  onSeeDetails,
 }: UpdateDialogProps) {
   const currentVersion = useAppVersion()
   const live = useUpdateStatus()
   const status = statusOverride ?? live.status
   const { check, download, cancel, install, installOnQuit } = live
+  const detailsPayload =
+    status.phase === "available" || status.phase === "downloaded"
+      ? { version: status.version, releaseNotes: status.releaseNotes }
+      : null
   const showBetaVersions =
     currentVersion != null &&
     getReleaseChannel(currentVersion) === "beta" &&
@@ -75,6 +81,11 @@ export function UpdateDialog({
             }}
             onClose={close}
             onShowWhatsNew={onShowWhatsNew}
+            onSeeDetails={
+              onSeeDetails && detailsPayload
+                ? () => onSeeDetails(detailsPayload)
+                : undefined
+            }
           />
         )}
       </DialogContent>

--- a/apps/studio/src/components/updates/UpdateDialogProvider.tsx
+++ b/apps/studio/src/components/updates/UpdateDialogProvider.tsx
@@ -4,12 +4,13 @@ import {
   useContext,
   useEffect,
   useMemo,
-  useRef,
   useState,
   type ReactNode,
 } from "react"
+import { useRouterState } from "@tanstack/react-router"
 import { UpdateDialog } from "./UpdateDialog"
 import { PostUpdateDialog } from "./PostUpdateDialog"
+import { UpdateToast } from "./UpdateToast"
 import { useAppVersion } from "@/hooks/use-app-version"
 import { useUpdateStatus } from "@/hooks/use-update-status"
 import { isElectron } from "@/lib/utils"
@@ -30,11 +31,21 @@ export function useUpdateDialog(): UpdateDialogContextValue {
   return useContext(UpdateDialogContext)
 }
 
+/**
+ * Pipeline routes are `/books/<label>/…`. `/books/new` and `/books/import` are
+ * the wizard and importer, which sit outside the pipeline shell.
+ */
+export function isPipelineRoute(pathname: string): boolean {
+  const match = /^\/books\/([^/]+)/.exec(pathname)
+  if (!match) return false
+  return match[1] !== "new" && match[1] !== "import"
+}
+
 export function UpdateDialogProvider({ children }: { children: ReactNode }) {
-  const { status, check } = useUpdateStatus()
+  const { status, check, download, cancel, install } = useUpdateStatus()
   const currentVersion = useAppVersion()
   const [open, setOpen] = useState(false)
-  const autoOpenedFor = useRef<string | null>(null)
+  const [dismissedVersion, setDismissedVersion] = useState<string | null>(null)
 
   const [postUpdate, setPostUpdate] = useState<ElectronPostUpdateInfo | null>(
     null,
@@ -42,17 +53,41 @@ export function UpdateDialogProvider({ children }: { children: ReactNode }) {
   const [currentRelease, setCurrentRelease] =
     useState<ElectronAvailableRelease | null>(null)
   const [whatsNewOpen, setWhatsNewOpen] = useState(false)
+  const [detailsOverride, setDetailsOverride] =
+    useState<ElectronPostUpdateInfo | null>(null)
 
   const phase = status.phase
   const hasPendingUpdate =
     phase === "available" || phase === "downloading" || phase === "downloaded"
 
-  useEffect(() => {
-    if (status.phase !== "available") return
-    if (autoOpenedFor.current === status.version) return
-    autoOpenedFor.current = status.version
-    setOpen(true)
-  }, [status])
+  const cardDetails =
+    status.phase === "available" || status.phase === "downloaded"
+      ? { version: status.version, releaseNotes: status.releaseNotes }
+      : null
+  const pendingVersion =
+    status.phase === "available" ||
+    status.phase === "downloading" ||
+    status.phase === "downloaded"
+      ? status.version
+      : null
+  // The card is the ambient surface; never stack it with an open dialog or the
+  // post-install "What's new" celebration.
+  const anyDialogOpen =
+    open || Boolean(postUpdate) || whatsNewOpen || Boolean(detailsOverride)
+  // Two places the ambient card stays out of: onboarding, a full-screen
+  // first-run flow that on the desktop runs in its own small window; and the
+  // pipeline, whose bottom-right corner already holds the debug console and the
+  // preview cards, and which is deep-focus work either way.
+  const hideAmbientCard = useRouterState({
+    select: (state) =>
+      state.location.pathname.startsWith("/onboarding") ||
+      isPipelineRoute(state.location.pathname),
+  })
+  const showToast =
+    hasPendingUpdate &&
+    !anyDialogOpen &&
+    !hideAmbientCard &&
+    dismissedVersion !== pendingVersion
 
   useEffect(() => {
     if (!isElectron() || !window.api?.updates?.getPostUpdate) return
@@ -94,9 +129,15 @@ export function UpdateDialogProvider({ children }: { children: ReactNode }) {
     [openUpdateDialog, showWhatsNew, hasPendingUpdate],
   )
 
-  const whatsNewVersion = postUpdate?.version ?? currentVersion ?? ""
-  const whatsNewNotes = postUpdate?.releaseNotes ?? currentRelease?.releaseNotes
-  const showPostUpdate = Boolean(postUpdate) || whatsNewOpen
+  const whatsNewVersion =
+    detailsOverride?.version ?? postUpdate?.version ?? currentVersion ?? ""
+  // When "See release notes" targets a specific release, show that release's
+  // notes as a unit — never fall through to a different release's notes.
+  const whatsNewNotes = detailsOverride
+    ? detailsOverride.releaseNotes
+    : (postUpdate?.releaseNotes ?? currentRelease?.releaseNotes)
+  const showPostUpdate =
+    Boolean(postUpdate) || whatsNewOpen || Boolean(detailsOverride)
 
   return (
     <UpdateDialogContext value={value}>
@@ -105,6 +146,10 @@ export function UpdateDialogProvider({ children }: { children: ReactNode }) {
         open={open}
         onOpenChange={setOpen}
         onShowWhatsNew={showWhatsNew}
+        onSeeDetails={(payload) => {
+          setDetailsOverride(payload)
+          setOpen(false)
+        }}
       />
       {showPostUpdate && (
         <PostUpdateDialog
@@ -113,10 +158,23 @@ export function UpdateDialogProvider({ children }: { children: ReactNode }) {
             if (!next) {
               setPostUpdate(null)
               setWhatsNewOpen(false)
+              setDetailsOverride(null)
             }
           }}
           version={whatsNewVersion}
           releaseNotes={whatsNewNotes}
+        />
+      )}
+      {showToast && (
+        <UpdateToast
+          status={status}
+          onDetails={
+            cardDetails ? () => setDetailsOverride(cardDetails) : undefined
+          }
+          onDownload={download}
+          onInstallNow={install}
+          onCancel={cancel}
+          onDismiss={() => setDismissedVersion(pendingVersion)}
         />
       )}
     </UpdateDialogContext>

--- a/apps/studio/src/components/updates/UpdateStateSurface.tsx
+++ b/apps/studio/src/components/updates/UpdateStateSurface.tsx
@@ -12,6 +12,7 @@ import type { ElementType, ReactNode } from "react"
 import { Button } from "@/components/ui/button"
 import type { UpdateStatus } from "@/hooks/use-update-status"
 import { cn, formatBytes } from "@/lib/utils"
+import { ReleaseCoverBanner } from "./ReleaseCoverBanner"
 import { formatVersion, getReleaseChannel } from "./release-banner-utils"
 import { IndeterminateBar, ProgressBar } from "./UpdateProgress"
 import { UpdateWhatsNew } from "./UpdateWhatsNew"
@@ -39,6 +40,7 @@ export interface UpdateStateSurfaceProps {
   onInstallLater?: () => void
   onClose?: () => void
   onShowWhatsNew?: () => void
+  onSeeDetails?: () => void
   TitleTag?: ElementType
 }
 
@@ -52,6 +54,7 @@ export function UpdateStateSurface({
   onInstallLater,
   onClose,
   onShowWhatsNew,
+  onSeeDetails,
   TitleTag = "h2",
 }: UpdateStateSurfaceProps) {
   const noop = () => {}
@@ -65,7 +68,13 @@ export function UpdateStateSurface({
     onInstallLater: onInstallLater ?? noop,
     onClose: onClose ?? noop,
     onShowWhatsNew,
+    onSeeDetails,
   })
+
+  const banner =
+    status.phase === "available" || status.phase === "downloaded" ? (
+      <ReleaseCoverBanner version={status.version} notes={status.releaseNotes} />
+    ) : null
 
   if (view.loading) {
     return (
@@ -87,19 +96,41 @@ export function UpdateStateSurface({
   }
 
   return (
-    <div className="flex h-[20rem] max-h-[calc(100vh-2rem)] flex-col">
-      <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 px-6 py-5 text-center">
-        <StateIcon tone={view.tone}>{view.icon}</StateIcon>
-        <TitleTag className="text-balance text-lg font-semibold">
-          {view.title}
-        </TitleTag>
-        {view.subtitle && (
-          <p className="max-w-[42ch] text-pretty text-sm text-muted-foreground">
-            {view.subtitle}
-          </p>
-        )}
-        {view.body && <div className="mt-2 w-full">{view.body}</div>}
-      </div>
+    <div
+      className={cn(
+        "flex max-h-[calc(100vh-2rem)] flex-col",
+        banner ? null : "h-[20rem]",
+      )}
+    >
+      {banner ? (
+        <>
+          <div className="shrink-0 px-6 pt-6 text-center">
+            <TitleTag className="text-balance text-lg font-semibold">
+              {view.title}
+            </TitleTag>
+            {view.subtitle && (
+              <p className="mx-auto mt-1 max-w-[42ch] text-pretty text-sm text-muted-foreground">
+                {view.subtitle}
+              </p>
+            )}
+          </div>
+          <div className="shrink-0 px-4 py-4">{banner}</div>
+          {view.body && <div className="shrink-0 px-6 pb-2">{view.body}</div>}
+        </>
+      ) : (
+        <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 px-6 py-5 text-center">
+          <StateIcon tone={view.tone}>{view.icon}</StateIcon>
+          <TitleTag className="text-balance text-lg font-semibold">
+            {view.title}
+          </TitleTag>
+          {view.subtitle && (
+            <p className="max-w-[42ch] text-pretty text-sm text-muted-foreground">
+              {view.subtitle}
+            </p>
+          )}
+          {view.body && <div className="mt-2 w-full">{view.body}</div>}
+        </div>
+      )}
 
       {view.footerStart ? (
         <div className="flex min-h-[4.5rem] shrink-0 flex-col gap-3 border-t px-6 py-3 sm:flex-row sm:items-center sm:justify-between">
@@ -129,6 +160,7 @@ interface BuildViewArgs {
   onInstallLater: () => void
   onClose: () => void
   onShowWhatsNew?: () => void
+  onSeeDetails?: () => void
 }
 
 function buildView({
@@ -141,6 +173,7 @@ function buildView({
   onInstallLater,
   onClose,
   onShowWhatsNew,
+  onSeeDetails,
 }: BuildViewArgs): DialogView {
   const current = currentVersion ?? undefined
 
@@ -171,6 +204,16 @@ function buildView({
           notes={status.releaseNotes}
         />
       ),
+      footerStart:
+        onSeeDetails && status.releaseNotes?.trim() ? (
+          <button
+            type="button"
+            onClick={onSeeDetails}
+            className="rounded-sm font-medium text-primary underline-offset-2 outline-none hover:underline focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <Trans>See release notes</Trans>
+          </button>
+        ) : undefined,
       actions: (
         <>
           <Button variant="outline" onClick={onClose}>

--- a/apps/studio/src/components/updates/UpdateToast.tsx
+++ b/apps/studio/src/components/updates/UpdateToast.tsx
@@ -1,0 +1,303 @@
+import { Trans, useLingui } from "@lingui/react/macro"
+import { CheckCircle2, Download, RotateCw, Sparkles, X } from "lucide-react"
+import type { ReactNode } from "react"
+import type { UpdateStatus } from "@/hooks/use-update-status"
+import { cn, formatBytes } from "@/lib/utils"
+import {
+  formatVersion,
+  getReleaseChannel,
+  releaseHeadline,
+  type ReleaseChannel,
+} from "./release-banner-utils"
+
+interface CardSkin {
+  border: string
+  shadow: string
+  gradient: string
+  motif: string
+  glow: string
+  eyebrow: string
+  primaryText: string
+  primaryShadow: string
+  progressGlow: string
+}
+
+const CARD_SKINS: Record<ReleaseChannel, CardSkin> = {
+  stable: {
+    border: "border-[oklch(0.62_0.17_255/0.32)]",
+    shadow: "shadow-[0_22px_60px_oklch(0.20_0.06_260/0.5)]",
+    gradient:
+      "bg-[radial-gradient(circle_at_84%_16%,oklch(0.60_0.21_252/0.9),transparent_42%),radial-gradient(circle_at_16%_94%,oklch(0.42_0.20_264/0.62),transparent_46%),linear-gradient(135deg,oklch(0.23_0.08_257),oklch(0.16_0.05_255)_58%,oklch(0.11_0.03_250))]",
+    motif: "text-[oklch(0.70_0.18_253)]",
+    glow: "bg-[oklch(0.62_0.24_255/0.5)]",
+    eyebrow: "text-[oklch(0.82_0.13_253)]",
+    primaryText: "text-[oklch(0.32_0.11_256)]",
+    primaryShadow: "shadow-[0_8px_22px_oklch(0.60_0.2_255/0.5)]",
+    progressGlow: "shadow-[0_0_12px_oklch(0.92_0.05_255/0.85)]",
+  },
+  beta: {
+    border: "border-[oklch(0.72_0.22_302/0.4)]",
+    shadow: "shadow-[0_22px_60px_oklch(0.16_0.08_292/0.5)]",
+    gradient:
+      "bg-[radial-gradient(circle_at_84%_16%,oklch(0.70_0.28_307/0.82),transparent_42%),radial-gradient(circle_at_16%_94%,oklch(0.46_0.27_286/0.66),transparent_46%),linear-gradient(135deg,oklch(0.30_0.16_293),oklch(0.19_0.10_275)_58%,oklch(0.12_0.05_264))]",
+    motif: "text-[oklch(0.78_0.20_306)]",
+    glow: "bg-[oklch(0.66_0.28_306/0.5)]",
+    eyebrow: "text-[oklch(0.86_0.16_308)]",
+    primaryText: "text-[oklch(0.34_0.16_300)]",
+    primaryShadow: "shadow-[0_8px_22px_oklch(0.62_0.26_305/0.5)]",
+    progressGlow: "shadow-[0_0_12px_oklch(0.90_0.10_305/0.85)]",
+  },
+}
+
+export interface UpdateToastProps {
+  status: UpdateStatus
+  onDetails?: () => void
+  onDownload?: () => void
+  onInstallNow?: () => void
+  onCancel?: () => void
+  onDismiss?: () => void
+  className?: string
+}
+
+/**
+ * Ambient, non-blocking update nudge anchored bottom-right — a compact cousin of
+ * the release hero banner. A deep-blue gradient card with an ambient glow, a
+ * shine sweep, and glass controls. Reflects the lifecycle in place
+ * (available → downloading → downloaded). All motion respects reduced-motion.
+ */
+export function UpdateToast({
+  status,
+  onDetails,
+  onDownload,
+  onInstallNow,
+  onCancel,
+  onDismiss,
+  className,
+}: UpdateToastProps) {
+  const { t } = useLingui()
+
+  if (
+    status.phase !== "available" &&
+    status.phase !== "downloading" &&
+    status.phase !== "downloaded"
+  ) {
+    return null
+  }
+
+  const version = formatVersion(status.version)
+  const channel = getReleaseChannel(status.version)
+  const beta = channel === "beta"
+  const skin = CARD_SKINS[channel]
+  const dismissible = status.phase !== "downloading"
+  const percent =
+    status.phase === "downloading" ? clampPercent(status.percent) : 0
+
+  return (
+    <div
+      className={cn(
+        "pointer-events-none fixed bottom-4 right-4 z-40 flex max-w-[calc(100vw-2rem)] justify-end",
+        className,
+      )}
+    >
+      <div
+        className={cn(
+          "pointer-events-auto relative isolate w-90 overflow-hidden rounded-2xl border text-[oklch(0.98_0.01_255)] duration-500 ease-out animate-in fade-in slide-in-from-bottom-6 motion-reduce:animate-none",
+          skin.border,
+          skin.shadow,
+        )}
+      >
+        <div
+          aria-hidden
+          className={cn("absolute inset-0 -z-10", skin.gradient)}
+        />
+        <div
+          aria-hidden
+          className={cn(
+            "absolute right-3 top-3 h-12 w-32 opacity-30 [background-image:radial-gradient(currentColor_1px,transparent_1px)] [background-size:12px_12px]",
+            skin.motif,
+          )}
+        />
+        <div
+          aria-hidden
+          className={cn(
+            "absolute -right-10 -top-12 size-32 animate-[update-card-glow_6s_ease-in-out_infinite] rounded-full blur-2xl motion-reduce:animate-none",
+            skin.glow,
+          )}
+        />
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-y-0 -left-1/3 w-1/3 animate-[update-card-shine_5s_ease-in-out_infinite] bg-gradient-to-r from-transparent via-white/25 to-transparent motion-reduce:hidden"
+        />
+
+        <div className="relative z-10 px-5 py-6">
+          <div className="flex items-start gap-3.5">
+            <div className="flex size-12 shrink-0 items-center justify-center rounded-xl border border-white/15 bg-white/10 shadow-inner backdrop-blur-sm">
+              {status.phase === "available" && <Sparkles className="size-6" />}
+              {status.phase === "downloading" && (
+                <Download className="size-6" />
+              )}
+              {status.phase === "downloaded" && (
+                <CheckCircle2 className="size-6" />
+              )}
+            </div>
+
+            <div className="min-w-0 flex-1 pt-0.5">
+              <p
+                className={cn(
+                  "text-[0.62rem] font-semibold uppercase tracking-[0.2em]",
+                  skin.eyebrow,
+                )}
+              >
+                {status.phase === "downloaded" ? (
+                  <Trans>Ready to install</Trans>
+                ) : status.phase === "downloading" ? (
+                  <Trans>Downloading</Trans>
+                ) : beta ? (
+                  <Trans>Beta {version}</Trans>
+                ) : (
+                  <Trans>Release {version}</Trans>
+                )}
+              </p>
+              <p className="mt-1.5 text-base font-semibold leading-tight">
+                {status.phase === "downloading" ? (
+                  <Trans>Downloading update…</Trans>
+                ) : status.phase === "downloaded" ? (
+                  <Trans>Update ready to install</Trans>
+                ) : (
+                  <Trans>Update available</Trans>
+                )}
+              </p>
+              <p className="mt-1.5 truncate text-[0.8rem] text-white/70">
+                {status.phase === "downloading"
+                  ? t`${Math.round(percent)}% · ${formatBytes(status.bytesPerSecond)}/s`
+                  : subtitleFor(status.releaseNotes, version, status)}
+              </p>
+            </div>
+
+            {dismissible && onDismiss && (
+              <button
+                type="button"
+                onClick={onDismiss}
+                aria-label={t`Dismiss`}
+                className="-mr-1 -mt-1 rounded-md p-1 text-white/60 outline-none transition-colors hover:bg-white/10 hover:text-white focus-visible:ring-2 focus-visible:ring-white/60"
+              >
+                <X className="size-4" />
+              </button>
+            )}
+          </div>
+
+          {status.phase === "downloading" && (
+            <div className="mt-5 h-2 w-full overflow-hidden rounded-full bg-white/15">
+              <div
+                className={cn(
+                  "h-full rounded-full bg-white transition-[width] duration-300 ease-out",
+                  skin.progressGlow,
+                )}
+                style={{ width: `${percent}%` }}
+              />
+            </div>
+          )}
+
+          <div className="mt-5 flex items-center justify-end gap-2">
+            {status.phase === "available" && (
+              <>
+                <GlassButton onClick={onDetails}>
+                  <Trans>What's new</Trans>
+                </GlassButton>
+                <PrimaryButton
+                  onClick={onDownload}
+                  textClass={skin.primaryText}
+                  glowClass={skin.primaryShadow}
+                >
+                  <Download className="size-4" />
+                  <Trans>Download</Trans>
+                </PrimaryButton>
+              </>
+            )}
+            {status.phase === "downloading" && (
+              <GlassButton onClick={onCancel}>
+                <Trans>Cancel</Trans>
+              </GlassButton>
+            )}
+            {status.phase === "downloaded" && (
+              <>
+                <GlassButton onClick={onDetails}>
+                  <Trans>What's new</Trans>
+                </GlassButton>
+                <PrimaryButton
+                  onClick={onInstallNow}
+                  textClass={skin.primaryText}
+                  glowClass={skin.primaryShadow}
+                >
+                  <RotateCw className="size-4" />
+                  <Trans>Restart</Trans>
+                </PrimaryButton>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function subtitleFor(
+  notes: string | undefined,
+  version: string,
+  status: Extract<UpdateStatus, { phase: "available" | "downloaded" }>,
+): string {
+  const headline = releaseHeadline(notes)
+  if (headline) return headline
+  if (status.phase === "available" && status.totalBytes != null) {
+    return `${version} · ${formatBytes(status.totalBytes)}`
+  }
+  return version
+}
+
+function GlassButton({
+  children,
+  onClick,
+}: {
+  children: ReactNode
+  onClick?: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="inline-flex h-9 items-center gap-1.5 rounded-lg border border-white/15 bg-white/10 px-3.5 text-xs font-medium text-white outline-none backdrop-blur-sm transition-all hover:bg-white/20 focus-visible:ring-2 focus-visible:ring-white/60 active:scale-95"
+    >
+      {children}
+    </button>
+  )
+}
+
+function PrimaryButton({
+  children,
+  onClick,
+  textClass,
+  glowClass,
+}: {
+  children: ReactNode
+  onClick?: () => void
+  textClass: string
+  glowClass: string
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "inline-flex h-9 items-center gap-1.5 rounded-lg bg-white px-3.5 text-xs font-semibold outline-none transition-all hover:bg-white/90 focus-visible:ring-2 focus-visible:ring-white active:scale-95",
+        textClass,
+        glowClass,
+      )}
+    >
+      {children}
+    </button>
+  )
+}
+
+function clampPercent(percent: number): number {
+  return Math.max(0, Math.min(100, percent))
+}

--- a/apps/studio/src/components/updates/release-banner-utils.ts
+++ b/apps/studio/src/components/updates/release-banner-utils.ts
@@ -13,6 +13,42 @@ export function trustedAssetUrl(url?: string): string | undefined {
     : undefined
 }
 
+export interface ReleaseCover {
+  light?: string
+  dark?: string
+}
+
+/**
+ * Extracts the themed release cover from release notes. Handles the GitHub
+ * `<picture>`/`<source media="(prefers-color-scheme: …)">` markup, a plain
+ * `<img>` fallback, and Markdown `![](…)`. Only trusted asset URLs are kept.
+ */
+export function parseReleaseCover(notes?: string): ReleaseCover {
+  if (!notes) return {}
+  let light: string | undefined
+  let dark: string | undefined
+
+  for (const tag of notes.match(/<source\b[^>]*>/gi) ?? []) {
+    const media = tag.match(/media=["']([^"']*)["']/i)?.[1]?.toLowerCase() ?? ""
+    const url = trustedAssetUrl(tag.match(/srcset=["']?([^"'\s>]+)/i)?.[1])
+    if (!url) continue
+    if (media.includes("dark")) dark ??= url
+    else if (media.includes("light")) light ??= url
+  }
+
+  if (!light || !dark) {
+    const fallback =
+      trustedAssetUrl(notes.match(/<img\b[^>]*\ssrc=["']([^"']+)["']/i)?.[1]) ??
+      trustedAssetUrl(notes.match(/!\[[^\]]*\]\(([^)\s]+)/)?.[1])
+    if (fallback) {
+      light ??= fallback
+      dark ??= fallback
+    }
+  }
+
+  return { light, dark }
+}
+
 export function getReleaseChannel(version: string): ReleaseChannel {
   return version.toLowerCase().includes("-beta") ? "beta" : "stable"
 }
@@ -20,6 +56,21 @@ export function getReleaseChannel(version: string): ReleaseChannel {
 export function formatVersion(version: string, fallback = "—"): string {
   if (!version) return fallback
   return version.startsWith("v") ? version : `v${version}`
+}
+
+/**
+ * The release's editorial headline — the first heading in the notes (HTML or
+ * Markdown), e.g. "Smoother, Safer Book Production". Used as a teaser line.
+ */
+export function releaseHeadline(notes?: string): string | undefined {
+  if (!notes) return undefined
+  const html = notes.match(/<h[1-3][^>]*>([\s\S]*?)<\/h[1-3]>/i)?.[1]
+  const markdown = notes.match(/^[ \t]*#{1,3}[ \t]+(.+)$/m)?.[1]
+  const text = (html ?? markdown)
+    ?.replace(/<[^>]+>/g, "")
+    .replace(/\s+/g, " ")
+    .trim()
+  return text || undefined
 }
 
 export function releaseNotesHaveImage(notes?: string): boolean {

--- a/apps/studio/src/components/updates/update-route-visibility.test.ts
+++ b/apps/studio/src/components/updates/update-route-visibility.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest"
+import { isPipelineRoute } from "./UpdateDialogProvider"
+
+describe("isPipelineRoute", () => {
+  it.each([
+    "/books/raven",
+    "/books/raven/book",
+    "/books/raven/storyboard/12",
+    "/books/raven/debug",
+    "/books/LP-4-Volcanoes-2/settings",
+  ])("treats %s as pipeline", (path) => {
+    expect(isPipelineRoute(path)).toBe(true)
+  })
+
+  it.each([
+    "/books/new",
+    "/books/import",
+    "/",
+    "/library",
+    "/handoffs",
+    "/settings/about",
+    "/onboarding",
+  ])("leaves %s alone", (path) => {
+    expect(isPipelineRoute(path)).toBe(false)
+  })
+})

--- a/apps/studio/src/hooks/use-is-dark-theme.ts
+++ b/apps/studio/src/hooks/use-is-dark-theme.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from "react"
+
+function readIsDark(): boolean {
+  if (typeof document !== "undefined") {
+    if (document.documentElement.classList.contains("dark")) return true
+  }
+  if (typeof window !== "undefined" && window.matchMedia) {
+    /* eslint-disable-next-line lingui/no-unlocalized-strings -- CSS media query */
+    return window.matchMedia("(prefers-color-scheme: dark)").matches
+  }
+  return false
+}
+
+/**
+ * Whether the app is currently rendering in dark mode. Dark mode is class-based
+ * (`.dark`); when no class is present we defer to the OS color scheme. Reacts to
+ * both the class toggling and the OS preference changing.
+ */
+export function useIsDarkTheme(): boolean {
+  const [isDark, setIsDark] = useState(readIsDark)
+
+  useEffect(() => {
+    const update = () => setIsDark(readIsDark())
+    update()
+
+    const observer = new MutationObserver(update)
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    })
+
+    /* eslint-disable-next-line lingui/no-unlocalized-strings -- CSS media query */
+    const media = window.matchMedia?.("(prefers-color-scheme: dark)")
+    media?.addEventListener("change", update)
+
+    return () => {
+      observer.disconnect()
+      media?.removeEventListener("change", update)
+    }
+  }, [])
+
+  return isDark
+}

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -1810,6 +1810,9 @@ msgstr "Best for your preset"
 msgid "Beta"
 msgstr "Beta"
 
+msgid "Beta {version}"
+msgstr "Beta {version}"
+
 msgid "Beta channel"
 msgstr "Beta channel"
 
@@ -3213,6 +3216,9 @@ msgstr "done"
 msgid "Done"
 msgstr "Done"
 
+msgid "Download"
+msgstr "Download"
+
 msgid "Download a full backup of this project"
 msgstr "Download a full backup of this project"
 
@@ -3227,6 +3233,9 @@ msgstr "Download update"
 
 msgid "Downloaded"
 msgstr "Downloaded"
+
+msgid "Downloading"
+msgstr "Downloading"
 
 msgid "Downloading update…"
 msgstr "Downloading update…"
@@ -7577,6 +7586,9 @@ msgstr "Reads in"
 msgid "Ready"
 msgstr "Ready"
 
+msgid "Ready to install"
+msgstr "Ready to install"
+
 msgid "Real books processed with this preset — before and after."
 msgstr "Real books processed with this preset — before and after."
 
@@ -7688,6 +7700,9 @@ msgstr "Relaxed"
 
 msgid "Release"
 msgstr "Release"
+
+msgid "Release {version}"
+msgstr "Release {version}"
 
 msgid "Release notes"
 msgstr "Release notes"
@@ -7878,6 +7893,9 @@ msgstr "Resolving source language..."
 
 msgid "Respiration"
 msgstr "Respiration"
+
+msgid "Restart"
+msgstr "Restart"
 
 msgid "Restart and install"
 msgstr "Restart and install"
@@ -8477,6 +8495,9 @@ msgstr "Sections"
 
 #~ msgid "See examples"
 #~ msgstr "See examples"
+
+msgid "See release notes"
+msgstr "See release notes"
 
 msgid "See the book & pick pages"
 msgstr "See the book & pick pages"

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -1810,6 +1810,9 @@ msgstr "Mejor para tu preajuste"
 msgid "Beta"
 msgstr "Beta"
 
+msgid "Beta {version}"
+msgstr "Beta {version}"
+
 msgid "Beta channel"
 msgstr "Canal beta"
 
@@ -3213,6 +3216,9 @@ msgstr "hecho"
 msgid "Done"
 msgstr "Hecho"
 
+msgid "Download"
+msgstr "Descargar"
+
 msgid "Download a full backup of this project"
 msgstr "Descargar una copia de seguridad completa de este proyecto"
 
@@ -3227,6 +3233,9 @@ msgstr "Descargar actualización"
 
 msgid "Downloaded"
 msgstr "Descargada"
+
+msgid "Downloading"
+msgstr "Descargando"
 
 msgid "Downloading update…"
 msgstr "Descargando actualización…"
@@ -7577,6 +7586,9 @@ msgstr "Lee en"
 msgid "Ready"
 msgstr "Listo"
 
+msgid "Ready to install"
+msgstr "Listo para instalar"
+
 msgid "Real books processed with this preset — before and after."
 msgstr "Libros reales procesados con este preajuste — antes y después."
 
@@ -7688,6 +7700,9 @@ msgstr "Relajado"
 
 msgid "Release"
 msgstr "Lanzamiento"
+
+msgid "Release {version}"
+msgstr "Versión {version}"
 
 msgid "Release notes"
 msgstr "Notas de la versión"
@@ -7878,6 +7893,9 @@ msgstr "Resolviendo idioma de origen..."
 
 msgid "Respiration"
 msgstr "Respiración"
+
+msgid "Restart"
+msgstr "Reiniciar"
 
 msgid "Restart and install"
 msgstr "Reiniciar e instalar"
@@ -8477,6 +8495,9 @@ msgstr "Secciones"
 
 #~ msgid "See examples"
 #~ msgstr "Ver ejemplos"
+
+msgid "See release notes"
+msgstr "Ver notas de la versión"
 
 msgid "See the book & pick pages"
 msgstr "Ver el libro y elegir páginas"

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -1812,6 +1812,9 @@ msgstr "Idéal pour votre préréglage"
 msgid "Beta"
 msgstr "Beta"
 
+msgid "Beta {version}"
+msgstr "Bêta {version}"
+
 msgid "Beta channel"
 msgstr "Canal bêta"
 
@@ -3215,6 +3218,9 @@ msgstr "terminé"
 msgid "Done"
 msgstr "Terminé"
 
+msgid "Download"
+msgstr "Télécharger"
+
 msgid "Download a full backup of this project"
 msgstr "Télécharger une sauvegarde complète de ce projet"
 
@@ -3229,6 +3235,9 @@ msgstr "Télécharger la mise à jour"
 
 msgid "Downloaded"
 msgstr "Téléchargée"
+
+msgid "Downloading"
+msgstr "Téléchargement"
 
 msgid "Downloading update…"
 msgstr "Téléchargement de la mise à jour…"
@@ -7579,6 +7588,9 @@ msgstr "Lit en"
 msgid "Ready"
 msgstr "Prêt"
 
+msgid "Ready to install"
+msgstr "Prêt à installer"
+
 msgid "Real books processed with this preset — before and after."
 msgstr "De vrais livres traités avec ce préréglage — avant et après."
 
@@ -7690,6 +7702,9 @@ msgstr "Détendu"
 
 msgid "Release"
 msgstr "Version"
+
+msgid "Release {version}"
+msgstr "Version {version}"
 
 msgid "Release notes"
 msgstr "Notes de version"
@@ -7880,6 +7895,9 @@ msgstr "Résolution de la langue source..."
 
 msgid "Respiration"
 msgstr "Respiration"
+
+msgid "Restart"
+msgstr "Redémarrer"
 
 msgid "Restart and install"
 msgstr "Redémarrer et installer"
@@ -8479,6 +8497,9 @@ msgstr "Sections"
 
 #~ msgid "See examples"
 #~ msgstr "Voir les exemples"
+
+msgid "See release notes"
+msgstr "Voir les notes de version"
 
 msgid "See the book & pick pages"
 msgstr "Voir le livre et choisir les pages"

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -1810,6 +1810,9 @@ msgstr "Melhor para seu predefinido"
 msgid "Beta"
 msgstr "Beta"
 
+msgid "Beta {version}"
+msgstr "Beta {version}"
+
 msgid "Beta channel"
 msgstr "Canal beta"
 
@@ -3213,6 +3216,9 @@ msgstr "concluído"
 msgid "Done"
 msgstr "Concluído"
 
+msgid "Download"
+msgstr "Baixar"
+
 msgid "Download a full backup of this project"
 msgstr "Baixar um backup completo deste projeto"
 
@@ -3227,6 +3233,9 @@ msgstr "Baixar atualização"
 
 msgid "Downloaded"
 msgstr "Baixada"
+
+msgid "Downloading"
+msgstr "Baixando"
 
 msgid "Downloading update…"
 msgstr "Baixando atualização…"
@@ -7577,6 +7586,9 @@ msgstr "Lê em"
 msgid "Ready"
 msgstr "Pronto"
 
+msgid "Ready to install"
+msgstr "Pronto para instalar"
+
 msgid "Real books processed with this preset — before and after."
 msgstr "Livros reais processados com este predefinido — antes e depois."
 
@@ -7688,6 +7700,9 @@ msgstr "Leve"
 
 msgid "Release"
 msgstr "Lançamento"
+
+msgid "Release {version}"
+msgstr "Versão {version}"
 
 msgid "Release notes"
 msgstr "Notas da versão"
@@ -7878,6 +7893,9 @@ msgstr "Resolvendo idioma de origem..."
 
 msgid "Respiration"
 msgstr "Respiração"
+
+msgid "Restart"
+msgstr "Reiniciar"
 
 msgid "Restart and install"
 msgstr "Reiniciar e instalar"
@@ -8477,6 +8495,9 @@ msgstr "Seções"
 
 #~ msgid "See examples"
 #~ msgstr "Ver exemplos"
+
+msgid "See release notes"
+msgstr "Ver notas da versão"
 
 msgid "See the book & pick pages"
 msgstr "Ver o livro e escolher páginas"

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -1812,6 +1812,9 @@ msgstr "Më i mirë për presetin tuaj"
 msgid "Beta"
 msgstr "Beta"
 
+msgid "Beta {version}"
+msgstr "Beta {version}"
+
 msgid "Beta channel"
 msgstr "Kanali beta"
 
@@ -3215,6 +3218,9 @@ msgstr "u krye"
 msgid "Done"
 msgstr "U krye"
 
+msgid "Download"
+msgstr "Shkarko"
+
 msgid "Download a full backup of this project"
 msgstr "Shkarko një kopje rezervë të plotë të këtij projekti"
 
@@ -3229,6 +3235,9 @@ msgstr "Shkarko përditësimin"
 
 msgid "Downloaded"
 msgstr "E shkarkuar"
+
+msgid "Downloading"
+msgstr "Duke shkarkuar"
 
 msgid "Downloading update…"
 msgstr "Duke shkarkuar përditësimin…"
@@ -7579,6 +7588,9 @@ msgstr "Lexohet në"
 msgid "Ready"
 msgstr "Gati"
 
+msgid "Ready to install"
+msgstr "Gati për instalim"
+
 msgid "Real books processed with this preset — before and after."
 msgstr "Libra të vërtetë të procesuar me këtë paracaktim — para dhe pas."
 
@@ -7690,6 +7702,9 @@ msgstr "I relaksuar"
 
 msgid "Release"
 msgstr "Publikim"
+
+msgid "Release {version}"
+msgstr "Versioni {version}"
 
 msgid "Release notes"
 msgstr "Shënimet e versionit"
@@ -7880,6 +7895,9 @@ msgstr "Duke zgjidhur gjuhën burimore..."
 
 msgid "Respiration"
 msgstr "Frymëmarrja"
+
+msgid "Restart"
+msgstr "Rinis"
 
 msgid "Restart and install"
 msgstr "Rinis dhe instalo"
@@ -8479,6 +8497,9 @@ msgstr "Seksione"
 
 #~ msgid "See examples"
 #~ msgstr "Shiko shembuj"
+
+msgid "See release notes"
+msgstr "Shih shënimet e versionit"
 
 msgid "See the book & pick pages"
 msgstr "Shihni librin dhe zgjidhni faqet"

--- a/apps/studio/src/styles/globals.css
+++ b/apps/studio/src/styles/globals.css
@@ -735,3 +735,34 @@
 .drag-region * {
   -webkit-app-region: no-drag;
 }
+
+/* Update card (UpdateToast) ambient effects. Reduced-motion is handled per
+ * element via Tailwind's `motion-reduce:` variants at the call site. */
+@keyframes update-card-shine {
+  0% {
+    transform: translateX(-160%) skewX(-14deg);
+    opacity: 0;
+  }
+  18% {
+    opacity: 0.5;
+  }
+  55% {
+    opacity: 0;
+  }
+  100% {
+    transform: translateX(320%) skewX(-14deg);
+    opacity: 0;
+  }
+}
+
+@keyframes update-card-glow {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0) scale(1);
+    opacity: 0.5;
+  }
+  50% {
+    transform: translate3d(-8px, 6px, 0) scale(1.09);
+    opacity: 0.82;
+  }
+}

--- a/scripts/release-source-notes.mjs
+++ b/scripts/release-source-notes.mjs
@@ -6,6 +6,11 @@ const COVER_URL_PREFIXES = [
   "https://github.com/user-attachments/",
   "https://user-images.githubusercontent.com/",
 ];
+// Official release covers are uploaded as GitHub release assets under the repo's
+// own release-download host, which is fully GitHub/repo controlled.
+const COVER_URL_PATTERNS = [
+  /^https:\/\/github\.com\/[^/]+\/[^/]+\/releases\/download\//,
+];
 const GENERIC_RELEASE_TITLES = new Set([
   "what's changed",
   "whats changed",
@@ -252,7 +257,10 @@ function plainInlineText(value) {
 }
 
 function isAllowedCoverUrl(value) {
-  return COVER_URL_PREFIXES.some((prefix) => value.startsWith(prefix));
+  return (
+    COVER_URL_PREFIXES.some((prefix) => value.startsWith(prefix)) ||
+    COVER_URL_PATTERNS.some((pattern) => pattern.test(value))
+  );
 }
 
 function validEditorialTitle(value) {


### PR DESCRIPTION
**Stack 2/3** (on top of the HTML-notes fix).

Redesigns the in-app update experience:

- **Ambient update card** (`UpdateToast`), bottom-left and non-blocking, replacing the auto-opening dialog. Blue (stable) / violet (beta) release-hero skin with ambient glow, shine sweep, and glass controls; reflects the lifecycle in place (available → downloading → downloaded). Never stacks with an open dialog.
- **Themed release cover banner** (light/dark from the active theme) in the update dialogs via `ReleaseCoverBanner` + `useIsDarkTheme`; official release-download covers are now trusted so the real cover renders (falls back to the generated hero).
- **"See release notes"** on the available state; title/version placed above the banner.

Motion respects `prefers-reduced-motion`; strings are Lingui-wrapped. Beta multi-version update UI redesign deferred to a follow-up.

Periodic update checks are stacked on top in the 3/3 PR.