### PR TITLE
fix(desktop): bound the Electron screenshot path with timeouts

### DIFF
--- a/apps/desktop/src/main/ipc/api-bridge/screenshot.ts
+++ b/apps/desktop/src/main/ipc/api-bridge/screenshot.ts
@@ -27,6 +27,7 @@ export function handleScreenshotMessages(apiProcess: Electron.UtilityProcess) {
         const base64 = await screenshot(
           m.html,
           m.viewport ?? { width: 1024, height: 768 },
+          m.timeoutMs,
         );
         apiProcess.postMessage(
           screenshotIpcReplySuccessSchema.parse({

--- a/apps/desktop/src/main/services/screenshot.test.ts
+++ b/apps/desktop/src/main/services/screenshot.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const instances: FakeBrowserWindow[] = [];
+const pngBase64 = Buffer.from("png").toString("base64");
+
+type Capture = () => Promise<{ toPNG: () => Buffer }>;
+
+const okCapture: Capture = async () => ({ toPNG: () => Buffer.from("png") });
+
+class FakeWebContents {
+  handlers = new Map<string, (...args: unknown[]) => void>();
+  capture: Capture = okCapture;
+
+  once(event: string, handler: (...args: unknown[]) => void) {
+    this.handlers.set(event, handler);
+  }
+
+  capturePage() {
+    return this.capture();
+  }
+
+  finishLoad() {
+    this.handlers.get("did-finish-load")?.();
+  }
+}
+
+class FakeBrowserWindow {
+  static autoFinishLoad = true;
+  static capture: Capture = okCapture;
+
+  webContents = new FakeWebContents();
+  destroy = vi.fn(() => {
+    this.destroyed = true;
+  });
+  destroyed = false;
+
+  constructor() {
+    instances.push(this);
+    this.webContents.capture = FakeBrowserWindow.capture;
+    setTimeout(() => {
+      if (FakeBrowserWindow.autoFinishLoad) this.webContents.finishLoad();
+    }, 0);
+  }
+
+  isDestroyed() {
+    return this.destroyed;
+  }
+
+  async loadURL() {}
+}
+
+vi.mock("electron", () => ({ BrowserWindow: FakeBrowserWindow }));
+vi.mock("electron/main", () => ({ protocol: { handle: vi.fn() } }));
+
+const { screenshot } = await import("./screenshot");
+const { htmlStore } = await import("../protocols/html-render");
+
+beforeEach(() => {
+  instances.length = 0;
+  htmlStore.clear();
+  FakeBrowserWindow.autoFinishLoad = true;
+  FakeBrowserWindow.capture = okCapture;
+});
+
+const viewport = { width: 800, height: 600 };
+
+describe("screenshot", () => {
+  it("captures the page, then destroys the window and drops the stored HTML", async () => {
+    await expect(screenshot("<p>hi</p>", viewport, 1_000)).resolves.toBe(
+      pngBase64,
+    );
+
+    expect(instances[0].destroy).toHaveBeenCalledOnce();
+    expect(htmlStore.size).toBe(0);
+  });
+
+  it("fails instead of hanging when the page never finishes loading", async () => {
+    FakeBrowserWindow.autoFinishLoad = false;
+
+    await expect(screenshot("<p>hi</p>", viewport, 25)).rejects.toThrow(
+      /never finished loading/i,
+    );
+
+    expect(instances[0].destroy).toHaveBeenCalledOnce();
+    expect(htmlStore.size).toBe(0);
+  });
+
+  it("fails instead of hanging when the capture never settles", async () => {
+    FakeBrowserWindow.capture = () => new Promise(() => {});
+
+    await expect(screenshot("<p>hi</p>", viewport, 25)).rejects.toThrow(
+      /capturing the screenshot/i,
+    );
+
+    expect(instances[0].destroy).toHaveBeenCalledOnce();
+    expect(htmlStore.size).toBe(0);
+  });
+});

--- a/apps/desktop/src/main/services/screenshot.ts
+++ b/apps/desktop/src/main/services/screenshot.ts
@@ -1,15 +1,10 @@
+import { DEFAULT_SCREENSHOT_TIMEOUT_MS } from "@adt/types";
 import { BrowserWindow } from "electron";
 import { randomUUID } from "node:crypto";
 import { htmlStore } from "../protocols/html-render";
 
 const windows = new Set<InstanceType<typeof BrowserWindow>>();
 
-const DEFAULT_SCREENSHOT_TIMEOUT_MS = 30_000;
-
-/* An offscreen BrowserWindow can wedge without ever emitting did-finish-load or
-   did-fail-load (a pending subresource, a window that never paints), so every
-   await here needs its own ceiling — otherwise the capture never settles, the
-   caller waits forever, and the window leaks. */
 function withDeadline<T>(
   promise: Promise<T>,
   timeoutMs: number,
@@ -53,6 +48,8 @@ async function screenshot(
         reject(new Error(desc)),
       );
     });
+
+    loadPromise.catch(() => {});
 
     await withDeadline(
       win.loadURL(`html-render://${id}`),

--- a/apps/desktop/src/main/services/screenshot.ts
+++ b/apps/desktop/src/main/services/screenshot.ts
@@ -4,7 +4,7 @@ import { htmlStore } from "../protocols/html-render";
 
 const windows = new Set<InstanceType<typeof BrowserWindow>>();
 
-const DEFAULT_SCREENSHOT_TIMEOUT_MS = 60_000;
+const DEFAULT_SCREENSHOT_TIMEOUT_MS = 30_000;
 
 /* An offscreen BrowserWindow can wedge without ever emitting did-finish-load or
    did-fail-load (a pending subresource, a window that never paints), so every

--- a/apps/desktop/src/main/services/screenshot.ts
+++ b/apps/desktop/src/main/services/screenshot.ts
@@ -3,9 +3,34 @@ import { randomUUID } from "node:crypto";
 import { htmlStore } from "../protocols/html-render";
 
 const windows = new Set<InstanceType<typeof BrowserWindow>>();
+
+const DEFAULT_SCREENSHOT_TIMEOUT_MS = 60_000;
+
+/* An offscreen BrowserWindow can wedge without ever emitting did-finish-load or
+   did-fail-load (a pending subresource, a window that never paints), so every
+   await here needs its own ceiling — otherwise the capture never settles, the
+   caller waits forever, and the window leaks. */
+function withDeadline<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  message: string,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`${message} (${timeoutMs}ms)`)),
+      timeoutMs,
+    );
+  });
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timer) clearTimeout(timer);
+  }) as Promise<T>;
+}
+
 async function screenshot(
   html: string,
   viewport: { width: number; height: number },
+  timeoutMs: number = DEFAULT_SCREENSHOT_TIMEOUT_MS,
 ): Promise<string> {
   const id = randomUUID();
   htmlStore.set(id, html);
@@ -18,6 +43,9 @@ async function screenshot(
   });
   windows.add(win);
 
