### PR TITLE
feat(studio): apply settings straight from the command palette

### DIFF
--- a/apps/studio/src/components/app/CommandPalette.tsx
+++ b/apps/studio/src/components/app/CommandPalette.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react"
 import { useNavigate } from "@tanstack/react-router"
 import { Trans, useLingui } from "@lingui/react/macro"
-import { Search, House, BookMarked, Split, Settings, Plus, Upload, CornerDownLeft, BookOpen, type LucideIcon } from "lucide-react"
+import { Search, House, BookMarked, Split, Settings, Plus, Upload, CornerDownLeft, BookOpen, Check, type LucideIcon } from "lucide-react"
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { cn } from "@/lib/utils"
@@ -12,6 +12,7 @@ import { Kbd } from "./ui/Kbd"
 import { useShortcutLabel } from "@/hooks/use-platform"
 import { APP_PATHS } from "./nav"
 import { rankBySearch, searchTokens } from "./search"
+import { buildQuickActions } from "./quick-actions"
 import { SETTINGS_PATHS } from "./screens/settings/nav"
 import {
   SETTINGS_SEARCH_ENTRIES,
@@ -30,6 +31,7 @@ interface PaletteItem {
   icon?: LucideIcon
   cover?: CoverSpec
   author?: string
+  active?: boolean
   run: () => void
 }
 interface PaletteGroup {
@@ -112,6 +114,9 @@ function PaletteResults({ onClose, books, locale, onOpenAdd }: PaletteResultsPro
         run: () => navigate({ to: "/books/$label/$step", params: { label: b.label, step: "book" } }),
       }
     })
