### PR TITLE
feat(desktop): periodic update checks

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -32,7 +32,10 @@ import {
   STUDIO_APP_SCHEME_PRIVILEGES,
 } from "./protocols/studio-app";
 
-import { checkForUpdates } from "./services/auto-updater";
+import {
+  checkForUpdates,
+  startPeriodicUpdateChecks,
+} from "./services/auto-updater";
 import { initPostUpdateDetection } from "./services/update-state";
 import { setStartupError } from "./services/debug-info";
 
@@ -101,6 +104,7 @@ app.whenReady().then(async () => {
     }
 
     checkForUpdates().catch(() => {});
+    startPeriodicUpdateChecks();
   });
 });
 

--- a/apps/desktop/src/main/services/auto-updater.ts
+++ b/apps/desktop/src/main/services/auto-updater.ts
@@ -217,6 +217,43 @@ export async function checkForUpdates(): Promise<UpdateStatus> {
   }
 }
 
+const PERIODIC_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6 hours
+
+let periodicCheckTimer: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * Poll for updates on a fixed interval so a new release surfaces mid-session,
+ * not only at launch. Skips while a check/download/install is already in flight
+ * (a re-check would clobber that state). Idempotent; no-op when unpacked / dev.
+ */
+export function startPeriodicUpdateChecks(
+  intervalMs: number = PERIODIC_CHECK_INTERVAL_MS,
+): void {
+  if (periodicCheckTimer || !app.isPackaged) return;
+
+  periodicCheckTimer = setInterval(() => {
+    const phase = lastStatus.phase;
+    if (
+      phase === "checking" ||
+      phase === "downloading" ||
+      phase === "downloaded" ||
+      phase === "installing"
+    ) {
+      return;
+    }
+    checkForUpdates().catch(() => {});
+  }, intervalMs);
+
+  // The interval must not keep the app alive on its own.
+  periodicCheckTimer.unref?.();
+}
+
+export function stopPeriodicUpdateChecks(): void {
+  if (!periodicCheckTimer) return;
+  clearInterval(periodicCheckTimer);
+  periodicCheckTimer = null;
+}
+
 export async function listAvailableVersions(
   force = false,
 ): Promise<AvailableRelease[]> {


### PR DESCRIPTION
**Stack 3/3** (on top of the update-UI redesign #792). Polls for updates every 6h so a release surfaces mid-session, not only at launch. Skips while a check/download/install is already in flight; idempotent and no-op when unpacked/dev. Pairs with the ambient card, which then appears on the fly.