+  const deadline = Date.now() + timeoutMs;
+  const remaining = () => Math.max(1, deadline - Date.now());
+
   try {
     const loadPromise = new Promise<void>((resolve, reject) => {
       win.webContents.once("did-finish-load", resolve);
@@ -26,10 +54,22 @@ async function screenshot(
       );
     });
 
-    await win.loadURL(`html-render://${id}`);
-    await loadPromise;
+    await withDeadline(
+      win.loadURL(`html-render://${id}`),
+      remaining(),
+      "Timed out loading the screenshot page",
+    );
+    await withDeadline(
+      loadPromise,
+      remaining(),
+      "Screenshot page never finished loading",
+    );
 
-    const image = await win.webContents.capturePage();
+    const image = await withDeadline(
+      win.webContents.capturePage(),
+      remaining(),
+      "Timed out capturing the screenshot",
+    );
     return image.toPNG().toString("base64");
   } finally {
     windows.delete(win);

--- a/packages/pipeline/src/__tests__/screenshot.test.ts
+++ b/packages/pipeline/src/__tests__/screenshot.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import {
+  DEFAULT_SCREENSHOT_TIMEOUT_MS,
+  _createElectronScreenshotRenderer,
+} from "../screenshot.js"
+
+type Listener = (ev: { data: unknown }) => void
+
+function fakeParentPort() {
+  const listeners = new Set<Listener>()
+  return {
+    posted: [] as unknown[],
+    listeners,
+    postMessage(message: unknown) {
+      this.posted.push(message)
+    },
+    on(_event: "message", listener: Listener) {
+      listeners.add(listener)
+    },
+    off(_event: "message", listener: Listener) {
+      listeners.delete(listener)
+    },
+    reply(data: unknown) {
+      for (const listener of [...listeners]) listener({ data })
+    },
+  }
+}
+
+const proc = process as NodeJS.Process & { type?: string; parentPort?: unknown }
+const originalType = proc.type
+const originalParentPort = proc.parentPort
+const originalElectron = process.versions.electron
+
+function stubUtilityProcess(parentPort: unknown) {
+  proc.type = "utility"
+  proc.parentPort = parentPort
+  Object.defineProperty(process.versions, "electron", {
+    value: "41.0.0",
+    configurable: true,
+    writable: true,
+  })
+}
+
+afterEach(() => {
+  proc.type = originalType
+  proc.parentPort = originalParentPort
+  Object.defineProperty(process.versions, "electron", {
+    value: originalElectron,
+    configurable: true,
+    writable: true,
+  })
+  vi.useRealTimers()
+})
+
+describe("_createElectronScreenshotRenderer", () => {
+  it("rejects when the main process never replies", async () => {
+    vi.useFakeTimers()
+    const port = fakeParentPort()
+    stubUtilityProcess(port)
+    const renderer = await _createElectronScreenshotRenderer()
+
+    const pending = renderer.screenshot(
+      "<p>hi</p>",
+      { width: 800, height: 600 },
+      { timeoutMs: 1_000 },
+    )
+    const assertion = expect(pending).rejects.toThrow(/timed out/i)
+    await vi.advanceTimersByTimeAsync(1_000 + 5_000 + 1)
+    await assertion
+
+    expect(port.listeners.size).toBe(0)
+  })
+
+  it("passes the capture budget to the main process", async () => {
+    const port = fakeParentPort()
+    stubUtilityProcess(port)
+    const renderer = await _createElectronScreenshotRenderer()
+
+    const pending = renderer.screenshot("<p>hi</p>", { width: 800, height: 600 })
+    const request = port.posted[0] as { id: string; timeoutMs?: number }
+    expect(request.timeoutMs).toBe(DEFAULT_SCREENSHOT_TIMEOUT_MS)
+
+    port.reply({
+      type: "screenshot-base64-reply",
+      id: request.id,
+      base64: "aGVsbG8=",
+    })
+    await expect(pending).resolves.toBe("aGVsbG8=")
+  })
+
+  it("clears the backstop timer once a reply arrives", async () => {
+    vi.useFakeTimers()
+    const port = fakeParentPort()
+    stubUtilityProcess(port)
+    const renderer = await _createElectronScreenshotRenderer()
+
+    const pending = renderer.screenshot(
+      "<p>hi</p>",
+      { width: 800, height: 600 },
+      { timeoutMs: 1_000 },
+    )
+    const request = port.posted[0] as { id: string }
+    port.reply({
+      type: "screenshot-base64-reply",
+      id: request.id,
+      base64: "aGVsbG8=",
+    })
+    await expect(pending).resolves.toBe("aGVsbG8=")
+
+    expect(vi.getTimerCount()).toBe(0)
+    expect(port.listeners.size).toBe(0)
+  })
+})

--- a/packages/pipeline/src/screenshot.ts
+++ b/packages/pipeline/src/screenshot.ts
@@ -33,12 +33,21 @@ export function getViewportBreakpoints() {
   }))
 }
 
