### PR TITLE
fix(desktop): patch electron-builder so macOS signing works on macOS 26.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ FROM base AS deps
 # package.json while preserving directory structure — no edits needed when
 # packages or apps are added to the workspace.
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY patches ./patches
 RUN --mount=type=bind,source=.,target=/ctx \
     find /ctx/packages /ctx/apps -maxdepth 2 -name "package.json" \
          -not -path "*/node_modules/*" \

--- a/package.json
+++ b/package.json
@@ -44,6 +44,9 @@
       "form-data": "^4.0.6",
       "@xmldom/xmldom": "0.9.10",
       "plist>@xmldom/xmldom": "^0.8.13"
+    },
+    "patchedDependencies": {
+      "app-builder-lib@26.8.1": "patches/app-builder-lib@26.8.1.patch"
     }
   },
   "license": "AGPL-3.0-or-later"

--- a/patches/app-builder-lib@26.8.1.patch
+++ b/patches/app-builder-lib@26.8.1.patch
@@ -1,0 +1,24 @@
+diff --git a/out/codeSign/macCodeSign.js b/out/codeSign/macCodeSign.js
+index 17e0c1e7be271b7bce8a7671bfe9d0760a0c9f9a..9a8176dba866a13da1a2e90af2ac289ce58a40f2 100644
+--- a/out/codeSign/macCodeSign.js
++++ b/out/codeSign/macCodeSign.js
+@@ -157,16 +157,16 @@ async function createKeychain({ tmpDir, cscLink, cscKeyPassword, cscILink, cscIK
+     if (cscIKeyPassword != null) {
+         cscPasswords.push(cscIKeyPassword);
+     }
+-    return await importCerts(keychainFile, certPaths, cscPasswords);
++    return await importCerts(keychainFile, certPaths, cscPasswords, keychainPassword);
+ }
+-async function importCerts(keychainFile, paths, keyPasswords) {
++async function importCerts(keychainFile, paths, keyPasswords, keychainPassword) {
+     var _a;
+     for (let i = 0; i < paths.length; i++) {
+         const password = (_a = keyPasswords[i]) !== null && _a !== void 0 ? _a : "";
+         await (0, builder_util_1.exec)("/usr/bin/security", ["import", paths[i], "-k", keychainFile, "-T", "/usr/bin/codesign", "-T", "/usr/bin/productbuild", "-P", password]);
+         // https://stackoverflow.com/questions/39868578/security-codesign-in-sierra-keychain-ignores-access-control-settings-and-ui-p
+         // https://github.com/electron-userland/electron-packager/issues/701#issuecomment-322315996
+-        await (0, builder_util_1.exec)("/usr/bin/security", ["set-key-partition-list", "-S", "apple-tool:,apple:", "-s", "-k", password, keychainFile]);
++        await (0, builder_util_1.exec)("/usr/bin/security", ["set-key-partition-list", "-S", "apple-tool:,apple:", "-s", "-k", keychainPassword, keychainFile]);
+     }
+     return {
+         keychainFile,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,11 @@ overrides:
   '@xmldom/xmldom': 0.9.10
   plist>@xmldom/xmldom: ^0.8.13
 
+patchedDependencies:
+  app-builder-lib@26.8.1:
+    hash: b01e9cad7d5cb7de17c9fa0e732aacaa0ca8e18d7d69796ec296ef2c152522fb
+    path: patches/app-builder-lib@26.8.1.patch
+
 importers:
 
   .:
@@ -8687,7 +8692,7 @@ snapshots:
 
   app-builder-bin@5.0.0-alpha.12: {}
 
-  app-builder-lib@26.8.1(dmg-builder@26.8.1)(electron-builder-squirrel-windows@26.8.1):
+  app-builder-lib@26.8.1(patch_hash=b01e9cad7d5cb7de17c9fa0e732aacaa0ca8e18d7d69796ec296ef2c152522fb)(dmg-builder@26.8.1)(electron-builder-squirrel-windows@26.8.1):
     dependencies:
       '@develar/schema-utils': 2.6.5
       '@electron/asar': 3.4.1
@@ -9247,7 +9252,7 @@ snapshots:
 
   dmg-builder@26.8.1(electron-builder-squirrel-windows@26.8.1):
     dependencies:
-      app-builder-lib: 26.8.1(dmg-builder@26.8.1)(electron-builder-squirrel-windows@26.8.1)
+      app-builder-lib: 26.8.1(patch_hash=b01e9cad7d5cb7de17c9fa0e732aacaa0ca8e18d7d69796ec296ef2c152522fb)(dmg-builder@26.8.1)(electron-builder-squirrel-windows@26.8.1)
       builder-util: 26.8.1
       fs-extra: 10.1.0
       iconv-lite: 0.6.3
@@ -9324,7 +9329,7 @@ snapshots:
 
   electron-builder-squirrel-windows@26.8.1(dmg-builder@26.8.1):
     dependencies:
-      app-builder-lib: 26.8.1(dmg-builder@26.8.1)(electron-builder-squirrel-windows@26.8.1)
+      app-builder-lib: 26.8.1(patch_hash=b01e9cad7d5cb7de17c9fa0e732aacaa0ca8e18d7d69796ec296ef2c152522fb)(dmg-builder@26.8.1)(electron-builder-squirrel-windows@26.8.1)
       builder-util: 26.8.1
       electron-winstaller: 5.4.0
     transitivePeerDependencies:
@@ -9333,7 +9338,7 @@ snapshots:
 
   electron-builder@26.8.1(electron-builder-squirrel-windows@26.8.1):
     dependencies:
-      app-builder-lib: 26.8.1(dmg-builder@26.8.1)(electron-builder-squirrel-windows@26.8.1)
+      app-builder-lib: 26.8.1(patch_hash=b01e9cad7d5cb7de17c9fa0e732aacaa0ca8e18d7d69796ec296ef2c152522fb)(dmg-builder@26.8.1)(electron-builder-squirrel-windows@26.8.1)
       builder-util: 26.8.1
       builder-util-runtime: 9.5.1
       chalk: 4.1.2


### PR DESCRIPTION
## The failure

[Release run 33771836400](https://github.com/unicef/adt-studio/actions/runs/33771836400/job/100703887914) — `desktop (macos-26)` dies in `Package MacOS`, at code signing rather than build:

```
⨯ /usr/bin/security process failed 1
Command failed: /usr/bin/security set-key-partition-list -S apple-tool:,apple: -s -k *** <tmp>.keychain
security: SecKeychainUnlock: The user name or passphrase you entered is not correct.
```

`finalize` needs `desktop`, so nothing was tagged or published — `v0.8.0-beta.1` never shipped.

## Root cause

`app-builder-lib` creates its temporary signing keychain with a **random** password, then passes the **certificate** password to `security set-key-partition-list -k` — where `-k` means the **keychain** password. Those never match.

The mismatch used to be harmless: `set-key-partition-list` ignored `-k` on an already-unlocked keychain. **macOS 26.6 validates it.**

This is the runner OS, not our secrets or our code:

- The last green mac build ([run 32286197815](https://github.com/unicef/adt-studio/actions/runs/32286197815), Aug 19) used the **same** electron-builder 26.8.1 and the **same** Xcode 26.6.0. The only difference is `os=25.5.0` then vs `os=25.6.0` now — runner image `macos-26-arm64` `20260728.0273.1` → `20260831.0337.3`.
- `CSC_LINK` and `CSC_KEY_PASSWORD` have not been modified since 2026-05-28 (`updated_at` on the `desktop` environment secrets).
- The bug is still present in electron-builder 26.15.3 / 26.16.0, so **upgrading does not fix it**.

## The fix

A pnpm patch on the one wrong argument:

```diff
-    return await importCerts(keychainFile, certPaths, cscPasswords);
+    return await importCerts(keychainFile, certPaths, cscPasswords, keychainPassword);
 }
-async function importCerts(keychainFile, paths, keyPasswords) {
+async function importCerts(keychainFile, paths, keyPasswords, keychainPassword) {
...
-    ["set-key-partition-list", ..., "-k", password, keychainFile]
+    ["set-key-partition-list", ..., "-k", keychainPassword, keychainFile]
```

`.github/workflows/release.yml` is untouched.

### Why a patch instead of a workflow workaround

The first version of this PR did the keychain setup in the workflow and handed electron-builder the result via `CSC_KEYCHAIN`. I dropped it:

- ~40 lines of `security` shell reimplementing what electron-builder already does.
- It still reached into electron-builder's internals — bypassing `createKeychain` also skips the bundled `app-builder-lib/certs/root_certs.keychain` it side-loads for Developer ID chain-building, so the step had to copy that file out of the pnpm store. A silent, unenforced coupling to a private path.
- It only fixed CI. `apps/desktop` has a `build:mac` script, so local signing on macOS 26.6 stayed broken.

The patch fixes the actual defect, fixes local builds too, and pnpm fails loudly if it stops applying on upgrade — which is the right moment to check whether upstream has fixed it.

## Verification

Drove `createKeychain` directly with a generated `.p12`, both copies side by side on macOS 26.6.2, after a CI-style `pnpm install --frozen-lockfile`:

```
UNPATCHED: FAILED -> Command failed: /usr/bin/security set-key-partition-list ... -k secretpw <tmp>.keychain
PATCHED:   createKeychain OK; cert present = true
```

The unpatched run reproduces the CI failure exactly, and `-k secretpw` shows the certificate password landing in the keychain-password slot — the diagnosis confirmed directly rather than inferred.

**Not verified locally:** signing + notarization with the real Developer ID cert, which needs a Release run on `develop`.
