### PR TITLE
fix(site): correct license label from MIT to AGPL-3.0

### DIFF
--- a/apps/site/src/components/sections/FinaleScene.tsx
+++ b/apps/site/src/components/sections/FinaleScene.tsx
@@ -115,7 +115,7 @@ export function FinaleScene() {
           </span>
           <span className="h-1 w-1 rounded-full bg-[color:var(--color-border)]" />
           <span className="font-mono">
-            <Trans>MIT licensed</Trans>
+            <Trans>AGPL-3.0 licensed</Trans>
           </span>
         </div>
 

--- a/apps/site/src/components/sections/Footer.tsx
+++ b/apps/site/src/components/sections/Footer.tsx
@@ -59,7 +59,7 @@ const COLUMNS: LinkCol[] = [
         href: "https://github.com/unicef/adt-studio/blob/main/docs/DECISIONS.md",
         external: true,
       },
-      { label: msg`License`, href: "https://opensource.org/licenses/MIT", external: true },
+      { label: msg`License`, href: "https://www.gnu.org/licenses/agpl-3.0.html", external: true },
     ],
   },
 ];
@@ -127,7 +127,7 @@ export function Footer() {
         <div className="mt-12 flex flex-col items-start justify-between gap-4 border-t border-[color:var(--color-border)] pt-6 text-xs text-[color:var(--color-muted-foreground)] sm:flex-row sm:items-center">
           <div>
             <Trans>
-              &copy; {new Date().getFullYear()} ADT Studio — MIT licensed.
+              &copy; {new Date().getFullYear()} ADT Studio — AGPL-3.0 licensed.
             </Trans>
           </div>
           <div className="flex items-center gap-2 font-mono">

--- a/apps/site/src/components/sections/WelcomeScene.tsx
+++ b/apps/site/src/components/sections/WelcomeScene.tsx
@@ -138,7 +138,7 @@ export function WelcomeScene() {
             style={{ transitionDelay: "650ms" }}
           >
             <span className="font-mono">
-              <Trans>MIT licensed</Trans>
+              <Trans>AGPL-3.0 licensed</Trans>
             </span>
             <span className="h-1 w-1 rounded-full bg-[color:var(--color-border)]" />
             <span className="font-mono">

--- a/apps/site/src/locales/en.po
+++ b/apps/site/src/locales/en.po
@@ -25,8 +25,8 @@ msgid "{0} latest is <0>{1}</0> — the project is on <1>{2}</1>. A {3} build fo
 msgstr "{0} latest is <0>{1}</0> — the project is on <1>{2}</1>. A {3} build for the newer tag isn’t available yet."
 
 #. placeholder {0}: new Date().getFullYear()
-msgid "© {0} ADT Studio — MIT licensed."
-msgstr "© {0} ADT Studio — MIT licensed."
+msgid "© {0} ADT Studio — AGPL-3.0 licensed."
+msgstr "© {0} ADT Studio — AGPL-3.0 licensed."
 
 msgid "4 languages"
 msgstr "4 languages"
@@ -63,6 +63,9 @@ msgstr "ADT Studio is currently in"
 
 msgid "ADT Studio takes one PDF and rebuilds it as a fully-editable, fully-yours accessible book — with the pieces that used to take a team of specialists."
 msgstr "ADT Studio takes one PDF and rebuilds it as a fully-editable, fully-yours accessible book — with the pieces that used to take a team of specialists."
+
+msgid "AGPL-3.0 licensed"
+msgstr "AGPL-3.0 licensed"
 
 msgid "AI providers & cost"
 msgstr "AI providers & cost"
@@ -169,9 +172,6 @@ msgstr "Close menu"
 msgid "Coming soon"
 msgstr "Coming soon"
 
-#~ msgid "Community & Support"
-#~ msgstr "Community & Support"
-
 msgid "Configure each stage — extract, storyboard, layout — then let ADT Studio build the book. Review the output, correct anything that needs a human touch."
 msgstr "Configure each stage — extract, storyboard, layout — then let ADT Studio build the book. Review the output, correct anything that needs a human touch."
 
@@ -187,9 +187,6 @@ msgstr "Convert a PDF into an ADT"
 msgid "Converting"
 msgstr "Converting"
 
-#~ msgid "Core Concepts"
-#~ msgstr "Core Concepts"
-
 msgid "Couldn’t load the changelog"
 msgstr "Couldn’t load the changelog"
 
@@ -198,9 +195,6 @@ msgstr "Couldn't reach GitHub"
 
 msgid "Cover · Chapter 1"
 msgstr "Cover · Chapter 1"
-
-#~ msgid "Create a New Project"
-#~ msgstr "Create a New Project"
 
 msgid "Custom"
 msgstr "Custom"
@@ -426,9 +420,6 @@ msgstr "Grouping content by purpose, then laying out every section as reviewable
 msgid "Guidelines"
 msgstr "Guidelines"
 
-#~ msgid "Help"
-#~ msgstr "Help"
-
 msgid "Here's what shipped in the latest version — and there are plenty more where this came from."
 msgstr "Here's what shipped in the latest version — and there are plenty more where this came from."
 
@@ -446,9 +437,6 @@ msgstr "If your device has been wrongly detected, <0>see all downloads</0>. Plea
 
 msgid "Image captions"
 msgstr "Image captions"
-
-#~ msgid "Image Captions"
-#~ msgstr "Image Captions"
 
 msgid "Import"
 msgstr "Import"
@@ -477,9 +465,6 @@ msgstr "Installing"
 msgid "Interactive activities"
 msgstr "Interactive activities"
 
-#~ msgid "Introduction"
-#~ msgstr "Introduction"
-
 msgid "Issues"
 msgstr "Issues"
 
@@ -504,9 +489,6 @@ msgstr "Layer on translations, text-to-speech, and a glossary — all inspectabl
 msgid "Laying out spreads"
 msgstr "Laying out spreads"
 
-#~ msgid "Learn"
-#~ msgstr "Learn"
-
 msgid "License"
 msgstr "License"
 
@@ -516,9 +498,6 @@ msgstr "Listen to the book, page by page."
 msgid "LIVE"
 msgstr "LIVE"
 
-#~ msgid "LLM Providers & API Keys"
-#~ msgstr "LLM Providers & API Keys"
-
 msgid "Localize your ADT"
 msgstr "Localize your ADT"
 
@@ -527,9 +506,6 @@ msgstr "Made possible by"
 
 msgid "Math that reads aloud"
 msgstr "Math that reads aloud"
-
-msgid "MIT licensed"
-msgstr "MIT licensed"
 
 msgid "Narration · 0:42"
 msgstr "Narration · 0:42"
@@ -610,9 +586,6 @@ msgstr "Open-source desktop pipeline for turning PDFs into accessible books — 
 msgid "Output"
 msgstr "Output"
 
-#~ msgid "Output Bundles"
-#~ msgstr "Output Bundles"
-
 msgid "Overview"
 msgstr "Overview"
 
@@ -643,17 +616,11 @@ msgstr "Personalize further"
 msgid "Pick a preset"
 msgstr "Pick a preset"
 
-#~ msgid "Pipeline"
-#~ msgstr "Pipeline"
-
 msgid "Pipeline · extract"
 msgstr "Pipeline · extract"
 
 msgid "Pipeline · storyboard"
 msgstr "Pipeline · storyboard"
-
-#~ msgid "Pipeline Overview"
-#~ msgstr "Pipeline Overview"
 
 msgid "Play"
 msgstr "Play"
@@ -687,9 +654,6 @@ msgstr "Project"
 
 msgid "Project Archive"
 msgstr "Project Archive"
-
-#~ msgid "Quick Start"
-#~ msgstr "Quick Start"
 
 msgid "Quickstart"
 msgstr "Quickstart"
@@ -839,12 +803,6 @@ msgstr "Supported by"
 
 msgid "Table of contents"
 msgstr "Table of contents"
-
-#~ msgid "Table of Contents"
-#~ msgstr "Table of Contents"
-
-#~ msgid "Templates"
-#~ msgstr "Templates"
 
 msgid "Text and sign language, side by side."
 msgstr "Text and sign language, side by side."

--- a/apps/site/src/locales/es.po
+++ b/apps/site/src/locales/es.po
@@ -26,8 +26,8 @@ msgid "{0} latest is <0>{1}</0> — the project is on <1>{2}</1>. A {3} build fo
 msgstr "La última versión de {0} es <0>{1}</0> — el proyecto está en <1>{2}</1>. Aún no hay un build de {3} para la nueva etiqueta."
 
 #. placeholder {0}: new Date().getFullYear()
-msgid "© {0} ADT Studio — MIT licensed."
-msgstr "© {0} ADT Studio — Licencia MIT."
+msgid "© {0} ADT Studio — AGPL-3.0 licensed."
+msgstr "© {0} ADT Studio — Licencia AGPL-3.0."
 
 msgid "4 languages"
 msgstr "4 idiomas"
@@ -64,6 +64,9 @@ msgstr "ADT Studio está actualmente en"
 
 msgid "ADT Studio takes one PDF and rebuilds it as a fully-editable, fully-yours accessible book — with the pieces that used to take a team of specialists."
 msgstr "ADT Studio toma un PDF y lo reconstruye como un libro accesible completamente editable y tuyo — con las piezas que solían requerir un equipo de especialistas."
+
+msgid "AGPL-3.0 licensed"
+msgstr "Licencia AGPL-3.0"
 
 msgid "AI providers & cost"
 msgstr "Proveedores de IA y costes"
@@ -170,9 +173,6 @@ msgstr "Cerrar menú"
 msgid "Coming soon"
 msgstr "Próximamente"
 
-#~ msgid "Community & Support"
-#~ msgstr "Comunidad y soporte"
-
 msgid "Configure each stage — extract, storyboard, layout — then let ADT Studio build the book. Review the output, correct anything that needs a human touch."
 msgstr "Configura cada etapa — extracción, storyboard, diseño — luego deja que ADT Studio construya el libro. Revisa el resultado, corrige cualquier cosa que necesite un toque humano."
 
@@ -188,9 +188,6 @@ msgstr "Convierte un PDF en un ADT"
 msgid "Converting"
 msgstr "Conversión"
 
-#~ msgid "Core Concepts"
-#~ msgstr "Conceptos básicos"
-
 msgid "Couldn’t load the changelog"
 msgstr "No se pudo cargar el registro de cambios"
 
@@ -199,9 +196,6 @@ msgstr "No se pudo acceder a GitHub"
 
 msgid "Cover · Chapter 1"
 msgstr "Portada · Capítulo 1"
-
-#~ msgid "Create a New Project"
-#~ msgstr "Crear un proyecto nuevo"
 
 msgid "Custom"
 msgstr "Personalizado"
@@ -427,9 +421,6 @@ msgstr "Agrupando contenido por propósito, luego diseñando cada sección como 
 msgid "Guidelines"
 msgstr "Directrices"
 
-#~ msgid "Help"
-#~ msgstr "Ayuda"
-
 msgid "Here's what shipped in the latest version — and there are plenty more where this came from."
 msgstr "Esto es lo que llegó en la última versión — y hay mucho más de donde vino esto."
 
@@ -475,9 +466,6 @@ msgstr "Instalación"
 msgid "Interactive activities"
 msgstr "Actividades interactivas"
 
-#~ msgid "Introduction"
-#~ msgstr "Introducción"
-
 msgid "Issues"
 msgstr "Problemas"
 
@@ -502,9 +490,6 @@ msgstr "Suma traducciones, texto a voz y un glosario — todo inspeccionable, al
 msgid "Laying out spreads"
 msgstr "Diseñando pliegos"
 
-#~ msgid "Learn"
-#~ msgstr "Aprender"
-
 msgid "License"
 msgstr "Licencia"
 
@@ -514,9 +499,6 @@ msgstr "Escucha el libro, página por página."
 msgid "LIVE"
 msgstr "EN VIVO"
 
-#~ msgid "LLM Providers & API Keys"
-#~ msgstr "Proveedores de LLM y claves de API"
-
 msgid "Localize your ADT"
 msgstr "Localiza tu ADT"
 
@@ -525,9 +507,6 @@ msgstr "Hecho posible gracias a"
 
 msgid "Math that reads aloud"
 msgstr "Matemáticas que se leen en voz alta"
-
-msgid "MIT licensed"
-msgstr "Licencia MIT"
 
 msgid "Narration · 0:42"
 msgstr "Narración · 0:42"
@@ -608,9 +587,6 @@ msgstr "Pipeline de escritorio de código abierto para convertir PDFs en libros 
 msgid "Output"
 msgstr "Salida"
 
-#~ msgid "Output Bundles"
-#~ msgstr "Paquetes de salida"
-
 msgid "Overview"
 msgstr "Descripción general"
 
@@ -641,17 +617,11 @@ msgstr "Personaliza aún más"
 msgid "Pick a preset"
 msgstr "Elige un preset"
 
-#~ msgid "Pipeline"
-#~ msgstr "Pipeline"
-
 msgid "Pipeline · extract"
 msgstr "Pipeline · extracción"
 
 msgid "Pipeline · storyboard"
 msgstr "Pipeline · storyboard"
-
-#~ msgid "Pipeline Overview"
-#~ msgstr "Descripción del pipeline"
 
 msgid "Play"
 msgstr "Reproducir"
@@ -685,9 +655,6 @@ msgstr "Proyecto"
 
 msgid "Project Archive"
 msgstr "Archivo del proyecto"
-
-#~ msgid "Quick Start"
-#~ msgstr "Inicio rápido"
 
 msgid "Quickstart"
 msgstr "Inicio rápido"
@@ -837,12 +804,6 @@ msgstr "Con el apoyo de"
 
 msgid "Table of contents"
 msgstr "Índice"
-
-#~ msgid "Table of Contents"
-#~ msgstr "Tabla de contenidos"
-
-#~ msgid "Templates"
-#~ msgstr "Plantillas"
 
 msgid "Text and sign language, side by side."
 msgstr "Texto y lengua de signos, lado a lado."

--- a/apps/site/src/locales/fr.po
+++ b/apps/site/src/locales/fr.po
@@ -26,8 +26,8 @@ msgid "{0} latest is <0>{1}</0> — the project is on <1>{2}</1>. A {3} build fo
 msgstr "La dernière version de {0} est <0>{1}</0> — le projet est sur <1>{2}</1>. Un build {3} pour le nouveau tag n'est pas encore disponible."
 
 #. placeholder {0}: new Date().getFullYear()
-msgid "© {0} ADT Studio — MIT licensed."
-msgstr "© {0} ADT Studio — sous licence MIT."
+msgid "© {0} ADT Studio — AGPL-3.0 licensed."
+msgstr "© {0} ADT Studio — sous licence AGPL-3.0."
 
 msgid "4 languages"
 msgstr "4 langues"
@@ -64,6 +64,9 @@ msgstr "ADT Studio est actuellement en"
 
 msgid "ADT Studio takes one PDF and rebuilds it as a fully-editable, fully-yours accessible book — with the pieces that used to take a team of specialists."
 msgstr "ADT Studio prend un PDF et le reconstruit en un livre accessible entièrement éditable, entièrement à vous — avec les éléments qui nécessitaient auparavant une équipe de spécialistes."
+
+msgid "AGPL-3.0 licensed"
+msgstr "Sous licence AGPL-3.0"
 
 msgid "AI providers & cost"
 msgstr "Fournisseurs d'IA et coûts"
@@ -170,9 +173,6 @@ msgstr "Fermer le menu"
 msgid "Coming soon"
 msgstr "Bientôt disponible"
 
-#~ msgid "Community & Support"
-#~ msgstr "Communauté et assistance"
-
 msgid "Configure each stage — extract, storyboard, layout — then let ADT Studio build the book. Review the output, correct anything that needs a human touch."
 msgstr "Configurez chaque étape — extraction, storyboard, mise en page — puis laissez ADT Studio construire le livre. Vérifiez le résultat, corrigez tout ce qui nécessite une intervention humaine."
 
@@ -188,9 +188,6 @@ msgstr "Convertir un PDF en ADT"
 msgid "Converting"
 msgstr "Conversion"
 
-#~ msgid "Core Concepts"
-#~ msgstr "Concepts clés"
-
 msgid "Couldn’t load the changelog"
 msgstr "Impossible de charger le journal des modifications"
 
@@ -199,9 +196,6 @@ msgstr "Impossible d'atteindre GitHub"
 
 msgid "Cover · Chapter 1"
 msgstr "Couverture · Chapitre 1"
-
-#~ msgid "Create a New Project"
-#~ msgstr "Créer un nouveau projet"
 
 msgid "Custom"
 msgstr "Personnalisé"
@@ -427,9 +421,6 @@ msgstr "Regrouper le contenu par objectif, puis disposer chaque section en HTML 
 msgid "Guidelines"
 msgstr "Directives"
 
-#~ msgid "Help"
-#~ msgstr "Aide"
-
 msgid "Here's what shipped in the latest version — and there are plenty more where this came from."
 msgstr "Voici ce qui a été livré dans la dernière version — et ce n'est qu'un début."
 
@@ -475,9 +466,6 @@ msgstr "Installation"
 msgid "Interactive activities"
 msgstr "Activités interactives"
 
-#~ msgid "Introduction"
-#~ msgstr "Introduction"
-
 msgid "Issues"
 msgstr "Problèmes"
 
@@ -502,9 +490,6 @@ msgstr "Ajoutez des traductions, de la synthèse vocale et un glossaire — tous
 msgid "Laying out spreads"
 msgstr "Mise en page des doubles pages"
 
-#~ msgid "Learn"
-#~ msgstr "Apprendre"
-
 msgid "License"
 msgstr "Licence"
 
@@ -514,9 +499,6 @@ msgstr "Écoutez le livre, page par page."
 msgid "LIVE"
 msgstr "EN DIRECT"
 
-#~ msgid "LLM Providers & API Keys"
-#~ msgstr "Fournisseurs de LLM et clés d'API"
-
 msgid "Localize your ADT"
 msgstr "Localisez votre ADT"
 
@@ -525,9 +507,6 @@ msgstr "Rendu possible par"
 
 msgid "Math that reads aloud"
 msgstr "Des maths lues à voix haute"
-
-msgid "MIT licensed"
-msgstr "Sous licence MIT"
 
 msgid "Narration · 0:42"
 msgstr "Narration · 0:42"
@@ -608,9 +587,6 @@ msgstr "Pipeline de bureau open-source pour transformer les PDF en livres access
 msgid "Output"
 msgstr "Sortie"
 
-#~ msgid "Output Bundles"
-#~ msgstr "Paquets de sortie"
-
 msgid "Overview"
 msgstr "Aperçu"
 
@@ -641,17 +617,11 @@ msgstr "Personnaliser davantage"
 msgid "Pick a preset"
 msgstr "Choisir un préréglage"
 
-#~ msgid "Pipeline"
-#~ msgstr "Pipeline"
-
 msgid "Pipeline · extract"
 msgstr "Pipeline · extraction"
 
 msgid "Pipeline · storyboard"
 msgstr "Pipeline · storyboard"
-
-#~ msgid "Pipeline Overview"
-#~ msgstr "Aperçu du pipeline"
 
 msgid "Play"
 msgstr "Lire"
@@ -685,9 +655,6 @@ msgstr "Projet"
 
 msgid "Project Archive"
 msgstr "Archive du projet"
-
-#~ msgid "Quick Start"
-#~ msgstr "Démarrage rapide"
 
 msgid "Quickstart"
 msgstr "Démarrage rapide"
@@ -837,12 +804,6 @@ msgstr "Avec le soutien de"
 
 msgid "Table of contents"
 msgstr "Table des matières"
-
-#~ msgid "Table of Contents"
-#~ msgstr "Table des matières"
-
-#~ msgid "Templates"
-#~ msgstr "Modèles"
 
 msgid "Text and sign language, side by side."
 msgstr "Texte et langue des signes, côte à côte."

--- a/apps/site/src/locales/pt-BR.po
+++ b/apps/site/src/locales/pt-BR.po
@@ -26,8 +26,8 @@ msgid "{0} latest is <0>{1}</0> — the project is on <1>{2}</1>. A {3} build fo
 msgstr "A versão mais recente de {0} é <0>{1}</0> — o projeto está em <1>{2}</1>. Ainda não há uma build de {3} para a tag mais nova."
 
 #. placeholder {0}: new Date().getFullYear()
-msgid "© {0} ADT Studio — MIT licensed."
-msgstr "© {0} ADT Studio — Licença MIT."
+msgid "© {0} ADT Studio — AGPL-3.0 licensed."
+msgstr "© {0} ADT Studio — Licença AGPL-3.0."
 
 msgid "4 languages"
 msgstr "4 idiomas"
@@ -64,6 +64,9 @@ msgstr "ADT Studio está atualmente em"
 
 msgid "ADT Studio takes one PDF and rebuilds it as a fully-editable, fully-yours accessible book — with the pieces that used to take a team of specialists."
 msgstr "ADT Studio pega um PDF e o reconstrói como um livro acessível totalmente editável e seu — com as partes que costumavam exigir uma equipe de especialistas."
+
+msgid "AGPL-3.0 licensed"
+msgstr "Licença AGPL-3.0"
 
 msgid "AI providers & cost"
 msgstr "Provedores de IA e custos"
@@ -170,9 +173,6 @@ msgstr "Fechar menu"
 msgid "Coming soon"
 msgstr "Em breve"
 
-#~ msgid "Community & Support"
-#~ msgstr "Comunidade e suporte"
-
 msgid "Configure each stage — extract, storyboard, layout — then let ADT Studio build the book. Review the output, correct anything that needs a human touch."
 msgstr "Configure cada etapa — extração, storyboard, layout — e deixe o ADT Studio construir o livro. Revise o resultado, corrija qualquer coisa que precise de um toque humano."
 
@@ -188,9 +188,6 @@ msgstr "Converter um PDF em um ADT"
 msgid "Converting"
 msgstr "Conversão"
 
-#~ msgid "Core Concepts"
-#~ msgstr "Conceitos centrais"
-
 msgid "Couldn’t load the changelog"
 msgstr "Não foi possível carregar o registro de alterações"
 
@@ -199,9 +196,6 @@ msgstr "Não foi possível acessar o GitHub"
 
 msgid "Cover · Chapter 1"
 msgstr "Capa · Capítulo 1"
-
-#~ msgid "Create a New Project"
-#~ msgstr "Criar um novo projeto"
 
 msgid "Custom"
 msgstr "Personalizado"
@@ -427,9 +421,6 @@ msgstr "Agrupando conteúdo por propósito, depois organizando cada seção como
 msgid "Guidelines"
 msgstr "Diretrizes"
 
-#~ msgid "Help"
-#~ msgstr "Ajuda"
-
 msgid "Here's what shipped in the latest version — and there are plenty more where this came from."
 msgstr "Aqui está o que foi enviado na última versão — e há muito mais de onde isso veio."
 
@@ -475,9 +466,6 @@ msgstr "Instalação"
 msgid "Interactive activities"
 msgstr "Atividades interativas"
 
-#~ msgid "Introduction"
-#~ msgstr "Introdução"
-
 msgid "Issues"
 msgstr "Problemas"
 
@@ -502,9 +490,6 @@ msgstr "Camada de traduções, texto-para-fala e um glossário — tudo inspecio
 msgid "Laying out spreads"
 msgstr "Diagramando spreads"
 
-#~ msgid "Learn"
-#~ msgstr "Aprender"
-
 msgid "License"
 msgstr "Licença"
 
@@ -514,9 +499,6 @@ msgstr "Ouça o livro, página por página."
 msgid "LIVE"
 msgstr "AO VIVO"
 
-#~ msgid "LLM Providers & API Keys"
-#~ msgstr "Provedores de LLM e chaves de API"
-
 msgid "Localize your ADT"
 msgstr "Localize seu ADT"
 
@@ -525,9 +507,6 @@ msgstr "Tornado possível por"
 
 msgid "Math that reads aloud"
 msgstr "Matemática que é lida em voz alta"
-
-msgid "MIT licensed"
-msgstr "Licença MIT"
 
 msgid "Narration · 0:42"
 msgstr "Narração · 0:42"
@@ -608,9 +587,6 @@ msgstr "Pipeline de desktop de código aberto para transformar PDFs em livros ac
 msgid "Output"
 msgstr "Saída"
 
-#~ msgid "Output Bundles"
-#~ msgstr "Pacotes de saída"
-
 msgid "Overview"
 msgstr "Visão geral"
 
@@ -641,17 +617,11 @@ msgstr "Personalize ainda mais"
 msgid "Pick a preset"
 msgstr "Escolha um preset"
 
-#~ msgid "Pipeline"
-#~ msgstr "Pipeline"
-
 msgid "Pipeline · extract"
 msgstr "Pipeline · extrair"
 
 msgid "Pipeline · storyboard"
 msgstr "Pipeline · storyboard"
-
-#~ msgid "Pipeline Overview"
-#~ msgstr "Visão geral do pipeline"
 
 msgid "Play"
 msgstr "Reproduzir"
@@ -685,9 +655,6 @@ msgstr "Projeto"
 
 msgid "Project Archive"
 msgstr "Arquivo do projeto"
-
-#~ msgid "Quick Start"
-#~ msgstr "Início rápido"
 
 msgid "Quickstart"
 msgstr "Início rápido"
@@ -837,12 +804,6 @@ msgstr "Com o apoio de"
 
 msgid "Table of contents"
 msgstr "Sumário"
-
-#~ msgid "Table of Contents"
-#~ msgstr "Sumário"
-
-#~ msgid "Templates"
-#~ msgstr "Modelos"
 
 msgid "Text and sign language, side by side."
 msgstr "Texto e língua de sinais, lado a lado."


### PR DESCRIPTION
## Problem

The landing page ([unicef.github.io/adt-studio](https://unicef.github.io/adt-studio/)) states the project is **"MIT licensed"** in the hero, the finale section, and the footer, and the footer **License** link points at `opensource.org/licenses/MIT`. The project is actually licensed under **AGPL-3.0** (GNU Affero GPL v3 — see [`LICENSE`](https://github.com/unicef/adt-studio/blob/main/LICENSE)).

## Changes

- **`WelcomeScene.tsx`** + **`FinaleScene.tsx`** — badge: `MIT licensed` → `AGPL-3.0 licensed`
- **`Footer.tsx`** — copyright line `— MIT licensed.` → `— AGPL-3.0 licensed.`; **License** link `opensource.org/licenses/MIT` → `https://www.gnu.org/licenses/agpl-3.0.html`
- **`en/es/fr/pt-BR.po`** — regenerated Lingui catalogs with translated strings (`Licencia AGPL-3.0` / `sous licence AGPL-3.0` / `Licença AGPL-3.0`)

### Note on the catalog diff size

I ran `pnpm --filter @adt/site extract --clean`. Besides the license strings, `--clean` also drops ~13 pre-existing **obsolete (`#~`) catalog entries** per locale — dead leftovers from the old docs nav that were still being compiled into the shipped bundle. That accounts for most of the deletions; the only *semantic* change is MIT → AGPL-3.0.

## Verification (all Site CI steps run locally)

- `lingui extract` is idempotent → "unextracted strings" check passes
- `check-translations.mjs --strict` → 100% translated, no empty `msgstr`
- `pnpm --filter @adt/site build` + `types:check` → exit 0
- Built bundle: **0** "MIT licensed", **0** `opensource.org/licenses/MIT`, **8** "AGPL-3.0 licensed", AGPL link present