### PR TITLE
fix(studio): apply the stored theme preference, and let scrollbars follow it

### DIFF
--- a/apps/studio/index.html
+++ b/apps/studio/index.html
@@ -5,6 +5,23 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <title>ADT Studio</title>
+    <script>
+      // Paint the stored theme before the first frame, so the app never flashes
+      // the wrong palette on launch. src/lib/theme.ts owns it from then on and
+      // reads the same key; keep the two in step.
+      (function () {
+        try {
+          var mode = localStorage.getItem("adt.theme") || "light";
+          var dark =
+            mode === "dark" ||
+            (mode === "system" &&
+              window.matchMedia("(prefers-color-scheme: dark)").matches);
+          document.documentElement.classList.toggle("dark", dark);
+        } catch (err) {
+          /* private mode or storage disabled — fall back to light */
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/studio/src/components/app/screens/settings/AppearanceSection.tsx
+++ b/apps/studio/src/components/app/screens/settings/AppearanceSection.tsx
@@ -5,31 +5,10 @@ import { Switch } from "@/components/ui/switch"
 import { cn } from "@/lib/utils"
 import { ComingSoon, SettingsCard, SettingsHeading, SettingsLead, SettingRow } from "./ui"
 import { THEME_OPTIONS, type ThemeMode, type ThemeOption } from "./options"
+import { readThemeMode, setThemeMode } from "@/lib/theme"
 import { SETTINGS_ANCHORS } from "./nav"
 
-const THEME_KEY = "adt.theme"
 const EASE = "ease-[cubic-bezier(0.23,1,0.32,1)]"
-
-function storedTheme(): ThemeMode {
-  try {
-    return (localStorage.getItem(THEME_KEY) as ThemeMode) || "light"
-  } catch {
-    return "light"
-  }
-}
-
-function applyTheme(mode: ThemeMode) {
-  const dark =
-    mode === "dark" ||
-    // eslint-disable-next-line lingui/no-unlocalized-strings
-    (mode === "system" && window.matchMedia?.("(prefers-color-scheme: dark)").matches)
-  document.documentElement.classList.toggle("dark", !!dark)
-  try {
-    localStorage.setItem(THEME_KEY, mode)
-  } catch {
-    /* ignore */
-  }
-}
 
 /** A mini window mock painted from the option's token set, used as the theme swatch. */
 function ThemePreview({ th }: { th: ThemeOption }) {
@@ -102,7 +81,7 @@ function ThemeCard({ th, selected, onSelect, index }: { th: ThemeOption; selecte
 
 export function AppearanceSection() {
   const { t } = useLingui()
-  const [theme, setTheme] = useState<ThemeMode>(storedTheme)
+  const [theme, setTheme] = useState<ThemeMode>(readThemeMode)
 
   return (
     <>
@@ -125,7 +104,7 @@ export function AppearanceSection() {
             selected={theme === th.key}
             onSelect={() => {
               setTheme(th.key)
-              applyTheme(th.key)
+              setThemeMode(th.key)
             }}
           />
         ))}

--- a/apps/studio/src/hooks/use-force-light-theme.test.tsx
+++ b/apps/studio/src/hooks/use-force-light-theme.test.tsx
@@ -1,39 +1,63 @@
 // @vitest-environment jsdom
-import { afterEach, describe, expect, it } from "vitest"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import { render } from "@testing-library/react"
 import { useForceLightTheme } from "./use-force-light-theme"
+import { setThemeMode, THEME_KEY } from "@/lib/theme"
 
 function Pipeline() {
   useForceLightTheme()
   return <div>pipeline</div>
 }
 
+const isDark = () => document.documentElement.classList.contains("dark")
+
+beforeEach(() => {
+  localStorage.clear()
+  document.documentElement.classList.remove("dark")
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    value: () => ({ matches: false, addEventListener: () => {}, removeEventListener: () => {} }),
+  })
+})
+
 afterEach(() => {
   document.documentElement.classList.remove("dark")
+  localStorage.clear()
 })
 
 describe("useForceLightTheme", () => {
-  it("drops dark while mounted and restores it on the way out", () => {
-    document.documentElement.classList.add("dark")
+  it("drops dark while mounted and restores the preference on the way out", () => {
+    setThemeMode("dark")
     const view = render(<Pipeline />)
-    expect(document.documentElement.classList.contains("dark")).toBe(false)
+    expect(isDark()).toBe(false)
     view.unmount()
-    expect(document.documentElement.classList.contains("dark")).toBe(true)
+    expect(isDark()).toBe(true)
   })
 
-  it("never adds dark to an app that was already light", () => {
-    expect(document.documentElement.classList.contains("dark")).toBe(false)
+  it("never darkens an app that was already light", () => {
+    setThemeMode("light")
     const view = render(<Pipeline />)
-    expect(document.documentElement.classList.contains("dark")).toBe(false)
-    // the important half: unmounting must not switch a light app to dark
+    expect(isDark()).toBe(false)
     view.unmount()
-    expect(document.documentElement.classList.contains("dark")).toBe(false)
+    expect(isDark()).toBe(false)
   })
 
-  it("leaves the theme alone once the pipeline is gone, across mounts", () => {
-    document.documentElement.classList.add("dark")
-    render(<Pipeline />).unmount()
-    render(<Pipeline />).unmount()
-    expect(document.documentElement.classList.contains("dark")).toBe(true)
+  it("honours a preference changed while the pipeline was open", () => {
+    setThemeMode("dark")
+    const view = render(<Pipeline />)
+    expect(isDark()).toBe(false)
+    // the user switches to light from inside the pipeline
+    localStorage.setItem(THEME_KEY, "light")
+    view.unmount()
+    expect(isDark()).toBe(false)
+  })
+
+  it("suspends painting so an OS flip cannot repaint the pipeline", () => {
+    setThemeMode("dark")
+    const view = render(<Pipeline />)
+    setThemeMode("dark") // a repaint attempt while suspended
+    expect(isDark()).toBe(false)
+    view.unmount()
+    expect(isDark()).toBe(true)
   })
 })

--- a/apps/studio/src/hooks/use-force-light-theme.ts
+++ b/apps/studio/src/hooks/use-force-light-theme.ts
@@ -1,4 +1,5 @@
 import { useEffect } from "react"
+import { applyStoredTheme, setThemeSuspended } from "@/lib/theme"
 
 /**
  * Renders the current screen in the light palette regardless of the app theme.
@@ -6,21 +7,29 @@ import { useEffect } from "react"
  * TEMPORARY. The pipeline was built against light-mode colours only — roughly
  * 700 hardcoded values across a hundred files — so on a dark theme it shows
  * black text on black panels. Rather than churn those files while the pipeline
- * refactor is in flight, we drop the `dark` class for as long as a pipeline
- * route is mounted and put it back on the way out.
+ * refactor is in flight, the pipeline opts out of the theme while it is open.
  *
- * Dropping the class (rather than re-declaring the tokens on a wrapper) also
+ * Dropping the `dark` class (rather than re-declaring tokens on a wrapper) also
  * covers dialogs, tooltips and toasts, which portal to document.body and would
- * otherwise stay dark over a light pipeline.
+ * otherwise stay dark over a light pipeline. Painting is suspended for the same
+ * reason: an OS colour-scheme change must not repaint the document underneath.
+ *
+ * On the way out the user's stored preference is re-applied — not simply the
+ * class that was there before — so a preference changed meanwhile still wins.
  *
  * Remove this hook, and its call in routes/books.$label.tsx, once the pipeline
  * is themed.
  */
 export function useForceLightTheme(): void {
   useEffect(() => {
+    setThemeSuspended(true)
     const root = document.documentElement
-    if (!root.classList.contains("dark")) return
+    const wasDark = root.classList.contains("dark")
     root.classList.remove("dark")
-    return () => root.classList.add("dark")
+
+    return () => {
+      setThemeSuspended(false)
+      if (wasDark) applyStoredTheme()
+    }
   }, [])
 }

--- a/apps/studio/src/lib/theme.test.ts
+++ b/apps/studio/src/lib/theme.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import {
+  applyStoredTheme,
+  initTheme,
+  paintTheme,
+  readThemeMode,
+  setThemeMode,
+  setThemeSuspended,
+  THEME_KEY,
+} from "./theme"
+
+const isDark = () => document.documentElement.classList.contains("dark")
+
+/** Stand in for the OS colour-scheme preference. */
+function mockSystemDark(dark: boolean, onChange?: (cb: () => void) => void) {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    value: () => ({
+      matches: dark,
+      addEventListener: (_: string, cb: () => void) => onChange?.(cb),
+      removeEventListener: () => {},
+    }),
+  })
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  document.documentElement.classList.remove("dark")
+  setThemeSuspended(false)
+  mockSystemDark(false)
+})
+
+afterEach(() => {
+  document.documentElement.classList.remove("dark")
+  setThemeSuspended(false)
+})
+
+describe("theme preference", () => {
+  it("defaults to light when nothing has been chosen", () => {
+    expect(readThemeMode()).toBe("light")
+    applyStoredTheme()
+    expect(isDark()).toBe(false)
+  })
+
+  it("stores the choice and paints it", () => {
+    setThemeMode("dark")
+    expect(localStorage.getItem(THEME_KEY)).toBe("dark")
+    expect(isDark()).toBe(true)
+  })
+
+  it("restores a stored dark preference on a fresh boot", () => {
+    localStorage.setItem(THEME_KEY, "dark")
+    expect(isDark()).toBe(false) // nothing painted yet
+    initTheme()
+    expect(isDark()).toBe(true)
+  })
+
+  it("ignores a corrupted stored value rather than painting nonsense", () => {
+    localStorage.setItem(THEME_KEY, "chartreuse")
+    expect(readThemeMode()).toBe("light")
+    applyStoredTheme()
+    expect(isDark()).toBe(false)
+  })
+
+  it("follows the OS when set to system", () => {
+    mockSystemDark(true)
+    setThemeMode("system")
+    expect(isDark()).toBe(true)
+    mockSystemDark(false)
+    applyStoredTheme()
+    expect(isDark()).toBe(false)
+  })
+
+  it("repaints when the OS flips and the mode is system", () => {
+    let fire: (() => void) | undefined
+    mockSystemDark(false, (cb) => { fire = cb })
+    setThemeMode("system")
+    initTheme()
+    expect(isDark()).toBe(false)
+    mockSystemDark(true, (cb) => { fire = cb })
+    fire?.()
+    expect(isDark()).toBe(true)
+  })
+
+  it("does not follow the OS when the user picked a fixed mode", () => {
+    let fire: (() => void) | undefined
+    mockSystemDark(false, (cb) => { fire = cb })
+    setThemeMode("light")
+    initTheme()
+    mockSystemDark(true, (cb) => { fire = cb })
+    fire?.()
+    expect(isDark()).toBe(false)
+  })
+
+  it("paints nothing while suspended, so an opted-out screen stays put", () => {
+    setThemeSuspended(true)
+    paintTheme("dark")
+    expect(isDark()).toBe(false)
+    setThemeSuspended(false)
+    paintTheme("dark")
+    expect(isDark()).toBe(true)
+  })
+})

--- a/apps/studio/src/lib/theme.ts
+++ b/apps/studio/src/lib/theme.ts
@@ -1,0 +1,80 @@
+export type ThemeMode = "light" | "dark" | "system"
+
+export const THEME_KEY = "adt.theme"
+/** Kept in sync with the boot script in index.html, which runs before this module. */
+export const DEFAULT_THEME: ThemeMode = "light"
+
+/* eslint-disable-next-line lingui/no-unlocalized-strings -- CSS media query, not UI copy */
+const DARK_QUERY = "(prefers-color-scheme: dark)"
+
+/** True while a screen opts out of the theme (see useForceLightTheme). */
+let suspended = false
+
+function isThemeMode(value: string | null): value is ThemeMode {
+  return value === "light" || value === "dark" || value === "system"
+}
+
+/** The user's stored preference, or the default when nothing is stored yet. */
+export function readThemeMode(): ThemeMode {
+  try {
+    const stored = localStorage.getItem(THEME_KEY)
+    return isThemeMode(stored) ? stored : DEFAULT_THEME
+  } catch {
+    return DEFAULT_THEME
+  }
+}
+
+/** Whether a mode resolves to dark right now — "system" asks the OS. */
+export function resolvesToDark(mode: ThemeMode): boolean {
+  if (mode === "dark") return true
+  if (mode !== "system") return false
+  return window.matchMedia?.(DARK_QUERY).matches ?? false
+}
+
+/** Paint a mode onto the document without storing it. */
+export function paintTheme(mode: ThemeMode): void {
+  if (suspended) return
+  document.documentElement.classList.toggle("dark", resolvesToDark(mode))
+}
+
+/** Store the user's choice and paint it. */
+export function setThemeMode(mode: ThemeMode): void {
+  try {
+    localStorage.setItem(THEME_KEY, mode)
+  } catch {
+    /* preference is best-effort; painting still works */
+  }
+  paintTheme(mode)
+}
+
+/** Re-paint whatever the user last chose. */
+export function applyStoredTheme(): void {
+  paintTheme(readThemeMode())
+}
+
+/**
+ * Suspends theme painting so a screen can opt out of it (the pipeline renders
+ * light regardless of preference until it is themed). While suspended, an OS
+ * colour-scheme change cannot repaint the document underneath that screen.
+ */
+export function setThemeSuspended(next: boolean): void {
+  suspended = next
+}
+
+/**
+ * Applies the stored preference and keeps "system" in step with the OS.
+ *
+ * The class itself is set by the boot script in index.html so the first paint
+ * is already correct; this re-applies it from the same source of truth and adds
+ * the listener React needs for later changes.
+ */
+export function initTheme(): () => void {
+  applyStoredTheme()
+  const media = window.matchMedia?.(DARK_QUERY)
+  if (!media) return () => {}
+  const onChange = () => {
+    if (readThemeMode() === "system") applyStoredTheme()
+  }
+  media.addEventListener("change", onChange)
+  return () => media.removeEventListener("change", onChange)
+}

--- a/apps/studio/src/main.tsx
+++ b/apps/studio/src/main.tsx
@@ -14,6 +14,7 @@ import { messages as esMessages } from "./locales/es.po"
 import { messages as frMessages } from "./locales/fr.po"
 import { messages as sqMessages } from "./locales/sq.po"
 import { getReleaseChannel } from "@/components/updates/release-banner-utils"
+import { initTheme } from "@/lib/theme"
 import { routeTree } from "./routeTree.gen"
 import "./styles/globals.css"
 import { LOCALES, activateLocale, getStoredLocale, matchSupportedLocale } from "./i18n/locales"
@@ -87,6 +88,9 @@ function PreviewSettingsListener(): null {
   usePreviewSettingsListener()
   return null
 }
+
+// Apply the user's stored theme and follow the OS while set to "system".
+initTheme()
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/apps/studio/src/styles/globals.css
+++ b/apps/studio/src/styles/globals.css
@@ -479,6 +479,35 @@
   }
 }
 
+/* App-wide scrollbars: slim, themed, and out of the way. The thumb is drawn
+   inside a transparent border so it reads as a floating pill rather than a
+   full-height bar, and the track never paints a light strip on dark surfaces. */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--scrollbar-thumb) transparent;
+}
+
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+::-webkit-scrollbar-track,
+::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background-color: var(--scrollbar-thumb);
+  border: 3px solid transparent;
+  background-clip: content-box;
+  border-radius: 9999px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background-color: var(--scrollbar-thumb-hover);
+}
+
 .wizard-scroll {
   scrollbar-width: thin;
   scrollbar-color: oklch(0.7 0 0 / 0.2) transparent;
@@ -638,9 +667,18 @@
   --brand-800: oklch(0.45 0.16 260);
   --brand-900: oklch(0.3 0.12 260);
   --brand-950: oklch(0.18 0.07 260);
+
+  /* Native scrollbars, form controls and text selection follow this. Without it
+     Chromium paints a light scrollbar over dark surfaces. */
+  color-scheme: light;
+  --scrollbar-thumb: oklch(0 0 0 / 0.18);
+  --scrollbar-thumb-hover: oklch(0 0 0 / 0.32);
 }
 
 .dark {
+  color-scheme: dark;
+  --scrollbar-thumb: oklch(1 0 0 / 0.18);
+  --scrollbar-thumb-hover: oklch(1 0 0 / 0.34);
   --background: oklch(0.15 0.02 250);
   --foreground: oklch(0.93 0.01 250);
   --card: oklch(0.17 0.02 250);


### PR DESCRIPTION
Stacked on #816. Two theme-correctness fixes found while testing dark mode in the desktop app.

### The stored theme preference was never applied at startup

Picking **Dark** only held until the next reload. `applyTheme`/`storedTheme` lived inside `AppearanceSection` and only ran from its click handler, so nothing applied the preference on boot — the choice looked like it hadn't saved.

- `lib/theme.ts` now owns the preference (`readThemeMode`, `setThemeMode`, `applyStoredTheme`, `initTheme`, `setThemeSuspended`).
- A boot script in `index.html` paints it **before the first frame**, so there's no flash of the wrong palette; `initTheme()` re-applies from the same source and keeps `"system"` in step with the OS.
- A corrupted stored value falls back to light rather than painting nonsense.
- `AppearanceSection` delegates instead of holding a second copy of the logic.

The pipeline's light opt-out (#816) now cooperates rather than fighting: it **suspends** painting so an OS colour-scheme change can't repaint the pipeline underneath, and on exit **re-applies the stored preference** instead of restoring whatever class it found — so a preference changed while the pipeline was open still wins.

Verified in the running app: `stored dark → reload → html="dark"`, `stored light → reload → light`.

### Scrollbars ignored the theme

`color-scheme` was never declared, so the engine painted its **light native scrollbar over dark surfaces** — a wide grey bar down the side of every dark dialog. Declaring it per theme also fixes native form controls and text selection.

Scrollbars are now styled once globally instead of per component: a slim thumb drawn inside a transparent border so it reads as a floating pill, over a track that never paints a light strip. The existing `.wizard-scroll` / `.scrollbar-hide` opt-ins still apply where a surface wants something different.

Verified in the What's-new dialog in both themes.

### Tests

12 new tests: default, persistence across boot, corrupted stored value, `system` following the OS, *not* following when a fixed mode is set, suspension, and the four pipeline-interaction cases.

`pnpm typecheck` clean · lint 0 errors · studio suite 62 files / 367 tests.