+/** Budget for one whole capture. Generous on purpose: this is a backstop against
+ *  a capture that never settles, not a performance knob. */
+export const DEFAULT_SCREENSHOT_TIMEOUT_MS = 60_000
+
 export interface ScreenshotRenderer {
   /** Render HTML to a PNG screenshot and return it as base64. */
   screenshot(
     html: string,
     viewport?: { width: number; height: number },
-    options?: { signal?: AbortSignal },
+    options?: {
+      signal?: AbortSignal
+      /** Budget for the whole capture. Honored by the Electron renderer; the
+       *  Playwright renderer is bounded by Playwright's own per-operation timeouts. */
+      timeoutMs?: number
+    },
   ): Promise<string>
   /** Release browser resources. */
   close(): Promise<void>
@@ -128,6 +137,10 @@ function utilityParentPort(): ParentPortLike | null {
   return p
 }
 
+/** Extra slack on top of the capture budget so main's own bounded failure — which
+ *  carries a descriptive error — normally wins the race against this backstop. */
+const SCREENSHOT_REPLY_GRACE_MS = 5_000
+
 /**
  * Electron `utilityProcess.fork` child: talk to main via `process.parentPort`.
  * `process.send` / `process.on("message")` are for Node `child_process.fork` only — they do not wire to main here.
@@ -144,12 +157,16 @@ export async function _createElectronScreenshotRenderer(): Promise<ScreenshotRen
     async screenshot(
       html: string,
       viewport = { width: 1024, height: 768 },
-      options: { signal?: AbortSignal } = {},
+      options: { signal?: AbortSignal; timeoutMs?: number } = {},
     ): Promise<string> {
       throwIfAborted(options.signal)
       const id = randomUUID()
+      const timeoutMs = options.timeoutMs ?? DEFAULT_SCREENSHOT_TIMEOUT_MS
+      const replyTimeoutMs = timeoutMs + SCREENSHOT_REPLY_GRACE_MS
       return new Promise((resolve, reject) => {
+        let timer: ReturnType<typeof setTimeout> | undefined
         const cleanup = () => {
+          if (timer) clearTimeout(timer)
           parentPort.off("message", onMessage)
           options.signal?.removeEventListener("abort", onAbort)
         }
@@ -172,11 +189,20 @@ export async function _createElectronScreenshotRenderer(): Promise<ScreenshotRen
         }
         parentPort.on("message", onMessage)
         options.signal?.addEventListener("abort", onAbort, { once: true })
+        timer = setTimeout(() => {
+          cleanup()
+          reject(
+            new Error(
+              `Screenshot timed out after ${replyTimeoutMs}ms: the main process never replied`
+            )
+          )
+        }, replyTimeoutMs)
         const payload = screenshotIpcRequestSchema.parse({
           type: "screenshot-base64",
           id,
           html,
           viewport,
+          timeoutMs,
         })
         parentPort.postMessage(payload)
       })

--- a/packages/pipeline/src/screenshot.ts
+++ b/packages/pipeline/src/screenshot.ts
@@ -35,7 +35,7 @@ export function getViewportBreakpoints() {
 
 /** Budget for one whole capture. Generous on purpose: this is a backstop against
  *  a capture that never settles, not a performance knob. */
-export const DEFAULT_SCREENSHOT_TIMEOUT_MS = 60_000
+export const DEFAULT_SCREENSHOT_TIMEOUT_MS = 30_000
 
 export interface ScreenshotRenderer {
   /** Render HTML to a PNG screenshot and return it as base64. */

--- a/packages/pipeline/src/screenshot.ts
+++ b/packages/pipeline/src/screenshot.ts
@@ -8,10 +8,13 @@
 
 import { randomUUID } from "node:crypto"
 import {
+  DEFAULT_SCREENSHOT_TIMEOUT_MS,
   screenshotIpcCloseSchema,
   screenshotIpcReplySchema,
   screenshotIpcRequestSchema,
 } from "@adt/types"
+
+export { DEFAULT_SCREENSHOT_TIMEOUT_MS }
 
 export const SCREENSHOT_VIEWPORTS = [
   { label: "desktop", width: 1280, height: 800 },
@@ -32,10 +35,6 @@ export function getViewportBreakpoints() {
       vp.width >= 640  ? "max-lg:" : "max-sm:",
   }))
 }
