### PR TITLE
fix(templates): render mixed-role heading containers

### DIFF
--- a/packages/pipeline/src/__tests__/render-template.test.ts
+++ b/packages/pipeline/src/__tests__/render-template.test.ts
@@ -374,6 +374,27 @@ describe("two_column_render.liquid", () => {
     )
   })
 
+  it("renders mixed-role heading-container children with their own semantic levels", async () => {
+    const engine = createTemplateEngine(templatesDir)
+    const input = makeInput({
+      nodes: [
+        groupNode("pg001_heading001", "heading", [
+          leafNode("pg001_title001", "chapter_title", "Book title"),
+          leafNode("pg001_subtitle001", "subheading", "Book subtitle"),
+        ]),
+      ],
+    })
+    const config = { ...templateConfig, templateName: "two_column_render" }
+    const result = await renderSectionTemplate(input, config, engine)
+
+    expect(result.html).toContain(
+      '<h1 class="adt-h1" data-id="pg001_title001">Book title</h1>',
+    )
+    expect(result.html).toContain(
+      '<h3 class="adt-h3" data-id="pg001_subtitle001">Book subtitle</h3>',
+    )
+  })
+
   it("routes a non-image_group container holding an image leaf into the image column", async () => {
     const engine = createTemplateEngine(templatesDir)
     const input = makeInput({

--- a/templates/_render_node.liquid
+++ b/templates/_render_node.liquid
@@ -39,12 +39,7 @@
 {%- elsif node.structure == "paragraph" -%}
 <p>{% if node.children and node.children.size > 0 and depth < 8 %}{% include "_render_inline", nodes: node.children %}{% endif %}</p>
 {%- elsif node.structure == "heading" -%}
-{%- assign heading_child = node.children[0] -%}
-{%- if heading_child.role == "chapter_title" -%}<h1 class="adt-h1">{% include "_render_inline", nodes: node.children %}</h1>
-{%- elsif heading_child.role == "section_heading" -%}<h2 class="adt-h2">{% include "_render_inline", nodes: node.children %}</h2>
-{%- elsif heading_child.role == "subheading" -%}<h3 class="adt-h3">{% include "_render_inline", nodes: node.children %}</h3>
-{%- elsif heading_child.heading_level -%}<h{{ heading_child.heading_level }} class="adt-h{{ heading_child.heading_level }}">{% include "_render_inline", nodes: node.children %}</h{{ heading_child.heading_level }}>
-{%- else -%}<h2 class="adt-h2">{% include "_render_inline", nodes: node.children %}</h2>{%- endif -%}
+{% if node.children and node.children.size > 0 and depth < 8 %}{%- assign _child_depth = depth | plus: 1 -%}{% include "_render_node", nodes: node.children, depth: _child_depth %}{% endif %}
 {%- elsif node.structure == "list" -%}
 <ul class="list-disc list-inside space-y-1 pl-4">{% if node.children and node.children.size > 0 and depth < 8 %}{%- assign _child_depth = depth | plus: 1 -%}{% include "_render_node", nodes: node.children, depth: _child_depth %}{% endif %}</ul>
 {%- elsif node.structure == "list_item" -%}


### PR DESCRIPTION
## Summary

- render children of a `heading` container independently, using each child role’s existing semantic element and `adt-h*` class
- prevent a title-plus-subtitle cover from nesting the subtitle inside the title’s `<h1>`, which the typography validator correctly rejects
- add template-renderer coverage for a `chapter_title` plus `subheading` container

## Manual verification

- render a title-plus-subtitle cover with the template strategy
- confirm Storyboard completes and renders separate `h1.adt-h1` and `h3.adt-h3` elements
- repeat with the one-column template and verify a normal single heading still renders correctly

Closes #812