### PR TITLE
fix(tts): consolidate debug logging

### DIFF
--- a/apps/api/src/routes/tts.ts
+++ b/apps/api/src/routes/tts.ts
@@ -1,4 +1,3 @@
-import crypto from "node:crypto"
 import fs from "node:fs"
 import path from "node:path"
 import { Hono } from "hono"
@@ -22,7 +21,6 @@ import {
   createGeminiTTSSynthesizer,
   createElevenLabsTTSSynthesizer,
   createTTSSynthesizer,
-  type LlmLogEntry,
 } from "@adt/llm"
 import {
   getBaseLanguage,
@@ -40,6 +38,7 @@ import {
   getCoreTtsCatalog,
   getReadyCoreTtsEntries,
   findAdjacentSpeechText,
+  buildTtsLogEntry,
   elevenLabsVoiceSettingsFromConfig,
   buildElevenLabsTtsLogParams,
   classifyElevenLabsTtsError,
@@ -400,32 +399,15 @@ function appendSingleTtsLog(
     durationMs: number
     success: boolean
     cached: boolean
+    attempt: number
     error?: string
     /** Resolved provider request parameters, for the debug panel. */
     params?: Record<string, unknown>
   }
 ): void {
-  const logEntry: LlmLogEntry = {
-    requestId: crypto.randomUUID(),
-    timestamp: new Date().toISOString(),
-    taskType: "tts",
-    pageId: options.textId,
-    promptName: `tts-${options.provider}`,
-    modelId: `${options.provider}/${options.model}`,
-    cacheHit: options.cached,
-    success: options.success,
-    errorCount: options.success ? 0 : 1,
-    attempt: 1,
-    durationMs: options.durationMs,
-    ...(options.params ? { params: options.params } : {}),
-    messages: [{
-      role: "user",
-      content: [{
-        type: "text" as const,
-        text: `[${options.language}] voice=${options.voice}\n${options.error ? `ERROR: ${options.error}\n\n` : ""}${options.text.slice(0, 300)}`,
-      }],
-    }],
-  }
+  const logEntry = buildTtsLogEntry({
+    ...options,
+  })
 
   storage.appendLlmLog(logEntry)
 }
@@ -954,12 +936,14 @@ export function createTTSRoutes(booksDir: string, configPath?: string, taskServi
        * timeout. Wrapping here rather than at the call sites covers the fallback
        * attempts too.
        */
+      let synthesisAttempts = 0
       const generateEntry = async (options: {
         targetProvider: string
         targetModel: string
         targetVoice: string
       }): Promise<Awaited<ReturnType<typeof synthesizeEntry>>> => {
         for (let attemptCount = 1; ; attemptCount++) {
+          synthesisAttempts++
           try {
             return await synthesizeEntry(options)
           } catch (err) {
@@ -1029,6 +1013,7 @@ export function createTTSRoutes(booksDir: string, configPath?: string, taskServi
           durationMs: Date.now() - startMs,
           success: true,
           cached: entry.cached,
+          attempt: synthesisAttempts,
           params: logParamsFor(usedProvider, usedModel, usedVoice),
         })
 
@@ -1076,6 +1061,9 @@ export function createTTSRoutes(booksDir: string, configPath?: string, taskServi
 
         const message = err instanceof Error ? err.message : String(err)
         let fallbackFailureMessage = message
+        let failedProvider = provider
+        let failedModel = model
+        let failedVoice = voice
 
         if (/did not include audio data/i.test(message)) {
           for (const attempt of fallbackAttempts) {
@@ -1105,6 +1093,7 @@ export function createTTSRoutes(booksDir: string, configPath?: string, taskServi
                 durationMs: Date.now() - startMs,
                 success: true,
                 cached: entry.cached,
+                attempt: synthesisAttempts,
                 params: logParamsFor(attempt.provider, attempt.model, attempt.voice),
               })
 
@@ -1152,6 +1141,9 @@ export function createTTSRoutes(booksDir: string, configPath?: string, taskServi
               const fallbackMessage =
                 fallbackErr instanceof Error ? fallbackErr.message : String(fallbackErr)
               fallbackFailureMessage = `${message}. Fallback ${attempt.provider} failed: ${fallbackMessage}`
+              failedProvider = attempt.provider
+              failedModel = attempt.model
+              failedVoice = attempt.voice
             }
           }
         }
@@ -1159,15 +1151,16 @@ export function createTTSRoutes(booksDir: string, configPath?: string, taskServi
         appendSingleTtsLog(storage, {
           textId: textEntry.id,
           language: normalizedLanguage,
-          voice,
-          model,
-          provider,
+          voice: failedVoice,
+          model: failedModel,
+          provider: failedProvider,
           text: textEntry.text,
           durationMs: Date.now() - startMs,
           success: false,
           cached: false,
+          attempt: synthesisAttempts,
           error: fallbackFailureMessage,
-          params: logParamsFor(provider, model, voice),
+          params: logParamsFor(failedProvider, failedModel, failedVoice),
         })
         storage.recordStepError(
           "tts",

--- a/apps/api/src/services/stage-runner.ts
+++ b/apps/api/src/services/stage-runner.ts
@@ -74,6 +74,7 @@ import {
   computeSpeechCacheKey,
   elevenLabsVoiceSettingsFromConfig,
   buildElevenLabsTtsLogParams,
+  buildTtsLogEntry,
   classifyElevenLabsTtsError,
   elevenLabsTtsRetryDelayMs,
   ELEVENLABS_TTS_MAX_CONCURRENCY,
@@ -3070,24 +3071,19 @@ async function runSpeechStep(
           // tracking), mirroring the per-entry path so batched Gemini calls
           // aren't invisible.
           const emitPageLog = (o: { success: boolean; cacheHit: boolean; attempt: number; error?: string }) => {
-            const preview = group.entries.map((e) => e.text).join(" ").slice(0, 300)
-            const logEntry: LlmLogEntry = {
-              requestId: crypto.randomUUID(),
-              timestamp: new Date().toISOString(),
-              taskType: "tts",
-              pageId: group.pageKey,
-              promptName: "tts-gemini",
-              modelId: `gemini/${providerModel}`,
-              cacheHit: o.cacheHit,
-              success: o.success,
-              errorCount: o.success ? 0 : 1,
-              attempt: Math.max(o.attempt, 1),
+            const logEntry = buildTtsLogEntry({
+              textId: group.pageKey,
+              language: group.language,
+              voice: `${voice} (page ${group.pageKey}, ${group.entries.length} entries)`,
+              model: providerModel,
+              provider: "gemini",
+              text: group.entries.map((entry) => entry.text).join(" "),
               durationMs: Date.now() - startMs,
-              messages: [{
-                role: "user",
-                content: [{ type: "text" as const, text: `[${group.language}] voice=${voice} (page ${group.pageKey}, ${group.entries.length} entries)${o.error ? `\nERROR: ${o.error}` : ""}\n${preview}` }],
-              }],
-            }
+              success: o.success,
+              cached: o.cacheHit,
+              attempt: o.attempt,
+              error: o.error,
+            })
             storage.appendLlmLog(logEntry)
             progress.emit({ type: "llm-log", step: "tts", itemId: group.pageKey, promptName: logEntry.promptName, modelId: logEntry.modelId, cacheHit: o.cacheHit, durationMs: logEntry.durationMs })
           }
@@ -3325,24 +3321,19 @@ async function runSpeechStep(
         const durationMs = Date.now() - startMs
         const cached = entry?.cached ?? false
 
-        const logEntry: LlmLogEntry = {
-          requestId: crypto.randomUUID(),
-          timestamp: new Date().toISOString(),
-          taskType: "tts",
-          pageId: item.textId,
-          promptName: `tts-${provider}`,
-          modelId: `${provider}/${providerModel}`,
-          cacheHit: cached,
-          success: true,
-          errorCount: 0,
-          attempt: attemptCount,
+        const logEntry = buildTtsLogEntry({
+          textId: item.textId,
+          language: item.language,
+          voice,
+          model: providerModel,
+          provider,
+          text: item.text,
           durationMs,
-          ...(logParams ? { params: logParams } : {}),
-          messages: [{
-            role: "user",
-            content: [{ type: "text" as const, text: `[${item.language}] voice=${voice}\n${item.text.slice(0, 300)}` }],
-          }],
-        }
+          success: true,
+          cached,
+          attempt: attemptCount,
+          params: logParams,
+        })
         storage.appendLlmLog(logEntry)
         progress.emit({
           type: "llm-log",
@@ -3372,24 +3363,20 @@ async function runSpeechStep(
           geminiFailedItems.push(`${item.textId}: ${msg}`)
         }
 
-        const logEntry: LlmLogEntry = {
-          requestId: crypto.randomUUID(),
-          timestamp: new Date().toISOString(),
-          taskType: "tts",
-          pageId: item.textId,
-          promptName: `tts-${provider}`,
-          modelId: `${provider}/${providerModel}`,
-          cacheHit: false,
-          success: false,
-          errorCount: 1,
-          attempt: Math.max(attemptCount, 1),
+        const logEntry = buildTtsLogEntry({
+          textId: item.textId,
+          language: item.language,
+          voice,
+          model: providerModel,
+          provider,
+          text: item.text,
           durationMs,
-          ...(logParams ? { params: logParams } : {}),
-          messages: [{
-            role: "user",
-            content: [{ type: "text" as const, text: `[${item.language}] voice=${voice}\nERROR: ${msg}\n\n${item.text.slice(0, 300)}` }],
-          }],
-        }
+          success: false,
+          cached: false,
+          attempt: attemptCount,
+          error: msg,
+          params: logParams,
+        })
         storage.appendLlmLog(logEntry)
         progress.emit({
           type: "llm-log",

--- a/apps/studio/src/api/client.ts
+++ b/apps/studio/src/api/client.ts
@@ -627,6 +627,7 @@ export interface LlmLogEntry {
     cacheHit: boolean
     /** Final status of this individual attempt. Older log entries may omit it. */
     success?: boolean
+    error?: string
     durationMs: number
     usage?: { inputTokens: number; outputTokens: number }
     validationErrors?: string[]

--- a/apps/studio/src/components/debug/LlmLogsTab.tsx
+++ b/apps/studio/src/components/debug/LlmLogsTab.tsx
@@ -247,6 +247,18 @@ function LogDetail({ data, label }: { data: LlmLogEntry["data"]; label: string }
             </pre>
           </div>
         )}
+
+        {data.success === false && data.error && (
+          <div>
+            <div className="font-medium text-destructive mb-1 flex items-center gap-1">
+              <AlertTriangle className="h-3 w-3" />
+              <Trans>Error</Trans>
+            </div>
+            <pre className="bg-red-50 dark:bg-red-950/30 p-3 rounded text-[11px] whitespace-pre-wrap text-destructive">
+              {data.error}
+            </pre>
+          </div>
+        )}
       </div>
     </td>
   )

--- a/packages/llm/src/log.ts
+++ b/packages/llm/src/log.ts
@@ -16,6 +16,8 @@ export interface LlmLogEntry {
   durationMs: number
   usage?: TokenUsage
   validationErrors?: string[]
+  /** Transport or provider failure, distinct from a structured-output validation error. */
+  error?: string
   /**
    * Resolved provider request parameters, recorded so a run is inspectable
    * after the fact ("which settings produced this output?").

--- a/packages/pipeline/src/__tests__/speech.test.ts
+++ b/packages/pipeline/src/__tests__/speech.test.ts
@@ -19,6 +19,7 @@ import {
   findAdjacentSpeechText,
   elevenLabsVoiceSettingsFromConfig,
   buildElevenLabsTtsLogParams,
+  buildTtsLogEntry,
   classifyElevenLabsTtsError,
   elevenLabsTtsRetryDelayMs,
   parseElevenLabsErrorStatus,
@@ -1022,6 +1023,44 @@ describe("buildElevenLabsTtsLogParams", () => {
       "language",
       "outputFormat",
     ])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildTtsLogEntry
+// ---------------------------------------------------------------------------
+
+describe("buildTtsLogEntry", () => {
+  it("keeps the complete request text and records provider failures separately", () => {
+    const text = "A very long narrated entry. ".repeat(30)
+    const entry = buildTtsLogEntry({
+      textId: "pg001_t001",
+      language: "en",
+      voice: "en-US-JennyNeural",
+      model: "azure-tts",
+      provider: "azure",
+      text,
+      durationMs: 250,
+      success: false,
+      cached: false,
+      attempt: 0,
+      error: "Azure TTS request failed (400): Bad Request",
+    })
+
+    expect(entry).toMatchObject({
+      taskType: "tts",
+      pageId: "pg001_t001",
+      promptName: "tts-azure",
+      modelId: "azure/azure-tts",
+      success: false,
+      errorCount: 1,
+      attempt: 1,
+      error: "Azure TTS request failed (400): Bad Request",
+    })
+    expect(entry.messages[0]?.content[0]).toEqual({
+      type: "text",
+      text: `[en] voice=en-US-JennyNeural\n${text}`,
+    })
   })
 })
 

--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -244,6 +244,7 @@ export {
   loadSpeechInstructions,
   computeSpeechCacheKey,
   findAdjacentSpeechText,
+  buildTtsLogEntry,
   elevenLabsVoiceSettingsFromConfig,
   buildElevenLabsTtsLogParams,
   classifyElevenLabsTtsError,

--- a/packages/pipeline/src/speech.ts
+++ b/packages/pipeline/src/speech.ts
@@ -15,6 +15,7 @@ import {
 } from "@adt/types"
 import type {
   ElevenLabsVoiceSettingsOverrides,
+  LlmLogEntry,
   RateLimiter,
   TTSSynthesizer,
   WhisperTranscriptionResult,
@@ -48,6 +49,49 @@ const GEMINI_AUDIO_FORMAT = "wav"
 export function stripEmojis(text: string): string {
   if (!text) return text
   return text.replace(EMOJI_RE, "")
+}
+
+/**
+ * Build the common debug-log record for a TTS request. Keeping this next to
+ * the generation helpers prevents the API runner, the one-item route, and the
+ * CLI/DAG executor from drifting in their representation of the same call.
+ */
+export function buildTtsLogEntry(options: {
+  textId: string
+  language: string
+  voice: string
+  model: string
+  provider: string
+  text: string
+  durationMs: number
+  success: boolean
+  cached: boolean
+  attempt: number
+  error?: string
+  params?: Record<string, unknown>
+}): LlmLogEntry {
+  return {
+    requestId: crypto.randomUUID(),
+    timestamp: new Date().toISOString(),
+    taskType: "tts",
+    pageId: options.textId,
+    promptName: `tts-${options.provider}`,
+    modelId: `${options.provider}/${options.model}`,
+    cacheHit: options.cached,
+    success: options.success,
+    errorCount: options.success ? 0 : 1,
+    attempt: Math.max(options.attempt, 1),
+    durationMs: options.durationMs,
+    ...(options.error ? { error: options.error } : {}),
+    ...(options.params ? { params: options.params } : {}),
+    messages: [{
+      role: "user",
+      content: [{
+        type: "text",
+        text: `[${options.language}] voice=${options.voice}\n${options.text}`,
+      }],
+    }],
+  }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #719 and the remaining presentation/persistence work in #713.

TTS debug records are now built in one shared pipeline helper across the single-item route, normal full Speech runs, and page-batched Gemini synthesis. This removes drift between execution paths and makes failures inspectable.

## Changes

- Add `buildTtsLogEntry()` as the shared TTS debug-log builder.
- Record complete narrated request text rather than truncating it to 300 characters.
- Store provider/transport failures in a dedicated `error` field instead of prefixing them into Messages.
- Render failed TTS errors in a separate red Error block in the Studio Debug Log detail.
- Record actual single-item synthesis attempts, including retries and fallback attempts.
- When a cross-provider fallback fails, attribute the terminal log entry to the final attempted provider/model/voice.

## Verification

- `packages/pipeline/src/__tests__/speech.test.ts` — 90 passing tests, including the shared-builder error/full-text test.
- Studio TypeScript check passed.
- Lingui extraction passed with all five locales fully translated.
- Manual Studio verification confirmed the separate Debug Log error block and complete message display.

## Review

A regression review found no merge-blocking issues. Its one metadata concern about failed fallback attribution was addressed before this PR.