### PR TITLE
fix(speech): fail fast when a TTS provider credential is missing

### DIFF
--- a/apps/api/src/services/stage-runner.test.ts
+++ b/apps/api/src/services/stage-runner.test.ts
@@ -1505,6 +1505,145 @@ speech:
     } finally {
       db.close()
     }
+
+    // The Speech view is driven by step-error, not by the rejection: assert the
+    // step goes red carrying the provider message, so the user sees one
+    // actionable error rather than a bare run failure with no step highlighted.
+    const ttsErrors = events.filter(
+      (event) => event.type === "step-error" && event.step === "tts"
+    )
+    expect(ttsErrors).toHaveLength(1)
+    expect((ttsErrors[0] as { error: string }).error).toMatch(
+      /ElevenLabs API key is required/
+    )
+  })
+
+  it("fails before any page-batched synthesis when the Gemini credential is missing", async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "stage-runner-tts-"))
+    const booksDir = path.join(tmpDir, "books")
+    const promptsDir = path.join(tmpDir, "prompts")
+    const configPath = path.join(tmpDir, "config.yaml")
+    fs.mkdirSync(promptsDir, { recursive: true })
+    // batch_by_page routes page-scoped Gemini entries into pageGroups, which
+    // deliberately skip the per-entry reuse check — so this is the path that
+    // reaches the pre-flight via the pageGroups half of its provider set.
+    fs.writeFileSync(
+      configPath,
+      `role_types:
+  section_text: Main body text
+structure_types:
+  paragraph: Paragraph
+speech:
+  default_provider: gemini
+  batch_by_page: true
+  providers:
+    gemini:
+      languages:
+        - en
+`
+    )
+    seedTextAndSpeechBook(booksDir, "gemini-batched-missing-key")
+    vi.stubEnv("GEMINI_API_KEY", "")
+
+    const events: ProgressEvent[] = []
+    const runner = createStageRunner()
+    await expect(
+      runner.run(
+        "gemini-batched-missing-key",
+        {
+          booksDir,
+          apiKey: "sk-test",
+          promptsDir,
+          configPath,
+          fromStage: "translate",
+          toStage: "speech",
+        },
+        { emit: (event) => events.push(event) }
+      )
+    ).rejects.toThrow(/Gemini API key is required/)
+
+    const db = openBookDb(
+      path.join(booksDir, "gemini-batched-missing-key", "gemini-batched-missing-key.db")
+    )
+    try {
+      expect(db.all("SELECT request_id FROM llm_log WHERE step = 'tts'")).toHaveLength(0)
+    } finally {
+      db.close()
+    }
+    expect(transcribeWithWhisperMock).not.toHaveBeenCalled()
+  })
+
+  it("does not require a credential when every entry is reused and there is no work", async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "stage-runner-tts-"))
+    const booksDir = path.join(tmpDir, "books")
+    const promptsDir = path.join(tmpDir, "prompts")
+    const configPath = path.join(tmpDir, "config.yaml")
+    fs.mkdirSync(promptsDir, { recursive: true })
+    fs.writeFileSync(
+      configPath,
+      `role_types:
+  section_text: Main body text
+structure_types:
+  paragraph: Paragraph
+speech:
+  default_provider: elevenlabs
+  providers:
+    elevenlabs:
+      languages:
+        - en
+`
+    )
+    const label = "elevenlabs-tts-all-reused"
+    seedTextAndSpeechBook(booksDir, label)
+
+    // A manual recording with its audio file present is reusable outright, so
+    // the entry never becomes a work item. With nothing to generate, the
+    // pre-flight's provider set is empty and no synthesizer is built — a run
+    // that needs no credential must not be failed by the fail-fast check.
+    const bookDir = path.join(booksDir, label)
+    const audioDir = path.join(bookDir, "audio", "en")
+    fs.mkdirSync(audioDir, { recursive: true })
+    fs.writeFileSync(path.join(audioDir, "pg001_t001.mp3"), Buffer.from("fake-audio"))
+    const storage = createBookStorage(label, booksDir)
+    try {
+      storage.putNodeData("tts", "en", {
+        entries: [
+          {
+            textId: "pg001_t001",
+            language: "en",
+            fileName: "pg001_t001.mp3",
+            voice: "manual",
+            model: "manual",
+            cached: true,
+            provider: "manual",
+          },
+        ],
+        generatedAt: "2026-01-01T00:00:00.000Z",
+      })
+    } finally {
+      storage.close()
+    }
+    vi.stubEnv("ELEVENLABS_API_KEY", "")
+
+    const events: ProgressEvent[] = []
+    const runner = createStageRunner()
+    await runner.run(
+      label,
+      {
+        booksDir,
+        apiKey: "sk-test",
+        promptsDir,
+        configPath,
+        fromStage: "translate",
+        toStage: "speech",
+      },
+      { emit: (event) => events.push(event) }
+    )
+
+    expect(generateSpeechFileMock).not.toHaveBeenCalled()
+    expect(
+      events.filter((event) => event.type === "step-error" && event.step === "tts")
+    ).toHaveLength(0)
   })
 
   it("stops admitting TTS items and unwinds without step errors when the run is cancelled", async () => {

--- a/apps/api/src/services/stage-runner.test.ts
+++ b/apps/api/src/services/stage-runner.test.ts
@@ -4,7 +4,7 @@ import path from "node:path"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { PIPELINE, type AppConfig, type ProgressEvent } from "@adt/types"
 import { computeSpeechCacheKey, stripEmojis } from "@adt/pipeline"
-import { createBookStorage } from "@adt/storage"
+import { createBookStorage, openBookDb } from "@adt/storage"
 import {
   buildStageRunnerImageClassifyConfig,
   createStageRunner,
@@ -1167,6 +1167,7 @@ describe("createStageRunner speech Gemini partial failures", () => {
   })
 
   afterEach(() => {
+    vi.unstubAllEnvs()
     if (tmpDir) {
       fs.rmSync(tmpDir, { recursive: true, force: true })
       tmpDir = ""
@@ -1448,6 +1449,61 @@ speech:
       expect(ttsStep?.status).toBe("done")
     } finally {
       storage.close()
+    }
+  })
+
+  it("fails the speech step before any synthesis when a provider credential is missing", async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "stage-runner-tts-"))
+    const booksDir = path.join(tmpDir, "books")
+    const promptsDir = path.join(tmpDir, "prompts")
+    const configPath = path.join(tmpDir, "config.yaml")
+    fs.mkdirSync(promptsDir, { recursive: true })
+    fs.writeFileSync(
+      configPath,
+      `role_types:
+  section_text: Main body text
+structure_types:
+  paragraph: Paragraph
+speech:
+  default_provider: elevenlabs
+  providers:
+    elevenlabs:
+      languages:
+        - en
+`
+    )
+    seedTextAndSpeechBook(booksDir, "elevenlabs-tts-missing-key")
+    // The synthesizer factory falls back to the ambient key, so a developer
+    // machine with one exported would otherwise pass the pre-flight.
+    vi.stubEnv("ELEVENLABS_API_KEY", "")
+
+    const events: ProgressEvent[] = []
+    const runner = createStageRunner()
+    await expect(
+      runner.run(
+        "elevenlabs-tts-missing-key",
+        {
+          booksDir,
+          apiKey: "sk-test",
+          promptsDir,
+          configPath,
+          fromStage: "translate",
+          toStage: "speech",
+        },
+        { emit: (event) => events.push(event) }
+      )
+    ).rejects.toThrow(/ElevenLabs API key is required/)
+
+    // The credential is checked once, before any item is admitted: no synthesis
+    // is attempted and no per-item failure is logged.
+    expect(generateSpeechFileMock).not.toHaveBeenCalled()
+    const db = openBookDb(
+      path.join(booksDir, "elevenlabs-tts-missing-key", "elevenlabs-tts-missing-key.db")
+    )
+    try {
+      expect(db.all("SELECT request_id FROM llm_log WHERE step = 'tts'")).toHaveLength(0)
+    } finally {
+      db.close()
     }
   })
 

