### PR TITLE
fix(export): keep authored side-by-side layout in PNLD/WebPub/EPUB on wide readers

### DIFF
--- a/packages/pipeline/src/__tests__/package-web.test.ts
+++ b/packages/pipeline/src/__tests__/package-web.test.ts
@@ -2606,6 +2606,9 @@ describe("packageWebpub", () => {
     expect(html).toContain("columns: auto !important")
     expect(html).toContain("flex-direction: column !important")
     expect(html).toContain("max-width: 100% !important")
+    expect(html).toContain("@media (max-width: 1023px)")
+    const forcedColumn = html.slice(html.indexOf("@media (max-width: 1023px)"))
+    expect(forcedColumn).toContain("flex-direction: column !important")
     // The glossref affordance is EPUB-only; webpub must not carry it.
     expect(html).not.toContain(".glossref")
   })

--- a/packages/pipeline/src/packaging/web.ts
+++ b/packages/pipeline/src/packaging/web.ts
@@ -985,18 +985,19 @@ body {
   opacity: 1 !important;
 }
 
-/* Force single-column layout for all section containers.
-   Side-by-side (lg:flex-row) layouts squeeze text in narrow
-   reader viewports. */
-section > div {
-  flex-direction: column !important;
-  max-width: 100% !important;
-}
+/* Force single-column layout only in narrow reader viewports. Above the
+   lg breakpoint the page's own lg:flex-row / max-w-* rules govern, so wide
+   readers (PNLD/LIP, wide EPUB) keep the authored side-by-side layout. */
+@media (max-width: 1023px) {
+  section > div {
+    flex-direction: column !important;
+    max-width: 100% !important;
+  }
 
-/* Remove max-width constraints on nested containers (max-w-6xl, max-w-xl, etc.) */
-.container,
-section [class*="max-w-"] {
-  max-width: 100% !important;
+  .container,
+  section [class*="max-w-"] {
+    max-width: 100% !important;
+  }
 }
 
 /* Responsive images */


### PR DESCRIPTION
## Problem

Books exported as **PNLD**, **WebPub**, or **EPUB** rendered with a stacked, single-column layout on wide readers (PNLD/LIP, wide browsers, wide EPUB viewers) — image on top, text below — while the **web** export (and Studio itself) rendered the authored side-by-side layout (image left, text right).

### Before → After (PNLD cover in a wide reader)

| Before (stacked) | After (authored side-by-side) |
|---|---|
| <img src="https://raw.githubusercontent.com/unicef/adt-studio/pr-804-assets/pr-assets/pnld-before.png" width="420"> | <img src="https://raw.githubusercontent.com/unicef/adt-studio/pr-804-assets/pr-assets/pnld-after.png" width="420"> |

## Cause

The three packagers share `REFLOWABLE_OVERRIDE_CSS` (injected via `injectWebpubStyles`). It was written for EPUB readers like Thorium that paginate into **narrow columns**, and unconditionally forced:

```css
section > div { flex-direction: column !important; max-width: 100% !important; }
.container, section [class*="max-w-"] { max-width: 100% !important; }
```

That overrides the page's own `lg:flex-row` / `max-w-6xl` responsive breakpoints, so even on a wide reader the layout was pinned to a single stacked column. The plain web export skips `injectWebpubStyles` entirely, which is why it looked correct.

## Fix

Gate the single-column rules behind `@media (max-width: 1023px)` (one below Tailwind's `lg` threshold):

- **Narrow readers** (EPUB columns, phones): unchanged — still collapse to single-column.
- **Wide readers** (PNLD/LIP, wide browsers, wide EPUB): the override no longer applies, so the page's own `lg:` breakpoints govern and the authored side-by-side layout is preserved — matching the web export.

The `body` / `#content` block-flow and anti-column-pagination rules stay ungated, so EPUB pagination is still defeated everywhere.

## Testing

- `package-web.test.ts`: 112 passed (strengthened the override test to assert the `@media (max-width: 1023px)` gating).
- `pnpm typecheck`: clean.

<sub>Screenshots hosted on the `pr-804-assets` branch (assets only — not part of this PR's diff).</sub>