### PR TITLE
fix(sign-language): make video section assignment searchable

### DIFF
--- a/apps/studio/src/components/pipeline/stages/sign-language/SignLanguageLandingPage.tsx
+++ b/apps/studio/src/components/pipeline/stages/sign-language/SignLanguageLandingPage.tsx
@@ -20,13 +20,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
 import { useStageStatus } from "@/hooks/use-stage-status"
 import { usePages } from "@/hooks/use-pages"
 import {
@@ -39,6 +32,7 @@ import { getSignLanguageVideoUrl } from "@/api/client"
 import type { SignLanguageVideo } from "@/api/client"
 import { isGlossaryVideoSectionId } from "@/lib/glossary-video"
 import { ManageSectionsDialog } from "./components/ManageSectionsDialog"
+import { SectionAssignmentCombobox } from "./components/SectionAssignmentCombobox"
 import { SignLanguageReaderPreview } from "./components/SignLanguageReaderPreview"
 import type { FilterValue, SectionEntry } from "./components/types"
 
@@ -322,30 +316,11 @@ export function SignLanguageLandingPage({ bookLabel }: { bookLabel: string }) {
                         >
                           {video.originalName}
                         </span>
-                        <Select
-                          value="__unassigned__"
-                          onValueChange={(val) =>
-                            handleAssign(
-                              video.videoId,
-                              val === "__unassigned__" ? null : val,
-                            )
-                          }
+                        <SectionAssignmentCombobox
+                          sections={sectionEntries}
                           disabled={assignMutation.isPending}
-                        >
-                          <SelectTrigger className="h-7 w-32 text-[11px]">
-                            <SelectValue placeholder={t`Assign...`} />
-                          </SelectTrigger>
-                          <SelectContent>
-                            <SelectItem value="__unassigned__">
-                              {t`Unassigned`}
-                            </SelectItem>
-                            {sectionEntries.map((s) => (
-                              <SelectItem key={s.sectionId} value={s.sectionId}>
-                                {s.sectionLabel}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
+                          onAssign={(sectionId) => handleAssign(video.videoId, sectionId)}
+                        />
                         <button
                           type="button"
                           onClick={() => handleDelete(video.videoId)}

--- a/apps/studio/src/components/pipeline/stages/sign-language/components/SectionAssignmentCombobox.test.tsx
+++ b/apps/studio/src/components/pipeline/stages/sign-language/components/SectionAssignmentCombobox.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+
+import React from "react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { SectionAssignmentCombobox } from "./SectionAssignmentCombobox"
+
+vi.mock("@lingui/react/macro", () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useLingui: () => ({
+    t: (strings: TemplateStringsArray, ...values: unknown[]) =>
+      strings.reduce(
+        (text, part, index) => text + part + (index < values.length ? String(values[index]) : ""),
+        "",
+      ),
+  }),
+}))
+
+afterEach(cleanup)
+
+describe("SectionAssignmentCombobox", () => {
+  it("filters a long section list and assigns the matching late-page section", () => {
+    const onAssign = vi.fn()
+    const sections = Array.from({ length: 100 }, (_, index) => {
+      const pageNumber = index + 1
+      return {
+        sectionId: `page-${pageNumber}`,
+        sectionIndex: 0,
+        pageNumber,
+        pageLabel: `Page ${pageNumber}`,
+        sectionLabel: `Page ${pageNumber}`,
+      }
+    })
+
+    render(<SectionAssignmentCombobox sections={sections} onAssign={onAssign} />)
+
+    fireEvent.click(screen.getByRole("button", { name: "Assign..." }))
+    fireEvent.change(screen.getByPlaceholderText("Search sections"), {
+      target: { value: "100" },
+    })
+    fireEvent.click(screen.getByRole("option", { name: "Page 100" }))
+
+    expect(onAssign).toHaveBeenCalledWith("page-100")
+    expect(screen.queryByPlaceholderText("Search sections")).toBeNull()
+  })
+})

--- a/apps/studio/src/components/pipeline/stages/sign-language/components/SectionAssignmentCombobox.tsx
+++ b/apps/studio/src/components/pipeline/stages/sign-language/components/SectionAssignmentCombobox.tsx
@@ -1,0 +1,126 @@
+import { useMemo, useRef, useState } from "react"
+import { Check, ChevronsUpDown, Search } from "lucide-react"
+import { Trans, useLingui } from "@lingui/react/macro"
+import { Input } from "@/components/ui/input"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { cn } from "@/lib/utils"
+import type { SectionEntry } from "./types"
+
+interface SectionAssignmentComboboxProps {
+  sections: SectionEntry[]
+  disabled?: boolean
+  onAssign: (sectionId: string | null) => void
+}
+
+function matchesQuery(section: SectionEntry, query: string): boolean {
+  return [section.sectionLabel, section.pageLabel, section.sectionId]
+    .join(" ")
+    .toLocaleLowerCase()
+    .includes(query)
+}
+
+/** A searchable section picker for assigning an unassigned sign-language video. */
+export function SectionAssignmentCombobox({
+  sections,
+  disabled = false,
+  onAssign,
+}: SectionAssignmentComboboxProps) {
+  const { t } = useLingui()
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState("")
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const normalizedQuery = query.trim().toLocaleLowerCase()
+  const matchingSections = useMemo(
+    () =>
+      normalizedQuery
+        ? sections.filter((section) => matchesQuery(section, normalizedQuery))
+        : sections,
+    [normalizedQuery, sections],
+  )
+
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next)
+    if (!next) setQuery("")
+  }
+
+  const select = (sectionId: string | null) => {
+    onAssign(sectionId)
+    handleOpenChange(false)
+  }
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          disabled={disabled}
+          className={cn(
+            "flex h-7 w-32 items-center gap-1.5 rounded-md border border-input bg-background px-2 text-left text-[11px]",
+            "ring-offset-0 focus:outline-none focus:ring-1 focus:ring-inset focus:ring-cyan-600",
+            "data-[state=open]:ring-1 data-[state=open]:ring-inset data-[state=open]:ring-cyan-600",
+            "disabled:cursor-not-allowed disabled:opacity-50",
+          )}
+        >
+          <span className="truncate">{t`Assign...`}</span>
+          <ChevronsUpDown className="ml-auto h-3.5 w-3.5 shrink-0 opacity-50" aria-hidden />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="end"
+        sideOffset={4}
+        className="w-72 p-0"
+        onOpenAutoFocus={(event) => {
+          event.preventDefault()
+          inputRef.current?.focus()
+        }}
+      >
+        <div className="border-b p-2">
+          <Input
+            ref={inputRef}
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" && matchingSections.length > 0) {
+                event.preventDefault()
+                select(matchingSections[0].sectionId)
+              }
+            }}
+            placeholder={t`Search sections`}
+            prependIcon={<Search className="h-3.5 w-3.5" aria-hidden />}
+            className="h-8 text-[12px]"
+          />
+        </div>
+        <div className="max-h-64 overflow-y-auto p-1.5" role="listbox">
+          <button
+            type="button"
+            role="option"
+            aria-selected
+            onClick={() => select(null)}
+            className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-[12px] transition-colors hover:bg-accent focus-visible:bg-accent focus-visible:outline-none"
+          >
+            <Check className="h-3.5 w-3.5 shrink-0 text-cyan-600" aria-hidden />
+            <span><Trans>Unassigned</Trans></span>
+          </button>
+          {matchingSections.map((section) => (
+            <button
+              key={section.sectionId}
+              type="button"
+              role="option"
+              aria-selected={false}
+              onClick={() => select(section.sectionId)}
+              className="flex w-full items-center gap-2 rounded px-2 py-1.5 pl-8 text-left text-[12px] transition-colors hover:bg-accent focus-visible:bg-accent focus-visible:outline-none"
+            >
+              <span className="truncate">{section.sectionLabel}</span>
+            </button>
+          ))}
+          {matchingSections.length === 0 ? (
+            <p className="px-2 py-4 text-center text-[12px] text-muted-foreground">
+              <Trans>No sections found</Trans>
+            </p>
+          ) : null}
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/studio/src/components/ui/select.tsx
+++ b/apps/studio/src/components/ui/select.tsx
@@ -73,7 +73,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]",
+        "relative z-50 max-h-[var(--radix-select-content-available-height)] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className