--- a/apps/api/src/services/stage-runner.test.ts
+++ b/apps/api/src/services/stage-runner.test.ts
@@ -1518,6 +1518,53 @@ speech:
     )
   })
 
+  it("fails fast when only the secondary narrator's provider credential is missing", async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "stage-runner-tts-"))
+    const booksDir = path.join(tmpDir, "books")
+    const promptsDir = path.join(tmpDir, "prompts")
+    const configPath = path.join(tmpDir, "config.yaml")
+    fs.mkdirSync(promptsDir, { recursive: true })
+    // The primary narrator routes to OpenAI (key present); only the secondary
+    // routes to ElevenLabs. A secondary voice carries its own provider, so
+    // deriving the pre-flight set from the language's routing would miss it
+    // entirely and fall back to one logged failure per item.
+    writeSecondarySpeechConfig(configPath, {
+      provider: "elevenlabs",
+      voice: "Rachel",
+    })
+    seedTextAndSpeechBook(booksDir, "secondary-tts-missing-key")
+    vi.stubEnv("ELEVENLABS_API_KEY", "")
+
+    const events: ProgressEvent[] = []
+    const runner = createStageRunner()
+    await expect(
+      runner.run(
+        "secondary-tts-missing-key",
+        {
+          booksDir,
+          apiKey: "sk-test",
+          promptsDir,
+          configPath,
+          fromStage: "translate",
+          toStage: "speech",
+        },
+        { emit: (event) => events.push(event) }
+      )
+    ).rejects.toThrow(/ElevenLabs API key is required/)
+
+    // Nothing is synthesized — not even the primary voice, whose credential is
+    // fine. One missing key fails the run before any item is admitted.
+    expect(generateSpeechFileMock).not.toHaveBeenCalled()
+    const db = openBookDb(
+      path.join(booksDir, "secondary-tts-missing-key", "secondary-tts-missing-key.db")
+    )
+    try {
+      expect(db.all("SELECT request_id FROM llm_log WHERE step = 'tts'")).toHaveLength(0)
+    } finally {
+      db.close()
+    }
+  })
+
   it("fails before any page-batched synthesis when the Gemini credential is missing", async () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "stage-runner-tts-"))
     const booksDir = path.join(tmpDir, "books")

