### PR TITLE
fix(studio): translate missing pipeline step labels

### DIFF
--- a/apps/studio/src/components/pipeline/pipeline-i18n.test.ts
+++ b/apps/studio/src/components/pipeline/pipeline-i18n.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest"
+import { PIPELINE } from "@adt/types"
 
 vi.mock("@lingui/core/macro", () => ({
   msg(strings: TemplateStringsArray, ...values: unknown[]) {
@@ -25,6 +26,8 @@ const {
   getStageDescriptionI18n,
   getStageLabelI18n,
   getStageRunningLabelI18n,
+  getStepLabelI18n,
+  STEP_LABEL_MESSAGES,
 } = await import("./pipeline-i18n")
 
 describe("pipeline-i18n", () => {
@@ -40,5 +43,13 @@ describe("pipeline-i18n", () => {
     expect(getStageLabelI18n("unknown-stage")).toBe("unknown-stage")
     expect(getStageRunningLabelI18n("unknown-stage")).toBe("unknown-stage")
     expect(getStageDescriptionI18n("unknown-stage")).toBeUndefined()
+  })
+
+  it("resolves labels for every pipeline step", () => {
+    expect(getStepLabelI18n("core-tts-catalog")).toBe("TTS Normalization")
+    expect(getStepLabelI18n("accessibility-assessment")).toBe("Accessibility Assessment")
+    expect(Object.keys(STEP_LABEL_MESSAGES).sort()).toEqual(
+      PIPELINE.flatMap((stage) => stage.steps.map((step) => step.name)).sort(),
+    )
   })
 })

--- a/apps/studio/src/components/pipeline/pipeline-i18n.ts
+++ b/apps/studio/src/components/pipeline/pipeline-i18n.ts
@@ -1,6 +1,7 @@
 import { msg } from "@lingui/core/macro"
 import type { MessageDescriptor } from "@lingui/core"
 import { i18n } from "@lingui/core"
+import type { StepName } from "@adt/types"
 
 /**
  * Stage label messages keyed by stage slug.
@@ -59,7 +60,7 @@ export const STAGE_DESCRIPTION_MESSAGES: Record<string, MessageDescriptor> = {
   export: msg`Export the packaged book and related artifacts for delivery.`,
 }
 
-export const STEP_LABEL_MESSAGES: Record<string, MessageDescriptor> = {
+export const STEP_LABEL_MESSAGES: Record<StepName, MessageDescriptor> = {
   extract: msg`PDF Extraction`,
   metadata: msg`Metadata`,
   "book-summary": msg`Book Summary`,
@@ -78,10 +79,12 @@ export const STEP_LABEL_MESSAGES: Record<string, MessageDescriptor> = {
   "text-catalog": msg`Text Catalog`,
   "easy-read": msg`Easy Read`,
   "catalog-translation": msg`Catalog Translation`,
+  "core-tts-catalog": msg`TTS Normalization`,
   "image-translation": msg`Image Translation`,
   tts: msg`Speech Generation`,
   "word-timestamps": msg`Word Highlighting`,
   "package-web": msg`Web Package`,
+  "accessibility-assessment": msg`Accessibility Assessment`,
 }
 
 export const STEP_DESCRIPTION_MESSAGES: Record<string, MessageDescriptor> = {
@@ -148,7 +151,7 @@ export function getStageDescriptionI18n(slug: string): string | undefined {
 
 /** Resolve a step label message descriptor to a translated string. Safe to call outside React. */
 export function getStepLabelI18n(slug: string): string {
-  const descriptor = STEP_LABEL_MESSAGES[slug]
+  const descriptor = STEP_LABEL_MESSAGES[slug as StepName]
   return descriptor ? i18n._(descriptor) : slug
 }
 

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -716,6 +716,9 @@ msgstr "Accepts any answer"
 msgid "Accessibility"
 msgstr "Accessibility"
 
+msgid "Accessibility Assessment"
+msgstr "Accessibility Assessment"
+
 msgid "Accessibility assessment configuration"
 msgstr "Accessibility assessment configuration"
 

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -714,6 +714,9 @@ msgstr "Acepta cualquier respuesta"
 msgid "Accessibility"
 msgstr "Accessibility"
 
+msgid "Accessibility Assessment"
+msgstr "Evaluación de accesibilidad"
+
 msgid "Accessibility assessment configuration"
 msgstr "Accessibility assessment configuration"
 

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -716,6 +716,9 @@ msgstr "Accepte n'importe quelle réponse"
 msgid "Accessibility"
 msgstr "Accessibilité"
 
+msgid "Accessibility Assessment"
+msgstr "Évaluation de l’accessibilité"
+
 msgid "Accessibility assessment configuration"
 msgstr "Configuration de l'évaluation d'accessibilité"
 

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -714,6 +714,9 @@ msgstr "Aceita qualquer resposta"
 msgid "Accessibility"
 msgstr "Accessibility"
 
+msgid "Accessibility Assessment"
+msgstr "Avaliação de acessibilidade"
+
 msgid "Accessibility assessment configuration"
 msgstr "Accessibility assessment configuration"
 

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -716,6 +716,9 @@ msgstr "Pranon çdo përgjigje"
 msgid "Accessibility"
 msgstr "Aksesueshmëria"
 
+msgid "Accessibility Assessment"
+msgstr "Vlerësimi i aksesueshmërisë"
+
 msgid "Accessibility assessment configuration"
 msgstr "Konfigurimi i vlerësimit të aksesueshmërisë"
 


### PR DESCRIPTION
## Summary

- Add translated labels for the core-tts-catalog and accessibility-assessment pipeline steps.
- Make the step-label descriptor map exhaustive for all StepName values.
- Add regression coverage ensuring the map stays synchronized with PIPELINE.
- Add the new Accessibility Assessment message to every supported locale.

## Verification

- Focused pipeline-i18n Vitest suite: passed (3 tests).
- TypeScript build check: passed.
- Studio lint: passed with 8 pre-existing warnings.
- Lingui extraction: 0 missing translations.
- Lingui catalog compilation: passed.

Closes #827