### PR TITLE
fix(speech): offer only TTS providers this browser has a key for

### DIFF
--- a/apps/studio/src/components/pipeline/stages/languages/LanguageSettings.tsx
+++ b/apps/studio/src/components/pipeline/stages/languages/LanguageSettings.tsx
@@ -19,6 +19,7 @@ import { Switch } from "@/components/ui/switch"
 import { ModelSelect, OPENAI_TTS_MODELS, AZURE_TTS_MODELS, GEMINI_TTS_MODELS, ELEVENLABS_TTS_MODELS, IMAGE_MODEL_GROUPS, LLM_MODEL_GROUPS } from "@/components/pipeline/components/ModelSelect"
 import { useBookConfig, useUpdateBookConfig } from "@/hooks/use-book-config"
 import { useActiveConfig } from "@/hooks/use-debug"
+import { useApiKey } from "@/hooks/use-api-key"
 import { api } from "@/api/client"
 import { PromptViewer, savePromptDraft, toPromptDraft, type PromptDraft } from "@/components/pipeline/components/PromptViewer"
 import { useStageSettingsBar } from "@/hooks/use-stage-settings-bar"
@@ -37,6 +38,10 @@ import { useLingui } from "@lingui/react/macro"
 import { displayLang } from "./lib/display-lang"
 import { tabContainerClass } from "./lib/tab-container-class"
 import { PROVIDER_LABELS } from "./lib/provider-labels"
+import {
+  isProviderOptionDisabled,
+  type ProviderKeyAvailability,
+} from "./lib/provider-availability"
 import { ElevenLabsVoiceTuning } from "./components/ElevenLabsVoiceTuning"
 import { ProviderVoicePicker } from "./components/ProviderVoicePicker"
 