--- a/apps/api/src/services/stage-runner.ts
+++ b/apps/api/src/services/stage-runner.ts
@@ -3096,6 +3096,25 @@ async function runSpeechStep(
     console.log(`[stage-run] ${label}: generating TTS for ${totalItems} entries and reusing ${reusedItems} existing entries across ${outputLanguages.length} languages (${outputLanguages.join(", ")})`)
     console.log(`[stage-run] ${label}: TTS routing — ${[...pageGroups.values()].map((g) => `${g.language}:${g.voiceSlot}→gemini`).concat(ttsWorkItems.map((item) => `${item.language}:${item.voiceSlot}→${item.provider}`)).join(", ")}`)
 
+    // Fail fast: build every synthesizer this run needs before admitting any
+    // item, so a missing credential surfaces as one clear stage error instead
+    // of one logged per-item failure for every entry that was in flight when
+    // the key turned out to be absent. getSynthesizer is memoized, so the
+    // generation loops below reuse these instances.
+    //
+    // Derived from the resolved work, not from the configured providers: a
+    // secondary narrator carries its own provider (speech.secondary_voices),
+    // so a per-language lookup would miss it, and a run whose entries are all
+    // reused needs no synthesizer at all and must not be failed here.
+    // Page groups are Gemini-only by construction (see getSynthesizer("gemini")
+    // in the batched executor below).
+    for (const provider of new Set([
+      ...ttsWorkItems.map((item) => item.provider),
+      ...(pageGroups.size > 0 ? ["gemini"] : []),
+    ])) {
+      getSynthesizer(provider)
+    }
+
     const hasGeminiTts =
       pageGroups.size > 0 || ttsWorkItems.some((item) => item.provider === "gemini")
     // Adaptive limiter: start at the documented ceiling for the selected model

--- a/packages/pipeline/src/pipeline-dag.ts
+++ b/packages/pipeline/src/pipeline-dag.ts
@@ -1150,6 +1150,17 @@ export async function runFullPipeline(
       const totalItems = workItems.length
       let completedItems = 0
 
+      // Fail fast: build every synthesizer this run needs before admitting any
+      // item, so a missing credential surfaces as one clear stage error instead
+      // of one logged per-item failure for every entry that was in flight when
+      // the key turned out to be absent. getSynthesizer is memoized, so
+      // runTtsItem below reuses these instances. Derived from the resolved
+      // work items, so a secondary narrator on its own provider is covered and
+      // a run whose entries are all reused builds nothing.
+      for (const provider of new Set(workItems.map((item) => item.provider))) {
+        getSynthesizer(provider)
+      }
+
       const elevenLabsVoiceSettings = elevenLabsVoiceSettingsFromConfig(config.speech)
 
       const runTtsItem = async (item: TTSWorkItem) => {


### PR DESCRIPTION
## Summary

A missing TTS provider credential produced **one logged failure per item** instead of one clear "key is missing" error.

Both TTS execution paths construct their synthesizer inside the per-item `try`, so an absent key is rediscovered once per item and recorded as a per-item synthesis failure:

- the API stage-runner logs a failure row for **every** entry and still completes the step with gaps;
- the CLI/DAG path logs one row per in-flight item before aborting.

Either way the real cause — a single missing credential — is buried under N identical rows that each look like a synthesis attempt.

## Changes

- Build every synthesizer the run needs **before** admitting any item, in both paths (`stage-runner.ts`, `pipeline-dag.ts`).
- Reuses the existing memoized `getSynthesizer` rather than adding a shared credential helper, so each path keeps its own error wording (the API points at the API Keys dialog, the CLI at env vars).
- The provider set is derived from the **resolved work items** (`item.provider`), plus `"gemini"` when any page groups exist. Not from the configured providers: a run whose entries are all reused needs no synthesizer and must not be failed here.

## Rebased onto `develop` — one behavioural change from the original

This PR predates the multi-voice work (#780 / #825). That work matters here:

**A secondary narrator carries its own provider**, straight from `speech.secondary_voices[<locale>].provider` (`speech.ts:399`), independent of the language's routing. The original pre-flight derived its set via `resolveProviderForLanguage(item.language, routing)` — which on today's `develop` **misses the secondary voice entirely**, i.e. exactly the case the PR exists to catch.

Deriving from `item.provider` fixes that and is simpler, since both `TTSWorkItem` types now carry a resolved provider. New test `"fails fast when only the secondary narrator's provider credential is missing"` pins it; with the old form that test **resolves instead of rejecting**.

> Note for reviewers: the `pipeline-dag.ts` hunk auto-merged cleanly but did **not** compile — `develop` deleted `resolveProviderForLanguage` and `routing` from that scope. Caught by `pnpm typecheck`.

## Behavior change

For a missing credential the API speech stage now **fails immediately** instead of reporting N failed items and completing with gaps. Every item would have failed anyway, and no `llm_log` noise is written — but this does change the error shape the Speech view receives, so it's worth a look.

## Verification

`pnpm build`, `pnpm typecheck`, `pnpm lint` (0 errors), full suite **2889 passing**.

Four tests in `stage-runner.test.ts`, each confirmed failing without the fix:

| Test | Guards |
|---|---|
| ElevenLabs routing, no key | run rejects with the provider-named message, `generateSpeechFile` never called, **zero** `tts` rows, `step-error` carries the message |
| Gemini `pageGroups` path | `pageGroups` skips the per-entry reuse check, so it can carry work the per-entry path never sees |
| Every entry reused | the pre-flight must **not** over-fire — a run needing no synthesizer still succeeds with no credential |
| Secondary narrator on its own provider | **new** — the multi-voice hole described above |

### Live run on `books/tts-log-799` (free — no key, no spend)

| Test | Result |
|---|---|
| **A** — `default_provider: elevenlabs`, no key | 4 work items; `creating TTS synthesizer for provider="elevenlabs"` logged **once**; run failed with the single clear error; `tts` rows still **6** |
| **B** — `openai`, no key | `generating TTS for 0 entries and reusing 4`; routing line empty; **no** `creating TTS synthesizer` line at all; run succeeded; rows still **6** |
| **A′** — primary `openai` (reused), secondary `elevenlabs` (no key) | routing `en:secondary→elevenlabs` ×4; synthesizer built **once**; one clear error; rows still **6**. The primary needs nothing, yet the secondary's missing key is still caught up front |

## Known gap

No automated test for the **CLI-side** pre-flight. `runFullPipeline` has no test harness and exercising it means a full paid run. #807 proposes extracting a testable helper from that same closure — the pre-flight should ride along with it. The CLI side is covered by typecheck and the shared `item.provider` derivation.