-
-/** Budget for one whole capture. Generous on purpose: this is a backstop against
- *  a capture that never settles, not a performance knob. */
-export const DEFAULT_SCREENSHOT_TIMEOUT_MS = 30_000
 
 export interface ScreenshotRenderer {
   /** Render HTML to a PNG screenshot and return it as base64. */
@@ -163,6 +162,13 @@ export async function _createElectronScreenshotRenderer(): Promise<ScreenshotRen
       const id = randomUUID()
       const timeoutMs = options.timeoutMs ?? DEFAULT_SCREENSHOT_TIMEOUT_MS
       const replyTimeoutMs = timeoutMs + SCREENSHOT_REPLY_GRACE_MS
+      const payload = screenshotIpcRequestSchema.parse({
+        type: "screenshot-base64",
+        id,
+        html,
+        viewport,
+        timeoutMs,
+      })
       return new Promise((resolve, reject) => {
         let timer: ReturnType<typeof setTimeout> | undefined
         const cleanup = () => {
@@ -197,13 +203,6 @@ export async function _createElectronScreenshotRenderer(): Promise<ScreenshotRen
             )
           )
         }, replyTimeoutMs)
-        const payload = screenshotIpcRequestSchema.parse({
-          type: "screenshot-base64",
-          id,
-          html,
-          viewport,
-          timeoutMs,
-        })
         parentPort.postMessage(payload)
       })
     },

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -412,6 +412,7 @@ export {
 } from "./translation-evaluation.js"
 
 export {
+  DEFAULT_SCREENSHOT_TIMEOUT_MS,
   screenshotIpcViewportSchema,
   screenshotIpcRequestSchema,
   screenshotIpcCloseSchema,

--- a/packages/types/src/screenshot-ipc.ts
+++ b/packages/types/src/screenshot-ipc.ts
@@ -1,5 +1,10 @@
 import { z } from "zod"
 
+/** Budget for one whole capture. Generous on purpose: this is a backstop against
+ *  a capture that never settles, not a performance knob. Shared by the utility
+ *  process renderer and the main-process handler so their deadlines stay aligned. */
+export const DEFAULT_SCREENSHOT_TIMEOUT_MS = 30_000
+
 export const screenshotIpcViewportSchema = z.object({
   width: z.number().finite().positive().int(),
   height: z.number().finite().positive().int(),

--- a/packages/types/src/screenshot-ipc.ts
+++ b/packages/types/src/screenshot-ipc.ts
@@ -10,6 +10,7 @@ export const screenshotIpcRequestSchema = z.object({
   id: z.string().uuid(),
   html: z.string(),
   viewport: screenshotIpcViewportSchema.optional(),
+  timeoutMs: z.number().finite().positive().int().optional(),
 })
 
 export const screenshotIpcCloseSchema = z.object({


### PR DESCRIPTION
## Problem

The Electron screenshot path had no timeout anywhere in the chain, so a capture that never settles hung forever instead of failing:

- **Utility-process side** — `_createElectronScreenshotRenderer` returned a Promise that only settled on an IPC reply or an abort. No timer.
- **Main-process side** — `apps/desktop/src/main/services/screenshot.ts` awaited `did-finish-load` / `did-fail-load` with no ceiling. If neither event fired (a pending subresource, an offscreen `BrowserWindow` that never paints), the load promise never settled, no reply was ever posted, and the utility process waited forever. `capturePage()` had the same exposure — and the wedged `BrowserWindow` leaked.

Since the desktop build is the primary target, this was the one path a screenshot hang could stall the Storyboard step with no progress and no error.

## Changes

### Utility process (`packages/pipeline/src/screenshot.ts`)
- The IPC wait now races against a backstop timer derived from the (new) `timeoutMs` option, defaulting to `DEFAULT_SCREENSHOT_TIMEOUT_MS` (30s). The backstop waits the capture budget **plus a 5s grace**, so main's own bounded failure — which carries a descriptive error — normally wins the race.
- The capture budget is forwarded to the main process through the IPC request (`timeoutMs` added to `screenshotIpcRequestSchema`).
- The request payload is validated **before** the Promise executor registers listeners/timers, so a schema parse failure can no longer leave a `parentPort` listener and backstop timer dangling.

### Main process (`apps/desktop/src/main/services/screenshot.ts`)
- `loadURL`, the `did-finish-load` wait, and `capturePage()` each run under a shared whole-capture deadline (`withDeadline`), so the handler always posts a reply — success or error — and the `finally` block always destroys the window and drops the stored HTML. No more leaked `BrowserWindow` instances.
- A side-branch `catch` on the load promise prevents a late `did-fail-load` (after the `loadURL` deadline fires first) from surfacing as an unhandled rejection in main.

### Shared contract (`packages/types/src/screenshot-ipc.ts`)
- `DEFAULT_SCREENSHOT_TIMEOUT_MS` lives in `@adt/types` next to the IPC schemas and is imported by both sides (re-exported from `@adt/pipeline` for existing consumers). A single source keeps the two deadlines aligned so the 5s grace semantics can't invert through drift.

## Tests

- `packages/pipeline/src/__tests__/screenshot.test.ts` — backstop rejects when main never replies; budget is forwarded in the IPC request; timer and listener are cleaned up once a reply arrives.
- `apps/desktop/src/main/services/screenshot.test.ts` — happy path; load that never finishes; capture that never settles — all three destroy the window and drop the stored HTML.
- `pnpm typecheck` passes.

## Notes

- Complements #635 (`fix(storyboard): don't fail a page when a visual-review screenshot times out`), which is **not merged yet**. Until it lands, a timed-out Electron capture surfaces as a page error instead of engaging the retry/skip-refinement path — strictly better than the silent hang, but the full recovery behavior depends on #635. Both branches touch `packages/pipeline/src/screenshot.ts`, so whichever merges second should reconcile (the Electron renderer now honors `timeoutMs`, so #635's 60s review budget will flow through unchanged).

Closes #662 