### PR TITLE
fix(speech): log Whisper timestamp calls

### DIFF
--- a/apps/api/src/routes/tts.ts
+++ b/apps/api/src/routes/tts.ts
@@ -1428,6 +1428,7 @@ export function createTTSRoutes(booksDir: string, configPath?: string, taskServi
         language: baseLanguage,
         prompt: textPrompt,
         cacheDir: path.join(bookDir, ".cache"),
+        onLog: (entry) => storage.appendLlmLog(entry),
       })
 
       const timestampEntry: WordTimestampEntry = {
@@ -1582,6 +1583,7 @@ export function createTTSRoutes(booksDir: string, configPath?: string, taskServi
                 language: baseLanguage,
                 prompt: textPrompt,
                 cacheDir: path.join(bookDir, ".cache"),
+                onLog: (entry) => storage.appendLlmLog(entry),
               })
 
               const entry: WordTimestampEntry = {

--- a/apps/api/src/services/stage-runner.ts
+++ b/apps/api/src/services/stage-runner.ts
@@ -707,6 +707,30 @@ function canReuseSpeechEntry(
   return true
 }
 
+/**
+ * Sink for Whisper word-timestamp log rows: persist, then mirror onto the live
+ * progress stream. Both halves matter — the TTS sites already pair them, so a
+ * Whisper row that only lands in the DB would be missing from the debug panel
+ * until the next reload.
+ */
+function appendWordTimestampsLog(
+  storage: Storage,
+  progress: StageRunProgress,
+): (entry: LlmLogEntry) => void {
+  return (entry) => {
+    storage.appendLlmLog(entry)
+    progress.emit({
+      type: "llm-log",
+      step: "word-timestamps",
+      itemId: entry.pageId ?? "",
+      promptName: entry.promptName,
+      modelId: entry.modelId,
+      cacheHit: entry.cacheHit,
+      durationMs: entry.durationMs,
+    })
+  }
+}
+
 interface GenerateSpeechWordTimestampsOptions {
   label: string
   bookDir: string
@@ -3187,7 +3211,7 @@ async function runSpeechStep(
                 geminiTemperature: config.speech?.temperature,
                 geminiSeed: config.speech?.seed,
                 signal: options.signal,
-                onWhisperLog: (entry) => storage.appendLlmLog(entry),
+                onWhisperLog: appendWordTimestampsLog(storage, progress),
               })
               for (const e of entries) ttsResultsByLang.get(group.language)?.push(e)
               // A page served from cache makes no request — don't reward the
@@ -3551,7 +3575,7 @@ async function runSpeechStep(
         textByLanguage,
         concurrency: effectiveConcurrency,
         progress,
-        onLog: (entry) => storage.appendLlmLog(entry),
+        onLog: appendWordTimestampsLog(storage, progress),
         signal: options.signal,
       })
       wordTimestampsByLang = generatedWordTimestamps.entriesByLanguage

--- a/apps/api/src/services/stage-runner.ts
+++ b/apps/api/src/services/stage-runner.ts
@@ -717,6 +717,7 @@ interface GenerateSpeechWordTimestampsOptions {
   textByLanguage: Map<string, Map<string, string>>
   concurrency: number
   progress: StageRunProgress
+  onLog?: (entry: LlmLogEntry) => void
   /** Run cancel — stops admitting new transcription items. */
   signal?: AbortSignal
 }
@@ -741,6 +742,7 @@ async function generateSpeechWordTimestamps(
     textByLanguage,
     concurrency,
     progress,
+    onLog,
     signal,
   } = options
 
@@ -811,6 +813,7 @@ async function generateSpeechWordTimestamps(
           language: getBaseLanguage(language),
           prompt,
           cacheDir,
+          onLog,
         })
         if (result.cached) {
           console.log(`[stage-run] ${label}: word timestamps cache hit for ${entry.textId} (${language})`)
@@ -3184,6 +3187,7 @@ async function runSpeechStep(
                 geminiTemperature: config.speech?.temperature,
                 geminiSeed: config.speech?.seed,
                 signal: options.signal,
+                onWhisperLog: (entry) => storage.appendLlmLog(entry),
               })
               for (const e of entries) ttsResultsByLang.get(group.language)?.push(e)
               // A page served from cache makes no request — don't reward the
@@ -3547,6 +3551,7 @@ async function runSpeechStep(
         textByLanguage,
         concurrency: effectiveConcurrency,
         progress,
+        onLog: (entry) => storage.appendLlmLog(entry),
         signal: options.signal,
       })
       wordTimestampsByLang = generatedWordTimestamps.entriesByLanguage

