### PR TITLE
fix(studio): render HTML release notes + size the What's new modal

### DIFF
--- a/apps/studio/src/components/updates/PostUpdateDialog.tsx
+++ b/apps/studio/src/components/updates/PostUpdateDialog.tsx
@@ -62,7 +62,7 @@ export function PostUpdateContent({
   const notes = releaseNotes?.trim()
 
   return (
-    <div className="flex h-200 max-h-[calc(100vh-2rem)] flex-col">
+    <div className="flex max-h-[calc(100vh-4rem)] flex-col">
       <div className="flex shrink-0 items-center gap-3 px-6 pb-4 pt-6">
         <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
           <Sparkles className="size-5" />

--- a/apps/studio/src/components/updates/ReleaseNotesMarkdown.test.tsx
+++ b/apps/studio/src/components/updates/ReleaseNotesMarkdown.test.tsx
@@ -28,6 +28,27 @@ Full Changelog: https://github.com/unicef/adt-studio/compare/v0.7.4-beta.3...v0.
     expect(screen.queryByText(/https:\/\/github\.com/)).toBeNull()
   })
 
+  it("renders GitHub HTML release notes as structured content, not raw tags", () => {
+    render(
+      <ReleaseNotesMarkdown>{`<h2>What's Changed</h2>
+<ul>
+<li>feat(i18n): add Albanian (Kosovo) locale to Studio by <a class="user-mention" href="https://github.com/Eliezir">@Eliezir</a> in <a href="https://github.com/unicef/adt-studio/pull/593">#593</a></li>
+</ul>`}</ReleaseNotesMarkdown>,
+    )
+
+    expect(screen.getByRole("heading", { name: "What's Changed" })).toBeTruthy()
+    expect(screen.getByRole("listitem").textContent).toContain(
+      "feat(i18n): add Albanian (Kosovo) locale to Studio",
+    )
+    expect(
+      screen.getByRole("link", { name: "@Eliezir" }).getAttribute("href"),
+    ).toBe("https://github.com/Eliezir")
+    expect(
+      screen.getByRole("link", { name: "#593" }).getAttribute("href"),
+    ).toBe("https://github.com/unicef/adt-studio/pull/593")
+    expect(screen.queryByText(/<li>|<ul>|<h2>/)).toBeNull()
+  })
+
   it("renders images from trusted hosts and drops untrusted ones", () => {
     render(
       <ReleaseNotesMarkdown>{`

--- a/apps/studio/src/components/updates/ReleaseNotesMarkdown.tsx
+++ b/apps/studio/src/components/updates/ReleaseNotesMarkdown.tsx
@@ -18,7 +18,9 @@ export function ReleaseNotesMarkdown({
   children,
   className,
 }: ReleaseNotesMarkdownProps) {
-  const blocks = parseBlocks(children)
+  const blocks = looksLikeHtml(children)
+    ? parseHtmlBlocks(children)
+    : parseBlocks(children)
 
   return (
     <div className={cn("space-y-3 text-sm leading-relaxed", className)}>
@@ -138,6 +140,117 @@ function parseBlocks(markdown: string): Block[] {
   flushParagraph()
   flushList()
   return blocks
+}
+
+const HTML_BLOCK_TAGS =
+  /<(?:h[1-6]|ul|ol|li|p|a|blockquote|pre|table|div|hr|strong|em|code|span)\b/i
+
+function looksLikeHtml(value: string): boolean {
+  return HTML_BLOCK_TAGS.test(value)
+}
+
+function parseHtmlBlocks(html: string): Block[] {
+  if (typeof DOMParser === "undefined") {
+    return parseBlocks(html.replace(/<[^>]+>/g, " "))
+  }
+  const doc = new DOMParser().parseFromString(html, "text/html")
+  const blocks: Block[] = []
+  collectHtmlBlocks(doc.body, blocks)
+  return blocks
+}
+
+function collectHtmlBlocks(root: ParentNode, blocks: Block[]): void {
+  for (const node of Array.from(root.childNodes)) {
+    if (node.nodeType === Node.TEXT_NODE) {
+      const text = collapse(node.textContent ?? "")
+      if (text) blocks.push({ type: "paragraph", text })
+      continue
+    }
+
+    if (!(node instanceof Element)) continue
+    const tag = node.tagName.toLowerCase()
+
+    if (/^h[1-6]$/.test(tag)) {
+      const text = htmlInlineToText(node)
+      if (text) blocks.push({ type: "heading", text })
+      continue
+    }
+
+    if (tag === "ul" || tag === "ol") {
+      const items = Array.from(node.children)
+        .filter((child) => child.tagName.toLowerCase() === "li")
+        .map((li) => htmlInlineToText(li))
+        .filter(Boolean)
+      if (items.length) blocks.push({ type: "list", items })
+      continue
+    }
+
+    if (tag === "img" || tag === "picture") {
+      const src = htmlImageSrc(node)
+      if (src) blocks.push({ type: "image", src, alt: htmlImageAlt(node) })
+      continue
+    }
+
+    if (tag === "hr") {
+      blocks.push({ type: "rule" })
+      continue
+    }
+
+    if (tag === "p" || tag === "blockquote") {
+      const image = node.querySelector("img")
+      const src = image ? htmlImageSrc(image) : undefined
+      if (src) blocks.push({ type: "image", src, alt: htmlImageAlt(image!) })
+      const text = htmlInlineToText(node)
+      if (text) blocks.push({ type: "paragraph", text })
+      continue
+    }
+
+    collectHtmlBlocks(node, blocks)
+  }
+}
+
+function htmlInlineToText(root: Node): string {
+  let out = ""
+  for (const node of Array.from(root.childNodes)) {
+    if (node.nodeType === Node.TEXT_NODE) {
+      out += node.textContent ?? ""
+      continue
+    }
+    if (!(node instanceof Element)) continue
+    const tag = node.tagName.toLowerCase()
+    if (tag === "br") {
+      out += " "
+      continue
+    }
+    if (tag === "img") continue
+    if (tag === "a") {
+      const href = node.getAttribute("href") ?? ""
+      const label = htmlInlineToText(node)
+      out += /^https?:\/\//i.test(href) && label ? `[${label}](${href})` : label
+      continue
+    }
+    out += htmlInlineToText(node)
+  }
+  return collapse(out)
+}
+
+function htmlImageSrc(node: Element): string | undefined {
+  if (node.tagName.toLowerCase() === "img") {
+    return trustedAssetUrl(node.getAttribute("src") ?? undefined)
+  }
+  const source = node.querySelector("source[srcset]")
+  const fromSource = source?.getAttribute("srcset")?.trim().split(/\s+/)[0]
+  const img = node.querySelector("img")
+  return trustedAssetUrl(fromSource ?? img?.getAttribute("src") ?? undefined)
+}
+
+function htmlImageAlt(node: Element): string {
+  const img = node.tagName.toLowerCase() === "img" ? node : node.querySelector("img")
+  return img?.getAttribute("alt") ?? ""
+}
+
+function collapse(value: string): string {
+  return value.replace(/\s+/g, " ").trim()
 }
 
 function normalizeImages(markdown: string): string {


### PR DESCRIPTION
**Stack 1/3.** Renders GitHub HTML release notes (atom feed) in the "What's new" modal instead of showing raw `<h2>`/`<ul>` tags, and sizes the modal to its content (short notes stay compact, long notes scroll). Foundation for the update-UI redesign (#792) and periodic checks stacked on top.