### PR TITLE
fix(tts): mark TTS entries that produced no audio on purpose

### DIFF
--- a/apps/api/src/routes/debug.test.ts
+++ b/apps/api/src/routes/debug.test.ts
@@ -261,6 +261,49 @@ describe("Debug routes", () => {
       expect(body.totals.errorCount).toBe(1)
     })
 
+    it("does not count no-audio TTS rows as calls, cache misses, or latency samples", async () => {
+      // A punctuation-only entry never reaches the provider, so counting it
+      // would understate the tts cache-hit rate and skew average latency.
+      const skippedLabel = "tts-skipped"
+      const storage = createBookStorage(skippedLabel, tmpDir)
+      storage.close()
+      const db = openBookDb(path.join(tmpDir, skippedLabel, `${skippedLabel}.db`))
+      try {
+        const rows = [
+          { promptName: "tts-azure", modelId: "azure/azure-tts", cacheHit: false, success: true, durationMs: 900 },
+          { promptName: "tts-azure", modelId: "azure/azure-tts", cacheHit: false, success: true, durationMs: 0, skippedReason: "no-speakable-text" },
+        ]
+        for (const data of rows) {
+          db.run(
+            "INSERT INTO llm_log (timestamp, step, item_id, data) VALUES (?, ?, ?, ?)",
+            [new Date().toISOString(), "tts", "pg001_t001", JSON.stringify(data)]
+          )
+        }
+      } finally {
+        db.close()
+      }
+
+      const res = await app.request(`/api/books/${skippedLabel}/debug/stats`)
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      const ttsStep = body.steps.find((s: { step: string }) => s.step === "tts")
+      expect(ttsStep.calls).toBe(1)
+      expect(ttsStep.cacheMisses).toBe(1)
+      expect(ttsStep.avgDurationMs).toBe(900)
+      expect(body.totals.calls).toBe(1)
+
+      // The row still has to be inspectable — it explains the missing audio.
+      const logsRes = await app.request(`/api/books/${skippedLabel}/debug/llm-logs`)
+      const logs = await logsRes.json()
+      expect(logs.logs).toHaveLength(2)
+      expect(
+        logs.logs.some(
+          (row: { data: { skippedReason?: string } }) =>
+            row.data.skippedReason === "no-speakable-text"
+        )
+      ).toBe(true)
+    })
+
     it("returns null pipeline run timing", async () => {
       const res = await app.request(`/api/books/${label}/debug/stats`)
       expect(res.status).toBe(200)

--- a/apps/api/src/routes/debug.ts
+++ b/apps/api/src/routes/debug.ts
@@ -96,22 +96,29 @@ export function createDebugRoutes(
 
     const db = openBookDb(dbPath)
     try {
-      // Aggregate stats using json_extract on the data column
+      // Aggregate stats using json_extract on the data column.
+      //
+      // Rows with a `skippedReason` never reached a provider (e.g. TTS text with
+      // nothing speakable in it), so they are counted separately: treating them
+      // as calls would understate the cache-hit rate, and their ~0ms would drag
+      // the average latency down. They stay queryable via /debug/llm-logs.
+      const notSkipped = "json_extract(data, '$.skippedReason') IS NULL"
       const stepRows = db.all(`
         SELECT
           step,
-          COUNT(*) as calls,
-          SUM(CASE WHEN json_extract(data, '$.cacheHit') = 1 THEN 1 ELSE 0 END) as cacheHits,
-          SUM(CASE WHEN json_extract(data, '$.cacheHit') = 0 OR json_extract(data, '$.cacheHit') IS NULL THEN 1 ELSE 0 END) as cacheMisses,
+          SUM(CASE WHEN ${notSkipped} THEN 1 ELSE 0 END) as calls,
+          SUM(CASE WHEN json_extract(data, '$.cacheHit') = 1 AND ${notSkipped} THEN 1 ELSE 0 END) as cacheHits,
+          SUM(CASE WHEN (json_extract(data, '$.cacheHit') = 0 OR json_extract(data, '$.cacheHit') IS NULL) AND ${notSkipped} THEN 1 ELSE 0 END) as cacheMisses,
           COALESCE(SUM(json_extract(data, '$.usage.inputTokens')), 0) as inputTokens,
           COALESCE(SUM(json_extract(data, '$.usage.outputTokens')), 0) as outputTokens,
-          ROUND(AVG(json_extract(data, '$.durationMs')), 0) as avgDurationMs,
+          COALESCE(ROUND(AVG(CASE WHEN ${notSkipped} THEN json_extract(data, '$.durationMs') END), 0), 0) as avgDurationMs,
           SUM(CASE
             WHEN json_extract(data, '$.success') = 0 THEN 1
             WHEN json_extract(data, '$.success') IS NULL
               AND json_array_length(json_extract(data, '$.validationErrors')) > 0 THEN 1
             ELSE 0
-          END) as errorCount
+          END) as errorCount,
+          SUM(CASE WHEN ${notSkipped} THEN 0 ELSE 1 END) as skipped
         FROM llm_log
         GROUP BY step
         ORDER BY step
@@ -124,6 +131,7 @@ export function createDebugRoutes(
         outputTokens: number
         avgDurationMs: number
         errorCount: number
+        skipped: number
       }>
 
       // Compute totals
@@ -134,6 +142,7 @@ export function createDebugRoutes(
         inputTokens: 0,
         outputTokens: 0,
         errorCount: 0,
+        skipped: 0,
       }
       for (const row of stepRows) {
         totals.calls += row.calls
@@ -142,6 +151,7 @@ export function createDebugRoutes(
         totals.inputTokens += row.inputTokens
         totals.outputTokens += row.outputTokens
         totals.errorCount += row.errorCount
+        totals.skipped += row.skipped
       }
 
       // Full-pipeline job tracking was removed; keep nullable field for compatibility.

--- a/apps/api/src/services/stage-runner.test.ts
+++ b/apps/api/src/services/stage-runner.test.ts
@@ -4,7 +4,7 @@ import path from "node:path"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { PIPELINE, type AppConfig, type ProgressEvent } from "@adt/types"
 import { computeSpeechCacheKey, stripEmojis } from "@adt/pipeline"
-import { createBookStorage } from "@adt/storage"
+import { createBookStorage, openBookDb } from "@adt/storage"
 import {
   buildStageRunnerImageClassifyConfig,
   createStageRunner,
@@ -2274,6 +2274,84 @@ structure_types:
       expect(entry?.voiceLabel).toBe("Renamed Narrator")
     } finally {
       storage.close()
+    }
+  })
+
+  it("marks a page-batched group with no speakable text as skipped", async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "stage-runner-tts-"))
+    const booksDir = path.join(tmpDir, "books")
+    const promptsDir = path.join(tmpDir, "prompts")
+    const configPath = path.join(tmpDir, "config.yaml")
+    fs.mkdirSync(promptsDir, { recursive: true })
+    fs.writeFileSync(
+      configPath,
+      `role_types:
+  section_text: Main body text
+structure_types:
+  paragraph: Paragraph
+speech:
+  default_provider: gemini
+  batch_by_page: true
+  providers:
+    gemini:
+      languages:
+        - en
+`
+    )
+    seedTextAndSpeechBook(booksDir, "gemini-page-batch-skip")
+
+    // Replace the seeded entry with punctuation only. generatePageSpeechFiles
+    // filters it out and returns [] without ever reaching the provider, which
+    // is the row that used to be logged as an ordinary success.
+    const seed = createBookStorage("gemini-page-batch-skip", booksDir)
+    try {
+      seed.putNodeData("text-catalog", "book", {
+        entries: [{ id: "pg001_t001", text: "—" }],
+        generatedAt: "2026-01-01T00:00:00.000Z",
+      })
+      seed.putNodeData("core-tts-catalog", "en", {
+        language: "en",
+        generatedAt: "2026-01-01T00:00:00.000Z",
+        entries: [readyCoreTtsEntry("pg001_t001", "—")],
+      })
+    } finally {
+      seed.close()
+    }
+
+    const runner = createStageRunner()
+    await runner.run(
+      "gemini-page-batch-skip",
+      {
+        booksDir,
+        apiKey: "sk-test",
+        geminiApiKey: "gm-test",
+        promptsDir,
+        configPath,
+        fromStage: "speech",
+        toStage: "speech",
+      },
+      { emit: () => {} }
+    )
+
+    const db = openBookDb(
+      path.join(booksDir, "gemini-page-batch-skip", "gemini-page-batch-skip.db")
+    )
+    try {
+      const rows = db.all("SELECT data FROM llm_log WHERE step = 'tts'") as {
+        data: string
+      }[]
+      expect(rows).toHaveLength(1)
+      const entry = JSON.parse(rows[0].data) as {
+        success: boolean
+        cacheHit: boolean
+        skippedReason?: string
+      }
+      // Kept, not dropped — an unexplained gap is worse than a marked one —
+      // but marked so it isn't read as a synthesis that happened.
+      expect(entry.success).toBe(true)
+      expect(entry.skippedReason).toBe("no-speakable-text")
+    } finally {
+      db.close()
     }
   })
 })

--- a/apps/api/src/services/stage-runner.ts
+++ b/apps/api/src/services/stage-runner.ts
@@ -76,6 +76,7 @@ import {
   elevenLabsVoiceSettingsFromConfig,
   buildElevenLabsTtsLogParams,
   buildTtsLogEntry,
+  NO_SPEAKABLE_TEXT_REASON,
   classifyElevenLabsTtsError,
   elevenLabsTtsRetryDelayMs,
   ELEVENLABS_TTS_MAX_CONCURRENCY,
@@ -3143,7 +3144,7 @@ async function runSpeechStep(
           // Record the page synthesis in the LLM log (transparency + cost
           // tracking), mirroring the per-entry path so batched Gemini calls
           // aren't invisible.
-          const emitPageLog = (o: { success: boolean; cacheHit: boolean; attempt: number; error?: string }) => {
+          const emitPageLog = (o: { success: boolean; cacheHit: boolean; attempt: number; error?: string; skippedReason?: string }) => {
             const logEntry = buildTtsLogEntry({
               textId: group.pageKey,
               // The slot rides along in `language` so a dual-voice book's two
@@ -3158,6 +3159,7 @@ async function runSpeechStep(
               cached: o.cacheHit,
               attempt: o.attempt,
               error: o.error,
+              ...(o.skippedReason ? { skippedReason: o.skippedReason } : {}),
             })
             storage.appendLlmLog(logEntry)
             progress.emit({ type: "llm-log", step: "tts", itemId: group.pageKey, promptName: logEntry.promptName, modelId: logEntry.modelId, cacheHit: o.cacheHit, durationMs: logEntry.durationMs })
@@ -3190,7 +3192,15 @@ async function runSpeechStep(
               // limiter for it (mirrors the per-entry `!entry.cached` guard).
               const pageCached = entries.length > 0 && entries.every((e) => e.cached)
               if (entries.length > 0 && !pageCached) geminiTtsRateLimiter?.reward()
-              emitPageLog({ success: true, cacheHit: pageCached, attempt })
+              emitPageLog({
+                success: true,
+                cacheHit: pageCached,
+                attempt,
+                // No entries back means every text in the group was
+                // unspeakable, so generatePageSpeechFiles returned early
+                // without calling the provider (speech.ts, `usable.length === 0`).
+                ...(entries.length === 0 ? { skippedReason: NO_SPEAKABLE_TEXT_REASON } : {}),
+              })
               break
             } catch (err) {
               if (isCancellation(err, [options.signal])) {
@@ -3416,6 +3426,9 @@ async function runSpeechStep(
           cached,
           attempt: attemptCount,
           params: logParams,
+          // No entry means generateSpeechFile found nothing speakable (e.g. an
+          // "—" entry) and never called the provider.
+          ...(entry ? {} : { skippedReason: NO_SPEAKABLE_TEXT_REASON }),
         })
         storage.appendLlmLog(logEntry)
         progress.emit({

--- a/apps/studio/src/api/client.ts
+++ b/apps/studio/src/api/client.ts
@@ -656,6 +656,10 @@ export interface LlmLogEntry {
     /** Final status of this individual attempt. Older log entries may omit it. */
     success?: boolean
     error?: string
+    /** Why no provider call was made (e.g. TTS text with nothing speakable in
+     *  it). Present only on deliberately skipped calls, which produced no
+     *  output at all — unlike a cache hit, which has one. */
+    skippedReason?: string
     durationMs: number
     usage?: { inputTokens: number; outputTokens: number }
     validationErrors?: string[]
@@ -687,6 +691,9 @@ export interface StepStats {
   outputTokens: number
   avgDurationMs: number
   errorCount: number
+  /** Rows that produced no output on purpose and never reached a provider, so
+   *  they are excluded from `calls`, the cache counts, and `avgDurationMs`. */
+  skipped: number
 }
 
 export interface PipelineStatsResponse {
@@ -698,6 +705,7 @@ export interface PipelineStatsResponse {
     inputTokens: number
     outputTokens: number
     errorCount: number
+    skipped: number
   }
   pipelineRun: {
     status: string

--- a/apps/studio/src/components/debug/LlmLogsTab.test.tsx
+++ b/apps/studio/src/components/debug/LlmLogsTab.test.tsx
@@ -39,7 +39,7 @@ vi.mock("@lingui/react/macro", () => ({
   }),
 }))
 
-const { ParamGrid } = await import("./LlmLogsTab")
+const { ParamGrid, getStatus } = await import("./LlmLogsTab")
 
 function renderGrid(data: Record<string, unknown>) {
   return render(<ParamGrid title="Request settings" data={data} />)
@@ -108,5 +108,29 @@ describe("ParamGrid", () => {
     const { container } = renderGrid({})
 
     expect(container.textContent).toBe("")
+  })
+})
+
+describe("getStatus", () => {
+  const entry = (data: Record<string, unknown>) =>
+    ({ data } as Parameters<typeof getStatus>[0])
+
+  it("marks a no-audio row as skipped rather than a successful call", () => {
+    expect(
+      getStatus(entry({ success: true, cacheHit: false, skippedReason: "no-speakable-text" }))
+    ).toBe("skipped")
+  })
+
+  // A failure still reads as a failure: a row can carry both a reason and an
+  // error, and the error is the thing the user has to act on.
+  it("keeps error precedence over a skipped reason", () => {
+    expect(
+      getStatus(entry({ success: false, skippedReason: "no-speakable-text" }))
+    ).toBe("error")
+  })
+
+  it("leaves ordinary rows unchanged", () => {
+    expect(getStatus(entry({ success: true, cacheHit: false }))).toBe("success")
+    expect(getStatus(entry({ success: true, cacheHit: true }))).toBe("cached")
   })
 })

--- a/apps/studio/src/components/debug/LlmLogsTab.tsx
+++ b/apps/studio/src/components/debug/LlmLogsTab.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react"
-import { RefreshCw, AlertTriangle } from "lucide-react"
+import { RefreshCw, AlertTriangle, MinusCircle } from "lucide-react"
 import { Trans } from "@lingui/react/macro"
 import { useLingui } from "@lingui/react/macro"
 import { msg } from "@lingui/core/macro"
@@ -21,17 +21,23 @@ import { ALL_STEP_NAMES } from "@adt/types"
 
 const STEP_FILTERS = Array.from(ALL_STEP_NAMES)
 
+/** Mirrors NO_SPEAKABLE_TEXT_REASON in @adt/pipeline — the studio can't import
+ *  from packages, so the one known reason is matched by value here and any other
+ *  reason falls back to showing the raw string. */
+const NO_SPEAKABLE_TEXT = "no-speakable-text"
+
 interface LlmLogsTabProps {
   label: string
   isRunning: boolean
 }
 
-type RowStatus = "success" | "cached" | "error"
+type RowStatus = "success" | "cached" | "error" | "skipped"
 
 const STATUS_DOT: Record<RowStatus, string> = {
   success: "bg-green-500",
   cached: "bg-yellow-400",
   error: "bg-red-500",
+  skipped: "bg-slate-400",
 }
 
 function formatSeconds(ms: number): string {
@@ -40,13 +46,20 @@ function formatSeconds(ms: number): string {
   return `${(ms / 60_000).toFixed(1)}m`
 }
 
-function getStatus(entry: LlmLogEntry): RowStatus {
+/**
+ * Exported for tests: the precedence between an error, a deliberate skip, and a
+ * cache hit is the part worth pinning down.
+ */
+export function getStatus(entry: LlmLogEntry): RowStatus {
   if (entry.data.success === false) return "error"
   if (
     entry.data.success === undefined &&
     entry.data.validationErrors &&
     entry.data.validationErrors.length > 0
   ) return "error"
+  // A skipped call produced no artifact at all, so it must not read as a
+  // success — but a failure still outranks it: that's what needs acting on.
+  if (entry.data.skippedReason) return "skipped"
   if (entry.data.cacheHit) return "cached"
   return "success"
 }
@@ -159,7 +172,11 @@ function LogDetail({ data, label }: { data: LlmLogEntry["data"]; label: string }
             <div className="text-muted-foreground mb-0.5">
               <Trans>Cache</Trans>
             </div>
-            <div className="font-medium">{data.cacheHit ? t`Hit` : t`Miss`}</div>
+            {/* A skipped call never consulted the cache, so "Miss" would be a
+                lie about a lookup that never happened. */}
+            <div className="font-medium">
+              {data.skippedReason ? "—" : data.cacheHit ? t`Hit` : t`Miss`}
+            </div>
           </div>
           {data.usage && (
             <>
@@ -259,6 +276,24 @@ function LogDetail({ data, label }: { data: LlmLogEntry["data"]; label: string }
             </pre>
           </div>
         )}
+
+        {/* Nothing failed here — the step deliberately produced no output. Kept
+            visible so the log answers "why is there no audio for this item?"
+            instead of leaving an unexplained gap. Neutral styling, separate
+            from the Error block above. */}
+        {data.skippedReason && (
+          <div>
+            <div className="font-medium text-muted-foreground mb-1 flex items-center gap-1">
+              <MinusCircle className="h-3 w-3" />
+              <Trans>No audio</Trans>
+            </div>
+            <p className="bg-muted p-3 rounded text-[11px] text-muted-foreground">
+              {data.skippedReason === NO_SPEAKABLE_TEXT
+                ? t`This entry has no speakable text, so no audio was generated and no request was sent to the provider.`
+                : data.skippedReason}
+            </p>
+          </div>
+        )}
       </div>
     </td>
   )
@@ -273,6 +308,7 @@ function HistoryLogRow({ entry, label }: { entry: LlmLogEntry; label: string }) 
     success: t`Success`,
     cached: t`Cached`,
     error: t`Error`,
+    skipped: t`No audio`,
   }
 
   function formatTimestamp(iso: string): string {

--- a/apps/studio/src/components/debug/StatsTab.tsx
+++ b/apps/studio/src/components/debug/StatsTab.tsx
@@ -26,7 +26,7 @@ function estimateCost(inputTokens: number, outputTokens: number): string {
 }
 
 export function StatsTab({ label, isRunning }: StatsTabProps) {
-  const { i18n } = useLingui()
+  const { i18n, t } = useLingui()
   const { data, isLoading, error } = usePipelineStats(label, {
     refetchInterval: isRunning ? 3000 : false,
   })
@@ -142,11 +142,6 @@ export function StatsTab({ label, isRunning }: StatsTabProps) {
                   <th className="py-2.5 px-4 font-medium text-right">
                     <Trans>Avg Duration</Trans>
                   </th>
-                  {/* Items the step deliberately produced nothing for. Shown so
-                      a step whose only rows are skipped isn't just "0 calls". */}
-                  <th className="py-2.5 px-4 font-medium text-right">
-                    <Trans>No audio</Trans>
-                  </th>
                   <th className="py-2.5 px-4 font-medium text-right">
                     <Trans>Errors</Trans>
                   </th>
@@ -163,7 +158,18 @@ export function StatsTab({ label, isRunning }: StatsTabProps) {
                         {s.step}
                       </Badge>
                     </td>
-                    <td className="py-2.5 px-4 text-right tabular-nums">{s.calls}</td>
+                    {/* Skipped rows are excluded from `calls`, so without this
+                        the Log tab would show more rows than Stats counts with
+                        nothing to explain the gap. Only rendered when non-zero:
+                        for almost every step there is nothing to say. */}
+                    <td className="py-2.5 px-4 text-right tabular-nums">
+                      {s.calls}
+                      {s.skipped > 0 && (
+                        <span className="ml-1 text-muted-foreground font-normal">
+                          {t`(+${s.skipped} skipped)`}
+                        </span>
+                      )}
+                    </td>
                     <td className="py-2.5 px-4 text-right tabular-nums">{s.cacheHits}</td>
                     <td className="py-2.5 px-4 text-right tabular-nums">{s.cacheMisses}</td>
                     <td className="py-2.5 px-4 text-right tabular-nums">

--- a/apps/studio/src/components/debug/StatsTab.tsx
+++ b/apps/studio/src/components/debug/StatsTab.tsx
@@ -142,6 +142,11 @@ export function StatsTab({ label, isRunning }: StatsTabProps) {
                   <th className="py-2.5 px-4 font-medium text-right">
                     <Trans>Avg Duration</Trans>
                   </th>
+                  {/* Items the step deliberately produced nothing for. Shown so
+                      a step whose only rows are skipped isn't just "0 calls". */}
+                  <th className="py-2.5 px-4 font-medium text-right">
+                    <Trans>No audio</Trans>
+                  </th>
                   <th className="py-2.5 px-4 font-medium text-right">
                     <Trans>Errors</Trans>
                   </th>
@@ -169,6 +174,9 @@ export function StatsTab({ label, isRunning }: StatsTabProps) {
                     </td>
                     <td className="py-2.5 px-4 text-right tabular-nums">
                       {formatDuration(s.avgDurationMs)}
+                    </td>
+                    <td className="py-2.5 px-4 text-right tabular-nums text-muted-foreground">
+                      {s.skipped > 0 ? s.skipped : "—"}
                     </td>
                     <td className="py-2.5 px-4 text-right tabular-nums">
                       {s.errorCount > 0 ? (

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -9439,6 +9439,9 @@ msgstr "This book renders fixed-layout, so it keeps the original PDF fonts. Atta
 msgid "This connection isn't available yet."
 msgstr "This connection isn't available yet."
 
+msgid "This entry has no speakable text, so no audio was generated and no request was sent to the provider."
+msgstr "This entry has no speakable text, so no audio was generated and no request was sent to the provider."
+
 msgid "This feature is not compatible with Fixed Layout. If you proceed, you may get undesirable results."
 msgstr "This feature is not compatible with Fixed Layout. If you proceed, you may get undesirable results."
 

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -43,6 +43,10 @@ msgstr "? This will remove all extracted data and cannot be undone."
 msgid "\"A landscape forged by fire.\""
 msgstr "\"A landscape forged by fire.\""
 
+#. placeholder {0}: s.skipped
+msgid "(+{0} skipped)"
+msgstr "(+{0} skipped)"
+
 msgid "(active)"
 msgstr "(active)"
 

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -43,6 +43,10 @@ msgstr "? Esto eliminará todos los datos extraídos y no se puede deshacer."
 msgid "\"A landscape forged by fire.\""
 msgstr "\\\"Un paisaje forjado por el fuego.\\\""
 
+#. placeholder {0}: s.skipped
+msgid "(+{0} skipped)"
+msgstr "(+{0} omitidas)"
+
 msgid "(active)"
 msgstr "(activo)"
 

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -9437,6 +9437,9 @@ msgstr "Este libro se renderiza con diseño fijo, por lo que mantiene las fuente
 msgid "This connection isn't available yet."
 msgstr "Esta conexión aún no está disponible."
 
+msgid "This entry has no speakable text, so no audio was generated and no request was sent to the provider."
+msgstr "Esta entrada no tiene texto pronunciable, por lo que no se generó audio ni se envió ninguna solicitud al proveedor."
+
 msgid "This feature is not compatible with Fixed Layout. If you proceed, you may get undesirable results."
 msgstr "Esta función no es compatible con Diseño Fijo. Si continúas, podrías obtener resultados no deseados."
 

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -45,6 +45,10 @@ msgstr "? Cela supprimera toutes les données extraites et est irréversible."
 msgid "\"A landscape forged by fire.\""
 msgstr "\\\"Un paysage forgé par le feu.\\\""
 
+#. placeholder {0}: s.skipped
+msgid "(+{0} skipped)"
+msgstr "(+{0} ignorées)"
+
 msgid "(active)"
 msgstr "(actif)"
 

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -9439,6 +9439,9 @@ msgstr "Ce livre est rendu en mise en page fixe, il conserve donc les polices d'
 msgid "This connection isn't available yet."
 msgstr "Cette connexion n'est pas encore disponible."
 
+msgid "This entry has no speakable text, so no audio was generated and no request was sent to the provider."
+msgstr "Cette entrée ne contient aucun texte prononçable : aucun audio n'a été généré et aucune requête n'a été envoyée au fournisseur."
+
 msgid "This feature is not compatible with Fixed Layout. If you proceed, you may get undesirable results."
 msgstr "Cette fonctionnalité n'est pas compatible avec la mise en page fixe. Si vous continuez, vous pourriez obtenir des résultats indésirables."
 

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -43,6 +43,10 @@ msgstr "? Isso removerá todos os dados extraídos e não poderá ser desfeito."
 msgid "\"A landscape forged by fire.\""
 msgstr "\\\"Uma paisagem forjada pelo fogo.\\\""
 
+#. placeholder {0}: s.skipped
+msgid "(+{0} skipped)"
+msgstr "(+{0} ignoradas)"
+
 msgid "(active)"
 msgstr "(ativo)"
 

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -9437,6 +9437,9 @@ msgstr "Este livro é renderizado em layout fixo, então mantém as fontes origi
 msgid "This connection isn't available yet."
 msgstr "Esta conexão ainda não está disponível."
 
+msgid "This entry has no speakable text, so no audio was generated and no request was sent to the provider."
+msgstr "Esta entrada não tem texto pronunciável, portanto nenhum áudio foi gerado e nenhuma solicitação foi enviada ao provedor."
+
 msgid "This feature is not compatible with Fixed Layout. If you proceed, you may get undesirable results."
 msgstr "Este recurso não é compatível com Layout Fixo. Se você continuar, poderá obter resultados indesejados."
 

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -9439,6 +9439,9 @@ msgstr "Ky libër shfaqet me strukturë fikse, kështu që ruan fontet origjinal
 msgid "This connection isn't available yet."
 msgstr "Kjo lidhje nuk është ende e disponueshme."
 
+msgid "This entry has no speakable text, so no audio was generated and no request was sent to the provider."
+msgstr "Kjo hyrje nuk ka tekst të shqiptueshëm, kështu që nuk u krijua audio dhe nuk u dërgua asnjë kërkesë tek ofruesi."
+
 msgid "This feature is not compatible with Fixed Layout. If you proceed, you may get undesirable results."
 msgstr "Kjo veçori nuk është e pajtueshme me Paraqitjen e fiksuar. Nëse vazhdoni, mund të merrni rezultate të padëshiruara."
 

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -45,6 +45,10 @@ msgstr "? Kjo do të heqë të gjitha të dhënat e nxjerra dhe nuk mund të zhb
 msgid "\"A landscape forged by fire.\""
 msgstr "\"Një peizazh i formuar nga zjarri.\""
 
+#. placeholder {0}: s.skipped
+msgid "(+{0} skipped)"
+msgstr "(+{0} të anashkaluara)"
+
 msgid "(active)"
 msgstr "(aktiv)"
 

--- a/packages/llm/src/log.ts
+++ b/packages/llm/src/log.ts
@@ -19,6 +19,16 @@ export interface LlmLogEntry {
   /** Transport or provider failure, distinct from a structured-output validation error. */
   error?: string
   /**
+   * Why no provider call was made, when the step deliberately produced nothing
+   * (e.g. punctuation-only TTS text, which has no audio to synthesize).
+   *
+   * Recorded rather than omitted so the log still answers "why is there no
+   * output for this item?". Distinct from a cache hit: a cache hit has an
+   * artifact, a skipped call has none. Callers must not count these rows as
+   * calls, cache misses, or latency samples.
+   */
+  skippedReason?: string
+  /**
    * Resolved provider request parameters, recorded so a run is inspectable
    * after the fact ("which settings produced this output?").
    *

--- a/packages/pipeline/src/__tests__/speech.test.ts
+++ b/packages/pipeline/src/__tests__/speech.test.ts
@@ -1369,6 +1369,48 @@ describe("buildTtsLogEntry", () => {
       text: `[en] voice=en-US-JennyNeural\n${text}`,
     })
   })
+
+  it("marks an entry that produced no audio so it isn't read as a synthesis", () => {
+    const entry = buildTtsLogEntry({
+      textId: "pg001_t002",
+      language: "en",
+      voice: "en-US-JennyNeural",
+      model: "azure-tts",
+      provider: "azure",
+      text: "—",
+      durationMs: 0,
+      success: true,
+      cached: false,
+      attempt: 1,
+      skippedReason: "no-speakable-text",
+    })
+
+    // Still a success (nothing went wrong) but distinguishable from an entry
+    // that actually reached the provider.
+    expect(entry).toMatchObject({
+      success: true,
+      errorCount: 0,
+      cacheHit: false,
+      skippedReason: "no-speakable-text",
+    })
+  })
+
+  it("omits skippedReason for an entry that really was synthesized", () => {
+    const entry = buildTtsLogEntry({
+      textId: "pg001_t001",
+      language: "en",
+      voice: "en-US-JennyNeural",
+      model: "azure-tts",
+      provider: "azure",
+      text: "Hello world",
+      durationMs: 250,
+      success: true,
+      cached: false,
+      attempt: 1,
+    })
+
+    expect(entry).not.toHaveProperty("skippedReason")
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -251,6 +251,7 @@ export {
   computeSpeechCacheKey,
   findAdjacentSpeechText,
   buildTtsLogEntry,
+  NO_SPEAKABLE_TEXT_REASON,
   elevenLabsVoiceSettingsFromConfig,
   buildElevenLabsTtsLogParams,
   classifyElevenLabsTtsError,

--- a/packages/pipeline/src/pipeline-dag.ts
+++ b/packages/pipeline/src/pipeline-dag.ts
@@ -91,6 +91,7 @@ import {
   generateSpeechFile,
   buildTtsLogEntry,
   buildElevenLabsTtsLogParams,
+  NO_SPEAKABLE_TEXT_REASON,
   findAdjacentSpeechText,
   elevenLabsVoiceSettingsFromConfig,
   classifyElevenLabsTtsError,
@@ -1248,6 +1249,9 @@ export async function runFullPipeline(
           textId: item.textId, language: item.language, voice, model: providerModel,
           provider, text: item.text, durationMs: Date.now() - startedAt,
           success: true, cached: entry?.cached ?? false, attempt: attemptCount, params: logParams,
+          // No entry means generateSpeechFile found nothing speakable (e.g. an
+          // "—" entry) and never called the provider.
+          ...(entry ? {} : { skippedReason: NO_SPEAKABLE_TEXT_REASON }),
         }))
         if (entry) {
           resultsByLang.get(item.language)!.push(entry)

--- a/packages/pipeline/src/speech.ts
+++ b/packages/pipeline/src/speech.ts
@@ -59,6 +59,13 @@ export function stripEmojis(text: string): string {
 }
 
 /**
+ * `skippedReason` for an entry whose text has nothing speakable in it, so
+ * `generateSpeechFile` returned null without calling a provider. Shared so both
+ * execution paths write the same value and the log stays filterable.
+ */
+export const NO_SPEAKABLE_TEXT_REASON = "no-speakable-text"
+
+/**
  * Build the common debug-log record for a TTS request. Keeping this next to
  * the generation helpers prevents the API runner, the one-item route, and the
  * CLI/DAG executor from drifting in their representation of the same call.
@@ -75,6 +82,13 @@ export function buildTtsLogEntry(options: {
   cached: boolean
   attempt: number
   error?: string
+  /**
+   * Set when the entry produced no audio on purpose — `generateSpeechFile`
+   * returns null for text with nothing speakable in it. Marks the row so it
+   * isn't read as a synthesis that happened, and so the stats aggregation can
+   * leave it out of call and cache counts.
+   */
+  skippedReason?: string
   params?: Record<string, unknown>
 }): LlmLogEntry {
   return {
@@ -90,6 +104,7 @@ export function buildTtsLogEntry(options: {
     attempt: Math.max(options.attempt, 1),
     durationMs: options.durationMs,
     ...(options.error ? { error: options.error } : {}),
+    ...(options.skippedReason ? { skippedReason: options.skippedReason } : {}),
     ...(options.params ? { params: options.params } : {}),
     messages: [{
       role: "user",


### PR DESCRIPTION
## Summary

`generateSpeechFile` returns `null` for text with nothing speakable in it (an `—` or `…` entry) — the only `null` path it has. Both TTS execution paths logged that as `success: true, cacheHit: false`, so:

- the log could not answer "why is there no audio for this item?" — the row looks like a synthesis that happened;
- the stats query counted it as a **call** and a **cache miss**, and averaged its ~0 ms into step latency, dragging the reported `tts` cache-hit rate and average duration away from the truth.

The row is kept rather than dropped — Principle 4 (Maximum Transparency) is exactly why an unexplained gap is worse than a marked one — but it's now marked.

## Changes

- `LlmLogEntry` gains an optional `skippedReason`. **No DB migration**: the whole entry is already stored as JSON in `llm_log.data`.
- `buildTtsLogEntry` passes it through, so both paths inherit it from the one shared builder (#797's consolidation). `NO_SPEAKABLE_TEXT_REASON` keeps the value identical across them and the log filterable.
- Debug log: a 4th row status — slate dot, **No audio** — with a neutral explanation block, separate from the red Error block. An error still outranks a skip. `getStatus` is exported so that precedence is pinned by a test.
- The Cache detail field shows `—` instead of a misleading **Miss** for a lookup that never happened.
- `/debug/stats` excludes skipped rows from `calls`, both cache counts, and `avgDurationMs`, and reports them in a new `skipped` column surfaced in the Stats tab — so a step whose only rows are skipped isn't silently "0 calls".

## Un-stacked and rebased onto `develop`

Previously stacked on #800 (and #799 before it). #799 merged; this PR's own hunks apply cleanly to `develop` on their own, so it has been **rebased directly onto `develop` and retargeted** — it no longer depends on #800 and can be reviewed and merged independently. The diff is now just this change: **+321/−14**.

### One addition the rebase made necessary

`develop`'s multi-voice work (#780) added a **third** `buildTtsLogEntry` call site this PR predates: `emitPageLog` in the page-batched Gemini path. `generatePageSpeechFiles` filters non-speakable entries and returns `[]` when none remain (`speech.ts`, `usable.length === 0`), so an all-punctuation page group logs the exact `success: true, cacheHit: false` row this PR exists to eliminate. Now marked too, keyed off the empty return, with a covering test.

## Scope notes

- The **single-item TTS route** needs no marker: it already returns 422 for a non-speakable entry *before* writing a log row.
- `StatsTab.tsx` derives `cacheHitRate` from `totals.cacheHits / totals.calls`, so excluding skipped rows from `calls` corrects the headline rate for free.

## Verification

`pnpm typecheck` clean, `pnpm lint` 0 errors, full suite **2892 passing**.

4 tests, all confirmed failing first:
- `buildTtsLogEntry` round-trip + absence when not passed (`speech.test.ts`)
- `getStatus` precedence (`LlmLogsTab.test.tsx`)
- stats exclusion while staying visible in `/debug/llm-logs` (`debug.test.ts`)
- **new** — a page-batched group with no speakable text is marked (`stage-runner.test.ts`), driven end-to-end through the real `generatePageSpeechFiles`, which returns early without reaching the provider

`pnpm --filter @adt/studio extract` ⇒ **0 missing** across `es`, `fr`, `pt-BR`, `sq`. Only one new string; "No audio" already existed and was already translated.

## Still to do before merge

End-to-end run on a real book with an `—` section (needs a paid API key): confirm the marker fires on a genuine punctuation-only entry through the **per-entry** path and compare `/debug/stats` before/after. The automated tests prove the marker, the UI status, the stats math, and the page-batched path end-to-end — not that the per-entry wiring triggers in a live paid run.

Adjacent, worth a look before this lands: **#809** (Core TTS normalization stability).