--- a/apps/studio/src/locales/en.po
+++ b/apps/studio/src/locales/en.po
@@ -6216,6 +6216,9 @@ msgstr "No sections"
 msgid "No sections for this page"
 msgstr "No sections for this page"
 
+msgid "No sections found"
+msgstr "No sections found"
+
 msgid "No sections on this page"
 msgstr "No sections on this page"
 
@@ -8386,6 +8389,9 @@ msgstr "Search questions or options…"
 
 msgid "Search questions, answers, or explanations…"
 msgstr "Search questions, answers, or explanations…"
+
+msgid "Search sections"
+msgstr "Search sections"
 
 msgid "Search sections..."
 msgstr "Search sections..."

--- a/apps/studio/src/locales/es.po
+++ b/apps/studio/src/locales/es.po
@@ -6216,6 +6216,9 @@ msgstr "No hay secciones"
 msgid "No sections for this page"
 msgstr "Sin secciones para esta página"
 
+msgid "No sections found"
+msgstr "No se encontraron secciones"
+
 msgid "No sections on this page"
 msgstr "Sin secciones en esta página"
 
@@ -8386,6 +8389,9 @@ msgstr "Buscar preguntas u opciones…"
 
 msgid "Search questions, answers, or explanations…"
 msgstr "Buscar preguntas, respuestas o explicaciones…"