+    const quickActions: PaletteItem[] = buildQuickActions(i18n, {
+      goToLibrary: () => navigate({ to: APP_PATHS.library }),
+    })
     const settingsItems: PaletteItem[] = buildSettingsSearchItems(
       i18n,
       tokens.length > 0 ? SETTINGS_SEARCH_ENTRIES : SETTINGS_SECTION_ENTRIES,
@@ -133,6 +138,7 @@ function PaletteResults({ onClose, books, locale, onOpenAdd }: PaletteResultsPro
     return [
       { label: t`Navigation`, items: rank(nav) },
       { label: t`Books`, items: rank(bookItems) },
+      { label: t`Change`, items: rank(quickActions) },
       { label: t`Settings`, items: rank(settingsItems) },
       { label: t`Actions`, items: rank(actions) },
     ].filter((g) => g.items.length > 0)
@@ -236,6 +242,12 @@ function PaletteResults({ onClose, books, locale, onOpenAdd }: PaletteResultsPro
                       <div className="text-[13.5px] font-medium text-foreground">{it.title}</div>
                       {it.sub && <div className="truncate text-xs text-muted-foreground">{it.sub}</div>}
                     </div>
+                    {it.active && (
+                      <Check
+                        className="size-3.5 shrink-0 text-brand-600"
+                        aria-label={t`Currently active`}
+                      />
+                    )}
                     {isActive && <CornerDownLeft className="size-3.5 text-muted-foreground" />}
                   </div>
                 )

--- a/apps/studio/src/components/app/quick-actions.test.ts
+++ b/apps/studio/src/components/app/quick-actions.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import type { I18n } from "@lingui/core"
+
+vi.mock("@lingui/core/macro", () => ({
+  msg(strings: TemplateStringsArray, ...values: unknown[]) {
+    let text = ""
+    for (let i = 0; i < strings.length; i += 1) {
+      text += strings[i]
+      if (i < values.length) text += String(values[i])
+    }
+    return { id: text }
+  },
+}))
+
+const goToLibrary = vi.fn()
+const deps = { goToLibrary }
+
+const i18n = {
+  _: (d: { id?: string } | string) => (typeof d === "string" ? d : (d.id ?? "")),
+} as unknown as I18n
+
+async function load() {
+  vi.resetModules()
+  const [{ buildQuickActions }, { readThemeMode }, { getLibraryPrefs }] = await Promise.all([
+    import("./quick-actions"),
+    import("@/lib/theme"),
+    import("@/hooks/use-library-prefs"),
+  ])
+  return { buildQuickActions, readThemeMode, getLibraryPrefs, i18n }
+}
+
+beforeEach(() => {
+  window.localStorage.clear()
+  goToLibrary.mockClear()
+  document.documentElement.classList.remove("dark")
+})
+
+afterEach(() => {
+  window.localStorage.clear()
+})
+
+describe("palette quick actions", () => {
+  it("offers the opposite theme, and applies it", async () => {
+    const { buildQuickActions, readThemeMode } = await load()
+    const toggle = buildQuickActions(i18n, deps).find((a) => a.id === "qa-theme-toggle")!
+    expect(toggle.title).toBe("Switch to dark theme")
+    toggle.run()
+    expect(readThemeMode()).toBe("dark")
+    expect(document.documentElement.classList.contains("dark")).toBe(true)
+
+    const back = buildQuickActions(i18n, deps).find((a) => a.id === "qa-theme-toggle")!
+    expect(back.title).toBe("Switch to light theme")
+  })
+
+  it("ticks the value a setting already holds", async () => {
+    const { buildQuickActions } = await load()
+    const grid = buildQuickActions(i18n, deps).find((a) => a.id === "qa-view-grid")!
+    grid.run()
+    const rebuilt = buildQuickActions(i18n, deps)
+    expect(rebuilt.find((a) => a.id === "qa-view-grid")!.active).toBe(true)
+    expect(rebuilt.find((a) => a.id === "qa-view-list")!.active).toBe(false)
+  })
+
+it("takes the reader to the Library, where a library change is visible", async () => {
+    const { buildQuickActions, getLibraryPrefs } = await load()
+    const actions = buildQuickActions(i18n, deps)
+    actions.find((a) => a.id === "qa-sort-title")!.run()
+    expect(getLibraryPrefs().sort).toBe("title")
+    expect(goToLibrary).toHaveBeenCalledTimes(1)
+  })
+
+  it("stays where it is for theme and language, which are visible in place", async () => {
+    const { buildQuickActions } = await load()
+    const actions = buildQuickActions(i18n, deps)
+    actions.find((a) => a.id === "qa-theme-toggle")!.run()
+    actions.find((a) => a.id === "qa-locale-pt-BR")!.run()
+    expect(goToLibrary).not.toHaveBeenCalled()
+  })
+
+  it("names every language in its own tongue", async () => {
+    const { buildQuickActions } = await load()
+    const titles = buildQuickActions(i18n, deps)
+      .filter((a) => a.id.startsWith("qa-locale-"))
+      .map((a) => a.title)
+    expect(titles).toEqual(["English", "Português (Brasil)", "Español", "Français", "Shqip"])
+  })
+
+  it("covers every bounded value exactly once", async () => {
+    const { buildQuickActions } = await load()
+    const ids = buildQuickActions(i18n, deps).map((a) => a.id)
+    expect(new Set(ids).size).toBe(ids.length)
+    expect(ids.filter((id) => id.startsWith("qa-locale-"))).toHaveLength(5)
+    expect(ids.filter((id) => id.startsWith("qa-sort-"))).toHaveLength(5)
+    expect(ids.filter((id) => id.startsWith("qa-view-"))).toHaveLength(2)
+    expect(ids.filter((id) => id.startsWith("qa-group-"))).toHaveLength(2)
+    expect(ids).toHaveLength(16)
+  })
+})

--- a/apps/studio/src/components/app/quick-actions.ts
+++ b/apps/studio/src/components/app/quick-actions.ts
@@ -1,0 +1,167 @@
+import { msg } from "@lingui/core/macro"
+import type { I18n, MessageDescriptor } from "@lingui/core"
+import {
+  Moon,
+  Sun,
+  MonitorCog,
+  Languages,
+  LayoutGrid,
+  Rows3,
+  ArrowDownWideNarrow,
+  Layers,
+  type LucideIcon,
+} from "lucide-react"
+import { readThemeMode, resolvesToDark, setThemeMode } from "@/lib/theme"
+import {
+  LIBRARY_GROUPS,
+  LIBRARY_SORTS,
+  LIBRARY_VIEWS,
+  getLibraryPrefs,
+  setLibraryPrefs,
+  type LibraryGroup,
+  type LibrarySort,
+  type LibraryViewMode,
+} from "@/hooks/use-library-prefs"
+import { LOCALES, activateLocale, getStoredLocale, type AppLocale } from "@/i18n/locales"
+
+export interface QuickAction {
+  id: string
+  title: string
+  sub?: string
+  keywords?: string
+  icon?: LucideIcon
+  active?: boolean
+  run: () => void
+}
+
+export interface QuickActionDeps {
+  goToLibrary: () => void
+}
+
+/* eslint-disable lingui/no-unlocalized-strings -- language names and English search aliases stay untranslated */
+const LOCALE_LABELS: Record<AppLocale, string> = {
+  en: "English",
+  "pt-BR": "Português (Brasil)",
+  es: "Español",
+  fr: "Français",
+  sq: "Shqip",
+}
+
+const SORT_LABELS: Record<LibrarySort, MessageDescriptor> = {
+  recent: msg`Recently edited`,
+  title: msg`Title`,
+  progress: msg`Progress`,
+  pages: msg`Pages`,
+  created: msg`Date added`,
+}
+
+const GROUP_LABELS: Record<LibraryGroup, MessageDescriptor> = {
+  none: msg`No grouping`,
+  attention: msg`Group by needs attention`,
+}
+
+const VIEW_LABELS: Record<LibraryViewMode, MessageDescriptor> = {
+  grid: msg`Grid view`,
+  list: msg`List view`,
+}
+
+const VIEW_ICONS: Record<LibraryViewMode, LucideIcon> = { grid: LayoutGrid, list: Rows3 }
+
+const KEYWORDS = {
+  theme: { msg: msg`theme appearance dark light mode`, en: "theme appearance dark light mode" },
+  system: { msg: msg`theme appearance system automatic`, en: "theme appearance system automatic" },
+  language: { msg: msg`language locale translation`, en: "language locale translation" },
+  view: { msg: msg`library view layout grid list`, en: "library view layout grid list" },
+  sort: { msg: msg`library sort order`, en: "library sort order" },
+  group: { msg: msg`library group needs attention`, en: "library group needs attention" },
+}
+/* eslint-enable lingui/no-unlocalized-strings */
+
+function terms(i18n: I18n, entry: { msg: MessageDescriptor; en: string }): string {
+  const translated = i18n._(entry.msg)
+  return translated === entry.en ? entry.en : `${translated} ${entry.en}`
+}
+
+export function buildQuickActions(i18n: I18n, deps: QuickActionDeps): QuickAction[] {
+  const themeMode = readThemeMode()
+  const isDark = resolvesToDark(themeMode)
+  const prefs = getLibraryPrefs()
+  const locale = getStoredLocale()
+
+  const items: QuickAction[] = [
+    {
+      id: "qa-theme-toggle",
+      title: isDark ? i18n._(msg`Switch to light theme`) : i18n._(msg`Switch to dark theme`),
+      keywords: terms(i18n, KEYWORDS.theme),
+      icon: isDark ? Sun : Moon,
+      run: () => setThemeMode(isDark ? "light" : "dark"),
+    },
+    {
+      id: "qa-theme-system",
+      title: i18n._(msg`Match system theme`),
+      keywords: terms(i18n, KEYWORDS.system),
+      icon: MonitorCog,
+      active: themeMode === "system",
+      run: () => setThemeMode("system"),
+    },
+  ]
+
+  for (const code of LOCALES) {
+    items.push({
+      id: `qa-locale-${code}`,
+      title: LOCALE_LABELS[code],
+      sub: i18n._(msg`Change language`),
+      keywords: `${terms(i18n, KEYWORDS.language)} ${code} ${LOCALE_LABELS[code]}`,
+      icon: Languages,
+      active: locale === code,
+      run: () => activateLocale(code),
+    })
+  }
+
+  for (const view of LIBRARY_VIEWS) {
+    items.push({
+      id: `qa-view-${view}`,
+      title: i18n._(VIEW_LABELS[view]),
+      sub: i18n._(msg`Library`),
+      keywords: `${terms(i18n, KEYWORDS.view)} ${view}`,
+      icon: VIEW_ICONS[view],
+      active: prefs.view === view,
+      run: () => {
+        setLibraryPrefs({ view })
+        deps.goToLibrary()
+      },
+    })
+  }
+
+  for (const sort of LIBRARY_SORTS) {
+    items.push({
+      id: `qa-sort-${sort}`,
+      title: i18n._(msg`Sort library by ${i18n._(SORT_LABELS[sort])}`),
+      sub: i18n._(msg`Library`),
+      keywords: `${terms(i18n, KEYWORDS.sort)} ${sort}`,
+      icon: ArrowDownWideNarrow,
+      active: prefs.sort === sort,
+      run: () => {
+        setLibraryPrefs({ sort })
+        deps.goToLibrary()
+      },
+    })
+  }
+
+  for (const group of LIBRARY_GROUPS) {
+    items.push({
+      id: `qa-group-${group}`,
+      title: i18n._(GROUP_LABELS[group]),
+      sub: i18n._(msg`Library`),
+      keywords: terms(i18n, KEYWORDS.group),
+      icon: Layers,
+      active: prefs.group === group,
+      run: () => {
+        setLibraryPrefs({ group })
+        deps.goToLibrary()
+      },
+    })
+  }
+
+  return items
+}

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -2865,6 +2865,9 @@ msgstr "Current Preview Page"
 msgid "Current version (v{currentVersion})"
 msgstr "Current version (v{currentVersion})"
 
+msgid "Currently active"
+msgstr "Currently active"
+
 msgid "Custom"
 msgstr "Custom"
 
@@ -2888,6 +2891,9 @@ msgstr "Cut a region out of any page"
 
 msgid "Dark"
 msgstr "Dark"
+
+msgid "Date added"
+msgstr "Date added"
 
 msgid "Date created"
 msgstr "Date created"
@@ -4418,6 +4424,9 @@ msgstr "Group"
 msgid "Group by attention"
 msgstr "Group by attention"
 
+msgid "Group by needs attention"
+msgstr "Group by needs attention"
+
 msgid "Group each page's text and images into typed sections with a structured content tree. Sections drive how downstream stages render, translate, and read the book aloud."
 msgstr "Group each page's text and images into typed sections with a structured content tree. Sections drive how downstream stages render, translate, and read the book aloud."
 
@@ -5047,6 +5056,9 @@ msgstr "Lang"
 msgid "Language"
 msgstr "Language"
 
+msgid "language locale translation"
+msgstr "language locale translation"
+
 msgid "language locale translation region"
 msgstr "language locale translation region"
 
@@ -5146,8 +5158,17 @@ msgstr "Library"
 msgid "Library apps"
 msgstr "Library apps"
 
+msgid "library group needs attention"
+msgstr "library group needs attention"
+
 msgid "Library guide"
 msgstr "Library guide"
+
+msgid "library sort order"
+msgstr "library sort order"
+
+msgid "library view layout grid list"
+msgstr "library view layout grid list"
 
 msgid "Life in the Coral Reef"
 msgstr "Life in the Coral Reef"
@@ -5469,6 +5490,9 @@ msgstr "Match each stage of the water cycle to its definition:"
 
 msgid "Match Source"
 msgstr "Match Source"
+
+msgid "Match system theme"
+msgstr "Match system theme"
 
 msgid "Matches the original book design with some flexibility."
 msgstr "Matches the original book design with some flexibility."
@@ -6020,6 +6044,9 @@ msgstr "No fonts found"
 
 msgid "No fonts match your search."
 msgstr "No fonts match your search."
+
+msgid "No grouping"
+msgstr "No grouping"
 
 msgid "No image"
 msgstr "No image"
@@ -8908,6 +8935,10 @@ msgstr "Sort"
 msgid "Sort by"
 msgstr "Sort by"
 
+#. placeholder {0}: i18n._(SORT_LABELS[sort])
+msgid "Sort library by {0}"
+msgstr "Sort library by {0}"
+
 msgid "Source"
 msgstr "Source"
 
@@ -9283,6 +9314,12 @@ msgstr "Sun"
 
 msgid "Switch languages in a tap."
 msgstr "Switch languages in a tap."
+
+msgid "Switch to dark theme"
+msgstr "Switch to dark theme"
+
+msgid "Switch to light theme"
+msgstr "Switch to light theme"
 
 msgid "Switching presentation failed"
 msgstr "Switching presentation failed"
@@ -9669,6 +9706,12 @@ msgstr "Theme"
 
 msgid "theme appearance dark light colors interface"
 msgstr "theme appearance dark light colors interface"
+
+msgid "theme appearance dark light mode"
+msgstr "theme appearance dark light mode"
+
+msgid "theme appearance system automatic"
+msgstr "theme appearance system automatic"
 
 msgid "These edits haven't been applied yet. Leave and they'll be lost — or save and re-run to apply them. The run continues in the background while you keep working."
 msgstr "These edits haven't been applied yet. Leave and they'll be lost — or save and re-run to apply them. The run continues in the background while you keep working."

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -2865,6 +2865,9 @@ msgstr "Página Actual de la Vista Previa"
 msgid "Current version (v{currentVersion})"
 msgstr "Versión actual (v{currentVersion})"
 
+msgid "Currently active"
+msgstr "Activo actualmente"
+
 msgid "Custom"
 msgstr "Personalizado"
 
@@ -2888,6 +2891,9 @@ msgstr "Recorta una región de cualquier página"
 
 msgid "Dark"
 msgstr "Oscuro"
+
+msgid "Date added"
+msgstr "Fecha de adición"
 
 msgid "Date created"
 msgstr "Fecha de creación"
@@ -4418,6 +4424,9 @@ msgstr "Grupo"
 msgid "Group by attention"
 msgstr "Agrupar por atención"
 
+msgid "Group by needs attention"
+msgstr "Agrupar por requiere atención"
+
 msgid "Group each page's text and images into typed sections with a structured content tree. Sections drive how downstream stages render, translate, and read the book aloud."
 msgstr "Agrupa el texto e imágenes de cada página en secciones escritas con un árbol de contenido estructurado. Las secciones determinan cómo las etapas posteriores renderizan, traducen y leen el libro en voz alta."
 
@@ -5047,6 +5056,9 @@ msgstr "Idioma"
 msgid "Language"
 msgstr "Idioma"
 
+msgid "language locale translation"
+msgstr "idioma configuración regional traducción lengua"
+
 msgid "language locale translation region"
 msgstr "idioma localización traducción región"
 
@@ -5146,8 +5158,17 @@ msgstr "Biblioteca"
 msgid "Library apps"
 msgstr "Aplicaciones de biblioteca"
 
+msgid "library group needs attention"
+msgstr "biblioteca agrupar requiere atención"
+
 msgid "Library guide"
 msgstr "Guía de la biblioteca"
+
+msgid "library sort order"
+msgstr "biblioteca ordenar orden clasificación"
+
+msgid "library view layout grid list"
+msgstr "biblioteca vista diseño cuadrícula lista"
 
 msgid "Life in the Coral Reef"
 msgstr "Vida en el Arrecife de Coral"
@@ -5469,6 +5490,9 @@ msgstr "Asocia cada etapa del ciclo del agua con su definición:"
 
 msgid "Match Source"
 msgstr "Coincidir con la Fuente"
+
+msgid "Match system theme"
+msgstr "Seguir el tema del sistema"
 
 msgid "Matches the original book design with some flexibility."
 msgstr "Coincide con el diseño original del libro con cierta flexibilidad."
@@ -6020,6 +6044,9 @@ msgstr "No se encontraron fuentes"
 
 msgid "No fonts match your search."
 msgstr "Ninguna fuente coincide con tu búsqueda."
+
+msgid "No grouping"
+msgstr "Sin agrupación"
 
 msgid "No image"
 msgstr "Sin imagen"
@@ -8908,6 +8935,10 @@ msgstr "Ordenar"
 msgid "Sort by"
 msgstr "Ordenar por"
 
+#. placeholder {0}: i18n._(SORT_LABELS[sort])
+msgid "Sort library by {0}"
+msgstr "Ordenar la biblioteca por {0}"
+
 msgid "Source"
 msgstr "Fuente"
 
@@ -9283,6 +9314,12 @@ msgstr "Sol"
 
 msgid "Switch languages in a tap."
 msgstr "Cambia de idioma con un toque."
+
+msgid "Switch to dark theme"
+msgstr "Cambiar al tema oscuro"
+
+msgid "Switch to light theme"
+msgstr "Cambiar al tema claro"
 
 msgid "Switching presentation failed"
 msgstr "Error al cambiar la presentación"
@@ -9669,6 +9706,12 @@ msgstr "Tema"
 
 msgid "theme appearance dark light colors interface"
 msgstr "tema apariencia oscuro claro colores interfaz"
+
+msgid "theme appearance dark light mode"
+msgstr "tema apariencia oscuro claro modo"
+
+msgid "theme appearance system automatic"
+msgstr "tema apariencia sistema automático"
 
 msgid "These edits haven't been applied yet. Leave and they'll be lost — or save and re-run to apply them. The run continues in the background while you keep working."
 msgstr "Estos cambios aún no se han aplicado. Si sales, se perderán, o guarda y re-ejecuta para aplicarlos. La ejecución continúa en segundo plano mientras sigues trabajando."

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -2867,6 +2867,9 @@ msgstr "Page d'aperçu actuelle"
 msgid "Current version (v{currentVersion})"
 msgstr "Version actuelle (v{currentVersion})"
 
+msgid "Currently active"
+msgstr "Actuellement actif"
+
 msgid "Custom"
 msgstr "Personnalisé"
 
@@ -2890,6 +2893,9 @@ msgstr "Découpez une région de n'importe quelle page"
 
 msgid "Dark"
 msgstr "Sombre"
+
+msgid "Date added"
+msgstr "Date d'ajout"
 
 msgid "Date created"
 msgstr "Date de création"
@@ -4420,6 +4426,9 @@ msgstr "Groupe"
 msgid "Group by attention"
 msgstr "Grouper par attention"
 
+msgid "Group by needs attention"
+msgstr "Grouper par à traiter"
+
 msgid "Group each page's text and images into typed sections with a structured content tree. Sections drive how downstream stages render, translate, and read the book aloud."
 msgstr "Regroupez le texte et les images de chaque page en sections tapées avec un arbre de contenu structuré. Les sections déterminent comment les étapes en aval rendent, traduisent et lisent le livre à haute voix."
 
@@ -5049,6 +5058,9 @@ msgstr "Langue"
 msgid "Language"
 msgstr "Langue"
 
+msgid "language locale translation"
+msgstr "langue paramètres régionaux traduction"
+
 msgid "language locale translation region"
 msgstr "langue locale traduction région"
 
@@ -5148,8 +5160,17 @@ msgstr "Bibliothèque"
 msgid "Library apps"
 msgstr "Applications de bibliothèque"
 
+msgid "library group needs attention"
+msgstr "bibliothèque grouper à traiter"
+
 msgid "Library guide"
 msgstr "Guide de la bibliothèque"
+
+msgid "library sort order"
+msgstr "bibliothèque trier ordre tri"
+
+msgid "library view layout grid list"
+msgstr "bibliothèque affichage disposition grille liste"
 
 msgid "Life in the Coral Reef"
 msgstr "Life dans le Coral Reef"
@@ -5471,6 +5492,9 @@ msgstr "Associez chaque étape du cycle de l'eau à sa définition :"
 
 msgid "Match Source"
 msgstr "Correspondre à la source"
+
+msgid "Match system theme"
+msgstr "Suivre le thème du système"
 
 msgid "Matches the original book design with some flexibility."
 msgstr "Correspond au design original du livre avec une certaine flexibilité."
@@ -6022,6 +6046,9 @@ msgstr "Aucune police trouvée"
 
 msgid "No fonts match your search."
 msgstr "Aucune police ne correspond à votre recherche."
+
+msgid "No grouping"
+msgstr "Aucun groupement"
 
 msgid "No image"
 msgstr "Aucune image"
@@ -8910,6 +8937,10 @@ msgstr "Trier"
 msgid "Sort by"
 msgstr "Trier par"
 
+#. placeholder {0}: i18n._(SORT_LABELS[sort])
+msgid "Sort library by {0}"
+msgstr "Trier la bibliothèque par {0}"
+
 msgid "Source"
 msgstr "Source"
 
@@ -9285,6 +9316,12 @@ msgstr "Sun"
 
 msgid "Switch languages in a tap."
 msgstr "Changez de langue d'un geste."
+
+msgid "Switch to dark theme"
+msgstr "Passer au thème sombre"
+
+msgid "Switch to light theme"
+msgstr "Passer au thème clair"
 
 msgid "Switching presentation failed"
 msgstr "Échec du changement de présentation"
@@ -9671,6 +9708,12 @@ msgstr "Thème"
 
 msgid "theme appearance dark light colors interface"
 msgstr "thème apparence sombre clair couleurs interface"
+
+msgid "theme appearance dark light mode"
+msgstr "thème apparence sombre clair mode"
+
+msgid "theme appearance system automatic"
+msgstr "thème apparence système automatique"
 
 msgid "These edits haven't been applied yet. Leave and they'll be lost — or save and re-run to apply them. The run continues in the background while you keep working."
 msgstr "Ces modifications n'ont pas encore été appliquées. Quittez et elles seront perdues — ou enregistrez et relancez pour les appliquer. L'exécution se poursuit en arrière-plan pendant que vous continuez à travailler."

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -2865,6 +2865,9 @@ msgstr "Página Atual da Pré-visualização"
 msgid "Current version (v{currentVersion})"
 msgstr "Versão atual (v{currentVersion})"
 
+msgid "Currently active"
+msgstr "Ativo no momento"
+
 msgid "Custom"
 msgstr "Personalizado"
 
@@ -2888,6 +2891,9 @@ msgstr "Recorte uma região de qualquer página"
 
 msgid "Dark"
 msgstr "Escuro"
+
+msgid "Date added"
+msgstr "Data de adição"
 
 msgid "Date created"
 msgstr "Data de criação"
@@ -4418,6 +4424,9 @@ msgstr "Agrupar"
 msgid "Group by attention"
 msgstr "Agrupar por atenção"
 
+msgid "Group by needs attention"
+msgstr "Agrupar por precisa de atenção"
+
 msgid "Group each page's text and images into typed sections with a structured content tree. Sections drive how downstream stages render, translate, and read the book aloud."
 msgstr "Agrupe o texto e as imagens de cada página em seções classificadas com uma árvore de conteúdo estruturada. As seções determinam como as etapas posteriores renderizam, traduzem e leem o livro em voz alta."
 
@@ -5047,6 +5056,9 @@ msgstr "Idioma"
 msgid "Language"
 msgstr "Idioma"
 
+msgid "language locale translation"
+msgstr "idioma localidade tradução língua"
+
 msgid "language locale translation region"
 msgstr "idioma local tradução região"
 
@@ -5146,8 +5158,17 @@ msgstr "Biblioteca"
 msgid "Library apps"
 msgstr "Aplicativos de biblioteca"
 
+msgid "library group needs attention"
+msgstr "biblioteca agrupar precisa de atenção"
+
 msgid "Library guide"
 msgstr "Guia da biblioteca"
+
+msgid "library sort order"
+msgstr "biblioteca ordenar ordem classificação"
+
+msgid "library view layout grid list"
+msgstr "biblioteca visualização layout grade lista"
 
 msgid "Life in the Coral Reef"
 msgstr "Vida no Recife de Coral"
@@ -5469,6 +5490,9 @@ msgstr "Associe cada estágio do ciclo da água à sua definição:"
 
 msgid "Match Source"
 msgstr "Corresponder à Fonte"
+
+msgid "Match system theme"
+msgstr "Acompanhar o tema do sistema"
 
 msgid "Matches the original book design with some flexibility."
 msgstr "Corresponde ao design original do livro com alguma flexibilidade."
@@ -6020,6 +6044,9 @@ msgstr "Nenhuma fonte encontrada"
 
 msgid "No fonts match your search."
 msgstr "Nenhuma fonte corresponde à sua busca."
+
+msgid "No grouping"
+msgstr "Sem agrupamento"
 
 msgid "No image"
 msgstr "Sem imagem"
@@ -8908,6 +8935,10 @@ msgstr "Ordenar"
 msgid "Sort by"
 msgstr "Ordenar por"
 
+#. placeholder {0}: i18n._(SORT_LABELS[sort])
+msgid "Sort library by {0}"
+msgstr "Ordenar a biblioteca por {0}"
+
 msgid "Source"
 msgstr "Fonte"
 
@@ -9283,6 +9314,12 @@ msgstr "Sol"
 
 msgid "Switch languages in a tap."
 msgstr "Troque de idioma com um toque."
+
+msgid "Switch to dark theme"
+msgstr "Mudar para o tema escuro"
+
+msgid "Switch to light theme"
+msgstr "Mudar para o tema claro"
 
 msgid "Switching presentation failed"
 msgstr "Falha ao mudar a apresentação"
@@ -9669,6 +9706,12 @@ msgstr "Tema"
 
 msgid "theme appearance dark light colors interface"
 msgstr "tema aparência escuro claro cores interface"
+
+msgid "theme appearance dark light mode"
+msgstr "tema aparência escuro claro modo"
+
+msgid "theme appearance system automatic"
+msgstr "tema aparência sistema automático"
 
 msgid "These edits haven't been applied yet. Leave and they'll be lost — or save and re-run to apply them. The run continues in the background while you keep working."
 msgstr "Estas alterações ainda não foram aplicadas. Se você sair, serão perdidas — ou salve e reexecute para aplicá-las. A execução continua em segundo plano enquanto você trabalha."

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -2867,6 +2867,9 @@ msgstr "Faqja aktuale e pamjes paraprake"
 msgid "Current version (v{currentVersion})"
 msgstr "Versioni aktual (v{currentVersion})"
 
+msgid "Currently active"
+msgstr "Aktiv aktualisht"
+
 msgid "Custom"
 msgstr "I personalizuar"
 
@@ -2890,6 +2893,9 @@ msgstr "Prit një zonë nga çdo faqe"
 
 msgid "Dark"
 msgstr "E errët"
+
+msgid "Date added"
+msgstr "Data e shtimit"
 
 msgid "Date created"
 msgstr "Data e krijimit"
@@ -4420,6 +4426,9 @@ msgstr "Grup"
 msgid "Group by attention"
 msgstr "Grup sipas vëmendjes"
 
+msgid "Group by needs attention"
+msgstr "Gruponi sipas kërkon vëmendje"
+
 msgid "Group each page's text and images into typed sections with a structured content tree. Sections drive how downstream stages render, translate, and read the book aloud."
 msgstr "Grupo tekstin dhe imazhet e çdo faqeje në seksione të tipizuara me një pemë të strukturuar përmbajtjeje. Seksionet drejtojnë mënyrën se si fazat pasuese renderojnë, përkthejnë dhe lexojnë librin me zë."
 
@@ -5049,6 +5058,9 @@ msgstr "Gjuha"
 msgid "Language"
 msgstr "Gjuhë"
 
+msgid "language locale translation"
+msgstr "gjuha lokaliteti përkthimi"
+
 msgid "language locale translation region"
 msgstr "gjuha lokalizimi përkthimi rajoni"
 
@@ -5148,8 +5160,17 @@ msgstr "Biblioteka"
 msgid "Library apps"
 msgstr "Aplikacione biblioteke"
 
+msgid "library group needs attention"
+msgstr "biblioteka grupo kërkon vëmendje"
+
 msgid "Library guide"
 msgstr "Udhëzuesi i bibliotekës"
+
+msgid "library sort order"
+msgstr "biblioteka rendit rendi klasifikimi"
+
+msgid "library view layout grid list"
+msgstr "biblioteka pamja shtrirja rrjetë listë"
 
 msgid "Life in the Coral Reef"
 msgstr "Jeta në Rifin Koral"
@@ -5471,6 +5492,9 @@ msgstr "Përputhni çdo fazë të ciklit të ujit me përkufizimin e saj:"
 
 msgid "Match Source"
 msgstr "Përputhje me Burimin"
+
+msgid "Match system theme"
+msgstr "Ndiq temën e sistemit"
 
 msgid "Matches the original book design with some flexibility."
 msgstr "Përputhet me dizajnin origjinal të librit me pak fleksibilitet."
@@ -6022,6 +6046,9 @@ msgstr "Nuk u gjet asnjë font"
 
 msgid "No fonts match your search."
 msgstr "Asnjë font nuk përputhet me kërkimin tuaj."
+
+msgid "No grouping"
+msgstr "Pa grupim"
 
 msgid "No image"
 msgstr "Pa imazh"
@@ -8910,6 +8937,10 @@ msgstr "Rendit"
 msgid "Sort by"
 msgstr "Rendit sipas"
 
+#. placeholder {0}: i18n._(SORT_LABELS[sort])
+msgid "Sort library by {0}"
+msgstr "Rendit bibliotekën sipas {0}"
+
 msgid "Source"
 msgstr "Burimi"
 
@@ -9285,6 +9316,12 @@ msgstr "Diell"
 
 msgid "Switch languages in a tap."
 msgstr "Ndërro gjuhë me një prekje."
+
+msgid "Switch to dark theme"
+msgstr "Kalo në temën e errët"
+
+msgid "Switch to light theme"
+msgstr "Kalo në temën e ndritshme"
 
 msgid "Switching presentation failed"
 msgstr "Ndryshimi i prezantimit dështoi"
@@ -9671,6 +9708,12 @@ msgstr "Tema"
 
 msgid "theme appearance dark light colors interface"
 msgstr "tema pamja ngjyrat e errëta të lehta ndërfaqe"
+
+msgid "theme appearance dark light mode"
+msgstr "tema pamja e errët e ndritshme mënyra"
+
+msgid "theme appearance system automatic"
+msgstr "tema pamja sistemi automatik"
 
 msgid "These edits haven't been applied yet. Leave and they'll be lost — or save and re-run to apply them. The run continues in the background while you keep working."
 msgstr "Këto ndryshime nuk janë zbatuar ende. Nëse del, do të humbasin — ose ruaji dhe ri-ekzekuto për t'i zbatuar. Ekzekutimi vazhdon në sfond ndërsa ti punon."


### PR DESCRIPTION
Stacked on #831.

⌘K could only *navigate* to a setting. The ones that take a single call and a bounded set of values are now applied in place, in a new **Change** group — 16 entries.

| setting | entries |
|---|---|
| Theme | "Switch to dark theme" / "Switch to light theme" (flips with the current theme) + "Match system theme" |
| Language | English · Português (Brasil) · Español · Français · Shqip |
| Library view | Grid · List |
| Library sort | Recently edited · Title · Progress · Pages · Date added |
| Library grouping | No grouping · Group by needs attention |

Anything that needs input — API keys, model pickers, prompts — stays a navigation entry.

### Decisions worth knowing about

**The theme entry states its outcome, not the setting's name.** "Switch to dark theme" when you're light, "Switch to light theme" when you're dark. A bare "Toggle theme" would be ambiguous with three modes (what does it do from *System*?) and would not match a search for "dark". "Match system theme" is a separate entry.

**Values a setting already holds are ticked**, so the list reads as switches rather than commands.

**Library entries navigate to the Library.** Applying a sort while on Settings changes nothing you can see, so those entries take you where the result is visible. Theme and language stay put — they're visible wherever you are. Neither toasts.

**Feedback lives in the palette, not in the stores**, so flipping the same switch from the Settings screens behaves exactly as before.

**Languages name themselves** ("Português (Brasil)", not "Portuguese"), so the way back is recognisable after a mis-fire into a language you can't read.

**Search terms are translated *and* carry English aliases.** Translating alone broke search: on pt-BR, "sort" and "dark" matched nothing. Both now work — `sort`/`ordenar`, `dark`/`escuro`, `grid`/`grade`.

### Verified in the running app

- `dark` → Enter → `html.dark` set, `adt.theme=dark` stored
- `portug` → Enter → whole UI switches to pt-BR
- from `/settings/about`: `sort library by title` → Enter → lands on `/library` with `sort=title`, no toast
- from `/settings/about`: `light theme` → Enter → stays on `/settings/about`
- ranking puts "Switch to dark theme" above the old "Dark · Appearance" navigation entry

6 unit tests cover the label flip, the ticks, navigate-vs-stay, the self-naming languages, and that every bounded value appears exactly once.

i18n complete: 15 new msgids extracted and translated across es/fr/pt-BR/sq, `compile --strict` clean, 0 missing.