@@ -1387,6 +1392,19 @@ function SpeechLanguageCards({
 }) {
   const { t } = useLingui()
 
+  // A provider with no key can be picked here but fails the whole Speech run
+  // on the first item it reaches, so mirror the Speech landing page and offer
+  // only the providers this browser actually holds a credential for.
+  const { hasApiKey, hasAzureKey, hasGeminiKey, hasElevenLabsKey } = useApiKey()
+  const providerKeyAvailable: ProviderKeyAvailability = {
+    openai: hasApiKey,
+    azure: hasAzureKey,
+    gemini: hasGeminiKey,
+    elevenlabs: hasElevenLabsKey,
+  }
+  const providerOptionDisabled = (option: string, current: string) =>
+    isProviderOptionDisabled(option, current, providerKeyAvailable)
+
   // Load voice mappings + speech instructions
   const { data: voiceMappings } = useQuery({
     queryKey: ["voice-mappings"],
@@ -1742,8 +1760,13 @@ function SpeechLanguageCards({
                     className="flex h-8 w-36 rounded-md border border-input bg-background px-2 py-1 text-xs shadow-sm"
                   >
                     {["openai", "azure", "gemini", "elevenlabs"].map((p) => (
-                      <option key={p} value={p}>
+                      <option
+                        key={p}
+                        value={p}
+                        disabled={providerOptionDisabled(p, provider)}
+                      >
                         {PROVIDER_LABELS[p]}{p === defaultProvider ? ` (${t`default`})` : ""}
+                        {providerOptionDisabled(p, provider) ? ` — ${t`no API key`}` : ""}
                       </option>
                     ))}
                   </select>
@@ -1809,8 +1832,15 @@ function SpeechLanguageCards({
                         className="flex h-8 w-36 rounded-md border border-input bg-background px-2 py-1 text-xs shadow-sm"
                       >
                         {(["openai", "azure", "gemini", "elevenlabs"] as const).map((option) => (
-                          <option key={option} value={option}>
+                          <option
+                            key={option}
+                            value={option}
+                            disabled={providerOptionDisabled(option, secondaryVoice.provider)}
+                          >
                             {PROVIDER_LABELS[option]}
+                            {providerOptionDisabled(option, secondaryVoice.provider)
+                              ? ` — ${t`no API key`}`
+                              : ""}
                           </option>
                         ))}
                       </select>

--- a/apps/studio/src/components/pipeline/stages/languages/lib/provider-availability.test.ts
+++ b/apps/studio/src/components/pipeline/stages/languages/lib/provider-availability.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest"
+import {
+  isProviderOptionDisabled,
+  type ProviderKeyAvailability,
+} from "./provider-availability"
+
+const onlyOpenAI: ProviderKeyAvailability = {
+  openai: true,
+  azure: false,
+  gemini: false,
+  elevenlabs: false,
+}
+
+describe("isProviderOptionDisabled", () => {
+  it("enables a provider whose key is present", () => {
+    expect(isProviderOptionDisabled("openai", "openai", onlyOpenAI)).toBe(false)
+    expect(isProviderOptionDisabled("openai", "azure", onlyOpenAI)).toBe(false)
+  })
+
+  it("disables a provider with no key", () => {
+    expect(isProviderOptionDisabled("elevenlabs", "openai", onlyOpenAI)).toBe(true)
+    expect(isProviderOptionDisabled("azure", "openai", onlyOpenAI)).toBe(true)
+    expect(isProviderOptionDisabled("gemini", "openai", onlyOpenAI)).toBe(true)
+  })
+
+  it("keeps the currently saved provider selectable even with no key", () => {
+    // An imported book carries its speech config but not the author's keys, so
+    // the saved provider must stay visible and re-selectable rather than being
+    // greyed out of the user's own configuration.
+    expect(isProviderOptionDisabled("elevenlabs", "elevenlabs", onlyOpenAI)).toBe(false)
+  })
+
+  it("disables everything but the current provider when no keys are held", () => {
+    const none: ProviderKeyAvailability = {
+      openai: false,
+      azure: false,
+      gemini: false,
+      elevenlabs: false,
+    }
+    expect(isProviderOptionDisabled("gemini", "gemini", none)).toBe(false)
+    for (const other of ["openai", "azure", "elevenlabs"]) {
+      expect(isProviderOptionDisabled(other, "gemini", none)).toBe(true)
+    }
+  })
+
+  it("treats an unknown provider id as unavailable", () => {
+    expect(isProviderOptionDisabled("not-a-provider", "openai", onlyOpenAI)).toBe(true)
+  })
+})

--- a/apps/studio/src/components/pipeline/stages/languages/lib/provider-availability.ts
+++ b/apps/studio/src/components/pipeline/stages/languages/lib/provider-availability.ts
@@ -1,0 +1,33 @@
+/**
+ * Which TTS providers a speech-settings dropdown may offer.
+ *
+ * Picking a provider this browser holds no key for produces a Speech run that
+ * fails on its credential pre-flight, so the choice is blocked at the point of
+ * selection rather than surfaced later as a run error.
+ */
+
+/** Provider keys held in this browser, as reported by `useApiKey()`. */
+export interface ProviderKeyAvailability {
+  openai: boolean
+  azure: boolean
+  gemini: boolean
+  elevenlabs: boolean
+}
+
+/**
+ * Whether `option` should be greyed out and unselectable.
+ *
+ * The provider already saved for this language stays selectable even with no
+ * key: disabling it would misrepresent the book's own configuration, and a user
+ * who navigated away from it could never return. A book's speech config travels
+ * with the book while keys live per-browser, so an imported book routinely
+ * arrives pointing at a provider this machine has no credential for.
+ */
+export function isProviderOptionDisabled(
+  option: string,
+  current: string,
+  available: ProviderKeyAvailability,
+): boolean {
+  if (option === current) return false
+  return !available[option as keyof ProviderKeyAvailability]
+}

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -5686,6 +5686,9 @@ msgstr "No AI edits yet for this section."
 msgid "No answer set"
 msgstr "No answer set"
 
+msgid "no API key"
+msgstr "no API key"
+
 #. placeholder {0}: linguiI18n._(PROVIDER_LABELS[provider])
 msgid "No API key for {0} yet. Add one in Book settings to enable this provider."
 msgstr "No API key for {0} yet. Add one in Book settings to enable this provider."
@@ -8204,8 +8207,8 @@ msgstr "sections"
 msgid "Sections"
 msgstr "Sections"
 
-msgid "See examples"
-msgstr "See examples"
+#~ msgid "See examples"
+#~ msgstr "See examples"
 
 msgid "See the book & pick pages"
 msgstr "See the book & pick pages"

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -5684,6 +5684,9 @@ msgstr "Aún no hay ediciones con IA para esta sección."
 msgid "No answer set"
 msgstr "Sin respuesta definida"
 
+msgid "no API key"
+msgstr "sin clave de API"
+
 #. placeholder {0}: linguiI18n._(PROVIDER_LABELS[provider])
 msgid "No API key for {0} yet. Add one in Book settings to enable this provider."
 msgstr "Aún no hay clave API para {0}. Añade una en la configuración del libro para habilitar este proveedor."
@@ -8202,8 +8205,8 @@ msgstr "secciones"
 msgid "Sections"
 msgstr "Secciones"
 
-msgid "See examples"
-msgstr "Ver ejemplos"
+#~ msgid "See examples"
+#~ msgstr "Ver ejemplos"
 
 msgid "See the book & pick pages"
 msgstr "Ver el libro y elegir páginas"

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -5686,6 +5686,9 @@ msgstr "Aucune modification IA pour cette section pour l'instant."
 msgid "No answer set"
 msgstr "Aucune réponse définie"
 
+msgid "no API key"
+msgstr "pas de clé API"
+
 #. placeholder {0}: linguiI18n._(PROVIDER_LABELS[provider])
 msgid "No API key for {0} yet. Add one in Book settings to enable this provider."
 msgstr "Pas encore de clé API pour {0}. Ajoutez-en une dans les paramètres du livre pour activer ce fournisseur."
@@ -8204,8 +8207,8 @@ msgstr "sections"
 msgid "Sections"
 msgstr "Sections"
 
-msgid "See examples"
-msgstr "Voir les exemples"
+#~ msgid "See examples"
+#~ msgstr "Voir les exemples"
 
 msgid "See the book & pick pages"
 msgstr "Voir le livre et choisir les pages"

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -5684,6 +5684,9 @@ msgstr "Ainda não há edições com IA para esta seção."
 msgid "No answer set"
 msgstr "Sem resposta definida"
 
+msgid "no API key"
+msgstr "sem chave de API"
+
 #. placeholder {0}: linguiI18n._(PROVIDER_LABELS[provider])
 msgid "No API key for {0} yet. Add one in Book settings to enable this provider."
 msgstr "Ainda não há chave de API para {0}. Adicione uma nas configurações do Livro para ativar este provedor."
@@ -8202,8 +8205,8 @@ msgstr "seções"
 msgid "Sections"
 msgstr "Seções"
 
-msgid "See examples"
-msgstr "Ver exemplos"
+#~ msgid "See examples"
+#~ msgstr "Ver exemplos"
 
 msgid "See the book & pick pages"
 msgstr "Ver o livro e escolher páginas"

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -5686,6 +5686,9 @@ msgstr "Nuk ka redaktime të AI ende për këtë seksion."
 msgid "No answer set"
 msgstr "Pa përgjigje të caktuar"
 
+msgid "no API key"
+msgstr "pa çelës API"
+
 #. placeholder {0}: linguiI18n._(PROVIDER_LABELS[provider])
 msgid "No API key for {0} yet. Add one in Book settings to enable this provider."
 msgstr "Nuk ka ende çelës API për {0}. Shto një te cilësimet e Librit për të aktivizuar këtë ofrues."
@@ -8204,8 +8207,8 @@ msgstr "seksione"
 msgid "Sections"
 msgstr "Seksione"
 
-msgid "See examples"
-msgstr "Shiko shembuj"
+#~ msgid "See examples"
+#~ msgstr "Shiko shembuj"
 
 msgid "See the book & pick pages"
 msgstr "Shihni librin dhe zgjidhni faqet"


### PR DESCRIPTION
## Summary

Found while manually testing #800. The **second-voice provider picker** in Language settings lets you select any of the four TTS providers, including ones this browser holds no API key for. Choosing one produces a Speech run that fails on its credential check.

The Speech landing page already guards against this — it disables a provider with no key and explains why ([`SpeechLandingPage.tsx:97-134`](https://github.com/unicef/adt-studio/blob/develop/apps/studio/src/components/pipeline/stages/speech/SpeechLandingPage.tsx#L97-L134)). The settings dropdowns were the only way left to reach the failure.

**Two dropdowns are affected**, not just the one that prompted this:

| Dropdown | Location |
|---|---|
| Second voice provider | `LanguageSettings.tsx` — the one reported |
| Per-language **primary** provider override | `LanguageSettings.tsx` — same gap, unnoticed |

Both hardcoded `["openai", "azure", "gemini", "elevenlabs"]` with no key check.

## Changes

- Grey out and disable a provider with no key in both dropdowns, appending `— no API key` to the option so the reason is visible (a native `<option>` can't carry a tooltip).
- Reuses the existing `useApiKey()` hook and mirrors the landing page's `providerKeyAvailable` shape — no new state, no new fetch.
- The predicate is extracted to `lib/provider-availability.ts` beside the existing colocated helpers in that folder, so the one non-obvious rule is unit-tested.

### The non-obvious rule

**The provider already saved for a language stays selectable even with no key.** A book's speech config travels with the book while keys live per-browser, so an imported book routinely arrives pointing at a provider this machine has no credential for. Disabling it would misrepresent the book's own configuration, and a user who navigated away from it could never return.

Adding a second voice defaults to the language's current primary provider, so the new picker can't open in a stuck state.

## Scope

This is **prevention, not a replacement for the run-time check in #800**. Keys live in `localStorage` per browser, so a book configured on one machine can still reach a keyless provider on another, and the CLI path has no UI at all. The two changes are complementary: this removes the easy way to walk into the failure, #800 makes the failure legible when it still happens.

## Verification

`pnpm typecheck` clean, `pnpm lint` 0 errors, full suite **2894 passing**.

5 new tests covering: key present ⇒ enabled; key absent ⇒ disabled; the saved provider stays enabled without a key; everything but the current one disabled when no keys are held; unknown provider id treated as unavailable.

`pnpm --filter @adt/studio extract` ⇒ **0 missing** across `es`, `fr`, `pt-BR`, `sq`. One new string (`no API key`), translated in all four.

> The `.po` diff also **removes** the `See examples` entries. That is `extract` catching up with 8d8f1fe6, which removed those links from source without re-extracting. Unrelated to this change, but it belongs in whichever PR next runs extract.

## Not verified

The visual result — greyed-out options in both dropdowns — has not been checked in a running Studio. The logic is unit-tested and typechecked; the rendering is not.