--- a/packages/pipeline/src/__tests__/speech.test.ts
+++ b/packages/pipeline/src/__tests__/speech.test.ts
@@ -22,6 +22,7 @@ import {
   elevenLabsVoiceSettingsFromConfig,
   buildElevenLabsTtsLogParams,
   buildTtsLogEntry,
+  buildWordTimestampsLogEntry,
   classifyElevenLabsTtsError,
   elevenLabsTtsRetryDelayMs,
   parseElevenLabsErrorStatus,
@@ -1367,6 +1368,75 @@ describe("buildTtsLogEntry", () => {
     expect(entry.messages[0]?.content[0]).toEqual({
       type: "text",
       text: `[en] voice=en-US-JennyNeural\n${text}`,
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildWordTimestampsLogEntry
+// ---------------------------------------------------------------------------
+
+describe("buildWordTimestampsLogEntry", () => {
+  it("records a successful transcription under the word-timestamps step", () => {
+    const entry = buildWordTimestampsLogEntry({
+      fileName: "pg001_t001.mp3",
+      language: "en",
+      prompt: "Hello world",
+      durationMs: 420,
+      success: true,
+      cached: false,
+      result: {
+        text: "Hello world",
+        words: [
+          { word: "Hello", start: 0, end: 0.4 },
+          { word: "world", start: 0.4, end: 0.9 },
+        ],
+        duration: 0.9,
+      },
+    })
+
+    // taskType is the real step name, so the Log tab's step filter and the
+    // step badge work with no extra wiring.
+    expect(entry).toMatchObject({
+      taskType: "word-timestamps",
+      pageId: "pg001_t001.mp3",
+      promptName: "whisper-transcribe",
+      modelId: "openai/whisper-1",
+      cacheHit: false,
+      success: true,
+      errorCount: 0,
+    })
+    expect(entry.params).toEqual({
+      language: "en",
+      fileName: "pg001_t001.mp3",
+      hasPrompt: true,
+      words: 2,
+      durationSec: 0.9,
+    })
+  })
+
+  it("marks a cache hit and a provider failure distinctly", () => {
+    const cached = buildWordTimestampsLogEntry({
+      fileName: "pg001_t001.mp3",
+      durationMs: 1,
+      success: true,
+      cached: true,
+    })
+    expect(cached.cacheHit).toBe(true)
+    // No result and no prompt — the row still says so rather than omitting it.
+    expect(cached.params).toEqual({ language: "", fileName: "pg001_t001.mp3", hasPrompt: false })
+
+    const failed = buildWordTimestampsLogEntry({
+      fileName: "pg001_t001.mp3",
+      durationMs: 30,
+      success: false,
+      cached: false,
+      error: "Whisper request failed (401): invalid api key",
+    })
+    expect(failed).toMatchObject({
+      success: false,
+      errorCount: 1,
+      error: "Whisper request failed (401): invalid api key",
     })
   })
 })

--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -251,6 +251,7 @@ export {
   computeSpeechCacheKey,
   findAdjacentSpeechText,
   buildTtsLogEntry,
+  buildWordTimestampsLogEntry,
   elevenLabsVoiceSettingsFromConfig,
   buildElevenLabsTtsLogParams,
   classifyElevenLabsTtsError,

--- a/packages/pipeline/src/speech.ts
+++ b/packages/pipeline/src/speech.ts
@@ -101,6 +101,54 @@ export function buildTtsLogEntry(options: {
   }
 }
 
+/**
+ * Build the debug-log record for a Whisper word-timestamp transcription.
+ * Sits beside {@link buildTtsLogEntry} for the same reason: four call sites
+ * feed this (the full Speech run, the two manual transcribe routes, and the
+ * page-batched alignment pass), and a hand-rolled record per site is how the
+ * TTS ones drifted.
+ *
+ * `taskType` is the real `word-timestamps` step name, so the Log tab's step
+ * filter and the step badge work with no extra wiring.
+ */
+export function buildWordTimestampsLogEntry(options: {
+  fileName: string
+  language?: string
+  prompt?: string
+  durationMs: number
+  success: boolean
+  cached: boolean
+  result?: WhisperTranscriptionResult
+  error?: string
+}): LlmLogEntry {
+  return {
+    requestId: crypto.randomUUID(),
+    timestamp: new Date().toISOString(),
+    taskType: "word-timestamps",
+    pageId: options.fileName,
+    promptName: "whisper-transcribe",
+    modelId: "openai/whisper-1",
+    cacheHit: options.cached,
+    success: options.success,
+    errorCount: options.success ? 0 : 1,
+    attempt: 1,
+    durationMs: options.durationMs,
+    ...(options.error ? { error: options.error } : {}),
+    params: {
+      language: options.language ?? "",
+      fileName: options.fileName,
+      hasPrompt: Boolean(options.prompt),
+      ...(options.result
+        ? { words: options.result.words.length, durationSec: options.result.duration }
+        : {}),
+    },
+    messages: [{
+      role: "user",
+      content: [{ type: "text", text: options.prompt ?? "" }],
+    }],
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Speakable text check
 // ---------------------------------------------------------------------------
@@ -1214,15 +1262,24 @@ export async function generateWordTimestamps(
 ): Promise<GenerateWordTimestampsResult> {
   const { audioBuffer, fileName, apiKey, language, prompt, cacheDir, onLog } = options
   const startedAt = Date.now()
-  const log = (success: boolean, cached: boolean, result?: WhisperTranscriptionResult, error?: string) =>
-    onLog?.({
-      requestId: crypto.randomUUID(), timestamp: new Date().toISOString(), taskType: "word-timestamps",
-      pageId: fileName, promptName: "whisper-transcribe", modelId: "openai/whisper-1", cacheHit: cached,
-      success, errorCount: success ? 0 : 1, attempt: 1, durationMs: Date.now() - startedAt,
-      ...(error ? { error } : {}),
-      params: { language: language ?? "", fileName, hasPrompt: Boolean(prompt), ...(result ? { words: result.words.length, durationSec: result.duration } : {}) },
-      messages: [{ role: "user", content: [{ type: "text", text: prompt ?? "" }] }],
-    })
+  const log = (
+    success: boolean,
+    cached: boolean,
+    result?: WhisperTranscriptionResult,
+    error?: string,
+  ) =>
+    onLog?.(
+      buildWordTimestampsLogEntry({
+        fileName,
+        language,
+        prompt,
+        durationMs: Date.now() - startedAt,
+        success,
+        cached,
+        result,
+        error,
+      }),
+    )
 
   const audioHash = crypto.createHash("sha256").update(audioBuffer).digest("hex")
   const hash = crypto
@@ -1245,8 +1302,14 @@ export async function generateWordTimestamps(
   }
 
   let result: WhisperTranscriptionResult
-  try { result = await transcribeWithWhisper(audioBuffer, fileName, apiKey, language, prompt) }
-  catch (cause) { const error = cause instanceof Error ? cause.message : String(cause); log(false, false, undefined, error); throw cause }
+  try {
+    result = await transcribeWithWhisper(audioBuffer, fileName, apiKey, language, prompt)
+  } catch (cause) {
+    // Record the failure before rethrowing — a Whisper error that leaves no
+    // trace is the black box this exists to remove.
+    log(false, false, undefined, cause instanceof Error ? cause.message : String(cause))
+    throw cause
+  }
 
   log(true, false, result)
   fs.mkdirSync(cacheRoot, { recursive: true })

--- a/packages/pipeline/src/speech.ts
+++ b/packages/pipeline/src/speech.ts
@@ -1034,6 +1034,7 @@ export interface GeneratePageSpeechFilesOptions {
   geminiTemperature?: number
   geminiSeed?: number
   signal?: AbortSignal
+  onWhisperLog?: (entry: LlmLogEntry) => void
 }
 
 /**
@@ -1056,7 +1057,7 @@ export async function generatePageSpeechFiles(
   const {
     entries, language, model, voice, instructions, format, bookDir, cacheDir,
     ttsSynthesizer, whisperApiKey, rateLimiter, provider, voiceSlot, voiceLabel,
-    geminiTemperature, geminiSeed, signal,
+    geminiTemperature, geminiSeed, signal, onWhisperLog,
   } = options
   const slot: VoiceSlot = voiceSlot ?? "primary"
 
@@ -1132,6 +1133,7 @@ export async function generatePageSpeechFiles(
     language: getBaseLanguage(language),
     prompt: transcript,
     cacheDir,
+    onLog: onWhisperLog,
   })
 
   // 3) Slice the page audio into per-entry files at sentence boundaries.
@@ -1196,6 +1198,7 @@ export interface GenerateWordTimestampsOptions {
   language?: string
   prompt?: string
   cacheDir: string
+  onLog?: (entry: LlmLogEntry) => void
 }
 
 export interface GenerateWordTimestampsResult extends WhisperTranscriptionResult {
@@ -1209,7 +1212,17 @@ export interface GenerateWordTimestampsResult extends WhisperTranscriptionResult
 export async function generateWordTimestamps(
   options: GenerateWordTimestampsOptions,
 ): Promise<GenerateWordTimestampsResult> {
-  const { audioBuffer, fileName, apiKey, language, prompt, cacheDir } = options
+  const { audioBuffer, fileName, apiKey, language, prompt, cacheDir, onLog } = options
+  const startedAt = Date.now()
+  const log = (success: boolean, cached: boolean, result?: WhisperTranscriptionResult, error?: string) =>
+    onLog?.({
+      requestId: crypto.randomUUID(), timestamp: new Date().toISOString(), taskType: "word-timestamps",
+      pageId: fileName, promptName: "whisper-transcribe", modelId: "openai/whisper-1", cacheHit: cached,
+      success, errorCount: success ? 0 : 1, attempt: 1, durationMs: Date.now() - startedAt,
+      ...(error ? { error } : {}),
+      params: { language: language ?? "", fileName, hasPrompt: Boolean(prompt), ...(result ? { words: result.words.length, durationSec: result.duration } : {}) },
+      messages: [{ role: "user", content: [{ type: "text", text: prompt ?? "" }] }],
+    })
 
   const audioHash = crypto.createHash("sha256").update(audioBuffer).digest("hex")
   const hash = crypto
@@ -1224,14 +1237,18 @@ export async function generateWordTimestamps(
   if (fs.existsSync(cachePath)) {
     try {
       const parsed = JSON.parse(fs.readFileSync(cachePath, "utf-8")) as WhisperTranscriptionResult
+      log(true, true, parsed)
       return { ...parsed, cached: true }
     } catch {
       // Fall through to regenerate on parse failure
     }
   }
 
-  const result = await transcribeWithWhisper(audioBuffer, fileName, apiKey, language, prompt)
+  let result: WhisperTranscriptionResult
+  try { result = await transcribeWithWhisper(audioBuffer, fileName, apiKey, language, prompt) }
+  catch (cause) { const error = cause instanceof Error ? cause.message : String(cause); log(false, false, undefined, error); throw cause }
 
+  log(true, false, result)
   fs.mkdirSync(cacheRoot, { recursive: true })
   fs.writeFileSync(cachePath, JSON.stringify(result, null, 2) + "\n")
 


### PR DESCRIPTION
## Summary

Fixes #714. Whisper transcription calls used for word highlighting and page-batched Gemini alignment are now recorded in the book Debug Log.

Whisper is a paid OpenAI call that previously left **no `llm_log` row at all** — a black box against core principle 4, for every book with `speech.word_highlighting` enabled.

## Changes

- Add an optional `onLog` hook to `generateWordTimestamps`, and `onWhisperLog` to `generatePageSpeechFiles`.
- Record Whisper model, cache status, latency, language, audio filename, prompt presence, word count, duration, and provider errors.
- `taskType: "word-timestamps"` is a real step name in `PIPELINE`, so the step badge and the Log tab's step filter work with no extra wiring.
- Wire the hook through all four paths:
  - full Speech word-timestamp generation;
  - manual single-item transcription;
  - manual bulk transcription;
  - page-batched Gemini alignment.
- Keep the existing Whisper cache key and cancellation semantics unchanged.

## Rebased onto `develop`, plus two cleanups

The rebase itself was mechanical — the multi-voice work (#780 / #825) inserted `voiceSlot`/`voiceLabel` exactly where this PR appends its option, so both conflicts resolve by keeping develop's fields and adding one more. `generateWordTimestamps` was untouched by develop.

Two things fixed while there:

- **The log record is now built by a shared `buildWordTimestampsLogEntry`**, next to `buildTtsLogEntry`. #797 merged specifically to consolidate four hand-rolled TTS log constructions that had drifted; the original inline closure here reintroduced exactly what that removed. Now exported and unit-tested.
- **Each row is mirrored onto the progress stream**, as every neighbouring TTS site already does. Appending only to the DB left the row missing from the debug panel until the next reload.

No multi-voice hazard: the Whisper `fileName` is `${pageHash}.${safeFormat}` and `pageHash` covers `voice`, so a dual-voice book's two page batches already produce distinct `pageId`s.

## Verification

`pnpm build`, `pnpm typecheck`, `pnpm lint` (0 errors), full suite **2887 passing**.

Two new tests for `buildWordTimestampsLogEntry`: a successful transcription (step name, model id, `params` summary) and the cache-hit / provider-failure shapes.

## Known gap

No live paid run. The tests pin the record shape and all four call sites are wired and typechecked, but confirming a real Whisper row lands in the panel needs a book with `word_highlighting` enabled and an OpenAI key.