+
+msgid "Search sections"
+msgstr "Buscar secciones"
 
 msgid "Search sections..."
 msgstr "Buscar secciones..."

--- a/apps/studio/src/locales/fr.po
+++ b/apps/studio/src/locales/fr.po
@@ -6218,6 +6218,9 @@ msgstr "Aucune section"
 msgid "No sections for this page"
 msgstr "Aucune section pour cette page"
 
+msgid "No sections found"
+msgstr "Aucune section trouvée"
+
 msgid "No sections on this page"
 msgstr "Aucune section sur cette page"
 
@@ -8388,6 +8391,9 @@ msgstr "Rechercher des questions ou des options…"
 
 msgid "Search questions, answers, or explanations…"
 msgstr "Rechercher des questions, des réponses ou des explications…"
+
+msgid "Search sections"
+msgstr "Rechercher des sections"
 
 msgid "Search sections..."
 msgstr "Rechercher des sections..."

--- a/apps/studio/src/locales/pt-BR.po
+++ b/apps/studio/src/locales/pt-BR.po
@@ -6216,6 +6216,9 @@ msgstr "Nenhuma seção"
 msgid "No sections for this page"
 msgstr "Sem seções para esta página"
 
+msgid "No sections found"
+msgstr "Nenhuma seção encontrada"
+
 msgid "No sections on this page"
 msgstr "Sem seções nesta página"
 
@@ -8386,6 +8389,9 @@ msgstr "Pesquisar perguntas ou opções…"
 
 msgid "Search questions, answers, or explanations…"
 msgstr "Pesquisar perguntas, respostas ou explicações…"
+
+msgid "Search sections"
+msgstr "Buscar seções"
 
 msgid "Search sections..."
 msgstr "Buscar seções..."

--- a/apps/studio/src/locales/sq.po
+++ b/apps/studio/src/locales/sq.po
@@ -6218,6 +6218,9 @@ msgstr "Nuk ka seksione"
 msgid "No sections for this page"
 msgstr "Nuk ka seksione për këtë faqe"
 
+msgid "No sections found"
+msgstr "Nuk u gjetën seksione"
+
 msgid "No sections on this page"
 msgstr "Nuk ka seksione në këtë faqe"
 
@@ -8388,6 +8391,9 @@ msgstr "Kërko pyetje ose opsione…"
 
 msgid "Search questions, answers, or explanations…"
 msgstr "Kërko pyetje, përgjigje ose shpjegime…"
+
+msgid "Search sections"
+msgstr "Kërko seksione"
 
 msgid "Search sections..."
 msgstr "Kërko seksione..."


### PR DESCRIPTION
## Summary
- Replace the unassigned-video section Select with a searchable, scrollable combobox.
- Keep the shared Select viewport height capped by the Radix available-height variable.
- Add translations and a regression test for selecting Page 100 from a long section list.

## Testing
- Manually tested by Guillermo Bergengruen in the Sign Language stage.
- pnpm exec vitest run apps/studio/src/components/pipeline/stages/sign-language/components/SectionAssignmentCombobox.test.tsx
- pnpm typecheck

Fixes #835